### PR TITLE
[BugFix] Be may crash after upgrading from 2.4.0-rc version to 2.4.0

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2282,7 +2282,17 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
         dest.key_size = src.key_size();
         dest.value_size = src.value_size();
         dest.nbucket = src.nbucket();
-        dest.data_size = src.data_size();
+        // This is for compatibility, we don't add data_size in shard_info in the rc version
+        // And data_size is added to reslove some bug(https://github.com/StarRocks/starrocks/issues/11868)
+        // However, if we upgrade from rc version, the data_size will be used as default value(0) which will cause
+        // some error in the subsequent logic
+        // So we will use file size as data_size which will cause some of disk space to be wasted, but it is a acceptable
+        // problem. And the wasted disk space will be reclaimed in the subsequent compaction, so it is acceptable
+        if (src.size() != 0 && src.data_size() == 0) {
+            dest.data_size = src.data().size();
+        } else {
+            dest.data_size = src.data_size();
+        }
     }
     size_t nlength = meta.shard_info_size();
     for (size_t i = 0; i < nlength; i++) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13126

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In order to fix the bug(https://github.com/StarRocks/starrocks/issues/11868), we add `data_size` into `ShardInfo` proto, but this may cause some compatibility problem and Be maybe crash after upgrade to 2.4.0.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
