### PR TITLE
[Enhancement] Compaction scheduling based on compaction score(1/3)

### DIFF
--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -19,8 +19,6 @@ public:
     StatusOr<std::vector<RowsetPtr>> pick_rowsets(int64_t version) override;
 
 private:
-    double get_cumulative_score();
-    double get_base_score();
     StatusOr<std::vector<RowsetPtr>> pick_cumulative_rowsets();
     StatusOr<std::vector<RowsetPtr>> pick_base_rowsets();
     void debug_rowsets(CompactionType type, const std::vector<uint32_t>& input_rowset_ids);
@@ -29,15 +27,15 @@ private:
     TabletMetadataPtr _tablet_metadata;
 };
 
-double BaseAndCumulativeCompactionPolicy::get_cumulative_score() {
-    if (_tablet_metadata->rowsets_size() == 0) {
+double cumulative_compaction_score(const TabletMetadataPB& metadata) {
+    if (metadata.rowsets_size() == 0) {
         return 0;
     }
 
     uint32_t segment_num_score = 0;
     size_t rowsets_size = 0;
-    for (uint32_t i = _tablet_metadata->cumulative_point(), size = _tablet_metadata->rowsets_size(); i < size; ++i) {
-        const auto& rowset = _tablet_metadata->rowsets(i);
+    for (uint32_t i = metadata.cumulative_point(), size = metadata.rowsets_size(); i < size; ++i) {
+        const auto& rowset = metadata.rowsets(i);
         segment_num_score += rowset.overlapped() ? rowset.segments_size() : 1;
         rowsets_size += rowset.data_size();
     }
@@ -45,22 +43,22 @@ double BaseAndCumulativeCompactionPolicy::get_cumulative_score() {
     double num_score = static_cast<double>(segment_num_score) / config::min_cumulative_compaction_num_singleton_deltas;
     double size_score = static_cast<double>(rowsets_size) / config::min_cumulative_compaction_size;
     double score = std::max(num_score, size_score);
-    VLOG(2) << "tablet: " << _tablet->id() << ", cumulative compaction score: " << score
+    VLOG(2) << "tablet: " << metadata.id() << ", cumulative compaction score: " << score
             << ", size_score: " << size_score << ", num_score: " << num_score << ", rowsets_size: " << rowsets_size
             << ", segment_num_score: " << segment_num_score;
     return score;
 }
 
-double BaseAndCumulativeCompactionPolicy::get_base_score() {
-    uint32_t cumulative_point = _tablet_metadata->cumulative_point();
-    if (cumulative_point == 0 || _tablet_metadata->rowsets_size() == 0) {
+double base_compaction_score(const TabletMetadataPB& metadata) {
+    uint32_t cumulative_point = metadata.cumulative_point();
+    if (cumulative_point == 0 || metadata.rowsets_size() == 0) {
         return 0;
     }
 
     uint32_t segment_num_score = 0;
     size_t rowsets_size = 0;
     for (uint32_t i = 1; i < cumulative_point; ++i) {
-        const auto& rowset = _tablet_metadata->rowsets(i);
+        const auto& rowset = metadata.rowsets(i);
         DCHECK(!rowset.overlapped());
         ++segment_num_score;
         rowsets_size += rowset.data_size();
@@ -69,21 +67,21 @@ double BaseAndCumulativeCompactionPolicy::get_base_score() {
     double num_score = static_cast<double>(segment_num_score) / config::min_base_compaction_num_singleton_deltas;
     double size_score = static_cast<double>(rowsets_size) / config::min_base_compaction_size;
     double score = std::max(num_score, size_score);
-    VLOG(2) << "tablet: " << _tablet->id() << ", base compaction score: " << score << ", size_score: " << size_score
+    VLOG(2) << "tablet: " << metadata.id() << ", base compaction score: " << score << ", size_score: " << size_score
             << ", num_score: " << num_score << ", rowsets_size: " << rowsets_size
             << ", segment_num_score: " << segment_num_score;
     if (score > kCompactionScoreThreshold) {
         return score;
     }
 
-    auto& base_rowset = _tablet_metadata->rowsets(0);
+    auto& base_rowset = metadata.rowsets(0);
     DCHECK(!base_rowset.overlapped());
     int64_t base_data_size = base_rowset.data_size();
     if (base_data_size > 0) {
         double size_ratio = static_cast<double>(rowsets_size) / base_data_size;
         if (size_ratio >= config::base_cumulative_delta_ratio) {
             score = 1.0;
-            VLOG(2) << "satisfy the base compaction size ratio policy. tablet: " << _tablet->id()
+            VLOG(2) << "satisfy the base compaction size ratio policy. tablet: " << metadata.id()
                     << ", base disk size: " << base_data_size << ", size_ratio: " << size_ratio;
             return score;
         }
@@ -168,8 +166,8 @@ void BaseAndCumulativeCompactionPolicy::debug_rowsets(CompactionType type,
 StatusOr<std::vector<RowsetPtr>> BaseAndCumulativeCompactionPolicy::pick_rowsets(int64_t version) {
     ASSIGN_OR_RETURN(_tablet_metadata, _tablet->get_metadata(version));
 
-    double cumulative_score = get_cumulative_score();
-    double base_score = get_base_score();
+    double cumulative_score = cumulative_compaction_score(*_tablet_metadata);
+    double base_score = base_compaction_score(*_tablet_metadata);
     if (base_score > cumulative_score) {
         return pick_base_rowsets();
     } else {

--- a/be/src/storage/lake/compaction_policy.h
+++ b/be/src/storage/lake/compaction_policy.h
@@ -14,6 +14,7 @@ class Tablet;
 using TabletPtr = std::shared_ptr<Tablet>;
 class CompactionPolicy;
 using CompactionPolicyPtr = std::shared_ptr<CompactionPolicy>;
+class TabletMetadataPB;
 
 // Compaction policy for lake tablet
 class CompactionPolicy {
@@ -23,5 +24,9 @@ public:
 
     static StatusOr<CompactionPolicyPtr> create_compaction_policy(TabletPtr tablet);
 };
+
+double cumulative_compaction_score(const TabletMetadataPB& metadata);
+
+double base_compaction_score(const TabletMetadataPB& metadata);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -35,7 +35,8 @@
 namespace starrocks::lake {
 
 static Status apply_txn_log(const TxnLog& log, TabletMetadata* metadata);
-static Status publish(Tablet* tablet, int64_t base_version, int64_t new_version, const int64_t* txns, int txns_size);
+static StatusOr<double> publish(Tablet* tablet, int64_t base_version, int64_t new_version, const int64_t* txns,
+                                int txns_size);
 static void* metadata_gc_trigger(void* arg);
 static void* segment_gc_trigger(void* arg);
 
@@ -443,8 +444,8 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id) {
     return schema;
 }
 
-Status TabletManager::publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version, const int64_t* txns,
-                                      int txns_size) {
+StatusOr<double> TabletManager::publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version,
+                                                const int64_t* txns, int txns_size) {
     ASSIGN_OR_RETURN(auto tablet, get_tablet(tablet_id));
     return publish(&tablet, base_version, new_version, txns, txns_size);
 }
@@ -577,19 +578,28 @@ Status apply_txn_log(const TxnLog& log, TabletMetadata* metadata) {
     return Status::OK();
 }
 
-Status publish(Tablet* tablet, int64_t base_version, int64_t new_version, const int64_t* txns, int txns_size) {
+StatusOr<double> publish(Tablet* tablet, int64_t base_version, int64_t new_version, const int64_t* txns,
+                         int txns_size) {
+    auto compaction_score = [](const TabletMetadata& metadata) {
+        return std::max(base_compaction_score(metadata), cumulative_compaction_score(metadata));
+    };
+
     // Read base version metadata
     auto res = tablet->get_metadata(base_version);
-    if (!res.ok()) {
-        // Check if the new version metadata exist.
-        if (res.status().is_not_found() && tablet->get_metadata(new_version).ok()) {
-            // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ optimization, there is no need to invoke `get_metadata` in all
-            // circumstances, e.g, network and permission problems.
-            return Status::OK();
+    if (res.status().is_not_found()) {
+        auto target_metadata_or = tablet->get_metadata(new_version);
+        if (target_metadata_or.ok()) {
+            // base version metadata does not exist but the new version metadata has been generated, maybe
+            // this is a duplicated publish version request.
+            return compaction_score(**target_metadata_or);
         }
+    }
+
+    if (!res.ok()) {
         LOG(WARNING) << "Fail to get " << tablet->metadata_location(base_version) << ": " << res.status();
         return res.status();
     }
+
     const TabletMetadataPtr& base_metadata = res.value();
 
     // make a copy of metadata
@@ -601,11 +611,17 @@ Status publish(Tablet* tablet, int64_t base_version, int64_t new_version, const 
     for (int i = 0; i < txns_size; i++) {
         auto txn_id = txns[i];
         auto txn_log_st = tablet->get_txn_log(txn_id);
-        if (txn_log_st.status().is_not_found() && tablet->get_metadata(new_version).ok()) {
-            // txn log does not exist but the new version metadata has been generated, maybe
-            // this is a duplicated publish version request.
-            return Status::OK();
-        } else if (!txn_log_st.ok()) {
+
+        if (txn_log_st.status().is_not_found()) {
+            auto target_metadata_or = tablet->get_metadata(new_version);
+            if (target_metadata_or.ok()) {
+                // txn log does not exist but the new version metadata has been generated, maybe
+                // this is a duplicated publish version request.
+                return compaction_score(**target_metadata_or);
+            }
+        }
+
+        if (!txn_log_st.ok()) {
             LOG(WARNING) << "Fail to get " << tablet->txn_log_location(txn_id) << ": " << txn_log_st.status();
             return txn_log_st.status();
         }
@@ -629,11 +645,16 @@ Status publish(Tablet* tablet, int64_t base_version, int64_t new_version, const 
         DCHECK(base_version == 1 && txns_size == 1);
         for (int64_t v = alter_version + 1; v < new_version; ++v) {
             auto txn_vlog = tablet->get_txn_vlog(v);
-            if (txn_vlog.status().is_not_found() && tablet->get_metadata(new_version).ok()) {
-                // txn version log does not exist but the new version metadata has been generated, maybe
-                // this is a duplicated publish version request.
-                return Status::OK();
-            } else if (!txn_vlog.ok()) {
+            if (txn_vlog.status().is_not_found()) {
+                auto target_metadata_or = tablet->get_metadata(new_version);
+                if (target_metadata_or.ok()) {
+                    // txn version log does not exist but the new version metadata has been generated, maybe
+                    // this is a duplicated publish version request.
+                    return compaction_score(**target_metadata_or);
+                }
+            }
+
+            if (!txn_vlog.ok()) {
                 LOG(WARNING) << "Fail to get " << tablet->txn_vlog_location(v) << ": " << txn_vlog.status();
                 return txn_vlog.status();
             }
@@ -665,7 +686,7 @@ Status publish(Tablet* tablet, int64_t base_version, int64_t new_version, const 
             LOG_IF(WARNING, !st.ok()) << "Fail to delete " << tablet->txn_vlog_location(v) << ": " << st;
         }
     }
-    return Status::OK();
+    return compaction_score(*new_metadata);
 }
 
 StatusOr<CompactionTaskPtr> TabletManager::compact(int64_t tablet_id, int64_t version, int64_t txn_id) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -49,7 +49,7 @@ public:
 
     // Returns the compaction score of the newly created tablet metadata
     StatusOr<double> publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version, const int64_t* txns,
-                           int txns_size);
+                                     int txns_size);
 
     void abort_txn(int64_t tablet_id, const int64_t* txns, int txns_size);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -47,7 +47,8 @@ public:
 
     Status delete_tablet(int64_t tablet_id);
 
-    Status publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version, const int64_t* txns,
+    // Returns the compaction score of the newly created tablet metadata
+    StatusOr<double> publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version, const int64_t* txns,
                            int txns_size);
 
     void abort_txn(int64_t tablet_id, const int64_t* txns, int txns_size);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -218,6 +218,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         request.add_txn_ids(1001);
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
+        ASSERT_EQ(1, response.compaction_scores_size());
     }
     // Send publish version request again with an non-exist tablet
     {
@@ -231,6 +232,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(9999, response.failed_tablets(0));
+        ASSERT_EQ(1, response.compaction_scores_size());
+        ASSERT_TRUE(response.compaction_scores().contains(_tablet_id));
     }
     // Send publish version request again with an non-exist txnlog
     {
@@ -243,6 +246,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+        ASSERT_EQ(0, response.compaction_scores_size());
     }
     // Delete old version metadata then send publish version again
     tablet.delete_metadata(1);
@@ -256,6 +260,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         request.add_txn_ids(1001);
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
+        ASSERT_TRUE(response.compaction_scores().contains(_tablet_id));
     }
 }
 
@@ -447,6 +452,7 @@ TEST_F(LakeServiceTest, test_compact) {
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
+        ASSERT_TRUE(response.compaction_scores().contains(_tablet_id));
     }
 }
 
@@ -605,6 +611,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
+        ASSERT_TRUE(response.compaction_scores().contains(_tablet_id));
     }
 
     _tablet_mgr->prune_metacache();

--- a/be/test/storage/lake/horizontal_compaction_task_test.cpp
+++ b/be/test/storage/lake/horizontal_compaction_task_test.cpp
@@ -170,7 +170,7 @@ TEST_F(DuplicateKeyHorizontalCompactionTest, test1) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -181,7 +181,7 @@ TEST_F(DuplicateKeyHorizontalCompactionTest, test1) {
 
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     ASSERT_OK(task->execute(nullptr));
-    ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1));
+    ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
 
@@ -325,7 +325,7 @@ TEST_F(UniqueKeyHorizontalCompactionTest, test1) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read(version));
@@ -336,7 +336,7 @@ TEST_F(UniqueKeyHorizontalCompactionTest, test1) {
 
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     ASSERT_OK(task->execute(nullptr));
-    ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1));
+    ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
 
@@ -479,7 +479,7 @@ TEST_F(UniqueKeyHorizontalCompactionWithDeleteTest, test_base_compaction_with_de
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read(version));
@@ -515,7 +515,7 @@ TEST_F(UniqueKeyHorizontalCompactionWithDeleteTest, test_base_compaction_with_de
 
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     ASSERT_OK(task->execute(nullptr));
-    ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1));
+    ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize - 4, read(version));
 

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -183,7 +183,7 @@ TEST_F(LinkedSchemaChangeTest, test_add_column) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
         version++;
         txn_id++;
     }
@@ -193,7 +193,7 @@ TEST_F(LinkedSchemaChangeTest, test_add_column) {
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
         version++;
         txn_id++;
     }
@@ -209,7 +209,7 @@ TEST_F(LinkedSchemaChangeTest, test_add_column) {
 
     SchemaChangeHandler handler;
     ASSERT_OK(handler.process_alter_tablet(request));
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &txn_id, 1));
+    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &txn_id, 1).status());
     version++;
     txn_id++;
 
@@ -389,7 +389,7 @@ TEST_F(DirectSchemaChangeTest, test_alter_column_type) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
         version++;
         txn_id++;
     }
@@ -399,7 +399,7 @@ TEST_F(DirectSchemaChangeTest, test_alter_column_type) {
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
         version++;
         txn_id++;
     }
@@ -415,7 +415,7 @@ TEST_F(DirectSchemaChangeTest, test_alter_column_type) {
 
     SchemaChangeHandler handler;
     ASSERT_OK(handler.process_alter_tablet(request));
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &txn_id, 1));
+    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &txn_id, 1).status());
     version++;
     txn_id++;
 
@@ -619,7 +619,7 @@ TEST_F(SortedSchemaChangeTest, test_alter_key_order) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
         version++;
         txn_id++;
     }
@@ -629,7 +629,7 @@ TEST_F(SortedSchemaChangeTest, test_alter_key_order) {
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1));
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
         version++;
         txn_id++;
     }
@@ -645,7 +645,7 @@ TEST_F(SortedSchemaChangeTest, test_alter_key_order) {
 
     SchemaChangeHandler handler;
     ASSERT_OK(handler.process_alter_tablet(request));
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &txn_id, 1));
+    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &txn_id, 1).status());
     version++;
     txn_id++;
 


### PR DESCRIPTION
This PR is part of the PR stack to support compaction scheduling based on the compaction score of each tablet.

Instead of scheduling compactions based on the number of versions, the new compaction policy will collect the compaction score of each tablet and make decisions based on the average and median compaction score.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

