### PR TITLE
[BugFix] fix money_format when the result only has fractional part (backport #6664)

### DIFF
--- a/be/test/exprs/vectorized/string_fn_money_format_decimal_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_money_format_decimal_test.cpp
@@ -47,7 +47,7 @@ void test_money_format_decimal(TestArray const& test_cases, int precision, int s
 
 TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqZero) {
     TestArray test_cases = {
-            {"0", ".00"},
+            {"0", "0.00"},
             {"9999999", "9,999,999.00"},
             {"-999999", "-999,999.00"},
             {"1", "1.00"},
@@ -62,7 +62,7 @@ TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqZero) {
 
 TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqTwo) {
     TestArray test_cases = {
-            {"0", ".00"},
+            {"0", "0.00"},
             {"9999999.99", "9,999,999.99"},
             {"-9999999.99", "-9,999,999.99"},
             {"1.01", "1.01"},
@@ -76,10 +76,9 @@ TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqTwo) {
 }
 
 TEST_F(MoneyFormatDecimalTest, moneyFormatDecimalScaleEqPrecision) {
-    TestArray test_cases = {
-            {"0", ".00"},         {"0.999999999", "1.00"}, {"-0.99", "-.99"},    {"0.000001", ".00"},
-            {"0.1234567", ".12"}, {"-0.101", "-.10"},      {"-0.55555", "-.56"}, {"0.555555", ".56"},
-    };
+    TestArray test_cases = {{"0", "0.00"},         {"0.999999999", "1.00"}, {"-0.99", "-0.99"},
+                            {"0.000001", "0.00"},  {"0.1234567", "0.12"},   {"-0.101", "-0.10"},
+                            {"-0.55555", "-0.56"}, {"0.555555", "0.56"},    {"-0.01", "-0.01"}};
     test_money_format_decimal<TYPE_DECIMAL32>(test_cases, 9, 9);
     test_money_format_decimal<TYPE_DECIMAL64>(test_cases, 18, 18);
     test_money_format_decimal<TYPE_DECIMAL128>(test_cases, 38, 38);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12391 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
