### PR TITLE
[Enhancement] Support cache persistence for block cache

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -16,12 +16,6 @@ BlockCache::BlockCache() {
     _kv_cache = std::make_unique<FbCacheLib>();
 }
 
-BlockCache::~BlockCache() {
-    if (_kv_cache) {
-        _kv_cache->destroy();
-    }
-}
-
 BlockCache* BlockCache::instance() {
     static BlockCache cache;
     return &cache;
@@ -90,6 +84,10 @@ Status BlockCache::remove_cache(const CacheKey& cache_key, off_t offset, size_t 
         RETURN_IF_ERROR(_kv_cache->remove_cache(block_key));
     }
     return Status::OK();
+}
+
+Status BlockCache::shutdown() {
+    return _kv_cache->shutdown();
 }
 
 } // namespace starrocks

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -11,8 +11,6 @@ class BlockCache {
 public:
     typedef std::string CacheKey;
 
-    ~BlockCache();
-
     // Return a singleton block cache instance
     static BlockCache* instance();
 
@@ -33,6 +31,9 @@ public:
 
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove_cache(const CacheKey& cache_key, off_t offset, size_t size);
+
+    // Shutdown the cache instance to save some state meta
+    Status shutdown();
 
     size_t block_size() const { return _block_size; }
 

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -16,6 +16,7 @@ struct CacheOptions {
     // basic
     size_t mem_space_size;
     std::vector<DirSpace> disk_spaces;
+    std::string meta_path;
 
     // advanced
     size_t block_size;

--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -4,6 +4,7 @@
 
 #include "common/logging.h"
 #include "common/statusor.h"
+#include "util/filesystem_util.h"
 
 namespace starrocks {
 
@@ -12,18 +13,18 @@ Status FbCacheLib::init(const CacheOptions& options) {
     config.setCacheSize(options.mem_space_size).setCacheName("default cache").setAccessConfig({25, 10});
     config.enableCachePersistence(options.meta_path).validate();
 
+    std::vector<std::string> nvm_files;
     if (!options.disk_spaces.empty()) {
         Cache::NvmCacheConfig nvmConfig;
         nvmConfig.navyConfig.setBlockSize(4096);
 
-        std::vector<std::string> files;
         for (auto& dir : options.disk_spaces) {
-            files.emplace_back(dir.path + "/cachelib_data");
+            nvm_files.emplace_back(dir.path + "/cachelib_data");
         }
-        if (files.size() == 1) {
-            nvmConfig.navyConfig.setSimpleFile(files[0], options.disk_spaces[0].size, false);
+        if (nvm_files.size() == 1) {
+            nvmConfig.navyConfig.setSimpleFile(nvm_files[0], options.disk_spaces[0].size, false);
         } else {
-            nvmConfig.navyConfig.setRaidFiles(files, options.disk_spaces[0].size, false);
+            nvmConfig.navyConfig.setRaidFiles(nvm_files, options.disk_spaces[0].size, false);
         }
         nvmConfig.navyConfig.blockCache().setRegionSize(16 * 1024 * 1024);
         nvmConfig.navyConfig.blockCache().setDataChecksum(options.checksum);
@@ -40,6 +41,12 @@ Status FbCacheLib::init(const CacheOptions& options) {
         // open file descriptors and associated fcntl locks).
         _cache.reset();
         LOG(INFO) << "couldn't attach to block cache: " << e.what() << ", creating a new one";
+
+        // Clean meta and data files
+        nvm_files.emplace_back(options.meta_path + "/metadata");
+        nvm_files.emplace_back(options.meta_path + "/NvmCacheState");
+        FileSystemUtil::remove_paths(nvm_files);
+
         _cache = std::make_unique<Cache>(Cache::SharedMemNew, config);
         _default_pool = _cache->addPool("default pool", _cache->getCacheMemoryStats().cacheSize);
     }

--- a/be/src/block_cache/fb_cachelib.h
+++ b/be/src/block_cache/fb_cachelib.h
@@ -16,7 +16,7 @@ public:
     using ReadHandle = facebook::cachelib::LruAllocator::ReadHandle;
 
     FbCacheLib() = default;
-    ~FbCacheLib();
+    ~FbCacheLib() override = default;
 
     Status init(const CacheOptions& options) override;
 
@@ -26,7 +26,7 @@ public:
 
     Status remove_cache(const std::string& key) override;
 
-    Status destroy() override;
+    Status shutdown() override;
 
 private:
     std::unique_ptr<Cache> _cache = nullptr;

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -24,7 +24,7 @@ public:
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove_cache(const std::string& key) = 0;
 
-    virtual Status destroy() = 0;
+    virtual Status shutdown() = 0;
 };
 
 } // namespace starrocks

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -869,6 +869,7 @@ CONF_Int64(max_length_for_bitmap_function, "1000000");
 CONF_Bool(block_cache_enable, "false");
 CONF_Int64(block_cache_disk_size, "0");
 CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
+CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
 CONF_Int64(block_cache_block_size, "1048576");  // 1MB
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 CONF_Bool(block_cache_checksum_enable, "true");

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -306,12 +306,12 @@ int main(int argc, char** argv) {
         start_be();
     }
 
-    daemon->stop();
-    daemon.reset();
-
 #ifdef WITH_BLOCK_CACHE
     starrocks::BlockCache::instance()->shutdown();
 #endif
+
+    daemon->stop();
+    daemon.reset();
 
 #ifdef USE_STAROS
     starrocks::shutdown_staros_worker();

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -187,6 +187,7 @@ int main(int argc, char** argv) {
                         {.path = p.path, .size = static_cast<size_t>(starrocks::config::block_cache_disk_size)});
             }
         }
+        cache_options.meta_path = starrocks::config::block_cache_meta_path;
         cache_options.block_size = starrocks::config::block_cache_block_size;
         cache_options.checksum = starrocks::config::block_cache_checksum_enable;
         cache->init(cache_options);
@@ -307,6 +308,10 @@ int main(int argc, char** argv) {
 
     daemon->stop();
     daemon.reset();
+
+#ifdef WITH_BLOCK_CACHE
+    starrocks::BlockCache::instance()->shutdown();
+#endif
 
 #ifdef USE_STAROS
     starrocks::shutdown_staros_worker();

--- a/build.sh
+++ b/build.sh
@@ -118,7 +118,7 @@ if [[ -z $(grep -o 'sse[^ ]*' /proc/cpuinfo) ]]; then
 fi
 
 if [[ -z ${WITH_BLOCK_CACHE} ]]; then
-	WITH_BLOCK_CACHE=OFF
+	WITH_BLOCK_CACHE=ON
 fi
 
 if [[ "${WITH_BLOCK_CACHE}" == "ON" && ! -f ${STARROCKS_THIRDPARTY}/installed/cachelib/lib/libcachelib_allocator.a ]]; then


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Support cache persistence for the block cache across process restarts. This is useful when you want to restart your binary that contains a cache and not lose the cache upon restart. 

Notice: cache persistence only works when your process stops gracefully and  the related meta data has been saved. So, you need to stop be process with the graceful mode, like `stop_be.sh -g`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
