### PR TITLE
[BugFix] fix project prune rule 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -221,6 +221,7 @@ public class RuleSet {
                 PruneHDFSScanColumnRule.HUDI_SCAN,
                 PruneScanColumnRule.JDBC_SCAN,
                 new PruneProjectColumnsRule(),
+                new PruneProjectRule(),
                 new PruneFilterColumnsRule(),
                 new PruneAggregateColumnsRule(),
                 new PruneTopNColumnsRule(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -221,7 +221,6 @@ public class RuleSet {
                 PruneHDFSScanColumnRule.HUDI_SCAN,
                 PruneScanColumnRule.JDBC_SCAN,
                 new PruneProjectColumnsRule(),
-                new PruneProjectRule(),
                 new PruneFilterColumnsRule(),
                 new PruneAggregateColumnsRule(),
                 new PruneTopNColumnsRule(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
@@ -59,7 +59,7 @@ public class PruneProjectColumnsRule extends TransformationRule {
             if (CollectionUtils.isNotEmpty(outputColumns)) {
                 ColumnRefOperator smallestColumn = Utils.findSmallestColumnRef(outputColumns);
                 ScalarOperator expr = projectOperator.getColumnRefMap().get(smallestColumn);
-                if (!smallestColumn.equals(expr)) {
+                if (!smallestColumn.equals(expr) && !expr.isVariable()) {
                     newMap.put(smallestColumn, expr);
                     requiredInputColumns.union(smallestColumn);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -708,10 +708,14 @@ public class AggregateTest extends PlanTestBase {
     public void testVarianceStddevAnalyze() throws Exception {
         String sql = "select stddev_pop(1222) from (select 1) t;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
                 "  |  output: stddev_pop(1222)\n" +
-                "  |  group by: ");
-        assertContains(plan, "  0:UNION\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 1\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -34,6 +34,22 @@ public class NestLoopJoinTest extends PlanTestBase {
                 "  |  other join predicates: 3: v3 < 6: v3\n" +
                 "  |  \n" +
                 "  |----2:EXCHANGE\n"));
+
+        // Prune should make the HASH JOIN(LEFT ANTI) could output the left table, but not join slot
+        sql = "select distinct('const') from t0, t1, " +
+                " (select * from t2 where cast(v7 as string) like 'ss%' ) sub1 " +
+                "left anti join " +
+                " (select * from t3 where cast(v10 as string) like 'ss%' ) sub2" +
+                " on substr(cast(sub1.v7 as string), 1) = substr(cast(sub2.v10 as string), 1)";
+
+        PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("auto");
+        assertPlanContains(sql, "  11:Project\n" +
+                "  |  <slot 7> : 7: v7\n" +
+                "  |  \n" +
+                "  10:HASH JOIN\n" +
+                "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 14: substr = 15: subst");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -43,13 +43,13 @@ public class NestLoopJoinTest extends PlanTestBase {
                 " on substr(cast(sub1.v7 as string), 1) = substr(cast(sub2.v10 as string), 1)";
 
         PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("auto");
-        assertPlanContains(sql, "  11:Project\n" +
-                "  |  <slot 7> : 7: v7\n" +
+        assertPlanContains(sql, " 11:Project\n" +
+                "  |  <slot 14> : 14: substr\n" +
                 "  |  \n" +
                 "  10:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 14: substr = 15: subst");
+                "  |  equal join conjunct: 14: substr = 15: substr");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -93,7 +93,7 @@ public class SelectConstTest extends PlanTestBase {
         assertPlanContains("select * from t0 where exists (select 9,10)", "  1:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL");
-        assertPlanContains("select * from t0 where not exists (select 9)", "  1:UNION\n" +
+        assertPlanContains("select * from t0 where not exists (select 9)", "  0:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL");
         assertPlanContains("select * from t0 where v3 = (select 6)", "  5:Project\n" +


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13205
Fixes #13260

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

**Why the SQL in #13205 make BE crash in `NestLoopJoinOperator` ?**
1. The `PruneProjectColumnsRule` would prune all output columns of operators under the Aggregate Node
2. So there's no required output columns for HashJoinOperator, it would output the build table's column as result, which is wrong for `LEFT ANTI JOIN`
3. Since the column type in plan is not consistent with actual output, the above operator `NestLoopJoinOperator` would failed to `down_cast` column type
4. Why previous `CrossJoinNode` does not have this issue? Cause it initializes its output chunk according to input chunk, regarding of the type info in plan. But it's not suitable for NestLoopJoin`, it must initialize the output chunk according to type info in plan


The wrong plan is:
```sql
|                         - HASH/LEFT ANTI JOIN [55:cast = 45:c_2_10] => [45:c_2_10]                                         |
|                                 Estimates: {row: 3, cpu: ?, memory: ?, network: ?, cost: 38.30769230769231}                |
|                             - EXCHANGE(SHUFFLE) [55]                                                                       |
|                                     Estimates: {row: 8, cpu: ?, memory: ?, network: ?, cost: 16.2}                         |
|                                 - SCAN [t1] => [55:cast]                                                                   |
|                                         Estimates: {row: 8, cpu: ?, memory: ?, network: ?, cost: 12.149999999999999}       |
|                                         partitionRatio: 1/19, tabletRatio: 3/3                                             |
|                                         55:cast := cast(34:c_1_10 as varchar(1048576))                                     |
|                                         predicate: 28:c_1_4 IS NOT NULL                                                    |
|                             - EXCHANGE(SHUFFLE) [45]                                                                       |
|                                     Estimates: {row: 6, cpu: ?, memory: ?, network: ?, cost: 6.0}                          |
|                                 - SCAN [t2] => [45:c_2_10]                                                                 |
|                                         Estimates: {row: 6, cpu: ?, memory: ?, network: ?, cost: 3.0}                      |
|                                         partitionRatio: 1/27, tabletRatio: 3/3                                             |
+-----------------------------------------------------------------------------------------------------------
```

**How to fix it ?**
1. Correct the output column, so the type info would not be chaos
2. Guarantee at least one output column for any operator, already checked in `PRUNE_PROJECT`, so copy it to `PRUNE_PROJECT_COLUMNS`
3. The special case is, the reserved output column is not self-reference(which introduce deadloop in statistic calculator), and is not a variable, which also introduce error in statistic calculator


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
