### PR TITLE
[BugFix]streamvbyte decode should use RawVectorPad16 to correctly use avx

### DIFF
--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -189,7 +189,7 @@ public:
         int64_t offsets_size = offsets.size() * sizeof(typename vectorized::BinaryColumnBase<T>::Offset);
         if ((encode_level & 2) && offsets_size >= ENCODE_SIZE_LIMIT) {
             res += sizeof(uint64_t) +
-                   std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(offsets_size));
+                   std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(offsets_size)));
         } else {
             res += offsets_size;
         }

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -59,15 +59,19 @@ const uint8_t* read_raw(const uint8_t* buff, void* target, size_t size) {
     return buff + size;
 }
 
+inline size_t upper_int32(size_t size) {
+    return (3 + size) / 4.0;
+}
+
 template <bool sorted_32ints>
 uint8_t* encode_integers(const void* data, size_t size, uint8_t* buff, int encode_level) {
     uint64_t encode_size = 0;
     if (sorted_32ints) { // only support sorted 32-bit integers
-        encode_size = streamvbyte_delta_encode(reinterpret_cast<const uint32_t*>(data), (3 + size) * 1.0 / 4.0,
+        encode_size = streamvbyte_delta_encode(reinterpret_cast<const uint32_t*>(data), upper_int32(size),
                                                buff + sizeof(uint64_t), 0);
     } else {
-        encode_size = streamvbyte_encode(reinterpret_cast<const uint32_t*>(data), (3 + size) * 1.0 / 4.0,
-                                         buff + sizeof(uint64_t));
+        encode_size =
+                streamvbyte_encode(reinterpret_cast<const uint32_t*>(data), upper_int32(size), buff + sizeof(uint64_t));
     }
     buff = write_little_endian_64(encode_size, buff);
 
@@ -82,9 +86,9 @@ const uint8_t* decode_integers(const uint8_t* buff, void* target, size_t size) {
     buff = read_little_endian_64(buff, &encode_size);
     uint64_t decode_size = 0;
     if (sorted_32ints) {
-        decode_size = streamvbyte_delta_decode(buff, (uint32_t*)target, (3 + size) * 1.0 / 4.0, 0);
+        decode_size = streamvbyte_delta_decode(buff, (uint32_t*)target, upper_int32(size), 0);
     } else {
-        decode_size = streamvbyte_decode(buff, (uint32_t*)target, (3 + size) * 1.0 / 4.0);
+        decode_size = streamvbyte_decode(buff, (uint32_t*)target, upper_int32(size));
     }
     if (encode_size != decode_size) {
         throw std::runtime_error(fmt::format(
@@ -133,7 +137,7 @@ public:
         uint32_t size = sizeof(T) * column.size();
         if ((encode_level & 2) && size >= ENCODE_SIZE_LIMIT) {
             return sizeof(uint32_t) + sizeof(uint64_t) +
-                   std::max((int64_t)size, (int64_t)streamvbyte_max_compressedbytes((size + 3) / 4.0));
+                   std::max((int64_t)size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(size)));
         } else {
             return sizeof(uint32_t) + size;
         }
@@ -160,14 +164,15 @@ public:
         uint32_t size = 0;
         buff = read_little_endian_32(buff, &size);
         std::vector<T>& data = column->get_data();
-        raw::make_room(&data, size / sizeof(T));
         if ((encode_level & 2) && size >= ENCODE_SIZE_LIMIT) {
+            raw::make_room_pad16(&data, size / sizeof(T));
             if (sizeof(T) == 4 && sorted) { // only support sorted 32-bit integers
                 buff = decode_integers<true>(buff, data.data(), size);
             } else {
                 buff = decode_integers<false>(buff, data.data(), size);
             }
         } else {
+            raw::make_room(&data, size / sizeof(T));
             buff = read_raw(buff, data.data(), size);
         }
         return buff;
@@ -184,7 +189,7 @@ public:
         int64_t offsets_size = offsets.size() * sizeof(typename vectorized::BinaryColumnBase<T>::Offset);
         if ((encode_level & 2) && offsets_size >= ENCODE_SIZE_LIMIT) {
             res += sizeof(uint64_t) +
-                   std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes((offsets_size + 3) / 4.0));
+                   std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(offsets_size));
         } else {
             res += offsets_size;
         }
@@ -254,14 +259,17 @@ public:
         } else {
             buff = read_little_endian_64(buff, &offsets_size);
         }
-        raw::make_room(&column->get_offset(), offsets_size / sizeof(typename vectorized::BinaryColumnBase<T>::Offset));
         if ((encode_level & 2) && offsets_size >= ENCODE_SIZE_LIMIT) {
+            raw::make_room_pad16(&column->get_offset(),
+                                 offsets_size / sizeof(typename vectorized::BinaryColumnBase<T>::Offset));
             if (sizeof(T) == 4) { // only support sorted 32-bit integers
                 buff = decode_integers<true>(buff, column->get_offset().data(), offsets_size);
             } else {
                 buff = decode_integers<false>(buff, column->get_offset().data(), offsets_size);
             }
         } else {
+            raw::make_room(&column->get_offset(),
+                           offsets_size / sizeof(typename vectorized::BinaryColumnBase<T>::Offset));
             buff = read_raw(buff, column->get_offset().data(), offsets_size);
         }
         return buff;

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -47,10 +47,10 @@ void EncodeContext::_adjust(const int col_id) {
         _column_encode_level[col_id] = 0;
     }
     if (old_level != _column_encode_level[col_id] || _session_encode_level < -1) {
-        LOG(INFO) << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
-                  << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
-                  << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
-                  << " higher than limit " << EncodeRatioLimit;
+        VLOG_ROW << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
+                 << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
+                 << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
+                 << " higher than limit " << EncodeRatioLimit;
     }
     _encoded_bytes[col_id] = 0;
     _raw_bytes[col_id] = 0;

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -47,10 +47,10 @@ void EncodeContext::_adjust(const int col_id) {
         _column_encode_level[col_id] = 0;
     }
     if (old_level != _column_encode_level[col_id] || _session_encode_level < -1) {
-        LOG(WARNING) << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
-                     << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
-                     << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
-                     << " higher than limit " << EncodeRatioLimit;
+        LOG(INFO) << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
+                  << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
+                  << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
+                  << " higher than limit " << EncodeRatioLimit;
     }
     _encoded_bytes[col_id] = 0;
     _raw_bytes[col_id] = 0;

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -154,6 +154,13 @@ inline void make_room(std::vector<T>* v, size_t n) {
     v->swap(reinterpret_cast<std::vector<T>&>(rv));
 }
 
+template <class T>
+inline void make_room_pad16(std::vector<T>* v, size_t n) {
+    RawVectorPad16<T> rv;
+    rv.resize(n);
+    v->swap(reinterpret_cast<std::vector<T>&>(rv));
+}
+
 inline void make_room(std::string* s, size_t n) {
     RawStringPad16 rs;
     rs.resize(n);


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksBenchmark/issues/273

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

https://github.com/lemire/streamvbyte/pull/44 fix a error that streamvbyte's decode may read up to 16 extra bytes from the input (beyond the actual compressed data). Thus the users of this library, for safety, should ensure that there is allocated data 16 bytes beyond the compressed data.

SR can use `RawVectorPad16` to allocate vector with extra 16 bytes. So this PR introduces `make_room_pad16` to make room for decoding integers that encoded by streamvbyte.

by the way, refactor some codes.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature _**(because this error is hard to be reporduced, so hard to constuct a test case.)**_
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
