### PR TITLE
[BugFix] intersect_count must use add_aggregate_mapping_variadic to register for nullable arguments

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
@@ -17,7 +17,7 @@ struct HLLUnionBuilder {
                     "hll_raw", false, AggregateFactory::MakeHllRawAggregateFunction<pt>());
 
             using IntersectCountState = BitmapIntersectAggregateState<BitmapRuntimeCppType<pt>>;
-            resolver->add_aggregate_mapping<pt, TYPE_BIGINT, IntersectCountState>(
+            resolver->add_aggregate_mapping_variadic<pt, TYPE_BIGINT, IntersectCountState>(
                     "intersect_count", false, AggregateFactory::MakeIntersectCountAggregateFunction<pt>());
 
             resolver->add_aggregate_mapping<pt, TYPE_BIGINT, HyperLogLog>(


### PR DESCRIPTION
…egister for nullable arguments

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
https://github.com/StarRocks/StarRocksTest/issues/1375
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
