### PR TITLE
[Enhancement] refactor hive auto sync

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -848,8 +848,7 @@ public class Database extends MetaObject implements Writable {
         this.exist = exist;
     }
 
-    public List<HiveTable> getHiveTables() {
-        return idToTable.values().stream().filter(tbl -> tbl.isHiveTable())
-                .map(tbl -> (HiveTable) tbl).collect(Collectors.toList());
+    public List<Table> getHiveTables() {
+        return idToTable.values().stream().filter(Table::isHiveTable).collect(Collectors.toList());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -373,19 +373,17 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
     @Override
     public void onCreate() {
-        if (Config.enable_hms_events_incremental_sync && isResourceMappingCatalog(catalogName)) {
-            String catalogName = getCatalogName();
+        if (Config.enable_hms_events_incremental_sync && isResourceMappingCatalog(getCatalogName())) {
             GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().registerTableFromResource(
-                    String.join(".", catalogName, hiveDbName, hiveTableName));
+                    String.join(".", getCatalogName(), hiveDbName, hiveTableName));
         }
     }
 
     @Override
     public void onDrop(Database db, boolean force, boolean replay) {
-        if (Config.enable_hms_events_incremental_sync && isResourceMappingCatalog(catalogName)) {
-            String catalogName = getCatalogName();
+        if (Config.enable_hms_events_incremental_sync && isResourceMappingCatalog(getCatalogName())) {
             GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().unRegisterTableFromResource(
-                    String.join(".", catalogName, hiveDbName, hiveTableName));
+                    String.join(".", getCatalogName(), hiveDbName, hiveTableName));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileIO.java
@@ -38,7 +38,6 @@ public class CachingRemoteFileIO implements RemoteFileIO {
     public static CachingRemoteFileIO createCatalogLevelInstance(RemoteFileIO fileIO, Executor executor,
                                                         long expireAfterWrite, long refreshInterval, long maxSize) {
         return new CachingRemoteFileIO(fileIO, executor, expireAfterWrite, refreshInterval, maxSize);
-
     }
 
     public static CachingRemoteFileIO createQueryLevelInstance(RemoteFileIO fileIO, long maxSize) {
@@ -81,6 +80,14 @@ public class CachingRemoteFileIO implements RemoteFileIO {
         cache.put(pathKey, loadRemoteFiles(pathKey));
     }
 
+    public synchronized void invalidateAll() {
+        cache.invalidateAll();
+    }
+
+    public void invalidatePartition(RemotePathKey pathKey) {
+        cache.invalidate(pathKey);
+    }
+
     private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {
         CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
         if (expiresAfterWriteSec >= 0) {
@@ -93,13 +100,5 @@ public class CachingRemoteFileIO implements RemoteFileIO {
 
         cacheBuilder.maximumSize(maximumSize);
         return cacheBuilder;
-    }
-
-    public void removeRemoteFile(RemotePathKey pathKey) {
-        cache.invalidate(pathKey);
-    }
-
-    public void invalidateAll() {
-        cache.invalidateAll();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -105,7 +105,7 @@ public interface ConnectorMetadata {
     default void clear() {
     }
 
-    default void refreshTable(String dbName, String tableName, Table table, List<String> partitionNames) {
+    default void refreshTable(String srDbName, Table table, List<String> partitionNames) {
     }
 
     default void createDb(String dbName) throws DdlException, AlreadyExistsException {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -24,16 +24,19 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.PartitionValue;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.FileUtils;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hive.common.FileUtils.escapePathName;
 import static org.apache.hadoop.hive.common.FileUtils.unescapePathName;
 
 public class PartitionUtil {
@@ -108,6 +111,22 @@ public class PartitionUtil {
     public static String toHivePartitionName(List<String> partitionColumnNames,
                                              List<String> partitionValues) {
         return FileUtils.makePartName(partitionColumnNames, partitionValues);
+    }
+
+    public static String toHivePartitionName(Map<String, String> partitionColNameToValue) {
+        int i = 0;
+        StringBuilder name = new StringBuilder();
+        for (Map.Entry<String, String> entry : partitionColNameToValue.entrySet()) {
+            if (i++ > 0) {
+                name.append(Path.SEPARATOR);
+            }
+            String partitionColName = entry.getKey();
+            String partitionValue = entry.getValue();
+            name.append(escapePathName(partitionColName.toLowerCase(Locale.ROOT)));
+            name.append('=');
+            name.append(escapePathName(partitionValue.toLowerCase(Locale.ROOT)));
+        }
+        return name.toString();
     }
 
     public static List<String> fromPartitionKey(PartitionKey key) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
@@ -11,9 +11,7 @@ import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.RemotePathKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.connector.hive.events.MetastoreEventType;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
-import com.starrocks.server.GlobalStateMgr;
 import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,14 +29,18 @@ import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceM
 public class CacheUpdateProcessor {
     private static final Logger LOG = LogManager.getLogger(CacheUpdateProcessor.class);
 
+    private enum Operator {
+        UPDATE,
+        DROP
+    }
+
     private final String catalogName;
     private final IHiveMetastore metastore;
     private final Optional<CachingRemoteFileIO> remoteFileIO;
     private final ExecutorService executor;
     private final boolean isRecursive;
 
-    // catalog => syncedEventId
-    // Record the latest catalog event id when processed hive events
+    // Record the latest synced event id when processing hive events
     private long lastSyncedEventId = -1;
 
     public CacheUpdateProcessor(String catalogName,
@@ -58,142 +60,129 @@ public class CacheUpdateProcessor {
         }
     }
 
-    public void setLastSyncedEventId(long lastSyncedEventId) {
-        this.lastSyncedEventId = lastSyncedEventId;
-    }
-
-    public void refreshTable(String dbName, String tableName, Table table) {
-        GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().getEventProcessorLock().writeLock().lock();
-        try {
-            HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
-            metastore.refreshTable(hmsTable.getDbName(), hmsTable.getTableName());
-            updateTableRemoteFileIO(hmsTable, "REFRESH");
-            boolean isSchemaChange = false;
-            if (isResourceMappingCatalog(catalogName) && table.isHiveTable()) {
-                HiveTable resourceMappingCatalogTable = (HiveTable) metastore.getTable(
-                        hmsTable.getDbName(), hmsTable.getTableName());
-                for (Column column : resourceMappingCatalogTable.getColumns()) {
-                    Column baseColumn = table.getColumn(column.getName());
-                    if (baseColumn == null) {
-                        isSchemaChange = true;
-                        break;
-                    }
-                    if (!baseColumn.equals(column)) {
-                        isSchemaChange = true;
-                        break;
-                    }
-                }
-
-                if (isSchemaChange) {
-                    ((HiveTable) table).modifyTableSchema(dbName, tableName, resourceMappingCatalogTable);
-                }
-            }
-        } finally {
-            GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().getEventProcessorLock().writeLock().unlock();
+    public void refreshTable(String dbName, Table table) {
+        HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
+        metastore.refreshTable(hmsTbl.getDbName(), hmsTbl.getTableName());
+        refreshRemoteFiles(hmsTbl.getTableLocation(), Operator.UPDATE);
+        if (isResourceMappingCatalog(catalogName) && table.isHiveTable()) {
+            processSchemaChange(dbName, (HiveTable) table);
         }
     }
 
     public void refreshPartition(Table table, List<String> hivePartitionNames) {
-        GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().getEventProcessorLock().writeLock().lock();
-        try {
-            HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
-            String hiveDbName = hmsTable.getDbName();
-            String hiveTableName = hmsTable.getTableName();
-            List<HivePartitionName> partitionNames = hivePartitionNames.stream()
-                    .map(partitionName -> HivePartitionName.of(hiveDbName, hiveTableName, partitionName))
+        HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
+        String hiveDbName = hmsTable.getDbName();
+        String hiveTableName = hmsTable.getTableName();
+        List<HivePartitionName> partitionNames = hivePartitionNames.stream()
+                .map(partitionName -> HivePartitionName.of(hiveDbName, hiveTableName, partitionName))
+                .collect(Collectors.toList());
+        metastore.refreshPartition(partitionNames);
+
+        if (remoteFileIO.isPresent()) {
+            Map<String, Partition> partitions = metastore.getPartitionsByNames(hiveDbName, hiveTableName, hivePartitionNames);
+            Optional<String> hudiBasePath = table.isHiveTable() ? Optional.empty() : Optional.of(hmsTable.getTableLocation());
+            List<RemotePathKey> remotePathKeys = partitions.values().stream()
+                    .map(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive, hudiBasePath))
                     .collect(Collectors.toList());
-            metastore.refreshPartition(partitionNames);
-            updatePartitionRemoteFileIO(table, hivePartitionNames, hmsTable, "REFRESH");
-        } finally {
-            GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().getEventProcessorLock().writeLock().unlock();
+            remotePathKeys.forEach(path -> remoteFileIO.get().updateRemoteFiles(path));
         }
     }
 
-    private void updateTableRemoteFileIO(HiveMetaStoreTable hmsTable, String type) {
-        if (remoteFileIO.isPresent()) {
-            String tableLocation = hmsTable.getTableLocation();
-            List<RemotePathKey> presentPathKey = remoteFileIO.get()
-                    .getPresentPathKeyInCache(tableLocation, isRecursive);
-            List<Future<?>> futures = Lists.newArrayList();
-            if ("drop".equalsIgnoreCase(type)) {
-                presentPathKey.forEach(pathKey -> {
-                    futures.add(executor.submit(() -> remoteFileIO.get().removeRemoteFile(pathKey)));
-                });
-            } else {
-                presentPathKey.forEach(pathKey -> {
-                    futures.add(executor.submit(() -> remoteFileIO.get().updateRemoteFiles(pathKey)));
-                });
+    private void processSchemaChange(String srDbName, HiveTable hiveTable) {
+        boolean isSchemaChange = false;
+        HiveTable resourceMappingCatalogTable = (HiveTable) metastore.getTable(
+                hiveTable.getDbName(), hiveTable.getTableName());
+        for (Column column : resourceMappingCatalogTable.getColumns()) {
+            Column baseColumn = hiveTable.getColumn(column.getName());
+            if (baseColumn == null) {
+                isSchemaChange = true;
+                break;
             }
+            if (!baseColumn.equals(column)) {
+                isSchemaChange = true;
+                break;
+            }
+        }
+
+        if (isSchemaChange) {
+            hiveTable.modifyTableSchema(srDbName, hiveTable.getName(), resourceMappingCatalogTable);
+        }
+    }
+
+    private void refreshRemoteFiles(String tableLocation, Operator operator) {
+        if (remoteFileIO.isPresent()) {
+            List<RemotePathKey> presentPathKey = remoteFileIO.get().getPresentPathKeyInCache(tableLocation, isRecursive);
+            List<Future<?>> futures = Lists.newArrayList();
+            presentPathKey.forEach(pathKey -> {
+                if (operator == Operator.UPDATE) {
+                    futures.add(executor.submit(() -> remoteFileIO.get().updateRemoteFiles(pathKey)));
+                } else {
+                    futures.add(executor.submit(() -> remoteFileIO.get().invalidatePartition(pathKey)));
+                }
+            });
 
             for (Future<?> future : futures) {
                 try {
                     future.get();
                 } catch (InterruptedException | ExecutionException e) {
-                    LOG.error("Failed to update remote files on [{}.{}]", hmsTable.getDbName(), hmsTable.getTableName());
+                    LOG.error("Failed to update remote files on [{}]", tableLocation, e);
                     throw new StarRocksConnectorException("Failed to update remote files", e);
                 }
             }
         }
     }
 
-    private void updatePartitionRemoteFileIO(Table table, List<String> hivePartitionNames,
-                                             HiveMetaStoreTable hmsTable, String type) {
-        if (remoteFileIO.isPresent()) {
-            Map<String, Partition> partitions = metastore.getPartitionsByNames(
-                    hmsTable.getDbName(), hmsTable.getTableName(), hivePartitionNames);
-            Optional<String> hudiBasePath = table.isHiveTable() ? Optional.empty() : Optional.of(hmsTable.getTableLocation());
-            List<RemotePathKey> remotePathKeys = partitions.values().stream()
-                    .map(partition -> RemotePathKey.of(partition.getFullPath(), isRecursive, hudiBasePath))
-                    .collect(Collectors.toList());
+    public boolean isTablePresent(HiveTableName tableName) {
+        return ((CachingHiveMetastore) metastore).isTablePresent(tableName);
+    }
 
-            List<Future<?>> futures = Lists.newArrayList();
-            if ("drop".equalsIgnoreCase(type)) {
-                if (remotePathKeys.size() > 1) {
-                    remotePathKeys.forEach(pathKey -> {
-                        futures.add(executor.submit(() -> remoteFileIO.get().removeRemoteFile(pathKey)));
-                    });
-                    for (Future<?> future : futures) {
-                        try {
-                            future.get();
-                        } catch (InterruptedException | ExecutionException e) {
-                            LOG.error("Failed to refresh remote files on [{}.{}], partitionNames: {}",
-                                    hmsTable.getDbName(), hmsTable.getTableName(), hivePartitionNames);
-                            throw new StarRocksConnectorException("Failed to refresh remote files", e);
-                        }
-                    }
-                } else {
-                    remotePathKeys.forEach(pathKey -> {
-                        remoteFileIO.get().removeRemoteFile(pathKey);
-                    });
-                }
-            } else {
-                if (remotePathKeys.size() > 1) {
-                    remotePathKeys.forEach(pathKey -> {
-                        futures.add(executor.submit(() -> remoteFileIO.get().updateRemoteFiles(pathKey)));
-                    });
-                    for (Future<?> future : futures) {
-                        try {
-                            future.get();
-                        } catch (InterruptedException | ExecutionException e) {
-                            LOG.error("Failed to refresh remote files on [{}.{}], partitionNames: {}",
-                                    hmsTable.getDbName(), hmsTable.getTableName(), hivePartitionNames);
-                            throw new StarRocksConnectorException("Failed to refresh remote files", e);
-                        }
-                    }
-                } else {
-                    remotePathKeys.forEach(pathKey -> {
-                        remoteFileIO.get().updateRemoteFiles(pathKey);
-                    });
-                }
-            }
+    public boolean isPartitionPresent(HivePartitionName partitionName) {
+        return ((CachingHiveMetastore) metastore).isPartitionPresent(partitionName);
+    }
+
+    public void refreshTableByEvent(HiveTable updatedHiveTable, HiveCommonStats commonStats, Partition partition) {
+        ((CachingHiveMetastore) metastore).refreshTableByEvent(updatedHiveTable, commonStats, partition);
+        refreshRemoteFiles(updatedHiveTable.getTableLocation(), Operator.UPDATE);
+    }
+
+    public void refreshPartitionByEvent(HivePartitionName hivePartitionName, HiveCommonStats commonStats, Partition partion) {
+        ((CachingHiveMetastore) metastore).refreshPartitionByEvent(hivePartitionName, commonStats, partion);
+        if (remoteFileIO.isPresent()) {
+            RemotePathKey pathKey = RemotePathKey.of(partion.getFullPath(), isRecursive);
+            remoteFileIO.get().updateRemoteFiles(pathKey);
         }
+    }
+
+    public void invalidateAll() {
+        metastore.invalidateAll();
+        remoteFileIO.ifPresent(CachingRemoteFileIO::invalidateAll);
+    }
+
+    public void invalidateTable(String dbName, String tableName) {
+        String tableLocation = ((HiveMetaStoreTable) metastore.getTable(dbName, tableName)).getTableLocation();
+        metastore.invalidateTable(dbName, tableName);
+        remoteFileIO.ifPresent(ignore -> refreshRemoteFiles(tableLocation, Operator.DROP));
+    }
+
+    public void invalidatePartition(HivePartitionName partitionName) {
+        Partition partition = metastore.getPartition(
+                partitionName.getDatabaseName(), partitionName.getTableName(), partitionName.getPartitionValues());
+        metastore.invalidatePartition(partitionName);
+        if (remoteFileIO.isPresent()) {
+            RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive);
+            remoteFileIO.get().invalidatePartition(pathKey);
+        }
+    }
+
+    public void setLastSyncedEventId(long lastSyncedEventId) {
+        this.lastSyncedEventId = lastSyncedEventId;
     }
 
     public NotificationEventResponse getNextEventResponse(String catalogName, final boolean getAllEvents)
             throws MetastoreNotificationFetchException {
         if (lastSyncedEventId == -1) {
             lastSyncedEventId = metastore.getCurrentEventId();
-            LOG.info("Last synced event id is null when pulling events on catalog [{}]", catalogName);
+            LOG.error("Last synced event id is null when pulling events on catalog [{}]", catalogName);
             return null;
         }
 
@@ -203,51 +192,5 @@ public class CacheUpdateProcessor {
             return null;
         }
         return ((CachingHiveMetastore) metastore).getNextEventResponse(lastSyncedEventId, catalogName, getAllEvents);
-    }
-
-    public boolean existIncache(MetastoreEventType eventType, Object key) {
-        return ((CachingHiveMetastore) metastore).existInCache(eventType, key);
-    }
-
-    public void refreshCacheByEvent(MetastoreEventType eventType, HiveTableName hiveTableName,
-                                    HivePartitionName hivePartitionName,
-                                    HiveCommonStats commonStats, Partition partion, HiveTable hiveTable) {
-        ((CachingHiveMetastore) metastore).refreshCacheByEvent(eventType, hiveTableName,
-                hivePartitionName, commonStats, partion, hiveTable);
-        updateRemoteFilebyEvent(eventType, hiveTableName, hivePartitionName, hiveTable);
-    }
-
-    public void updateRemoteFilebyEvent(MetastoreEventType eventType, HiveTableName hiveTableName,
-                                        HivePartitionName hivePartitionName, HiveTable hiveTable) {
-        switch (eventType) {
-            case ALTER_TABLE:
-                updateTableRemoteFileIO(hiveTable, "ALTER");
-                break;
-            case ALTER_PARTITION:
-                updatePartitionRemoteFileIO(hiveTable,
-                        Lists.newArrayList(hivePartitionName.getPartitionNames().get()), hiveTable, "ALTER");
-                break;
-            case DROP_PARTITION:
-                updatePartitionRemoteFileIO(hiveTable,
-                        Lists.newArrayList(hivePartitionName.getPartitionNames().get()), hiveTable, "DROP");
-                break;
-            case DROP_TABLE:
-                updateTableRemoteFileIO(hiveTable, "DROP");
-                break;
-            case INSERT:
-                if (hiveTable.isUnPartitioned()) {
-                    updateTableRemoteFileIO(hiveTable, "ALTER");
-                } else {
-                    updatePartitionRemoteFileIO(hiveTable, hivePartitionName.getPartitionValues(), hiveTable, "ALTER");
-                }
-                break;
-            default:
-                return;
-        }
-    }
-
-    public void invalidateAll() {
-        metastore.invalidateAll();
-        remoteFileIO.ifPresent(CachingRemoteFileIO::invalidateAll);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -64,13 +64,14 @@ public class HiveConnector implements Connector {
                 internalMgr.getHiveMetastoreConf(),
                 internalMgr.getRemoteFileConf(),
                 internalMgr.getPullRemoteFileExecutor(),
-                internalMgr.isSearchRecursive()
+                internalMgr.isSearchRecursive(),
+                internalMgr.enableHmsEventsIncrementalSync()
         );
     }
 
     public void onCreate() {
-        if (internalMgr.isEnableHmsEventsIncrementalSync()) {
-            Optional<CacheUpdateProcessor> updateProcessor = metadataFactory.getCacheUpdateProcessor(true);
+        if (internalMgr.enableHmsEventsIncrementalSync()) {
+            Optional<CacheUpdateProcessor> updateProcessor = metadataFactory.getCacheUpdateProcessor();
             updateProcessor.ifPresent(processor -> GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor()
                     .registerCacheUpdateProcessor(catalogName, updateProcessor.get()));
         }
@@ -79,7 +80,7 @@ public class HiveConnector implements Connector {
     @Override
     public void shutdown() {
         internalMgr.shutdown();
-        metadataFactory.getCacheUpdateProcessor(false).ifPresent(CacheUpdateProcessor::invalidateAll);
+        metadataFactory.getCacheUpdateProcessor().ifPresent(CacheUpdateProcessor::invalidateAll);
         GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().unRegisterCacheUpdateProcessor(catalogName);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.starrocks.connector.CachingRemoteFileIO.NEVER_REFRESH;
+
 public class HiveConnectorInternalMgr {
     private final String catalogName;
     private final Map<String, String> properties;
@@ -73,7 +75,7 @@ public class HiveConnectorInternalMgr {
                     hiveMetastore,
                     new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
                     hmsConf.getCacheTtlSec(),
-                    hmsConf.getCacheRefreshIntervalSec(),
+                    enableHmsEventsIncrementalSync ? NEVER_REFRESH : hmsConf.getCacheRefreshIntervalSec(),
                     hmsConf.getCacheMaxNum(),
                     hmsConf.enableListNamesCache());
         }
@@ -96,7 +98,7 @@ public class HiveConnectorInternalMgr {
                     remoteFileIO,
                     new ReentrantExecutor(refreshRemoteFileExecutor, remoteFileConf.getPerQueryCacheMaxSize()),
                     remoteFileConf.getCacheTtlSec(),
-                    remoteFileConf.getCacheRefreshIntervalSec(),
+                    enableHmsEventsIncrementalSync ? NEVER_REFRESH : remoteFileConf.getCacheRefreshIntervalSec(),
                     remoteFileConf.getCacheMaxSize());
         }
 
@@ -124,7 +126,7 @@ public class HiveConnectorInternalMgr {
         return remoteFileConf;
     }
 
-    public boolean isEnableHmsEventsIncrementalSync() {
+    public boolean enableHmsEventsIncrementalSync() {
         return enableHmsEventsIncrementalSync;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -148,11 +148,11 @@ public class HiveMetadata implements ConnectorMetadata {
         return statistics;
     }
 
-    public void refreshTable(String dbName, String tableName, Table table, List<String> partitionNames) {
+    public void refreshTable(String srDbName, Table table, List<String> partitionNames) {
         if (partitionNames != null && partitionNames.size() > 1) {
             cacheUpdateProcessor.ifPresent(processor -> processor.refreshPartition(table, partitionNames));
         } else {
-            cacheUpdateProcessor.ifPresent(processor -> processor.refreshTable(dbName, tableName, table));
+            cacheUpdateProcessor.ifPresent(processor -> processor.refreshTable(srDbName, table));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
@@ -20,6 +20,7 @@ public class HiveMetadataFactory {
     private final long perQueryCacheRemotePathMaxNum;
     private final ExecutorService pullRemoteFileExecutor;
     private final boolean isRecursive;
+    private final boolean enableHmsEventsIncrementalSync;
 
     public HiveMetadataFactory(String catalogName,
                                IHiveMetastore metastore,
@@ -27,7 +28,8 @@ public class HiveMetadataFactory {
                                CachingHiveMetastoreConf hmsConf,
                                CachingRemoteFileConf fileConf,
                                ExecutorService pullRemoteFileExecutor,
-                               boolean isRecursive) {
+                               boolean isRecursive,
+                               boolean enableHmsEventsIncrementalSync) {
         this.catalogName = catalogName;
         this.metastore = metastore;
         this.remoteFileIO = remoteFileIO;
@@ -35,6 +37,7 @@ public class HiveMetadataFactory {
         this.perQueryCacheRemotePathMaxNum = fileConf.getPerQueryCacheMaxSize();
         this.pullRemoteFileExecutor = pullRemoteFileExecutor;
         this.isRecursive = isRecursive;
+        this.enableHmsEventsIncrementalSync = enableHmsEventsIncrementalSync;
     }
 
     public HiveMetadata create() {
@@ -47,12 +50,12 @@ public class HiveMetadataFactory {
                 remoteFileIO instanceof CachingRemoteFileIO);
         HiveStatisticsProvider statisticsProvider = new HiveStatisticsProvider(hiveMetastoreOperations, remoteFileOperations);
 
-        Optional<CacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor(false);
+        Optional<CacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
         return new HiveMetadata(catalogName, hiveMetastoreOperations,
                 remoteFileOperations, statisticsProvider, cacheUpdateProcessor);
     }
 
-    public synchronized Optional<CacheUpdateProcessor> getCacheUpdateProcessor(boolean enableHmsEventsIncrementalSync) {
+    public synchronized Optional<CacheUpdateProcessor> getCacheUpdateProcessor() {
         Optional<CacheUpdateProcessor> cacheUpdateProcessor;
         if (remoteFileIO instanceof CachingRemoteFileIO || metastore instanceof CachingHiveMetastore) {
             cacheUpdateProcessor = Optional.of(new CacheUpdateProcessor(

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -174,9 +174,9 @@ public class HiveMetastore implements IHiveMetastore {
 
             return response;
         } catch (MetastoreNotificationFetchException e) {
-            throw new MetastoreNotificationFetchException(
-                    "Unable to fetch notifications from metastore. Last synced event id is "
-                            + lastSyncedEventId, e);
+            LOG.error("Unable to fetch notifications from metastore. Last synced event id is {}", lastSyncedEventId, e);
+            throw new MetastoreNotificationFetchException("Unable to fetch notifications from metastore. " +
+                    "Last synced event id is " + lastSyncedEventId, e);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -20,11 +20,11 @@ public interface IHiveMetastore {
 
     List<String> getPartitionKeys(String dbName, String tableName);
 
-    Partition getPartition(String dbName, String tblName, List<String> partitionValues);
+    Partition getPartition(String dbName, String tableName, List<String> partitionValues);
 
-    Map<String, Partition> getPartitionsByNames(String dbName, String tblName, List<String> partitionNames);
+    Map<String, Partition> getPartitionsByNames(String dbName, String tableName, List<String> partitionNames);
 
-    HivePartitionStats getTableStatistics(String dbName, String tblName);
+    HivePartitionStats getTableStatistics(String dbName, String tableName);
 
     Map<String, HivePartitionStats> getPartitionStatistics(Table table, List<String> partitions);
 
@@ -35,6 +35,12 @@ public interface IHiveMetastore {
     }
 
     default void invalidateAll() {
+    }
+
+    default void invalidateTable(String dbName, String tableName) {
+    }
+
+    default void invalidatePartition(HivePartitionName partitionName) {
     }
 
     default long getCurrentEventId() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/DropTableEvent.java
@@ -49,7 +49,7 @@ public class DropTableEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean existInCache() {
-        return cache.existIncache(DROP_TABLE, HiveTableName.of(dbName, tableName));
+        return cache.isTablePresent(HiveTableName.of(dbName, tableName));
     }
 
     @Override
@@ -68,7 +68,8 @@ public class DropTableEvent extends MetastoreTableEvent {
         }
 
         try {
-            cache.refreshCacheByEvent(DROP_TABLE, HiveTableName.of(dbName, tblName), null, null, null, null);
+            LOG.info("Start to process DROP_TABLE event on {}.{}.{}", catalogName, dbName, tblName);
+            cache.invalidateTable(dbName, tableName);
         } catch (Exception e) {
             LOG.error("Failed to process {} event, event detail msg: {}",
                     getEventType(), metastoreNotificationEvent, e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/MetastoreEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/events/MetastoreEvent.java
@@ -96,7 +96,7 @@ public abstract class MetastoreEvent {
 
     /**
      * If the table key or partition key doesn't exist in the
-     * <code>{@link com.starrocks.external.hive.CachingHiveMetastore}</code> of fe. that is,
+     * <code>{@link com.starrocks.connector.hive.CachingHiveMetastore}</code> of fe. that is,
      * the user has never queried the table/partition or refreshed the table/partition manually since the start of fe.
      * When processing incremental events, the event corresponding to the table/partition will not be processed.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -147,11 +147,11 @@ public class HudiMetadata implements ConnectorMetadata {
         return statistics;
     }
 
-    public void refreshTable(String dbName, String tableName, Table table, List<String> partitionNames) {
+    public void refreshTable(String srDbName, Table table, List<String> partitionNames) {
         if (partitionNames != null && partitionNames.size() > 1) {
             cacheUpdateProcessor.ifPresent(processor -> processor.refreshPartition(table, partitionNames));
         } else {
-            cacheUpdateProcessor.ifPresent(processor -> processor.refreshTable(dbName, tableName, table));
+            cacheUpdateProcessor.ifPresent(processor -> processor.refreshTable(srDbName, table));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -160,7 +160,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
             Table table = tablePair.second;
             if (!table.isLocalTable()) {
                 context.getCtx().getGlobalStateMgr().getMetadataMgr().refreshTable(baseTableInfo.getCatalogName(),
-                        baseTableInfo.getDbName(), baseTableInfo.getTableName(), table, Lists.newArrayList());
+                        baseTableInfo.getDbName(), table, Lists.newArrayList());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -3091,7 +3091,7 @@ public class GlobalStateMgr {
             catalogName = hmsTable.getCatalogName();
         }
 
-        metadataMgr.refreshTable(catalogName, dbName, tblName, table, partitions);
+        metadataMgr.refreshTable(catalogName, dbName, table, partitions);
     }
 
     public void initDefaultCluster() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -319,9 +319,7 @@ public class LocalMetastore implements ConnectorMetadata {
             fullNameToDb.put(db.getFullName(), db);
             stateMgr.getGlobalTransactionMgr().addDatabaseTransactionMgr(db.getId());
             db.getMaterializedViews().forEach(Table::onCreate);
-            if (Config.enable_hms_events_incremental_sync) {
-                db.getHiveTables().forEach(HiveTable::onCreate);
-            }
+            db.getHiveTables().forEach(Table::onCreate);
         }
         LOG.info("finished replay databases from image");
         return newChecksum;

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -144,9 +144,9 @@ public class MetadataMgr {
         return ImmutableList.copyOf(files.build());
     }
 
-    public void refreshTable(String catalogName, String dbName, String tableName, Table table, List<String> partitionNames) {
+    public void refreshTable(String catalogName, String srDbName, Table table, List<String> partitionNames) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
-        connectorMetadata.ifPresent(metadata -> metadata.refreshTable(dbName, tableName, table, partitionNames));
+        connectorMetadata.ifPresent(metadata -> metadata.refreshTable(srDbName, table, partitionNames));
     }
 
     private class QueryMetadatas {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -3,6 +3,7 @@
 package com.starrocks.connector;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Column;
@@ -18,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.starrocks.connector.PartitionUtil.createPartitionKey;
@@ -86,5 +88,13 @@ public class PartitionUtilTest {
                 partitionValues, Optional.of(partitionNames));
         Assert.assertEquals("HivePartitionName{databaseName='db', tableName='table'," +
                 " partitionValues=[1, 2, 3], partitionNames=Optional[a=1/b=2/c=3]}", hivePartitionName.toString());
+
+        Map<String, String> partitionColToValue = Maps.newHashMap();
+        partitionColToValue.put("k1", "1");
+        Assert.assertEquals("k1=1", PartitionUtil.toHivePartitionName(partitionColToValue));
+
+        partitionColToValue.put("k3", "c");
+        Assert.assertEquals("k1=1/k3=c", PartitionUtil.toHivePartitionName(partitionColToValue));
     }
+
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
adjust https://github.com/StarRocks/starrocks/pull/12569
1. Every catalog or resource mapping catalog can pull hive metastore events by set "enable_hms_events_incremental_sync" in fe.conf or catalog properties to ture.  
2. support to process ALTER_PARTITION/ALTER_TABLE/DROP_PARTITION/DROP_TABLE event. Because we disable list partition names cache, we don't handle ADD_PARTITION  event.
3. hive external table with resource couldn't process schema change when receiving ALTER_TABLE event.

ref https://github.com/StarRocks/starrocks/issues/11349
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
