### PR TITLE
[BugFix] array_append/remove solve only null array

### DIFF
--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -52,7 +52,7 @@ using ColumnPtr = std::shared_ptr<Column>;
 using MutableColumnPtr = std::unique_ptr<Column>;
 using Columns = std::vector<ColumnPtr>;
 using MutableColumns = std::vector<MutableColumnPtr>;
-using ArrayColumnPtr = std::shared_ptr<ArrayColumn>;
+
 using Int8Column = FixedLengthColumn<int8_t>;
 using UInt8Column = FixedLengthColumn<uint8_t>;
 using BooleanColumn = UInt8Column;

--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -52,7 +52,7 @@ using ColumnPtr = std::shared_ptr<Column>;
 using MutableColumnPtr = std::unique_ptr<Column>;
 using Columns = std::vector<ColumnPtr>;
 using MutableColumns = std::vector<MutableColumnPtr>;
-
+using ArrayColumnPtr = std::shared_ptr<ArrayColumn>;
 using Int8Column = FixedLengthColumn<int8_t>;
 using UInt8Column = FixedLengthColumn<uint8_t>;
 using BooleanColumn = UInt8Column;

--- a/be/src/exprs/vectorized/array_functions.cpp
+++ b/be/src/exprs/vectorized/array_functions.cpp
@@ -332,7 +332,7 @@ private:
             return NullableColumn::create(std::move(result), nullable->null_column());
         }
 
-        return _array_remove_non_nullable(down_cast<const ArrayColumn&>(*array), *target);
+        return _array_remove_non_nullable(down_cast<ArrayColumn&>(*array), *target);
     }
 };
 

--- a/be/src/exprs/vectorized/array_functions.cpp
+++ b/be/src/exprs/vectorized/array_functions.cpp
@@ -80,7 +80,7 @@ static ColumnPtr do_array_append(const Column& elements, const UInt32Column& off
 ColumnPtr ArrayFunctions::array_append([[maybe_unused]] FunctionContext* context, const Columns& columns) {
     const Column* arg0 = columns[0].get();
     const Column* arg1 = columns[1].get();
-    if(arg0->only_null()) {
+    if (arg0->only_null()) {
         return columns[0];
     }
 

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -1922,6 +1922,21 @@ TEST_F(ArrayFunctionsTest, array_remove_nullable_array) {
         EXPECT_TRUE(result->get(1).is_null());
         EXPECT_TRUE(result->get(2).is_null());
     }
+    // array_remove(NULL,1)
+    {
+        auto array = ColumnHelper::create_const_null_column(3);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+        target->append_datum(Datum((int8_t)2));
+        target->append_datum(Datum((int8_t)4));
+        target->append_datum(Datum());
+
+        auto result = ArrayFunctions::array_remove(nullptr, {array, target});
+        EXPECT_EQ(3, result->size());
+
+        EXPECT_TRUE(result->get(0).is_null());
+        EXPECT_TRUE(result->get(1).is_null());
+        EXPECT_TRUE(result->get(2).is_null());
+    }
 }
 
 // NOLINTNEXTLINE
@@ -2027,6 +2042,22 @@ TEST_F(ArrayFunctionsTest, array_append) {
         EXPECT_EQ(13, row[1].get_array()[1].get_int32());
         EXPECT_EQ(14, row[2].get_array()[0].get_int32());
         EXPECT_EQ(15, row[2].get_array()[1].get_int32());
+    }
+
+    // array_append(NULL,1)
+    {
+        auto array = ColumnHelper::create_const_null_column(3);
+        auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_TINYINT), true);
+        target->append_datum(Datum((int8_t)2));
+        target->append_datum(Datum((int8_t)4));
+        target->append_datum(Datum());
+
+        auto result = ArrayFunctions::array_append(nullptr, {array, target});
+        EXPECT_EQ(3, result->size());
+
+        EXPECT_TRUE(result->get(0).is_null());
+        EXPECT_TRUE(result->get(1).is_null());
+        EXPECT_TRUE(result->get(2).is_null());
     }
 }
 


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/10123

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

array_append/remove should directly return for only null array.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
