### PR TITLE
[BugFix] fix blocking the in-cancelling exchangeSink resulted from OOM

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -294,12 +294,15 @@ inline const Status& to_status(const StatusOr<T>& st) {
 #define AS_STRING_INTERNAL(x) #x
 #endif
 
-#define RETURN_IF_ERROR_INTERNAL(stmt)                                                                \
-    do {                                                                                              \
-        auto&& status__ = (stmt);                                                                     \
-        if (UNLIKELY(!status__.ok())) {                                                               \
-            return to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
-        }                                                                                             \
+#define RETURN_IF_ERROR_INTERNAL(stmt)                                                                          \
+    do {                                                                                                        \
+        auto&& status__ = (stmt);                                                                               \
+        if (UNLIKELY(!status__.ok())) {                                                                         \
+            auto status___ = to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
+            std::string msg = status___.detailed_message().to_string();                                         \
+            LOG(ERROR) << msg;                                                                                  \
+            return status___;                                                                                   \
+        }                                                                                                       \
     } while (false)
 
 #if defined(ENABLE_STATUS_FAILED)

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -294,15 +294,12 @@ inline const Status& to_status(const StatusOr<T>& st) {
 #define AS_STRING_INTERNAL(x) #x
 #endif
 
-#define RETURN_IF_ERROR_INTERNAL(stmt)                                                                          \
-    do {                                                                                                        \
-        auto&& status__ = (stmt);                                                                               \
-        if (UNLIKELY(!status__.ok())) {                                                                         \
-            auto status___ = to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
-            std::string msg = status___.detailed_message().to_string();                                         \
-            LOG(ERROR) << msg;                                                                                  \
-            return status___;                                                                                   \
-        }                                                                                                       \
+#define RETURN_IF_ERROR_INTERNAL(stmt)                                                                \
+    do {                                                                                              \
+        auto&& status__ = (stmt);                                                                     \
+        if (UNLIKELY(!status__.ok())) {                                                               \
+            return to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
+        }                                                                                             \
     } while (false)
 
 #if defined(ENABLE_STATUS_FAILED)

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -171,9 +171,15 @@ int64_t SinkBuffer::_network_time() {
     return max;
 }
 
-void SinkBuffer::cancel_one_sinker() {
+void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
     if (--_num_uncancelled_sinkers == 0) {
         _is_finishing = true;
+    }
+    if (state != nullptr) {
+        LOG(INFO) << fmt::format(
+                "fragment_instance_id {} -> {}, _num_uncancelled_sinkers {}, _is_finishing {}, _num_remaining_eos {}",
+                print_id(_fragment_ctx->fragment_instance_id()), print_id(state->fragment_instance_id()),
+                _num_uncancelled_sinkers, _is_finishing, _num_remaining_eos);
     }
 }
 

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -81,7 +81,7 @@ public:
 
     // When all the ExchangeSinkOperator shared this SinkBuffer are cancelled,
     // the rest chunk request and EOS request needn't be sent anymore.
-    void cancel_one_sinker();
+    void cancel_one_sinker(RuntimeState* const state);
 
 private:
     using Mutex = bthread::Mutex;

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -151,12 +151,15 @@ Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::goog
     }
 
     bool eos = request.eos();
+    DeferOp op([this, &eos, &recvr, &request]() {
+        if (eos) {
+            recvr->remove_sender(request.sender_id(), request.be_number());
+        }
+    });
     if (request.chunks_size() > 0 || request.use_pass_through()) {
         RETURN_IF_ERROR(recvr->add_chunks(request, eos ? nullptr : done));
     }
-    if (eos) {
-        recvr->remove_sender(request.sender_id(), request.be_number());
-    }
+
     return Status::OK();
 }
 

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -491,6 +491,9 @@ void DataStreamRecvr::PipelineSenderQueue::decrement_senders(int be_number) {
         _sender_eos_set.insert(be_number);
     }
     _num_remaining_senders--;
+    VLOG_FILE << "decremented senders: fragment_instance_id=" << print_id(_recvr->fragment_instance_id())
+              << " node_id=" << _recvr->dest_node_id() << " #senders=" << _num_remaining_senders
+              << " be_number=" << be_number;
 }
 
 void DataStreamRecvr::PipelineSenderQueue::cancel() {


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/12980

https://github.com/StarRocks/starrocks/blob/d9758a590f669cf09d49c828f03ade7910018dd0/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp#L277-L297

### problem 1
if return directly at L286 due to errors, the error status is not returned to the top caller, but is absorb at L296. This does not trigger cancel this driver, resulting into the driver's exchange_sink blocked.

### problem 2
`_mark_operator_cancelled()` may not actually cancel the driver if it returns earily, this is not as expected.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
