### PR TITLE
[cherry-pick][BugFix][Branch-2.4] Fix primary key table vertical compaction bug (#12797)

### DIFF
--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -285,6 +285,9 @@ private:
                 std::unique_ptr<vector<RowSourceMask>> rowset_source_masks = std::make_unique<vector<RowSourceMask>>();
                 rowsets_source_masks.emplace_back(std::move(rowset_source_masks));
                 entry.source_masks = rowsets_source_masks.back().get();
+            } else if (rowsets_mask_buffer) {
+                std::unique_ptr<vector<RowSourceMask>> rowset_source_masks = std::make_unique<vector<RowSourceMask>>();
+                rowsets_source_masks.emplace_back(std::move(rowset_source_masks));
             }
             entry.order = order++;
             auto st = entry.init();


### PR DESCRIPTION
In vertical compaction of PrimaryKey table, The `rowsets_mask_buffer` parameter should correspond to the rowsets because we use `rowsets_mask_buffer` to determine the order in which subsequent segments are read. And if rowset only has one segment, we should push a emtpy RowSourceMask into `rowsets_mask_buffer` but not skip it, otherwise the misalignment may cause some unexpected error.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/12856

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
