### PR TITLE
[Cherry-pick][Branch-2.2][BugFix]Fix sync issue (backport #12343) (#12543)

### DIFF
--- a/be/src/env/env_posix.cpp
+++ b/be/src/env/env_posix.cpp
@@ -309,6 +309,7 @@ public:
         size_t bytes_written = 0;
         RETURN_IF_ERROR(do_writev_at(_fd, _filename, _filesize, data, cnt, &bytes_written));
         _filesize += bytes_written;
+        _pending_sync = true;
         return Status::OK();
     }
 

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -355,6 +355,12 @@ Status DataDir::get_shard(uint64_t* shard) {
     std::string shard_path = shard_path_stream.str();
     if (!FileUtils::check_exist(shard_path)) {
         RETURN_IF_ERROR(FileUtils::create_dir(shard_path));
+        std::string data_path = _path + DATA_PREFIX;
+        Status st = FileUtils::sync_dir(data_path, Env::Default());
+        if (!st.ok()) {
+            LOG(WARNING) << "Fail to sync " << data_path << ": " << st.to_string();
+            return st;
+        }
     }
 
     *shard = next_shard;

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -103,7 +103,8 @@ Status BetaRowsetWriter::init() {
 }
 
 StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
-    if (_num_rows_written > 0) {
+    if (_num_rows_written > 0 ||
+        (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && _segment_has_deletes.size() > 0)) {
         RETURN_IF_ERROR(_context.env->sync_dir(_context.rowset_path_prefix));
     }
     _rowset_meta->set_num_rows(_num_rows_written);

--- a/be/src/util/file_utils.cpp
+++ b/be/src/util/file_utils.cpp
@@ -62,6 +62,10 @@ Status FileUtils::create_dir(const std::string& dir_path) {
     return create_dir(dir_path, Env::Default());
 }
 
+Status FileUtils::sync_dir(const std::string& path, Env* env) {
+    return env->sync_dir(path);
+}
+
 Status FileUtils::remove_all(const std::string& file_path) {
     std::error_code ec;
     std::filesystem::remove_all(file_path, ec);

--- a/be/src/util/file_utils.h
+++ b/be/src/util/file_utils.h
@@ -57,6 +57,8 @@ public:
     //  Status::OK()      if create directory success or directory already exists
     static Status create_dir(const std::string& dir_path, Env* env);
 
+    static Status sync_dir(const std::string& path, Env* env);
+
     // Delete file recursively.
     static Status remove_all(const std::string& dir_path);
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
After the segment file is written, add a sync operation to ensure the durability of data.
Sync tablet's parent directories after creating a tablet.
Sync primary key tablet dir when new rowsets with only delete files are created
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
