### PR TITLE
[BugFix] fix some problems when be exits gracefully

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -826,6 +826,13 @@ install(FILES
     ${BASE_DIR}/../conf/log4j.properties
     DESTINATION ${OUTPUT_DIR}/conf)
 
+message(${CMAKE_BUILD_TYPE})
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN" OR "${CMAKE_BUILD_TYPE}" STREQUAL "LSAN")
+install(FILES
+    ${BASE_DIR}/../conf/asan_suppressions.conf
+    DESTINATION ${OUTPUT_DIR}/conf)
+endif()
+
 install(DIRECTORY
     ${BASE_DIR}/../webroot/be/
     DESTINATION ${OUTPUT_DIR}/www)

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -826,7 +826,6 @@ install(FILES
     ${BASE_DIR}/../conf/log4j.properties
     DESTINATION ${OUTPUT_DIR}/conf)
 
-message(${CMAKE_BUILD_TYPE})
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN" OR "${CMAKE_BUILD_TYPE}" STREQUAL "LSAN")
 install(FILES
     ${BASE_DIR}/../conf/asan_suppressions.conf

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -60,6 +60,8 @@ public:
 
     void init_or_die();
 
+    void stop();
+
     void submit_tasks(TAgentResult& agent_result, const std::vector<TAgentTaskRequest>& tasks);
 
     void make_snapshot(TAgentResult& agent_result, const TSnapshotRequest& snapshot_request);
@@ -212,7 +214,7 @@ void AgentServer::Impl::init_or_die() {
 #undef CREATE_AND_START_POOL
 }
 
-AgentServer::Impl::~Impl() {
+void AgentServer::Impl::stop() {
     _thread_pool_publish_version->shutdown();
     _thread_pool_drop->shutdown();
     _thread_pool_create_tablet->shutdown();
@@ -243,6 +245,8 @@ AgentServer::Impl::~Impl() {
     STOP_POOL(REPORT_WORKGROUP, _report_workgroup_workers);
 #undef STOP_POOL
 }
+
+AgentServer::Impl::~Impl() {}
 
 // TODO(lingbin): each task in the batch may have it own status or FE must check and
 // resend request when something is wrong(BE may need some logic to guarantee idempotence.
@@ -550,6 +554,10 @@ ThreadPool* AgentServer::get_thread_pool(int type) const {
 
 void AgentServer::init_or_die() {
     return _impl->init_or_die();
+}
+
+void AgentServer::stop() {
+    return _impl->stop();
 }
 
 } // namespace starrocks

--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -46,6 +46,8 @@ public:
 
     void init_or_die();
 
+    void stop();
+
     void submit_tasks(TAgentResult& agent_result, const std::vector<TAgentTaskRequest>& tasks);
 
     void make_snapshot(TAgentResult& agent_result, const TSnapshotRequest& snapshot_request);

--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -290,6 +290,9 @@ void* my_malloc(size_t size) __THROW {
 
 // free
 void my_free(void* p) __THROW {
+    if (UNLIKELY(p == nullptr)) {
+        return;
+    }
     MEMORY_RELEASE_PTR(p);
     STARROCKS_FREE(p);
 }
@@ -352,6 +355,9 @@ void* my_calloc(size_t n, size_t size) __THROW {
 }
 
 void my_cfree(void* ptr) __THROW {
+    if (UNLIKELY(ptr == nullptr)) {
+        return;
+    }
     MEMORY_RELEASE_PTR(ptr);
     STARROCKS_CFREE(ptr);
 }

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -33,6 +33,7 @@
 #include <curl/curl.h>
 #include <thrift/TOutput.h>
 
+#include "agent/agent_server.h"
 #include "agent/heartbeat_server.h"
 #include "agent/status.h"
 #include "common/config.h"
@@ -316,6 +317,7 @@ int main(int argc, char** argv) {
     heartbeat_thrift_server->stop();
     heartbeat_thrift_server->join();
 
+    exec_env->agent_server()->stop();
     engine->stop();
     delete engine;
     starrocks::ExecEnv::destroy(exec_env);

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -109,10 +109,11 @@ StorageEngine::~StorageEngine() {
     if (_s_instance == this) {
         _s_instance = _p_instance;
     }
-#endif
+#else
     if (_s_instance != nullptr) {
         _s_instance = nullptr;
     }
+#endif
 }
 
 void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -110,6 +110,9 @@ StorageEngine::~StorageEngine() {
         _s_instance = _p_instance;
     }
 #endif
+    if (_s_instance != nullptr) {
+        _s_instance = nullptr;
+    }
 }
 
 void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -126,6 +126,7 @@ fi
 export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true"
 # enable coredump when BE build with ASAN
 export ASAN_OPTIONS=abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
+export LSAN_OPTIONS=suppressions=${STARROCKS_HOME}/conf/asan_suppressions.conf
 
 # Prevent JVM from handling any internally or externally generated signals.
 # Otherwise, JVM will overwrite the signal handlers for SIGINT and SIGTERM.

--- a/build.sh
+++ b/build.sh
@@ -358,6 +358,9 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_HOME}/be/output/conf/cn.conf ${STARROCKS_OUTPUT}/be/conf/
     cp -r -p ${STARROCKS_HOME}/be/output/conf/hadoop_env.sh ${STARROCKS_OUTPUT}/be/conf/
     cp -r -p ${STARROCKS_HOME}/be/output/conf/log4j.properties ${STARROCKS_OUTPUT}/be/conf/
+    if [ "${BUILD_TYPE}" == "ASAN" ]; then
+        cp -r -p ${STARROCKS_HOME}/be/output/conf/asan_suppressions.conf ${STARROCKS_OUTPUT}/be/conf/
+    fi
     cp -r -p ${STARROCKS_HOME}/be/output/lib/* ${STARROCKS_OUTPUT}/be/lib/
     cp -r -p ${STARROCKS_HOME}/be/output/www/* ${STARROCKS_OUTPUT}/be/www/
     cp -r -p ${STARROCKS_HOME}/be/output/udf/*.a ${STARROCKS_OUTPUT}/udf/lib/

--- a/conf/asan_suppressions.conf
+++ b/conf/asan_suppressions.conf
@@ -1,0 +1,2 @@
+# This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+leak:brpc

--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -1,3 +1,5 @@
+# This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
 # log configuration for jars called via JNI in BE
 # Because there are almost no other logs except jdbc bridge now, so it's enough to only output to stdout.
 # If necessary, we can add special log files later


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12815 #12838 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`ExecEnv`, `StorageEngine` and `AgentServer` have complex dependencies, some threads in AgentServer need to access `StorageEngine::instance()`, we should make sure the lifetime of StorageEngine is longer than these threads, so I add a stop method into `AgentServer` to release resources which will be invoked before deleting `StorageEngine`.

After I fixed the above issue, a memory leak of brpc was detected by ASAN(I mentioned it in the comment of #12815 ), but from the comments of brpc's code, this leak is expected, so I add `asan_supressions.conf` to filter it out.
![image](https://user-images.githubusercontent.com/3675229/199476165-c0d2b443-c3ea-4a75-93d0-6e194ac07e13.png)

The above problem of memory access errors may cause jemalloc calls to appear on the coredump stack. In addition, I found that when the process exits, in some cases, `nullptr` may be passed to `my_free` function, which will cause coredump when calling `je_malloc_usable_size`, I don't know where the root case is yet, but  a special check for `nullptr` can avoid this problem.



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
