### PR TITLE
[Enhancement] optimize in_const_predicate

### DIFF
--- a/be/src/column/column_builder.h
+++ b/be/src/column/column_builder.h
@@ -92,12 +92,19 @@ public:
 
     ColumnPtr build_nullable_column() { return NullableColumn::create(_column, _null_column); }
 
-    void reserve(int size) {
+    void reserve(size_t size) {
         _column->reserve(size);
         _null_column->reserve(size);
     }
 
+    void resize_uninitialized(size_t size) {
+        _column->resize_uninitialized(size);
+        _null_column->resize_uninitialized(size);
+    }
+
     DataColumnPtr data_column() { return _column; }
+    NullColumnPtr null_column() { return _null_column; }
+    void set_has_null(bool v) { _has_null = v; }
 
 protected:
     DataColumnPtr _column;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to optmize `in_const_predicate.hpp`.

Before this PR, we can see a lot of overhead on `column_builder.append`(this function is not inlined)

<img width="1161" alt="Samples 478K of event" src="https://user-images.githubusercontent.com/1081215/200172033-20797e1c-e88b-4bf6-97aa-308e56d7742c.png">


And after this PR, we remove this `append_null` function, and put more efficient implementation in `in_const_predicate.hppp`

<img width="1371" alt="sr-tunnel (ssh)" src="https://user-images.githubusercontent.com/1081215/200172107-95a46930-2cd5-4ac0-bee7-bdd700d6eaec.png">


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
