### PR TITLE
[Enhancement] Split tablets into small batches to decrease db lock occupation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -311,8 +311,10 @@ public class ColocateTableBalancer extends LeaderDaemon {
                         if (partitionChecked % partitionBatchNum == 0) {
                             lockTotalTime += System.nanoTime() - lockStart;
                             // release lock, so that lock can be acquired by other threads.
+                            LOG.debug("partition checked reached batch value, release lock");
                             db.readUnlock();
                             db.readLock();
+                            LOG.debug("balancer get lock again");
                             lockStart = System.nanoTime();
                             if (globalStateMgr.getDbIncludeRecycleBin(groupId.dbId) == null) {
                                 continue GROUP;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -274,8 +274,12 @@ public class ColocateTableBalancer extends LeaderDaemon {
         TabletScheduler tabletScheduler = globalStateMgr.getTabletScheduler();
         long checkStartTime = System.currentTimeMillis();
 
+        long start = System.nanoTime();
+        long lockTotalTime = 0;
+        long lockStart;
         // check each group
         Set<GroupId> groupIds = colocateIndex.getAllGroupIds();
+        GROUP:
         for (GroupId groupId : groupIds) {
             List<Long> tableIds = colocateIndex.getAllTableIds(groupId);
             Database db = globalStateMgr.getDbIncludeRecycleBin(groupId.dbId);
@@ -289,9 +293,13 @@ public class ColocateTableBalancer extends LeaderDaemon {
             }
 
             boolean isGroupStable = true;
+            // set the config to a local variable to avoid config params changed.
+            int partitionBatchNum = Config.tablet_checker_partition_batch_num;
+            int partitionChecked = 0;
             db.readLock();
+            lockStart = System.nanoTime();
             try {
-                OUT:
+                TABLE:
                 for (Long tableId : tableIds) {
                     OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tableId);
                     if (olapTable == null || !colocateIndex.isColocateTable(olapTable.getId())) {
@@ -299,6 +307,23 @@ public class ColocateTableBalancer extends LeaderDaemon {
                     }
 
                     for (Partition partition : globalStateMgr.getPartitionsIncludeRecycleBin(olapTable)) {
+                        partitionChecked++;
+                        if (partitionChecked % partitionBatchNum == 0) {
+                            lockTotalTime += System.nanoTime() - lockStart;
+                            // release lock, so that lock can be acquired by other threads.
+                            db.readUnlock();
+                            db.readLock();
+                            lockStart = System.nanoTime();
+                            if (globalStateMgr.getDbIncludeRecycleBin(groupId.dbId) == null) {
+                                continue GROUP;
+                            }
+                            if (globalStateMgr.getTableIncludeRecycleBin(db, olapTable.getId()) == null) {
+                                continue TABLE;
+                            }
+                            if (globalStateMgr.getPartitionIncludeRecycleBin(olapTable, partition.getId()) == null) {
+                                continue;
+                            }
+                        }
                         short replicationNum =
                                 globalStateMgr.getReplicationNumIncludeRecycleBin(olapTable.getPartitionInfo(),
                                         partition.getId());
@@ -364,7 +389,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
                                                 // tablet in scheduler exceed limit, skip this group and check next one.
                                                 LOG.info("number of scheduling tablets in tablet scheduler"
                                                         + " exceed to limit. stop colocate table check");
-                                                break OUT;
+                                                break TABLE;
                                             }
                                             if (res == AddResult.ADDED && tabletCtx.getRelocationForRepair()) {
                                                 LOG.info("add tablet relocation task to scheduler, tablet id: {}, " +
@@ -399,9 +424,14 @@ public class ColocateTableBalancer extends LeaderDaemon {
                     colocateIndex.markGroupUnstable(groupId, true);
                 }
             } finally {
+                lockTotalTime += System.nanoTime() - lockStart;
                 db.readUnlock();
             }
         } // end for groups
+
+        long cost = (System.nanoTime() - start) / 1000000;
+        lockTotalTime = lockTotalTime / 1000000;
+        LOG.info("finished to match colocate group. cost: {} ms, in lock time: {} ms", cost, lockTotalTime);
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -1368,7 +1368,11 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         Map<Pair<Long, Long>, PartitionStat> partitionStats = Maps.newHashMap();
+        long start = System.nanoTime();
+        long lockTotalTime = 0;
+        long lockStart;
         List<Long> dbIds = globalStateMgr.getDbIdsIncludeRecycleBin();
+        DATABASE:
         for (Long dbId : dbIds) {
             Database db = globalStateMgr.getDbIncludeRecycleBin(dbId);
             if (db == null) {
@@ -1379,8 +1383,13 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                 continue;
             }
 
+            // set the config to a local variable to avoid config params changed.
+            int partitionBatchNum = Config.tablet_checker_partition_batch_num;
+            int partitionChecked = 0;
             db.readLock();
+            lockStart = System.nanoTime();
             try {
+                TABLE:
                 for (Table table : globalStateMgr.getTablesIncludeRecycleBin(db)) {
                     // check table is olap table or colocate table
                     if (!table.needSchedule(isLocalBalance)) {
@@ -1393,6 +1402,23 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
 
                     OlapTable olapTbl = (OlapTable) table;
                     for (Partition partition : globalStateMgr.getAllPartitionsIncludeRecycleBin(olapTbl)) {
+                        partitionChecked++;
+                        if (partitionChecked % partitionBatchNum == 0) {
+                            lockTotalTime += System.nanoTime() - lockStart;
+                            // release lock, so that lock can be acquired by other threads.
+                            db.readUnlock();
+                            db.readLock();
+                            lockStart = System.nanoTime();
+                            if (globalStateMgr.getDbIncludeRecycleBin(dbId) == null) {
+                                continue DATABASE;
+                            }
+                            if (globalStateMgr.getTableIncludeRecycleBin(db, olapTbl.getId()) == null) {
+                                continue TABLE;
+                            }
+                            if (globalStateMgr.getPartitionIncludeRecycleBin(olapTbl, partition.getId()) == null) {
+                                continue;
+                            }
+                        }
                         if (partition.getState() != PartitionState.NORMAL) {
                             // when alter job is in FINISHING state, partition state will be set to NORMAL,
                             // and we can schedule the tablets in it.
@@ -1477,9 +1503,15 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                     }
                 }
             } finally {
+                lockTotalTime += System.nanoTime() - lockStart;
                 db.readUnlock();
             }
         }
+
+        long cost = (System.nanoTime() - start) / 1000000;
+        lockTotalTime = lockTotalTime / 1000000;
+        LOG.info("finished to calculate partition stats. cost: {} ms, in lock time: {} ms",
+                cost, lockTotalTime);
 
         return partitionStats;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -1406,8 +1406,10 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                         if (partitionChecked % partitionBatchNum == 0) {
                             lockTotalTime += System.nanoTime() - lockStart;
                             // release lock, so that lock can be acquired by other threads.
+                            LOG.debug("partition checked reached batch value, release lock");
                             db.readUnlock();
                             db.readLock();
+                            LOG.debug("balancer get lock again");
                             lockStart = System.nanoTime();
                             if (globalStateMgr.getDbIncludeRecycleBin(dbId) == null) {
                                 continue DATABASE;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -227,15 +227,17 @@ public class TabletChecker extends LeaderDaemon {
     }
 
     private void doCheck(boolean checkInPrios) {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         long totalTabletNum = 0;
         long unhealthyTabletNum = 0;
         long addToSchedulerTabletNum = 0;
         long tabletInScheduler = 0;
         long tabletNotReady = 0;
 
+        long lockTotalTime = 0;
+        long lockStart;
         List<Long> dbIds = globalStateMgr.getDbIdsIncludeRecycleBin();
-        OUT:
+        DATABASE:
         for (Long dbId : dbIds) {
             Database db = globalStateMgr.getDbIncludeRecycleBin(dbId);
             if (db == null) {
@@ -246,9 +248,14 @@ public class TabletChecker extends LeaderDaemon {
                 continue;
             }
 
+            // set the config to a local variable to avoid config params changed.
+            int partitionBatchNum = Config.tablet_checker_partition_batch_num;
+            int partitionChecked = 0;
             db.readLock();
+            lockStart = System.nanoTime();
             try {
                 List<Long> aliveBeIdsInCluster = infoService.getBackendIds(true);
+                TABLE:
                 for (Table table : globalStateMgr.getTablesIncludeRecycleBin(db)) {
                     if (!table.needSchedule(false)) {
                         continue;
@@ -265,6 +272,23 @@ public class TabletChecker extends LeaderDaemon {
 
                     OlapTable olapTbl = (OlapTable) table;
                     for (Partition partition : globalStateMgr.getAllPartitionsIncludeRecycleBin(olapTbl)) {
+                        partitionChecked++;
+                        if (partitionChecked % partitionBatchNum == 0) {
+                            lockTotalTime += System.nanoTime() - lockStart;
+                            // release lock, so that lock can be acquired by other threads.
+                            db.readUnlock();
+                            db.readLock();
+                            lockStart = System.nanoTime();
+                            if (globalStateMgr.getDbIncludeRecycleBin(dbId) == null) {
+                                continue DATABASE;
+                            }
+                            if (globalStateMgr.getTableIncludeRecycleBin(db, olapTbl.getId()) == null) {
+                                continue TABLE;
+                            }
+                            if (globalStateMgr.getPartitionIncludeRecycleBin(olapTbl, partition.getId()) == null) {
+                                continue;
+                            }
+                        }
                         if (partition.getState() != PartitionState.NORMAL) {
                             // when alter job is in FINISHING state, partition state will be set to NORMAL,
                             // and we can schedule the tablets in it.
@@ -336,7 +360,7 @@ public class TabletChecker extends LeaderDaemon {
                                 if (res == AddResult.LIMIT_EXCEED) {
                                     LOG.info("number of scheduling tablets in tablet scheduler"
                                             + " exceed to limit. stop tablet checker");
-                                    break OUT;
+                                    break DATABASE;
                                 } else if (res == AddResult.ADDED) {
                                     addToSchedulerTabletNum++;
                                 }
@@ -354,11 +378,13 @@ public class TabletChecker extends LeaderDaemon {
                     } // partitions
                 } // tables
             } finally {
+                lockTotalTime += System.nanoTime() - lockStart;
                 db.readUnlock();
             }
         } // end for dbs
 
-        long cost = System.currentTimeMillis() - start;
+        long cost = (System.nanoTime() - start) / 1000000;
+        lockTotalTime = lockTotalTime / 1000000;
 
         stat.counterTabletCheckCostMs.addAndGet(cost);
         stat.counterTabletChecked.addAndGet(totalTabletNum);
@@ -366,9 +392,10 @@ public class TabletChecker extends LeaderDaemon {
         stat.counterTabletAddToBeScheduled.addAndGet(addToSchedulerTabletNum);
 
         LOG.info("finished to check tablets. checkInPrios: {}, " +
-                        "unhealthy/total/added/in_sched/not_ready: {}/{}/{}/{}/{}, cost: {} ms",
+                        "unhealthy/total/added/in_sched/not_ready: {}/{}/{}/{}/{}, " +
+                        "cost: {} ms, in lock time: {} ms",
                 checkInPrios, unhealthyTabletNum, totalTabletNum, addToSchedulerTabletNum,
-                tabletInScheduler, tabletNotReady, cost);
+                tabletInScheduler, tabletNotReady, cost, lockTotalTime);
     }
 
     private boolean isTableInPrios(long dbId, long tblId) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -274,10 +274,12 @@ public class TabletChecker extends LeaderDaemon {
                     for (Partition partition : globalStateMgr.getAllPartitionsIncludeRecycleBin(olapTbl)) {
                         partitionChecked++;
                         if (partitionChecked % partitionBatchNum == 0) {
+                            LOG.debug("partition checked reached batch value, release lock");
                             lockTotalTime += System.nanoTime() - lockStart;
                             // release lock, so that lock can be acquired by other threads.
                             db.readUnlock();
                             db.readLock();
+                            LOG.debug("checker get lock again");
                             lockStart = System.nanoTime();
                             if (globalStateMgr.getDbIncludeRecycleBin(dbId) == null) {
                                 continue DATABASE;
@@ -329,7 +331,7 @@ public class TabletChecker extends LeaderDaemon {
 
                                 if (statusWithPrio.first == TabletStatus.HEALTHY) {
                                     // Only set last status check time when status is healthy.
-                                    localTablet.setLastStatusCheckTime(start);
+                                    localTablet.setLastStatusCheckTime(System.currentTimeMillis());
                                     continue;
                                 } else if (isPartitionInPrios) {
                                     statusWithPrio.second = TabletSchedCtx.Priority.VERY_HIGH;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1118,6 +1118,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int tablet_sched_max_migration_task_sent_once = 1000;
 
+    @ConfField(mutable = true)
+    public static int tablet_checker_partition_batch_num = 500;
+
     @Deprecated
     @ConfField(mutable = true)
     public static int report_queue_size = 100;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1118,6 +1118,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int tablet_sched_max_migration_task_sent_once = 1000;
 
+    /**
+     * After checked tablet_checker_partition_batch_num partitions, db lock will be released,
+     * so that other threads can get the lock.
+     */
     @ConfField(mutable = true)
     public static int tablet_checker_partition_batch_num = 500;
 

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
@@ -15,8 +15,10 @@ public class DecommissionTest {
     public static void setUp() throws Exception {
         Config.tablet_sched_checker_interval_seconds = 1;
         Config.tablet_sched_repair_delay_factor_second = 1;
+        Config.tablet_checker_partition_batch_num = 1;
         Config.enable_new_publish_mechanism = true;
         Config.drop_backend_after_decommission = false;
+        Config.sys_log_verbose_modules = new String[] {"com.starrocks.clone"};
         FeConstants.default_scheduler_interval_millisecond = 5000;
         PseudoCluster.getOrCreateWithRandomPort(true, 4);
         GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
@@ -38,7 +40,11 @@ public class DecommissionTest {
         final String[] insertSqls = new String[numTable];
         for (int i = 0; i < numTable; i++) {
             tableNames[i] = "test_" + i;
-            createTableSqls[i] = PseudoCluster.newCreateTableSqlBuilder().setTableName(tableNames[i]).build();
+            PseudoCluster.CreateTableSqlBuilder sqlBuilder = PseudoCluster.newCreateTableSqlBuilder().setTableName(tableNames[i]);
+            if (i % 2 == 0) {
+                sqlBuilder.setColocateGroup("g1");
+            }
+            createTableSqls[i] = sqlBuilder.build();
             insertSqls[i] = PseudoCluster.buildInsertSql("test", tableNames[i]);
             cluster.runSqls("test", createTableSqls[i], insertSqls[i], insertSqls[i], insertSqls[i]);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -431,6 +431,7 @@ public class PseudoCluster {
         private int buckets = 3;
         private int replication = 3;
         private String quorum = "MAJORITY";
+        private String colocateGroup = "";
 
         private boolean ssd = true;
 
@@ -459,13 +460,23 @@ public class PseudoCluster {
             return this;
         }
 
+        public CreateTableSqlBuilder setColocateGroup(String colocateGroup) {
+            this.colocateGroup = colocateGroup;
+            return this;
+        }
+
         public String build() {
             return String.format("create table %s (id bigint not null, name varchar(64) not null, age int null) " +
                             "primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS %d " +
-                            "PROPERTIES(\"write_quorum\" = \"%s\", \"replication_num\" = \"%d\", \"storage_medium\" = \"%s\")",
+                            "PROPERTIES(" +
+                                "\"write_quorum\" = \"%s\", " +
+                                "\"replication_num\" = \"%d\", " +
+                                "\"storage_medium\" = \"%s\", " +
+                                "\"group_with\" = \"%s\")",
                     tableName,
                     buckets, quorum, replication,
-                    ssd ? "SSD" : "HDD");
+                    ssd ? "SSD" : "HDD",
+                    colocateGroup);
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13069

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
TabletChecker/ColocateTableBalancer/DiskAndTabletLoadReBalancer scan all tablets to repair or balance tablet, and the db lock is occupied all the check time. If the number of tablet is large, lock conflicts can be frequent, and the writeLock request will have to wait for long time.
Divide all partitions into small batch to check tablets, so that db.readLock can be released between batches.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
