### PR TITLE
[BugFix] BE crashes on illegal JSON

### DIFF
--- a/be/src/exec/vectorized/json_parser.cpp
+++ b/be/src/exec/vectorized/json_parser.cpp
@@ -19,7 +19,6 @@ Status JsonDocumentStreamParser::parse(uint8_t* data, size_t len, size_t allocat
 
         _doc_stream_itr = _doc_stream.begin();
 
-
     } catch (simdjson::simdjson_error& e) {
         auto err_msg = strings::Substitute("Failed to parse json as document stream. error: $0",
                                            simdjson::error_message(e.error()));

--- a/be/src/exec/vectorized/json_parser.h
+++ b/be/src/exec/vectorized/json_parser.h
@@ -38,8 +38,6 @@ public:
 private:
     uint8_t* _data = nullptr;
     size_t _len = 0;
-    // _off records offset when the parser get failure.
-    size_t _off = 0;
 
     // data is parsed as a document stream.
 

--- a/be/src/exec/vectorized/json_parser.h
+++ b/be/src/exec/vectorized/json_parser.h
@@ -70,9 +70,6 @@ public:
     std::string left_bytes_string() noexcept override;
 
 private:
-    uint8_t* _data = nullptr;
-    size_t _len = 0;
-
     // data is parsed as a document in array type.
     simdjson::ondemand::document _doc;
 

--- a/be/src/exec/vectorized/json_parser.h
+++ b/be/src/exec/vectorized/json_parser.h
@@ -18,7 +18,7 @@ public:
     // next forwards the inner iterator.
     virtual Status advance() noexcept = 0;
     // left_bytes_string returns bytes not parsed in std:string.
-    virtual std::string left_bytes_string() noexcept = 0;
+    virtual std::string left_bytes_string(size_t sz) noexcept = 0;
 
 protected:
     simdjson::ondemand::parser* const _parser;
@@ -33,7 +33,7 @@ public:
     Status parse(uint8_t* data, size_t len, size_t allocated) noexcept override;
     Status get_current(simdjson::ondemand::object* row) noexcept override;
     Status advance() noexcept override;
-    std::string left_bytes_string() noexcept override;
+    std::string left_bytes_string(size_t sz) noexcept override;
 
 private:
     uint8_t* _data = nullptr;
@@ -67,7 +67,7 @@ public:
     Status parse(uint8_t* data, size_t len, size_t allocated) noexcept override;
     Status get_current(simdjson::ondemand::object* row) noexcept override;
     Status advance() noexcept override;
-    std::string left_bytes_string() noexcept override;
+    std::string left_bytes_string(size_t sz) noexcept override;
 
 private:
     // data is parsed as a document in array type.

--- a/be/src/exec/vectorized/json_parser.h
+++ b/be/src/exec/vectorized/json_parser.h
@@ -17,6 +17,8 @@ public:
     virtual Status get_current(simdjson::ondemand::object* row) noexcept = 0;
     // next forwards the inner iterator.
     virtual Status advance() noexcept = 0;
+    // left_bytes_string returns bytes not parsed in std:string.
+    virtual std::string left_bytes_string() noexcept = 0;
 
 protected:
     simdjson::ondemand::parser* const _parser;
@@ -31,8 +33,14 @@ public:
     Status parse(uint8_t* data, size_t len, size_t allocated) noexcept override;
     Status get_current(simdjson::ondemand::object* row) noexcept override;
     Status advance() noexcept override;
+    std::string left_bytes_string() noexcept override;
 
 private:
+    uint8_t* _data = nullptr;
+    size_t _len = 0;
+    // _off records offset when the parser get failure.
+    size_t _off = 0;
+
     // data is parsed as a document stream.
 
     // iterator context for document stream.
@@ -59,8 +67,12 @@ public:
     Status parse(uint8_t* data, size_t len, size_t allocated) noexcept override;
     Status get_current(simdjson::ondemand::object* row) noexcept override;
     Status advance() noexcept override;
+    std::string left_bytes_string() noexcept override;
 
 private:
+    uint8_t* _data = nullptr;
+    size_t _len = 0;
+
     // data is parsed as a document in array type.
     simdjson::ondemand::document _doc;
 

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -28,6 +28,7 @@
 namespace starrocks::vectorized {
 
 const int64_t MAX_ERROR_LINES_IN_FILE = 50;
+const int64_t MAX_ERROR_LOG_LENGTH = 64;
 
 JsonScanner::JsonScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
                          ScannerCounter* counter)
@@ -446,8 +447,9 @@ Status JsonReader::_read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_
                 return st;
             }
             _counter->num_rows_filtered++;
-            _state->append_error_msg_to_file(fmt::format("not parsed: {}", parser->left_bytes_string()),
-                                             st.to_string());
+            _state->append_error_msg_to_file(
+                    fmt::format("parser current location: {}", parser->left_bytes_string(MAX_ERROR_LOG_LENGTH)),
+                    st.to_string());
             return st;
         }
         size_t chunk_row_num = chunk->num_rows();

--- a/be/src/exec/vectorized/json_scanner.cpp
+++ b/be/src/exec/vectorized/json_scanner.cpp
@@ -446,7 +446,8 @@ Status JsonReader::_read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_
                 return st;
             }
             _counter->num_rows_filtered++;
-            _state->append_error_msg_to_file("", st.to_string());
+            _state->append_error_msg_to_file(fmt::format("not parsed: {}", parser->left_bytes_string()),
+                                             st.to_string());
             return st;
         }
         size_t chunk_row_num = chunk->num_rows();

--- a/be/test/exec/vectorized/json_parser_test.cpp
+++ b/be/test/exec/vectorized/json_parser_test.cpp
@@ -414,7 +414,7 @@ PARALLEL_TEST(JsonParserTest, test_illegal_document_stream) {
 
 PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
     // json array with ' ', '/t', '\n'
-    std::string input = R"( [  {"key1": 1}, {"key2": 2},    {"key3": 3},
+    std::string input = R"( [  {"key1": 1}, "key2": 2},    {"key3": 3},
     {"key4": 4}])";
     // Reserved for simdjson padding.
     auto size = input.size();
@@ -436,38 +436,13 @@ PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
     int64_t val = row.find_field("key1").get_int64();
     ASSERT_EQ(val, 1);
 
-    // double get.
-    st = parser->get_current(&row);
-    ASSERT_TRUE(st.ok());
-    val = row.find_field("key1").get_int64();
-    ASSERT_EQ(val, 1);
-
     st = parser->advance();
     ASSERT_TRUE(st.ok());
 
     st = parser->get_current(&row);
-    ASSERT_TRUE(st.ok());
-    val = row.find_field("key2").get_int64();
-    ASSERT_EQ(val, 2);
-
-    st = parser->advance();
-    ASSERT_TRUE(st.ok());
-
-    st = parser->get_current(&row);
-    ASSERT_TRUE(st.ok());
-    val = row.find_field("key3").get_int64();
-    ASSERT_EQ(val, 3);
-
-    st = parser->advance();
-    ASSERT_TRUE(st.ok());
-
-    st = parser->get_current(&row);
-    ASSERT_TRUE(st.ok());
-    val = row.find_field("key4").get_int64();
-    ASSERT_EQ(val, 4);
-
-    st = parser->advance();
-    ASSERT_TRUE(st.is_end_of_file());
+    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_STREQ(parser->left_bytes_string().data(), R"("key2": 2},    {"key3": 3},
+    {"key4": 4}])");
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/exec/vectorized/json_parser_test.cpp
+++ b/be/test/exec/vectorized/json_parser_test.cpp
@@ -381,4 +381,93 @@ PARALLEL_TEST(JsonParserTest, test_expanded_json_array_parser_with_jsonroot) {
     ASSERT_TRUE(st.is_end_of_file());
 }
 
+PARALLEL_TEST(JsonParserTest, test_illegal_document_stream) {
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key1": 1} "key2": 2}    {"key3": 3}
+    {"key4": 4})";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
+
+    auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_STREQ(parser->left_bytes_string().data(), R"("key2": 2}    {"key3": 3}
+    {"key4": 4})");
+}
+
+PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
+    // json array with ' ', '/t', '\n'
+    std::string input = R"( [  {"key1": 1}, {"key2": 2},    {"key3": 3},
+    {"key4": 4}])";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonArrayParser(&simdjson_parser));
+
+    auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
+
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    // double get.
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key2").get_int64();
+    ASSERT_EQ(val, 2);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key3").get_int64();
+    ASSERT_EQ(val, 3);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key4").get_int64();
+    ASSERT_EQ(val, 4);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.is_end_of_file());
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/exec/vectorized/json_parser_test.cpp
+++ b/be/test/exec/vectorized/json_parser_test.cpp
@@ -408,7 +408,7 @@ PARALLEL_TEST(JsonParserTest, test_illegal_document_stream) {
 
     st = parser->get_current(&row);
     ASSERT_TRUE(st.is_data_quality_error());
-    ASSERT_STREQ(parser->left_bytes_string().data(), R"("key2": 2}    {"key3": 3}
+    ASSERT_STREQ(parser->left_bytes_string(64).data(), R"("key2": 2}    {"key3": 3}
     {"key4": 4})");
 }
 
@@ -441,7 +441,7 @@ PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
 
     st = parser->get_current(&row);
     ASSERT_TRUE(st.is_data_quality_error());
-    ASSERT_STREQ(parser->left_bytes_string().data(), R"("key2": 2},    {"key3": 3},
+    ASSERT_STREQ(parser->left_bytes_string(64).data(), R"("key2": 2},    {"key3": 3},
     {"key4": 4}])");
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/12816

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When the input is invalid JSON, like `{"key": 1} "key": 2}`, the 2nd document would not be parsed successfully. In order to get the context that leads the parsing failure, we use `JsonFunctions::to_json_string(doc)` to print the content of the doc. But for doc that is not parsed successfully, the  `JsonFunctions::to_json_string(doc)` would lead the BE crash.
This PR removes the printing of not parsed doc. The BE would record the current parsed location, and print the not-parsed content to the error log. In this way, not only the bug leading the crash would be resolved, but also the user is easier to get to know the error in the json input.
Besides, this PR would not change the behavior of the SR. It would modify the error message and adds more content to the error log file.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
