### PR TITLE
[Feature] Support cluster manage statements in new RBAC privilege framework

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -304,8 +304,12 @@ public class ResourceMgr implements Writable {
                 // Since `nameToResource.entrySet` may change after it is called, resource
                 // may be dropped during `show resources`.So that we should do a null pointer
                 // check here. If resource is not null then we should check resource privs.
-                if (resource == null || !GlobalStateMgr.getCurrentState().getAuth().checkResourcePriv(
-                        ConnectContext.get(), resource.getName(), PrivPredicate.SHOW)) {
+                if (resource == null) {
+                    continue;
+                }
+                if (!GlobalStateMgr.getCurrentState().isUsingNewPrivilege() &&
+                        !GlobalStateMgr.getCurrentState().getAuth().checkResourcePriv(
+                            ConnectContext.get(), resource.getName(), PrivPredicate.SHOW)) {
                     continue;
                 }
                 resource.getProcNodeData(result);

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeType.java
@@ -91,7 +91,8 @@ public enum PrivilegeType {
         CREATE_RESOURCE(3),
         PLUGIN(4),
         FILE(5),
-        BLACKLIST(6);  // AND MORE...
+        BLACKLIST(6),
+        OPERATE(7);  // AND MORE...
 
         private final int id;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -667,14 +667,15 @@ public class StmtExecutor {
             // Suicide
             context.setKilled();
         } else {
-            // Check auth
-            // Only user itself and user with admin priv can kill connection
-            if (!killCtx.getQualifiedUser().equals(ConnectContext.get().getQualifiedUser())
-                    && !GlobalStateMgr.getCurrentState().getAuth().checkGlobalPriv(ConnectContext.get(),
-                    PrivPredicate.ADMIN)) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_KILL_DENIED_ERROR, id);
+            if (!GlobalStateMgr.getCurrentState().isUsingNewPrivilege()) {
+                // Check auth
+                // Only user itself and user with admin priv can kill connection
+                if (!killCtx.getQualifiedUser().equals(ConnectContext.get().getQualifiedUser())
+                        && !GlobalStateMgr.getCurrentState().getAuth().checkGlobalPriv(ConnectContext.get(),
+                                                                                   PrivPredicate.ADMIN)) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_KILL_DENIED_ERROR, id);
+                }
             }
-
             killCtx.kill(killStmt.isConnectionKill());
         }
         context.getState().setOk();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -150,6 +150,18 @@ public class PrivilegeCheckerV2 {
         }
     }
 
+    static void checkStmtOperatePrivilege(ConnectContext context) {
+        if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.OPERATE)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "OPERATE");
+        }
+    }
+
+    static void checkStmtNodePrivilege(ConnectContext context) {
+        if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.OPERATE)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "NODE");
+        }
+    }
+
     /**
      * check privilege by AST tree
      */
@@ -587,70 +599,83 @@ public class PrivilegeCheckerV2 {
         // ---------------------------------------- Show tablet Statement -------------------------------------------------
         @Override
         public Void visitShowTabletStatement(ShowTabletStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         // ---------------------------------------- Admin operate Statement -------------------------------------------------
 
         @Override
         public Void visitAdminSetConfigStatement(AdminSetConfigStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitAdminSetReplicaStatusStatement(AdminSetReplicaStatusStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitAdminShowConfigStatement(AdminShowConfigStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitAdminShowReplicaDistributionStatement(AdminShowReplicaDistributionStmt statement,
                                                                 ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitAdminRepairTableStatement(AdminRepairTableStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitAdminCancelRepairTableStatement(AdminCancelRepairTableStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitAdminCheckTabletsStatement(AdminCheckTabletsStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitKillStatement(KillStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitAlterSystemStatement(AlterSystemStmt statement, ConnectContext context) {
-            return checkStmtNodePrivilege(context);
+            checkStmtNodePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitCancelAlterSystemStatement(CancelAlterSystemStmt statement, ConnectContext context) {
-            return checkStmtNodePrivilege(context);
+            checkStmtNodePrivilege(context);
+            return null;
         }
 
         @Override
         public Void visitShowProcStmt(ShowProcStmt statement, ConnectContext context) {
-            return checkStmtOperatePrivilege(context);
+            checkStmtOperatePrivilege(context);
+            return null;
         }
 
         @Override
@@ -675,21 +700,6 @@ public class PrivilegeCheckerV2 {
                     checkStmtOperatePrivilege(context);
                 }
             });
-            return null;
-        }
-
-        // ---------------------------------------- Common Privilege logic -------------------------------------------------
-        private Void checkStmtOperatePrivilege(ConnectContext context) {
-            if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.OPERATE)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "OPERATE");
-            }
-            return null;
-        }
-
-        private Void checkStmtNodePrivilege(ConnectContext context) {
-            if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.OPERATE)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "NODE");
-            }
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -4,6 +4,7 @@ package com.starrocks.sql.analyzer;
 
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.UserIdentity;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.privilege.PrivilegeManager;
@@ -11,15 +12,25 @@ import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.sql.ast.AddSqlBlackListStmt;
+import com.starrocks.sql.ast.AdminCancelRepairTableStmt;
+import com.starrocks.sql.ast.AdminCheckTabletsStmt;
+import com.starrocks.sql.ast.AdminRepairTableStmt;
+import com.starrocks.sql.ast.AdminSetConfigStmt;
+import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowConfigStmt;
+import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
+import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
 import com.starrocks.sql.ast.AlterDatabaseQuotaStmt;
 import com.starrocks.sql.ast.AlterDatabaseRenameStatement;
 import com.starrocks.sql.ast.AlterResourceStmt;
+import com.starrocks.sql.ast.AlterSystemStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.BaseCreateAlterUserStmt;
 import com.starrocks.sql.ast.BaseGrantRevokePrivilegeStmt;
 import com.starrocks.sql.ast.BaseGrantRevokeRoleStmt;
 import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.CancelAlterSystemStmt;
 import com.starrocks.sql.ast.CreateFileStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoleStmt;
@@ -37,25 +48,40 @@ import com.starrocks.sql.ast.ExecuteAsStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.InstallPluginStmt;
 import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.KillStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RecoverDbStmt;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.SetPassVar;
+import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.SetUserPropertyStmt;
+import com.starrocks.sql.ast.SetVar;
 import com.starrocks.sql.ast.ShowAuthenticationStmt;
+import com.starrocks.sql.ast.ShowBackendsStmt;
+import com.starrocks.sql.ast.ShowBrokerStmt;
+import com.starrocks.sql.ast.ShowComputeNodesStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
+import com.starrocks.sql.ast.ShowFrontendsStmt;
 import com.starrocks.sql.ast.ShowGrantsStmt;
 import com.starrocks.sql.ast.ShowPluginsStmt;
+import com.starrocks.sql.ast.ShowProcStmt;
 import com.starrocks.sql.ast.ShowRolesStmt;
 import com.starrocks.sql.ast.ShowSmallFilesStmt;
 import com.starrocks.sql.ast.ShowSqlBlackListStmt;
+import com.starrocks.sql.ast.ShowTabletStmt;
+import com.starrocks.sql.ast.ShowTransactionStmt;
 import com.starrocks.sql.ast.ShowUserPropertyStmt;
+import com.starrocks.sql.ast.ShowVariablesStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UninstallPluginStmt;
 import com.starrocks.sql.ast.UseDbStmt;
 import com.starrocks.sql.ast.ViewRelation;
+
+import java.util.List;
 
 public class PrivilegeCheckerV2 {
     private static final String EXTERNAL_CATALOG_NOT_SUPPORT_ERR_MSG = "external catalog is not supported for now!";
@@ -257,7 +283,7 @@ public class PrivilegeCheckerV2 {
 
         @Override
         public Void visitCreateResourceStatement(CreateResourceStmt statement, ConnectContext context) {
-            if (! PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.CREATE_RESOURCE)) {
+            if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.CREATE_RESOURCE)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE_RESOURCE");
             }
             return null;
@@ -287,6 +313,35 @@ public class PrivilegeCheckerV2 {
         public Void visitInstallPluginStatement(InstallPluginStmt statement, ConnectContext context) {
             if (! PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.PLUGIN)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "PLUGIN");
+            }
+            return null;
+        }
+
+        // ---------------------------------------- Show Node Info Statement---------------------------------------------
+        @Override
+        public Void visitShowBackendsStatement(ShowBackendsStmt statement, ConnectContext context) {
+            return checkShowNodePrivilege(context);
+        }
+
+        @Override
+        public Void visitShowFrontendsStatement(ShowFrontendsStmt statement, ConnectContext context) {
+            return checkShowNodePrivilege(context);
+        }
+
+        @Override
+        public Void visitShowBrokerStatement(ShowBrokerStmt statement, ConnectContext context) {
+            return checkShowNodePrivilege(context);
+        }
+
+        @Override
+        public Void visitShowComputeNodes(ShowComputeNodesStmt statement, ConnectContext context) {
+            return checkShowNodePrivilege(context);
+        }
+
+        private Void checkShowNodePrivilege(ConnectContext context) {
+            if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.OPERATE)
+                    && !PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.NODE)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "OPERATE/NODE");
             }
             return null;
         }
@@ -483,6 +538,13 @@ public class PrivilegeCheckerV2 {
             return null;
         }
 
+        // ---------------------------------------- Show Transaction Statement ---------------------------------------------
+        @Override
+        public Void visitShowTransactionStatement(ShowTransactionStmt statement, ConnectContext context) {
+            // No authentication required
+            return null;
+        }
+
         @Override
         public Void visitAlterViewStatement(AlterViewStmt statement, ConnectContext context) {
             // 1. check if user can alter view in this db
@@ -511,6 +573,122 @@ public class PrivilegeCheckerV2 {
                 checkViewAction(session, statement.getTbl(), PrivilegeType.ViewAction.DROP);
             } else {
                 checkTableAction(session, statement.getTbl(), PrivilegeType.TableAction.DROP);
+            }
+            return null;
+        }
+
+        // ---------------------------------------- Show ariables Statement -----------------------------------------------
+        @Override
+        public Void visitShowVariablesStatement(ShowVariablesStmt statement, ConnectContext context) {
+            // No authentication required
+            return null;
+        }
+
+        // ---------------------------------------- Show tablet Statement -------------------------------------------------
+        @Override
+        public Void visitShowTabletStatement(ShowTabletStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        // ---------------------------------------- Admin operate Statement -------------------------------------------------
+
+        @Override
+        public Void visitAdminSetConfigStatement(AdminSetConfigStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitAdminSetReplicaStatusStatement(AdminSetReplicaStatusStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitAdminShowConfigStatement(AdminShowConfigStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitAdminShowReplicaDistributionStatement(AdminShowReplicaDistributionStmt statement,
+                                                                ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitAdminRepairTableStatement(AdminRepairTableStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitAdminCancelRepairTableStatement(AdminCancelRepairTableStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitAdminCheckTabletsStatement(AdminCheckTabletsStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitKillStatement(KillStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitAlterSystemStatement(AlterSystemStmt statement, ConnectContext context) {
+            return checkStmtNodePrivilege(context);
+        }
+
+        @Override
+        public Void visitCancelAlterSystemStatement(CancelAlterSystemStmt statement, ConnectContext context) {
+            return checkStmtNodePrivilege(context);
+        }
+
+        @Override
+        public Void visitShowProcStmt(ShowProcStmt statement, ConnectContext context) {
+            return checkStmtOperatePrivilege(context);
+        }
+
+        @Override
+        public Void visitSetStatement(SetStmt statement, ConnectContext context) {
+            List<SetVar> varList = statement.getSetVars();
+            varList.forEach(setVer -> {
+                if ((setVer instanceof SetPassVar)) {
+                    UserIdentity prepareChangeUser = ((SetPassVar) setVer).getUserIdent();
+                    try {
+                        prepareChangeUser.analyze();
+                    } catch (AnalysisException e) {
+                        ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_ERROR, "ANALYZE ERROR");
+                    }
+                    if (!context.getUserIdentity().equals(prepareChangeUser)) {
+                        if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.GRANT)) {
+                            ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
+                        }
+                    }
+                    return;
+                }
+                if (setVer.getType().equals(SetType.GLOBAL)) {
+                    checkStmtOperatePrivilege(context);
+                }
+            });
+            return null;
+        }
+
+        // ---------------------------------------- Common Privilege logic -------------------------------------------------
+        private Void checkStmtOperatePrivilege(ConnectContext context) {
+            if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.OPERATE)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "OPERATE");
+            }
+            return null;
+        }
+
+        private Void checkStmtNodePrivilege(ConnectContext context) {
+            if (!PrivilegeManager.checkSystemAction(context, PrivilegeType.SystemAction.OPERATE)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "NODE");
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AdminCancelRepairTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AdminCancelRepairTableStmt.java
@@ -7,6 +7,7 @@ import com.starrocks.analysis.TableRef;
 
 import java.util.List;
 
+// ADMIN CANCEL REPAIR TABLE example_db.example_table PARTITION(p1);
 public class AdminCancelRepairTableStmt extends DdlStmt {
 
     private final TableRef tblRef;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AdminShowReplicaDistributionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AdminShowReplicaDistributionStmt.java
@@ -10,7 +10,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSetMetaData;
 
-// admin show replica distribution from tbl [partition(p1, p2, ...)]
+// ADMIN SHOW REPLICA DISTRIBUTION FROM db1.tbl1 PARTITION(p1, p2);
 public class AdminShowReplicaDistributionStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("BackendId").add("ReplicaNum").add("Graph").add("Percent").build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AdminShowReplicaStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AdminShowReplicaStatusStmt.java
@@ -16,6 +16,7 @@ import com.starrocks.qe.ShowResultSetMetaData;
 
 import java.util.List;
 
+// ADMIN SHOW REPLICA STATUS FROM example_db.example_table;
 public class AdminShowReplicaStatusStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("TabletId").add("ReplicaId").add("BackendId").add("Version").add("LastFailedVersion")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetPassVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetPassVar.java
@@ -71,8 +71,10 @@ public class SetPassVar extends SetVar {
         }
 
         // 3. user has grant privs
-        if (!GlobalStateMgr.getCurrentState().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
+        if (!GlobalStateMgr.getCurrentState().isUsingNewPrivilege()) {
+            if (!GlobalStateMgr.getCurrentState().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetVar.java
@@ -92,10 +92,12 @@ public class SetVar implements ParseNode {
         }
 
         if (type == SetType.GLOBAL) {
-            if (!GlobalStateMgr.getCurrentState().getAuth()
-                    .checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                        "ADMIN");
+            if (!GlobalStateMgr.getCurrentState().isUsingNewPrivilege()) {
+                if (!GlobalStateMgr.getCurrentState().getAuth()
+                        .checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
+                                                        "ADMIN");
+                }
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -85,6 +85,7 @@ public class VariableMgrTest {
 
     @Test
     public void testNormal() throws IllegalAccessException, NoSuchFieldException, UserException {
+        GlobalStateMgr.getCurrentState().initAuth(false);
         SessionVariable var = VariableMgr.newSessionVariable();
         Assert.assertEquals(2147483648L, var.getMaxExecMemByte());
         Assert.assertEquals(300, var.getQueryTimeoutS());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2Test.java
@@ -113,7 +113,7 @@ public class PrivilegeCheckerV2Test {
 
         try {
             ctxToTestUser();
-            // user 'test' not has GRANT/NOD privilege
+            // user 'test' not has GRANT/NODE privilege
             PrivilegeCheckerV2.check(statement, starRocksAssert.getCtx());
             Assert.fail();
         } catch (SemanticException e) {
@@ -519,10 +519,18 @@ public class PrivilegeCheckerV2Test {
                 "revoke OPERATE on system from test",
                 "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
 
+        verifyNODEAndGRANT(
+                "show backends",
+                "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+
         verifyGrantRevoke(
                 "show frontends",
                 "grant OPERATE on system to test",
                 "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+
+        verifyNODEAndGRANT(
+                "show frontends",
                 "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
 
         verifyGrantRevoke(
@@ -530,10 +538,25 @@ public class PrivilegeCheckerV2Test {
                 "grant OPERATE on system to test",
                 "revoke OPERATE on system from test",
                 "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+
+        verifyNODEAndGRANT(
+                "show broker",
+                "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+
+        verifyGrantRevoke(
+                "show compute nodes",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+
+        verifyNODEAndGRANT(
+                "show compute nodes",
+                "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+
     }
 
     @Test
-    public void testShowTransactionAndTabletStmt() throws Exception {
+    public void testShowTabletStmt() throws Exception {
 
         verifyGrantRevoke(
                 "show tablet from example_db.example_table",
@@ -541,6 +564,16 @@ public class PrivilegeCheckerV2Test {
                 "revoke OPERATE on system from test",
                 "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
     }
+
+    @Test
+    public void testShowTransactionStmt() throws Exception {
+
+        ctxToTestUser();
+        ConnectContext ctx = starRocksAssert.getCtx();
+        StatementBase statement = UtFrameUtils.parseStmtWithNewParser("SHOW TRANSACTION FROM db WHERE ID=4005;", ctx);
+        PrivilegeCheckerV2.check(statement, starRocksAssert.getCtx());
+    }
+
 
     @Test
     public void testAdminOperateStmt() throws Exception {
@@ -618,7 +651,7 @@ public class PrivilegeCheckerV2Test {
 
     @Test
     public void testKillStmt() throws Exception {
-        // ShowProcStmt
+        // KillStmt
         verifyGrantRevoke(
                 "kill query 1",
                 "grant OPERATE on system to test",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2Test.java
@@ -104,6 +104,24 @@ public class PrivilegeCheckerV2Test {
         }
     }
 
+    private static void verifyNODEAndGRANT(String sql, String expectError) throws Exception {
+        ctxToRoot();
+        ConnectContext ctx = starRocksAssert.getCtx();
+        StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        // user 'root' has GRANT/NODE privilege
+        PrivilegeCheckerV2.check(statement, starRocksAssert.getCtx());
+
+        try {
+            ctxToTestUser();
+            // user 'test' not has GRANT/NOD privilege
+            PrivilegeCheckerV2.check(statement, starRocksAssert.getCtx());
+            Assert.fail();
+        } catch (SemanticException e) {
+            System.out.println(e.getMessage());
+            Assert.assertTrue(e.getMessage().contains(expectError));
+        }
+    }
+
     @Test
     public void testTableSelectDeleteInsert() throws Exception {
         verifyGrantRevoke(
@@ -490,5 +508,140 @@ public class PrivilegeCheckerV2Test {
                 "grant ALTER on database " + testDbName + " to test",
                 "revoke ALTER on database " + testDbName + " from test",
                 "Access denied for user 'test' to database '" + testDbName + "'");
+    }
+    
+    @Test
+    public void testShowNodeStmt() throws Exception {
+
+        verifyGrantRevoke(
+                "show backends",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+
+        verifyGrantRevoke(
+                "show frontends",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+
+        verifyGrantRevoke(
+                "show broker",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE/NODE privilege(s) for this operation");
+    }
+
+    @Test
+    public void testShowTransactionAndTabletStmt() throws Exception {
+
+        verifyGrantRevoke(
+                "show tablet from example_db.example_table",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+    }
+
+    @Test
+    public void testAdminOperateStmt() throws Exception {
+
+        // AdminSetConfigStmt
+        verifyGrantRevoke(
+                "admin set frontend config (\"key\" = \"value\");",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+
+        // AdminSetReplicaStatusStmt
+        verifyGrantRevoke(
+                "ADMIN SET REPLICA STATUS PROPERTIES(\"tablet_id\" = \"10003\", " +
+                    "\"backend_id\" = \"10001\", \"status\" = \"bad\");",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+
+        // AdminShowConfigStmt
+        verifyGrantRevoke(
+                "ADMIN SHOW FRONTEND CONFIG;",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+
+        // AdminShowReplicaDistributionStatement
+        verifyGrantRevoke(
+                "ADMIN SHOW REPLICA DISTRIBUTION FROM example_db.example_table PARTITION(p1, p2);",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+
+        // AdminShowReplicaStatusStatement
+        verifyGrantRevoke(
+                "ADMIN SHOW REPLICA STATUS FROM example_db.example_table;",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+
+        // AdminRepairTableStatement
+        verifyGrantRevoke(
+                "ADMIN REPAIR TABLE example_db.example_table PARTITION(p1);",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+
+        // AdminCancelRepairTableStatement
+        verifyGrantRevoke(
+                "ADMIN CANCEL REPAIR TABLE example_db.example_table PARTITION(p1);",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+
+        // AdminCheckTabletsStatement
+        verifyGrantRevoke(
+                "ADMIN CHECK TABLET (1, 2) PROPERTIES (\"type\" = \"CONSISTENCY\");",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+    }
+
+
+    @Test
+    public void testAlterSystemStmt() throws Exception {
+
+        // AlterSystemStmt
+        verifyNODEAndGRANT("ALTER SYSTEM ADD FOLLOWER \"127.0.0.1:9010\";",
+                           "Access denied; you need (at least one of) the NODE privilege(s) for this operation");
+
+        // CancelAlterSystemStmt
+        verifyNODEAndGRANT("CANCEL DECOMMISSION BACKEND \"host1:port\", \"host2:port\";",
+                           "Access denied; you need (at least one of) the NODE privilege(s) for this operation");
+    }
+
+    @Test
+    public void testKillStmt() throws Exception {
+        // ShowProcStmt
+        verifyGrantRevoke(
+                "kill query 1",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+    }
+
+    @Test
+    public void testShowProcStmt() throws Exception {
+        // ShowProcStmt
+        verifyGrantRevoke(
+                "show proc '/backends'",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied; you need (at least one of) the OPERATE privilege(s) for this operation");
+    }
+
+
+    @Test
+    public void testSetStmt() throws Exception {
+
+        String sql = "SET PASSWORD FOR 'jack'@'192.%' = PASSWORD('123456');";
+        String expectError = "Access denied; you need (at least one of) the GRANT privilege(s) for this operation";
+        verifyNODEAndGRANT(sql, expectError);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13107

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

PrivilegeCheckerV2 support cluster manage statements
1. `show backends`, `show frontends`, `show broker` statements.
2. `show tablet`, `show transaction`.

Support upgrading the privilege of system.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
