### PR TITLE
[BugFix] Fix hive column statistics Min/Max with wrong default value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveColumnStats.java
@@ -49,6 +49,11 @@ public class HiveColumnStats {
         }
         min = boolStats.isSetNumFalses() ? 0 : 1;
         max = boolStats.isSetNumTrues() ? 1 : 0;
+        if (min > max) {
+            // when this column is all null values
+            min = 0.0;
+            max = 0.0;
+        }
         type = StatisticType.ESTIMATE;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveColumnStats.java
@@ -84,6 +84,8 @@ public class HiveColumnStats {
 
     private void initStringColumnStats(StringColumnStatsData stringStats, long rowNums) {
         numNulls = getNumNulls(stringStats.getNumNulls());
+        min = Double.NEGATIVE_INFINITY;
+        max = Double.POSITIVE_INFINITY;
         ndv = stringStats.isSetNumDVs() ? getNdvValue(stringStats.getNumDVs(), rowNums) : -1;
         double avgColLen = stringStats.isSetAvgColLen() ? stringStats.getAvgColLen() : -1;
         totalSizeBytes = getStringColumnTotalSizeBytes(avgColLen, rowNums);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveColumnStats.java
@@ -30,8 +30,8 @@ public class HiveColumnStats {
     private long totalSizeBytes;
     private long numNulls;
     private long ndv;
-    private double min;
-    private double max;
+    private double min = Double.NEGATIVE_INFINITY;
+    private double max = Double.POSITIVE_INFINITY;
     private StatisticType type;
 
     public HiveColumnStats() {
@@ -47,6 +47,8 @@ public class HiveColumnStats {
         } else {
             ndv = -1;
         }
+        min = boolStats.isSetNumFalses() ? 0 : 1;
+        max = boolStats.isSetNumTrues() ? 1 : 0;
         type = StatisticType.ESTIMATE;
     }
 
@@ -84,8 +86,6 @@ public class HiveColumnStats {
 
     private void initStringColumnStats(StringColumnStatsData stringStats, long rowNums) {
         numNulls = getNumNulls(stringStats.getNumNulls());
-        min = Double.NEGATIVE_INFINITY;
-        max = Double.POSITIVE_INFINITY;
         ndv = stringStats.isSetNumDVs() ? getNdvValue(stringStats.getNumDVs(), rowNums) : -1;
         double avgColLen = stringStats.isSetAvgColLen() ? stringStats.getAvgColLen() : -1;
         totalSizeBytes = getStringColumnTotalSizeBytes(avgColLen, rowNums);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -226,5 +226,7 @@ public class HiveStatisticsProviderTest {
         columnStatisticsData.setStringStats(stringColumnStatsData);
         stats.initialize(columnStatisticsData, 90);
         Assert.assertEquals(5, stats.getNumNulls());
+        Assert.assertEquals(Double.NEGATIVE_INFINITY, stats.getMin(), 0.000001);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, stats.getMax(), 0.000001);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.utframe.UtFrameUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.DecimalColumnStatsData;
@@ -193,6 +194,14 @@ public class HiveStatisticsProviderTest {
     public void testHiveColumnInit() {
         HiveColumnStats stats = new HiveColumnStats();
         ColumnStatisticsData columnStatisticsData = new ColumnStatisticsData();
+        BooleanColumnStatsData booleanColumnStatsData = new BooleanColumnStatsData();
+        booleanColumnStatsData.setNumTrues(10);
+        columnStatisticsData.setBooleanStats(booleanColumnStatsData);
+        stats.initialize(columnStatisticsData, 10);
+        Assert.assertEquals(1, stats.getMax(), 0.000001);
+        Assert.assertEquals(1, stats.getMin(), 0.000001);
+
+        columnStatisticsData = new ColumnStatisticsData();
         LongColumnStatsData longColumnStatsData = new LongColumnStatsData();
         longColumnStatsData.setNumNulls(1);
         columnStatisticsData.setLongStats(longColumnStatsData);
@@ -220,6 +229,7 @@ public class HiveStatisticsProviderTest {
         stats.initialize(columnStatisticsData, 80);
         Assert.assertEquals(4, stats.getNumNulls());
 
+        stats = new HiveColumnStats();
         columnStatisticsData = new ColumnStatisticsData();
         StringColumnStatsData stringColumnStatsData = new StringColumnStatsData();
         stringColumnStatsData.setNumNulls(5);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -201,6 +201,14 @@ public class HiveStatisticsProviderTest {
         Assert.assertEquals(1, stats.getMax(), 0.000001);
         Assert.assertEquals(1, stats.getMin(), 0.000001);
 
+        booleanColumnStatsData = new BooleanColumnStatsData();
+        booleanColumnStatsData.setNumNulls(10);
+        columnStatisticsData.setBooleanStats(booleanColumnStatsData);
+        stats.initialize(columnStatisticsData, 10);
+        Assert.assertEquals(0, stats.getMax(), 0.000001);
+        Assert.assertEquals(0, stats.getMin(), 0.000001);
+
+
         columnStatisticsData = new ColumnStatisticsData();
         LongColumnStatsData longColumnStatsData = new LongColumnStatsData();
         longColumnStatsData.setNumNulls(1);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
