### PR TITLE
[BugFix] Don't select unsupported type when choosing materialized column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnType.java
@@ -34,7 +34,7 @@ public abstract class ColumnType {
     private static Boolean[][] schemaChangeMatrix;
 
     static {
-        schemaChangeMatrix = new Boolean[PrimitiveType.BINARY.ordinal() + 1][PrimitiveType.BINARY.ordinal() + 1];
+        schemaChangeMatrix = new Boolean[PrimitiveType.UNKNOWN_TYPE.ordinal() + 1][PrimitiveType.UNKNOWN_TYPE.ordinal() + 1];
 
         for (int i = 0; i < schemaChangeMatrix.length; i++) {
             for (int j = 0; j < schemaChangeMatrix[i].length; j++) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
@@ -72,7 +72,7 @@ public enum PrimitiveType {
     BINARY("BINARY", -1, TPrimitiveType.BINARY),
 
     // If external table column type is unsupported, it will be converted to UNKNOWN_TYPE
-    UNKNOWN_TYPE("UNKNOWN_TYPE", 0, TPrimitiveType.INVALID_TYPE);
+    UNKNOWN_TYPE("UNKNOWN_TYPE", -1, TPrimitiveType.INVALID_TYPE);
 
     private static final int DATE_INDEX_LEN = 3;
     private static final int DATETIME_INDEX_LEN = 8;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
@@ -55,7 +55,8 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
         // if not, we have to choose one materialized column from scan operator output columns
         // with the minimal cost.
         if (!containsMaterializedColumn(scanOperator, scanColumns)) {
-            List<ColumnRefOperator> preOutputColumns = new ArrayList<>(scanOperator.getColRefToColumnMetaMap().keySet());
+            List<ColumnRefOperator> preOutputColumns =
+                    new ArrayList<>(scanOperator.getColRefToColumnMetaMap().keySet());
             List<ColumnRefOperator> outputColumns = preOutputColumns.stream()
                     .filter(column -> !column.getType().getPrimitiveType().equals(PrimitiveType.UNKNOWN_TYPE))
                     .collect(Collectors.toList());
@@ -71,7 +72,7 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
                     smallestIndex = index;
                 }
                 Type columnType = outputColumns.get(index).getType();
-                if (columnType.isScalarType()) {
+                if (columnType.isScalarType() && columnType.isSupported()) {
                     int columnLength = columnType.getTypeSize();
                     if (columnLength < smallestColumnLength) {
                         smallestIndex = index;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/1435

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to fix:
- don't select unsupported column when using `select count(*)` and pruning column
- `UNKNOWN_TYPE` is the last type, ordinal of it is the maximum. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
