### PR TITLE
[BugFix] Different column types in different chunks

### DIFF
--- a/be/src/exec/vectorized/csv_scanner.cpp
+++ b/be/src/exec/vectorized/csv_scanner.cpp
@@ -181,7 +181,7 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
 
         fill_columns_from_path(src_chunk, _num_fields_in_csv, _scan_range.ranges[_curr_file_index].columns_from_path,
                                src_chunk->num_rows());
-        ASSIGN_OR_RETURN(chunk, _materialize(src_chunk));
+        ASSIGN_OR_RETURN(chunk, materialize(nullptr, src_chunk));
     } while ((chunk)->num_rows() == 0);
     return std::move(chunk);
 }
@@ -272,43 +272,6 @@ ChunkPtr CSVScanner::_create_chunk(const std::vector<SlotDescriptor*>& slots) {
         chunk->append_column(std::move(column), slots[i]->id());
     }
     return chunk;
-}
-
-// TODO(zhuming): move this function to `FileScanner` or `FileScanNode`
-StatusOr<ChunkPtr> CSVScanner::_materialize(ChunkPtr& src_chunk) {
-    SCOPED_RAW_TIMER(&_counter->materialize_ns);
-
-    if (src_chunk->num_rows() == 0) {
-        return src_chunk;
-    }
-
-    ChunkPtr dest_chunk = std::make_shared<Chunk>();
-
-    // CREATE ROUTINE LOAD routine_load_job_1
-    // on table COLUMNS (k1,k2,k3=k1)
-    // The column k3 and k1 will pointer to the same entity.
-    // The k3 should be copied to avoid this case.
-    // column_pointers is a hashset to check the repeatability.
-    HashSet<uintptr_t> column_pointers;
-    int ctx_index = 0;
-    int src_rows = src_chunk->num_rows();
-    for (const auto& slot : _dest_tuple_desc->slots()) {
-        if (!slot->is_materialized()) {
-            continue;
-        }
-
-        int dest_index = ctx_index++;
-        ASSIGN_OR_RETURN(auto dst_col, _dest_expr_ctx[dest_index]->evaluate(src_chunk.get()));
-        auto col_pointer = reinterpret_cast<uintptr_t>(dst_col.get());
-        if (column_pointers.contains(col_pointer)) {
-            dst_col = dst_col->clone();
-        } else {
-            column_pointers.emplace(col_pointer);
-        }
-        dst_col = ColumnHelper::unfold_const_column(slot->type(), src_rows, dst_col);
-        dest_chunk->append_column(dst_col, slot->id());
-    }
-    return dest_chunk;
 }
 
 void CSVScanner::_report_error(const std::string& line, const std::string& err_msg) {

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -139,6 +139,11 @@ void FileScanner::fill_columns_from_path(starrocks::vectorized::ChunkPtr& chunk,
 StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::vectorized::ChunkPtr& src,
                                             starrocks::vectorized::ChunkPtr& cast) {
     SCOPED_RAW_TIMER(&_counter->materialize_ns);
+
+    if (cast->num_rows() == 0) {
+        return cast;
+    }
+
     // materialize
     ChunkPtr dest_chunk = std::make_shared<Chunk>();
 
@@ -166,10 +171,17 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::vectorized::ChunkPt
         } else {
             column_pointers.emplace(col_pointer);
         }
+
+        // The column builder in ctx->evaluate may build column as non-nullable.
+        // See be/src/column/column_builder.h#L79.
+        if (!col->is_nullable() && slot->is_nullable()) {
+            col = ColumnHelper::cast_to_nullable_column(col);
+        }
+
         col = ColumnHelper::unfold_const_column(slot->type(), cast->num_rows(), col);
         dest_chunk->append_column(col, slot->id());
 
-        if (col->is_nullable() && col->has_null()) {
+        if (src != nullptr && col->is_nullable() && col->has_null()) {
             if (_strict_mode && _dest_slot_desc_mappings[dest_index] != nullptr) {
                 ColumnPtr& src_col = src->get_column_by_slot_id(_dest_slot_desc_mappings[dest_index]->id());
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13053

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The column type like `datetime` is casted from `varchar` in the file scanner. `cast_from_string_to_datetime_fn` would build a column as nullable when there're nulls in the column, while it would build a column as non-nullable when there's no null in the column. So, the column types of different chunks may be different. 
The exchange node gets the chunk schema according to the first chunk it receives, and then parses the chunk according to the schema. In this way, the exchange node cannot handle the variable column type.
This PR corrects the columns returned by the `cast_from_string_to_datetime_fn` according to the actual schema. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
