### PR TITLE
[cherry-pick][branch-2.2][BugFix] Fix NPE when broker_addresses of export sink is empty. (#12345)

### DIFF
--- a/be/src/runtime/export_sink.cpp
+++ b/be/src/runtime/export_sink.cpp
@@ -112,6 +112,10 @@ Status ExportSink::open_file_writer(int timeout_ms) {
         break;
     }
     case TFileType::FILE_BROKER: {
+        if (_t_export_sink.broker_addresses.empty()) {
+            LOG(WARNING) << "ExportSink broker_addresses empty";
+            return Status::InternalError("ExportSink broker_addresses empty");
+        }
         const TNetworkAddress& broker_addr = _t_export_sink.broker_addresses[0];
         EnvBroker env_broker(broker_addr, _t_export_sink.properties, timeout_ms);
         ASSIGN_OR_RETURN(output_file, env_broker.new_writable_file(options, file_path));


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12301

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
![image](https://user-images.githubusercontent.com/16617323/201095660-588ce258-fea5-4a43-86d8-aafd20e12f79.png)