### PR TITLE
[Enhancement] add privilege collection cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Pair.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Pair.java
@@ -51,11 +51,28 @@ public class Pair<F, S> {
      * A pair is equal if both parts are equal().
      */
     public boolean equals(Object o) {
-        if (o instanceof Pair) {
-            Pair<F, S> other = (Pair<F, S>) o;
-            return this.first.equals(other.first) && this.second.equals(other.second);
+        if (!(o instanceof Pair)) {
+            return false;
         }
-        return false;
+        Pair<F, S> other = (Pair<F, S>) o;
+
+        // compare first
+        if (this.first == null) {
+            if (other.first != null) {
+                return false;
+            }
+        } else {
+            if (! this.first.equals(other.first)) {
+                return false;
+            }
+        }
+
+        // compare second
+        if (this.second == null) {
+            return other.second == null;
+        } else {
+            return this.second.equals(other.second);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/RolePrivilegeCollection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/RolePrivilegeCollection.java
@@ -68,11 +68,13 @@ public class RolePrivilegeCollection extends PrivilegeCollection {
         return (this.mask & flag.mask) != 0;
     }
 
-    public void addParentRole(long parentRoleId) {
+    public void addParentRole(long parentRoleId) throws PrivilegeException {
+        assertMutable();
         parentRoleIds.add(parentRoleId);
     }
 
-    public void removeParentRole(long parentRoleId) {
+    public void removeParentRole(long parentRoleId) throws PrivilegeException {
+        assertMutable();
         parentRoleIds.remove(parentRoleId);
     }
 
@@ -80,13 +82,11 @@ public class RolePrivilegeCollection extends PrivilegeCollection {
         return parentRoleIds;
     }
 
-    public void addSubRole(long subRoleId) throws PrivilegeException {
-        assertMutable();
+    public void addSubRole(long subRoleId) {
         subRoleIds.add(subRoleId);
     }
 
-    public void removeSubRole(long subRoleId) throws PrivilegeException {
-        assertMutable();
+    public void removeSubRole(long subRoleId) {
         subRoleIds.remove(subRoleId);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/RolePrivilegeCollectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/RolePrivilegeCollectionTest.java
@@ -11,7 +11,7 @@ public class RolePrivilegeCollectionTest {
         RolePrivilegeCollection collection = new RolePrivilegeCollection("nolabel");
         Assert.assertFalse(collection.isRemovable());
         try {
-            collection.addSubRole(-1);
+            collection.addParentRole(-1);
             Assert.fail();
         } catch (PrivilegeException e) {
             Assert.assertTrue(e.getMessage().contains("is not mutable"));
@@ -25,7 +25,7 @@ public class RolePrivilegeCollectionTest {
         collection.addSubRole(-1);
         collection.disableMutable();
         try {
-            collection.addSubRole(-1);
+            collection.addParentRole(-1);
             Assert.fail();
         } catch (PrivilegeException e) {
             Assert.assertTrue(e.getMessage().contains("is not mutable"));
@@ -37,7 +37,7 @@ public class RolePrivilegeCollectionTest {
                 RolePrivilegeCollection.RoleFlags.REMOVABLE);
         Assert.assertTrue(collection.isRemovable());
         try {
-            collection.addSubRole(-1);
+            collection.addParentRole(-1);
             Assert.fail();
         } catch (PrivilegeException e) {
             Assert.assertTrue(e.getMessage().contains("is not mutable"));


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Use a cache in PrivilegeManager to avoid constantly merging privilege collections of a user & its roles. All corresponding modifications will lead to the invalidation of certain entries in this cache within corresponding locks.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
