### PR TITLE
[BugFix] [WIP] fix re2 library conflict when staros is ON

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -158,8 +158,18 @@ endif()
 add_library(glog STATIC IMPORTED)
 set_target_properties(glog PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libglog.a)
 
-add_library(re2 STATIC IMPORTED)
-set_target_properties(re2 PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libre2.a)
+
+if ("${USE_STAROS}" STREQUAL "ON")
+    find_package(re2 REQUIRED)
+    get_target_property(re2_INCLUDE_DIR re2::re2 INTERFACE_INCLUDE_DIRECTORIES)
+    message(STATUS "Using staros re2 includes: ${re2_INCLUDE_DIR}")
+    include_directories(${re2_INCLUDE_DIR})
+    set(RE2_RE2 re2::re2)
+else()
+    add_library(re2 STATIC IMPORTED)
+    set_target_properties(re2 PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libre2.a)
+    set(RE2_RE2 re2)
+endif()
 
 add_library(pprof STATIC IMPORTED)
 set_target_properties(pprof PROPERTIES IMPORTED_LOCATION
@@ -602,7 +612,7 @@ set(STARROCKS_DEPENDENCIES
     thrift
     thriftnb
     glog
-    re2
+    ${RE2_RE2}
     pprof
     # Put lz4 in front of librdkafka to make sure that segment use the native lz4 library to compress/decompress page
     # Otherwise, he will use the lz4 Library in librdkafka

--- a/build.sh
+++ b/build.sh
@@ -252,6 +252,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
                     -DgRPC_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/grpc \
                     -Dprometheus-cpp_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/prometheus-cpp \
+                    -Dre2_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/re2  \
                     -Dstarlet_DIR=${STARLET_INSTALL_DIR}/starlet_install/lib64/cmake ..
     else
       ${CMAKE_CMD} -G "${CMAKE_GENERATOR}" \

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -143,6 +143,7 @@ if [ "${USE_STAROS}" == "ON"  ]; then
               -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
               -DgRPC_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/grpc \
               -Dprometheus-cpp_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/prometheus-cpp \
+              -Dre2_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/re2  \
               -Dstarlet_DIR=${STARLET_INSTALL_DIR}/starlet_install/lib64/cmake ..
 else
   ${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \


### PR DESCRIPTION
* when build with staros, there are two paths link to re2 library, 1) starrocks -> re2 (imported starrocks thirdparty) 2) starrocks -> starlet -> grpc -> re2 (cmake starlet thirdparty)

  fix the conflict by using startlet thirdparty re2 library when build with staros, use starrocks its own re2 library otherwise.

Signed-off-by: Kevin Xiaohua Cai <caixiaohua@starrocks.com>

## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
