### PR TITLE
[Enhancement] Flush l0 when index file large in case of the l0 index file keep growing.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -869,7 +869,9 @@ CONF_Int64(block_cache_block_size, "1048576");  // 1MB
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 CONF_Bool(block_cache_checksum_enable, "true");
 
-CONF_mInt64(l0_l1_merge_ratio, "10");
+CONF_Double(l0_l1_merge_ratio, "0.1");
+CONF_Int64(flush_or_merge_compaction_l0_max_version, "10000");
+CONF_Int64(flush_or_merge_compaction_l0_max_file_size, "2147483648"); // 2GB
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -869,9 +869,8 @@ CONF_Int64(block_cache_block_size, "1048576");  // 1MB
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 CONF_Bool(block_cache_checksum_enable, "true");
 
-CONF_Double(l0_l1_merge_ratio, "0.1");
-CONF_Int64(flush_or_merge_compaction_l0_max_version, "10000");
-CONF_Int64(flush_or_merge_compaction_l0_max_file_size, "2147483648"); // 2GB
+CONF_mInt64(l0_l1_merge_ratio, "10");
+CONF_mInt64(flush_l0_max_file_size, "209715200"); // 200MB
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -870,7 +870,7 @@ CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 CONF_Bool(block_cache_checksum_enable, "true");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
-CONF_mInt64(flush_l0_max_file_size, "209715200"); // 200MB
+CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2659,7 +2659,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
         _flushed = true;
         RETURN_IF_ERROR(_flush_l0());
     } else {
-        _dump_snapshot |= _l0->file_size() > config::flush_l0_max_file_size;
+        _dump_snapshot |= _l0->file_size() > config::l0_max_file_size;
     }
     // for case1 and case2
     if (_flushed) {

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2641,7 +2641,26 @@ Status PersistentIndex::abort() {
 // case4 will append wals into l0 file
 Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
     DCHECK_EQ(index_meta->key_size(), _key_size);
-    RETURN_IF_ERROR(_check_and_flush_l0());
+    // check if _l0 need be flush, there are two conditions:
+    //   1. _l1 is not exist, _flush_l0 and build _l1
+    //   2. _l1 is exist, merge _l0 and _l1
+    // rebuild _l0 and _l1
+    // In addition, there may be I/O waste because we append wals firstly and do _flush_l0 or _merge_compaction.
+    const auto l0_mem_size = _l0->memory_usage();
+    uint64_t l1_file_size = _l1 ? _l1->file_size() : 0;
+    // if l1 is not empty, and l0 memory usage is large enough,
+    if (l1_file_size != 0 && l0_mem_size * config::l0_l1_merge_ratio > l1_file_size) {
+        _flushed = true;
+        // do l0 l1 merge compaction
+        RETURN_IF_ERROR(_merge_compaction());
+        // if l1 is empty, l0 memory usage is large enough
+    } else if (l1_file_size == 0 && l0_mem_size > kL0SnapshotSizeMax) {
+        // do flush l0
+        _flushed = true;
+        RETURN_IF_ERROR(_flush_l0());
+    } else {
+        _dump_snapshot |= _l0->file_size() > config::flush_l0_max_file_size;
+    }
     // for case1 and case2
     if (_flushed) {
         // update PersistentIndexMetaPB
@@ -2811,40 +2830,6 @@ Status PersistentIndex::_reload(const PersistentIndexMetaPB& index_meta) {
         LOG(WARNING) << "reload persistent index failed, status: " << st.to_string();
     }
     return st;
-}
-
-// check if _l0 need be flush, if not, return directly
-// if _l0 need be flush, there are two conditions:
-//   1. _l1 is not exist, _flush_l0 and build _l1
-//   2. _l1 is exist, merge _l0 and _l1
-// rebuild _l0 and _l1
-// In addition, there may be I/O waste because we append wals firstly and
-// do _flush_l0 or _merge_compaction.
-Status PersistentIndex::_check_and_flush_l0() {
-    const auto l0_mem_size = _l0->memory_usage();
-    uint64_t l1_file_size = 0;
-    if (_l1 != nullptr) {
-        _l1->file_size(&l1_file_size);
-    }
-    // if l1 is empty,
-    if (l1_file_size == 0) {
-        // and l0 memory usage is large enough or the l0 file size is large enough
-        if (l0_mem_size > kL0SnapshotSizeMax || _l0->file_size() > config::flush_l0_max_file_size) {
-            _flushed = true;
-            // do flush l0
-            RETURN_IF_ERROR(_flush_l0());
-        }
-    } else {
-        // else if l1 is not empty,
-        // and l0 memory usage is large enough or the l0 file size is large enough
-        if (l0_mem_size * config::l0_l1_merge_ratio > l1_file_size ||
-            _l0->file_size() > config::flush_l0_max_file_size) {
-            _flushed = true;
-            // do l0 l1 merge compaction
-            RETURN_IF_ERROR(_merge_compaction());
-        }
-    }
-    return Status::OK();
 }
 
 size_t PersistentIndex::_dump_bound() {

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2641,7 +2641,7 @@ Status PersistentIndex::abort() {
 // case4 will append wals into l0 file
 Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
     DCHECK_EQ(index_meta->key_size(), _key_size);
-    RETURN_IF_ERROR(_check_and_flush_l0(index_meta));
+    RETURN_IF_ERROR(_check_and_flush_l0());
     // for case1 and case2
     if (_flushed) {
         // update PersistentIndexMetaPB
@@ -2820,7 +2820,7 @@ Status PersistentIndex::_reload(const PersistentIndexMetaPB& index_meta) {
 // rebuild _l0 and _l1
 // In addition, there may be I/O waste because we append wals firstly and
 // do _flush_l0 or _merge_compaction.
-Status PersistentIndex::_check_and_flush_l0(PersistentIndexMetaPB* index_meta) {
+Status PersistentIndex::_check_and_flush_l0() {
     const auto l0_mem_size = _l0->memory_usage();
     uint64_t l1_file_size = 0;
     if (_l1 != nullptr) {
@@ -2828,36 +2828,21 @@ Status PersistentIndex::_check_and_flush_l0(PersistentIndexMetaPB* index_meta) {
     }
     // if l1 is empty,
     if (l1_file_size == 0) {
-        // and l0 memory usage is not large enough,
-        if (l0_mem_size <= kL0SnapshotSizeMax) {
-            // not flush to l1
-            return Status::OK();
+        // and l0 memory usage is large enough or the l0 file size is large enough
+        if (l0_mem_size > kL0SnapshotSizeMax || _l0->file_size() > config::flush_l0_max_file_size) {
+            _flushed = true;
+            // do flush l0
+            RETURN_IF_ERROR(_flush_l0());
         }
     } else {
-        // if l1 is not empty,
-        // and l0 memory usage is not large enough,
-        if (static_cast<double>(l0_mem_size) / l1_file_size <= config::l0_l1_merge_ratio) {
-            // and the accumulated version is not large enough,
-            if (_version.major() - index_meta->l0_meta().snapshot().version().major() <=
-                config::flush_or_merge_compaction_l0_max_version) {
-                uint64_t l0_file_size = _l0->file_size();
-                // and the l0 file size is not large enough,
-                if (l0_file_size <= config::flush_or_merge_compaction_l0_max_file_size) {
-                    // do not perform l0 l1 merge compaction
-                    return Status::OK();
-                } else {
-                    // should not be here normally, frequently, so log it.
-                    LOG(WARNING) << "l0 large file appeared, size=" << l0_file_size;
-                }
-            }
+        // else if l1 is not empty,
+        // and l0 memory usage is large enough or the l0 file size is large enough
+        if (l0_mem_size * config::l0_l1_merge_ratio > l1_file_size ||
+            _l0->file_size() > config::flush_l0_max_file_size) {
+            _flushed = true;
+            // do l0 l1 merge compaction
+            RETURN_IF_ERROR(_merge_compaction());
         }
-    }
-
-    _flushed = true;
-    if (_l1 == nullptr) {
-        RETURN_IF_ERROR(_flush_l0());
-    } else {
-        RETURN_IF_ERROR(_merge_compaction());
     }
     return Status::OK();
 }

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -190,6 +190,14 @@ public:
 
     Status init();
 
+    uint64_t file_size() {
+        if (_index_file != nullptr) {
+            return _index_file->size();
+        } else {
+            return 0;
+        }
+    }
+
     // batch get
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
@@ -530,7 +538,7 @@ private:
 
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version);
 
-    Status _check_and_flush_l0();
+    Status _check_and_flush_l0(PersistentIndexMetaPB* index_meta);
 
     Status _flush_l0();
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -538,7 +538,7 @@ private:
 
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version);
 
-    Status _check_and_flush_l0(PersistentIndexMetaPB* index_meta);
+    Status _check_and_flush_l0();
 
     Status _flush_l0();
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -326,11 +326,13 @@ public:
     Status check_not_exist(size_t n, const Slice* keys, size_t key_size);
 
     // get Immutable index file size;
-    void file_size(uint64_t* file_size) {
+    uint64_t file_size() {
         if (_file != nullptr) {
             auto res = _file->get_size();
             CHECK(res.ok()) << res.status(); // FIXME: no abort
-            *file_size = *res;
+            return *res;
+        } else {
+            return 0;
         }
     }
 
@@ -537,8 +539,6 @@ private:
     bool _can_dump_directly();
 
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version);
-
-    Status _check_and_flush_l0();
 
     Status _flush_l0();
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The L0 index file of primary key persistent index may keep growing, keep appending WAL, this PR add some stricter conditions for not doing flush or merge compaction.