### PR TITLE
[cherry-pick][branch-2.1][BugFix] Column_from_field_type not support array, use column_from_field.

### DIFF
--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -150,9 +150,9 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
         //                                                        &_is_asc_order, &_is_null_first, _offset, _limit,
         //                                                        SIZE_OF_CHUNK_FOR_TOPN);
         // } else {
-            _chunks_sorter = std::make_unique<ChunksSorterTopn>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                &_is_asc_order, &_is_null_first, _offset, _limit,
-                                                                SIZE_OF_CHUNK_FOR_TOPN);
+        _chunks_sorter =
+                std::make_unique<ChunksSorterTopn>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order,
+                                                   &_is_null_first, _offset, _limit, SIZE_OF_CHUNK_FOR_TOPN);
         // }
 
     } else {

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -218,6 +218,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
         }
     }
 
+    auto read_column_schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema, read_column_ids);
     std::vector<std::unique_ptr<vectorized::Column>> read_columns(read_column_ids.size());
     size_t num_segments = rowset->num_segments();
     _parital_update_states.resize(num_segments);
@@ -225,9 +226,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
         _parital_update_states[i].write_columns.resize(read_columns.size());
         _parital_update_states[i].src_rss_rowids.resize(_upserts[i]->size());
         for (uint32_t j = 0; j < read_columns.size(); ++j) {
-            const auto read_column_id = read_column_ids[j];
-            auto tablet_column = tablet_schema.column(read_column_id);
-            auto column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+            const auto column = ChunkHelper::column_from_field(*read_column_schema.field(j));
             read_columns[j] = column->clone_empty();
             _parital_update_states[i].write_columns[j] = column->clone_empty();
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10274