### PR TITLE
[Cherry-pick][Branch-2.3][BugFix] Fix sync issue (backport #12343) (#12543)

### DIFF
--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -181,6 +181,7 @@ public:
         size_t bytes_written = 0;
         RETURN_IF_ERROR(do_writev_at(_fd, _filename, _filesize, data, cnt, &bytes_written));
         _filesize += bytes_written;
+        _pending_sync = true;
         return Status::OK();
     }
 

--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -43,6 +43,16 @@ inline Status create_directories(const std::string& path) {
     return fs->create_dir_recursive(path);
 }
 
+inline Status sync_dir(const std::string& path) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
+    return fs->sync_dir(path);
+}
+
+inline Status delete_file(const std::string& path) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
+    return fs->delete_file(path);
+}
+
 inline Status remove(const std::string& path) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
     ASSIGN_OR_RETURN(auto is_dir, fs->is_directory(path));

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -160,7 +160,20 @@ Status DataDir::get_shard(uint64_t* shard) {
     }
     shard_path_stream << _path << DATA_PREFIX << "/" << next_shard;
     std::string shard_path = shard_path_stream.str();
+    // First check whether the shard path exists. If it does not exist, sync the data directory.
+    bool sync_data_path = false;
+    if (!fs::path_exist(shard_path)) {
+        sync_data_path = true;
+    }
     RETURN_IF_ERROR(_fs->create_dir_recursive(shard_path));
+    if (sync_data_path) {
+        std::string data_path = _path + DATA_PREFIX;
+        Status st = fs::sync_dir(data_path);
+        if (!st.ok()) {
+            LOG(WARNING) << "Fail to sync " << data_path << ": " << st.to_string();
+            return st;
+        }
+    }
     *shard = next_shard;
     return Status::OK();
 }

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -105,7 +105,7 @@ Status BetaRowsetWriter::init() {
 }
 
 StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
-    if (_num_rows_written > 0) {
+    if (_num_rows_written > 0 || (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && _num_delfile > 0)) {
         RETURN_IF_ERROR(_fs->sync_dir(_context.rowset_path_prefix));
     }
     _rowset_meta->set_num_rows(_num_rows_written);

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -333,6 +333,20 @@ TabletSharedPtr TabletManager::_create_tablet_meta_and_dir_unlocked(const TCreat
             LOG(WARNING) << "Fail to create " << new_tablet->schema_hash_path() << ": " << st.to_string();
             continue;
         }
+
+        std::filesystem::path schema_hash_path(new_tablet->schema_hash_path());
+        std::filesystem::path tablet_id_path = schema_hash_path.parent_path();
+        st = fs::sync_dir(tablet_id_path.string());
+        if (!st.ok()) {
+            LOG(WARNING) << "Fail to sync " << tablet_id_path.string() << ": " << st.to_string();
+            continue;
+        }
+        std::filesystem::path shard_id_path = tablet_id_path.parent_path();
+        st = fs::sync_dir(shard_id_path.string());
+        if (!st.ok()) {
+            LOG(WARNING) << "Fail to sync " << shard_id_path.string() << ": " << st.to_string();
+            continue;
+        }
         return new_tablet;
     }
     return nullptr;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
After the segment file is written, add a sync operation to ensure the durability of data.
Sync tablet's parent directories after creating a tablet.
Sync primary key tablet dir when new rowsets with only delete files are created

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
