### PR TITLE
[BugFix] Fix excessive recursion and optimizer timeout due to too many OR

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1569,4 +1569,173 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             connectContext.getSessionVariable().setEnableLocalShuffleAgg(prevEnableLocalShuffleAgg);
         }
     }
+
+    @Test
+    public void testExcessiveOR() throws Exception {
+        String sql = "SELECT\n" +
+                "  *\n" +
+                "FROM t0\n" +
+                "WHERE\n" +
+                "  (\n" +
+                "    (v1 >= 27)\n" +
+                "    AND (v1 < 28)\n" +
+                "  )\n" +
+                "  OR (\n" +
+                "    (\n" +
+                "      (v1 >= 26)\n" +
+                "      AND (v1 < 27)\n" +
+                "    )\n" +
+                "    OR (\n" +
+                "      (\n" +
+                "        (v1 >= 25)\n" +
+                "        AND (v1 < 26)\n" +
+                "      )\n" +
+                "      OR (\n" +
+                "        (\n" +
+                "          (v1 >= 24)\n" +
+                "          AND (v1 < 25)\n" +
+                "        )\n" +
+                "        OR (\n" +
+                "          (\n" +
+                "            (v1 >= 23)\n" +
+                "            AND (v1 < 24)\n" +
+                "          )\n" +
+                "          OR (\n" +
+                "            (\n" +
+                "              (v1 >= 22)\n" +
+                "              AND (v1 < 23)\n" +
+                "            )\n" +
+                "            OR (\n" +
+                "              (\n" +
+                "                (v1 >= 21)\n" +
+                "                AND (v1 < 22)\n" +
+                "              )\n" +
+                "              OR (\n" +
+                "                (\n" +
+                "                  (v1 >= 20)\n" +
+                "                  AND (v1 < 21)\n" +
+                "                )\n" +
+                "                OR (\n" +
+                "                  (\n" +
+                "                    (v1 >= 19)\n" +
+                "                    AND (v1 < 20)\n" +
+                "                  )\n" +
+                "                  OR (\n" +
+                "                    (\n" +
+                "                      (v1 >= 18)\n" +
+                "                      AND (v1 < 19)\n" +
+                "                    )\n" +
+                "                    OR (\n" +
+                "                      (\n" +
+                "                        (v1 >= 17)\n" +
+                "                        AND (v1 < 18)\n" +
+                "                      )\n" +
+                "                      OR (\n" +
+                "                        (\n" +
+                "                          (v1 >= 16)\n" +
+                "                          AND (v1 < 17)\n" +
+                "                        )\n" +
+                "                        OR (\n" +
+                "                          (\n" +
+                "                            (v1 >= 15)\n" +
+                "                            AND (v1 < 16)\n" +
+                "                          )\n" +
+                "                          OR (\n" +
+                "                            (\n" +
+                "                              (v1 >= 14)\n" +
+                "                              AND (v1 < 15)\n" +
+                "                            )\n" +
+                "                            OR (\n" +
+                "                              (\n" +
+                "                                (v1 >= 13)\n" +
+                "                                AND (v1 < 14)\n" +
+                "                              )\n" +
+                "                              OR (\n" +
+                "                                (\n" +
+                "                                  (v1 >= 12)\n" +
+                "                                  AND (v1 < 13)\n" +
+                "                                )\n" +
+                "                                OR (\n" +
+                "                                  (\n" +
+                "                                    (v1 >= 11)\n" +
+                "                                    AND (v1 < 12)\n" +
+                "                                  )\n" +
+                "                                  OR (\n" +
+                "                                    (\n" +
+                "                                      (v1 >= 10)\n" +
+                "                                      AND (v1 < 11)\n" +
+                "                                    )\n" +
+                "                                    OR (\n" +
+                "                                      (\n" +
+                "                                        (v1 >= 09)\n" +
+                "                                        AND (v1 < 10)\n" +
+                "                                      )\n" +
+                "                                      OR (\n" +
+                "                                        (\n" +
+                "                                          (v1 >= 08)\n" +
+                "                                          AND (v1 < 09)\n" +
+                "                                        )\n" +
+                "                                        OR (\n" +
+                "                                          (\n" +
+                "                                            (v1 >= 07)\n" +
+                "                                            AND (v1 < 08)\n" +
+                "                                          )\n" +
+                "                                          OR (\n" +
+                "                                            (\n" +
+                "                                              (v1 >= 06)\n" +
+                "                                              AND (v1 < 07)\n" +
+                "                                            )\n" +
+                "                                            OR (\n" +
+                "                                              (\n" +
+                "                                                (v1 >= 05)\n" +
+                "                                                AND (v1 < 06)\n" +
+                "                                              )\n" +
+                "                                              OR (\n" +
+                "                                                (\n" +
+                "                                                  (v1 >= 04)\n" +
+                "                                                  AND (v1 < 05)\n" +
+                "                                                )\n" +
+                "                                                OR (\n" +
+                "                                                  (\n" +
+                "                                                    (v1 >= 03)\n" +
+                "                                                    AND (v1 < 04)\n" +
+                "                                                  )\n" +
+                "                                                  OR (\n" +
+                "                                                    (\n" +
+                "                                                      (v1 >= 02)\n" +
+                "                                                      AND (v1 < 03)\n" +
+                "                                                    )\n" +
+                "                                                    OR (\n" +
+                "                                                      (v1 >= 01)\n" +
+                "                                                      AND (v1 < 02)\n" +
+                "                                                    )\n" +
+                "                                                  )\n" +
+                "                                                )\n" +
+                "                                              )\n" +
+                "                                            )\n" +
+                "                                          )\n" +
+                "                                        )\n" +
+                "                                      )\n" +
+                "                                    )\n" +
+                "                                  )\n" +
+                "                                )\n" +
+                "                              )\n" +
+                "                            )\n" +
+                "                          )\n" +
+                "                        )\n" +
+                "                      )\n" +
+                "                    )\n" +
+                "                  )\n" +
+                "                )\n" +
+                "              )\n" +
+                "            )\n" +
+                "          )\n" +
+                "        )\n" +
+                "      )\n" +
+                "    )\n" +
+                "  )";
+
+        //Test excessive recursion and optimizer timeout due to too many OR
+        getFragmentPlan(sql);
+    }
 }

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
@@ -64,7 +64,7 @@ OutPut Exchange Id: 08
 6:Project
 |  output columns:
 |  26 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast(1 - [7: l_discount, DECIMAL64(15,2), true] as DECIMAL128(18,2))
-|  cardinality: 19277
+|  cardinality: 25518
 |  column statistics:
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 2856.1332873207584] ESTIMATE
 |
@@ -75,7 +75,7 @@ OutPut Exchange Id: 08
 |  build runtime filters:
 |  - filter_id = 0, build_expr = (17: p_partkey), remote = true
 |  output columns: 6, 7
-|  cardinality: 19277
+|  cardinality: 25518
 |  column statistics:
 |  * l_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2856.1332873207584] ESTIMATE
 |  * l_quantity-->[5.0, 35.0, 0.0, 8.0, 50.0] ESTIMATE


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12875

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In the original method, there are too many repeated recursive calculations, which leads to a very slow acquisition time of statistical information when the number of ORs is large.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
