### PR TITLE
[BugFix] Fix BE crash when RuntimeFilter close without prepared

### DIFF
--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -42,9 +42,7 @@ ExprContext::ExprContext(Expr* root)
 
 ExprContext::~ExprContext() {
     // DCHECK(!_prepared || _closed) << ". expr context address = " << this;
-    if (_prepared) {
-        close(_runtime_state);
-    }
+    close(_runtime_state);
     for (auto& _fn_context : _fn_contexts) {
         delete _fn_context;
     }
@@ -82,6 +80,9 @@ Status ExprContext::open(std::vector<ExprContext*> evals, RuntimeState* state) {
 }
 
 void ExprContext::close(RuntimeState* state) {
+    if (!_prepared) {
+        return;
+    }
     bool expected = false;
     if (!_closed.compare_exchange_strong(expected, true)) {
         return;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #12801 

## Problem Summary(Required) ：
for such SQL:
```
 select count(*) from tmp,tmp2 where `'kkk'` like concat('%',`'k'`,'%');
```
we will build a RuntimeFilter if tmp2 only has one row.

when we build RuntimeFilter for `"'kkk' like concat('%','k','%')"` we won't call prepare or open method for it.
they will be called in `OperatorFactory::_prepare_runtime_in_filters(RuntimeState* state)`

but in some times. driver will return or query context call cancel, `OperatorFactory::_prepare_runtime_in_filters` won't be called.

then an unprepared ExprContext::close will be called, which will cause BE crash


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
