### PR TITLE
[cherry-pick][branch-2.2-yunlu][Enhancement] Support large delete only batches for primary key table. (#5466)

### DIFF
--- a/be/src/exec/vectorized/topn_node.cpp
+++ b/be/src/exec/vectorized/topn_node.cpp
@@ -150,9 +150,9 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
         //                                                        &_is_asc_order, &_is_null_first, _sort_keys, _offset,
         //                                                        _limit, SIZE_OF_CHUNK_FOR_TOPN);
         // } else {
-            _chunks_sorter = std::make_unique<ChunksSorterTopn>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                &_is_asc_order, &_is_null_first, _sort_keys, _offset,
-                                                                _limit, SIZE_OF_CHUNK_FOR_TOPN);
+        _chunks_sorter = std::make_unique<ChunksSorterTopn>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
+                                                            &_is_asc_order, &_is_null_first, _sort_keys, _offset,
+                                                            _limit, SIZE_OF_CHUNK_FOR_TOPN);
         // }
 
     } else {

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -37,6 +37,8 @@ class WritableBlock;
 
 class SegmentWriter;
 
+enum class FlushChunkState { UNKNOWN, UPSERT, DELETE, MIXED };
+
 class BetaRowsetWriter : public RowsetWriter {
 public:
     explicit BetaRowsetWriter(const RowsetWriterContext& context);
@@ -77,6 +79,8 @@ protected:
 
     bool _is_pending = false;
     bool _already_built = false;
+
+    FlushChunkState _flush_chunk_state = FlushChunkState::UNKNOWN;
 };
 
 // Chunk contains all schema columns data.
@@ -105,6 +109,8 @@ private:
     Status _flush_segment_writer(std::unique_ptr<SegmentWriter>* segment_writer);
 
     Status _final_merge();
+
+    Status _flush_chunk(const vectorized::Chunk& chunk);
 
     std::unique_ptr<SegmentWriter> _segment_writer;
 };

--- a/be/src/storage/vectorized/memtable.cpp
+++ b/be/src/storage/vectorized/memtable.cpp
@@ -227,10 +227,10 @@ Status MemTable::flush() {
     int64_t duration_ns = 0;
     {
         SCOPED_RAW_TIMER(&duration_ns);
-        if (!_deletes || _deletes->empty()) {
-            RETURN_IF_ERROR(_rowset_writer->flush_chunk(*_result_chunk));
-        } else {
+        if (_deletes) {
             RETURN_IF_ERROR(_rowset_writer->flush_chunk_with_deletes(*_result_chunk, *_deletes));
+        } else {
+            RETURN_IF_ERROR(_rowset_writer->flush_chunk(*_result_chunk));
         }
     }
     StarRocksMetrics::instance()->memtable_flush_total.increment(1);

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -981,5 +981,4 @@ TEST_F(JsonScannerTest, test_illegal_input_with_jsonpath) {
     ASSERT_TRUE(scanner->get_next().status().is_data_quality_error());
 }
 
-
 } // namespace starrocks::vectorized

--- a/be/test/exprs/vectorized/json_functions_test.cpp
+++ b/be/test/exprs/vectorized/json_functions_test.cpp
@@ -772,7 +772,8 @@ TEST_F(JsonFunctionsTest, extract_from_object_test) {
     EXPECT_STATUS(Status::NotFound(""),
                   test_extract_from_object(R"({"data": [{"key": 1},{"key": 2}]})", "$.data[3].key", &output));
 
-    EXPECT_STATUS(Status::DataQualityError(""), test_extract_from_object(R"({"data1 " : 1, "data2":})", "$.data", &output));
+    EXPECT_STATUS(Status::DataQualityError(""),
+                  test_extract_from_object(R"({"data1 " : 1, "data2":})", "$.data", &output));
 }
 
 } // namespace vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4772

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Supports committing multi-segment rowsets if it's all upserts/deletes, and supports committing a single-segment rowset.