### PR TITLE
[Cherry-pick 2.2][BugFix] Validate kafka offset either by custom offset or kafka meta before alter (#13061)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
@@ -124,21 +124,8 @@ public class KafkaProgress extends RoutineLoadProgress {
     }
 
     // modify the partition offset of this progress.
-    // throw exception is the specified partition does not exist in progress.
-    //
-    // `kafkaPartitionOffsets`, the parameter of this function, CAN BE MODIFIED to fit the actual value so that when
-    // all operations end, it will represent the actual offset of this job and will be persisted to the journal.
-    // All follower will replay this journal and load the actual offset of this job as well.
-    // For example:
-    //   if current offset is {0:11, 1:22, 2:33, 3:55}, the parameter `kafkaPartitionOffsets` is {0: 22, 2:44}
-    //   in this function, current offset is modified as {0: 22, 1: 22, 2:44, 3:55}
-    //   so is the parameter `kafkaPartitionOffsets`.
+    // all partitions are validated by the caller
     public void modifyOffset(List<Pair<Integer, Long>> kafkaPartitionOffsets) throws DdlException {
-        for (Pair<Integer, Long> pair : kafkaPartitionOffsets) {
-            if (!partitionIdToOffset.containsKey(pair.first)) {
-                throw new DdlException("The specified partition " + pair.first + " is not in the consumed partitions");
-            }
-        }
         for (Pair<Integer, Long> pair : kafkaPartitionOffsets) {
             partitionIdToOffset.put(pair.first, pair.second);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -51,6 +51,8 @@ import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.common.util.SmallFileMgr;
 import com.starrocks.common.util.SmallFileMgr.SmallFile;
+import com.starrocks.load.RoutineLoadDesc;
+import com.starrocks.qe.OriginStatement;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
@@ -65,6 +67,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * KafkaRoutineLoadJob is a kind of RoutineLoadJob which fetch data from kafka.
@@ -384,12 +387,12 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 stmt.getKafkaBrokerList(), stmt.getKafkaTopic());
         kafkaRoutineLoadJob.setOptional(stmt);
         kafkaRoutineLoadJob.checkCustomProperties();
-        kafkaRoutineLoadJob.checkCustomPartition();
+        kafkaRoutineLoadJob.checkCustomPartition(kafkaRoutineLoadJob.customKafkaPartitions);
 
         return kafkaRoutineLoadJob;
     }
 
-    private void checkCustomPartition() throws UserException {
+    private void checkCustomPartition(List<Integer> customKafkaPartitions) throws UserException {
         if (customKafkaPartitions.isEmpty()) {
             return;
         }
@@ -512,6 +515,35 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 }
             }
         }
+    }
+
+    /**
+     * add extra parameter check for changing kafka offset
+     * 1. if customKafkaParition is specified, only the specific partitions can be modified
+     * 2. otherwise, will check if partition is validated by actually reading kafka meta from kafka proxy
+     */
+    @Override
+    public void modifyJob(RoutineLoadDesc routineLoadDesc, Map<String, String> jobProperties,
+                          RoutineLoadDataSourceProperties dataSourceProperties, OriginStatement originStatement,
+                          boolean isReplay) throws DdlException {
+        if (!isReplay && dataSourceProperties != null && dataSourceProperties.hasAnalyzedProperties()) {
+            List<Pair<Integer, Long>> kafkaPartitionOffsets = dataSourceProperties.getKafkaPartitionOffsets();
+            if (customKafkaPartitions != null && customKafkaPartitions.size() != 0) {
+                for (Pair<Integer, Long> pair : kafkaPartitionOffsets) {
+                    if (! customKafkaPartitions.contains(pair.first)) {
+                        throw new DdlException("The specified partition " + pair.first + " is not in the custom partitions");
+                    }
+                }
+            } else {
+                // check if partition is validate
+                try {
+                    checkCustomPartition(kafkaPartitionOffsets.stream().map(k -> k.first).collect(Collectors.toList()));
+                } catch (UserException e) {
+                    throw new DdlException("The specified partition is not in the consumed partitions ", e);
+                }
+            }
+        }
+        super.modifyJob(routineLoadDesc, jobProperties, dataSourceProperties, originStatement, isReplay);
     }
 
     @Override


### PR DESCRIPTION
Fixes #13048

Altering the Kafka offset of a routine load job may cause FE to crash in various ways. I myself have committed two PRs to fix two of the scenarios.
https://github.com/StarRocks/starrocks/pull/8290
https://github.com/StarRocks/starrocks/pull/12227

The main reason is because, the Kafka partition offset from the job's metadata, won't initialize unless the job is scheduled, and it won't persist the progress unless data is loaded. Yet we often need it to validate the partitions from the statement. Thus in some cases, the Kafka offset between the leader and the followers may end up different.

The easiest way to fix all these meta-insistency problems is to initialize the offset and persist them in the first journal of creating this job. But if a new partition is created, the offset of this new partition still won't persist until data was loaded in it.

Another way to fix it is to avoid using the Kafka partition offset from the job's meta which won't persist in certain circumstances.

* If `customKafkaParition` is specified, then this job is created with specific partitions set by the user, which means only these partitions can be modified
* Otherwise, we shall check if the partition is validated by actually reading the Kafka meta from the Kafka proxy.

This PR is manually cherry-picked from ae08905fffb39fdded69f56abae104511a09dd0f