### PR TITLE
[Enhancement] Increase load parallelism default value to speedup load job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -22,6 +22,7 @@
 package com.starrocks.common;
 
 import com.starrocks.StarRocksFE;
+import com.starrocks.system.BackendCoreStat;
 
 public class Config extends ConfigBase {
 
@@ -832,7 +833,7 @@ public class Config extends ConfigBase {
      * Parallel load fragment instance num in single host
      */
     @ConfField(mutable = true)
-    public static int load_parallel_instance_num = 1;
+    public static int load_parallel_instance_num = BackendCoreStat.getAvgNumOfHardwareCoresOfBe();
 
     /**
      * Export checker's running interval.

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
@@ -62,7 +62,7 @@ public class FileScanNodeTest {
         loadId = new TUniqueId(3, 4);
         brokerDesc = new BrokerDesc("broker0", null);
 
-        loadParallelInstanceNum = Config.load_parallel_instance_num;
+        loadParallelInstanceNum = 1;
 
         // backends
         Map<Long, Backend> idToBackendTmp = Maps.newHashMap();


### PR DESCRIPTION
## What type of PR is this：
- [ X] Enhancement

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) --> 
By default, load parallelism is 1 per host. Increase it to be: `number of cores / 2`, speedup data load and leverage more CPU for loading
