### PR TITLE
[Enhancement] Add a default group id for routine load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -78,6 +78,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
     public static final String KAFKA_FILE_CATALOG = "kafka";
 
+    private static final String PROPERTY_KAFKA_GROUP_ID = "group.id";
+
     private String brokerList;
     private String topic;
     // optional, user want to load partitions.
@@ -447,6 +449,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         if (!stmt.getCustomKafkaProperties().isEmpty()) {
             setCustomKafkaProperties(stmt.getCustomKafkaProperties());
         }
+
+        setDefaultKafkaGroupID();
     }
 
     // this is a unprotected method which is called in the initialization function
@@ -459,6 +463,13 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
     private void setCustomKafkaProperties(Map<String, String> kafkaProperties) {
         this.customProperties = kafkaProperties;
+    }
+
+    private void setDefaultKafkaGroupID() {
+        if (this.customProperties.containsKey(PROPERTY_KAFKA_GROUP_ID)) {
+            return;
+        }
+        this.customProperties.put(PROPERTY_KAFKA_GROUP_ID, name + "_" + UUID.randomUUID());
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the consumer group id is not set by the user, the routine load coordinator BE would generate a random consumer group id for every routine load task. The kafka would retain these consumer groups until `offsets.retention.minutes` later.
This PR is to avoid the creation of the consumer group on every task scheduling. It generates a random consumer group id for the routine load job whose group id is not set. All tasks of the job would share the same group id.

The doc is updated by https://github.com/StarRocks/docs.zh-cn/pull/2748.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function
