### PR TITLE
[Enhancement] Load id in printed by planner

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.TupleDescriptor;
@@ -227,7 +228,7 @@ public class StreamLoadPlanner {
         queryGlobals.setTime_zone(streamLoadTask.getTimezone());
         params.setQuery_globals(queryGlobals);
 
-        LOG.info("load job id: {} tx id {} parallel {} compress {} replicated {} quorum {}", loadId,
+        LOG.info("load job id: {} tx id {} parallel {} compress {} replicated {} quorum {}", DebugUtil.printId(loadId),
                 streamLoadTask.getTxnId(),
                 queryOptions.getLoad_dop(),
                 queryOptions.getLoad_transmission_compression_type(), destTable.enableReplicatedStorage(),


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The origin load job id printed in fe.log is 
```
2022-11-08 10:54:05,311 INFO (thrift-server-pool-116|5022) [StreamLoadPlanner.plan():225] load job id: TUniqueId(hi:1822162106588316686, lo:-8722074479202054733) tx id 9134 parallel 0 compress NO_COMPRESSION
```
This PR corrects it as
```
2022-11-08 17:29:22,553 INFO (thrift-server-pool-4|158) [StreamLoadPlanner.plan():231] load job id: 314f9965-b5a3-9fde-b21d-b318499f8c98 tx id 10011 parallel 0 compress NO_COMPRESSION replicated false quorum MAJORITY
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
