### PR TITLE
[BugFix] purge zero-charge cache entry

### DIFF
--- a/be/src/exec/query_cache/cache_manager.h
+++ b/be/src/exec/query_cache/cache_manager.h
@@ -51,7 +51,9 @@ struct CacheValue {
     ~CacheValue() { result.clear(); }
 
     size_t size() {
-        size_t value_size = 0;
+        // zero-charge cache entry can not be purged in LRU cache, so size of CacheValue must be at least
+        // greater than zero, so add sizeof(CacheValue) to size.
+        size_t value_size = sizeof(CacheValue);
         for (auto& chk : result) {
             value_size += chk->memory_usage();
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
From the code of LRUCache, zero-charge cache entry cannot be purged, so for empty cache entry, we also add a small charge.
```cpp
void LRUCache::_evict_from_lru(size_t charge, std::vector<LRUHandle*>* deleted) {
    LRUHandle* cur = &_lru;
    // 1. evict normal cache entries
    while (_usage + charge > _capacity && cur->next != &_lru) {
        LRUHandle* old = cur->next;
        if (old->priority == CachePriority::DURABLE) {
            cur = cur->next;
            continue;
        }
        _evict_one_entry(old);
        deleted->push_back(old);
    }
    // 2. evict durable cache entries if need
    while (_usage + charge > _capacity && _lru.next != &_lru) {
        LRUHandle* old = _lru.next;
        DCHECK(old->priority == CachePriority::DURABLE);
        _evict_one_entry(old);
        deleted->push_back(old);
    }
}
```