### PR TITLE
[BugFix] align the return column of array_map with the return type

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -187,7 +187,7 @@ public:
     static ColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable);
 
     // expression trees' return column should align return type when some return columns may be different from
-    // the required return type. e.g., expr returns col from create_const_null_column(), it's type is Nullable(int8),
+    // the required return type. e.g., concat_ws returns col from create_const_null_column(), it's type is Nullable(int8),
     // but required return type is nullable(string), so col need align return type to nullable(string).
     static ColumnPtr align_return_type(const ColumnPtr& old_col, const TypeDescriptor& type_desc, size_t num_rows);
 

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -186,6 +186,11 @@ public:
     // Create an empty column
     static ColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable);
 
+    // expression trees' return column should align return type when some return columns may be different from
+    // the required return type. e.g., expr returns col from create_const_null_column(), it's type is Nullable(int8),
+    // but required return type is nullable(string), so col need align return type to nullable(string).
+    static ColumnPtr align_return_type(const ColumnPtr& old_col, const TypeDescriptor& type_desc, size_t num_rows);
+
     // Create a column with specified size, the column will be resized to size
     static ColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size);
 

--- a/be/src/exprs/vectorized/array_map_expr.cpp
+++ b/be/src/exprs/vectorized/array_map_expr.cpp
@@ -20,6 +20,8 @@
 namespace starrocks::vectorized {
 ArrayMapExpr::ArrayMapExpr(const TExprNode& node) : Expr(node, false) {}
 
+ArrayMapExpr::ArrayMapExpr(TypeDescriptor type) : Expr(std::move(type), false) {}
+
 inline bool offsets_equal(const UInt32Column::Ptr& array1, const UInt32Column::Ptr& array2) {
     if (array1->size() != array2->size()) {
         return false;

--- a/be/src/exprs/vectorized/array_map_expr.h
+++ b/be/src/exprs/vectorized/array_map_expr.h
@@ -19,6 +19,9 @@ class ArrayMapExpr final : public Expr {
 public:
     ArrayMapExpr(const TExprNode& node);
 
+    // for tests
+    explicit ArrayMapExpr(TypeDescriptor type);
+
     Expr* clone(ObjectPool* pool) const override { return pool->add(new ArrayMapExpr(*this)); }
 
     ColumnPtr evaluate(ExprContext* context, Chunk* ptr) override;

--- a/be/test/exprs/vectorized/lambda_function_expr_test.cpp
+++ b/be/test/exprs/vectorized/lambda_function_expr_test.cpp
@@ -266,6 +266,13 @@ private:
     ObjectPool _objpool;
 };
 
+TypeDescriptor new_array_type(const TypeDescriptor& child_type) {
+    TypeDescriptor t;
+    t.type = TYPE_ARRAY;
+    t.children.emplace_back(child_type);
+    return t;
+}
+
 // just consider one level, not nested
 // array_map(lambdaFunction(x<type>, lambdaExpr),array<type>)
 TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_normal_array) {
@@ -274,8 +281,10 @@ TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_normal_array) {
     cur_chunk->append_column(build_int_column(vec_a), 1);
     for (int i = 0; i < 1; ++i) {
         for (int j = 0; j < _lambda_func.size(); ++j) {
-            expr_node.fn.name.function_name = "array_map";
-            ArrayMapExpr array_map_expr(expr_node);
+            expr_node.is_nullable = true;
+            auto array_type = new_array_type(expr_node);
+            array_type.fn.name.function_name = "array_map";
+            ArrayMapExpr array_map_expr(array_type);
             array_map_expr.clear_children();
             array_map_expr.add_child(_lambda_func[j]);
             array_map_expr.add_child(_array_expr[i]);

--- a/be/test/exprs/vectorized/lambda_function_expr_test.cpp
+++ b/be/test/exprs/vectorized/lambda_function_expr_test.cpp
@@ -515,10 +515,10 @@ TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_const_array) {
                 if (result->is_nullable()) {
                     auto col = std::dynamic_pointer_cast<NullableColumn>(result);
                     auto array_col = std::dynamic_pointer_cast<ArrayColumn>(col->data_column());
-                    EXPECT_EQ(2, array_col->elements_column()->type_size()); // bool
+                    EXPECT_EQ(2, array_col->elements_column()->type_size()); // nullable bool
                 } else {
                     auto array_col = std::dynamic_pointer_cast<ArrayColumn>(result);
-                    EXPECT_EQ(2, array_col->elements_column()->type_size()); // bool
+                    EXPECT_EQ(2, array_col->elements_column()->type_size()); // nullable bool
                 }
             }
             Expr::close(expr_ctxs, &_runtime_state);

--- a/be/test/exprs/vectorized/lambda_function_expr_test.cpp
+++ b/be/test/exprs/vectorized/lambda_function_expr_test.cpp
@@ -504,6 +504,11 @@ TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_const_array) {
                 ASSERT_TRUE(result->get(0).get_array().empty());
                 ASSERT_TRUE(result->get(1).get_array().empty());
                 ASSERT_TRUE(result->get(2).get_array().empty());
+                if (j == 1) { // array<int> -> array<bool>
+                    auto col = std::dynamic_pointer_cast<NullableColumn>(result);
+                    auto array_col = std::dynamic_pointer_cast<ArrayColumn>(col->data_column());
+                    EXPECT_EQ(1, array_col->elements_column()->type_size()); // bool
+                }
             }
 
             Expr::close(expr_ctxs, &_runtime_state);


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/starrocks/issues/12872, https://github.com/StarRocks/starrocks/issues/12793, https://github.com/StarRocks/starrocks/issues/12791

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

expression trees' return column should align return type when some return columns may be different from
the required return type. e.g., expr returns col from create_const_null_column(), it's type is Nullable(int8),
but required return type is nullable(string), so col need align return type to nullable(string).

the result column of array_map does not align return type, resulting in the binary of serialization and deserialization are different.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
