### PR TITLE
[Enhancement] Compaction scheduling based on compaction score(2/3)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1759,19 +1759,22 @@ public class Config extends ConfigBase {
     public static String jaeger_grpc_endpoint = "";
 
     @ConfField
-    public static String lake_compaction_selector = "SimpleSelector";
+    public static String lake_compaction_selector = "ScoreSelector";
 
     @ConfField
-    public static String lake_compaction_sorter = "RandomSorter";
+    public static String lake_compaction_sorter = "ScoreSorter";
 
-    @ConfField
+    @ConfField(mutable = true)
     public static long lake_compaction_simple_selector_min_versions = 3;
 
-    @ConfField
+    @ConfField(mutable = true)
     public static long lake_compaction_simple_selector_threshold_versions = 10;
 
-    @ConfField
+    @ConfField(mutable = true)
     public static long lake_compaction_simple_selector_threshold_seconds = 300;
+
+    @ConfField(mutable = true)
+    public static double lake_compaction_score_selector_min_score = 1.0;
 
     /**
      * -1 means calculate the value in an adaptive way.

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -73,8 +73,13 @@ public class Utils {
         return groupMap;
     }
 
-    @NotNull
     public static void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion)
+            throws NoAliveBackendException, RpcException {
+        publishVersion(tablets, txnId, baseVersion, newVersion, null);
+    }
+
+    public static void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion, Map<Long,
+            Double> compactionScores)
             throws NoAliveBackendException, RpcException {
         Map<Long, List<Long>> beToTablets = new HashMap<>();
         for (Tablet tablet : tablets) {
@@ -116,13 +121,15 @@ public class Utils {
                     throw new RpcException(backendList.get(i).getHost(),
                             "Fail to publish version for tablets {}" + response.failedTablets);
                 }
+                if (compactionScores != null && response != null && response.compactionScores != null) {
+                    compactionScores.putAll(response.compactionScores);
+                }
             } catch (Exception e) {
                 throw new RpcException(backendList.get(i).getHost(), e.getMessage());
             }
         }
     }
 
-    @NotNull
     public static void publishLogVersion(@NotNull List<Tablet> tablets, long txnId, long version)
             throws NoAliveBackendException, RpcException {
         Map<Long, List<Long>> beToTablets = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionContext.java
@@ -1,0 +1,108 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.lake.compaction;
+
+import com.google.common.collect.Lists;
+import com.starrocks.proto.CompactResponse;
+import com.starrocks.transaction.VisibleStateWaiter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.validation.constraints.NotNull;
+
+public class CompactionContext {
+    private long txnId;
+    private long startTs;
+    private long commitTs;
+    private long visibleTs;
+    private String partitionName;
+    private Map<Long, List<Long>> beToTablets;
+    private List<Future<CompactResponse>> responseList;
+    private VisibleStateWaiter visibleStateWaiter;
+
+    public CompactionContext() {
+        responseList = Lists.newArrayList();
+    }
+
+    public void setTxnId(long txnId) {
+        this.txnId = txnId;
+    }
+
+    public long getTxnId() {
+        return txnId;
+    }
+
+    public void setResponseList(@NotNull List<Future<CompactResponse>> futures) {
+        responseList = futures;
+    }
+
+    public List<Future<CompactResponse>> getResponseList() {
+        return responseList;
+    }
+
+    public void setVisibleStateWaiter(VisibleStateWaiter visibleStateWaiter) {
+        this.visibleStateWaiter = visibleStateWaiter;
+    }
+
+    public boolean waitTransactionVisible(long timeout, TimeUnit unit) {
+        return visibleStateWaiter.await(timeout, unit);
+    }
+
+    public boolean transactionHasCommitted() {
+        return visibleStateWaiter != null;
+    }
+
+    public void setBeToTablets(@NotNull Map<Long, List<Long>> beToTablets) {
+        this.beToTablets = beToTablets;
+    }
+
+    public Map<Long, List<Long>> getBeToTablets() {
+        return beToTablets;
+    }
+
+    public boolean compactionFinishedOnBE() {
+        return responseList.stream().allMatch(Future::isDone);
+    }
+
+    public int getNumCompactionTasks() {
+        return beToTablets.values().stream().mapToInt(List::size).sum();
+    }
+
+    public void setStartTs(long startTs) {
+        this.startTs = startTs;
+    }
+
+    public long getStartTs() {
+        return startTs;
+    }
+
+    public void setCommitTs(long commitTs) {
+        this.commitTs = commitTs;
+    }
+
+    public long getCommitTs() {
+        return commitTs;
+    }
+
+    public void setVisibleTs(long visibleTs) {
+        this.visibleTs = visibleTs;
+    }
+
+    public long getVisibleTs() {
+        return visibleTs;
+    }
+
+    public void setPartitionName(String partitionName) {
+        this.partitionName = partitionName;
+    }
+
+    public String getPartitionName() {
+        return partitionName;
+    }
+
+    public String getDebugString() {
+        return String.format("TxnId=%d partition=%s", txnId, partitionName);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionManager.java
@@ -14,19 +14,21 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 public class CompactionManager {
     private static final Logger LOG = LogManager.getLogger(CompactionManager.class);
 
     @SerializedName(value = "partitionStatisticsHashMap")
-    private final Map<PartitionIdentifier, PartitionStatistics> partitionStatisticsHashMap = new HashMap<>();
+    private final ConcurrentHashMap<PartitionIdentifier, PartitionStatistics> partitionStatisticsHashMap =
+            new ConcurrentHashMap<>();
 
     private Selector selector;
     private Sorter sorter;
@@ -50,7 +52,7 @@ public class CompactionManager {
         sorter = (Sorter) sorterClazz.getConstructor().newInstance();
     }
 
-    public synchronized void start() {
+    public void start() {
         if (compactionScheduler == null) {
             compactionScheduler = new CompactionScheduler(this, GlobalStateMgr.getCurrentSystemInfo(),
                     GlobalStateMgr.getCurrentGlobalTransactionMgr(), GlobalStateMgr.getCurrentState());
@@ -58,69 +60,98 @@ public class CompactionManager {
         }
     }
 
-    public synchronized void handleLoadingFinished(PartitionIdentifier partition, long version, long versionTime) {
-        PartitionStatistics statistics = partitionStatisticsHashMap.computeIfAbsent(partition, PartitionStatistics::new);
+    public void handleLoadingFinished(PartitionIdentifier partition, long version, long versionTime,
+                                      Quantiles compactionScore) {
         PartitionVersion currentVersion = new PartitionVersion(version, versionTime);
-        statistics.setCurrentVersion(currentVersion);
-        if (statistics.getLastCompactionVersion() == null) {
-            // Set version-1 as last compaction version
-            statistics.setLastCompactionVersion(new PartitionVersion(version - 1, versionTime));
-        }
+        PartitionStatistics statistics = partitionStatisticsHashMap.compute(partition, (k, v) -> {
+            if (v == null) {
+                v = new PartitionStatistics(partition);
+            }
+            v.setCurrentVersion(currentVersion);
+            v.setCompactionScore(compactionScore);
+            if (v.getCompactionVersion() == null) {
+                // Set version-1 as last compaction version
+                v.setCompactionVersion(new PartitionVersion(version - 1, versionTime));
+            }
+            return v;
+        });
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finished loading: {}", statistics);
         }
     }
 
-    public synchronized void handleCompactionFinished(PartitionIdentifier partition, long version, long versionTime) {
-        PartitionStatistics statistics = partitionStatisticsHashMap.computeIfAbsent(partition, PartitionStatistics::new);
+    public void handleCompactionFinished(PartitionIdentifier partition, long version, long versionTime,
+                                         Quantiles compactionScore) {
         PartitionVersion compactionVersion = new PartitionVersion(version, versionTime);
-        statistics.setCurrentVersion(compactionVersion);
-        statistics.setLastCompactionVersion(compactionVersion);
+        PartitionStatistics statistics = partitionStatisticsHashMap.compute(partition, (k, v) -> {
+            if (v == null) {
+                v = new PartitionStatistics(partition);
+            }
+            v.setCurrentVersion(compactionVersion);
+            v.setCompactionVersion(compactionVersion);
+            v.setCompactionScore(compactionScore);
+            return v;
+        });
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finished compaction: {}", statistics);
         }
     }
 
     @NotNull
-    synchronized List<PartitionIdentifier> choosePartitionsToCompact(@NotNull Set<PartitionIdentifier> excludes) {
+    List<PartitionIdentifier> choosePartitionsToCompact(@NotNull Set<PartitionIdentifier> excludes) {
         return choosePartitionsToCompact().stream().filter(p -> !excludes.contains(p)).collect(Collectors.toList());
     }
 
     @NotNull
-    synchronized List<PartitionIdentifier> choosePartitionsToCompact() {
+    List<PartitionIdentifier> choosePartitionsToCompact() {
         List<PartitionStatistics> selection = sorter.sort(selector.select(partitionStatisticsHashMap.values()));
         return selection.stream().map(PartitionStatistics::getPartition).collect(Collectors.toList());
     }
 
     @NotNull
-    synchronized Set<PartitionIdentifier> getAllPartitions() {
+    Set<PartitionIdentifier> getAllPartitions() {
         return new HashSet<>(partitionStatisticsHashMap.keySet());
     }
 
-    synchronized void enableCompactionAfter(PartitionIdentifier partition, long delayMs) {
-        PartitionStatistics statistics = partitionStatisticsHashMap.get(partition);
-        if (statistics != null) {
+    @NotNull
+    public Collection<PartitionStatistics> getAllStatistics() {
+        return partitionStatisticsHashMap.values();
+    }
+
+    @Nullable
+    public PartitionStatistics getStatistics(PartitionIdentifier identifier) {
+        return partitionStatisticsHashMap.get(identifier);
+    }
+
+    void enableCompactionAfter(PartitionIdentifier partition, long delayMs) {
+        PartitionStatistics statistics = partitionStatisticsHashMap.computeIfPresent(partition, (k, v) -> {
             // FE's follower nodes may have a different timestamp with the leader node.
-            statistics.setNextCompactionTime(System.currentTimeMillis() + delayMs);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Enable compaction after {}ms: {}", delayMs, statistics);
-            }
+            v.setNextCompactionTime(System.currentTimeMillis() + delayMs);
+            return v;
+        });
+        if (statistics != null && LOG.isDebugEnabled()) {
+            LOG.debug("Enable compaction after {}ms: {}", delayMs, statistics);
         }
     }
 
-    synchronized void removePartition(PartitionIdentifier partition) {
+    void removePartition(PartitionIdentifier partition) {
         partitionStatisticsHashMap.remove(partition);
     }
 
-    public synchronized long saveCompactionManager(DataOutput out, long checksum) throws IOException {
+    public long saveCompactionManager(DataOutput out, long checksum) throws IOException {
         String json = GsonUtils.GSON.toJson(this);
         Text.writeString(out, json);
         checksum ^= getChecksum();
         return checksum;
     }
 
-    public synchronized long getChecksum() {
+    public long getChecksum() {
         return partitionStatisticsHashMap.size();
+    }
+
+    @NotNull
+    public ConcurrentHashMap<PartitionIdentifier, CompactionContext> getRunningCompactions() {
+        return compactionScheduler.getRunningCompactions();
     }
 
     public static CompactionManager loadCompactionManager(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -4,7 +4,6 @@ package com.starrocks.lake.compaction;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -40,6 +39,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +60,7 @@ public class CompactionScheduler extends Daemon {
     private final SystemInfoService systemInfoService;
     private final GlobalTransactionMgr transactionMgr;
     private final GlobalStateMgr stateMgr;
-    private final Map<PartitionIdentifier, CompactionContext> runningCompactions;
+    private final ConcurrentHashMap<PartitionIdentifier, CompactionContext> runningCompactions;
     private long lastPartitionCleanTime;
 
     CompactionScheduler(@NotNull CompactionManager compactionManager, @NotNull SystemInfoService systemInfoService,
@@ -70,7 +70,7 @@ public class CompactionScheduler extends Daemon {
         this.systemInfoService = systemInfoService;
         this.transactionMgr = transactionMgr;
         this.stateMgr = stateMgr;
-        this.runningCompactions = Maps.newHashMap();
+        this.runningCompactions = new ConcurrentHashMap();
         this.lastPartitionCleanTime = System.currentTimeMillis();
     }
 
@@ -122,11 +122,11 @@ public class CompactionScheduler extends Daemon {
             }
 
             if (context.transactionHasCommitted() && context.waitTransactionVisible(100, TimeUnit.MILLISECONDS)) {
-                context.setCommitTs(System.currentTimeMillis());
+                context.setVisibleTs(System.currentTimeMillis());
                 iterator.remove();
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Removed published compaction. {} cost={}ms running={}", context.getDebugString(),
-                            (context.getCommitTs() - context.getStartTs()), runningCompactions.size());
+                            (context.getVisibleTs() - context.getStartTs()), runningCompactions.size());
                 }
                 compactionManager.enableCompactionAfter(partition, MIN_COMPACTION_INTERVAL_MS_ON_SUCCESS);
             }
@@ -380,89 +380,8 @@ public class CompactionScheduler extends Daemon {
         }
     }
 
-    private static class CompactionContext {
-        private long txnId;
-        private long startTs;
-        private long commitTs;
-        private String partitionName;
-        private Map<Long, List<Long>> beToTablets;
-        private List<Future<CompactResponse>> responseList;
-        private VisibleStateWaiter visibleStateWaiter;
-
-        CompactionContext() {
-            responseList = Lists.newArrayList();
-        }
-
-        void setTxnId(long txnId) {
-            this.txnId = txnId;
-        }
-
-        long getTxnId() {
-            return txnId;
-        }
-
-        void setResponseList(@NotNull List<Future<CompactResponse>> futures) {
-            responseList = futures;
-        }
-
-        List<Future<CompactResponse>> getResponseList() {
-            return responseList;
-        }
-
-        void setVisibleStateWaiter(VisibleStateWaiter visibleStateWaiter) {
-            this.visibleStateWaiter = visibleStateWaiter;
-        }
-
-        boolean waitTransactionVisible(long timeout, TimeUnit unit) {
-            return visibleStateWaiter.await(timeout, unit);
-        }
-
-        boolean transactionHasCommitted() {
-            return visibleStateWaiter != null;
-        }
-
-        void setBeToTablets(@NotNull Map<Long, List<Long>> beToTablets) {
-            this.beToTablets = beToTablets;
-        }
-
-        Map<Long, List<Long>> getBeToTablets() {
-            return beToTablets;
-        }
-
-        boolean compactionFinishedOnBE() {
-            return responseList.stream().allMatch(Future::isDone);
-        }
-
-        int getNumCompactionTasks() {
-            return beToTablets.values().stream().mapToInt(List::size).sum();
-        }
-
-        void setStartTs(long startTs) {
-            this.startTs = startTs;
-        }
-
-        long getStartTs() {
-            return startTs;
-        }
-
-        void setCommitTs(long commitTs) {
-            this.commitTs = commitTs;
-        }
-
-        long getCommitTs() {
-            return commitTs;
-        }
-
-        void setPartitionName(String partitionName) {
-            this.partitionName = partitionName;
-        }
-
-        String getPartitionName() {
-            return partitionName;
-        }
-
-        String getDebugString() {
-            return String.format("TxnId=%d partition=%s", txnId, partitionName);
-        }
+    @NotNull
+    ConcurrentHashMap<PartitionIdentifier, CompactionContext> getRunningCompactions() {
+        return runningCompactions;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatistics.java
@@ -5,56 +5,69 @@ package com.starrocks.lake.compaction;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 
-class PartitionStatistics {
+import javax.annotation.Nullable;
+
+public class PartitionStatistics {
     @SerializedName(value = "partition")
     private final PartitionIdentifier partition;
-    @SerializedName(value = "lastCompactionVersion")
-    private PartitionVersion lastCompactionVersion;
+    @SerializedName(value = "compactionVersion")
+    private PartitionVersion compactionVersion;
     @SerializedName(value = "currentVersion")
     private PartitionVersion currentVersion;
     @SerializedName(value = "nextCompactionTime")
     private long nextCompactionTime;
+    @SerializedName(value = "compactionScore")
+    private Quantiles compactionScore;
 
-    PartitionStatistics(PartitionIdentifier partition) {
+    public PartitionStatistics(PartitionIdentifier partition) {
         this.partition = partition;
-        this.lastCompactionVersion = null;
+        this.compactionVersion = null;
         this.nextCompactionTime = 0;
     }
 
-    PartitionIdentifier getPartition() {
+    public PartitionIdentifier getPartition() {
         return partition;
     }
 
-    PartitionVersion getCurrentVersion() {
+    public PartitionVersion getCurrentVersion() {
         return currentVersion;
     }
 
-    void setCurrentVersion(PartitionVersion currentVersion) {
+    public void setCurrentVersion(PartitionVersion currentVersion) {
         this.currentVersion = currentVersion;
     }
 
-    PartitionVersion getLastCompactionVersion() {
-        return lastCompactionVersion;
+    public PartitionVersion getCompactionVersion() {
+        return compactionVersion;
     }
 
-    void setLastCompactionVersion(PartitionVersion value) {
-        lastCompactionVersion = value;
+    public void setCompactionVersion(PartitionVersion value) {
+        compactionVersion = value;
     }
 
-    long getLastCompactionTime() {
-        return getLastCompactionVersion().getCreateTime();
+    public long getLastCompactionTime() {
+        return getCompactionVersion().getCreateTime();
     }
 
-    void setNextCompactionTime(long nextCompactionTime) {
+    public void setNextCompactionTime(long nextCompactionTime) {
         this.nextCompactionTime = nextCompactionTime;
     }
 
-    long getNextCompactionTime() {
+    public long getNextCompactionTime() {
         return nextCompactionTime;
     }
 
-    long getDeltaVersions() {
-        return getCurrentVersion().getVersion() - getLastCompactionVersion().getVersion();
+    public long getDeltaVersions() {
+        return getCurrentVersion().getVersion() - getCompactionVersion().getVersion();
+    }
+
+    public void setCompactionScore(@Nullable Quantiles compactionScore) {
+        this.compactionScore = compactionScore;
+    }
+
+    @Nullable
+    public Quantiles getCompactionScore() {
+        return compactionScore;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionVersion.java
@@ -17,11 +17,11 @@ public class PartitionVersion {
         this.createTime = createTime;
     }
 
-    long getVersion() {
+    public long getVersion() {
         return version;
     }
 
-    long getCreateTime() {
+    public long getCreateTime() {
         return createTime;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Quantiles.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Quantiles.java
@@ -1,0 +1,70 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.lake.compaction;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
+
+public class Quantiles implements Comparable<Quantiles> {
+    @SerializedName(value = "avg")
+    private final double avg;
+    @SerializedName(value = "p50")
+    private final double p50;
+    @SerializedName(value = "max")
+    private final double max;
+
+    @NotNull
+    public static Quantiles compute(@NotNull Collection<Double> values) {
+        if (values.isEmpty()) {
+            return new Quantiles(0, 0, 0);
+        }
+        List<Double> sortedValues = values.stream().sorted().collect(Collectors.toList());
+        int size = sortedValues.size();
+        double avg = sortedValues.stream().mapToDouble(a -> a).average().orElse(0);
+        double p50 = sortedValues.get(size / 2);
+        double max = sortedValues.get(size - 1);
+        return new Quantiles(avg, p50, max);
+    }
+
+    private Quantiles(double avg, double p50, double max) {
+        this.avg = avg;
+        this.p50 = p50;
+        this.max = max;
+    }
+
+    public double getAvg() {
+        return avg;
+    }
+
+    public double getP50() {
+        return p50;
+    }
+
+    public double getMax() {
+        return max;
+    }
+
+    @Override
+    public int compareTo(@NotNull Quantiles o) {
+        if (avg != o.avg) {
+            return avg > o.avg ? 1 : -1;
+        }
+        if (p50 != o.p50) {
+            return p50 > o.p50 ? 1 : -1;
+        }
+        if (max != o.max) {
+            return max > o.max ? 1 : -1;
+        }
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSelector.java
@@ -1,0 +1,25 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.lake.compaction;
+
+import com.starrocks.common.Config;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
+
+public class ScoreSelector implements Selector {
+
+    @Override
+    @NotNull
+    public List<PartitionStatistics> select(@NotNull Collection<PartitionStatistics> statistics) {
+        double minScore = Config.lake_compaction_score_selector_min_score;
+        long now = System.currentTimeMillis();
+        return statistics.stream()
+                .filter(p -> p.getNextCompactionTime() <= now)
+                .filter(p -> p.getCompactionScore() != null)
+                .filter(p -> p.getCompactionScore().getAvg() >= minScore || p.getCompactionScore().getP50() >= minScore)
+                .collect(Collectors.toList());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSorter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSorter.java
@@ -1,0 +1,19 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.lake.compaction;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
+
+public class ScoreSorter implements Sorter {
+    @Override
+    @NotNull
+    public List<PartitionStatistics> sort(@NotNull List<PartitionStatistics> partitionStatistics) {
+        return partitionStatistics.stream()
+                .filter(p -> p.getCompactionScore() != null)
+                .sorted(Comparator.comparing(PartitionStatistics::getCompactionScore).reversed())
+                .collect(Collectors.toList());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -26,6 +26,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.lake.compaction.Quantiles;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 
@@ -33,6 +34,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public class PartitionCommitInfo implements Writable {
 
@@ -59,6 +61,10 @@ public class PartitionCommitInfo implements Writable {
     private List<String> invalidDictCacheColumns = Lists.newArrayList();
     @SerializedName(value = "validColumns")
     private List<String> validDictCacheColumns = Lists.newArrayList();
+
+    // compaction score quantiles of lake table
+    @SerializedName(value = "compactionScore")
+    private Quantiles compactionScore;
 
     public PartitionCommitInfo() {
 
@@ -126,6 +132,15 @@ public class PartitionCommitInfo implements Writable {
 
     public List<String> getValidDictCacheColumns() {
         return validDictCacheColumns;
+    }
+
+    public void setCompactionScore(Quantiles compactionScore) {
+        this.compactionScore = compactionScore;
+    }
+
+    @Nullable
+    public Quantiles getCompactionScore() {
+        return compactionScore;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -38,6 +38,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.compaction.Quantiles;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.server.GlobalStateMgr;
@@ -50,10 +51,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 public class PublishVersionDaemon extends LeaderDaemon {
@@ -340,24 +341,16 @@ public class PublishVersionDaemon extends LeaderDaemon {
             db.readUnlock();
         }
 
-        return publishNormalTablets(normalTablets, txnId, txnVersion) && publishShadowTablets(shadowTablets, txnId, txnVersion);
-    }
-
-    private boolean publishNormalTablets(@Nullable List<Tablet> tablets, long txnId, long version)
-            throws RpcException, NoAliveBackendException {
-        if (tablets == null || tablets.isEmpty()) {
-            return true;
+        if (shadowTablets != null && !shadowTablets.isEmpty()) {
+            Utils.publishLogVersion(shadowTablets, txnId, txnVersion);
         }
-        Utils.publishVersion(tablets, txnId, version - 1, version);
-        return true;
-    }
+        if (normalTablets != null && !normalTablets.isEmpty()) {
+            Map<Long, Double> compactionScores = new HashMap<>();
+            Utils.publishVersion(normalTablets, txnId, txnVersion - 1, txnVersion, compactionScores);
 
-    private boolean publishShadowTablets(@Nullable List<Tablet> tablets, long txnId, long version)
-            throws RpcException, NoAliveBackendException {
-        if (tablets == null || tablets.isEmpty()) {
-            return true;
+            Quantiles quantiles = Quantiles.compute(compactionScores.values());
+            partitionCommitInfo.setCompactionScore(quantiles);
         }
-        Utils.publishLogVersion(tablets, txnId, version);
         return true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionManagerTest.java
@@ -4,32 +4,29 @@ package com.starrocks.lake.compaction;
 
 import com.starrocks.common.Config;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
 
 public class CompactionManagerTest {
-    private CompactionManager compactionManager;
-
-    @Before
-    public void init() {
-        compactionManager = new CompactionManager();
-    }
 
     @Test
     public void testChoosePartitionsToCompact() {
+        Config.lake_compaction_selector = "SimpleSelector";
+        Config.lake_compaction_sorter = "RandomSorter";
+        CompactionManager compactionManager = new CompactionManager();
+
         PartitionIdentifier partition1 = new PartitionIdentifier(1, 2, 3);
         PartitionIdentifier partition2 = new PartitionIdentifier(1, 2, 4);
 
         for (int i = 1; i <= Config.lake_compaction_simple_selector_threshold_versions - 1; i++) {
-            compactionManager.handleLoadingFinished(partition1, i, System.currentTimeMillis());
-            compactionManager.handleLoadingFinished(partition2, i, System.currentTimeMillis());
+            compactionManager.handleLoadingFinished(partition1, i, System.currentTimeMillis(), null);
+            compactionManager.handleLoadingFinished(partition2, i, System.currentTimeMillis(), null);
             Assert.assertEquals(0, compactionManager.choosePartitionsToCompact().size());
         }
         compactionManager.handleLoadingFinished(partition1, Config.lake_compaction_simple_selector_threshold_versions,
-                System.currentTimeMillis());
+                System.currentTimeMillis(), null);
         List<PartitionIdentifier> compactionList = compactionManager.choosePartitionsToCompact();
         Assert.assertEquals(1, compactionList.size());
         Assert.assertSame(partition1, compactionList.get(0));
@@ -37,7 +34,7 @@ public class CompactionManagerTest {
         Assert.assertEquals(compactionList, compactionManager.choosePartitionsToCompact());
 
         compactionManager.handleLoadingFinished(partition2, Config.lake_compaction_simple_selector_threshold_versions,
-                System.currentTimeMillis());
+                System.currentTimeMillis(), null);
 
         compactionList = compactionManager.choosePartitionsToCompact();
         Assert.assertEquals(2, compactionList.size());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSelectorTest.java
@@ -1,0 +1,47 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.lake.compaction;
+
+import com.starrocks.common.Config;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ScoreSelectorTest {
+    private ScoreSelector selector;
+
+    @Before
+    public void setUp() {
+        Config.lake_compaction_score_selector_min_score = 1.0;
+        selector = new ScoreSelector();
+    }
+
+    @Test
+    public void test() {
+        List<PartitionStatistics> statisticsList = new ArrayList<>();
+        PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 3));
+        statistics.setCompactionScore(Quantiles.compute(Collections.singleton(0.0)));
+        statisticsList.add(statistics);
+
+        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 4));
+        statistics.setCompactionScore(Quantiles.compute(Collections.singleton(0.99)));
+        statisticsList.add(statistics);
+
+        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 5));
+        statistics.setCompactionScore(Quantiles.compute(Collections.singleton(1.0)));
+        statisticsList.add(statistics);
+
+        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 6));
+        statistics.setCompactionScore(Quantiles.compute(Collections.singleton(1.1)));
+        statisticsList.add(statistics);
+
+        List<PartitionStatistics> targetList = selector.select(statisticsList);
+        Assert.assertEquals(2, targetList.size());
+        Assert.assertEquals(5, targetList.get(0).getPartition().getPartitionId());
+        Assert.assertEquals(6, targetList.get(1).getPartition().getPartitionId());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSorterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSorterTest.java
@@ -1,0 +1,42 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.lake.compaction;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ScoreSorterTest {
+
+    @Test
+    public void test() {
+        List<PartitionStatistics> statisticsList = new ArrayList<>();
+        PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 3));
+        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(0.0, 0.0, 0.0)));
+        statisticsList.add(statistics);
+
+        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 6));
+        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.1, 1.1, 1.2)));
+        statisticsList.add(statistics);
+
+        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 4));
+        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(0.99, 0.99, 0.99)));
+        statisticsList.add(statistics);
+
+        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 5));
+        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.0, 1.0)));
+        statisticsList.add(statistics);
+
+        ScoreSorter sorter = new ScoreSorter();
+
+        List<PartitionStatistics> sortedList = sorter.sort(statisticsList);
+        Assert.assertEquals(4, sortedList.size());
+        Assert.assertEquals(6, sortedList.get(0).getPartition().getPartitionId());
+        Assert.assertEquals(5, sortedList.get(1).getPartition().getPartitionId());
+        Assert.assertEquals(4, sortedList.get(2).getPartition().getPartitionId());
+        Assert.assertEquals(3, sortedList.get(3).getPartition().getPartitionId());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/SimpleSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/SimpleSelectorTest.java
@@ -37,7 +37,7 @@ public class SimpleSelectorTest {
         final PartitionIdentifier partitionIdentifier = new PartitionIdentifier(1, 2, 3);
         PartitionStatistics statistics = new PartitionStatistics(partitionIdentifier);
         statistics.setCurrentVersion(new PartitionVersion(MIN_COMPACTION_VERSIONS - 1, System.currentTimeMillis()));
-        statistics.setLastCompactionVersion(new PartitionVersion(1, 0));
+        statistics.setCompactionVersion(new PartitionVersion(1, 0));
         statisticsList.add(statistics);
 
         Assert.assertEquals(0, selector.select(statisticsList).size());
@@ -49,13 +49,13 @@ public class SimpleSelectorTest {
 
         final PartitionIdentifier partitionIdentifier1 = new PartitionIdentifier(1, 2, 3);
         PartitionStatistics statistics1 = new PartitionStatistics(partitionIdentifier1);
-        statistics1.setLastCompactionVersion(new PartitionVersion(1, 0));
+        statistics1.setCompactionVersion(new PartitionVersion(1, 0));
         statistics1.setCurrentVersion(new PartitionVersion(MIN_COMPACTION_VERSIONS, System.currentTimeMillis()));
         statisticsList.add(statistics1);
 
         final PartitionIdentifier partitionIdentifier2 = new PartitionIdentifier(1, 2, 4);
         PartitionStatistics statistics2 = new PartitionStatistics(partitionIdentifier2);
-        statistics2.setLastCompactionVersion(new PartitionVersion(1, 0));
+        statistics2.setCompactionVersion(new PartitionVersion(1, 0));
         statistics2.setCurrentVersion(new PartitionVersion(MIN_COMPACTION_VERSIONS + 1, System.currentTimeMillis()));
         statisticsList.add(statistics2);
 
@@ -68,7 +68,7 @@ public class SimpleSelectorTest {
 
         final PartitionIdentifier partitionIdentifier = new PartitionIdentifier(1, 2, 4);
         PartitionStatistics statistics = new PartitionStatistics(partitionIdentifier);
-        statistics.setLastCompactionVersion(new PartitionVersion(1, 0));
+        statistics.setCompactionVersion(new PartitionVersion(1, 0));
         statistics.setCurrentVersion(new PartitionVersion(MIN_COMPACTION_VERSIONS + 1, System.currentTimeMillis()));
         statisticsList.add(statistics);
 


### PR DESCRIPTION
This PR is part of the PR stack to support compaction scheduling based on the compaction score of each tablet.

Instead of scheduling compactions based on the number of versions, the new compaction policy will collect the compaction score of each tablet and make decisions based on the average and median compaction score: compact a partition if the average compaction score or the median compaction score of the partition is greater than or equals to `lake_compaction_score_selector_min_score`(configurable).

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
