### PR TITLE
[Enhancement] Improve performance of `strings::memcpy_inlined`

### DIFF
--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -4,6 +4,7 @@
 
 #include "common/logging.h"
 #include "common/statusor.h"
+#include "gutil/strings/fastmem.h"
 #include "util/filesystem_util.h"
 
 namespace starrocks {
@@ -60,7 +61,8 @@ Status FbCacheLib::write_cache(const std::string& key, const char* value, size_t
     if (!handle) {
         return Status::InternalError("allocate cachelib item failed");
     }
-    std::memcpy(handle->getMemory(), value, size);
+    // std::memcpy(handle->getMemory(), value, size);
+    strings::memcpy_inlined(handle->getMemory(), value, size);
     _cache->insertOrReplace(handle);
     return Status::OK();
 }
@@ -74,7 +76,9 @@ StatusOr<size_t> FbCacheLib::read_cache(const std::string& key, char* value, siz
         return Status::NotFound("not found cachelib item");
     }
     DCHECK((off + size) <= handle->getSize());
-    std::memcpy(value, (char*)handle->getMemory() + off, size);
+    // std::memcpy(value, (char*)handle->getMemory() + off, size);
+    strings::memcpy_inlined(value, (char*)handle->getMemory() + off, size);
+
     if (handle->hasChainedItem()) {
     }
     return size;

--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -138,48 +138,41 @@ inline void memcpy_inlined(void* __restrict _dst, const void* __restrict _src, s
             _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + size - 32),
                                 _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + size - 32)));
         } else {
-            // erms version.
-            static constexpr size_t KB = 1024;
-            static constexpr size_t MB = 1024 * 1024;
-            if ((size >= 4 * KB && size <= 16 * KB) || (size >= 512 * KB && size <= 2 * MB)) {
-                asm volatile("rep movsb" : "=D"(dst), "=S"(src), "=c"(size) : "0"(dst), "1"(src), "2"(size) : "memory");
-            } else {
-                size_t padding = (32 - (reinterpret_cast<size_t>(dst) & 31)) & 31;
+            size_t padding = (32 - (reinterpret_cast<size_t>(dst) & 31)) & 31;
 
-                if (padding > 0) {
-                    __m256i head = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
-                    _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), head);
-                    dst += padding;
-                    src += padding;
-                    size -= padding;
-                }
-
-                while (size >= 256) {
-                    __m256i c0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
-                    __m256i c1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
-                    __m256i c2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 64));
-                    __m256i c3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 96));
-                    __m256i c4 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 128));
-                    __m256i c5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 160));
-                    __m256i c6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 192));
-                    __m256i c7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 224));
-                    src += 256;
-
-                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst)), c0);
-                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 32)), c1);
-                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 64)), c2);
-                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 96)), c3);
-                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 128)), c4);
-                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 160)), c5);
-                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 192)), c6);
-                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 224)), c7);
-                    dst += 256;
-
-                    size -= 256;
-                }
-
-                goto tail;
+            if (padding > 0) {
+                __m256i head = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+                _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), head);
+                dst += padding;
+                src += padding;
+                size -= padding;
             }
+
+            while (size >= 256) {
+                __m256i c0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+                __m256i c1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
+                __m256i c2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 64));
+                __m256i c3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 96));
+                __m256i c4 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 128));
+                __m256i c5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 160));
+                __m256i c6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 192));
+                __m256i c7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 224));
+                src += 256;
+
+                _mm256_store_si256((reinterpret_cast<__m256i*>(dst)), c0);
+                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 32)), c1);
+                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 64)), c2);
+                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 96)), c3);
+                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 128)), c4);
+                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 160)), c5);
+                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 192)), c6);
+                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 224)), c7);
+                dst += 256;
+
+                size -= 256;
+            }
+
+            goto tail;
         }
 #else
         std::memcpy(dst, src, size);

--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -138,10 +138,9 @@ inline void memcpy_inlined(void* __restrict _dst, const void* __restrict _src, s
             _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + size - 32),
                                 _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + size - 32)));
         } else {
-            // erms version.
             static constexpr size_t KB = 1024;
-            static constexpr size_t MB = 1024 * 1024;
-            if ((size >= 4 * KB && size <= 16 * KB) || (size >= 512 * KB && size <= 2 * MB)) {
+            if (size >= 512 * KB && size <= 2048 * KB) {
+                // erms(enhanced repeat movsv/stosb) version works well in this region.
                 asm volatile("rep movsb" : "=D"(dst), "=S"(src), "=c"(size) : "0"(dst), "1"(src), "2"(size) : "memory");
             } else {
                 size_t padding = (32 - (reinterpret_cast<size_t>(dst) & 31)) & 31;

--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -138,41 +138,48 @@ inline void memcpy_inlined(void* __restrict _dst, const void* __restrict _src, s
             _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + size - 32),
                                 _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + size - 32)));
         } else {
-            size_t padding = (32 - (reinterpret_cast<size_t>(dst) & 31)) & 31;
+            // erms version.
+            static constexpr size_t KB = 1024;
+            static constexpr size_t MB = 1024 * 1024;
+            if ((size >= 4 * KB && size <= 16 * KB) || (size >= 512 * KB && size <= 2 * MB)) {
+                asm volatile("rep movsb" : "=D"(dst), "=S"(src), "=c"(size) : "0"(dst), "1"(src), "2"(size) : "memory");
+            } else {
+                size_t padding = (32 - (reinterpret_cast<size_t>(dst) & 31)) & 31;
 
-            if (padding > 0) {
-                __m256i head = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
-                _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), head);
-                dst += padding;
-                src += padding;
-                size -= padding;
+                if (padding > 0) {
+                    __m256i head = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+                    _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), head);
+                    dst += padding;
+                    src += padding;
+                    size -= padding;
+                }
+
+                while (size >= 256) {
+                    __m256i c0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+                    __m256i c1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
+                    __m256i c2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 64));
+                    __m256i c3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 96));
+                    __m256i c4 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 128));
+                    __m256i c5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 160));
+                    __m256i c6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 192));
+                    __m256i c7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 224));
+                    src += 256;
+
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst)), c0);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 32)), c1);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 64)), c2);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 96)), c3);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 128)), c4);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 160)), c5);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 192)), c6);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 224)), c7);
+                    dst += 256;
+
+                    size -= 256;
+                }
+
+                goto tail;
             }
-
-            while (size >= 256) {
-                __m256i c0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
-                __m256i c1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
-                __m256i c2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 64));
-                __m256i c3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 96));
-                __m256i c4 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 128));
-                __m256i c5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 160));
-                __m256i c6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 192));
-                __m256i c7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 224));
-                src += 256;
-
-                _mm256_store_si256((reinterpret_cast<__m256i*>(dst)), c0);
-                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 32)), c1);
-                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 64)), c2);
-                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 96)), c3);
-                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 128)), c4);
-                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 160)), c5);
-                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 192)), c6);
-                _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 224)), c7);
-                dst += 256;
-
-                size -= 256;
-            }
-
-            goto tail;
         }
 #else
         std::memcpy(dst, src, size);

--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <emmintrin.h>
+#include <immintrin.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -94,68 +97,93 @@ inline int fastmemcmp_inlined(const void* a_void, const void* b_void, size_t n) 
     return 0;
 }
 
-// The standard memcpy operation is slow for variable small sizes.
-// This implementation inlines the optimal realization for sizes 1 to 16.
-// To avoid code bloat don't use it in case of not performance-critical spots,
-// nor when you don't expect very frequent values of size <= 16.
-inline void memcpy_inlined(void* dst, const void* src, size_t size) {
-    // Compiler inlines code with minimal amount of data movement when third
-    // parameter of memcpy is a constant.
-    switch (size) {
-    case 0:
-        break;
-    case 1:
-        memcpy(dst, src, 1);
-        break;
-    case 2:
-        memcpy(dst, src, 2);
-        break;
-    case 3:
-        memcpy(dst, src, 3);
-        break;
-    case 4:
-        memcpy(dst, src, 4);
-        break;
-    case 5:
-        memcpy(dst, src, 5);
-        break;
-    case 6:
-        memcpy(dst, src, 6);
-        break;
-    case 7:
-        memcpy(dst, src, 7);
-        break;
-    case 8:
-        memcpy(dst, src, 8);
-        break;
-    case 9:
-        memcpy(dst, src, 9);
-        break;
-    case 10:
-        memcpy(dst, src, 10);
-        break;
-    case 11:
-        memcpy(dst, src, 11);
-        break;
-    case 12:
-        memcpy(dst, src, 12);
-        break;
-    case 13:
-        memcpy(dst, src, 13);
-        break;
-    case 14:
-        memcpy(dst, src, 14);
-        break;
-    case 15:
-        memcpy(dst, src, 15);
-        break;
-    case 16:
-        memcpy(dst, src, 16);
-        break;
-    default:
-        memcpy(dst, src, size);
-        break;
+inline void memcpy_inlined(void* __restrict _dst, const void* __restrict _src, size_t size) {
+    auto dst = static_cast<uint8_t*>(_dst);
+    auto src = static_cast<const uint8_t*>(_src);
+
+    [[maybe_unused]] tail : if (size <= 16) {
+        if (size >= 8) {
+            __builtin_memcpy(dst + size - 8, src + size - 8, 8);
+            __builtin_memcpy(dst, src, 8);
+        } else if (size >= 4) {
+            __builtin_memcpy(dst + size - 4, src + size - 4, 4);
+            __builtin_memcpy(dst, src, 4);
+        } else if (size >= 2) {
+            __builtin_memcpy(dst + size - 2, src + size - 2, 2);
+            __builtin_memcpy(dst, src, 2);
+        } else if (size >= 1) {
+            *dst = *src;
+        }
+    }
+    else {
+#ifdef __AVX2__
+        if (size <= 256) {
+            if (size <= 32) {
+                __builtin_memcpy(dst, src, 8);
+                __builtin_memcpy(dst + 8, src + 8, 8);
+                size -= 16;
+                dst += 16;
+                src += 16;
+                goto tail;
+            }
+
+            while (size > 32) {
+                _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst),
+                                    _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src)));
+                dst += 32;
+                src += 32;
+                size -= 32;
+            }
+
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + size - 32),
+                                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + size - 32)));
+        } else {
+            // erms version.
+            static constexpr size_t KB = 1024;
+            static constexpr size_t MB = 1024 * 1024;
+            if ((size >= 4 * KB && size <= 16 * KB) || (size >= 512 * KB && size <= 2 * MB)) {
+                asm volatile("rep movsb" : "=D"(dst), "=S"(src), "=c"(size) : "0"(dst), "1"(src), "2"(size) : "memory");
+            } else {
+                size_t padding = (32 - (reinterpret_cast<size_t>(dst) & 31)) & 31;
+
+                if (padding > 0) {
+                    __m256i head = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+                    _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), head);
+                    dst += padding;
+                    src += padding;
+                    size -= padding;
+                }
+
+                while (size >= 256) {
+                    __m256i c0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+                    __m256i c1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
+                    __m256i c2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 64));
+                    __m256i c3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 96));
+                    __m256i c4 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 128));
+                    __m256i c5 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 160));
+                    __m256i c6 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 192));
+                    __m256i c7 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 224));
+                    src += 256;
+
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst)), c0);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 32)), c1);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 64)), c2);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 96)), c3);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 128)), c4);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 160)), c5);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 192)), c6);
+                    _mm256_store_si256((reinterpret_cast<__m256i*>(dst + 224)), c7);
+                    dst += 256;
+
+                    size -= 256;
+                }
+
+                goto tail;
+            }
+        }
+#else
+        std::memcpy(dst, src, size);
+#endif
     }
 }
-
 } // namespace strings

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "block_cache/block_cache.h"
+#include "gutil/strings/fastmem.h"
 #include "util/hash_util.hpp"
 #include "util/runtime_profile.h"
 #include "util/stack_util.h"
@@ -84,7 +85,8 @@ StatusOr<int64_t> CacheInputStream::read(void* out, int64_t count) {
         }
 
         if (!can_zero_copy) {
-            memcpy(p, src + shift, size);
+            // memcpy(p, src + shift, size);
+            strings::memcpy_inlined(p, src + shift, size);
             _stats.read_cache_bytes += size;
         }
         p += size;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to improve `memcpy` to accelerate block cache:
- use overlapped move to optimize the case when size <= 16
- use avx(256bit reg) move to optimize the case when size <= 256
- use erms(enhanced repeat movsb/stosb) to optimize the case when size in [512KB,2MB]
- use unrolled avx(256bit reg) move to optimze the rest cases.

----

The overlapped move is very useful when copying irregular size like 5,7,11bytes.
- if we don't use overlapped move, 11 bytes will be copied in (movq, mov ax, mov al) (8+2+1)
- but if we use overlapped move, 11 bytes can be copied by (movq, movl) (8+4)


----

erms version works very wll when size in [512KB, 2MB], in 1 thread or 8 threads

![image](https://user-images.githubusercontent.com/1081215/202383639-97d634bb-a141-449e-a12d-4b77d5a4465d.png)

![image](https://user-images.githubusercontent.com/1081215/202383728-1b4532af-ec3f-49bb-b92c-06fe59a0db18.png)


---

avx unrolled version works well when size is large. this version works better than glibc `__memcpy_avx_unaligned` version when thread =1, but is worse when thread = 8.  so it's really difficult to write a very general good performance memcpy for all workload.

![image](https://user-images.githubusercontent.com/1081215/202384214-ce581045-d40f-469d-b63a-8f572b789ffa.png)

![image](https://user-images.githubusercontent.com/1081215/202384351-7d6fe9e1-2291-43fe-ab64-339e050d56dc.png)

----

  | native ssb | parquet ssb | io tuned | memcpy | memcpy(io tuned)
-- | -- | -- | -- | -- | --
Q01 | 109 | 173 | 169 | 179 | 163
Q02 | 91 | 126 | 128 | 126 | 122
Q03 | 87 | 118 | 121 | 122 | 115
Q04 | 578 | 905 | 773 | 813 | 739
Q05 | 524 | 1015 | 883 | 708 | 654
Q06 | 484 | 774 | 674 | 688 | 649
Q07 | 766 | 1450 | 1100 | 1214 | 1073
Q08 | 517 | 926 | 786 | 802 | 748
Q09 | 505 | 888 | 754 | 757 | 716
Q10 | 139 | 182 | 183 | 177 | 173
Q11 | 1000 | 1567 | 1315 | 1418 | 1263
Q12 | 376 | 590 | 568 | 539 | 502
Q13 | 301 | 389 | 388 | 378 | 362
SUM | 5477 | 9103 | 7842 | 7921 | 7279


---

benchmark comparison between this impl and previous impl

```
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
memcpy_sr/16                 2.01 ns         2.01 ns    347320268
memcpy_sr/32                 2.26 ns         2.26 ns    309545548
memcpy_sr/64                 3.66 ns         3.66 ns    191179564
memcpy_sr/128                4.61 ns         4.61 ns    151792072
memcpy_sr/256                6.84 ns         6.84 ns    102082429
memcpy_sr/512                9.67 ns         9.67 ns     72437612
memcpy_sr/1024               15.0 ns         15.0 ns     46503179
memcpy_sr/2048               29.0 ns         29.0 ns     24160369
memcpy_sr/4096               38.5 ns         38.5 ns     18135859
memcpy_sr/8192               63.9 ns         63.9 ns     10980053
memcpy_sr/16384               132 ns          132 ns      5287391
memcpy_sr/32768               781 ns          781 ns       889899
memcpy_sr/65536              1582 ns         1582 ns       450258
memcpy_sr/131072             3112 ns         3112 ns       224624
memcpy_sr/262144             6292 ns         6291 ns       111086
memcpy_sr/524288            17364 ns        17364 ns        39997
memcpy_sr/1048576           70380 ns        70378 ns        10529
memcpy_sr/2097152          256405 ns       256397 ns         2647
memcpy_sr/4194304          682078 ns       682056 ns         1021
memcpy_sr/8388608         1494222 ns      1494169 ns          469
memcpy_sr/16777216        3031167 ns      3031001 ns          231
memcpy_sr/33554432        6110517 ns      6110305 ns          115
memcpy_sr/67108864       12198513 ns     12198063 ns           58
memcpy_sr/134217728      23999964 ns     23998751 ns           29
memcpy_gutil/16              2.10 ns         2.10 ns    333638027
memcpy_gutil/32              4.68 ns         4.68 ns    149708142
memcpy_gutil/64              4.68 ns         4.68 ns    149662819
memcpy_gutil/128             4.99 ns         4.99 ns    140184350
memcpy_gutil/256             6.89 ns         6.89 ns    101552625
memcpy_gutil/512             11.9 ns         11.9 ns     58626829
memcpy_gutil/1024            21.7 ns         21.7 ns     32212684
memcpy_gutil/2048            42.0 ns         42.0 ns     16680581
memcpy_gutil/4096            84.7 ns         84.7 ns      8264949
memcpy_gutil/8192             163 ns          163 ns      4285315
memcpy_gutil/16384            361 ns          361 ns      1933720
memcpy_gutil/32768           1042 ns         1042 ns       670798
memcpy_gutil/65536           2069 ns         2069 ns       338344
memcpy_gutil/131072          4157 ns         4157 ns       165195
memcpy_gutil/262144          9016 ns         9015 ns        80531
memcpy_gutil/524288         34986 ns        34984 ns        22445
memcpy_gutil/1048576       149037 ns       149032 ns         5211
memcpy_gutil/2097152       386921 ns       386908 ns         1843
memcpy_gutil/4194304       923590 ns       923556 ns          753
memcpy_gutil/8388608      1904319 ns      1904252 ns          367
memcpy_gutil/16777216     3549960 ns      3549845 ns          196
memcpy_gutil/33554432     7838210 ns      7837956 ns           91
memcpy_gutil/67108864    15422806 ns     15422286 ns           46
memcpy_gutil/134217728   30822498 ns     30821511 ns           23
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
