### PR TITLE
[BugFix] fix CompoundPredicateOperator equals method

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 /**
@@ -304,5 +305,11 @@ public class GroupExpression {
             sb.append(input.toPrettyString(childHeadlineIndent, childDetailIndent));
         }
         return sb.toString();
+    }
+
+    public String printExploredRules() {
+        StringJoiner joiner = new StringJoiner(", ", "{", "}");
+        ruleMasks.stream().forEach(e -> joiner.add(RuleType.values()[e].name()));
+        return joiner.toString();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/CompoundPredicateOperatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/CompoundPredicateOperatorTest.java
@@ -1,0 +1,124 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.operator.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.junit.Assert;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class CompoundPredicateOperatorTest {
+
+
+    @ParameterizedTest
+    @MethodSource("compareOperatorList")
+    void predicateCompare(Pair<Boolean, List<ScalarOperator>> pair) {
+        boolean isEqual = pair.first;
+        ScalarOperator left = pair.second.get(0);
+        ScalarOperator right = pair.second.get(1);
+        if (isEqual) {
+            Assert.assertEquals(left, right);
+        } else {
+            Assert.assertNotEquals(left, right);
+        }
+
+    }
+
+    private static Stream<Arguments> compareOperatorList() {
+        ConstantOperator constA = new ConstantOperator(1, Type.INT);
+        ConstantOperator constB = new ConstantOperator("abc", Type.STRING);
+
+        ColumnRefOperator col1 = new ColumnRefOperator(1, Type.INT, "c1", false);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, Type.INT, "c2", false);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, Type.INT, "c3", false);
+        ColumnRefOperator col4 = new ColumnRefOperator(4, Type.STRING, "c4", false);
+        ColumnRefOperator col5 = new ColumnRefOperator(5, Type.STRING, "c5", false);
+        ColumnRefOperator col6 = new ColumnRefOperator(6, Type.BOOLEAN, "c6", false);
+
+
+        CallOperator call1 = new CallOperator(FunctionSet.SUM, Type.BIGINT, ImmutableList.of(constA));
+        CallOperator call2 = new CallOperator(FunctionSet.ADD, Type.BIGINT, ImmutableList.of(constA, constA));
+
+        BinaryPredicateOperator gt1 = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GT, col1, col2);
+        BinaryPredicateOperator gt2 = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GT, col3, col4);
+
+        BinaryPredicateOperator lt1 = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.LT, col4, col6);
+        BinaryPredicateOperator lt2 = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.LT, col5, col6);
+
+        BinaryPredicateOperator ge1 = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GE, col1, constA);
+        BinaryPredicateOperator ge2 = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GE, col4, constB);
+
+        BinaryPredicateOperator le1 = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.LE, col1, call1);
+        BinaryPredicateOperator le2 = new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.LE, col2, call2);
+
+        CompoundPredicateOperator and1 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, gt1, gt2);
+        CompoundPredicateOperator and2 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, lt1, lt2);
+        CompoundPredicateOperator and3 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, ge1, ge2);
+        CompoundPredicateOperator and4 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, le1, le2);
+
+
+        CompoundPredicateOperator or1 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, gt1, gt2);
+        CompoundPredicateOperator or2 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, lt1, lt2);
+        CompoundPredicateOperator or3 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, ge1, ge2);
+        CompoundPredicateOperator or4 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, le1, le2);
+
+        List<List<ScalarOperator>> equalList = Lists.newArrayList();
+        List<List<ScalarOperator>> notEqualList = Lists.newArrayList();
+
+        ScalarOperator fullAnd = Utils.compoundAnd(and1, and2, and3, and4);
+        equalList.add(ImmutableList.of(fullAnd, Utils.compoundAnd(and1, and2, and4, and3)));
+        equalList.add(ImmutableList.of(fullAnd, Utils.compoundAnd(and1, and3, and2, and4)));
+        equalList.add(ImmutableList.of(fullAnd, Utils.compoundAnd(and2, and4, and1, and3)));
+        equalList.add(ImmutableList.of(fullAnd, Utils.compoundAnd(and3, and1, and2, and4)));
+
+        ScalarOperator fullOr = Utils.compoundOr(or1, or2, or3, or4);
+        equalList.add(ImmutableList.of(fullOr, Utils.compoundOr(or1, or2, or3, or4)));
+        equalList.add(ImmutableList.of(fullOr, Utils.compoundOr(or1, or3, or2, or4)));
+        equalList.add(ImmutableList.of(fullOr, Utils.compoundOr(or2, or3, or1, or4)));
+        equalList.add(ImmutableList.of(fullOr, Utils.compoundOr(or3, or1, or2, or4)));
+
+        ScalarOperator halfAnd = Utils.compoundAnd(Utils.compoundOr(and1, and2), and3, or4);
+        equalList.add(ImmutableList.of(halfAnd, Utils.compoundAnd(and3, or4, Utils.compoundOr(and1, and2))));
+        equalList.add(ImmutableList.of(halfAnd, Utils.compoundAnd(or4, and3, Utils.compoundOr(and2, and1))));
+        equalList.add(ImmutableList.of(halfAnd, Utils.compoundAnd(or4, Utils.compoundOr(and2, and1), and3)));
+
+        ScalarOperator halfOr = Utils.compoundOr(Utils.compoundAnd(and1, and2), or3, or4);
+        equalList.add(ImmutableList.of(halfOr, Utils.compoundOr(or3, or4, Utils.compoundAnd(and1, and2))));
+        equalList.add(ImmutableList.of(halfOr, Utils.compoundOr(or4, or3, Utils.compoundAnd(and2, and1))));
+        equalList.add(ImmutableList.of(halfOr, Utils.compoundOr(or4, Utils.compoundAnd(and2, and1), or3)));
+
+
+        notEqualList.add(ImmutableList.of(fullAnd, Utils.compoundAnd(and1, or2, and3, and4)));
+        notEqualList.add(ImmutableList.of(fullAnd, Utils.compoundAnd(and1, or1, and2, or4)));
+
+        notEqualList.add(ImmutableList.of(fullOr, Utils.compoundOr(and1, or1, and2, or4)));
+        notEqualList.add(ImmutableList.of(fullOr, Utils.compoundOr(and1, or1, and2, or4)));
+
+        notEqualList.add(ImmutableList.of(halfAnd, Utils.compoundAnd(Utils.compoundOr(and1, and2), and3, and4)));
+        notEqualList.add(ImmutableList.of(halfAnd, Utils.compoundAnd(or4, and3, Utils.compoundOr(or2, and1))));
+
+        notEqualList.add(ImmutableList.of(halfOr, Utils.compoundOr(Utils.compoundAnd(and1, and2), and3, and4)));
+        notEqualList.add(ImmutableList.of(halfOr, Utils.compoundOr(Utils.compoundAnd(and1, or2), or3, and4)));
+
+        List<Pair<Boolean, List<ScalarOperator>>> cases = Lists.newArrayList();
+        equalList.stream().forEach(e -> cases.add(Pair.create(true, e)));
+        notEqualList.stream().forEach(e -> cases.add(Pair.create(false, e)));
+
+        return cases.stream().map(Arguments::of);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanTest.java
@@ -114,7 +114,7 @@ public class TPCHPlanTest extends PlanTestBase {
         runFileUnitTest("tpch/q7");
     }
 
-    //@Test
+    @Test
     public void testTPCH8() {
         runFileUnitTest("tpch/q8");
     }

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -543,9 +543,9 @@ LEFT SEMI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d
 [end]
 
 [sql]
-RIGHT ANTI JOIN (join-predicate [1: v1 = 1 AND 4: v4 = 1: v1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
+select v1 from t0 where not exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
 [result]
-RIGHT ANTI JOIN (join-predicate [4: v4 = 1: v1 AND 1: v1 = 1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
+RIGHT ANTI JOIN (join-predicate [1: v1 = 1 AND 4: v4 = 1: v1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
     SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
     EXCHANGE SHUFFLE[1]
         SCAN (columns[1: v1, 2: v2] predicate[null])

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -543,7 +543,7 @@ LEFT SEMI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d
 [end]
 
 [sql]
-select v1 from t0 where not exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
+RIGHT ANTI JOIN (join-predicate [1: v1 = 1 AND 4: v4 = 1: v1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
 [result]
 RIGHT ANTI JOIN (join-predicate [4: v4 = 1: v1 AND 1: v1 = 1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
     SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
@@ -589,7 +589,7 @@ LEFT SEMI JOIN (join-predicate [19: add = 18: cast AND add(add(18: cast, 10: t1d
 [sql]
 select v1 from t0 where not exists (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
 [result]
-RIGHT ANTI JOIN (join-predicate [4: v4 = 1: v1 AND 1: v1 = 1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
+RIGHT ANTI JOIN (join-predicate [1: v1 = 1 AND 4: v4 = 1: v1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
     SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
     EXCHANGE SHUFFLE[1]
         SCAN (columns[1: v1, 2: v2] predicate[null])

--- a/fe/fe-core/src/test/resources/sql/subquery/in-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/in-subquery.sql
@@ -833,7 +833,7 @@ LEFT SEMI JOIN (join-predicate [19: cast = 20: abs AND add(cast(9: t1c as bigint
 [sql]
 select v1 from t0 where v2 not in (select v5 + v4 from t1 where v1 = 1 and v1 = v4 and v2 + v5 = v6);
 [result]
-NULL AWARE LEFT ANTI JOIN (join-predicate [2: v2 = 9: add AND 1: v1 = 4: v4 AND 1: v1 = 1 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
+NULL AWARE LEFT ANTI JOIN (join-predicate [2: v2 = 9: add AND 1: v1 = 1 AND 1: v1 = 4: v4 AND add(2: v2, 5: v5) = 6: v6] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2] predicate[null])
     EXCHANGE BROADCAST
         SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])

--- a/fe/fe-core/src/test/resources/sql/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q8.sql
@@ -39,30 +39,30 @@ order by
 [result]
 TOP-N (order by [[69: year ASC NULLS FIRST]])
     TOP-N (order by [[69: year ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{72: sum=sum(72: sum), 73: sum(70: expr)=sum(73: sum(70: expr))}] group by [[69: year]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{72: sum=sum(72: sum), 73: sum=sum(73: sum)}] group by [[69: year]] having [null]
             EXCHANGE SHUFFLE[69]
-                AGGREGATE ([LOCAL] aggregate [{72: sum=sum(71: expr), 73: sum(70: expr)=sum(70: expr)}] group by [[69: year]] having [null]
-                    INNER JOIN (join-predicate [65: R_REGIONKEY = 57: N_REGIONKEY] post-join-predicate [null])
-                        SCAN (columns[65: R_REGIONKEY, 66: R_NAME] predicate[66: R_NAME = MIDDLE EAST])
-                        EXCHANGE BROADCAST
-                            INNER JOIN (join-predicate [55: N_NATIONKEY = 49: C_NATIONKEY] post-join-predicate [null])
-                                SCAN (columns[55: N_NATIONKEY, 57: N_REGIONKEY] predicate[null])
-                                EXCHANGE BROADCAST
-                                    INNER JOIN (join-predicate [46: C_CUSTKEY = 37: O_CUSTKEY] post-join-predicate [null])
-                                        SCAN (columns[49: C_NATIONKEY, 46: C_CUSTKEY] predicate[null])
+                AGGREGATE ([LOCAL] aggregate [{72: sum=sum(71: case), 73: sum=sum(70: expr)}] group by [[69: year]] having [null]
+                    INNER JOIN (join-predicate [60: N_NATIONKEY = 14: S_NATIONKEY] post-join-predicate [null])
+                        SCAN (columns[60: N_NATIONKEY, 61: N_NAME] predicate[null])
+                        EXCHANGE SHUFFLE[14]
+                            INNER JOIN (join-predicate [21: L_SUPPKEY = 11: S_SUPPKEY] post-join-predicate [null])
+                                INNER JOIN (join-predicate [19: L_ORDERKEY = 36: O_ORDERKEY] post-join-predicate [null])
+                                    INNER JOIN (join-predicate [20: L_PARTKEY = 1: P_PARTKEY] post-join-predicate [null])
+                                        SCAN (columns[19: L_ORDERKEY, 20: L_PARTKEY, 21: L_SUPPKEY, 24: L_EXTENDEDPRICE, 25: L_DISCOUNT] predicate[null])
                                         EXCHANGE BROADCAST
-                                            INNER JOIN (join-predicate [60: N_NATIONKEY = 14: S_NATIONKEY] post-join-predicate [null])
-                                                SCAN (columns[60: N_NATIONKEY, 61: N_NAME] predicate[null])
-                                                EXCHANGE BROADCAST
-                                                    INNER JOIN (join-predicate [11: S_SUPPKEY = 21: L_SUPPKEY] post-join-predicate [null])
-                                                        SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
-                                                        EXCHANGE SHUFFLE[21]
-                                                            INNER JOIN (join-predicate [36: O_ORDERKEY = 19: L_ORDERKEY] post-join-predicate [null])
-                                                                SCAN (columns[36: O_ORDERKEY, 37: O_CUSTKEY, 40: O_ORDERDATE] predicate[40: O_ORDERDATE >= 1995-01-01 AND 40: O_ORDERDATE <= 1996-12-31])
-                                                                EXCHANGE SHUFFLE[19]
-                                                                    INNER JOIN (join-predicate [20: L_PARTKEY = 1: P_PARTKEY] post-join-predicate [null])
-                                                                        SCAN (columns[19: L_ORDERKEY, 20: L_PARTKEY, 21: L_SUPPKEY, 24: L_EXTENDEDPRICE, 25: L_DISCOUNT] predicate[null])
-                                                                        EXCHANGE BROADCAST
-                                                                            SCAN (columns[1: P_PARTKEY, 5: P_TYPE] predicate[5: P_TYPE = ECONOMY ANODIZED STEEL])
+                                            SCAN (columns[1: P_PARTKEY, 5: P_TYPE] predicate[5: P_TYPE = ECONOMY ANODIZED STEEL])
+                                    EXCHANGE SHUFFLE[36]
+                                        INNER JOIN (join-predicate [37: O_CUSTKEY = 46: C_CUSTKEY] post-join-predicate [null])
+                                            SCAN (columns[36: O_ORDERKEY, 37: O_CUSTKEY, 40: O_ORDERDATE] predicate[40: O_ORDERDATE >= 1995-01-01 AND 40: O_ORDERDATE <= 1996-12-31])
+                                            EXCHANGE BROADCAST
+                                                INNER JOIN (join-predicate [49: C_NATIONKEY = 55: N_NATIONKEY] post-join-predicate [null])
+                                                    SCAN (columns[49: C_NATIONKEY, 46: C_CUSTKEY] predicate[null])
+                                                    EXCHANGE BROADCAST
+                                                        INNER JOIN (join-predicate [57: N_REGIONKEY = 65: R_REGIONKEY] post-join-predicate [null])
+                                                            SCAN (columns[55: N_NATIONKEY, 57: N_REGIONKEY] predicate[null])
+                                                            EXCHANGE BROADCAST
+                                                                SCAN (columns[65: R_REGIONKEY, 66: R_NAME] predicate[66: R_NAME = MIDDLE EAST])
+                                EXCHANGE BROADCAST
+                                    SCAN (columns[11: S_SUPPKEY, 14: S_NATIONKEY] predicate[null])
 [end]
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In memo phase, we use join transform rules to generate more plans. These rules split conjuncts and generate new predicate which may change the order of nodes in compoundPredicate. For a predicate like `v1 = v2 and v3 = v4 and v5 = v6`, the order of these three eqaul predicates doesn't affect the meaning of the compoundPredicate. For exampe, `v3 = v4 and v5 = v6 and v1 = v2` should equal `v1 = v2 and v3 = v4 and v5 = v6`. 

This pr helps to prevent  groupExpression acctually with the same meaning from being repeatedly inserted into the memo.
BTW, a test had been disabled and this pr restored it.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
