### PR TITLE
[Enhancement] remove not-required manual cache.prune

### DIFF
--- a/be/src/exec/query_cache/cache_manager.cpp
+++ b/be/src/exec/query_cache/cache_manager.cpp
@@ -14,9 +14,6 @@ Status CacheManager::populate(const std::string& key, const CacheValue& value) {
     auto* cache_value = new CacheValue(value);
     auto* handle = _cache.insert(key, cache_value, cache_value->size(), &delete_cache_entry, CachePriority::NORMAL);
     DeferOp defer([this, handle]() { _cache.release(handle); });
-    if (_cache.get_memory_usage() > _cache.get_capacity()) {
-        _cache.prune();
-    }
     return handle != nullptr ? Status::OK() : Status::InternalError("Insert failure");
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

Not-required to prune the cache manually, cache shall evict the least-recent-used(LRU) entries when its usage exceeds the its capacity internally.