### PR TITLE
[BugFix] Fix compilation error of simdjson

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -328,7 +328,7 @@ build_simdjson() {
     #ref: https://github.com/simdjson/simdjson/blob/master/HACKING.md
     mkdir -p $BUILD_DIR
     cd $BUILD_DIR
-    $CMAKE_CMD -G "${CMAKE_GENERATOR}" -DCMAKE_CXX_FLAGS="-O3" -DCMAKE_C_FLAGS="-O3" ..
+    $CMAKE_CMD -G "${CMAKE_GENERATOR}" -DCMAKE_CXX_FLAGS="-O3" -DCMAKE_C_FLAGS="-O3" -DSIMDJSON_AVX512_ALLOWED=OFF ..
     $CMAKE_CMD --build .
     mkdir -p $TP_INSTALL_DIR/lib
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/pull/12776/files
```
16:18:16 ===== begin build simdjson-2.2.0
16:18:16 -- The CXX compiler identification is GNU 10.3.0
16:18:16 -- The C compiler identification is GNU 10.3.0
16:18:16 -- Detecting CXX compiler ABI info
16:18:16 -- Detecting CXX compiler ABI info - done
16:18:16 -- Check for working CXX compiler: /usr/bin/g++ - skipped
16:18:16 -- Detecting CXX compile features
16:18:16 -- Detecting CXX compile features - done
16:18:16 -- Detecting C compiler ABI info
16:18:16 -- Detecting C compiler ABI info - done
16:18:16 -- Check for working C compiler: /usr/bin/gcc - skipped
16:18:16 -- Detecting C compile features
16:18:16 -- Detecting C compile features - done
16:18:16 -- No build type selected, default to Release
16:18:16 -- Looking for fork
16:18:16 -- Looking for fork - found
16:18:16 -- Looking for wait
16:18:16 -- Looking for wait - found
16:18:16 -- Looking for pthread.h
16:18:16 -- Looking for pthread.h - found
16:18:16 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
16:18:16 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
16:18:16 -- Check if compiler accepts -pthread
16:18:16 -- Check if compiler accepts -pthread - yes
16:18:17 -- Found Threads: TRUE  
16:18:17 -- Building only the library. Advanced users may want to turn SIMDJSON_DEVELOPER_MODE to ON, e.g., via -D SIMDJSON_DEVELOPER_MODE=ON.
16:18:17 -- Configuring done
16:18:17 -- Generating done
16:18:17 -- Build files have been written to: /var/local/thirdparty/src/simdjson-2.2.0/starrocks_build
16:18:17 [ 50%] Building CXX object CMakeFiles/simdjson.dir/src/simdjson.cpp.o
16:18:17 /tmp/ccFLKO9S.s: Assembler messages:
16:18:27 /tmp/ccFLKO9S.s:1419: Error: no such instruction: `vpcompressb %zmm2,(%rcx){%k3}'
16:18:27 /tmp/ccFLKO9S.s:1435: Error: no such instruction: `vpcompressb %zmm1,(%rcx){%k5}'
16:18:27 /tmp/ccFLKO9S.s:1546: Error: no such instruction: `vpcompressb %zmm1,(%r9){%k6}'
16:18:27 /tmp/ccFLKO9S.s:1555: Error: no such instruction: `vpcompressb %zmm2,(%rax){%k6}'
16:18:27 /tmp/ccFLKO9S.s:1961: Error: no such instruction: `vpcompressb %zmm13,%zmm1{%k4}{z}'
16:18:27 /tmp/ccFLKO9S.s:2006: Error: no such instruction: `vpcompressb %zmm13,%zmm4{%k5}{z}'
16:18:27 /tmp/ccFLKO9S.s:2196: Error: no such instruction: `vpcompressb %zmm0,%zmm4{%k6}{z}'
16:18:27 /tmp/ccFLKO9S.s:2226: Error: no such instruction: `vpcompressb %zmm0,%zmm2{%k7}{z}'
16:18:27 /tmp/ccFLKO9S.s:2248: Error: no such instruction: `vpcompressb %zmm0,%zmm2{%k6}{z}'
16:18:27 gmake[2]: *** [CMakeFiles/simdjson.dir/src/simdjson.cpp.o] Error 1
16:18:28 gmake[1]: *** [CMakeFiles/simdjson.dir/all] Error 2
16:18:28 gmake: *** [all] Error 2
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
