### PR TITLE
[Refactor] Fix clang-tidy for persistent index.

### DIFF
--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -47,8 +47,6 @@ struct IndexValue {
 static constexpr size_t kIndexValueSize = 8;
 static_assert(sizeof(IndexValue) == kIndexValueSize);
 
-class ImmutableIndexShard;
-
 uint64_t key_index_hash(const void* data, size_t len);
 
 struct KeysInfo {
@@ -61,10 +59,11 @@ struct KVRef {
     const uint8_t* kv_pos;
     uint64_t hash;
     uint16_t size;
-    KVRef() {}
+    KVRef() = default;
     KVRef(const uint8_t* kv_pos, uint64_t hash, uint16_t size) : kv_pos(kv_pos), hash(hash), size(size) {}
 };
 
+struct ImmutableIndexShard;
 class PersistentIndex;
 class ImmutableIndexWriter;
 
@@ -177,9 +176,9 @@ public:
 
 class ShardByLengthMutableIndex {
 public:
-    ShardByLengthMutableIndex() {}
+    ShardByLengthMutableIndex() = default;
 
-    ShardByLengthMutableIndex(const size_t key_size, const std::string& path)
+    ShardByLengthMutableIndex(const size_t key_size, const std::string& path) // NOLINT
             : _fixed_key_size(key_size), _path(path) {}
 
     ~ShardByLengthMutableIndex() {

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -36,7 +36,7 @@ namespace starrocks {
 
 class DelVector;
 using DelVectorPtr = std::shared_ptr<DelVector>;
-class EditVersion;
+struct EditVersion;
 class EditVersionMetaPB;
 class RowsetMetaPB;
 class TabletMetaPB;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
just fix several lines of clang tidy warnings of persistent index.