### PR TITLE
[BugFix] when output has duplicate item, order by works on wrong columnref

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -131,6 +131,7 @@ class QueryTransformer {
 
         List<ColumnRefOperator> fieldMappings = new ArrayList<>();
         Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
+        int orderByScope = 0;
 
         for (Expr expression : expressions) {
             Map<ScalarOperator, SubqueryOperator> subqueryPlaceholders = Maps.newHashMap();
@@ -145,6 +146,7 @@ class QueryTransformer {
             projections.put(columnRefOperator, scalarOperator);
             fieldMappings.add(columnRefOperator);
             outputTranslations.put(expression, columnRefOperator);
+            orderByScope++;
         }
 
         if (!withAggregation) {
@@ -156,6 +158,7 @@ class QueryTransformer {
 
         LogicalProjectOperator projectOperator = new LogicalProjectOperator(projections);
         outputTranslations.setFieldMappings(fieldMappings);
+        outputTranslations.setDeDuplicationScope(orderByScope);
         return new OptExprBuilder(projectOperator, Lists.newArrayList(subOpt), outputTranslations);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -177,4 +177,11 @@ public class OrderByTest extends PlanTestBase {
                 "  |  \n" +
                 "  14:NESTLOOP JOIN\n");
     }
+
+    @Test
+    public void testOrderDuplicateColumnRef() throws Exception {
+        String sql = "select v1, * from t0 order by v2";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 2> 2: v2 ASC");
+    }
 }


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13341 
Fixes #13169 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The reason is that orderby scope is de-duplicate with `SelectAnalyzer::computeAndAssignOrderScope`.
but the columnRef all added into `fieldMappings` when `QueryTransformer::projectForOrder`, so when project for orderby use `SqlToScalarOperatorTranslator visitSlot` and get columnRefOperator with index, it will get wrong columnRefOperator.
<img width="1174" alt="截屏2022-11-14 16 06 53" src="https://user-images.githubusercontent.com/28446271/201607501-dbf565d7-e3f5-4e9c-a081-c8876b50c147.png">


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
