### PR TITLE
[BugFix] Increase default broker_client_timeout.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1593,7 +1593,7 @@ public class Config extends ConfigBase {
      * connection and socket timeout for broker client
      */
     @ConfField
-    public static int broker_client_timeout_ms = 10000;
+    public static int broker_client_timeout_ms = 120000;
 
     /**
      * Unused config field, leave it here for backward compatibility


### PR DESCRIPTION
Increase default broker_client_timeout from 10s to 2min. Get rid of timeout errors when listing directories in S3 or Hadoop.

## What type of PR is this：
- [X ] BugFix

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # directory listing timeout when loading data into Starrocks

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Starrocks get timeout when loading data from S3 or Hadoop. The root reason is, broker get timeout after 10s. This PR increase the default broker timeout to 2min, to get rid of the timeout problem

