### PR TITLE
[BugFix] Pruning of bucketed columns first follows TABLET HINT

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPruneRule.java
@@ -45,17 +45,16 @@ public class DistributionPruneRule extends TransformationRule {
         OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
 
         List<Long> result = Lists.newArrayList();
-        for (Long partitionId : olapScanOperator.getSelectedPartitionId()) {
-            Partition partition = olapTable.getPartition(partitionId);
-            MaterializedIndex table = partition.getIndex(olapScanOperator.getSelectedIndexId());
-            Collection<Long> tabletIds = distributionPrune(table, partition.getDistributionInfo(), olapScanOperator);
-            result.addAll(tabletIds);
-        }
-
-        // prune hint tablet
         Preconditions.checkState(olapScanOperator.getHintsTabletIds() != null);
         if (!olapScanOperator.getHintsTabletIds().isEmpty()) {
-            result.retainAll(olapScanOperator.getHintsTabletIds());
+            result.addAll(olapScanOperator.getHintsTabletIds());
+        } else {
+            for (Long partitionId : olapScanOperator.getSelectedPartitionId()) {
+                Partition partition = olapTable.getPartition(partitionId);
+                MaterializedIndex table = partition.getIndex(olapScanOperator.getSelectedIndexId());
+                Collection<Long> tabletIds = distributionPrune(table, partition.getDistributionInfo(), olapScanOperator);
+                result.addAll(tabletIds);
+            }
         }
 
         if (result.equals(olapScanOperator.getSelectedTabletId())) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
@@ -169,5 +169,13 @@ public class DistributionPrunerRuleTest {
                         .get(0);
 
         assertEquals(20, ((LogicalOlapScanOperator) optExpression.getOp()).getSelectedTabletId().size());
+
+
+        LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) optExpression.getOp();
+        LogicalOlapScanOperator newScanOperator = new LogicalOlapScanOperator.Builder()
+                .withOperator(olapScanOperator)
+                .setSelectedTabletId(Lists.newArrayList(1L, 2L, 3L))
+                .build();
+        assertEquals(3, newScanOperator.getSelectedTabletId().size());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13141

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
There are currently two problems.
1. The optimizer will cut out the tablet specified in the tablet hint, which does not conform to the logic of hint. If the user specifies hint, no automatic optimization should be performed on the position corresponding to hint.
2. If the number of tablets in the table is very large, the logic of bucketing tablet clipping will make an intersection "retainAll" between the full tablet and the hint tablet. This is very time-consuming and may cause the query plan to take too long.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
