### PR TITLE
[Enhancement] Detect Too many versions to avoid failure due to too fast statistics collection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -82,19 +82,32 @@ public abstract class StatisticsCollectJob {
     }
 
     public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
-        LOG.debug("statistics collect sql : " + sql);
-        StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
-        StmtExecutor executor = new StmtExecutor(context, parsedStmt);
-        context.setExecutor(executor);
-        context.setQueryId(UUIDUtil.genUUID());
-        context.setStartTime();
-        executor.execute();
+        int count = 0;
+        int maxRetryTimes = 10;
+        do {
+            LOG.debug("statistics collect sql : " + sql);
+            StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
+            StmtExecutor executor = new StmtExecutor(context, parsedStmt);
+            context.setExecutor(executor);
+            context.setQueryId(UUIDUtil.genUUID());
+            context.setStartTime();
+            executor.execute();
 
-        if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
-            LOG.warn("Statistics collect fail | Error Message [" + context.getState().getErrorMessage() + "] | " +
-                    "SQL [" + sql + "]");
-            throw new DdlException(context.getState().getErrorMessage());
-        }
+            if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+                LOG.warn("Statistics collect fail | Error Message [" + context.getState().getErrorMessage() + "] | " +
+                        "SQL [" + sql + "]");
+                if (context.getState().getErrorMessage().contains("Too many versions")) {
+                    Thread.sleep(60000);
+                    count++;
+                } else {
+                    throw new DdlException(context.getState().getErrorMessage());
+                }
+            } else {
+                return;
+            }
+        } while (count < maxRetryTimes);
+
+        throw new DdlException(context.getState().getErrorMessage());
     }
 
     protected String getDataSize(Column column, boolean isSample) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -1,0 +1,107 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+package com.starrocks.statistic;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.PlanTestBase;
+import jersey.repackaged.com.google.common.collect.Lists;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StatisticsExecutorTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+
+        starRocksAssert.withTable("CREATE TABLE `t0_stats` (\n" +
+                "  `v1` bigint NULL COMMENT \"\",\n" +
+                "  `v2` bigint NULL COMMENT \"\",\n" +
+                "  `v3` bigint NULL,\n" +
+                "  `v4` date NULL,\n" +
+                "  `v5` datetime NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`, `v2`, v3)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
+
+        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0_stats");
+        Partition partition = new ArrayList<>(t0.getPartitions()).get(0);
+        partition.updateVisibleVersion(2, LocalDateTime.of(2022, 1, 1, 1, 1, 1)
+                .atZone(Clock.systemDefaultZone().getZone()).toEpochSecond() * 1000);
+        setTableStatistics(t0, 20000000);
+    }
+
+    @Test
+    public void testCollectStatisticSync(@Mocked StmtExecutor executor) throws Exception {
+        // mock
+        MockUp<StmtExecutor> mock = new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() {
+            }
+        };
+
+        Database database = connectContext.getGlobalStateMgr().getDb("test");
+        OlapTable table = (OlapTable) database.getTable("t0_stats");
+        List<Long> partitionIdList = table.getAllPartitions().stream().map(Partition::getId).collect(Collectors.toList());
+
+        FullStatisticsCollectJob collectJob = new FullStatisticsCollectJob(database, table, partitionIdList,
+                Lists.newArrayList("v1", "v2", "v3", "v4", "v5"),
+                StatsConstants.AnalyzeType.FULL,
+                StatsConstants.ScheduleType.SCHEDULE,
+                Maps.newHashMap());
+
+        String sql = "insert into test.t0 values(1,2,3)";
+        ConnectContext context = StatisticUtils.buildConnectContext();
+
+        QueryState errorState = new QueryState();
+        errorState.setStateType(QueryState.MysqlStateType.ERR);
+        errorState.setError("Too many versions");
+
+        QueryState okState = new QueryState();
+        okState.setStateType(QueryState.MysqlStateType.OK);
+
+        new Expectations(context) {
+            {
+                context.getState().getStateType();
+                result = QueryState.MysqlStateType.ERR;
+
+                context.getState().getErrorMessage();
+                result = "Error";
+            }
+        };
+
+        Assert.assertThrows(DdlException.class, () -> collectJob.collectStatisticSync(sql, context));
+
+        new Expectations(context) {
+            {
+                context.getState().getStateType();
+                result = QueryState.MysqlStateType.OK;
+            }
+        };
+
+        collectJob.collectStatisticSync(sql, context);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13261

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Preconditions that trigger this issue
1. statistic_collect_parallel is very small, such as 1
2. The number of partitions is very large
3. The number of columns is very large
4. There is very little data in the table, so the collection of statistical information is very fast

If statistic_collect_parallel, only one partition of one column can be collected at a time. Because the number of rows in the table is small, the collection speed is very fast. However, because there are many partitions and columns, the tablet "Too many version" will soon be caused by the high load frequency.

Solution
A verification mechanism is added. If the error is found to be because of "Too many version", it will pause for a while and then try again.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
