### PR TITLE
[BugFix] Fix NPE for array_map when lambda function is null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -63,6 +63,8 @@ public class FunctionAnalyzer {
 
         if (fnName.getFunction().equals(FunctionSet.ARRAY_MAP)) {
             Preconditions.checkState(functionCallExpr.getChildren().size() > 1);
+            Preconditions.checkState(functionCallExpr.getChild(0).getChild(0) != null,
+                    "lambda function can not be null");
             // the normalized high_order functions:
             // high-order function(lambda_func(lambda_expr, lambda_arguments), input_arrays),
             // which puts various arguments/inputs at the tail e.g.,


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12866

Before the change:
<img width="261" alt="image" src="https://user-images.githubusercontent.com/55134131/200205921-45b98864-20e9-4783-94c4-9ba2e9708ebe.png">

After the change:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/55134131/200205889-8a42c1bf-07f0-4da2-bbb4-0419a84b4562.png">

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix NPE for `array_map` when lambda function is null.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
