### PR TITLE
[Enhancement] improve performance of array_agg function

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -86,7 +86,7 @@ void ArrayColumn::append_datum(const Datum& datum) {
 void ArrayColumn::append_array_element(const Column& elem, size_t null_elem) {
     _elements->append(elem);
     _elements->append_nulls(null_elem);
-    _offsets->append(_offsets->get_data().back() + elem.size());
+    _offsets->append(_offsets->get_data().back() + elem.size() + null_elem);
 }
 
 void ArrayColumn::append(const Column& src, size_t offset, size_t count) {
@@ -457,6 +457,12 @@ std::pair<size_t, size_t> ArrayColumn::get_element_offset_size(size_t idx) const
     size_t offset = _offsets->get_data()[idx];
     size_t size = _offsets->get_data()[idx + 1] - _offsets->get_data()[idx];
     return {offset, size};
+}
+
+size_t ArrayColumn::get_element_null_count(size_t idx) const {
+    auto offset_size = get_element_offset_size(idx);
+    auto nullable = down_cast<NullableColumn*>(_elements.get());
+    return nullable->null_count(offset_size.first, offset_size.second);
 }
 
 size_t ArrayColumn::get_element_size(size_t idx) const {

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -83,6 +83,12 @@ void ArrayColumn::append_datum(const Datum& datum) {
     _offsets->append(_offsets->get_data().back() + array_size);
 }
 
+void ArrayColumn::append_array_element(const Column& elem, size_t null_elem) {
+    _elements->append(elem);
+    _elements->append_nulls(null_elem);
+    _offsets->append(_offsets->get_data().back() + elem.size());
+}
+
 void ArrayColumn::append(const Column& src, size_t offset, size_t count) {
     const auto& array_column = down_cast<const ArrayColumn&>(src);
 
@@ -444,6 +450,13 @@ Datum ArrayColumn::get(size_t idx) const {
         res[i] = _elements->get(offset + i);
     }
     return {res};
+}
+
+std::pair<size_t, size_t> ArrayColumn::get_element_offset_size(size_t idx) const {
+    DCHECK_LT(idx + 1, _offsets->size());
+    size_t offset = _offsets->get_data()[idx];
+    size_t size = _offsets->get_data()[idx + 1] - _offsets->get_data()[idx];
+    return {offset, size};
 }
 
 size_t ArrayColumn::get_element_size(size_t idx) const {

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -126,6 +126,7 @@ public:
     Datum get(size_t idx) const override;
 
     std::pair<size_t, size_t> get_element_offset_size(size_t idx) const;
+    size_t get_element_null_count(size_t idx) const;
     size_t get_element_size(size_t idx) const;
 
     bool set_null(size_t idx) override;

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -65,6 +65,9 @@ public:
 
     void append(const Column& src, size_t offset, size_t count) override;
 
+    // Append a single element, which is represented as a column
+    void append_array_element(const Column& elem, size_t null_elem);
+
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
     void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
@@ -122,6 +125,7 @@ public:
 
     Datum get(size_t idx) const override;
 
+    std::pair<size_t, size_t> get_element_offset_size(size_t idx) const;
     size_t get_element_size(size_t idx) const;
 
     bool set_null(size_t idx) override;

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -113,7 +113,9 @@ ColumnPtr NullableColumn::replicate(const std::vector<uint32_t>& offsets) {
 }
 
 bool NullableColumn::append_nulls(size_t count) {
-    DCHECK_GT(count, 0u);
+    if (count == 0) {
+        return true;
+    }
     _data_column->append_default(count);
     null_column_data().insert(null_column_data().end(), count, 1);
     DCHECK_EQ(_null_column->size(), _data_column->size());

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -38,6 +38,13 @@ size_t NullableColumn::null_count() const {
     return SIMD::count_nonzero(_null_column->get_data());
 }
 
+size_t NullableColumn::null_count(size_t offset, size_t count) const {
+    if (!_has_null) {
+        return 0;
+    }
+    return SIMD::count_nonzero(_null_column->raw_data() + offset, count);
+}
+
 void NullableColumn::append_datum(const Datum& datum) {
     if (datum.is_null()) {
         append_nulls(1);

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -213,6 +213,7 @@ public:
     const NullColumnPtr& null_column() const { return _null_column; }
 
     size_t null_count() const;
+    size_t null_count(size_t offset, size_t count) const;
 
     Datum get(size_t n) const override {
         if (_has_null && _null_column->get_data()[n]) {

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "column/array_column.h"
+#include "column/column_helper.h"
 #include "column/type_traits.h"
 #include "exprs/agg/aggregate.h"
 #include "runtime/mem_pool.h"
@@ -12,12 +13,12 @@ namespace starrocks::vectorized {
 
 template <PrimitiveType PT>
 struct ArrayAggAggregateState {
-    using CppType = RunTimeCppType<PT>;
     using ColumnType = RunTimeColumnType<PT>;
 
     void update(const ColumnType& column, size_t offset, size_t count) { data_column.append(column, offset, count); }
 
     void append_null() { null_count++; }
+    void append_null(size_t count) { null_count += count; }
 
     ColumnType data_column; // Aggregated elements for array_agg
     size_t null_count = 0;
@@ -27,12 +28,12 @@ template <PrimitiveType PT>
 class ArrayAggAggregateFunction
         : public AggregateFunctionBatchHelper<ArrayAggAggregateState<PT>, ArrayAggAggregateFunction<PT>> {
 public:
-    using InputCppType = RunTimeCppType<PT>;
     using InputColumnType = RunTimeColumnType<PT>;
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
         const auto& column = down_cast<const InputColumnType&>(*columns[0]);
+        // TODO: update is random access, so we could not pre-reserve memory for State, which is the bottleneck
         this->data(state).update(column, row_num, 1);
     }
 
@@ -41,11 +42,16 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        // Array element is nullable, so we need to extract the data from nullable column first
         const auto* input_column = down_cast<const ArrayColumn*>(column);
-        auto& element_column = down_cast<const InputColumnType&>(input_column->elements());
         auto offset_size = input_column->get_element_offset_size(row_num);
+        auto& array_element = down_cast<const NullableColumn&>(input_column->elements());
+        auto* element_data_column = down_cast<const InputColumnType*>(ColumnHelper::get_data_column(&array_element));
+        size_t element_null_count = array_element.null_count(offset_size.first, offset_size.second);
+        DCHECK_LE(element_null_count, offset_size.second);
 
-        this->data(state).update(element_column, offset_size.first, offset_size.second);
+        this->data(state).update(*element_data_column, offset_size.first, offset_size.second - element_null_count);
+        this->data(state).append_null(element_null_count);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -61,7 +67,13 @@ public:
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      ColumnPtr* dst) const override {
         auto* column = down_cast<ArrayColumn*>(dst->get());
-        column->append(*src[0], 0, chunk_size);
+        auto& offsets = column->offsets_column()->get_data();
+        auto& elements_column = column->elements_column();
+
+        for (size_t i = 0; i < chunk_size; i++) {
+            elements_column->append_datum(src[0]->get(i));
+            offsets.emplace_back(offsets.back() + 1);
+        }
     }
 
     std::string get_name() const override { return "array_agg"; }

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -10,7 +10,6 @@
 #include "exprs/agg/aggregate.h"
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/agg/any_value.h"
-#include "exprs/agg/array_agg.h"
 #include "exprs/agg/avg.h"
 #include "exprs/agg/bitmap_intersect.h"
 #include "exprs/agg/bitmap_union.h"
@@ -150,9 +149,6 @@ public:
 
     template <PrimitiveType PT>
     static AggregateFunctionPtr MakePercentileContAggregateFunction();
-
-    template <PrimitiveType PT>
-    static AggregateFunctionPtr MakeArrayAggAggregateFunction();
 
     // Windows functions:
     static AggregateFunctionPtr MakeDenseRankWindowFunction();
@@ -305,11 +301,6 @@ AggregateFunctionPtr AggregateFactory::MakeHllRawAggregateFunction() {
 template <PrimitiveType PT>
 AggregateFunctionPtr AggregateFactory::MakePercentileContAggregateFunction() {
     return std::make_shared<PercentileContAggregateFunction<PT>>();
-}
-
-template <PrimitiveType PT>
-AggregateFunctionPtr AggregateFactory::MakeArrayAggAggregateFunction() {
-    return std::make_shared<ArrayAggAggregateFunction<PT>>();
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
@@ -25,7 +25,7 @@ struct ArrayAggDispatcher {
     template <PrimitiveType pt>
     void operator()(AggregateFuncResolver* resolver) {
         if constexpr (pt_is_aggregate<pt> || pt_is_string<pt>) {
-            auto func = AggregateFactory::MakeArrayAggAggregateFunction<pt>();
+            auto func = std::make_shared<ArrayAggAggregateFunction<pt>>();
             using AggState = ArrayAggAggregateState<pt>;
             resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>("array_agg", false,
                                                                                                    func);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Improve the performance of `array_agg` function:
1. Eliminate virtual function call
2. Eliminate the `datum` intermediate representation

Benchmark Result:
1. `select * from (select lo_orderkey, array_agg(lo_orderkey) as agg from lineorder group by lo_orderkey) r order by lo_orderkey limit 1` 
    1. Before: `3s369ms`
    2. After: `2s958ms`
2. `select * from (select lo_custkey, array_agg(lo_custkey) as agg from lineorder group by lo_custkey) r order by lo_custkey limit 1`
    1. Before: `5s596ms `
    2. After: `3s760ms`
3. The first sql generate array whose max length is 7, and the second is 611. For large array, this PR has significant improment

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
