### PR TITLE
[BugFix] export be crash if disconnect with broker(#13201)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExportSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExportSink.java
@@ -92,7 +92,11 @@ public class ExportSink extends DataSink {
         FsBroker broker = GlobalStateMgr.getCurrentState().getBrokerMgr().getAnyBroker(brokerDesc.getName());
         if (broker != null) {
             tExportSink.addToBroker_addresses(new TNetworkAddress(broker.ip, broker.port));
+        } else {
+            // make be fail to exec Export job but not crash.
+            tExportSink.addToBroker_addresses(new TNetworkAddress("", -1));
         }
+
         tExportSink.setUse_broker(brokerDesc.hasBroker());
         tExportSink.setHdfs_write_buffer_size_kb(Config.hdfs_write_buffer_size_kb);
         if (!brokerDesc.hasBroker()) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13201 

## Problem Summary(Required) ：
Problem:
If fe disconnect with broker and we exec a Export Job, fe may pass a illegal parameter to be and make be crash.

Solution:
There are two ways to fix this problem:
1. throw an exception when broker is disconnected.
2. pass a legal but useless parameter to be when broker is disconnected and make be fail to exec Export job but not crash. Here, we prefer the second one, because in general, toThrift generally do not throw exceptions in fe.

