### PR TITLE
[Enhancement] Catch unexpected exception when processing column type convert

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
 import com.starrocks.connector.iceberg.StarRocksIcebergException;
 import io.delta.standalone.DeltaLog;
@@ -14,13 +15,16 @@ import io.delta.standalone.types.DataType;
 import io.delta.standalone.types.StructField;
 import io.delta.standalone.types.StructType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-import static com.starrocks.connector.ColumnTypeConverter.fromDeltaLakeType;
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.CONNECTOR_ID_GENERATOR;
 
 public class DeltaUtils {
+    private static final Logger LOG = LogManager.getLogger(DeltaUtils.class);
+
     public static DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
                                                        Configuration configuration) {
         DeltaLog deltaLog = DeltaLog.forTable(configuration, path);
@@ -41,8 +45,14 @@ public class DeltaUtils {
 
         for (StructField field : metadata.getSchema().getFields()) {
             DataType dataType = field.getDataType();
-            Type srType = fromDeltaLakeType(dataType);
-            Column column = new Column(field.getName(), srType, true);
+            Type type;
+            try {
+                type = ColumnTypeConverter.fromDeltaLakeType(dataType);
+            } catch (InternalError | Exception e) {
+                LOG.error("Failed to convert delta type {} on {}.{}.{}", dataType.getTypeName(), catalog, dbName, tblName, e);
+                type = Type.UNKNOWN_TYPE;
+            }
+            Column column = new Column(field.getName(), type, true);
             fullSchema.add(column);
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
After we send "use catalog or catalog or catalog.db" to StarRocks FE from mysql client. The mysql client will continue to send the following requests：

SELECT DATABASE() : get current database from connect context
show databases
show tables;
if current database isn't empty. mysql client will send COM_FIELD_LIST for every table of the current db to get table columns.

If some external tables with the column that sr doesn't support and throw exception. mysql client will hang and keeping resend get table until it return success. So we need to convert column type to UNKNOWN_TYPE once the conversion fails to ensure that mysql client is available.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
