### PR TITLE
[BugFix] Add nest subquery check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -485,8 +485,14 @@ public final class SqlToScalarOperatorTranslator {
                         "Unsupported correlated in predicate subquery with grouping or aggregation");
             }
 
-            ScalarOperator leftColRef = SqlToScalarOperatorTranslator
-                    .translate(node.getChild(0), builder.getExpressionMapping(), columnRefFactory);
+            List<ColumnRefOperator> leftCorrelationColumns = Lists.newArrayList();
+            ScalarOperator leftColRef = SqlToScalarOperatorTranslator.translate(node.getChild(0),
+                    builder.getExpressionMapping(), leftCorrelationColumns, columnRefFactory);
+
+            if (leftCorrelationColumns.size() > 0) {
+                throw new SemanticException("Unsupported complex nested in-subquery");
+            }
+
             List<ColumnRefOperator> rightColRefs = subqueryPlan.getOutputColumn();
             if (rightColRefs.size() > 1) {
                 throw new SemanticException("subquery must return a single column when used in InPredicate");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1757,4 +1757,17 @@ public class SubqueryTest extends PlanTestBase {
             assertNotContains(plan, "ANALYTIC");
         }
     }
+
+    @Test
+    public void testNestSubquery() throws Exception {
+        String sql = "select * from t0 where exists (select * from t1 where t0.v1 in (select v7 from t2));";
+        assertExceptionMessage(sql, "Unsupported complex nested in-subquery");
+
+        sql = "select * from t0 where exists (select * from t1 where t0.v1 = (select v7 from t2));";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "10:HASH JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 10: v7");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12901

should return exception message, not `UNKNOW ERROR` 
```
MySQL td> explain  select * from t0 where exists (select t1.v2 from t1 where t0.v1 in (select t4.v1 from t4 ));
(1064, 'Unsupported complex nested in-subquery')

```


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
