### PR TITLE
[BugFix] Notify CoordinatorMonitor for metadata aliveStatus

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -361,6 +361,7 @@ public class ComputeNode implements IComputable, Writable {
      * return true if any port changed, or alive state is changed.
      */
     public boolean handleHbResponse(BackendHbResponse hbResponse, boolean isReplay) {
+        boolean becomeDead = false;
         boolean isChanged = false;
         if (hbResponse.getStatus() == HeartbeatResponse.HbStatus.OK) {
             if (!this.version.equals(hbResponse.getVersion())) {
@@ -418,8 +419,8 @@ public class ComputeNode implements IComputable, Writable {
                 this.heartbeatRetryTimes++;
             } else {
                 if (isAlive.compareAndSet(true, false)) {
-                    CoordinatorMonitor.getInstance().addDeadBackend(id);
-                    LOG.info("{} is dead,", this.toString());
+                    becomeDead = true;
+                    LOG.info("{} is dead due to exceed heartbeatRetryTimes", this);
                 }
                 heartbeatErrMsg = hbResponse.getMsg() == null ? "Unknown error" : hbResponse.getMsg();
                 lastMissingHeartbeatTime = System.currentTimeMillis();
@@ -438,10 +439,19 @@ public class ComputeNode implements IComputable, Writable {
             if (hbResponse.aliveStatus != null) {
                 // The metadata before the upgrade does not contain hbResponse.aliveStatus,
                 // in which case the alive status needs to be handled according to the original logic
-                isAlive.getAndSet(hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE);
+                boolean newIsAlive = hbResponse.aliveStatus == HeartbeatResponse.AliveStatus.ALIVE;
+                if (isAlive.compareAndSet(!newIsAlive, newIsAlive)) {
+                    becomeDead = !newIsAlive;
+                    LOG.info("{} alive status is changed to {}", this, newIsAlive);
+                }
                 heartbeatRetryTimes = 0;
             }
         }
+
+        if (becomeDead) {
+            CoordinatorMonitor.getInstance().addDeadBackend(id);
+        }
+
         return isChanged;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
@@ -4,10 +4,9 @@ package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
-import com.starrocks.planner.PlanFragment;
 import com.starrocks.proto.PPlanFragmentCancelReason;
-import com.starrocks.thrift.TUniqueId;
 import mockit.Expectations;
+import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -18,18 +17,13 @@ import java.util.concurrent.TimeUnit;
 public class CoordinatorMonitorTest {
 
     @Test
-    public void testDeadBackendAndComputeNodeChecker() throws InterruptedException {
+    public void testDeadBackendAndComputeNodeChecker(@Mocked Coordinator coord1,
+                                                     @Mocked Coordinator coord2,
+                                                     @Mocked Coordinator coord3) throws InterruptedException {
         int prevHeartbeatTimeout = Config.heartbeat_timeout_second;
         Config.heartbeat_timeout_second = 1;
 
         try {
-            // Prepare coordinators.
-            ConnectContext connCtx = new ConnectContext();
-            connCtx.setExecutionId(new TUniqueId(0, 0));
-            List<PlanFragment> fragments = ImmutableList.of();
-            Coordinator coord1 = new Coordinator(connCtx, fragments, null, null);
-            Coordinator coord2 = new Coordinator(connCtx, fragments, null, null);
-            Coordinator coord3 = new Coordinator(connCtx, fragments, null, null);
             List<Coordinator> coordinators = ImmutableList.of(coord1, coord2, coord3);
 
             final QeProcessor qeProcessor = QeProcessorImpl.INSTANCE;

--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -1,28 +1,97 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 package com.starrocks.system;
 
+import com.google.common.collect.ImmutableList;
+import com.starrocks.common.Config;
+import com.starrocks.qe.CoordinatorMonitor;
 import com.starrocks.system.HeartbeatResponse.HbStatus;
+import mockit.Expectations;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
+
 public class ComputeNodeTest {
-    
+
     @Test
-    public void testHbStatusBadNeedSync() {
+    public void testHbStatusAliveChanged() {
+
+        class TestCase {
+            final boolean isReplay;
+
+            final HbStatus responseStatus;
+            final HeartbeatResponse.AliveStatus aliveStatus;
+            final boolean nodeAlive;
+
+            final boolean expectedNeedSync;
+            final boolean expectedNeedNotifyCoordinatorMonitor;
+            final boolean expectedAlive;
+
+            public TestCase(boolean isReplay,
+                            HbStatus responseStatus, HeartbeatResponse.AliveStatus aliveStatus,
+                            boolean nodeAlive,
+                            boolean expectedNeedSync, boolean expectedNeedNotifyCoordinatorMonitor,
+                            boolean expectedAlive) {
+                this.isReplay = isReplay;
+                this.responseStatus = responseStatus;
+                this.aliveStatus = aliveStatus;
+                this.nodeAlive = nodeAlive;
+                this.expectedNeedSync = expectedNeedSync;
+                this.expectedNeedNotifyCoordinatorMonitor = expectedNeedNotifyCoordinatorMonitor;
+                this.expectedAlive = expectedAlive;
+            }
+        }
 
         BackendHbResponse hbResponse = new BackendHbResponse();
-        hbResponse.status = HbStatus.BAD;
-
         ComputeNode node = new ComputeNode();
-        boolean needSync = node.handleHbResponse(hbResponse, false);
-        Assert.assertTrue(needSync);
+        node.setBrpcPort(hbResponse.getBrpcPort()); // Don't return needSync by different BrpcPort.
+        CoordinatorMonitor coordinatorMonitor = CoordinatorMonitor.getInstance();
 
-        hbResponse.aliveStatus = HeartbeatResponse.AliveStatus.ALIVE;
-        node.handleHbResponse(hbResponse, true);
-        Assert.assertTrue(node.isAlive());
-        hbResponse.aliveStatus = HeartbeatResponse.AliveStatus.NOT_ALIVE;
-        node.handleHbResponse(hbResponse, true);
-        Assert.assertFalse(node.isAlive());
+        List<TestCase> testCases = ImmutableList.of(
+                new TestCase(false, HbStatus.BAD, null, true, true, true, false),
+                new TestCase(false, HbStatus.BAD, null, false, true, false, false),
+                new TestCase(false, HbStatus.OK, null, true, false, false, true),
+                new TestCase(false, HbStatus.OK, null, false, true, false, true),
+
+                new TestCase(true, HbStatus.BAD, null, true, false, true, false),
+                new TestCase(true, HbStatus.BAD, null, false, false, false, false),
+                new TestCase(true, HbStatus.OK, null, true, false, false, true),
+                new TestCase(true, HbStatus.OK, null, false, false, false, true),
+
+                new TestCase(true, HbStatus.BAD, HeartbeatResponse.AliveStatus.NOT_ALIVE, true, false, true, false),
+                new TestCase(true, HbStatus.BAD, HeartbeatResponse.AliveStatus.NOT_ALIVE, false, false, false, false),
+                new TestCase(true, HbStatus.BAD, HeartbeatResponse.AliveStatus.ALIVE, true, false, false, true),
+                new TestCase(true, HbStatus.BAD, HeartbeatResponse.AliveStatus.ALIVE, false, false, false, true),
+                new TestCase(true, HbStatus.OK, HeartbeatResponse.AliveStatus.ALIVE, true, false, false, true),
+                new TestCase(true, HbStatus.OK, HeartbeatResponse.AliveStatus.ALIVE, false, false, false, true)
+
+        );
+
+        int prevHeartbeatRetryTimes = Config.heartbeat_retry_times;
+        try {
+            Config.heartbeat_retry_times = 0;
+
+            long nextNodeId = 0L;
+            for (TestCase tc : testCases) {
+                hbResponse.status = tc.responseStatus;
+                hbResponse.aliveStatus = tc.aliveStatus;
+                node.setId(nextNodeId++);
+                node.setAlive(tc.nodeAlive);
+                new Expectations(coordinatorMonitor) {
+                    {
+                        coordinatorMonitor.addDeadBackend(node.getId());
+                        times = tc.expectedNeedNotifyCoordinatorMonitor ? 1 : 0;
+                    }
+                };
+                boolean needSync = node.handleHbResponse(hbResponse, tc.isReplay);
+                if (!tc.isReplay) { // Only check needSync for the FE leader.
+                    Assert.assertEquals("nodeId: " + node.getId(), tc.expectedNeedSync, needSync);
+                }
+                Assert.assertEquals("nodeId: " + node.getId(), tc.expectedAlive, node.isAlive());
+            }
+        } finally {
+            Config.heartbeat_retry_times = prevHeartbeatRetryTimes;
+        }
     }
 
     @Test
@@ -33,7 +102,7 @@ public class ComputeNodeTest {
         hbResponse.setRebootTime(1000L);
         ComputeNode node = new ComputeNode();
         boolean needSync = node.handleHbResponse(hbResponse, false);
-        Assert.assertTrue(node.getLastStartTime() == 1000000L);    
+        Assert.assertTrue(node.getLastStartTime() == 1000000L);
         Assert.assertTrue(needSync);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
From version 2.5, the FE leader syncs alive status of BE by a new filed `HeartbeatResponse.AliveStatus` metadata.

However, this new sync logic doesn't notify CoordinatorMonitor.

This modification is already in the branch-2.2/2.3/2.4 (#12954, #12955, #12958).

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
