### PR TITLE
[cherry-pick] [branch-2.3] [BugFix] Fix the  delete predicate bug on new added column (#12907)

### DIFF
--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -95,6 +95,9 @@ Status DefaultValueColumnIterator::next_batch(size_t* n, ColumnBlockView* dst, b
         }
     }
     _current_rowid += *n;
+    if (_may_contain_deleted_row) {
+        dst->column_block()->set_delete_state(DEL_PARTIAL_SATISFIED);
+    }
     return Status::OK();
 }
 
@@ -116,6 +119,9 @@ Status DefaultValueColumnIterator::next_batch(size_t* n, vectorized::Column* dst
             dst->append_value_multiple_times(_mem_value, *n);
         }
         _current_rowid += *n;
+    }
+    if (_may_contain_deleted_row) {
+        dst->set_delete_state(DEL_PARTIAL_SATISFIED);
     }
     return Status::OK();
 }
@@ -140,6 +146,9 @@ Status DefaultValueColumnIterator::next_batch(const vectorized::SparseRange& ran
         }
         _current_rowid = range.end();
     }
+    if (_may_contain_deleted_row) {
+        dst->set_delete_state(DEL_PARTIAL_SATISFIED);
+    }
     return Status::OK();
 }
 
@@ -154,6 +163,11 @@ Status DefaultValueColumnIterator::get_row_ranges_by_zone_map(
     DCHECK(row_ranges->empty());
     // TODO
     row_ranges->add({0, static_cast<rowid_t>(_num_rows)});
+    // TODO: Setting `_may_contained_deleted_row` to true is a temporary fix,
+    // which will affect performance in some scenarios.
+    // It is best to filter according to DefaultValue,
+    // but the current Expr framework does not support filter for a single line, which will be added later.
+    _may_contain_deleted_row = true;
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -97,6 +97,7 @@ private:
     // current rowid
     ordinal_t _current_rowid = 0;
     ordinal_t _num_rows = 0;
+    bool _may_contain_deleted_row = false;
 };
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -172,6 +172,7 @@ set(EXEC_FILES
         ./storage/rowset/segment_iterator_test.cpp
         ./storage/rowset/zone_map_index_test.cpp
         ./storage/rowset/unique_rowset_id_generator_test.cpp
+        ./storage/rowset/default_value_column_iterator_test.cpp
         ./storage/rowset/index_page_test.cpp
         ./storage/async_delta_writer_executor_test.cpp
         ./storage/selection_vector_test.cpp

--- a/be/test/storage/rowset/default_value_column_iterator_test.cpp
+++ b/be/test/storage/rowset/default_value_column_iterator_test.cpp
@@ -1,0 +1,47 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "storage/rowset/default_value_column_iterator.h"
+
+#include "column/column_helper.h"
+#include "gtest/gtest.h"
+#include "storage/rowset/column_iterator.h"
+#include "storage/types.h"
+#include "storage/vectorized_column_predicate.h"
+
+namespace starrocks::vectorized {
+class DefaultValueColumnIteratorTest : public testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// NOLINTNEXTLINE
+TEST_F(DefaultValueColumnIteratorTest, delete_after_column) {
+    TypeInfoPtr type_info = get_type_info(OLAP_FIELD_TYPE_INT);
+    DefaultValueColumnIterator iter(false, "", true, type_info, 0, 10);
+
+    ColumnIteratorOptions opts;
+    Status st = iter.init(opts);
+    ASSERT_TRUE(st.ok());
+
+    std::vector<const ColumnPredicate*> preds;
+    std::unique_ptr<ColumnPredicate> del_pred(new_column_null_predicate(type_info, 1, true));
+    SparseRange row_ranges;
+    st = iter.get_row_ranges_by_zone_map(preds, del_pred.get(), &row_ranges);
+    ASSERT_TRUE(st.ok());
+
+    TypeDescriptor type_desc(PrimitiveType::TYPE_INT);
+    ColumnPtr column = ColumnHelper::create_column(type_desc, true);
+
+    size_t num_rows = 10;
+    st = iter.next_batch(&num_rows, column.get());
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(column->delete_state(), DEL_PARTIAL_SATISFIED);
+    ASSERT_EQ(num_rows, 10);
+    ASSERT_EQ(column->size(), 10);
+    for (size_t i = 0; i < 10; i++) {
+        ASSERT_TRUE(column->is_null(i));
+    }
+}
+
+} // namespace starrocks::vectorized


### PR DESCRIPTION
If a new column is added, before the compaction is completed, only the metadata is changed, but the data file is not modified. In this way, a DefaultValueIterator will be generated when querying. If the delete involved the newly added column, we will no set column delete state at this time. So the segment iterator will not execute the delete predicate, resulting in incorrect results. In some scenarios, vectical compaction crash will occur.

TODO: Setting _may_contained_deleted_row to true is a temporary fix, which will affect performance in some scenarios. It is best to filter according to DefaultValue, but the current predicate framework does not support filter for a single row, which will be added later.

