### PR TITLE
[Cherry-Pick-2.2][Enhancement] Add more safe lock function to Database

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -2716,6 +2716,9 @@ public class Catalog {
     public void unprotectCreateDb(Database db) {
         idToDb.put(db.getId(), db);
         fullNameToDb.put(db.getFullName(), db);
+        db.writeLock();
+        db.setExist(true);
+        db.writeUnlock();
         final Cluster cluster = nameToCluster.get(db.getClusterName());
         cluster.addDb(db.getFullName(), db.getId());
         globalTransactionMgr.addDatabaseTransactionMgr(db.getId());
@@ -2810,6 +2813,7 @@ public class Catalog {
                 } else {
                     Catalog.getCurrentCatalog().onEraseDatabase(db.getId());
                 }
+                db.setExist(false);
             } finally {
                 db.writeUnlock();
             }
@@ -2876,6 +2880,7 @@ public class Catalog {
                 } else {
                     Catalog.getCurrentCatalog().onEraseDatabase(db.getId());
                 }
+                db.setExist(false);
             } finally {
                 db.writeUnlock();
             }
@@ -2912,6 +2917,9 @@ public class Catalog {
 
             fullNameToDb.put(db.getFullName(), db);
             idToDb.put(db.getId(), db);
+            db.writeLock();
+            db.setExist(true);
+            db.writeUnlock();
             final Cluster cluster = nameToCluster.get(db.getClusterName());
             cluster.addDb(db.getFullName(), db.getId());
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [x] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Many places call db.writeLock after getting db from catalog, and then write bdb log. But the db may be dropped in the process of writing bdb log, which will cause the NPE error when replay bdb log. To solve this problem, add an exist flag to mark whether db is dropped, and users can only obtain the lock when this flag is true. 
This PR only add the new lock functions. Subsequent PRs will change the operational logic of the upper layers.
In the future, only a few scenes can get the lock without checking whether the db is dropped, and the others should call the newly added function to get the lock.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
