### PR TITLE
[Feature] upgrade admin/node/grant to new privilege system

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
@@ -620,21 +620,9 @@ public class AuthUpgrader {
         }
     }
 
+    // `grantPattern` only contains dbx.tblx or dbx.*.
     private boolean matchTableGrant(Set<Pair<String, String>> grantPattern, String db, String table) {
-        // check db.table
-        if (grantPattern.contains(Pair.create(db, table))) {
-            return true;
-        }
-        // check db.*
-        if (!table.equals(STAR) && grantPattern.contains(Pair.create(db, STAR))) {
-            return true;
-        }
-        // check *.*
-        if (!db.equals(STAR) && grantPattern.contains(Pair.create(STAR, STAR))) {
-            return true;
-        }
-        // check *.*
-        return false;
+        return grantPattern.contains(Pair.create(db, table)) || grantPattern.contains(Pair.create(db, STAR));
     }
 
     protected void upgradeImpersontaePrivileges(UserIdentity user, PrivilegeCollection collection)

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationProvider.java
@@ -74,7 +74,12 @@ public interface AuthorizationProvider {
             PEntryObject object,
             PrivilegeCollection currentPrivilegeCollection);
 
-    boolean checkAnyAction(
+    /**
+     * Search if any object in collection matches the specified object
+     * The specified object can be fuzzy-matching object.
+     * For example, `use db1` statement will pass a (db1, ALL) as the object to check if any table exists
+     */
+    boolean searchObject(
             short type,
             PEntryObject object,
             PrivilegeCollection currentPrivilegeCollection);

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
@@ -38,15 +38,22 @@ public class DbPEntryObject implements PEntryObject {
         id = dbId;
     }
 
+    /**
+     * if the current db matches other db, including fuzzy matching.
+     *
+     * this(db1), other(db1) -> true
+     * this(db1), other(ALL) -> true
+     * this(ALL), other(db1) -> false
+     */
     @Override
     public boolean match(Object obj) {
         if (!(obj instanceof DbPEntryObject)) {
             return false;
         }
-        if (id == ALL_DATABASE_ID) {
+        DbPEntryObject other = (DbPEntryObject) obj;
+        if (other.id == ALL_DATABASE_ID) {
             return true;
         }
-        DbPEntryObject other = (DbPEntryObject) obj;
         return other.id == id;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DefaultAuthorizationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DefaultAuthorizationProvider.java
@@ -152,8 +152,8 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public boolean checkAnyAction(short type, PEntryObject object, PrivilegeCollection currentPrivilegeCollection) {
-        return currentPrivilegeCollection.checkAnyAction(type, object);
+    public boolean searchObject(short type, PEntryObject object, PrivilegeCollection currentPrivilegeCollection) {
+        return currentPrivilegeCollection.searchObject(type, object);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PEntryObject.java
@@ -9,22 +9,34 @@ import com.starrocks.server.GlobalStateMgr;
  * For example, `GRANT SELECT ON TABLE db1.tbl1 TO user1` will create an object like (db1, tbl1)
  * Thus when user1 executes `SELECT * FROM db1.tbl1`, `PrivilegeChecker` will try to find a matching one in all the table
  * object and check if SELECT action is granted on it.
+ *
  * If the GRANT statement contains `ALL`, for example, `GRANT SELECT ON ALL TABLES IN DATABASE db1 TO user1`, a slightly
  * different object like (db1, ALL) will be created to represent fuzzy matching.
+ *
  * Another scenario that will take usage of this fuzzy matching is when user1 execute statement like `USE DATABASE db1`.
  * We shall create a (db1, ALL) to check if there's any table in the database db1 that user1 have any privilege on.
+ *
+ * But things will get a bit confused on fuzzy matching when checking allow grant. For example, if we execute
+ *   GRANT SELECT ON db1.tbl1 TO userx with grant option
+ * Then `userx` should be denied to execute
+ *   GRANT SELECT ON *.* TO usery
+ * In other words, fuzzy matching should be one-way matching.
  *
  * The matching rule on the above description can be simplified as this:
  * (db1, tbl1) matches (db1, tbl1)
  * (db1, ALL) matches (db1, tbl1)
- * (db1, tbl1) matches (db1, ALL)
+ * (db1, tbl1) doesn't match (db1, ALL)
  **/
 public interface PEntryObject extends Comparable<PEntryObject> {
 
     /**
-     * if the specific object matches current object, including fuzzy matching.
+     * if the current object matches other object, including fuzzy matching.
+     *
+     * this(db1.tbl1), other(db1.tbl1) -> true
+     * this(db1.tbl1), other(db1.ALL) -> true
+     * this(db1.ALL), other(db1.tbl1) -> false
      */
-    boolean match(Object obj);
+    boolean match(Object other);
 
     /**
      * return true if current object can be used for fuzzy matching

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeCollection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeCollection.java
@@ -186,7 +186,7 @@ public class PrivilegeCollection {
             return false;
         }
         for (PrivilegeEntry privilegeEntry : privilegeEntryList) {
-            if (objectMatch(privilegeEntry.object, object) && privilegeEntry.actionSet.contains(want)) {
+            if (objectMatch(object, privilegeEntry.object) && privilegeEntry.actionSet.contains(want)) {
                 return true;
             }
             // still looking for the next entry, maybe object match but with/without grant option
@@ -200,7 +200,7 @@ public class PrivilegeCollection {
             return false;
         }
         for (PrivilegeEntry privilegeEntry : privilegeEntryList) {
-            if (objectMatch(privilegeEntry.object, object)) {
+            if (objectMatch(object, privilegeEntry.object) || objectMatch(privilegeEntry.object, object)) {
                 return true;
             }
         }
@@ -217,7 +217,7 @@ public class PrivilegeCollection {
             Iterator<PEntryObject> iterator = unCheckedObjects.iterator();
             while (iterator.hasNext()) {
                 PEntryObject object = iterator.next();
-                if (privilegeEntry.isGrant && objectMatch(privilegeEntry.object, object)) {
+                if (privilegeEntry.isGrant && objectMatch(object, privilegeEntry.object)) {
                     if (privilegeEntry.actionSet.contains(wantSet)) {
                         iterator.remove();
                         if (unCheckedObjects.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeCollection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeCollection.java
@@ -194,12 +194,16 @@ public class PrivilegeCollection {
         return false;
     }
 
-    public boolean checkAnyAction(short type, PEntryObject object) {
+    public boolean searchObject(short type, PEntryObject object) {
         List<PrivilegeEntry> privilegeEntryList = typeToPrivilegeEntryList.get(type);
         if (privilegeEntryList == null) {
             return false;
         }
         for (PrivilegeEntry privilegeEntry : privilegeEntryList) {
+            // 1. objectMatch(object, privilegeEntry.object):
+            //    checking if db1.table1 exists for a user that's granted with `ALL tables in db1` will return true
+            // 2. objectMatch(privilegeEntry.object, object):
+            //    checking if any table in db1 exists for a user that's granted with `db1.table1` will return true
             if (objectMatch(object, privilegeEntry.object) || objectMatch(privilegeEntry.object, object)) {
                 return true;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -627,7 +627,7 @@ public class PrivilegeManager {
             PEntryObject dbObject = manager.provider.generateObject(
                     PrivilegeType.DATABASE.name(), Arrays.asList(db), manager.globalStateMgr);
             short dbTypeId = manager.analyzeType(PrivilegeType.DATABASE.name());
-            if (manager.provider.checkAnyAction(dbTypeId, dbObject, collection)) {
+            if (manager.provider.searchObject(dbTypeId, dbObject, collection)) {
                 return true;
             }
             // 2. check for any action in any table in this db
@@ -638,7 +638,7 @@ public class PrivilegeManager {
                     db,
                     manager.globalStateMgr);
             short tableTypeId = manager.analyzeType(PrivilegeType.TABLE.name());
-            return manager.provider.checkAnyAction(tableTypeId, allTableInDbObject, collection);
+            return manager.provider.searchObject(tableTypeId, allTableInDbObject, collection);
         } catch (PrivilegeException e) {
             LOG.warn("caught exception when check any on db {}", db, e);
             return false;
@@ -655,7 +655,7 @@ public class PrivilegeManager {
             PEntryObject tableObject = manager.provider.generateObject(
                     PrivilegeType.TABLE.name(), Arrays.asList(db, table), manager.globalStateMgr);
             short tableTypeId = manager.analyzeType(PrivilegeType.TABLE.name());
-            return manager.provider.checkAnyAction(tableTypeId, tableObject, collection);
+            return manager.provider.searchObject(tableTypeId, tableObject, collection);
         } catch (PrivilegeException e) {
             LOG.warn("caught exception when check any on db {}", db, e);
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -1377,7 +1377,6 @@ public class PrivilegeManager {
     }
 
     public void upgradeRoleInitPrivilegeUnlock(long roleId, RolePrivilegeCollection collection) {
-        // will produce journal in bdb
         roleIdToPrivilegeCollection.put(roleId, collection);
         roleNameToId.put(collection.getName(), roleId);
         LOG.info("upgrade role {}[{}]", collection.getName(), roleId);
@@ -1388,5 +1387,11 @@ public class PrivilegeManager {
         for (long roleId : roleIds) {
             collection.grantRole(roleId);
         }
+    }
+
+    // This function only change data in parent roles
+    // Child role will be update as a whole by upgradeRoleInitPrivilegeUnlock
+    public void upgradeParentRoleRelationUnlock(long parentRoleId, long subRoleId) {
+        roleIdToPrivilegeCollection.get(parentRoleId).addSubRole(subRoleId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ResourcePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ResourcePEntryObject.java
@@ -36,15 +36,22 @@ public class ResourcePEntryObject implements PEntryObject {
         this.name = name;
     }
 
+    /**
+     * if the current resource matches other resource, including fuzzy matching.
+     *
+     * this(hive0), other(hive0) -> true
+     * this(hive0), other(ALL) -> true
+     * this(ALL), other(hive0) -> false
+     */
     @Override
     public boolean match(Object obj) {
         if (!(obj instanceof ResourcePEntryObject)) {
             return false;
         }
-        if (name == null) {
+        ResourcePEntryObject other = (ResourcePEntryObject) obj;
+        if (other.name == null) {
             return true;
         }
-        ResourcePEntryObject other = (ResourcePEntryObject) obj;
         return other.name.equals(name);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
@@ -66,16 +66,23 @@ public class TablePEntryObject implements PEntryObject {
         this.databaseId = databaseId;
     }
 
+    /**
+     * if the current table matches other table, including fuzzy matching.
+     *
+     * this(db1.tbl1), other(db1.tbl1) -> true
+     * this(db1.tbl1), other(db1.ALL) -> true
+     * this(db1.ALL), other(db1.tbl1) -> false
+     */
     @Override
     public boolean match(Object obj) {
         if (!(obj instanceof TablePEntryObject)) {
             return false;
         }
         TablePEntryObject other = (TablePEntryObject) obj;
-        if (databaseId == ALL_DATABASE_ID || other.databaseId == ALL_DATABASE_ID) {
+        if (other.databaseId == ALL_DATABASE_ID) {
             return true;
         }
-        if (tableId == ALL_TABLES_ID || other.tableId == ALL_TABLES_ID) {
+        if (other.tableId == ALL_TABLES_ID) {
             return databaseId == other.databaseId;
         }
         return other.databaseId == databaseId && other.tableId == tableId;

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/UserPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/UserPEntryObject.java
@@ -32,15 +32,22 @@ public class UserPEntryObject implements PEntryObject {
         return new UserPEntryObject(null);
     }
 
+    /**
+     * if the current user matches other user, including fuzzy matching.
+     *
+     * this(userx), other(userx) -> true
+     * this(userx), other(ALL) -> true
+     * this(ALL), other(userx) -> false
+     */
     @Override
     public boolean match(Object obj) {
         if (!(obj instanceof UserPEntryObject)) {
             return false;
         }
-        if (userIdentity == null) {
+        UserPEntryObject other = (UserPEntryObject) obj;
+        if (other.userIdentity == null) {
             return true; // this object is all
         }
-        UserPEntryObject other = (UserPEntryObject) obj;
         return userIdentity.equals(other.userIdentity);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
@@ -29,11 +29,11 @@ public class PrivilegeCollectionTest {
         Assert.assertTrue(collection.check(system, admin, null));
 
         // grant select on object1
-        Assert.assertFalse(collection.checkAnyAction(table, table1));
+        Assert.assertFalse(collection.searchObject(table, table1));
         Assert.assertFalse(collection.check(table, select, table1));
         collection.grant(table, new ActionSet(Arrays.asList(select)), Arrays.asList(table1), false);
         Assert.assertTrue(collection.check(table, select, table1));
-        Assert.assertTrue(collection.checkAnyAction(table, table1));
+        Assert.assertTrue(collection.searchObject(table, table1));
 
         // grant select, insert on object1
         Assert.assertFalse(collection.check(table, insert, table1));
@@ -64,12 +64,12 @@ public class PrivilegeCollectionTest {
         Assert.assertFalse(collection.allowGrant(table, new ActionSet(Arrays.asList(insert)), Arrays.asList(table1)));
 
         // revoke insert,delete
-        Assert.assertTrue(collection.checkAnyAction(table, table1));
+        Assert.assertTrue(collection.searchObject(table, table1));
         collection.revoke(table, new ActionSet(Arrays.asList(insert, delete)), Arrays.asList(table1), false);
         Assert.assertFalse(collection.check(table, insert, table1));
         Assert.assertFalse(collection.allowGrant(table, new ActionSet(Arrays.asList(delete, insert)), Arrays.asList(table1)));
         Assert.assertFalse(collection.check(table, delete, table1));
-        Assert.assertFalse(collection.checkAnyAction(table, table1));
+        Assert.assertFalse(collection.searchObject(table, table1));
 
         // revoke system
         collection.revoke(system, new ActionSet(Arrays.asList(admin)), null, false);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Implement upgrading old admin_priv, node_priv, grant_priv to new privilege framework in AuthUpgrade.
* `node_priv` & `admin_priv` can only be granted at the global level.
  * User with `node_priv` in the old privilege framework will be granted a built-in role called `cluster_admin` after upgrading to the new privilege framework.
 * User with `admin_priv` in the old privilege framework will be granted two built-in roles called `cluster_admin` and `db_admin` after upgrading to the new privilege framework.
* `grant_priv` is very complicated.
  * User with `grant_priv ` on *global* level will be granted to a built-in role called `user_admin` after upgraded to the new privilege framework.
  * User with `grant_priv ` on *non-global* level will be granted `with grant option` for every other privilege of that level and the child level after upgrading to the new privilege framework. 
 
For example, let's say we have a userx with the following privileges.
```sql
grant grant_priv, select_priv, drop_priv in db1.* to userx;
grant insert_priv in db1.tbl1 to userx
grant insert_priv in db2.tbl1 to userx
```
After upgrading, the user will have the following privileges.
```
grant drop on database db1 to userx with grant option
grant select on all tables in db1 to userx with grant option
grant insert on db1.tbl1 to userx with grant option
grant insert on db2.tbl1 to userx
```

I also find a bug about fuzzy matching. The previous implementation is a two-way matching, but sometimes we need one-way.

* To find if the user has a certain privilege, we are using one-way matching. For example, if we are checking privilege on `select * from tablex` but the user is only granted with some columns of tablex, we should deny the statement.
* To find if the user has any object, we are using two-way matching. For example, if we are checking privilege on `use db1`, but the user is only granted with db1.tbl1, we should allow the statement.
* To find if the user can grant privilege, we are using one-way matching. For example, if we are checking privilege on `grant select on all tables in database db1` but the user is only granted with `db1.tbl1, we should deny the statement.

I have renamed the function in the second case from `checkAnyAction` to `searchObject`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
