### PR TITLE
[Enhancement] add scan op dop multiplier

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -755,6 +755,8 @@ CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
 
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 CONF_Int32(io_tasks_per_scan_operator, "4");
+CONF_Int32(connector_scan_operator_dop_multiplier, "4");
+CONF_Int32(scan_operator_dop_multiplier, "1");
 CONF_Bool(connector_chunk_source_accumulate_chunk_enable, "true");
 CONF_Bool(connector_dynamic_chunk_buffer_limiter_enable, "true");
 CONF_Bool(connector_min_max_predicate_from_runtime_filter_enable, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -755,8 +755,8 @@ CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
 
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 CONF_Int32(io_tasks_per_scan_operator, "4");
-CONF_Int32(connector_scan_operator_dop_multiplier, "4");
-CONF_Int32(scan_operator_dop_multiplier, "1");
+CONF_Double(connector_scan_operator_dop_multiplier, "4");
+CONF_Double(scan_operator_dop_multiplier, "1");
 CONF_Bool(connector_chunk_source_accumulate_chunk_enable, "true");
 CONF_Bool(connector_dynamic_chunk_buffer_limiter_enable, "true");
 CONF_Bool(connector_min_max_predicate_from_runtime_filter_enable, "true");

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -329,7 +329,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
 
     for (auto& i : scan_nodes) {
         auto* scan_node = down_cast<ScanNode*>(i);
-        size_t scan_dop = dop * scan_node->scan_operator_dop_multiplier();
+        size_t scan_dop = size_t(dop * scan_node->scan_operator_dop_multiplier());
         const std::vector<TScanRangeParams>& scan_ranges = request.scan_ranges_of_node(scan_node->id());
 
         PerDriverScanRangesMap& scan_ranges_per_driver = _fragment_ctx->scan_ranges_per_driver();
@@ -389,10 +389,10 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
     int64_t physical_scan_limit = 0;
     for (auto& i : scan_nodes) {
         auto* scan_node = down_cast<ScanNode*>(i);
-        size_t scan_dop = dop * scan_node->scan_operator_dop_multiplier();
+        size_t scan_dop = size_t(dop * scan_node->scan_operator_dop_multiplier());
 
         if (scan_node->limit() > 0) {
-            // the upper bound of records we actually will scan is `lim it * dop * io_parallelism`.
+            // the upper bound of records we actually will scan is `limit * dop * io_parallelism`.
             // For SQL like: select * from xxx limit 5, the underlying scan_limit should be 5 * parallelism
             // Otherwise this SQL would exceed the bigquery_rows_limit due to underlying IO parallelization
             logical_scan_limit += scan_node->limit();

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -102,7 +102,7 @@ public:
     const std::string& name() const { return _name; }
 
     virtual int io_tasks_per_scan_operator() const { return config::io_tasks_per_scan_operator; }
-    virtual int scan_operator_dop_multiplier() const { return config::scan_operator_dop_multiplier; }
+    virtual double scan_operator_dop_multiplier() const { return config::scan_operator_dop_multiplier; }
 
     // TODO: support more share_scan strategy
     void enable_shared_scan(bool enable);

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -102,6 +102,7 @@ public:
     const std::string& name() const { return _name; }
 
     virtual int io_tasks_per_scan_operator() const { return config::io_tasks_per_scan_operator; }
+    virtual int scan_operator_dop_multiplier() const { return config::scan_operator_dop_multiplier; }
 
     // TODO: support more share_scan strategy
     void enable_shared_scan(bool enable);

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -560,7 +560,7 @@ int ConnectorScanNode::io_tasks_per_scan_operator() const {
     return config::connector_io_tasks_per_scan_operator;
 }
 
-int ConnectorScanNode::scan_operator_dop_multiplier() const {
+double ConnectorScanNode::scan_operator_dop_multiplier() const {
     return config::connector_scan_operator_dop_multiplier;
 }
 

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -560,4 +560,8 @@ int ConnectorScanNode::io_tasks_per_scan_operator() const {
     return config::connector_io_tasks_per_scan_operator;
 }
 
+int ConnectorScanNode::scan_operator_dop_multiplier() const {
+    return config::connector_scan_operator_dop_multiplier;
+}
+
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/connector_scan_node.h
+++ b/be/src/exec/vectorized/connector_scan_node.h
@@ -37,6 +37,7 @@ public:
     connector::ConnectorType connector_type() { return _connector_type; }
 
     int io_tasks_per_scan_operator() const override;
+    int scan_operator_dop_multiplier() const override;
 
 private:
     RuntimeState* _runtime_state = nullptr;

--- a/be/src/exec/vectorized/connector_scan_node.h
+++ b/be/src/exec/vectorized/connector_scan_node.h
@@ -37,7 +37,7 @@ public:
     connector::ConnectorType connector_type() { return _connector_type; }
 
     int io_tasks_per_scan_operator() const override;
-    int scan_operator_dop_multiplier() const override;
+    double scan_operator_dop_multiplier() const override;
 
 private:
     RuntimeState* _runtime_state = nullptr;

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -47,10 +47,10 @@ void EncodeContext::_adjust(const int col_id) {
         _column_encode_level[col_id] = 0;
     }
     if (old_level != _column_encode_level[col_id] || _session_encode_level < -1) {
-        LOG(WARNING) << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
-                     << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
-                     << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
-                     << " higher than limit " << EncodeRatioLimit;
+        VLOG_FILE << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
+                  << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
+                  << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
+                  << " higher than limit " << EncodeRatioLimit;
     }
     _encoded_bytes[col_id] = 0;
     _raw_bytes[col_id] = 0;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


__This PR looks only promosing look ssb__

This PR is to add a `scan_operator_dop_multiplier` option, to increase dop of scan pipeline.

The background is when I try to improve performance of lake scan node on (ssb100g/q7), I find 
- connector_io_tasks_per_scan_operator = 16. 1369ms
- connector_io_tasks_per_scan_operator = 4, 1012ms

it's very hard to explain such case when shared scan feature is enabled. 


----


In recent days, I submit a feature  [[[Enhancement] extend query trace by dirtysalt · Pull Request #12982 · StarRocks/starrocks](https://github.com/StarRocks/starrocks/pull/12982)](https://github.com/StarRocks/starrocks/pull/12982), so I can see trace graph in POV of thread.

In following paragraph, I set connector_io_tasks_per_scan_operator = 16. I find that chunk source are less scheduled in late stage of query. (dop = 8, time = 1369ms)

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/1081215/200157755-c6c0e484-768c-45fc-b363-d0ebf1532905.png">

and if I increase dop = 16, chunk source scheduling looks much more dense. (dop= 16, time = 1065ms)

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/1081215/200157828-6c1a406e-4cab-47d6-babf-2406436f43a6.png">

----

My hypothesis is:
1. chunk source is scheduled by scan operator(scan pipeline)
2. but at late stage of query, non-scan pipeline driver are more scheduled.
3. scan pipeline driver is less scheduled.
4. there are many tailed chunk sources.

So I try to increase dop of scan pipeline. After I set `connector_scan_operator_dop_multiplier = 4`, the trace graph looks like followng (dop = 8, time = 950ms)

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/1081215/200158029-ee2b392c-9de1-4e24-94db-921cc3a5a542.png">

----

ssb100g



Before PR | ssb | ssbflat | After PR | ssb | ssbflat
-- | -- | -- | -- | -- | --
Q01 | 170 | 91 | Q01 | 168 | 94
Q02 | 125 | 50 | Q02 | 123 | 51
Q03 | 116 | 75 | Q03 | 119 | 79
Q04 | 850 | 382 | Q04 | 705 | 384
Q05 | 902 | 318 | Q05 | 876 | 327
Q06 | 744 | 226 | Q06 | 654 | 231
Q07 | 1269 | 562 | Q07 | 935 | 576
Q08 | 817 | 482 | Q08 | 711 | 495
Q09 | 772 | 227 | Q09 | 695 | 226
Q10 | 178 | 42 | Q10 | 178 | 48
Q11 | 1529 | 524 | Q11 | 1188 | 524
Q12 | 540 | 196 | Q12 | 463 | 203
Q13 | 390 | 189 | Q13 | 365 | 196
SUM | 8402 | 3364 | SUM | 7180 | 3434


---

tpch-100g



  | Before | After
-- | -- | --
Q01 | 3080 | 3076
Q02 | 317 | 279
Q03 | 2088 | 1999
Q04 | 961 | 946
Q05 | 2236 | 2194
Q06 | 709 | 733
Q07 | 1343 | 1345
Q08 | 1501 | 1454
Q09 | 4015 | 4146
Q10 | 1903 | 1898
Q11 | 372 | 366
Q12 | 1187 | 981
Q13 | 2440 | 2451
Q14 | 883 | 888
Q15 | 764 | 780
Q16 | 1068 | 1082
Q17 | 801 | 777
Q18 | 6757 | 6748
Q19 | 875 | 890
Q20 | 1148 | 1132
Q21 | 3317 | 3267
Q22 | 601 | 619
SUM | 38366 | 38051






## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
