### PR TITLE
[Cherry-pick][Branch-2.4][BugFix] Fix be crash when do compaction of PrimaryKey table

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1812,6 +1812,10 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker, const vector<uint32_t>
             }
         }
     }
+    if (info->inputs.empty()) {
+        LOG(INFO) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
+        return Status::OK();
+    }
     // do not reset _last_compaction_time_ms so we can continue doing compaction
     std::sort(info->inputs.begin(), info->inputs.end());
     LOG(INFO) << "update compaction with specified rowsets start tablet:" << _tablet.tablet_id()


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13079

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If there are no eligible rowsets in the primary key table, we will do a meaningless compaction and may cause NPE in the following code.
```
void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info) {
...
    // info->inputs is empty, so be will crash when calling the following function
    uint32_t max_rowset_id = *std::max_element(info->inputs.begin(), info->inputs.end());
    Rowset* rowset = _get_rowset(max_rowset_id).get();
...
}
```
We should return success directly when we don't find eligible rowset to do compaction.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
