### PR TITLE
[Enhancement] QueryCache support primary_key and unique_key

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -327,6 +327,8 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
             cache_param.slot_remapping[slot] = remapped_slot;
             cache_param.reverse_slot_remapping[remapped_slot] = slot;
         }
+        cache_param.can_use_multiversion = tcache_param.can_use_multiversion;
+        cache_param.keys_type = tcache_param.keys_type;
         _fragment_ctx->set_enable_cache(true);
     }
 
@@ -358,14 +360,14 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
                         continue;
                     }
                     const auto& region = tcache_param.region_map.at(partition_id);
-                    std::string cache_suffix_key;
-                    cache_suffix_key.reserve(sizeof(partition_id) + region.size() + sizeof(tablet_id));
-                    cache_suffix_key.insert(cache_suffix_key.end(), (uint8_t*)&partition_id,
+                    std::string cache_prefix_key;
+                    cache_prefix_key.reserve(sizeof(partition_id) + region.size() + sizeof(tablet_id));
+                    cache_prefix_key.insert(cache_prefix_key.end(), (uint8_t*)&partition_id,
                                             ((uint8_t*)&partition_id) + sizeof(partition_id));
-                    cache_suffix_key.insert(cache_suffix_key.end(), region.begin(), region.end());
-                    cache_suffix_key.insert(cache_suffix_key.end(), (uint8_t*)&tablet_id,
+                    cache_prefix_key.insert(cache_prefix_key.end(), region.begin(), region.end());
+                    cache_prefix_key.insert(cache_prefix_key.end(), (uint8_t*)&tablet_id,
                                             ((uint8_t*)&tablet_id) + sizeof(tablet_id));
-                    _fragment_ctx->cache_param().cache_key_prefixes[tablet_id] = std::move(cache_suffix_key);
+                    _fragment_ctx->cache_param().cache_key_prefixes[tablet_id] = std::move(cache_prefix_key);
                 }
             }
         }

--- a/be/src/exec/query_cache/cache_operator.cpp
+++ b/be/src/exec/query_cache/cache_operator.cpp
@@ -193,7 +193,7 @@ void CacheOperator::close(RuntimeState* state) {
 
 void CacheOperator::_handle_stale_cache_value(int64_t tablet_id, CacheValue& cache_value, PerLaneBufferPtr& buffer,
                                               int64_t version) {
-    // In BE unittest, stale value is considered as partial-hit
+// In BE unittest, stale value is considered as partial-hit
 #ifdef BE_TEST
     {
         buffer->state = PLBS_HIT_PARTIAL;
@@ -212,6 +212,15 @@ void CacheOperator::_handle_stale_cache_value(int64_t tablet_id, CacheValue& cac
     }
 #endif
 
+    if (_cache_param.keys_type != TKeysType::PRIMARY_KEYS) {
+        _handle_stale_cache_value_for_non_pk(tablet_id, cache_value, buffer, version);
+    } else {
+        _handle_stale_cache_value_for_pk(tablet_id, cache_value, buffer, version);
+    }
+}
+
+void CacheOperator::_handle_stale_cache_value_for_non_pk(int64_t tablet_id, CacheValue& cache_value,
+                                                         PerLaneBufferPtr& buffer, int64_t version) {
     // Try to reuse partial cache result when cached version is less than required version, delta versions
     // should be captured at first.
     auto status = StorageEngine::instance()->tablet_manager()->capture_tablet_and_rowsets(
@@ -237,8 +246,9 @@ void CacheOperator::_handle_stale_cache_value(int64_t tablet_id, CacheValue& cac
     Version delta_versions(min_version, max_version);
     buffer->tablet = tablet;
     auto has_delete_predicates = tablet->has_delete_predicates(delta_versions);
-    // case 1: there exist delete predicates in delta versions, the cache result is not reuse, so cache miss.
-    if (has_delete_predicates) {
+    // case 1: there exist delete predicates in delta versions, or data model can not support multiversion cache and
+    // the tablet has non-empty delta rowsets; then cache result is not reuse, so cache miss.
+    if (has_delete_predicates || (!_cache_param.can_use_multiversion && !all_rs_empty)) {
         buffer->state = PLBS_MISS;
         buffer->cached_version = 0;
         return;
@@ -266,6 +276,40 @@ void CacheOperator::_handle_stale_cache_value(int64_t tablet_id, CacheValue& cac
         buffer->num_bytes += chunk->bytes_usage();
     }
     buffer->chunks.back()->owner_info().set_last_chunk(false);
+}
+
+void CacheOperator::_handle_stale_cache_value_for_pk(int64_t tablet_id, starrocks::query_cache::CacheValue& cache_value,
+                                                     starrocks::query_cache::PerLaneBufferPtr& buffer,
+                                                     int64_t version) {
+    DCHECK(_cache_param.keys_type == TKeysType::PRIMARY_KEYS);
+    // At the present, PRIMARY_KEYS can not support merge-on-read, so we can not merge stale cache values and delta
+    // rowsets. Capturing delta rowsets is meaningless and unsupported, thus we capture all rowsets of the PK tablet.
+    auto status = StorageEngine::instance()->tablet_manager()->capture_tablet_and_rowsets(tablet_id, 0, version);
+    if (!status.ok()) {
+        buffer->state = PLBS_MISS;
+        buffer->cached_version = 0;
+        return;
+    }
+    auto& [tablet, rowsets] = status.value();
+    const auto snapshot_version = cache_value.version;
+    bool has_compacted_delta_rowsets = false;
+    bool exists_non_empty_delta_rowsets = false;
+    for (auto& rs : rowsets) {
+        has_compacted_delta_rowsets |= rs->start_version() == snapshot_version + 1;
+        exists_non_empty_delta_rowsets |= rs->start_version() > snapshot_version && rs->has_data_files();
+    }
+    if (exists_non_empty_delta_rowsets && has_compacted_delta_rowsets) {
+        buffer->state = PLBS_MISS;
+        buffer->cached_version = 0;
+        return;
+    }
+
+    buffer->cached_version = cache_value.version;
+    auto chunks = remap_chunks(cache_value.result, _cache_param.reverse_slot_remapping);
+    _update_probe_metrics(tablet_id, chunks);
+    buffer->chunks = std::move(chunks);
+    buffer->state = PLBS_HIT_TOTAL;
+    buffer->chunks.back()->owner_info().set_last_chunk(true);
 }
 
 void CacheOperator::_update_probe_metrics(int64_t tablet_id, const std::vector<vectorized::ChunkPtr>& chunks) {

--- a/be/src/exec/query_cache/cache_operator.cpp
+++ b/be/src/exec/query_cache/cache_operator.cpp
@@ -292,13 +292,13 @@ void CacheOperator::_handle_stale_cache_value_for_pk(int64_t tablet_id, starrock
     }
     auto& [tablet, rowsets] = status.value();
     const auto snapshot_version = cache_value.version;
-    bool has_compacted_delta_rowsets = false;
+    bool can_pickup_delta_rowsets = false;
     bool exists_non_empty_delta_rowsets = false;
     for (auto& rs : rowsets) {
-        has_compacted_delta_rowsets |= rs->start_version() == snapshot_version + 1;
+        can_pickup_delta_rowsets |= rs->start_version() == snapshot_version + 1;
         exists_non_empty_delta_rowsets |= rs->start_version() > snapshot_version && rs->has_data_files();
     }
-    if (exists_non_empty_delta_rowsets && has_compacted_delta_rowsets) {
+    if (exists_non_empty_delta_rowsets || !can_pickup_delta_rowsets) {
         buffer->state = PLBS_MISS;
         buffer->cached_version = 0;
         return;

--- a/be/src/exec/query_cache/cache_operator.h
+++ b/be/src/exec/query_cache/cache_operator.h
@@ -53,6 +53,10 @@ private:
     void _update_probe_metrics(int64_t, const std::vector<vectorized::ChunkPtr>& chunks);
     void _handle_stale_cache_value(int64_t tablet_id, CacheValue& cache_value, PerLaneBufferPtr& buffer,
                                    int64_t version);
+    void _handle_stale_cache_value_for_non_pk(int64_t tablet_id, CacheValue& cache_value, PerLaneBufferPtr& buffer,
+                                              int64_t version);
+    void _handle_stale_cache_value_for_pk(int64_t tablet_id, CacheValue& cache_value, PerLaneBufferPtr& buffer,
+                                          int64_t version);
     bool _should_passthrough(size_t num_rows, size_t num_bytes);
     vectorized::ChunkPtr _pull_chunk_from_per_lane_buffer(PerLaneBufferPtr& buffer);
     CacheManagerRawPtr _cache_mgr;

--- a/be/src/exec/query_cache/cache_param.h
+++ b/be/src/exec/query_cache/cache_param.h
@@ -3,19 +3,23 @@
 
 #include <string>
 #include <unordered_map>
+
+#include "gen_cpp/Types_types.h"
 namespace starrocks::query_cache {
 
-using CacheKeySuffixMap = std::unordered_map<int64_t, std::string>;
+using CacheKeyPrefixMap = std::unordered_map<int64_t, std::string>;
 using SlotRemapping = std::unordered_map<int32_t, int32_t>;
 struct CacheParam {
     int num_lanes;
     int32_t plan_node_id;
     std::string digest;
-    CacheKeySuffixMap cache_key_prefixes;
+    CacheKeyPrefixMap cache_key_prefixes;
     SlotRemapping slot_remapping;
     SlotRemapping reverse_slot_remapping;
     bool force_populate;
     size_t entry_max_bytes;
     size_t entry_max_rows;
+    bool can_use_multiversion;
+    TKeysType::type keys_type;
 };
 } // namespace starrocks::query_cache

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -715,7 +715,7 @@ public class OlapScanNode extends ScanNode {
         return selectedIndexId;
     }
 
-    private Set<Long> getHotPartitionIds(RangePartitionInfo partitionInfo, boolean canUseMultiversion) {
+    private Set<Long> getHotPartitionIds(RangePartitionInfo partitionInfo) {
         KeysType keysType = olapTable.getKeysType();
         ConnectContext connectContext = ConnectContext.get();
         Set<Long> hotIds = Sets.newHashSet();
@@ -725,12 +725,9 @@ public class OlapScanNode extends ScanNode {
         List<Map.Entry<Long, Range<PartitionKey>>> partitions = partitionInfo.getSortedRangeMap(false);
         int numHotIds = 0;
         int numPartitions = partitions.size();
-        if (keysType == KeysType.PRIMARY_KEYS) {
-            int pkHotNum = connectContext.getSessionVariable().getQueryCachePrimaryKeysHotPartitionNum();
+        if (!canUseMultiVersionCache()) {
+            int pkHotNum = connectContext.getSessionVariable().getQueryCacheHotPartitionNum();
             numHotIds = Math.min(numPartitions, Math.max(0, pkHotNum));
-        } else if (keysType == KeysType.UNIQUE_KEYS || (keysType == KeysType.AGG_KEYS && !canUseMultiversion)) {
-            int ukHotNum = connectContext.getSessionVariable().getQueryCacheUniqueKeysHotPartitionNum();
-            numHotIds = Math.min(numPartitions, Math.max(0, ukHotNum));
         }
         return partitions.subList(numPartitions - numHotIds, numPartitions).stream().map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
@@ -751,7 +748,7 @@ public class OlapScanNode extends ScanNode {
             return;
         }
         Set<Long> selectedPartIdSet = new HashSet<>(selectedPartitionIds);
-        selectedPartIdSet.removeAll(getHotPartitionIds(rangePartitionInfo, normalizer.isCanUseMultiVersion()));
+        selectedPartIdSet.removeAll(getHotPartitionIds(rangePartitionInfo));
 
         Column column = partitionColumns.get(0);
         List<SlotDescriptor> slots = normalizer.getExecPlan().getDescTbl().getTupleDesc(tupleIds.get(0)).getSlots();
@@ -797,26 +794,26 @@ public class OlapScanNode extends ScanNode {
     // Only DUP_KEYS and AGG_KEYS without columns carrying REPLACE modifier can support
     // multi-version cache, for other types of data models, we can not get the final result
     // of the tablet from merging the snapshot result in cache and the delta rowsets in disk.
-    private void setIfCanUseMultiVersionCache(FragmentNormalizer normalizer) {
-        normalizer.setKeysType(olapTable.getKeysType());
+    private boolean canUseMultiVersionCache() {
         switch (olapTable.getKeysType()) {
             case DUP_KEYS:
-                normalizer.setCanUseMultiVersion(true);
+                return true;
             case PRIMARY_KEYS:
             case UNIQUE_KEYS:
-                normalizer.setCanUseMultiVersion(false);
+                return false;
             case AGG_KEYS: {
                 List<Column> columns = selectedIndexId == -1 ? olapTable.getBaseSchema() :
                         olapTable.getSchemaByIndexId(selectedIndexId);
-                boolean hasReplaceAgg = columns.stream().anyMatch(
+                return columns.stream().noneMatch(
                         c -> c.isAggregated() && c.getAggregationType().isReplaceFamily());
-                normalizer.setCanUseMultiVersion(!hasReplaceAgg);
             }
         }
+        return false;
     }
 
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
-        setIfCanUseMultiVersionCache(normalizer);
+        normalizer.setKeysType(olapTable.getKeysType());
+        normalizer.setCanUseMultiVersion(canUseMultiVersionCache());
         TNormalOlapScanNode scanNode = new TNormalOlapScanNode();
         scanNode.setTablet_id(olapTable.getId());
         scanNode.setIndex_id(selectedIndexId);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.analysis.DescriptorTable;
@@ -198,7 +199,8 @@ public class OlapScanNode extends ScanNode {
 
     private final List<String> unUsedOutputStringColumns = new ArrayList<>();
 
-    public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds, Set<String> aggOrPrimaryKeyTableValueColumnNames) {
+    public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds,
+                                             Set<String> aggOrPrimaryKeyTableValueColumnNames) {
         for (SlotDescriptor slot : desc.getSlots()) {
             if (!slot.isMaterialized()) {
                 continue;
@@ -350,7 +352,8 @@ public class OlapScanNode extends ScanNode {
                     }
                 }
                 throw new UserException(
-                        "Failed to get scan range, no queryable replica found in tablet: " + tabletId + " " + replicaInfos);
+                        "Failed to get scan range, no queryable replica found in tablet: " + tabletId + " " +
+                                replicaInfos);
             }
 
             List<Replica> replicas = null;
@@ -509,7 +512,8 @@ public class OlapScanNode extends ScanNode {
             if (isPreAggregation) {
                 output.append(prefix).append("PREAGGREGATION: ON").append("\n");
             } else {
-                output.append(prefix).append("PREAGGREGATION: OFF. Reason: ").append(reasonOfPreAggregation).append("\n");
+                output.append(prefix).append("PREAGGREGATION: OFF. Reason: ").append(reasonOfPreAggregation)
+                        .append("\n");
             }
             if (!conjuncts.isEmpty()) {
                 output.append(prefix).append("PREDICATES: ").append(
@@ -519,14 +523,16 @@ public class OlapScanNode extends ScanNode {
             if (isPreAggregation) {
                 output.append(prefix).append("preAggregation: on").append("\n");
             } else {
-                output.append(prefix).append("preAggregation: off. Reason: ").append(reasonOfPreAggregation).append("\n");
+                output.append(prefix).append("preAggregation: off. Reason: ").append(reasonOfPreAggregation)
+                        .append("\n");
             }
             if (!conjuncts.isEmpty()) {
                 output.append(prefix).append("Predicates: ").append(getVerboseExplain(conjuncts)).append("\n");
             }
             if (!dictStringIdToIntIds.isEmpty()) {
                 List<String> flatDictList = dictStringIdToIntIds.entrySet().stream().limit(5)
-                        .map((entry) -> "(" + entry.getKey() + "," + entry.getValue() + ")").collect(Collectors.toList());
+                        .map((entry) -> "(" + entry.getKey() + "," + entry.getValue() + ")")
+                        .collect(Collectors.toList());
                 String format_template = "dictStringIdToIntIds=%s";
                 if (dictStringIdToIntIds.size() > 5) {
                     format_template = format_template + "...";
@@ -559,7 +565,8 @@ public class OlapScanNode extends ScanNode {
             // We print up to 10 tablet, and we print "..." if the number is more than 10
             if (scanTabletIds.size() > 10) {
                 List<Long> firstTenTabletIds = scanTabletIds.subList(0, 10);
-                output.append(prefix).append(String.format("tabletList=%s ...", Joiner.on(",").join(firstTenTabletIds)));
+                output.append(prefix)
+                        .append(String.format("tabletList=%s ...", Joiner.on(",").join(firstTenTabletIds)));
             } else {
                 output.append(prefix).append(String.format("tabletList=%s", Joiner.on(",").join(scanTabletIds)));
             }
@@ -577,7 +584,8 @@ public class OlapScanNode extends ScanNode {
 
             if (scanTabletIds.size() > 10) {
                 List<Long> firstTenTabletIds = scanTabletIds.subList(0, 10);
-                output.append(prefix).append(String.format("tabletList=%s ...", Joiner.on(",").join(firstTenTabletIds)));
+                output.append(prefix)
+                        .append(String.format("tabletList=%s ...", Joiner.on(",").join(firstTenTabletIds)));
             } else {
                 output.append(prefix).append(String.format("tabletList=%s", Joiner.on(",").join(scanTabletIds)));
             }
@@ -707,6 +715,26 @@ public class OlapScanNode extends ScanNode {
         return selectedIndexId;
     }
 
+    private Set<Long> getHotPartitionIds(RangePartitionInfo partitionInfo, boolean canUseMultiversion) {
+        KeysType keysType = olapTable.getKeysType();
+        ConnectContext connectContext = ConnectContext.get();
+        Set<Long> hotIds = Sets.newHashSet();
+        if (connectContext == null) {
+            return hotIds;
+        }
+        List<Map.Entry<Long, Range<PartitionKey>>> partitions = partitionInfo.getSortedRangeMap(false);
+        int numHotIds = 0;
+        int numPartitions = partitions.size();
+        if (keysType == KeysType.PRIMARY_KEYS) {
+            int pkHotNum = connectContext.getSessionVariable().getQueryCachePrimaryKeysHotPartitionNum();
+            numHotIds = Math.min(numPartitions, Math.max(0, pkHotNum));
+        } else if (keysType == KeysType.UNIQUE_KEYS || (keysType == KeysType.AGG_KEYS && !canUseMultiversion)) {
+            int ukHotNum = connectContext.getSessionVariable().getQueryCacheUniqueKeysHotPartitionNum();
+            numHotIds = Math.min(numPartitions, Math.max(0, ukHotNum));
+        }
+        return partitions.subList(numPartitions - numHotIds, numPartitions).stream().map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+    }
     @Override
     public void normalizeConjuncts(FragmentNormalizer normalizer, TNormalPlanNode planNode, List<Expr> conjuncts) {
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
@@ -722,6 +750,9 @@ public class OlapScanNode extends ScanNode {
             normalizer.setUncacheable(true);
             return;
         }
+        Set<Long> selectedPartIdSet = new HashSet<>(selectedPartitionIds);
+        selectedPartIdSet.removeAll(getHotPartitionIds(rangePartitionInfo, normalizer.isCanUseMultiVersion()));
+
         Column column = partitionColumns.get(0);
         List<SlotDescriptor> slots = normalizer.getExecPlan().getDescTbl().getTupleDesc(tupleIds.get(0)).getSlots();
         List<Pair<SlotId, String>> slotIdToColNames =
@@ -751,25 +782,35 @@ public class OlapScanNode extends ScanNode {
         List<Integer> remappedSlotIds = normalizer.remapSlotIds(slotIds);
 
         planNode.olap_scan_node.setRemapped_slot_ids(remappedSlotIds);
-        planNode.olap_scan_node.setSelected_column(slotIdToColNames.stream().map(c->c.second).collect(Collectors.toList()));
+        planNode.olap_scan_node.setSelected_column(
+                slotIdToColNames.stream().map(c -> c.second).collect(Collectors.toList()));
 
         List<Map.Entry<Long, Range<PartitionKey>>> rangeMap = Lists.newArrayList();
         try {
-            rangeMap = rangePartitionInfo.getSortedRangeMap(new HashSet<>(selectedPartitionIds));
+            rangeMap = rangePartitionInfo.getSortedRangeMap(selectedPartIdSet);
         } catch (AnalysisException ignored) {
         }
         conjuncts = normalizer.getPartitionRangePredicates(conjuncts, rangeMap, rangePartitionInfo, slotId);
         planNode.setConjuncts(normalizer.normalizeExprs(conjuncts));
     }
 
-    private boolean isUnCacheable() {
+    private boolean isUnCacheable(FragmentNormalizer normalizer) {
+        normalizer.setKeysType(olapTable.getKeysType());
         switch (olapTable.getKeysType()) {
             case DUP_KEYS:
+                normalizer.setCanUseMultiVersion(true);
+                return false;
+            case PRIMARY_KEYS:
+            case UNIQUE_KEYS:
+                normalizer.setCanUseMultiVersion(false);
+                return false;
             case AGG_KEYS: {
                 List<Column> columns = selectedIndexId == -1 ? olapTable.getBaseSchema() :
                         olapTable.getSchemaByIndexId(selectedIndexId);
-                return columns.stream().anyMatch(
+                boolean hasReplaceAgg = columns.stream().anyMatch(
                         c -> c.isAggregated() && c.getAggregationType().isReplaceFamily());
+                normalizer.setCanUseMultiVersion(!hasReplaceAgg);
+                return false;
             }
             default:
                 return true;
@@ -777,7 +818,7 @@ public class OlapScanNode extends ScanNode {
     }
 
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
-        if (isUnCacheable()) {
+        if (isUnCacheable(normalizer)) {
             normalizer.setUncacheable(true);
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -142,10 +142,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     private boolean hasJoinNode = false;
     private boolean hasOlapScanNode = false;
 
-    private PlanNodeId cachePlanNodeId = null;
-    private ByteBuffer digest = null;
-    private Map<Integer, Integer> slotRemapping = Maps.newHashMap();
-    private Map<Long, String> rangeMap = Maps.newHashMap();
+    private TCacheParam cacheParam = null;
     private boolean hasOlapTableSink = false;
     private boolean forceSetTableSinkDop = false;
     private boolean forceAssignScanRangesPerDriverSeq = false;
@@ -292,38 +289,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.outputExprs = Expr.cloneList(outputExprs, null);
     }
 
-    public void setCachePlanNodeId(PlanNodeId cachePlanNodeId) {
-        this.cachePlanNodeId = cachePlanNodeId;
-    }
-
-    public PlanNodeId getCachePlanNodeId() {
-        return cachePlanNodeId;
-    }
-
-    public ByteBuffer getDigest() {
-        return digest;
-    }
-
-    public void setDigest(ByteBuffer digest) {
-        this.digest = digest;
-    }
-
-    public Map<Integer, Integer> getSlotRemapping() {
-        return slotRemapping;
-    }
-
-    public void setSlotRemapping(Map<Integer, Integer> slotRemapping) {
-        this.slotRemapping = slotRemapping;
-    }
-
-    public Map<Long, String> getRangeMap() {
-        return rangeMap;
-    }
-
-    public void setRangeMap(Map<Long, String> rangeMap) {
-        this.rangeMap = rangeMap;
-    }
-
     /**
      * Finalize plan tree and create stream sink, if needed.
      */
@@ -381,12 +346,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         if (!loadGlobalDicts.isEmpty()) {
             result.setLoad_global_dicts(dictToThrift(loadGlobalDicts));
         }
-        if (cachePlanNodeId != null && cachePlanNodeId.isValid()) {
-            TCacheParam cacheParam = new TCacheParam();
-            cacheParam.setId(getCachePlanNodeId().asInt());
-            cacheParam.setDigest(getDigest());
-            cacheParam.setRegion_map(getRangeMap());
-            cacheParam.setSlot_remapping(getSlotRemapping());
+        if (cacheParam != null) {
             if (ConnectContext.get() != null) {
                 SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
                 cacheParam.setForce_populate(sessionVariable.isQueryCacheForcePopulate());
@@ -664,5 +624,13 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public boolean hasOlapScanNode() {
         return hasOlapScanNode;
+    }
+
+    public TCacheParam getCacheParam() {
+        return cacheParam;
+    }
+
+    public void setCacheParam(TCacheParam cacheParam) {
+        this.cacheParam = cacheParam;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -296,10 +296,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String QUERY_CACHE_ENTRY_MAX_BYTES = "query_cache_entry_max_bytes";
     public static final String QUERY_CACHE_ENTRY_MAX_ROWS = "query_cache_entry_max_rows";
 
-    // We assume that the latest partitions are hot partitions that are updated frequently, so it should be
-    // cached in query cache since its disruptive cache invalidation.
-    public static final String QUERY_CACHE_PRIMARY_KEYS_HOT_PARTITION_NUM = "query_cache_primary_keys_hot_partition_num";
-    public static final String QUERY_CACHE_UNIQUE_KEYS_HOT_PARTITION_NUM = "query_cache_unique_keys_hot_partition_num";
+    // We assume that for PRIMARY_KEYS and UNIQUE_KEYS, the latest partitions are hot partitions that are updated
+    // frequently, so it should not be cached in query cache since its disruptive cache invalidation.
+    public static final String QUERY_CACHE_HOT_PARTITION_NUM = "query_cache_hot_partition_num";
     public static final String TRANSMISSION_ENCODE_LEVEL = "transmission_encode_level";
 
     public static final String NESTED_MV_REWRITE_MAX_LEVEL = "nested_mv_rewrite_max_level";
@@ -757,11 +756,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = QUERY_CACHE_ENTRY_MAX_ROWS)
     private long queryCacheEntryMaxRows = 409600;
 
-    @VarAttr(name = QUERY_CACHE_PRIMARY_KEYS_HOT_PARTITION_NUM)
-    private int queryCachePrimaryKeysHotPartitionNum = 3;
-
-    @VarAttr(name = QUERY_CACHE_UNIQUE_KEYS_HOT_PARTITION_NUM)
-    private int queryCacheUniqueKeysHotPartitionNum = 3;
+    @VarAttr(name = QUERY_CACHE_HOT_PARTITION_NUM)
+    private int queryCacheHotPartitionNum = 3;
 
     @VarAttr(name = NESTED_MV_REWRITE_MAX_LEVEL)
     private int nestedMvRewriteMaxLevel = 3;
@@ -1412,19 +1408,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return queryCacheEntryMaxRows;
     }
 
-    public void setQueryCachePrimaryKeysHotPartitionNum(int n) {
-        queryCachePrimaryKeysHotPartitionNum = n;
-    }
-    public void setQueryCacheUniqueKeysHotPartitionNum(int n) {
-        queryCacheUniqueKeysHotPartitionNum = n;
+    public void setQueryCacheHotPartitionNum(int n) {
+        queryCacheHotPartitionNum = n;
     }
 
-    public int getQueryCachePrimaryKeysHotPartitionNum() {
-        return queryCachePrimaryKeysHotPartitionNum;
-    }
-
-    public int getQueryCacheUniqueKeysHotPartitionNum() {
-        return queryCacheUniqueKeysHotPartitionNum;
+    public int getQueryCacheHotPartitionNum() {
+        return queryCacheHotPartitionNum;
     }
 
     public void setEnableQueryCache(boolean on) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -295,6 +295,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
     public static final String QUERY_CACHE_ENTRY_MAX_BYTES = "query_cache_entry_max_bytes";
     public static final String QUERY_CACHE_ENTRY_MAX_ROWS = "query_cache_entry_max_rows";
+
+    // We assume that the latest partitions are hot partitions that are updated frequently, so it should be
+    // cached in query cache since its disruptive cache invalidation.
+    public static final String QUERY_CACHE_PRIMARY_KEYS_HOT_PARTITION_NUM = "query_cache_primary_keys_hot_partition_num";
+    public static final String QUERY_CACHE_UNIQUE_KEYS_HOT_PARTITION_NUM = "query_cache_unique_keys_hot_partition_num";
     public static final String TRANSMISSION_ENCODE_LEVEL = "transmission_encode_level";
 
     public static final String NESTED_MV_REWRITE_MAX_LEVEL = "nested_mv_rewrite_max_level";
@@ -751,6 +756,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = QUERY_CACHE_ENTRY_MAX_ROWS)
     private long queryCacheEntryMaxRows = 409600;
+
+    @VarAttr(name = QUERY_CACHE_PRIMARY_KEYS_HOT_PARTITION_NUM)
+    private int queryCachePrimaryKeysHotPartitionNum = 3;
+
+    @VarAttr(name = QUERY_CACHE_UNIQUE_KEYS_HOT_PARTITION_NUM)
+    private int queryCacheUniqueKeysHotPartitionNum = 3;
 
     @VarAttr(name = NESTED_MV_REWRITE_MAX_LEVEL)
     private int nestedMvRewriteMaxLevel = 3;
@@ -1399,6 +1410,21 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getQueryCacheEntryMaxRows() {
         return queryCacheEntryMaxRows;
+    }
+
+    public void setQueryCachePrimaryKeysHotPartitionNum(int n) {
+        queryCachePrimaryKeysHotPartitionNum = n;
+    }
+    public void setQueryCacheUniqueKeysHotPartitionNum(int n) {
+        queryCacheUniqueKeysHotPartitionNum = n;
+    }
+
+    public int getQueryCachePrimaryKeysHotPartitionNum() {
+        return queryCachePrimaryKeysHotPartitionNum;
+    }
+
+    public int getQueryCacheUniqueKeysHotPartitionNum() {
+        return queryCacheUniqueKeysHotPartitionNum;
     }
 
     public void setEnableQueryCache(boolean on) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
@@ -4,6 +4,7 @@ package com.starrocks.planner;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
@@ -390,7 +391,7 @@ public class QueryCacheTest {
             Assert.fail();
         }
         Optional<PlanFragment> optFragment = plan.getFragments().stream()
-                .filter(f -> f.getCachePlanNodeId() != null && f.getCachePlanNodeId().isValid()).findFirst();
+                .filter(f -> f.getCacheParam() != null).findFirst();
         if (!optFragment.isPresent()) {
             System.out.println("wrong query:" + sql);
             try {
@@ -405,9 +406,11 @@ public class QueryCacheTest {
     private void testHelper(List<String> queryList) {
         List<PlanFragment> frags = queryList.stream()
                 .map(q -> getCachedFragment(q).get()).collect(Collectors.toList());
-        List<ByteBuffer> digests = frags.stream().map(PlanFragment::getDigest).collect(Collectors.toList());
+        List<ByteBuffer> digests =
+                frags.stream().map(f -> ByteBuffer.wrap(f.getCacheParam().getDigest())).collect(Collectors.toList());
         List<Set<Integer>> slotRemappings =
-                frags.stream().map(f -> new HashSet<>(f.getSlotRemapping().values())).collect(Collectors.toList());
+                frags.stream().map(f -> new HashSet<>(f.getCacheParam().getSlot_remapping().values()))
+                        .collect(Collectors.toList());
         ByteBuffer digest = digests.get(0);
         Set<Integer> slotRemapping = slotRemappings.get(0);
         Assert.assertTrue(digest != null && digest.array().length > 0);
@@ -798,15 +801,19 @@ public class QueryCacheTest {
 
     @Test
     public void testDifferentDataModels() {
-        List<String> unCacheableQueryList = Lists.newArrayList(
+        List<String> NonMultiVersionCacheableQueryList = Lists.newArrayList(
                 "select sum(v1) from t4",
                 "select sum(v1) from t5",
                 "select sum(v1) from t6");
-        Assert.assertTrue(unCacheableQueryList.stream().noneMatch(q -> getCachedFragment(q).isPresent()));
+        Assert.assertTrue(NonMultiVersionCacheableQueryList.stream().map(this::getCachedFragment)
+                .allMatch(f -> f.isPresent() && !f.get().getCacheParam().isCan_use_multiversion()));
+
         List<String> cachableQueryList = Lists.newArrayList(
-                "select sum(v1), count(distinct v2) from t7"
+                "select sum(v1), count(distinct v2) from t7",
+                "select sum(v1), count(distinct v2) from t1"
         );
-        Assert.assertTrue(cachableQueryList.stream().allMatch(q -> getCachedFragment(q).isPresent()));
+        Assert.assertTrue(cachableQueryList.stream().map(this::getCachedFragment)
+                .allMatch(f -> f.isPresent() && f.get().getCacheParam().isCan_use_multiversion()));
     }
 
     @Test
@@ -824,7 +831,7 @@ public class QueryCacheTest {
         String q1 = "select sum(v1) from t1 where ts between '2022-01-02 12:55:00' and '2022-01-08 01:30:00'";
         Optional<PlanFragment> optFrag = getCachedFragment(q1);
         Assert.assertTrue(optFrag.isPresent());
-        Map<Long, String> rangeMap = optFrag.get().getRangeMap();
+        Map<Long, String> rangeMap = optFrag.get().getCacheParam().getRegion_map();
         Assert.assertTrue(!rangeMap.isEmpty());
         List<String> expectRanges = Lists.newArrayList();
         PartitionKey startKey;
@@ -856,7 +863,7 @@ public class QueryCacheTest {
         String q1 = "select sum(v1) from t1 where ts >= '2022-01-02 12:55:00' and ts < '2022-01-08 01:30:00'";
         Optional<PlanFragment> optFrag = getCachedFragment(q1);
         Assert.assertTrue(optFrag.isPresent());
-        Map<Long, String> rangeMap = optFrag.get().getRangeMap();
+        Map<Long, String> rangeMap = optFrag.get().getCacheParam().getRegion_map();
         Assert.assertTrue(!rangeMap.isEmpty());
         List<String> expectRanges = Lists.newArrayList();
         PartitionKey startKey;
@@ -888,7 +895,7 @@ public class QueryCacheTest {
         String q1 = "select sum(v1) from t1 where ts >= '2022-01-02 12:55:00' and ts <= '2022-01-08 01:30:00'";
         Optional<PlanFragment> optFrag = getCachedFragment(q1);
         Assert.assertTrue(optFrag.isPresent());
-        Map<Long, String> rangeMap = optFrag.get().getRangeMap();
+        Map<Long, String> rangeMap = optFrag.get().getCacheParam().getRegion_map();
         Assert.assertTrue(!rangeMap.isEmpty());
         List<String> expectRanges = Lists.newArrayList();
         PartitionKey startKey;
@@ -920,7 +927,7 @@ public class QueryCacheTest {
         String q1 = "select sum(v1) from t1 where ts > '2022-01-02 12:55:00' and  ts <= '2022-01-08 01:30:00'";
         Optional<PlanFragment> optFrag = getCachedFragment(q1);
         Assert.assertTrue(optFrag.isPresent());
-        Map<Long, String> rangeMap = optFrag.get().getRangeMap();
+        Map<Long, String> rangeMap = optFrag.get().getCacheParam().getRegion_map();
         Assert.assertTrue(!rangeMap.isEmpty());
         List<String> expectRanges = Lists.newArrayList();
         PartitionKey startKey;
@@ -952,7 +959,7 @@ public class QueryCacheTest {
         String q1 = "select sum(v1) from t1 where ts > '2022-01-02 12:55:00' and ts < '2022-01-08 01:30:00'";
         Optional<PlanFragment> optFrag = getCachedFragment(q1);
         Assert.assertTrue(optFrag.isPresent());
-        Map<Long, String> rangeMap = optFrag.get().getRangeMap();
+        Map<Long, String> rangeMap = optFrag.get().getCacheParam().getRegion_map();
         Assert.assertTrue(!rangeMap.isEmpty());
         List<String> expectRanges = Lists.newArrayList();
         PartitionKey startKey;
@@ -987,7 +994,7 @@ public class QueryCacheTest {
         String q1 = "select sum(v1) from t1 where ts in ('2022-01-03 00:00:00')";
         Optional<PlanFragment> optFrag = getCachedFragment(q1);
         Assert.assertTrue(optFrag.isPresent());
-        Map<Long, String> rangeMap = optFrag.get().getRangeMap();
+        Map<Long, String> rangeMap = optFrag.get().getCacheParam().getRegion_map();
         Assert.assertTrue(!rangeMap.isEmpty());
         PartitionKey startKey = new PartitionKey();
         startKey.pushColumn(new DateLiteral("2022-01-03 00:00:00", Type.DATETIME), PrimitiveType.DATETIME);
@@ -1003,7 +1010,6 @@ public class QueryCacheTest {
         Optional<PlanFragment> optFrag = getCachedFragment(q1);
         Assert.assertFalse(optFrag.isPresent());
     }
-
 
     private static String toHexString(byte[] bytes) {
         StringBuffer s = new StringBuffer(bytes.length * 2);
@@ -1034,16 +1040,52 @@ public class QueryCacheTest {
                 "/*Q14*/ SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC",
         };
 
-        Map<String,String> digests = new HashMap<String,String>();
-        for (String q: queries) {
+        Map<String, String> digests = new HashMap<String, String>();
+        for (String q : queries) {
             Optional<PlanFragment> optFrag = getCachedFragment(q);
             Assert.assertTrue(optFrag.isPresent());
-            String s = toHexString(optFrag.get().getDigest().array());
+            String s = toHexString(optFrag.get().getCacheParam().getDigest());
             if (digests.containsKey(s)) {
                 System.out.println(String.format("Conflicting digest:'%s',\nq1=%s\nq2=%s", s, q, digests.get(s)));
                 Assert.fail();
             }
-            digests.put(s,q);
+            digests.put(s, q);
+        }
+    }
+
+    @Test
+    public void testHotPartitions() {
+        ctx.getSessionVariable().setQueryCachePrimaryKeysHotPartitionNum(3);
+        ctx.getSessionVariable().setQueryCacheUniqueKeysHotPartitionNum(3);
+        String queriesWithHotPartitions[] = {
+                "/*PRIMARY_KEYS*/ SELECT COUNT(*) FROM t4 where ts between '2022-02-01 00:00:00' and '2022-03-31 00:00:00'",
+                "/*UNIQUE_KEYS*/ SELECT COUNT(*) FROM t5 where ts between '2022-02-01 00:00:00' and '2022-03-31 00:00:00'",
+                "/*AGGREGATE_KEYS with replace*/ SELECT COUNT(*) FROM t6 where ts between '2022-02-01 00:00:00' and '2022-03-31 00:00:00'",
+        };
+
+        String queriesWithoutHotPartitions[] = {
+                "/*DUP_KEYS*/ SELECT COUNT(*) FROM t1 where ts between '2022-02-01 00:00:00' and '2022-03-31 00:00:00'",
+                "/*AGGREGATE_KEYS*/ SELECT COUNT(*) FROM t7 where ts between '2022-02-01 00:00:00' and '2022-03-31 00:00:00'",
+        };
+        Set<String> expectRanges = Sets.newHashSet(
+                "[types: [DATETIME]; keys: [2022-02-26 00:00:00]; ..types: [DATETIME]; keys: [2022-02-27 00:00:00]; )",
+                "[types: [DATETIME]; keys: [2022-02-27 00:00:00]; ..types: [DATETIME]; keys: [2022-02-28 00:00:00]; )",
+                "[types: [DATETIME]; keys: [2022-02-28 00:00:00]; ..types: [DATETIME]; keys: [2022-03-01 00:00:00]; )"
+        );
+
+        for (String q : queriesWithHotPartitions) {
+            Optional<PlanFragment> optFrag = getCachedFragment(q);
+            Assert.assertTrue(optFrag.isPresent());
+            Map<Long, String> rangeMap = optFrag.get().getCacheParam().getRegion_map();
+            Assert.assertFalse(rangeMap.values().stream().anyMatch(expectRanges::contains));
+        }
+        for (String q : queriesWithoutHotPartitions) {
+            Optional<PlanFragment> optFrag = getCachedFragment(q);
+            Assert.assertTrue(optFrag.isPresent());
+            Map<Long, String> rangeMap = optFrag.get().getCacheParam().getRegion_map();
+            List<String> matchedRanges =
+                    rangeMap.values().stream().filter(expectRanges::contains).collect(Collectors.toList());
+            Assert.assertEquals(matchedRanges.size(), expectRanges.size());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
@@ -13,6 +13,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.statistic.StatsConstants;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
@@ -31,10 +32,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.optimizer.statistics.CachedStatisticStorageTest.DEFAULT_CREATE_TABLE_TEMPLATE;
+
 public class QueryCacheTest {
     private static ConnectContext ctx;
-    @Rule
-    public ExpectedException expectedEx = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -369,6 +370,9 @@ public class QueryCacheTest {
         ctx.getSessionVariable().setEnableQueryCache(true);
         FeConstants.runningUnitTest = true;
         StarRocksAssert starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase(StatsConstants.STATISTICS_DB_NAME)
+                .useDatabase(StatsConstants.STATISTICS_DB_NAME)
+                .withTable(DEFAULT_CREATE_TABLE_TEMPLATE);
         starRocksAssert.withDatabase("qc_db").useDatabase("qc_db");
         starRocksAssert.withTable(createTbl0StmtStr);
         starRocksAssert.withTable(createTbl1StmtStr);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
@@ -1059,8 +1059,7 @@ public class QueryCacheTest {
 
     @Test
     public void testHotPartitions() {
-        ctx.getSessionVariable().setQueryCachePrimaryKeysHotPartitionNum(3);
-        ctx.getSessionVariable().setQueryCacheUniqueKeysHotPartitionNum(3);
+        ctx.getSessionVariable().setQueryCacheHotPartitionNum(3);
         String queriesWithHotPartitions[] = {
                 "/*PRIMARY_KEYS*/ SELECT COUNT(*) FROM t4 where ts between '2022-02-01 00:00:00' and '2022-03-31 00:00:00'",
                 "/*UNIQUE_KEYS*/ SELECT COUNT(*) FROM t5 where ts between '2022-02-01 00:00:00' and '2022-03-31 00:00:00'",

--- a/gensrc/thrift/Planner.thrift
+++ b/gensrc/thrift/Planner.thrift
@@ -37,6 +37,8 @@ struct TCacheParam {
 5: optional bool force_populate;
 6: optional i64 entry_max_bytes;
 7: optional i64 entry_max_rows;
+8: optional bool can_use_multiversion;
+10:optional Types.TKeysType keys_type;
 }
 
 // TPlanFragment encapsulates info needed to execute a particular


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

Query cache support data models of  UNIQUE_KEYS and PRIMARY_KEYS. now query cache support all data models. different models have different policies to support multiversion:
1. support multiversion cache:  DUP_KEYS, AGG_KEYS(contains no replace aggfunc)
2. not support multiversion cache: UNIQUE_KEYS, PRIMARY_KEYS, AGG(contains replace aggfunc). Althrough these scenarios do not support multiversion cache, but if cache contains a stale cache value and the delta version has not data, the cache can be hit totally.