### PR TITLE
[BugFix] fix arrayMap without lambda functions error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -105,7 +105,7 @@ public class ExpressionAnalyzer {
             if (((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ARRAY_MAP) ||
                     ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ARRAY_FILTER)) {
                 return true;
-            } else if (((FunctionCallExpr) expr).getFnName().getFunction().equalsIgnoreCase(FunctionSet.TRANSFORM)) {
+            } else if (((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.TRANSFORM)) {
                 // transform just a alias of array_map
                 ((FunctionCallExpr) expr).resetFnName("", FunctionSet.ARRAY_MAP);
                 return true;
@@ -172,7 +172,7 @@ public class ExpressionAnalyzer {
     }
 
     private void bottomUpAnalyze(Visitor visitor, Expr expression, Scope scope) {
-        if (expression.hasLambdaFunction()) {
+        if (expression.hasLambdaFunction(expression)) {
             analyzeHighOrderFunction(visitor, expression, scope);
         } else {
             for (Expr expr : expression.getChildren()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -62,9 +62,10 @@ public class FunctionAnalyzer {
         }
 
         if (fnName.getFunction().equals(FunctionSet.ARRAY_MAP)) {
-            Preconditions.checkState(functionCallExpr.getChildren().size() > 1);
+            Preconditions.checkState(functionCallExpr.getChildren().size() > 1,
+                    "array_map should have at least two inputs");
             Preconditions.checkState(functionCallExpr.getChild(0).getChild(0) != null,
-                    "lambda function can not be null");
+                    "array_map's lambda function can not be null");
             // the normalized high_order functions:
             // high-order function(lambda_func(lambda_expr, lambda_arguments), input_arrays),
             // which puts various arguments/inputs at the tail e.g.,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -112,6 +112,18 @@ public class AnalyzeExprTest {
         analyzeFail("select array_map((x,x) -> x+1, [1],[1])");
         analyzeFail("select array_map((x,y) -> x+1)");
         analyzeFail("select array_map((x,x) -> x+1, [1], x ->x+1)");
+        analyzeFail("select array_map()");
+        analyzeFail("select array_map(null)");
+        analyzeFail("select array_map(null, [1])");
+        analyzeFail("select array_map(null, null)");
+        analyzeFail("select array_map([1],null);");
+        analyzeFail("select array_map(1)");
+        analyzeFail("select transform()");
+        analyzeFail("select transform(null)");
+        analyzeFail("select transform(null, [1])");
+        analyzeFail("select transform(null, null)");
+        analyzeFail("select transform([1],null);");
+        analyzeFail("select transform(1)");
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/12866

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

fix the analyze error that array_map()/transform() without lambda functions, and update the error msg of the PR https://github.com/StarRocks/starrocks/pull/13016

```
ERROR 1064 (HY000): array_map should not without lambda function input.
mysql> select array_sum(array_map(null,null));
ERROR 1064 (HY000): array_map should not without lambda function input.
mysql> select array_sum(array_map(null,[1,1]));
ERROR 1064 (HY000): array_map should not without lambda function input.
mysql> select array_sum(array_map(null,null));
ERROR 1064 (HY000): array_map should not without lambda function input.
mysql> select transform();
ERROR 1064 (HY000): transform should not without lambda function input.
mysql> select transform(null);
ERROR 1064 (HY000): transform should not without lambda function input.
mysql> select transform([1,2]);
ERROR 1064 (HY000): transform should not without lambda function input.
mysql> select transform(1);
ERROR 1064 (HY000): transform should not without lambda function input.
mysql> select transform(1,3);
ERROR 1064 (HY000): transform should not without lambda function input.
mysql> select transform(null,[1,2]);
ERROR 1064 (HY000): transform should not without lambda function input.
mysql> select array_map();
ERROR 1064 (HY000): array_map should not without lambda function input.
mysql> select array_map(null);
ERROR 1064 (HY000): array_map should not without lambda function input.
mysql> select array_map(null,null);
ERROR 1064 (HY000): array_map should not without lambda function input.
mysql> select array_map(null,[1]);
ERROR 1064 (HY000): array_map should not without lambda function input.
mysql> select array_map([1],null);
ERROR 1064 (HY000): array_map should not without lambda function input.
```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
