### PR TITLE
[Tool] More explicit prompts should be given when thirdparty library build is triggered

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,11 +42,6 @@ export STARROCKS_HOME=${ROOT}
 
 . ${STARROCKS_HOME}/env.sh
 
-if [[ ! -f ${STARROCKS_THIRDPARTY}/installed/include/fast_float/fast_float.h ]]; then
-    echo "Thirdparty libraries need to be build because fast_float has not been built yet ..."
-    ${STARROCKS_THIRDPARTY}/build-thirdparty.sh
-fi
-
 if [[ ! -f ${STARROCKS_THIRDPARTY}/installed/include/pulsar/Client.h ]]; then
     echo "Thirdparty libraries need to be build because pulsar has not been built yet ..."
     ${STARROCKS_HOME}/thirdparty/build-thirdparty.sh

--- a/build.sh
+++ b/build.sh
@@ -43,12 +43,12 @@ export STARROCKS_HOME=${ROOT}
 . ${STARROCKS_HOME}/env.sh
 
 if [[ ! -f ${STARROCKS_THIRDPARTY}/installed/include/fast_float/fast_float.h ]]; then
-    echo "Thirdparty libraries need to be build ..."
+    echo "Thirdparty libraries need to be build because fast_float has not been built yet ..."
     ${STARROCKS_THIRDPARTY}/build-thirdparty.sh
 fi
 
 if [[ ! -f ${STARROCKS_THIRDPARTY}/installed/include/pulsar/Client.h ]]; then
-    echo "Thirdparty libraries need to be build ..."
+    echo "Thirdparty libraries need to be build because pulsar has not been built yet ..."
     ${STARROCKS_HOME}/thirdparty/build-thirdparty.sh
 fi
 


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Problem Summary(Required) ：
More explicit prompts should be given when thirdparty library build is triggered. Otherwise the user doesn't know what the reason is and needs to debug it.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
