### PR TITLE
[Enhancement] load delvec when tablet scanner is openned

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -84,7 +84,7 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _cached_pages_num_counter = ADD_COUNTER(_runtime_profile, "CachedPagesNum", TUnit::UNIT);
     _pushdown_predicates_counter = ADD_COUNTER(_runtime_profile, "PushdownPredicates", TUnit::UNIT);
 
-    _get_rowset_timer = ADD_TIMER(_runtime_profile, "GetRowsets");
+    _get_rowsets_timer = ADD_TIMER(_runtime_profile, "GetRowsets");
     _get_delvec_timer = ADD_TIMER(_runtime_profile, "GetDelVec");
 
     // SegmentInit
@@ -394,7 +394,7 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_block_seek_timer, _reader->stats().block_seek_ns);
 
     COUNTER_UPDATE(_chunk_copy_timer, _reader->stats().vec_cond_chunk_copy_ns);
-    COUNTER_UPDATE(_get_rowset_timer, _reader->stats().get_rowsets_ns);
+    COUNTER_UPDATE(_get_rowsets_timer, _reader->stats().get_rowsets_ns);
     COUNTER_UPDATE(_get_delvec_timer, _reader->stats().get_delvec_ns);
     COUNTER_UPDATE(_seg_init_timer, _reader->stats().segment_init_ns);
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -84,6 +84,9 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _cached_pages_num_counter = ADD_COUNTER(_runtime_profile, "CachedPagesNum", TUnit::UNIT);
     _pushdown_predicates_counter = ADD_COUNTER(_runtime_profile, "PushdownPredicates", TUnit::UNIT);
 
+    _get_rowset_timer = ADD_TIMER(_runtime_profile, "GetRowsets");
+    _get_delvec_timer = ADD_TIMER(_runtime_profile, "GetDelVec");
+
     // SegmentInit
     _seg_init_timer = ADD_TIMER(_runtime_profile, "SegmentInit");
     _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", "SegmentInit");
@@ -391,6 +394,8 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_block_seek_timer, _reader->stats().block_seek_ns);
 
     COUNTER_UPDATE(_chunk_copy_timer, _reader->stats().vec_cond_chunk_copy_ns);
+    COUNTER_UPDATE(_get_rowset_timer, _reader->stats().get_rowsets_ns);
+    COUNTER_UPDATE(_get_delvec_timer, _reader->stats().get_delvec_ns);
     COUNTER_UPDATE(_seg_init_timer, _reader->stats().segment_init_ns);
 
     COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -103,7 +103,7 @@ private:
     RuntimeProfile::Counter* _del_vec_filter_counter = nullptr;
     RuntimeProfile::Counter* _pred_filter_timer = nullptr;
     RuntimeProfile::Counter* _chunk_copy_timer = nullptr;
-    RuntimeProfile::Counter* _get_rowset_timer = nullptr;
+    RuntimeProfile::Counter* _get_rowsets_timer = nullptr;
     RuntimeProfile::Counter* _get_delvec_timer = nullptr;
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -103,6 +103,8 @@ private:
     RuntimeProfile::Counter* _del_vec_filter_counter = nullptr;
     RuntimeProfile::Counter* _pred_filter_timer = nullptr;
     RuntimeProfile::Counter* _chunk_copy_timer = nullptr;
+    RuntimeProfile::Counter* _get_rowset_timer = nullptr;
+    RuntimeProfile::Counter* _get_delvec_timer = nullptr;
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bf_filtered_counter = nullptr;

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -478,6 +478,9 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _cached_pages_num_counter = ADD_COUNTER(_scan_profile, "CachedPagesNum", TUnit::UNIT);
     _pushdown_predicates_counter = ADD_COUNTER(_scan_profile, "PushdownPredicates", TUnit::UNIT);
 
+    _get_rowsets_timer = ADD_TIMER(_scan_profile, "GetRowsets");
+    _get_delvec_timer = ADD_TIMER(_scan_profile, "GetDelVec");
+
     /// SegmentInit
     _seg_init_timer = ADD_TIMER(_scan_profile, "SegmentInit");
     _bi_filter_timer = ADD_CHILD_TIMER(_scan_profile, "BitmapIndexFilter", "SegmentInit");

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -203,6 +203,8 @@ private:
     RuntimeProfile::Counter* _del_vec_filter_counter = nullptr;
     RuntimeProfile::Counter* _pred_filter_timer = nullptr;
     RuntimeProfile::Counter* _chunk_copy_timer = nullptr;
+    RuntimeProfile::Counter* _get_rowsets_timer = nullptr;
+    RuntimeProfile::Counter* _get_delvec_timer = nullptr;
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -323,6 +323,8 @@ void TabletScanner::update_counter() {
     _raw_rows_read += _reader->mutable_stats()->raw_rows_read;
     COUNTER_UPDATE(_parent->_chunk_copy_timer, _reader->stats().vec_cond_chunk_copy_ns);
 
+    COUNTER_UPDATE(_parent->_get_rowsets_timer, _reader->stats().get_rowsets_ns);
+    COUNTER_UPDATE(_parent->_get_delvec_timer, _reader->stats().get_delvec_ns);
     COUNTER_UPDATE(_parent->_seg_init_timer, _reader->stats().segment_init_ns);
 
     int64_t cond_evaluate_ns = 0;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -436,6 +436,8 @@ struct OlapReaderStatistics {
     int64_t branchless_cond_evaluate_ns = 0;
     int64_t expr_cond_evaluate_ns = 0;
 
+    int64_t get_rowsets_ns = 0;
+    int64_t get_delvec_ns = 0;
     int64_t segment_init_ns = 0;
     int64_t segment_create_chunk_ns = 0;
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -260,6 +260,7 @@ private:
     // delete predicates
     std::map<ColumnId, ColumnOrPredicate> _del_predicates;
 
+    Status _get_del_vec_st;
     DelVectorPtr _del_vec;
     roaring_uint32_iterator_t _roaring_iter;
 
@@ -307,19 +308,30 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, vectorized::S
         : ChunkIterator(std::move(schema), options.chunk_size),
           _segment(std::move(segment)),
           _opts(std::move(options)),
-          _predicate_columns(_opts.predicates.size()) {}
-
-Status SegmentIterator::_init() {
-    SCOPED_RAW_TIMER(&_opts.stats->segment_init_ns);
+          _predicate_columns(_opts.predicates.size()) {
+    // for very long queries(>30min), delvec may got GCed, to prevent this, load delvec at query start, call stack:
+    //   olap_chunk_source::prepare -> tablet_reader::open -> get_segment_iterators -> create SegmentIterator
+    SCOPED_RAW_TIMER(&_opts.stats->get_delvec_ns);
     if (_opts.is_primary_keys && _opts.version > 0) {
         TabletSegmentId tsid;
         tsid.tablet_id = _opts.tablet_id;
         tsid.segment_id = _opts.rowset_id + segment_id();
-        RETURN_IF_ERROR(
-                StorageEngine::instance()->update_manager()->get_del_vec(_opts.meta, tsid, _opts.version, &_del_vec));
-        if (_del_vec && _del_vec->empty()) {
-            _del_vec.reset();
+        _get_del_vec_st =
+                StorageEngine::instance()->update_manager()->get_del_vec(_opts.meta, tsid, _opts.version, &_del_vec);
+        if (_get_del_vec_st.ok()) {
+            if (_del_vec && _del_vec->empty()) {
+                _del_vec.reset();
+            }
         }
+    }
+}
+
+Status SegmentIterator::_init() {
+    SCOPED_RAW_TIMER(&_opts.stats->segment_init_ns);
+    if (!_get_del_vec_st.ok()) {
+        return _get_del_vec_st;
+    }
+    if (_opts.is_primary_keys && _opts.version > 0) {
         if (_del_vec) {
             if (_segment->num_rows() == _del_vec->cardinality()) {
                 return Status::EndOfFile("all rows deleted");

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1611,6 +1611,9 @@ Status SegmentIterator::_get_row_ranges_by_rowid_range() {
 }
 
 void SegmentIterator::close() {
+    if (_del_vec) {
+        _del_vec.reset();
+    }
     _context_list[0].close();
     _context_list[1].close();
     _obj_pool.clear();

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -56,6 +56,7 @@ void TabletReader::close() {
 }
 
 Status TabletReader::prepare() {
+    SCOPED_RAW_TIMER(&_stats.get_rowsets_ns);
     std::shared_lock l(_tablet->get_header_lock());
     auto st = _tablet->capture_consistent_rowsets(_version, &_rowsets);
     if (!st.ok()) {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -952,9 +952,10 @@ void TabletUpdatesTest::test_remove_expired_versions(bool enable_persistent_inde
     EXPECT_EQ(N, read_until_eof(iter_v4));
     EXPECT_EQ(0, read_until_eof(iter_v1)); // iter_v1 is empty iterator
 
+    // read already opened iterator/reader should succeed
+    EXPECT_EQ(N, read_until_eof(iter_v3));
+    EXPECT_EQ(N, read_until_eof(iter_v2));
     // Read expired versions should fail.
-    EXPECT_EQ(-1, read_until_eof(iter_v3));
-    EXPECT_EQ(-1, read_until_eof(iter_v2));
     EXPECT_EQ(-1, read_tablet(_tablet, 3));
     EXPECT_EQ(-1, read_tablet(_tablet, 2));
     EXPECT_EQ(-1, read_tablet(_tablet, 1));


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12721

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR changes segment_iterator, get delvec when segment_iterator is created, not in `_init`, so delvecs are got when the query started, preventing delvec not found error when query runs for a very long time(>30min) and delvec got GCed.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
