### PR TITLE
[BugFix] update storage_cache_ttl default 30 days

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1689,6 +1689,12 @@ public class Config extends ConfigBase {
     public static String starmgr_s3_sk = "";
 
     /**
+     * default storage cache ttl of lake table
+     */
+    @ConfField(mutable = true)
+    public static long lake_default_cache_ttl_seconds = 2592000L;
+
+    /**
      * default bucket number when create OLAP table without buckets info
      */
     @ConfField(mutable = true)
@@ -1844,10 +1850,4 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean enable_check_db_state = true;
-
-    /**
-     * default storage cache ttl of lake table
-     */
-    @ConfField(mutable = true)
-    public static long default_cache_ttl_seconds = 2592000L;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1692,7 +1692,7 @@ public class Config extends ConfigBase {
      * default storage cache ttl of lake table
      */
     @ConfField(mutable = true)
-    public static long lake_default_cache_ttl_seconds = 2592000L;
+    public static long lake_default_storage_cache_ttl_seconds = 2592000L;
 
     /**
      * default bucket number when create OLAP table without buckets info

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1073,6 +1073,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, aliases = {"storage_cooldown_second"})
     public static long tablet_sched_storage_cooldown_second = -1L; // won't cool down by default
 
+
     /**
      * FOR BeLoadBalancer:
      * the threshold of cluster balance score, if a backend's load score is 10% lower than average score,
@@ -1843,4 +1844,10 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean enable_check_db_state = true;
+
+    /**
+     * default storage cache ttl of lake table
+     */
+    @ConfField(mutable = true)
+    public static long default_cache_ttl_seconds = 2592000L;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -54,7 +54,6 @@ import static com.starrocks.catalog.TableProperty.INVALID;
 
 
 public class PropertyAnalyzer {
-    public static final long DEFAULT_STORAGE_CACHE_TTL = 2592000L;
     private static final Logger LOG = LogManager.getLogger(PropertyAnalyzer.class);
     private static final String COMMA_SEPARATOR = ",";
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -54,6 +54,7 @@ import static com.starrocks.catalog.TableProperty.INVALID;
 
 
 public class PropertyAnalyzer {
+    public static final long DEFAULT_STORAGE_CACHE_TTL = 2592000L;
     private static final Logger LOG = LogManager.getLogger(PropertyAnalyzer.class);
     private static final String COMMA_SEPARATOR = ",";
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2038,7 +2038,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 long storageCacheTtlS = 0;
                 try {
                     storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(properties,
-                            PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, 0);
+                            PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, PropertyAnalyzer.DEFAULT_STORAGE_CACHE_TTL);
                 } catch (AnalysisException e) {
                     throw new DdlException(e.getMessage());
                 }
@@ -2048,8 +2048,9 @@ public class LocalMetastore implements ConnectorMetadata {
                 if (!enableStorageCache && storageCacheTtlS != 0) {
                     throw new DdlException("Storage cache ttl should be 0 when cache is disabled");
                 }
+                // default ttl is 30 days
                 if (enableStorageCache && storageCacheTtlS == 0) {
-                    storageCacheTtlS = Config.tablet_sched_storage_cooldown_second;
+                    storageCacheTtlS = PropertyAnalyzer.DEFAULT_STORAGE_CACHE_TTL;
                 }
 
                 // set to false if absent

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2038,7 +2038,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 long storageCacheTtlS = 0;
                 try {
                     storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(properties,
-                            PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, PropertyAnalyzer.DEFAULT_STORAGE_CACHE_TTL);
+                            PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.default_cache_ttl_seconds);
                 } catch (AnalysisException e) {
                     throw new DdlException(e.getMessage());
                 }
@@ -2048,9 +2048,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 if (!enableStorageCache && storageCacheTtlS != 0) {
                     throw new DdlException("Storage cache ttl should be 0 when cache is disabled");
                 }
-                // default ttl is 30 days
                 if (enableStorageCache && storageCacheTtlS == 0) {
-                    storageCacheTtlS = PropertyAnalyzer.DEFAULT_STORAGE_CACHE_TTL;
+                    throw new DdlException("Storage cache ttl should not be 0 when cache is enabled");
                 }
 
                 // set to false if absent

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2038,14 +2038,14 @@ public class LocalMetastore implements ConnectorMetadata {
                 long storageCacheTtlS = 0;
                 try {
                     storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(properties,
-                            PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.lake_default_cache_ttl_seconds);
+                            PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.lake_default_storage_cache_ttl_seconds);
                 } catch (AnalysisException e) {
                     throw new DdlException(e.getMessage());
                 }
                 if (storageCacheTtlS < -1) {
                     throw new DdlException("Storage cache ttl should not be less than -1");
                 }
-                if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.lake_default_cache_ttl_seconds) {
+                if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.lake_default_storage_cache_ttl_seconds) {
                     throw new DdlException("Storage cache ttl should be 0 when cache is disabled");
                 }
                 if (enableStorageCache && storageCacheTtlS == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2038,14 +2038,14 @@ public class LocalMetastore implements ConnectorMetadata {
                 long storageCacheTtlS = 0;
                 try {
                     storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(properties,
-                            PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.default_cache_ttl_seconds);
+                            PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.lake_default_cache_ttl_seconds);
                 } catch (AnalysisException e) {
                     throw new DdlException(e.getMessage());
                 }
                 if (storageCacheTtlS < -1) {
                     throw new DdlException("Storage cache ttl should not be less than -1");
                 }
-                if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.default_cache_ttl_seconds) {
+                if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.lake_default_cache_ttl_seconds) {
                     throw new DdlException("Storage cache ttl should be 0 when cache is disabled");
                 }
                 if (enableStorageCache && storageCacheTtlS == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2045,8 +2045,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 if (storageCacheTtlS < -1) {
                     throw new DdlException("Storage cache ttl should not be less than -1");
                 }
-                if (!enableStorageCache && storageCacheTtlS != 0 
-                    && storageCacheTtlS != Config.lake_default_storage_cache_ttl_seconds) {
+                if (!enableStorageCache && storageCacheTtlS != 0 &&
+                        storageCacheTtlS != Config.lake_default_storage_cache_ttl_seconds) {
                     throw new DdlException("Storage cache ttl should be 0 when cache is disabled");
                 }
                 if (enableStorageCache && storageCacheTtlS == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2045,7 +2045,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 if (storageCacheTtlS < -1) {
                     throw new DdlException("Storage cache ttl should not be less than -1");
                 }
-                if (!enableStorageCache && storageCacheTtlS != 0) {
+                if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.default_cache_ttl_seconds) {
                     throw new DdlException("Storage cache ttl should be 0 when cache is disabled");
                 }
                 if (enableStorageCache && storageCacheTtlS == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2045,7 +2045,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 if (storageCacheTtlS < -1) {
                     throw new DdlException("Storage cache ttl should not be less than -1");
                 }
-                if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.lake_default_storage_cache_ttl_seconds) {
+                if (!enableStorageCache && storageCacheTtlS != 0 
+                    && storageCacheTtlS != Config.lake_default_storage_cache_ttl_seconds) {
                     throw new DdlException("Storage cache ttl should be 0 when cache is disabled");
                 }
                 if (enableStorageCache && storageCacheTtlS == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -144,7 +144,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         if (storageCacheTtlS < -1) {
             throw new AnalysisException("Storage cache ttl should not be less than -1");
         }
-        if (!enableStorageCache && storageCacheTtlS != 0) {
+        if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.default_cache_ttl_seconds) {
             throw new AnalysisException("Storage cache ttl should be 0 when cache is disabled");
         }
         if (enableStorageCache && storageCacheTtlS == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -137,14 +137,14 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         boolean enableStorageCache = PropertyAnalyzer.analyzeBooleanProp(
                 properties, PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, false);
         long storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(
-                properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.lake_default_cache_ttl_seconds);
+                properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.lake_default_storage_cache_ttl_seconds);
         boolean allowAsyncWriteBack = PropertyAnalyzer.analyzeBooleanProp(
                 properties, PropertyAnalyzer.PROPERTIES_ALLOW_ASYNC_WRITE_BACK, false);
 
         if (storageCacheTtlS < -1) {
             throw new AnalysisException("Storage cache ttl should not be less than -1");
         }
-        if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.lake_default_cache_ttl_seconds) {
+        if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.lake_default_storage_cache_ttl_seconds) {
             throw new AnalysisException("Storage cache ttl should be 0 when cache is disabled");
         }
         if (enableStorageCache && storageCacheTtlS == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -8,6 +8,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.util.PrintableMap;
@@ -136,7 +137,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         boolean enableStorageCache = PropertyAnalyzer.analyzeBooleanProp(
                 properties, PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, false);
         long storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(
-                properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, PropertyAnalyzer.DEFAULT_STORAGE_CACHE_TTL);
+                properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.default_cache_ttl_seconds);
         boolean allowAsyncWriteBack = PropertyAnalyzer.analyzeBooleanProp(
                 properties, PropertyAnalyzer.PROPERTIES_ALLOW_ASYNC_WRITE_BACK, false);
 
@@ -146,9 +147,8 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         if (!enableStorageCache && storageCacheTtlS != 0) {
             throw new AnalysisException("Storage cache ttl should be 0 when cache is disabled");
         }
-        // default ttl is 30 days
         if (enableStorageCache && storageCacheTtlS == 0) {
-            storageCacheTtlS = PropertyAnalyzer.DEFAULT_STORAGE_CACHE_TTL;
+            throw new AnalysisException("Storage cache ttl should not be 0 when cache is enabled");
         }
         if (!enableStorageCache && allowAsyncWriteBack) {
             throw new AnalysisException("storage allow_async_write_back can't be enabled when cache is disabled");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -8,7 +8,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.util.PrintableMap;
@@ -137,7 +136,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         boolean enableStorageCache = PropertyAnalyzer.analyzeBooleanProp(
                 properties, PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, false);
         long storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(
-                properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, 0);
+                properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, PropertyAnalyzer.DEFAULT_STORAGE_CACHE_TTL);
         boolean allowAsyncWriteBack = PropertyAnalyzer.analyzeBooleanProp(
                 properties, PropertyAnalyzer.PROPERTIES_ALLOW_ASYNC_WRITE_BACK, false);
 
@@ -147,8 +146,9 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         if (!enableStorageCache && storageCacheTtlS != 0) {
             throw new AnalysisException("Storage cache ttl should be 0 when cache is disabled");
         }
+        // default ttl is 30 days
         if (enableStorageCache && storageCacheTtlS == 0) {
-            storageCacheTtlS = Config.tablet_sched_storage_cooldown_second;
+            storageCacheTtlS = PropertyAnalyzer.DEFAULT_STORAGE_CACHE_TTL;
         }
         if (!enableStorageCache && allowAsyncWriteBack) {
             throw new AnalysisException("storage allow_async_write_back can't be enabled when cache is disabled");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -137,14 +137,14 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         boolean enableStorageCache = PropertyAnalyzer.analyzeBooleanProp(
                 properties, PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, false);
         long storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(
-                properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.default_cache_ttl_seconds);
+                properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.lake_default_cache_ttl_seconds);
         boolean allowAsyncWriteBack = PropertyAnalyzer.analyzeBooleanProp(
                 properties, PropertyAnalyzer.PROPERTIES_ALLOW_ASYNC_WRITE_BACK, false);
 
         if (storageCacheTtlS < -1) {
             throw new AnalysisException("Storage cache ttl should not be less than -1");
         }
-        if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.default_cache_ttl_seconds) {
+        if (!enableStorageCache && storageCacheTtlS != 0 && storageCacheTtlS != Config.lake_default_cache_ttl_seconds) {
             throw new AnalysisException("Storage cache ttl should be 0 when cache is disabled");
         }
         if (enableStorageCache && storageCacheTtlS == 0) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -194,16 +194,16 @@ public class CreateLakeTableTest {
             // check table property
             StorageInfo storageInfo = lakeTable.getTableProperty().getStorageInfo();
             Assert.assertFalse(storageInfo.isEnableStorageCache());
-            Assert.assertEquals(Config.lake_default_cache_ttl_seconds, storageInfo.getStorageCacheTtlS());
+            Assert.assertEquals(Config.lake_default_storage_cache_ttl_seconds, storageInfo.getStorageCacheTtlS());
             // check partition property
             long partition1Id = lakeTable.getPartition("p1").getId();
             StorageCacheInfo partition1StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition1Id);
             Assert.assertFalse(partition1StorageCacheInfo.isEnableStorageCache());
-            Assert.assertEquals(Config.lake_default_cache_ttl_seconds, partition1StorageCacheInfo.getStorageCacheTtlS());
+            Assert.assertEquals(Config.lake_default_storage_cache_ttl_seconds, partition1StorageCacheInfo.getStorageCacheTtlS());
             long partition2Id = lakeTable.getPartition("p2").getId();
             StorageCacheInfo partition2StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition2Id);
             Assert.assertTrue(partition2StorageCacheInfo.isEnableStorageCache());
-            Assert.assertEquals(Config.lake_default_cache_ttl_seconds,
+            Assert.assertEquals(Config.lake_default_storage_cache_ttl_seconds,
                     partition2StorageCacheInfo.getStorageCacheTtlS());
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -194,16 +194,16 @@ public class CreateLakeTableTest {
             // check table property
             StorageInfo storageInfo = lakeTable.getTableProperty().getStorageInfo();
             Assert.assertFalse(storageInfo.isEnableStorageCache());
-            Assert.assertEquals(0, storageInfo.getStorageCacheTtlS());
+            Assert.assertEquals(Config.lake_default_cache_ttl_seconds, storageInfo.getStorageCacheTtlS());
             // check partition property
             long partition1Id = lakeTable.getPartition("p1").getId();
             StorageCacheInfo partition1StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition1Id);
             Assert.assertFalse(partition1StorageCacheInfo.isEnableStorageCache());
-            Assert.assertEquals(0, partition1StorageCacheInfo.getStorageCacheTtlS());
+            Assert.assertEquals(Config.lake_default_cache_ttl_seconds, partition1StorageCacheInfo.getStorageCacheTtlS());
             long partition2Id = lakeTable.getPartition("p2").getId();
             StorageCacheInfo partition2StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition2Id);
             Assert.assertTrue(partition2StorageCacheInfo.isEnableStorageCache());
-            Assert.assertEquals(Config.tablet_sched_storage_cooldown_second,
+            Assert.assertEquals(Config.lake_default_cache_ttl_seconds,
                     partition2StorageCacheInfo.getStorageCacheTtlS());
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Specify default storage_cache_ttl when creating lake table is 30 days. If you set it to be 0 or you don't set it, fe would transfer this value to be 30 days.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
