### PR TITLE
[Feature] New RBAC privilege framework: basic upgrader

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationManager.java
@@ -5,6 +5,8 @@ package com.starrocks.authentication;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.DdlException;
+import com.starrocks.mysql.privilege.AuthPlugin;
+import com.starrocks.mysql.privilege.Password;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
@@ -63,6 +65,9 @@ public class AuthenticationManager {
     private final ReentrantReadWriteLock hostnameToIpLock = new ReentrantReadWriteLock();
 
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    // set by load() to distinguish brand-new environment with upgraded environment
+    private boolean isLoaded = false;
 
     private void readLock() {
         lock.readLock().lock();
@@ -423,9 +428,29 @@ public class AuthenticationManager {
             }
             assert ret != null; // can't be NULL
             LOG.info("loaded {} users", ret.userToAuthenticationInfo.size());
+            // mark data is loaded
+            ret.isLoaded = true;
             return ret;
         } catch (SRMetaBlockException | AuthenticationException e) {
             throw new DdlException("failed to load AuthenticationManager!", e);
         }
+    }
+
+    public boolean isLoaded() {
+        return isLoaded;
+    }
+
+    /**
+     * upgrade user
+     */
+    public void upgradeUserUnlocked(UserIdentity userIdentity, Password password) throws AuthenticationException {
+        AuthPlugin plugin = password.getAuthPlugin();
+        if (plugin == null) {
+            plugin = AuthPlugin.MYSQL_NATIVE_PASSWORD;
+        }
+        AuthenticationProvider provider = AuthenticationProviderFactory.create(plugin.toString());
+        UserAuthenticationInfo info = provider.upgradedFromPassword(userIdentity, password);
+        userToAuthenticationInfo.put(userIdentity, info);
+        LOG.info("upgrade user {}", userIdentity);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationManager.java
@@ -440,6 +440,9 @@ public class AuthenticationManager {
         return isLoaded;
     }
 
+    public void setLoaded() {
+        isLoaded = true;
+    }
     /**
      * upgrade user
      */
@@ -452,5 +455,11 @@ public class AuthenticationManager {
         UserAuthenticationInfo info = provider.upgradedFromPassword(userIdentity, password);
         userToAuthenticationInfo.put(userIdentity, info);
         LOG.info("upgrade user {}", userIdentity);
+    }
+
+    public void upgradeUserProperty(String userName, long maxConn) {
+        UserProperty userProperty = new UserProperty();
+        userProperty.setMaxConn(maxConn);
+        userNameToProperty.put(userName, new UserProperty());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationManager.java
@@ -443,8 +443,9 @@ public class AuthenticationManager {
     public void setLoaded() {
         isLoaded = true;
     }
+
     /**
-     * upgrade user
+     * these public interfaces are for AuthUpgrader to upgrade from 2.x
      */
     public void upgradeUserUnlocked(UserIdentity userIdentity, Password password) throws AuthenticationException {
         AuthPlugin plugin = password.getAuthPlugin();

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationProvider.java
@@ -3,6 +3,7 @@
 package com.starrocks.authentication;
 
 import com.starrocks.analysis.UserIdentity;
+import com.starrocks.mysql.privilege.Password;
 
 public interface AuthenticationProvider {
 
@@ -24,4 +25,10 @@ public interface AuthenticationProvider {
             byte[] password,
             byte[] randomString,
             UserAuthenticationInfo authenticationInfo) throws AuthenticationException;
+
+    /**
+     * upgraded from 2.x
+     **/
+    UserAuthenticationInfo upgradedFromPassword(UserIdentity userIdentity, Password password)
+            throws AuthenticationException;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/PlainPasswordAuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/PlainPasswordAuthenticationProvider.java
@@ -5,6 +5,7 @@ package com.starrocks.authentication;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.mysql.MysqlPassword;
+import com.starrocks.mysql.privilege.Password;
 
 public class PlainPasswordAuthenticationProvider implements AuthenticationProvider {
     public static final String PLUGIN_NAME = "MYSQL_NATIVE_PASSWORD";
@@ -74,5 +75,16 @@ public class PlainPasswordAuthenticationProvider implements AuthenticationProvid
                 && !MysqlPassword.checkScramble(remotePassword, randomString, saltPassword)) {
             throw new AuthenticationException("password mismatch!");
         }
+    }
+
+    @Override
+    public UserAuthenticationInfo upgradedFromPassword(UserIdentity userIdentity, Password password)
+            throws AuthenticationException {
+        UserAuthenticationInfo ret = new UserAuthenticationInfo();
+        ret.setPassword(password.getPassword());
+        ret.setAuthPlugin(PLUGIN_NAME);
+        ret.setOrigUserHost(userIdentity.getQualifiedUser(), userIdentity.getHost());
+        ret.setTextForAuthPlugin(password.getUserForAuthPlugin());
+        return ret;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
@@ -11,4 +11,8 @@ public class UserProperty {
     public long getMaxConn() {
         return maxConn;
     }
+
+    public void setMaxConn(long maxConn) {
+        this.maxConn = maxConn;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DomainResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DomainResolver.java
@@ -65,6 +65,10 @@ public class DomainResolver extends LeaderDaemon {
         this.authenticationManager = authenticationManager;
     }
 
+    /**
+     * if a follower has just transfered to leader, or if it is replaying a AuthUpgrade journal.
+     * this function will be called to switch from using Auth to using AuthenticationManager.
+     */
     public void setAuthenticationManager(AuthenticationManager manager) {
         lock.writeLock().lock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1799,4 +1799,10 @@ public class Config extends ConfigBase {
      **/
     @ConfField(mutable = true)
     public static int privilege_max_role_depth = 16;
+
+    /**
+     * ignore invalid privilege & authentication when upgraded to new RBAC privilege framework in 3.0
+     */
+    @ConfField(mutable = true)
+    public static boolean ignore_invalid_privilege_authentications = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -56,6 +56,7 @@ import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
 import com.starrocks.persist.AlterUserInfo;
 import com.starrocks.persist.AlterViewInfo;
+import com.starrocks.persist.AuthUpgradeInfo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
 import com.starrocks.persist.BackendTabletsInfo;
 import com.starrocks.persist.BatchDropInfo;
@@ -732,6 +733,11 @@ public class JournalEntity implements Writable {
             case OperationType.OP_DROP_ROLE_V2:
             case OperationType.OP_UPDATE_ROLE_PRIVILEGE_V2: {
                 data = RolePrivilegeCollectionInfo.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_AUTH_UPGRDE_V2: {
+                data = AuthUpgradeInfo.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -95,7 +95,7 @@ public class Auth implements Writable {
     private ResourcePrivTable resourcePrivTable = new ResourcePrivTable();
     private ImpersonateUserPrivTable impersonateUserPrivTable = new ImpersonateUserPrivTable();
 
-    private RoleManager roleManager = new RoleManager();
+    protected RoleManager roleManager = new RoleManager();
     private UserPropertyMgr propertyMgr = new UserPropertyMgr();
 
     private ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -129,12 +129,20 @@ public class Auth implements Writable {
         return userPrivTable;
     }
 
-    public DbPrivTable getDbPrivTable() {
+    protected DbPrivTable getDbPrivTable() {
         return dbPrivTable;
     }
 
-    public TablePrivTable getTablePrivTable() {
+    protected TablePrivTable getTablePrivTable() {
         return tablePrivTable;
+    }
+
+    protected ResourcePrivTable getResourcePrivTable() {
+        return resourcePrivTable;
+    }
+
+    protected ImpersonateUserPrivTable getImpersonateUserPrivTable() {
+        return impersonateUserPrivTable;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -145,6 +145,9 @@ public class Auth implements Writable {
         return impersonateUserPrivTable;
     }
 
+    protected UserPropertyMgr getPropertyMgr() {
+        return propertyMgr;
+    }
     /**
      * check if role exist, this function can be used in analyze phrase to validate role
      */

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
@@ -130,7 +130,7 @@ public class AuthUpgrader {
                 authenticationManager.upgradeUserUnlocked(userIdentity, entry.getPassword());
             } catch (AuthenticationException e) {
                 if (Config.ignore_invalid_privilege_authentications) {
-                    LOG.warn("discard user priv entry:{}\n{}", entry.toString(), entry.toGrantSQL(), e);
+                    LOG.warn("discard user priv entry:{}\n{}", entry, entry.toGrantSQL(), e);
                 } else {
                     throw new AuthUpgradeUnrecoveredException("bad user priv entry " + entry, e);
                 }
@@ -175,7 +175,7 @@ public class AuthUpgrader {
 
             } catch (AuthUpgradeUnrecoveredException | PrivilegeException e) {
                 if (Config.ignore_invalid_privilege_authentications) {
-                    LOG.warn("discard user priv entry:{}\n{}", entry.toString(), entry.toGrantSQL(), e);
+                    LOG.warn("discard user priv entry:{}\n{}", entry, entry.toGrantSQL(), e);
                 } else {
                     throw new AuthUpgradeUnrecoveredException("bad user priv entry " + entry, e);
                 }
@@ -189,7 +189,7 @@ public class AuthUpgrader {
         PrivBitSet bitSet = entry.getPrivSet();
 
         for (Privilege privilege : bitSet.toPrivilegeList()) {
-            upgradeTablePrivileges(TablePrivEntry.ANY_DB, TablePrivEntry.ANY_DB, privilege, collection);
+            upgradeTablePrivileges(DbPrivEntry.ANY_DB, DbPrivEntry.ANY_DB, privilege, collection);
         }
     }
 
@@ -200,7 +200,7 @@ public class AuthUpgrader {
             DbPrivEntry entry = (DbPrivEntry) iterator.next();
             PrivBitSet bitSet = entry.getPrivSet();
             for (Privilege privilege : bitSet.toPrivilegeList()) {
-                upgradeTablePrivileges(entry.getOrigDb(), TablePrivEntry.ANY_DB, privilege, collection);
+                upgradeTablePrivileges(entry.getOrigDb(), DbPrivEntry.ANY_DB, privilege, collection);
             }
         }
     }
@@ -267,7 +267,7 @@ public class AuthUpgrader {
                 }
             } catch (AuthUpgradeUnrecoveredException | PrivilegeException e) {
                 if (Config.ignore_invalid_privilege_authentications) {
-                    LOG.warn("discard role[{}] priv:{}", roleName, role.toString(), e);
+                    LOG.warn("discard role[{}] priv:{}", roleName, role, e);
                 } else {
                     throw new AuthUpgradeUnrecoveredException("bad role priv " + roleName, e);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
@@ -1,0 +1,371 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.mysql.privilege;
+
+import com.starrocks.analysis.ResourcePattern;
+import com.starrocks.analysis.TablePattern;
+import com.starrocks.analysis.UserIdentity;
+import com.starrocks.authentication.AuthenticationException;
+import com.starrocks.authentication.AuthenticationManager;
+import com.starrocks.common.Config;
+import com.starrocks.privilege.ActionSet;
+import com.starrocks.privilege.PEntryObject;
+import com.starrocks.privilege.PrivilegeCollection;
+import com.starrocks.privilege.PrivilegeException;
+import com.starrocks.privilege.PrivilegeManager;
+import com.starrocks.privilege.PrivilegeTypes;
+import com.starrocks.privilege.RolePrivilegeCollection;
+import com.starrocks.privilege.UserPrivilegeCollection;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AuthUpgrader {
+
+    private static final Logger LOG = LogManager.getLogger(AuthUpgrader.class);
+    private Auth auth;
+    private AuthenticationManager authenticationManager;
+    private PrivilegeManager privilegeManager;
+    private GlobalStateMgr globalStateMgr;
+
+    // constants to
+    private short tableTypeId;
+    private short userTypeId;
+    private String tableTypeStr;
+    private String dbTypeStr;
+    private String userTypeStr;
+    private List<PEntryObject> allTablesInAllDbObject;
+    private ActionSet selectActionSet;
+    private ActionSet impersonateActionSet;
+
+    public AuthUpgrader(
+            Auth auth,
+            AuthenticationManager authenticationManager,
+            PrivilegeManager privilegeManager,
+            GlobalStateMgr globalStateMgr) {
+        this.auth = auth;
+        this.authenticationManager = authenticationManager;
+        this.privilegeManager = privilegeManager;
+        this.globalStateMgr = globalStateMgr;
+    }
+
+    public boolean needUpgrade() {
+        return !this.authenticationManager.isLoaded() || !this.privilegeManager.isLoaded();
+    }
+
+
+    public void upgradeAsLeader() throws IOException {
+        try {
+            init();
+            upgradeUser();
+            Map<String, Long> roleNameToId = upgradeRole(null);
+            this.globalStateMgr.getEditLog().logAuthUpgrade(roleNameToId);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    public void replayUpgradeAsFollower(Map<String, Long> roleNameToId) throws AuthUpgradeUnrecoveredException {
+        init();
+        upgradeUser();
+        upgradeRole(roleNameToId);
+    }
+
+    private void init() throws AuthUpgradeUnrecoveredException {
+        try {
+            tableTypeStr = PrivilegeTypes.TABLE.name();
+            dbTypeStr = PrivilegeTypes.DATABASE.name();
+            userTypeStr = PrivilegeTypes.USER.name();
+            tableTypeId = privilegeManager.analyzeType(tableTypeStr);
+            userTypeId = privilegeManager.analyzeType(userTypeStr);
+            allTablesInAllDbObject = Arrays.asList(privilegeManager.analyzeObject(
+                    tableTypeStr,
+                    Arrays.asList(PrivilegeTypes.TABLE.getPlural(), PrivilegeTypes.DATABASE.getPlural()),
+                    null, null));
+            selectActionSet = privilegeManager.analyzeActionSet(
+                    tableTypeStr,
+                    tableTypeId,
+                    Arrays.asList(PrivilegeTypes.TableActions.SELECT.toString()));
+            impersonateActionSet = privilegeManager.analyzeActionSet(
+                    userTypeStr,
+                    userTypeId,
+                    Arrays.asList(PrivilegeTypes.UserActions.IMPERSONATE.toString()));
+        } catch (PrivilegeException e) {
+            throw new AuthUpgradeUnrecoveredException("should not happen", e);
+        }
+    }
+
+
+    protected void upgradeUser() throws AuthUpgradeUnrecoveredException {
+        UserPrivTable globalTable = this.auth.getUserPrivTable();
+        DbPrivTable dbTable = this.auth.getDbPrivTable();
+        TablePrivTable tableTable = this.auth.getTablePrivTable();
+        ResourcePrivTable resourceTable = this.auth.getResourcePrivTable();
+        ImpersonateUserPrivTable impersonateUserPrivTable = this.auth.getImpersonateUserPrivTable();
+
+        // 1. create all users
+        Iterator<PrivEntry> iter = globalTable.getFullReadOnlyIterator();
+        while (iter.hasNext()) {
+            GlobalPrivEntry entry = (GlobalPrivEntry) iter.next();
+            try {
+                UserIdentity userIdentity = entry.getUserIdent();
+                if (userIdentity.equals(UserIdentity.ROOT)) {
+                    LOG.info("ignore root entry : {}", entry);
+                    continue;
+                }
+                // 1. ignore fake entries created by domain resolver
+                if (entry.isSetByDomainResolver) {
+                    LOG.info("ignore entry created by domain resolver : {}", entry);
+                    continue;
+                }
+                // 2. create user in authentication manager
+                authenticationManager.upgradeUserUnlocked(userIdentity, entry.getPassword());
+            } catch (AuthenticationException e) {
+                if (Config.ignore_invalid_privilege_authentications) {
+                    LOG.warn("discard user priv entry:{}\n{}", entry.toString(), entry.toGrantSQL(), e);
+                } else {
+                    throw new AuthUpgradeUnrecoveredException("bad user priv entry " + entry, e);
+                }
+            }
+        }
+
+        // 2. grant all user privileges
+        // must loop twice, otherwise impersonate may fail on non-existence user
+        iter = globalTable.getFullReadOnlyIterator();
+        while (iter.hasNext()) {
+            GlobalPrivEntry entry = (GlobalPrivEntry) iter.next();
+            try {
+                UserIdentity userIdentity = entry.getUserIdent();
+                if (userIdentity.equals(UserIdentity.ROOT)) {
+                    LOG.info("ignore root entry : {}", entry);
+                    continue;
+                }
+                // 1. ignore fake entries created by domain resolver
+                if (entry.isSetByDomainResolver) {
+                    LOG.info("ignore entry created by domain resolver : {}", entry);
+                    continue;
+                }
+                UserPrivilegeCollection collection = new UserPrivilegeCollection();
+
+                // 3. grant global privileges
+                upgradeUserGlobalPrivileges(entry, collection);
+
+                // 4. grant db privileges
+                upgradeUserDbPrivileges(dbTable.getReadOnlyIteratorByUser(userIdentity), collection);
+
+                // 5. grant table privilege
+                upgradeUserTablePrivileges(tableTable.getReadOnlyIteratorByUser(userIdentity), collection);
+
+                // 6. grant resource privileges
+                upgradeUserResourcePrivileges(resourceTable.getReadOnlyIteratorByUser(userIdentity), collection);
+
+                // 7. grant impersonate privileges
+                upgradeUserImpersonate(impersonateUserPrivTable.getReadOnlyIteratorByUser(userIdentity), collection);
+
+                // 8. set privilege to user
+                privilegeManager.upgradeUserInitPrivilegeUnlock(userIdentity, collection);
+
+            } catch (AuthUpgradeUnrecoveredException | PrivilegeException e) {
+                if (Config.ignore_invalid_privilege_authentications) {
+                    LOG.warn("discard user priv entry:{}\n{}", entry.toString(), entry.toGrantSQL(), e);
+                } else {
+                    throw new AuthUpgradeUnrecoveredException("bad user priv entry " + entry, e);
+                }
+            }
+        } // for iter in globalTable
+    }
+
+    protected void upgradeUserGlobalPrivileges(GlobalPrivEntry entry, UserPrivilegeCollection collection)
+            throws PrivilegeException, AuthUpgradeUnrecoveredException {
+
+        PrivBitSet bitSet = entry.getPrivSet();
+
+        for (Privilege privilege : bitSet.toPrivilegeList()) {
+            upgradeTablePrivileges(TablePrivEntry.ANY_DB, TablePrivEntry.ANY_DB, privilege, collection);
+        }
+    }
+
+    protected void upgradeUserDbPrivileges(Iterator<PrivEntry> iterator, UserPrivilegeCollection collection)
+            throws PrivilegeException, AuthUpgradeUnrecoveredException {
+
+        while (iterator.hasNext()) {
+            DbPrivEntry entry = (DbPrivEntry) iterator.next();
+            PrivBitSet bitSet = entry.getPrivSet();
+            for (Privilege privilege : bitSet.toPrivilegeList()) {
+                upgradeTablePrivileges(entry.getOrigDb(), TablePrivEntry.ANY_DB, privilege, collection);
+            }
+        }
+    }
+
+    protected void upgradeUserTablePrivileges(Iterator<PrivEntry> iterator, UserPrivilegeCollection collection)
+            throws PrivilegeException, AuthUpgradeUnrecoveredException {
+        while (iterator.hasNext()) {
+            TablePrivEntry entry = (TablePrivEntry) iterator.next();
+            PrivBitSet bitSet = entry.getPrivSet();
+            for (Privilege privilege : bitSet.toPrivilegeList()) {
+                upgradeTablePrivileges(entry.getOrigDb(), entry.getOrigTbl(), privilege, collection);
+            }
+        }
+    }
+    protected void upgradeUserResourcePrivileges(Iterator<PrivEntry> iterator, UserPrivilegeCollection collection) {
+        // TODO
+    }
+
+    protected void upgradeUserImpersonate(Iterator<PrivEntry> iterator, UserPrivilegeCollection collection)
+            throws PrivilegeException {
+        while (iterator.hasNext()) {
+            ImpersonateUserPrivEntry entry = (ImpersonateUserPrivEntry) iterator.next();
+            upgradeImpersontaePrivileges(entry.getSecuredUserIdentity(), collection);
+        }
+    }
+
+    /**
+     * @param roleNameToId, can be null, meaning that leader is upgrading
+     */
+    protected Map<String, Long> upgradeRole(Map<String, Long> roleNameToId) throws AuthUpgradeUnrecoveredException {
+        Map<String, Long> ret = new HashMap<>();
+        Iterator<Map.Entry<String, Role>> iterator = this.auth.roleManager.roles.entrySet().iterator();
+        Long roleId;
+        while (iterator.hasNext()) {
+            Map.Entry<String, Role> entry = iterator.next();
+            String roleName = entry.getKey();
+            if (roleNameToId == null) {
+                roleId = globalStateMgr.getNextId();
+                ret.put(roleName, roleId);
+            } else {
+                roleId = roleNameToId.get(roleName);
+                if (roleId == null) {
+                    LOG.warn("cannot find {} in {}", roleName, roleNameToId);
+                    throw new AuthUpgradeUnrecoveredException(
+                            "failed to upgrade role " + roleName + " while replaying!");
+                }
+            }
+            Role role = entry.getValue();
+            try {
+                if (isBuiltInRoles(roleName)) {
+                    grantBuiltInRoles(roleName, role.getUsers());
+                } else {
+                    // create new role
+                    RolePrivilegeCollection collection = new RolePrivilegeCollection(
+                            roleName, RolePrivilegeCollection.RoleFlags.MUTABLE,
+                            RolePrivilegeCollection.RoleFlags.REMOVABLE);
+                    upgradeRoleTablePrivileges(role.getTblPatternToPrivs(), collection);
+                    upgradeRoleResourcePrivileges(role.getResourcePatternToPrivs(), collection);
+                    upgradeRoleImpersonatePrivileges(role.getImpersonateUsers(), collection);
+                    privilegeManager.upgradeRoleInitPrivilegeUnlock(roleId, collection);
+                    for (UserIdentity user : role.getUsers()) {
+                        privilegeManager.upgradeUserRoleUnlock(user, roleId);
+                    }
+                }
+            } catch (AuthUpgradeUnrecoveredException | PrivilegeException e) {
+                if (Config.ignore_invalid_privilege_authentications) {
+                    LOG.warn("discard role[{}] priv:{}", roleName, role.toString(), e);
+                } else {
+                    throw new AuthUpgradeUnrecoveredException("bad role priv " + roleName, e);
+                }
+            }
+        }
+        return ret;
+    }
+
+    protected void upgradeRoleTablePrivileges(
+            Map<TablePattern, PrivBitSet> tblPatternToPrivs, RolePrivilegeCollection collection)
+            throws PrivilegeException, AuthUpgradeUnrecoveredException {
+        Iterator<Map.Entry<TablePattern, PrivBitSet>> iterator = tblPatternToPrivs.entrySet().iterator();
+
+        while (iterator.hasNext()) {
+            Map.Entry<TablePattern, PrivBitSet> entry = iterator.next();
+            TablePattern pattern = entry.getKey();
+            PrivBitSet bitSet = entry.getValue();
+
+            for (Privilege privilege : bitSet.toPrivilegeList()) {
+                upgradeTablePrivileges(pattern.getQuolifiedDb(), pattern.getTbl(), privilege, collection);
+            }
+        }
+    }
+
+
+    protected void upgradeRoleResourcePrivileges(
+            Map<ResourcePattern, PrivBitSet> resourcePatternToPrivs, RolePrivilegeCollection collection) {
+    }
+
+    protected void upgradeRoleImpersonatePrivileges(Set<UserIdentity> impersonateUsers, RolePrivilegeCollection collection)
+            throws PrivilegeException {
+        Iterator<UserIdentity> iterator = impersonateUsers.iterator();
+        while (iterator.hasNext()) {
+            UserIdentity securedUser = iterator.next();
+            upgradeImpersontaePrivileges(securedUser, collection);
+        }
+    }
+
+    protected boolean isBuiltInRoles(String roleName) {
+        return roleName.equals(Role.ADMIN_ROLE) || roleName.equals(Role.OPERATOR_ROLE);
+    }
+
+    protected void grantBuiltInRoles(String roleName, Set<UserIdentity> users) {
+        if (roleName.equals(Role.ADMIN_ROLE)) {
+            for (UserIdentity user : users) {
+                privilegeManager.upgradeUserRoleUnlock(
+                        user,
+                        PrivilegeManager.DB_ADMIN_ROLE_ID,
+                        PrivilegeManager.CLUSTER_ADMIN_ROLE_ID,
+                        PrivilegeManager.USER_ADMIN_ROLE_ID);
+            }
+        } else if (roleName.equals(Role.OPERATOR_ROLE)) {
+            for (UserIdentity user : users) {
+                privilegeManager.upgradeUserRoleUnlock(user, PrivilegeManager.ROOT_ROLE_ID);
+            }
+        }
+    }
+
+    protected void upgradeTablePrivileges(String db, String table, Privilege privilege, PrivilegeCollection collection)
+            throws PrivilegeException, AuthUpgradeUnrecoveredException {
+        switch (privilege) {
+            case SELECT_PRIV: {
+                List<PEntryObject> objects;
+                if (db.equals(TablePattern.ALL.getQuolifiedDb())) {
+                    objects = allTablesInAllDbObject;
+                } else if (table.equals(TablePattern.ALL.getTbl())) {
+                    // ALL TABLES in db
+                    objects = Arrays.asList(privilegeManager.analyzeObject(
+                            tableTypeStr, Arrays.asList(tableTypeStr), dbTypeStr, db));
+                } else {
+                    // db.table
+                    objects = Arrays.asList(privilegeManager.analyzeObject(
+                            tableTypeStr, Arrays.asList(db, table)));
+                }
+                collection.grant(tableTypeId, selectActionSet, objects, false);
+                break;
+            }
+
+            default:
+                throw new AuthUpgradeUnrecoveredException("table privilege " + privilege + " hasn't implemented");
+        }
+    }
+
+    protected void upgradeImpersontaePrivileges(UserIdentity user, PrivilegeCollection collection)
+            throws PrivilegeException {
+        List<PEntryObject> objects = Arrays.asList(privilegeManager.analyzeUserObject(
+                userTypeStr, user));
+        collection.grant(userTypeId, impersonateActionSet, objects, false);
+    }
+
+    public static class AuthUpgradeUnrecoveredException extends Exception {
+        public AuthUpgradeUnrecoveredException(String s) {
+            super(s);
+        }
+
+        public AuthUpgradeUnrecoveredException(String s, Exception e) {
+            super(s);
+            initCause(e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
@@ -73,14 +73,14 @@ public class AuthUpgrader {
         }
     }
 
-    public void replayUpgradeAsFollower(Map<String, Long> roleNameToId) throws AuthUpgradeUnrecoveredException {
-        LOG.info("start to replay upgrade as follower.");
+    public void replayUpgrade(Map<String, Long> roleNameToId) throws AuthUpgradeUnrecoveredException {
+        LOG.info("start to replay upgrade journal.");
         init();
         upgradeUser();
         upgradeRole(roleNameToId);
         authenticationManager.setLoaded();
         privilegeManager.setLoaded();
-        LOG.info("replayed upgrade as follower successfully.");
+        LOG.info("replayed upgrade journal successfully.");
     }
 
     private void init() throws AuthUpgradeUnrecoveredException {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
@@ -56,10 +56,6 @@ public class AuthUpgrader {
         this.globalStateMgr = globalStateMgr;
     }
 
-    public boolean needUpgrade() {
-        return !this.authenticationManager.isLoaded() || !this.privilegeManager.isLoaded();
-    }
-
     public void upgradeAsLeader() throws RuntimeException {
         try {
             LOG.info("start to upgrade as leader.");

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/RoleManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/RoleManager.java
@@ -45,7 +45,7 @@ import java.util.Set;
 
 public class RoleManager implements Writable {
     private static final Logger LOG = LogManager.getLogger(RoleManager.class);
-    private Map<String, Role> roles = Maps.newHashMap();
+    protected Map<String, Role> roles = Maps.newHashMap();
 
     public RoleManager() {
         roles.put(Role.OPERATOR.getRoleName(), Role.OPERATOR);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/WhiteList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/WhiteList.java
@@ -120,6 +120,10 @@ public class WhiteList implements Writable {
         return passwordMap.containsKey(domain) && passwordMap.get(domain).length > 0;
     }
 
+    protected byte[] getPassword(String domain) {
+        return passwordMap.get(domain);
+    }
+
     @Override
     public String toString() {
         return Joiner.on(", ").join(passwordMap.keySet());

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AuthUpgradeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AuthUpgradeInfo.java
@@ -1,0 +1,36 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Map;
+
+public class AuthUpgradeInfo implements Writable {
+    @SerializedName(value = "m")
+    private Map<String, Long> roleNameToId;
+
+    public AuthUpgradeInfo(Map<String, Long> roleNameToId) {
+        this.roleNameToId = roleNameToId;
+    }
+
+    public Map<String, Long> getRoleNameToId() {
+        return roleNameToId;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static AuthUpgradeInfo read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, AuthUpgradeInfo.class);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -416,54 +416,19 @@ public class EditLog {
                     globalStateMgr.replayUpdateFrontend(fe);
                     break;
                 }
-                case OperationType.OP_CREATE_USER: {
-                    PrivInfo privInfo = (PrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayCreateUser(privInfo);
-                    break;
-                }
-                case OperationType.OP_NEW_DROP_USER: {
-                    UserIdentity userIdent = (UserIdentity) journal.getData();
-                    globalStateMgr.getAuth().replayDropUser(userIdent);
-                    break;
-                }
-                case OperationType.OP_GRANT_PRIV: {
-                    PrivInfo privInfo = (PrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayGrant(privInfo);
-                    break;
-                }
-                case OperationType.OP_REVOKE_PRIV: {
-                    PrivInfo privInfo = (PrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayRevoke(privInfo);
-                    break;
-                }
-                case OperationType.OP_SET_PASSWORD: {
-                    PrivInfo privInfo = (PrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replaySetPassword(privInfo);
-                    break;
-                }
-                case OperationType.OP_CREATE_ROLE: {
-                    PrivInfo privInfo = (PrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayCreateRole(privInfo);
-                    break;
-                }
-                case OperationType.OP_DROP_ROLE: {
-                    PrivInfo privInfo = (PrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayDropRole(privInfo);
-                    break;
-                }
-                case OperationType.OP_GRANT_ROLE: {
-                    PrivInfo privInfo = (PrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayGrantRole(privInfo);
-                    break;
-                }
-                case OperationType.OP_REVOKE_ROLE: {
-                    PrivInfo privInfo = (PrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayRevokeRole(privInfo);
-                    break;
-                }
-                case OperationType.OP_UPDATE_USER_PROPERTY: {
-                    UserPropertyInfo propertyInfo = (UserPropertyInfo) journal.getData();
-                    globalStateMgr.getAuth().replayUpdateUserProperty(propertyInfo);
+                case OperationType.OP_CREATE_USER:
+                case OperationType.OP_NEW_DROP_USER:
+                case OperationType.OP_GRANT_PRIV:
+                case OperationType.OP_REVOKE_PRIV:
+                case OperationType.OP_SET_PASSWORD:
+                case OperationType.OP_CREATE_ROLE:
+                case OperationType.OP_DROP_ROLE:
+                case OperationType.OP_GRANT_ROLE:
+                case OperationType.OP_REVOKE_ROLE:
+                case OperationType.OP_UPDATE_USER_PROPERTY:
+                case OperationType.OP_GRANT_IMPERSONATE:
+                case OperationType.OP_REVOKE_IMPERSONATE: {
+                    GlobalStateMgr.getCurrentState().replayOldAuthJournal(opCode, journal.getData());
                     break;
                 }
                 case OperationType.OP_TIMESTAMP: {
@@ -858,16 +823,7 @@ public class EditLog {
                     globalStateMgr.getCatalogMgr().replayDropCatalog(dropCatalogLog);
                     break;
                 }
-                case OperationType.OP_GRANT_IMPERSONATE: {
-                    ImpersonatePrivInfo info = (ImpersonatePrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayGrantImpersonate(info);
-                    break;
-                }
-                case OperationType.OP_REVOKE_IMPERSONATE: {
-                    ImpersonatePrivInfo info = (ImpersonatePrivInfo) journal.getData();
-                    globalStateMgr.getAuth().replayRevokeImpersonate(info);
-                    break;
-                }
+
                 case OperationType.OP_CREATE_INSERT_OVERWRITE: {
                     CreateInsertOverwriteJobLog jobInfo = (CreateInsertOverwriteJobLog) journal.getData();
                     globalStateMgr.getInsertOverwriteJobManager().replayCreateInsertOverwrite(jobInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -88,6 +88,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
@@ -933,6 +934,11 @@ public class EditLog {
                     globalStateMgr.getPrivilegeManager().replayDropRole(info);
                     break;
                 }
+                case OperationType.OP_AUTH_UPGRDE_V2: {
+                    AuthUpgradeInfo info = (AuthUpgradeInfo) journal.getData();
+                    globalStateMgr.replayAuthUpgrade(info);
+                    break;
+                }
                 default: {
                     if (Config.ignore_unknown_log_id) {
                         LOG.warn("UNKNOWN Operation Type {}", opCode);
@@ -1623,5 +1629,9 @@ public class EditLog {
         RolePrivilegeCollectionInfo info = new RolePrivilegeCollectionInfo(
                 roleId, privilegeCollection, pluginId, pluginVersion);
         logEdit(OperationType.OP_DROP_ROLE_V2, info);
+    }
+
+    public void logAuthUpgrade(Map<String, Long> roleNameToId) {
+        logEdit(OperationType.OP_AUTH_UPGRDE_V2, new AuthUpgradeInfo(roleNameToId));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -262,13 +262,14 @@ public class OperationType {
     // only used in lake table currently
     public static final short OP_ADD_PARTITIONS_V2 = 10242;
 
-    // new privilege, all endswith V2
+    // new privilege, all ends with V2
     public static final short OP_CREATE_USER_V2 = 10261;
     public static final short OP_UPDATE_USER_PRIVILEGE_V2 = 10262;
     public static final short OP_ALTER_USER_V2 = 10263;
     public static final short OP_DROP_USER_V2 = 10264;
     public static final short OP_UPDATE_ROLE_PRIVILEGE_V2 = 10265;
     public static final short OP_DROP_ROLE_V2 = 10266;
+    public static final short OP_AUTH_UPGRDE_V2 = 10267;
 
     // integrate with starmgr
     public static final short OP_STARMGR = 11000;

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeCollection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeCollection.java
@@ -274,4 +274,8 @@ public class PrivilegeCollection {
             }
         } // for typeId, privilegeEntryList in other
     }
+
+    public boolean isEmpty() {
+        return typeToPrivilegeEntryList.isEmpty();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -1262,6 +1262,9 @@ public class PrivilegeManager {
         return isLoaded;
     }
 
+    public void setLoaded() {
+        isLoaded = true;
+    }
     /**
      * for AuthUpgrader
      */

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -28,12 +28,14 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -42,6 +44,11 @@ public class PrivilegeManager {
     private static final String ALL_ACTIONS = "ALL";
     // builtin roles and users
     private static final String ROOT_ROLE_NAME = "root";
+    public static long ROOT_ROLE_ID = -1;
+    public static long DB_ADMIN_ROLE_ID = -2;
+    public static long CLUSTER_ADMIN_ROLE_ID = -3;
+    public static long USER_ADMIN_ROLE_ID = -4;
+    public static long PUBLIC_ROLE_ID = -5;
 
     @SerializedName(value = "t")
     private final Map<String, Short> typeStringToId;
@@ -61,6 +68,9 @@ public class PrivilegeManager {
     private final ReentrantReadWriteLock userLock;
 
     private String publicRoleName = null; // ut may be null
+
+    // set by load() to distinguish brand-new environment with upgraded environment
+    private boolean isLoaded = false;
 
     // only when deserialized
     protected PrivilegeManager() {
@@ -99,9 +109,8 @@ public class PrivilegeManager {
     public void initBuiltinRolesAndUsers() {
         try {
             // built-in role ids are hard-coded negative numbers because globalStateMgr.getNextId() cannot be called by a follower
-            long builtinRoleId = -1;
             // 1. builtin root role
-            RolePrivilegeCollection rolePrivilegeCollection = initBuiltinRoleUnlocked(builtinRoleId--, ROOT_ROLE_NAME);
+            RolePrivilegeCollection rolePrivilegeCollection = initBuiltinRoleUnlocked(ROOT_ROLE_ID, ROOT_ROLE_NAME);
             if (rolePrivilegeCollection != null) {
                 // GRANT ALL ON ALL
                 for (String typeStr : typeStringToId.keySet()) {
@@ -112,7 +121,7 @@ public class PrivilegeManager {
             }
 
             // 2. builtin db_admin role
-            rolePrivilegeCollection = initBuiltinRoleUnlocked(builtinRoleId--, "db_admin");
+            rolePrivilegeCollection = initBuiltinRoleUnlocked(DB_ADMIN_ROLE_ID, "db_admin");
             PrivilegeTypes systemTypes = PrivilegeTypes.SYSTEM;
             if (rolePrivilegeCollection != null) {
                 // ALL system but GRANT AND NODE
@@ -126,7 +135,7 @@ public class PrivilegeManager {
             }
 
             // 3. cluster_admin
-            rolePrivilegeCollection = initBuiltinRoleUnlocked(builtinRoleId--, "cluster_admin");
+            rolePrivilegeCollection = initBuiltinRoleUnlocked(CLUSTER_ADMIN_ROLE_ID, "cluster_admin");
             if (rolePrivilegeCollection != null) {
                 // GRANT NODE ON SYSTEM
                 initPrivilegeCollections(
@@ -139,7 +148,7 @@ public class PrivilegeManager {
             }
 
             // 4. user_admin
-            rolePrivilegeCollection = initBuiltinRoleUnlocked(builtinRoleId--, "user_admin");
+            rolePrivilegeCollection = initBuiltinRoleUnlocked(USER_ADMIN_ROLE_ID, "user_admin");
             if (rolePrivilegeCollection != null) {
                 // GRANT GRANT ON SYSTEM
                 initPrivilegeCollections(
@@ -155,7 +164,7 @@ public class PrivilegeManager {
 
             // 5. public
             publicRoleName = "public";
-            rolePrivilegeCollection = initBuiltinRoleUnlocked(builtinRoleId--, publicRoleName);
+            rolePrivilegeCollection = initBuiltinRoleUnlocked(PUBLIC_ROLE_ID, publicRoleName);
             if (rolePrivilegeCollection != null) {
                 // GRANT SELECT ON ALL TABLES IN infomation_schema
                 String tableTypeStr = PrivilegeTypes.TABLE.name();
@@ -179,21 +188,23 @@ public class PrivilegeManager {
 
     private void initIdNameMaps() {
         Map<String, List<String>> map = this.provider.getValidPrivilegeTypeToActions();
-        short typeId = 0;
-        for (Map.Entry<String, List<String>> entry : map.entrySet()) {
-            typeStringToId.put(entry.getKey(), typeId);
-            PrivilegeTypes types = PrivilegeTypes.valueOf(entry.getKey());
+        List<String> typeStrings = new ArrayList<>(map.keySet());
+        Collections.sort(typeStrings);
+        for (short typeId = 0; typeId != typeStrings.size(); typeId ++) {
+            String typeStr = typeStrings.get(typeId);
+            typeStringToId.put(typeStr, typeId);
+            PrivilegeTypes types = PrivilegeTypes.valueOf(typeStr);
             if (types.getPlural() != null) {
-                pluralToType.put(types.getPlural(), entry.getKey());
+                pluralToType.put(types.getPlural(), typeStr);
             }
             Map<String, Action> actionMap = new HashMap<>();
             typeToActionMap.put(typeId, actionMap);
-            typeId++;
 
-            short actionId = 0;
-            for (String actionName : map.get(entry.getKey())) {
-                actionMap.put(actionName, new Action(actionId, actionName));
-                actionId++;
+            List<String> actionStrings = new ArrayList<>(map.get(typeStr));
+            Collections.sort(actionStrings);
+            for (short actionId = 0; actionId != actionStrings.size(); ++ actionId) {
+                String actionStr = actionStrings.get(actionId);
+                actionMap.put(actionStr, new Action(actionId, actionStr));
             }
         }
     }
@@ -1240,9 +1251,38 @@ public class PrivilegeManager {
             assert ret != null; // can't be NULL
             LOG.info("loaded {} users, {} roles",
                     ret.userToPrivilegeCollection.size(), ret.roleIdToPrivilegeCollection.size());
+            // mark data is loaded
+            ret.isLoaded = true;
             return ret;
         } catch (SRMetaBlockException e) {
             throw new DdlException("failed to load PrivilegeManager!", e);
+        }
+    }
+
+    public boolean isLoaded() {
+        return isLoaded;
+    }
+
+    /**
+     * for AuthUpgrader
+     */
+    public void upgradeUserInitPrivilegeUnlock(UserIdentity userIdentity, UserPrivilegeCollection collection) {
+        collection.grantRole(PUBLIC_ROLE_ID);
+        userToPrivilegeCollection.put(userIdentity, collection);
+        LOG.info("upgrade user {}", userIdentity);
+    }
+
+    public void upgradeRoleInitPrivilegeUnlock(long roleId, RolePrivilegeCollection collection) {
+        // will produce journal in bdb
+        roleIdToPrivilegeCollection.put(roleId, collection);
+        roleNameToId.put(collection.getName(), roleId);
+        LOG.info("upgrade role {}[{}]", collection.getName(), roleId);
+    }
+
+    public void upgradeUserRoleUnlock(UserIdentity user, long... roleIds) {
+        UserPrivilegeCollection collection = userToPrivilegeCollection.get(user);
+        for (long roleId : roleIds) {
+            collection.grantRole(roleId);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -1265,8 +1265,9 @@ public class PrivilegeManager {
     public void setLoaded() {
         isLoaded = true;
     }
+
     /**
-     * for AuthUpgrader
+     * these public interfaces are for AuthUpgrader to upgrade from 2.x
      */
     public void upgradeUserInitPrivilegeUnlock(UserIdentity userIdentity, UserPrivilegeCollection collection) {
         collection.grantRole(PUBLIC_ROLE_ID);

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -43,11 +43,11 @@ public class PrivilegeManager {
     private static final String ALL_ACTIONS = "ALL";
     // builtin roles and users
     private static final String ROOT_ROLE_NAME = "root";
-    public static long ROOT_ROLE_ID = -1;
-    public static long DB_ADMIN_ROLE_ID = -2;
-    public static long CLUSTER_ADMIN_ROLE_ID = -3;
-    public static long USER_ADMIN_ROLE_ID = -4;
-    public static long PUBLIC_ROLE_ID = -5;
+    public static final long ROOT_ROLE_ID = -1;
+    public static final long DB_ADMIN_ROLE_ID = -2;
+    public static final long CLUSTER_ADMIN_ROLE_ID = -3;
+    public static final long USER_ADMIN_ROLE_ID = -4;
+    public static final long PUBLIC_ROLE_ID = -5;
 
     @SerializedName(value = "t")
     private final Map<String, Short> typeStringToId;

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -190,7 +189,7 @@ public class PrivilegeManager {
         Map<String, List<String>> map = this.provider.getValidPrivilegeTypeToActions();
         List<String> typeStrings = new ArrayList<>(map.keySet());
         Collections.sort(typeStrings);
-        for (short typeId = 0; typeId != typeStrings.size(); typeId ++) {
+        for (short typeId = 0; typeId != typeStrings.size(); typeId++) {
             String typeStr = typeStrings.get(typeId);
             typeStringToId.put(typeStr, typeId);
             PrivilegeTypes types = PrivilegeTypes.valueOf(typeStr);
@@ -202,7 +201,7 @@ public class PrivilegeManager {
 
             List<String> actionStrings = new ArrayList<>(map.get(typeStr));
             Collections.sort(actionStrings);
-            for (short actionId = 0; actionId != actionStrings.size(); ++ actionId) {
+            for (short actionId = 0; actionId != actionStrings.size(); actionId++) {
                 String actionStr = actionStrings.get(actionId);
                 actionMap.put(actionStr, new Action(actionId, actionStr));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/RolePrivilegeCollection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/RolePrivilegeCollection.java
@@ -20,7 +20,7 @@ public class RolePrivilegeCollection extends PrivilegeCollection {
     @SerializedName(value = "s")
     private Set<Long> subRoleIds;
 
-    enum RoleFlags {
+    public enum RoleFlags {
         MUTABLE(1),
         REMOVABLE(2);
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -364,7 +364,7 @@ public class GlobalStateMgr {
     // This is used to turned on in hard code.
     public static final boolean USING_NEW_PRIVILEGE = false;
     // change to true in UT
-    private AtomicBoolean usingNewPrivilege = new AtomicBoolean(USING_NEW_PRIVILEGE);
+    private AtomicBoolean usingNewPrivilege = new AtomicBoolean(false);
 
     private AuthenticationManager authenticationManager;
     private PrivilegeManager privilegeManager;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -3223,7 +3223,7 @@ public class GlobalStateMgr {
 
     public void replayAuthUpgrade(AuthUpgradeInfo info) throws AuthUpgrader.AuthUpgradeUnrecoveredException {
         AuthUpgrader upgrader = new AuthUpgrader(auth, authenticationManager, privilegeManager, this);
-        upgrader.replayUpgradeAsFollower(info.getRoleNameToId());
+        upgrader.replayUpgrade(info.getRoleNameToId());
         usingNewPrivilege.set(true);
         domainResolver.setAuthenticationManager(authenticationManager);
         if (!isCheckpointThread()) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -364,7 +364,7 @@ public class GlobalStateMgr {
     // This is used to turned on in hard code.
     public static final boolean USING_NEW_PRIVILEGE = false;
     // change to true in UT
-    private AtomicBoolean usingNewPrivilege;
+    private AtomicBoolean usingNewPrivilege = new AtomicBoolean(USING_NEW_PRIVILEGE);
 
     private AuthenticationManager authenticationManager;
     private PrivilegeManager privilegeManager;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -3226,7 +3226,9 @@ public class GlobalStateMgr {
         upgrader.replayUpgradeAsFollower(info.getRoleNameToId());
         usingNewPrivilege.set(true);
         domainResolver.setAuthenticationManager(authenticationManager);
-        this.auth = null;
+        if (!isCheckpointThread()) {
+            this.auth = null;
+        }
     }
 
     // entry of checking tablets operation

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowGrantsStmtTest.java
@@ -41,6 +41,10 @@ public class ShowGrantsStmtTest {
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;
+
+                globalStateMgr.isUsingNewPrivilege();
+                minTimes = 0;
+                result = false;
             }
         };
         new Expectations(auth) {

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationProviderFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationProviderFactoryTest.java
@@ -3,6 +3,7 @@
 package com.starrocks.authentication;
 
 import com.starrocks.analysis.UserIdentity;
+import com.starrocks.mysql.privilege.Password;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -21,6 +22,12 @@ public class AuthenticationProviderFactoryTest {
             public void authenticate(String user, String host, byte[] password, byte[] randomString,
                                      UserAuthenticationInfo authenticationInfo) throws AuthenticationException {
 
+            }
+
+            @Override
+            public UserAuthenticationInfo upgradedFromPassword(UserIdentity userIdentity, Password password)
+                    throws AuthenticationException {
+                return null;
             }
         };
         String fakeName = "fake";

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
@@ -2064,6 +2064,10 @@ public class AuthTest {
                 globalStateMgr.getEditLog();
                 minTimes = 0;
                 result = editLog;
+
+                globalStateMgr.isUsingNewPrivilege();
+                minTimes = 0;
+                result = false;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthUpgraderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthUpgraderTest.java
@@ -185,11 +185,13 @@ public class AuthUpgraderTest {
                 replayUpgrade(image);
             }
             ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("harry", "%"));
-            ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory", "%"));
+            ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(
+                    ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory", "%"));
 
             UserIdentity user = createUserByRole("harry");
             ctx.setCurrentUserIdentity(user);
-            ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory", "%"));
+            ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(
+                    ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory", "%"));
         }
 
     }

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthUpgraderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthUpgraderTest.java
@@ -1,0 +1,197 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.mysql.privilege;
+
+import com.starrocks.analysis.UserIdentity;
+import com.starrocks.common.Config;
+import com.starrocks.persist.AuthUpgradeInfo;
+import com.starrocks.persist.OperationType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.PrivilegeCheckerV2;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+
+public class AuthUpgraderTest {
+    private ConnectContext ctx;
+    private long roleUserId = 0;
+
+    private UtFrameUtils.PseudoImage executeAndUpgrade(String...sqls) throws Exception {
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        // 1. execute old grant
+        for (String sql : sqls) {
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, ctx), ctx);
+        }
+        // 2. save image
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        ctx.getGlobalStateMgr().getAuth().saveAuth(image.getDataOutputStream(), -1);
+        ctx.getGlobalStateMgr().getAuth().writeAsGson(image.getDataOutputStream(), -1);
+
+        // 3. load image
+        ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        DataInputStream dis = image.getDataInputStream();
+        Auth auth = Auth.read(dis);
+        auth.readAsGson(dis, -1);
+        ctx.getGlobalStateMgr().initAuth(true);
+        AuthUpgrader authUpgrader = new AuthUpgrader(
+                auth,
+                ctx.getGlobalStateMgr().getAuthenticationManager(),
+                ctx.getGlobalStateMgr().getPrivilegeManager(),
+                ctx.getGlobalStateMgr());
+        UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
+        authUpgrader.upgradeAsLeader();
+        return image;
+    }
+
+    private void replayUpgrade(UtFrameUtils.PseudoImage image) throws Exception {
+        // pretend it's a old privilege
+        GlobalStateMgr.getCurrentState().initAuth(false);
+        // 1. load image
+        ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        DataInputStream dis = image.getDataInputStream();
+        Auth auth = Auth.read(dis);
+        auth.readAsGson(dis, -1);
+        ctx.getGlobalStateMgr().setAuth(auth);
+        AuthUpgradeInfo info = (AuthUpgradeInfo) UtFrameUtils.PseudoJournalReplayer.replayNextJournal(
+                OperationType.OP_AUTH_UPGRDE_V2);
+        ctx.getGlobalStateMgr().replayAuthUpgrade(info);
+    }
+
+    private void checkPrivilegeAsUser(UserIdentity user, String... verifiedSqls) throws Exception {
+        ctx.setCurrentUserIdentity(user);
+        ctx.setQualifiedUser(user.getQualifiedUser());
+        for (String sql : verifiedSqls) {
+            PrivilegeCheckerV2.check(UtFrameUtils.parseStmtWithNewParser(sql, ctx), ctx);
+        }
+    }
+
+    private void checkBadPrivilegeAsUser(UserIdentity user, String badSql, String expectError) {
+        ctx.setCurrentUserIdentity(user);
+        ctx.setQualifiedUser(user.getQualifiedUser());
+        try {
+            PrivilegeCheckerV2.check(UtFrameUtils.parseStmtWithNewParser(badSql, ctx), ctx);
+            Assert.fail();
+        } catch (Exception e) {
+            System.err.println("got exception as expect: " + e.getMessage());
+            Assert.assertTrue(e.getMessage().contains(expectError));
+        }
+    }
+
+    private UserIdentity createUserByRole(String roleName) throws Exception {
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        // create a user & grant
+        String user = "test_role_user_" + roleUserId;
+        roleUserId += 1;
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "create user " + user, ctx), ctx);
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "grant " + roleName + " to  " + user, ctx), ctx);
+        return UserIdentity.createAnalyzedUserIdentWithIp(user, "%");
+    }
+
+    @Before
+    public void init() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        // default is old privilege
+        GlobalStateMgr.getCurrentState().initAuth(false);
+        UtFrameUtils.setUpForPersistTest();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        StarRocksAssert starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("db0");
+        starRocksAssert.withDatabase("db1");
+        for (int i = 0; i != 2; ++ i) {
+            for (int j = 0; j != 2; ++ j) {
+                String createTblStmtStr = "create table db" + i + ".tbl" + j
+                        + "(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
+                        +
+                        "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
+                starRocksAssert.withTable(createTblStmtStr);
+            }
+        }
+        ctx = starRocksAssert.getCtx();
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        Config.ignore_invalid_privilege_authentications = true;
+    }
+
+    @After
+    public void cleanUp() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testSelect() throws Exception {
+        UtFrameUtils.PseudoImage image = executeAndUpgrade(
+                "create user globalSelect",
+                "GRANT select_priv on *.* TO globalSelect",
+                "create user dbSelect",
+                "GRANT select_priv on db0.* TO dbSelect",
+                "create user tblSelect",
+                "GRANT select_priv on db0.tbl0 TO tblSelect",
+                "create role globalSelect",
+                "GRANT select_priv on *.* TO role globalSelect",
+                "create role dbSelect",
+                "GRANT select_priv on db0.* TO role dbSelect",
+                "create role tblSelect",
+                "GRANT select_priv on db0.tbl0 TO role tblSelect");
+        // check twice, the second time is as follower
+        for (int i = 0; i != 2; ++ i) {
+            if (i == 1) {
+                replayUpgrade(image);
+            }
+            checkPrivilegeAsUser(
+                    UserIdentity.createAnalyzedUserIdentWithIp("globalSelect", "%"),
+                    "select * from db1.tbl1",
+                    "select * from db0.tbl0");
+            UserIdentity user = createUserByRole("globalSelect");
+            checkPrivilegeAsUser(user, "select * from db1.tbl1", "select * from db0.tbl0");
+
+            user = UserIdentity.createAnalyzedUserIdentWithIp("dbSelect", "%");
+            checkPrivilegeAsUser(user, "select * from db0.tbl0", "select * from db0.tbl1");
+            checkBadPrivilegeAsUser(user, "select * from db1.tbl1", "SELECT command denied to user 'dbSelect'");
+            user = createUserByRole("dbSelect");
+            checkPrivilegeAsUser(user, "select * from db0.tbl0", "select * from db0.tbl1");
+            checkBadPrivilegeAsUser(user, "select * from db1.tbl1", "SELECT command denied to user");
+
+            user = UserIdentity.createAnalyzedUserIdentWithIp("tblSelect", "%");
+            checkPrivilegeAsUser(user, "select * from db0.tbl0");
+            checkBadPrivilegeAsUser(user, "select * from db1.tbl1", "SELECT command denied to user 'tblSelect'");
+            user = createUserByRole("tblSelect");
+            checkPrivilegeAsUser(user, "select * from db0.tbl0");
+            checkBadPrivilegeAsUser(user, "select * from db1.tbl1", "SELECT command denied to user");
+        }
+    }
+
+    @Test
+    public void testImpersonate() throws Exception {
+        UtFrameUtils.PseudoImage image = executeAndUpgrade(
+                "create user harry",
+                "create user gregory",
+                "GRANT impersonate on gregory TO harry",
+                "create role harry",
+                "GRANT impersonate on gregory TO ROLE harry");
+
+        // check twice, the second time is as follower
+        for (int i = 0; i != 2; ++ i) {
+            if (i == 1) {
+                replayUpgrade(image);
+            }
+            ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("harry", "%"));
+            ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory", "%"));
+
+            UserIdentity user = createUserByRole("harry");
+            ctx.setCurrentUserIdentity(user);
+            ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory", "%"));
+        }
+
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthUpgraderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthUpgraderTest.java
@@ -193,7 +193,6 @@ public class AuthUpgraderTest {
             ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(
                     ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory", "%"));
         }
-
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/ExecuteAsStmtTest.java
@@ -31,6 +31,10 @@ public class ExecuteAsStmtTest {
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;
+
+                globalStateMgr.isUsingNewPrivilege();
+                minTimes = 0;
+                result = false;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeRoleStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/GrantRevokeRoleStmtTest.java
@@ -31,6 +31,10 @@ public class GrantRevokeRoleStmtTest {
                 globalStateMgr.getAuth();
                 minTimes = 0;
                 result = auth;
+
+                globalStateMgr.isUsingNewPrivilege();
+                minTimes = 0;
+                result = false;
             }
         };
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR implements a basic upgrader for the new RBAC privilege framework.

* Support upgrading users with select & impersonate privileges.
* Support upgrading roles with select & impersonate privileges.
* Both leader & follower can upgrade consistently, which seems a bit tricky
  * Leader will upgrade right after the image is loaded and journals are replayed. It will write a journal after the upgrade.
  * Follower will only upgrade when replaying the journal from the leader. If there's no journal, nor is the image loaded with new privilege managers, it will pretend to use the old framework.
* Add ut to simulate the upgrade & replay procedure.
* Check for meta upgrade when loading the image. This is actually a bugfix.
* Pretend to use the old framework when replaying older versions of auth journal.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
