### PR TITLE
[BugFix] Set 'could_local_shuffle' correctly when decompose pipeline

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -50,13 +50,7 @@ public:
                                                                  _aggregator_factory->get_or_create(driver_sequence));
     }
 
-    bool need_local_shuffle() const override { return _need_local_shuffle; }
-    void set_need_local_shuffle(bool need_local_shuffle) override { _need_local_shuffle = need_local_shuffle; }
-
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
-    // This flag will be inherited from the source operator of AggregateBlockingSinkOperator,
-    // by calling `set_need_local_shuffle` when decomposing to pipeline.
-    bool _need_local_shuffle = true;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.h
@@ -51,13 +51,7 @@ public:
                 this, _id, _plan_node_id, driver_sequence, _aggregator_factory->get_or_create(driver_sequence));
     }
 
-    bool need_local_shuffle() const override { return _need_local_shuffle; }
-    void set_need_local_shuffle(bool need_local_shuffle) override { _need_local_shuffle = need_local_shuffle; }
-
 private:
     AggregatorFactoryPtr _aggregator_factory = nullptr;
-    // This flag will be inherited from the source operator of AggregateDistinctBlockingSinkOperator,
-    // by calling `set_need_local_shuffle` when decomposing to pipeline.
-    bool _need_local_shuffle = true;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_source_operator.h
@@ -38,12 +38,7 @@ public:
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
-    bool need_local_shuffle() const override { return _need_local_shuffle; }
-    void set_need_local_shuffle(bool need_local_shuffle) override { _need_local_shuffle = need_local_shuffle; }
-
 private:
     StreamingAggregatorFactoryPtr _aggregator_factory = nullptr;
-    bool _need_local_shuffle = true;
 };
-
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -57,7 +57,7 @@ void ExchangeSourceOperatorFactory::close_stream_recvr() {
     }
 }
 
-bool ExchangeSourceOperatorFactory::need_local_shuffle() const {
+bool ExchangeSourceOperatorFactory::could_local_shuffle() const {
     DCHECK(_texchange_node.__isset.partition_type);
     // There are two ways of shuffle
     // 1. If previous op is ExchangeSourceOperator and its partition type is HASH_PARTITIONED or BUCKET_SHUFFLE_HASH_PARTITIONED

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -50,7 +50,7 @@ public:
         return std::make_shared<ExchangeSourceOperator>(this, _id, _plan_node_id, driver_sequence);
     }
 
-    bool need_local_shuffle() const override;
+    bool could_local_shuffle() const override;
     TPartitionType::type partition_type() const override;
 
     std::shared_ptr<DataStreamRecvr> create_stream_recvr(RuntimeState* state,

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -175,8 +175,8 @@ MorselQueueFactory* PipelineBuilderContext::morsel_queue_factory_of_source_opera
     return morsel_queue_factory_of_source_operator(source_op->plan_node_id());
 }
 
-bool PipelineBuilderContext::need_local_shuffle(OpFactories ops) const {
-    return down_cast<SourceOperatorFactory*>(ops[0].get())->need_local_shuffle();
+bool PipelineBuilderContext::could_local_shuffle(OpFactories ops) const {
+    return down_cast<SourceOperatorFactory*>(ops[0].get())->could_local_shuffle();
 }
 
 bool PipelineBuilderContext::should_interpolate_cache_operator(OpFactoryPtr& source_op, int32_t plan_node_id) {

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -64,7 +64,7 @@ public:
     MorselQueueFactory* morsel_queue_factory_of_source_operator(int source_node_id);
     MorselQueueFactory* morsel_queue_factory_of_source_operator(const SourceOperatorFactory* source_op);
     // Whether the building pipeline `ops` need local shuffle for the next operator.
-    bool need_local_shuffle(OpFactories ops) const;
+    bool could_local_shuffle(OpFactories ops) const;
 
     bool should_interpolate_cache_operator(OpFactoryPtr& source_op, int32_t plan_node_id);
     OpFactories interpolate_cache_operator(

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -37,8 +37,8 @@ size_t IndividualMorselQueueFactory::num_original_morsels() const {
 }
 
 IndividualMorselQueueFactory::IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq,
-                                                           bool need_local_shuffle)
-        : _need_local_shuffle(need_local_shuffle) {
+                                                           bool could_local_shuffle)
+        : _could_local_shuffle(could_local_shuffle) {
     if (queue_per_driver_seq.empty()) {
         _queue_per_driver_seq.emplace_back(pipeline::create_empty_morsel_queue());
         return;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -24,7 +24,7 @@ class Segment;
 using SegmentSharedPtr = std::shared_ptr<Segment>;
 
 namespace vectorized {
-class TabletReaderParams;
+struct TabletReaderParams;
 class SeekTuple;
 struct RowidRangeOption;
 using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
@@ -136,7 +136,7 @@ public:
     virtual size_t num_original_morsels() const = 0;
 
     virtual bool is_shared() const = 0;
-    virtual bool need_local_shuffle() const = 0;
+    virtual bool could_local_shuffle() const = 0;
 };
 
 class SharedMorselQueueFactory final : public MorselQueueFactory {
@@ -149,7 +149,7 @@ public:
     size_t num_original_morsels() const override;
 
     bool is_shared() const override { return true; }
-    bool need_local_shuffle() const override { return true; }
+    bool could_local_shuffle() const override { return true; }
 
 private:
     MorselQueuePtr _queue;
@@ -158,7 +158,7 @@ private:
 
 class IndividualMorselQueueFactory final : public MorselQueueFactory {
 public:
-    IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq, bool need_local_shuffle);
+    IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq, bool could_local_shuffle);
     ~IndividualMorselQueueFactory() override = default;
 
     MorselQueue* create(int driver_sequence) override {
@@ -171,11 +171,11 @@ public:
     size_t num_original_morsels() const override;
 
     bool is_shared() const override { return false; }
-    bool need_local_shuffle() const override { return _need_local_shuffle; }
+    bool could_local_shuffle() const override { return _could_local_shuffle; }
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;
-    const bool _need_local_shuffle;
+    const bool _could_local_shuffle;
 };
 
 /// MorselQueue.

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -476,7 +476,7 @@ pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperat
 
     const auto* morsel_queue_factory = context->morsel_queue_factory_of_source_operator(scan_operator.get());
     scan_operator->set_degree_of_parallelism(morsel_queue_factory->size());
-    scan_operator->set_need_local_shuffle(morsel_queue_factory->need_local_shuffle());
+    scan_operator->set_could_local_shuffle(morsel_queue_factory->could_local_shuffle());
 
     ops.emplace_back(std::move(scan_operator));
 

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -166,8 +166,8 @@ public:
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
-    bool need_local_shuffle() const override { return _need_local_shuffle; }
-    void set_need_local_shuffle(bool need_local_shuffle) override { _need_local_shuffle = need_local_shuffle; }
+    bool could_local_shuffle() const override { return _could_local_shuffle; }
+    void set_could_local_shuffle(bool could_local_shuffle) override { _could_local_shuffle = could_local_shuffle; }
 
     // interface for different scan node
     virtual Status do_prepare(RuntimeState* state) = 0;
@@ -176,7 +176,7 @@ public:
 
 protected:
     ScanNode* const _scan_node;
-    bool _need_local_shuffle = true;
+    bool _could_local_shuffle = true;
 };
 
 pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> factory, ScanNode* scan_node,

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -166,9 +166,6 @@ public:
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
-    bool could_local_shuffle() const override { return _could_local_shuffle; }
-    void set_could_local_shuffle(bool could_local_shuffle) override { _could_local_shuffle = could_local_shuffle; }
-
     // interface for different scan node
     virtual Status do_prepare(RuntimeState* state) = 0;
     virtual void do_close(RuntimeState* state) = 0;
@@ -176,7 +173,6 @@ public:
 
 protected:
     ScanNode* const _scan_node;
-    bool _could_local_shuffle = true;
 };
 
 pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> factory, ScanNode* scan_node,

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -42,12 +42,13 @@ public:
     // There are two source operators returning false.
     // - The scan operator, which has been assigned tablets with the specific bucket sequences.
     // - The exchange source operator, partitioned by HASH_PARTITIONED or BUCKET_SHUFFLE_HASH_PARTITIONED.
-    virtual bool need_local_shuffle() const { return true; }
-    virtual void set_need_local_shuffle(bool need){};
+    virtual bool could_local_shuffle() const { return _could_local_shuffle; }
+    virtual void set_could_local_shuffle(bool could_local_shuffle) { _could_local_shuffle = could_local_shuffle; };
     virtual TPartitionType::type partition_type() const { return TPartitionType::type::HASH_PARTITIONED; }
 
 protected:
     size_t _degree_of_parallelism = 1;
+    bool _could_local_shuffle = true;
     MorselQueueFactory* _morsel_queue_factory = nullptr;
 };
 

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -90,7 +90,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
             morsel_queue->num_original_morsels() <= io_parallelism) {
             auto morsel_queue_map = uniform_distribute_morsels(std::move(morsel_queue), scan_dop);
             return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(morsel_queue_map),
-                                                                            /*need_local_shuffle*/ true);
+                                                                            /*could_local_shuffle*/ true);
         } else {
             return std::make_unique<pipeline::SharedMorselQueueFactory>(std::move(morsel_queue), scan_dop);
         }
@@ -109,7 +109,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
         }
 
         return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(queue_per_driver_seq),
-                                                                        /*need_local_shuffle*/ false);
+                                                                        /*could_local_shuffle*/ false);
     }
 }
 

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -108,18 +108,18 @@ public:
     bool is_shared_scan_enabled() const;
 
 protected:
-    RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
+    RuntimeProfile::Counter* _bytes_read_counter = nullptr; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())
-    RuntimeProfile::Counter* _rows_read_counter;
-    RuntimeProfile::Counter* _read_timer; // total read time
+    RuntimeProfile::Counter* _rows_read_counter = nullptr;
+    RuntimeProfile::Counter* _read_timer = nullptr; // total read time
     // Wall based aggregate read throughput [bytes/sec]
-    RuntimeProfile::Counter* _total_throughput_counter;
+    RuntimeProfile::Counter* _total_throughput_counter = nullptr;
     // Per thread read throughput [bytes/sec]
-    RuntimeProfile::Counter* _num_disks_accessed_counter;
-    RuntimeProfile::Counter* _materialize_tuple_timer; // time writing tuple slots
+    RuntimeProfile::Counter* _num_disks_accessed_counter = nullptr;
+    RuntimeProfile::Counter* _materialize_tuple_timer = nullptr; // time writing tuple slots
     // Aggregated scanner thread counters
-    RuntimeProfile::ThreadCounters* _scanner_thread_counters;
-    RuntimeProfile::Counter* _num_scanner_threads_started_counter;
+    RuntimeProfile::ThreadCounters* _scanner_thread_counters = nullptr;
+    RuntimeProfile::Counter* _num_scanner_threads_started_counter = nullptr;
     std::string _name;
     bool _enable_shared_scan = false;
 };

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -173,7 +173,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> AggregateBlockingNode::_
     size_t degree_of_parallelism = down_cast<SourceOperatorFactory*>(ops_with_sink[0].get())->degree_of_parallelism();
 
     auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
-    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
+    bool could_local_shuffle = !should_cache && context->could_local_shuffle(ops_with_sink);
     auto operators_generator = [this, should_cache, could_local_shuffle, &context](bool post_cache) {
         // shared by sink operator and source operator
         auto aggregator_factory = std::make_shared<AggFactory>(_tnode);

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -211,7 +211,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
     size_t degree_of_parallelism = down_cast<SourceOperatorFactory*>(ops_with_sink[0].get())->degree_of_parallelism();
 
     auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
-    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
+    bool could_local_shuffle = !should_cache && context->could_local_shuffle(ops_with_sink);
     if (!should_cache && _tnode.agg_node.__isset.interpolate_passthrough && _tnode.agg_node.interpolate_passthrough &&
         could_local_shuffle) {
         ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink,

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.cpp
@@ -205,19 +205,20 @@ void AggregateStreamingNode::_output_chunk_from_hash_map(ChunkPtr* chunk) {
 std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode::decompose_to_pipeline(
         pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
-    OpFactories operators_with_sink = _children[0]->decompose_to_pipeline(context);
+    OpFactories ops_with_sink = _children[0]->decompose_to_pipeline(context);
     // We cannot get degree of parallelism from PipelineBuilderContext, of which is only a suggest value
     // and we may set other parallelism for source operator in many special cases
-    size_t degree_of_parallelism =
-            down_cast<SourceOperatorFactory*>(operators_with_sink[0].get())->degree_of_parallelism();
+    size_t degree_of_parallelism = down_cast<SourceOperatorFactory*>(ops_with_sink[0].get())->degree_of_parallelism();
 
-    auto should_cache = context->should_interpolate_cache_operator(operators_with_sink[0], id());
-    if (!should_cache && _tnode.agg_node.__isset.interpolate_passthrough && _tnode.agg_node.interpolate_passthrough) {
-        operators_with_sink = context->maybe_interpolate_local_passthrough_exchange(
-                runtime_state(), operators_with_sink, degree_of_parallelism, true);
+    auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
+    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
+    if (!should_cache && _tnode.agg_node.__isset.interpolate_passthrough && _tnode.agg_node.interpolate_passthrough &&
+        could_local_shuffle) {
+        ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink,
+                                                                              degree_of_parallelism, true);
     }
 
-    auto operators_generator = [this, should_cache, &context](bool post_cache) {
+    auto operators_generator = [this, should_cache, could_local_shuffle, &context](bool post_cache) {
         // shared by sink operator factory and source operator factory
         AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
         auto aggr_mode = should_cache ? (post_cache ? AM_STREAMING_POST_CACHE : AM_STREAMING_PRE_CACHE) : AM_DEFAULT;
@@ -226,6 +227,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
                                                                                      aggregator_factory);
         auto source_operator = std::make_shared<AggregateStreamingSourceOperatorFactory>(context->next_operator_id(),
                                                                                          id(), aggregator_factory);
+        source_operator->set_could_local_shuffle(could_local_shuffle);
         return std::tuple<OpFactoryPtr, SourceOperatorFactoryPtr>{sink_operator, source_operator};
     };
 
@@ -236,28 +238,27 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > AggregateStreamingNode:
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(sink_operator.get(), context, rc_rf_probe_collector);
-    operators_with_sink.emplace_back(sink_operator);
+    ops_with_sink.emplace_back(sink_operator);
 
-    OpFactories operators_with_source;
+    OpFactories ops_with_source;
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(source_operator.get(), context, rc_rf_probe_collector);
 
     // Aggregator must be used by a pair of sink and source operators,
     // so operators_with_source's degree of parallelism must be equal with operators_with_sink's
     source_operator->set_degree_of_parallelism(degree_of_parallelism);
-    operators_with_source.push_back(std::move(source_operator));
+    ops_with_source.push_back(std::move(source_operator));
 
     if (should_cache) {
-        operators_with_source =
-                context->interpolate_cache_operator(operators_with_sink, operators_with_source, operators_generator);
+        ops_with_source = context->interpolate_cache_operator(ops_with_sink, ops_with_source, operators_generator);
     }
-    context->add_pipeline(operators_with_sink);
+    context->add_pipeline(ops_with_sink);
 
     if (limit() != -1) {
-        operators_with_source.emplace_back(
+        ops_with_source.emplace_back(
                 std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
-    return operators_with_source;
+    return ops_with_source;
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -124,7 +124,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
 
     // shared by sink operator and source operator
     auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
-    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
+    bool could_local_shuffle = !should_cache && context->could_local_shuffle(ops_with_sink);
     auto operators_generator = [this, should_cache, could_local_shuffle, &context](bool post_cache) {
         AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
         AggrMode aggr_mode = should_cache ? (post_cache ? AM_BLOCKING_POST_CACHE : AM_BLOCKING_PRE_CACHE) : AM_DEFAULT;

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -179,7 +179,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
     // and we may set other parallelism for source operator in many special cases
     size_t degree_of_parallelism = down_cast<SourceOperatorFactory*>(ops_with_sink[0].get())->degree_of_parallelism();
     auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
-    auto operators_generator = [this, should_cache, &context](bool post_cache) {
+    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
+    auto operators_generator = [this, should_cache, could_local_shuffle, &context](bool post_cache) {
         // shared by sink operator factory and source operator factory
         AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
         AggrMode aggr_mode =
@@ -189,6 +190,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
                 context->next_operator_id(), id(), aggregator_factory);
         auto source_operator = std::make_shared<AggregateDistinctStreamingSourceOperatorFactory>(
                 context->next_operator_id(), id(), aggregator_factory);
+        source_operator->set_could_local_shuffle(could_local_shuffle);
         return std::tuple<OpFactoryPtr, SourceOperatorFactoryPtr>(sink_operator, source_operator);
     };
     auto operators = operators_generator(true);

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -179,7 +179,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::
     // and we may set other parallelism for source operator in many special cases
     size_t degree_of_parallelism = down_cast<SourceOperatorFactory*>(ops_with_sink[0].get())->degree_of_parallelism();
     auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
-    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
+    bool could_local_shuffle = !should_cache && context->could_local_shuffle(ops_with_sink);
     auto operators_generator = [this, should_cache, could_local_shuffle, &context](bool post_cache) {
         // shared by sink operator factory and source operator factory
         AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -438,7 +438,7 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
                     down_cast<SourceOperatorFactory*>(rhs_operators[0].get())->partition_type();
 
             // Make sure that local shuffle use the same hash function as the remote exchange sink do
-            if (context->need_local_shuffle(rhs_operators)) {
+            if (context->could_local_shuffle(rhs_operators)) {
                 if (part_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
                     DCHECK(!_build_equivalence_partition_expr_ctxs.empty());
                     rhs_operators = context->maybe_interpolate_local_shuffle_exchange(
@@ -448,7 +448,7 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
                                                                                       _build_expr_ctxs, part_type);
                 }
             }
-            if (context->need_local_shuffle(lhs_operators)) {
+            if (context->could_local_shuffle(lhs_operators)) {
                 if (part_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
                     DCHECK(!_probe_equivalence_partition_expr_ctxs.empty());
                     lhs_operators = context->maybe_interpolate_local_shuffle_exchange(

--- a/be/src/runtime/memory/chunk_allocator.h
+++ b/be/src/runtime/memory/chunk_allocator.h
@@ -29,7 +29,7 @@
 
 namespace starrocks {
 
-class Chunk;
+struct Chunk;
 class ChunkArena;
 class MemTracker;
 

--- a/be/src/util/debug/query_trace_impl.h
+++ b/be/src/util/debug/query_trace_impl.h
@@ -17,10 +17,9 @@
 #include "util/hash_util.hpp"
 #include "util/spinlock.h"
 
-namespace starrocks {
-namespace debug {
+namespace starrocks::debug {
 
-class QueryTraceContext;
+struct QueryTraceContext;
 
 struct QueryTraceEvent {
     std::string name;
@@ -138,5 +137,4 @@ inline thread_local QueryTraceContext tls_trace_ctx;
             buffer->add(event);                       \
         }                                             \
     } while (0);
-} // namespace debug
-} // namespace starrocks
+} // namespace starrocks::debug


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12563

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When use the feature of plan enumeration, there may be two-stage aggregates within single fragment, which is of couse not the optimal plan, but the legal plan nevertheless. 

For example, see the below piece of fragment, these two-stage aggregates(node_id=6/7) are the left child of hashJoin node(node_id=10), whose join type is `BUCKET_SHUFFLE_JOIN`, the fe will arrange the tablet list for every parallelism, so along the execution path from scan(node_id=0) to join(node_id=10), no shuffle operators are allowed to interwaved. But obviously, the logical of `decompose_to_pipeline` not live up to the the distribution requirement.

```
|   10:HASH JOIN                                                                                          |
|   |  join op: INNER JOIN (BUCKET_SHUFFLE)                                                               |
|   |  colocate: false, reason:                                                                           |
|   |  equal join conjunct: 107: ss_item_sk = 30: i_item_sk                                               |
|   |                                                                                                     |
|   |----9:EXCHANGE                                                                                       |
|   |                                                                                                     |
|   7:AGGREGATE (merge finalize)                                                                          |
|   |  output: sum(156: sum)                                                                              |
|   |  group by: 112: ss_store_sk, 107: ss_item_sk                                                        |
|   |                                                                                                     |
|   6:AGGREGATE (update serialize)                                                                        |
|   |  STREAMING                                                                                          |
|   |  output: sum(118: ss_sales_price)                                                                   |
|   |  group by: 112: ss_store_sk, 107: ss_item_sk                                                        |
|   |                                                                                                     |
|   5:Project                                                                                             |
|   |  <slot 107> : 107: ss_item_sk                                                                       |
|   |  <slot 112> : 112: ss_store_sk                                                                      |
|   |  <slot 118> : 118: ss_sales_price                                                                   |
|   |                                                                                                     |
|   4:HASH JOIN                                                                                           |
|   |  join op: INNER JOIN (BROADCAST)                                                                    |
|   |  colocate: false, reason:                                                                           |
|   |  equal join conjunct: 105: ss_sold_date_sk = 128: d_date_sk                                         |
|   |                                                                                                     |
|   |----3:EXCHANGE                                                                                       |
|   |                                                                                                     |
|   0:OlapScanNode                                                                                        |
|      TABLE: store_sales                                                                                 |
|      PREAGGREGATION: ON                                                                                 |
|      PREDICATES: 112: ss_store_sk IS NOT NULL                                                           |
|      partitions=1/1                                                                                     |
|      rollup: store_sales                                                                                |
|      tabletRatio=192/192                                                                                |
|      tabletList=62912,62914,62916,62918,62920,62922,62924,62926,62928,62930 ...                         |
|      cardinality=2750370                                                                                |
|      avgRowSize=20.0                                                                                    |
|      numNodes=0
```

## Changelist

1. Pipeline cannot adjust the distribution if `need_local_shuffle = false`, so the better naming is `could_local_shuffle`
2. When decompose aggregate nodes to pipeline, the original pipeline need to split into two pipelines, if the `could_local_shuffle` of the original pipeline is false, then we must pass it on to the new created pipeline.
3. Fix some warnings reported by `tscancode` and `clang-tidy` tests

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] I have added user document for my new feature or new function
