### PR TITLE
[Refactor] make cpu time more accurate & add `RequestBytesRead` metric

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -224,12 +224,18 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
     _profile.column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
 
     if (_use_block_cache) {
-        _profile.block_cache_read_counter = ADD_COUNTER(_runtime_profile, "BlockCacheReadCounter", TUnit::UNIT);
-        _profile.block_cache_read_bytes = ADD_COUNTER(_runtime_profile, "BlockCacheReadBytes", TUnit::BYTES);
-        _profile.block_cache_read_timer = ADD_TIMER(_runtime_profile, "BlockCacheReadTimer");
-        _profile.block_cache_write_counter = ADD_COUNTER(_runtime_profile, "BlockCacheWriteCounter", TUnit::UNIT);
-        _profile.block_cache_write_bytes = ADD_COUNTER(_runtime_profile, "BlockCacheWriteBytes", TUnit::BYTES);
-        _profile.block_cache_write_timer = ADD_TIMER(_runtime_profile, "BlockCacheWriteTimer");
+        static const char* prefix = "BlockCache";
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
+        _profile.block_cache_read_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadCounter", TUnit::UNIT, prefix);
+        _profile.block_cache_read_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadBytes", TUnit::BYTES, prefix);
+        _profile.block_cache_read_timer = ADD_CHILD_TIMER(_runtime_profile, "BlockCacheReadTimer", prefix);
+        _profile.block_cache_write_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteCounter", TUnit::UNIT, prefix);
+        _profile.block_cache_write_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteBytes", TUnit::BYTES, prefix);
+        _profile.block_cache_write_timer = ADD_CHILD_TIMER(_runtime_profile, "BlockCacheWriteTimer", prefix);
     }
 
     if (hdfs_scan_node.__isset.table_name) {

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -11,11 +11,6 @@
 
 namespace starrocks::vectorized {
 
-int64_t HdfsScanStats::get_cpu_time_ns() const {
-    // TODO: make it more accurate
-    return expr_filter_ns + column_convert_ns + column_read_ns + reader_init_ns - io_ns;
-}
-
 class CountedSeekableInputStream : public io::SeekableInputStreamWrapper {
 public:
     explicit CountedSeekableInputStream(const std::shared_ptr<io::SeekableInputStream>& stream,

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -11,6 +11,11 @@
 
 namespace starrocks::vectorized {
 
+int64_t HdfsScanStats::get_cpu_time_ns() const {
+    // TODO: make it more accurate
+    return expr_filter_ns + column_convert_ns + column_read_ns + reader_init_ns - io_ns;
+}
+
 class CountedSeekableInputStream : public io::SeekableInputStreamWrapper {
 public:
     explicit CountedSeekableInputStream(const std::shared_ptr<io::SeekableInputStream>& stream,
@@ -186,26 +191,33 @@ Status HdfsScanner::open_random_access_file() {
     CHECK(_file == nullptr) << "File has already been opened";
     ASSIGN_OR_RETURN(_raw_file, _scanner_params.fs->new_random_access_file(_scanner_params.path))
     _raw_file->set_size(_scanner_params.file_size);
-    auto stream = std::make_shared<CountedSeekableInputStream>(_raw_file->stream(), &_stats);
-    std::shared_ptr<io::SeekableInputStream> input_stream = stream;
+
+    std::shared_ptr<io::SeekableInputStream> input_stream = _raw_file->stream();
+    // if compression
+    // input_stream = DecompressInputStream(input_stream)
     if (_compression_type != CompressionTypePB::NO_COMPRESSION) {
         using DecompressorPtr = std::shared_ptr<StreamCompression>;
         std::unique_ptr<StreamCompression> dec;
         RETURN_IF_ERROR(StreamCompression::create_decompressor(_compression_type, &dec));
         auto compressed_input_stream =
-                std::make_shared<io::CompressedInputStream>(stream, DecompressorPtr(dec.release()));
+                std::make_shared<io::CompressedInputStream>(input_stream, DecompressorPtr(dec.release()));
         input_stream = std::make_shared<io::CompressedSeekableInputStream>(compressed_input_stream);
     }
 
+    // if block cache
+    // input_stream = CacheInputStream(input_stream)
     if (_scanner_params.use_block_cache && _compression_type == CompressionTypePB::NO_COMPRESSION) {
         _cache_input_stream = std::make_shared<io::CacheInputStream>(_raw_file->filename(), input_stream);
         _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_block_cache);
-        _file = std::make_unique<RandomAccessFile>(_cache_input_stream, _raw_file->filename());
-        _scanner_ctx.enable_block_cache = true;
-    } else {
-        _file = std::make_unique<RandomAccessFile>(input_stream, _raw_file->filename());
-        _scanner_ctx.enable_block_cache = false;
+        input_stream = _cache_input_stream;
     }
+
+    // input_stream = CountedInputStream(input_stream)
+    // NOTE: make sure `CountedInputStream` is last applied, so io time can be accurately timed.
+    input_stream = std::make_shared<CountedSeekableInputStream>(input_stream, &_stats);
+
+    // so wrap function is f(x) = (CountedInputStream (CacheInputStream (DecompressInputStream x)))
+    _file = std::make_unique<RandomAccessFile>(input_stream, _raw_file->filename());
     _file->set_size(_scanner_params.file_size);
     return Status::OK();
 }

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -49,10 +49,7 @@ struct HdfsScanStats {
     // late materialization
     int64_t skip_read_rows = 0;
 
-    int64_t get_cpu_time_ns() const {
-        // TODO: make it more accurate
-        return expr_filter_ns + column_convert_ns + column_read_ns + reader_init_ns;
-    }
+    int64_t get_cpu_time_ns() const;
 };
 
 class HdfsParquetProfile;
@@ -203,8 +200,6 @@ struct HdfsScannerContext {
 
     void append_not_existed_columns_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
     void append_partition_column_to_chunk(vectorized::ChunkPtr* chunk, size_t row_count);
-
-    bool enable_block_cache = false;
 };
 
 // if *lvalue == expect, swap(*lvalue,*rvalue)

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -36,7 +36,7 @@ struct HdfsScanStats {
 
     // parquet only!
     // read & decode
-    int64_t page_bytes_read = 0;
+    int64_t request_bytes_read = 0;
     int64_t level_decode_ns = 0;
     int64_t value_decode_ns = 0;
     int64_t page_read_ns = 0;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -36,6 +36,7 @@ struct HdfsScanStats {
 
     // parquet only!
     // read & decode
+    int64_t page_bytes_read = 0;
     int64_t level_decode_ns = 0;
     int64_t value_decode_ns = 0;
     int64_t page_read_ns = 0;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -51,7 +51,6 @@ struct HdfsScanStats {
     int64_t skip_read_rows = 0;
 
     int64_t get_cpu_time_ns() const {
-        // TODO: make it more accurate
         return expr_filter_ns + column_convert_ns + column_read_ns + reader_init_ns - io_ns;
     }
 };

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -49,7 +49,10 @@ struct HdfsScanStats {
     // late materialization
     int64_t skip_read_rows = 0;
 
-    int64_t get_cpu_time_ns() const;
+    int64_t get_cpu_time_ns() const {
+        // TODO: make it more accurate
+        return expr_filter_ns + column_convert_ns + column_read_ns + reader_init_ns - io_ns;
+    }
 };
 
 class HdfsParquetProfile;

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -14,7 +14,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 }
 
 void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
-    RuntimeProfile::Counter* page_bytes_read = nullptr;
+    RuntimeProfile::Counter* request_bytes_read = nullptr;
     RuntimeProfile::Counter* level_decode_timer = nullptr;
     RuntimeProfile::Counter* value_decode_timer = nullptr;
     RuntimeProfile::Counter* page_read_timer = nullptr;
@@ -30,7 +30,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
 
     RuntimeProfile* root = profile->runtime_profile;
     ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::UNIT);
-    page_bytes_read = ADD_CHILD_COUNTER(root, "PageBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
+    request_bytes_read = ADD_CHILD_COUNTER(root, "RequestBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
 
     level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
     value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
@@ -43,7 +43,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
 
-    COUNTER_UPDATE(page_bytes_read, _stats.page_bytes_read);
+    COUNTER_UPDATE(request_bytes_read, _stats.request_bytes_read);
     COUNTER_UPDATE(value_decode_timer, _stats.value_decode_ns);
     COUNTER_UPDATE(level_decode_timer, _stats.level_decode_ns);
     COUNTER_UPDATE(page_read_timer, _stats.page_read_ns);

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -14,7 +14,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 }
 
 void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
-    RuntimeProfile::Counter* parsed_bytes_read = nullptr;
+    RuntimeProfile::Counter* page_bytes_read = nullptr;
     RuntimeProfile::Counter* level_decode_timer = nullptr;
     RuntimeProfile::Counter* value_decode_timer = nullptr;
     RuntimeProfile::Counter* page_read_timer = nullptr;
@@ -30,7 +30,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
 
     RuntimeProfile* root = profile->runtime_profile;
     ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::UNIT);
-    parsed_bytes_read = ADD_CHILD_COUNTER(root, "ParsedBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
+    page_bytes_read = ADD_CHILD_COUNTER(root, "PageBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
 
     level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
     value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
@@ -43,7 +43,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
 
-    COUNTER_UPDATE(parsed_bytes_read, _stats.page_bytes_read);
+    COUNTER_UPDATE(page_bytes_read, _stats.page_bytes_read);
     COUNTER_UPDATE(value_decode_timer, _stats.value_decode_ns);
     COUNTER_UPDATE(level_decode_timer, _stats.level_decode_ns);
     COUNTER_UPDATE(page_read_timer, _stats.page_read_ns);

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -14,6 +14,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 }
 
 void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
+    RuntimeProfile::Counter* parsed_bytes_read = nullptr;
     RuntimeProfile::Counter* level_decode_timer = nullptr;
     RuntimeProfile::Counter* value_decode_timer = nullptr;
     RuntimeProfile::Counter* page_read_timer = nullptr;
@@ -29,6 +30,8 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
 
     RuntimeProfile* root = profile->runtime_profile;
     ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::UNIT);
+    parsed_bytes_read = ADD_CHILD_COUNTER(root, "ParsedBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
+
     level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
     value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
 
@@ -40,6 +43,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
 
+    COUNTER_UPDATE(parsed_bytes_read, _stats.page_bytes_read);
     COUNTER_UPDATE(value_decode_timer, _stats.value_decode_ns);
     COUNTER_UPDATE(level_decode_timer, _stats.level_decode_ns);
     COUNTER_UPDATE(page_read_timer, _stats.page_read_ns);

--- a/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_parquet.cpp
@@ -28,7 +28,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
 
     RuntimeProfile* root = profile->runtime_profile;
-    ADD_TIMER(root, kParquetProfileSectionPrefix);
+    ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::UNIT);
     level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
     value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
 

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -213,8 +213,6 @@ public:
     void clearIORanges() override;
     void setIORanges(std::vector<orc::InputStream::IORange>& io_ranges) override;
 
-    void set_enable_block_cache(bool v) { _buffer_stream.set_enable_block_cache(v); }
-
 private:
     void doRead(void* buf, uint64_t length, uint64_t offset, bool direct);
     bool canUseCacheBuffer(uint64_t offset, uint64_t length);

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -87,7 +87,10 @@ Status ColumnChunkReader::skip_page() {
 
 Status ColumnChunkReader::_parse_page_header() {
     DCHECK(_page_parse_state == INITIALIZED || _page_parse_state == PAGE_DATA_PARSED);
+    size_t off = _page_reader->get_offset();
     RETURN_IF_ERROR(_page_reader->next_header());
+    size_t now = _page_reader->get_offset();
+    _opts.stats->page_bytes_read += (now - off);
 
     // The page num values will be used for late materialization before parsing page data,
     // so we set _num_values when parsing header.
@@ -129,6 +132,7 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
                                                          bool is_compressed) {
     RETURN_IF_ERROR(CurrentThread::mem_tracker()->check_mem_limit("read and decompress page"));
     if (is_compressed && _compress_codec != nullptr) {
+        _opts.stats->page_bytes_read += compressed_size;
         Slice com_slice("", compressed_size);
         RETURN_IF_ERROR(_page_reader->read_bytes((const uint8_t**)&com_slice.data, com_slice.size));
 
@@ -136,6 +140,7 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
         _data = Slice(_uncompressed_buf.get(), uncompressed_size);
         RETURN_IF_ERROR(_compress_codec->decompress(com_slice, &_data));
     } else {
+        _opts.stats->page_bytes_read += uncompressed_size;
         _data.size = uncompressed_size;
         RETURN_IF_ERROR(_page_reader->read_bytes((const uint8_t**)&_data.data, _data.size));
     }

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -90,7 +90,7 @@ Status ColumnChunkReader::_parse_page_header() {
     size_t off = _page_reader->get_offset();
     RETURN_IF_ERROR(_page_reader->next_header());
     size_t now = _page_reader->get_offset();
-    _opts.stats->page_bytes_read += (now - off);
+    _opts.stats->request_bytes_read += (now - off);
 
     // The page num values will be used for late materialization before parsing page data,
     // so we set _num_values when parsing header.
@@ -132,7 +132,7 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
                                                          bool is_compressed) {
     RETURN_IF_ERROR(CurrentThread::mem_tracker()->check_mem_limit("read and decompress page"));
     if (is_compressed && _compress_codec != nullptr) {
-        _opts.stats->page_bytes_read += compressed_size;
+        _opts.stats->request_bytes_read += compressed_size;
         Slice com_slice("", compressed_size);
         RETURN_IF_ERROR(_page_reader->read_bytes((const uint8_t**)&com_slice.data, com_slice.size));
 
@@ -140,7 +140,7 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
         _data = Slice(_uncompressed_buf.get(), uncompressed_size);
         RETURN_IF_ERROR(_compress_codec->decompress(com_slice, &_data));
     } else {
-        _opts.stats->page_bytes_read += uncompressed_size;
+        _opts.stats->request_bytes_read += uncompressed_size;
         _data.size = uncompressed_size;
         RETURN_IF_ERROR(_page_reader->read_bytes((const uint8_t**)&_data.data, _data.size));
     }

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -80,6 +80,8 @@ Status FileReader::_parse_footer() {
         }
     }
 
+    _scanner_ctx->stats->page_bytes_read += footer_size + 8;
+
     tparquet::FileMetaData t_metadata;
     // deserialize footer
     RETURN_IF_ERROR(deserialize_thrift_msg(footer_buf + to_read - 8 - footer_size, &footer_size, TProtocolType::COMPACT,

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -80,7 +80,7 @@ Status FileReader::_parse_footer() {
         }
     }
 
-    _scanner_ctx->stats->page_bytes_read += footer_size + 8;
+    _scanner_ctx->stats->request_bytes_read += footer_size + 8;
 
     tparquet::FileMetaData t_metadata;
     // deserialize footer

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -453,7 +453,6 @@ Status FileReader::_init_group_readers() {
             r->set_end_offset(end_offset);
         }
         _sb_stream->set_io_ranges(ranges);
-        _sb_stream->set_enable_block_cache(fd_scanner_ctx.enable_block_cache);
         param.shared_buffered_stream = _sb_stream.get();
     }
 

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -43,6 +43,8 @@ public:
         _next_header_pos = offset;
     }
 
+    uint64_t get_offset() const { return _offset; }
+
 private:
     IBufferedInputStream* _stream;
     tparquet::PageHeader _cur_header;

--- a/be/src/util/buffered_stream.h
+++ b/be/src/util/buffered_stream.h
@@ -98,7 +98,6 @@ public:
     Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes, bool peek) override;
     void release();
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
-    void set_enable_block_cache(bool v) { _enable_block_cache = v; }
 
 private:
     struct SharedBuffer {
@@ -111,7 +110,6 @@ private:
     RandomAccessFile* _file;
     std::map<int64_t, SharedBuffer> _map;
     CoalesceOptions _options;
-    bool _enable_block_cache = false;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to:
1. put `block_cache` metrics under section of `BlockCache`
2. remove unsued `_enable_block_cache` field
3. refactor input stream, from bottom to up:
   - RawFileInputStream (s3/hdfs)
   - DecompressionInputStream (to decompress)
   - CacheInputStream ( to do some block cache work) 
   - CountedInputStream (to record io time and count)
   - So that `io_ns` is more accurate about time spent on IO.
 4. fix `cpu_time_ns` ( have to minus `io_ns` )
 5. add `RequestBytesRead` metric to show __how many bytes are really need by parquet parser__

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
