### PR TITLE
[BugFix] support subfiled decimal type for map

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1321,6 +1321,11 @@ static void _try_implicit_cast(TypeDescriptor* from, const TypeDescriptor& to) {
     PrimitiveType t2 = to.type;
     if (t1 == TYPE_ARRAY && t2 == TYPE_ARRAY) {
         _try_implicit_cast(&from->children[0], to.children[0]);
+    } else if (t1 == TYPE_MAP && t2 == TYPE_MAP) {
+        DCHECK(from->children.size() == 2);
+        DCHECK(to.children.size() == 2);
+        _try_implicit_cast(&from->children[0], to.children[0]);
+        _try_implicit_cast(&from->children[1], to.children[1]);
     } else if (is_integer_type(t1) && is_integer_type(t2)) {
         from->type = t2;
     } else if (is_decimal_type(t1) && is_decimal_type(t2)) {
@@ -1330,9 +1335,9 @@ static void _try_implicit_cast(TypeDescriptor* from, const TypeDescriptor& to) {
         // violated during creating a DecimalV3Column via ColumnHelper::create(...).
         if (t2 == PrimitiveType::TYPE_DECIMALV2) {
             from->type = t2;
-        } else if (from->precision > decimal_precision_limit<int64_t>) {
+        } else if ((from->precision > decimal_precision_limit<int64_t>)) {
             from->type = PrimitiveType::TYPE_DECIMAL128;
-        } else if (from->precision > decimal_precision_limit<int32_t>) {
+        } else if ((from->precision > decimal_precision_limit<int32_t>) || (to.type == PrimitiveType::TYPE_DECIMAL64)) {
             from->type = PrimitiveType::TYPE_DECIMAL64;
         } else {
             from->type = PrimitiveType::TYPE_DECIMAL32;


### PR DESCRIPTION
We only convert Decimal to Decimal64 or Decimal128 for DLA, 
and ORC will check the precision to decide the src decimal type, so there is a chance the src is Decimal32, and the slot need Decimal64.
But Decimal32 is filled by Decimal64/128 cvb, so if we need the slot type is Decimal64 just let the src type be Decimal64, it will be better. 
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12849 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
