### PR TITLE
[Enhancement] Format of fragement instance id

### DIFF
--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -49,6 +49,7 @@
 #include "util/compression/compression_utils.h"
 #include "util/ref_count_closure.h"
 #include "util/thrift_client.h"
+#include "util/uid_util.h"
 
 namespace starrocks {
 
@@ -119,10 +120,7 @@ public:
 
     int64_t num_data_bytes_sent() const { return _num_data_bytes_sent; }
 
-    std::string get_fragment_instance_id_str() {
-        UniqueId uid(_fragment_instance_id);
-        return uid.to_string();
-    }
+    std::string get_fragment_instance_id_str() { return print_id(_fragment_instance_id); }
 
     TUniqueId get_fragment_instance_id() { return _fragment_instance_id; }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now, the formats of fragment instance ids are different, which is confusing.
```
I1104 15:22:55.149001 157816 plan_fragment_executor.cpp:449] Fragment 9c870302-f622-4373-93ca-aedbd06657ee:(Active: 81.411ms, non-child: 0.00%)
   - AverageThreadTokens: 0.00
   - MemoryLimit: -1.00 B
   - PeakMemoryUsage: 2.69 KB
   - RowsProduced: 0
```
```
I1104 15:22:55.158905 157815 plan_fragment_executor.cpp:449] Fragment 9c870302-f622-4373-93ca-aedbd06657ed:(Active: 78.549ms, non-child: 0.23%)
   - AverageThreadTokens: 0.00
   - MemoryLimit: -1.00 B
   - PeakMemoryUsage: 21.14 MB
   - RowsProduced: 61.44K
  DataStreamSender (dst_id=1, dst_fragments=[9c870302f6224373-93caaedbd06657ee]):(Active: 6.087ms, non-child: 7.75%)
```
The id `9c870302-f622-4373-93ca-aedbd06657ee` and `9c870302f6224373-93caaedbd06657ee` are actually of the same value, but in different formats.
This PR unifies the format as `9c870302-f622-4373-93ca-aedbd06657ee`. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
