### PR TITLE
[Bugfix] fix NPE if hostname can't be resolved (#12627)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/FrontendsProcNode.java
@@ -147,7 +147,11 @@ public class FrontendsProcNode implements ProcNodeInterface {
             if (InetAddressValidator.getInstance().isValidInet4Address(fe.getHost())) {
                 realHost = addr.getAddress().getHostAddress();
             } else {
-                realHost = addr.getAddress().getHostName();
+                try {
+                    realHost = addr.getAddress().getHostName();
+                } catch (Exception e) {
+                    LOG.warn("Fail to get address hostname of fe: {} msg: {}", addr, e);
+                }
             }
             if (fe.getHost().equals(realHost) && fe.getEditLogPort() == addr.getPort()) {
                 return true;

--- a/fe/fe-core/src/test/java/com/starrocks/proc/FrontendsProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/proc/FrontendsProcNodeTest.java
@@ -17,13 +17,13 @@ import org.junit.Test;
 
 
 import mockit.Expectations;
-import mockit.Mocked;
+import mockit.Injectable;
 
 public class FrontendsProcNodeTest {
 
-    @Mocked
+    @Injectable
     InetSocketAddress socketAddr1;
-    @Mocked
+    @Injectable
     InetAddress addr1;
 
     private void mockAddress() {
@@ -83,6 +83,15 @@ public class FrontendsProcNodeTest {
         Frontend feCouldNotFoundByHostName = new Frontend(FrontendNodeType.LEADER,"test","sandbox1",1000);
         boolean result4 = (boolean) isJoin.invoke(FrontendsProcNode.class, list, feCouldNotFoundByHostName);
         Assert.assertTrue(!result4);
+
+        // Cover the following case:
+        // 1. dns name `A.B` can be resolved
+        // 2. `A.B` added to FE
+        // 3. dns name `A.B` is removed from DNS server, can't be resolved any more
+        // 4. run `show frontends`
+        list.add(InetSocketAddress.createUnresolved("hostname.can.not.be.resolved", 9010));
+        boolean result5 = (boolean) isJoin.invoke(FrontendsProcNode.class, list, feCouldNotFoundByHostName);
+        Assert.assertTrue(!result5);
     }
 
     @Test    


### PR DESCRIPTION
Don't panic if the hostname can't be resolved to IP address

(cherry picked from commit ccb35b572533644832f1f3c3c2cb0c3e03fa4be7)

## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
