### PR TITLE
[BugFix] streamvbyte encode buffer should have extra 16 bytes of padding size

### DIFF
--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -59,19 +59,15 @@ const uint8_t* read_raw(const uint8_t* buff, void* target, size_t size) {
     return buff + size;
 }
 
-inline size_t upper_int32(size_t size) {
-    return (3 + size) / 4.0;
-}
-
 template <bool sorted_32ints>
 uint8_t* encode_integers(const void* data, size_t size, uint8_t* buff, int encode_level) {
     uint64_t encode_size = 0;
     if (sorted_32ints) { // only support sorted 32-bit integers
-        encode_size = streamvbyte_delta_encode(reinterpret_cast<const uint32_t*>(data), upper_int32(size),
+        encode_size = streamvbyte_delta_encode(reinterpret_cast<const uint32_t*>(data), (3 + size) * 1.0 / 4.0,
                                                buff + sizeof(uint64_t), 0);
     } else {
-        encode_size =
-                streamvbyte_encode(reinterpret_cast<const uint32_t*>(data), upper_int32(size), buff + sizeof(uint64_t));
+        encode_size = streamvbyte_encode(reinterpret_cast<const uint32_t*>(data), (3 + size) * 1.0 / 4.0,
+                                         buff + sizeof(uint64_t));
     }
     buff = write_little_endian_64(encode_size, buff);
 
@@ -86,9 +82,9 @@ const uint8_t* decode_integers(const uint8_t* buff, void* target, size_t size) {
     buff = read_little_endian_64(buff, &encode_size);
     uint64_t decode_size = 0;
     if (sorted_32ints) {
-        decode_size = streamvbyte_delta_decode(buff, (uint32_t*)target, upper_int32(size), 0);
+        decode_size = streamvbyte_delta_decode(buff, (uint32_t*)target, (3 + size) * 1.0 / 4.0, 0);
     } else {
-        decode_size = streamvbyte_decode(buff, (uint32_t*)target, upper_int32(size));
+        decode_size = streamvbyte_decode(buff, (uint32_t*)target, (3 + size) * 1.0 / 4.0);
     }
     if (encode_size != decode_size) {
         throw std::runtime_error(fmt::format(
@@ -137,7 +133,7 @@ public:
         uint32_t size = sizeof(T) * column.size();
         if ((encode_level & 2) && size >= ENCODE_SIZE_LIMIT) {
             return sizeof(uint32_t) + sizeof(uint64_t) +
-                   std::max((int64_t)size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(size)));
+                   std::max((int64_t)size, (int64_t)streamvbyte_max_compressedbytes((size + 3) / 4.0));
         } else {
             return sizeof(uint32_t) + size;
         }
@@ -164,15 +160,14 @@ public:
         uint32_t size = 0;
         buff = read_little_endian_32(buff, &size);
         std::vector<T>& data = column->get_data();
+        raw::make_room(&data, size / sizeof(T));
         if ((encode_level & 2) && size >= ENCODE_SIZE_LIMIT) {
-            raw::make_room_pad16(&data, size / sizeof(T));
             if (sizeof(T) == 4 && sorted) { // only support sorted 32-bit integers
                 buff = decode_integers<true>(buff, data.data(), size);
             } else {
                 buff = decode_integers<false>(buff, data.data(), size);
             }
         } else {
-            raw::make_room(&data, size / sizeof(T));
             buff = read_raw(buff, data.data(), size);
         }
         return buff;
@@ -189,7 +184,7 @@ public:
         int64_t offsets_size = offsets.size() * sizeof(typename vectorized::BinaryColumnBase<T>::Offset);
         if ((encode_level & 2) && offsets_size >= ENCODE_SIZE_LIMIT) {
             res += sizeof(uint64_t) +
-                   std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(offsets_size)));
+                   std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes((offsets_size + 3) / 4.0));
         } else {
             res += offsets_size;
         }
@@ -259,17 +254,14 @@ public:
         } else {
             buff = read_little_endian_64(buff, &offsets_size);
         }
+        raw::make_room(&column->get_offset(), offsets_size / sizeof(typename vectorized::BinaryColumnBase<T>::Offset));
         if ((encode_level & 2) && offsets_size >= ENCODE_SIZE_LIMIT) {
-            raw::make_room_pad16(&column->get_offset(),
-                                 offsets_size / sizeof(typename vectorized::BinaryColumnBase<T>::Offset));
             if (sizeof(T) == 4) { // only support sorted 32-bit integers
                 buff = decode_integers<true>(buff, column->get_offset().data(), offsets_size);
             } else {
                 buff = decode_integers<false>(buff, column->get_offset().data(), offsets_size);
             }
         } else {
-            raw::make_room(&column->get_offset(),
-                           offsets_size / sizeof(typename vectorized::BinaryColumnBase<T>::Offset));
             buff = read_raw(buff, column->get_offset().data(), offsets_size);
         }
         return buff;

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -21,6 +21,7 @@
 #include "column/struct_column.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptors.h"
+#include "serde/protobuf_serde.h"
 #include "types/hll.h"
 #include "util/coding.h"
 #include "util/json.h"
@@ -135,7 +136,7 @@ class FixedLengthColumnSerde {
 public:
     static int64_t max_serialized_size(const vectorized::FixedLengthColumnBase<T>& column, const int encode_level) {
         uint32_t size = sizeof(T) * column.size();
-        if ((encode_level & 2) && size >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_integer(encode_level) && size >= ENCODE_SIZE_LIMIT) {
             return sizeof(uint32_t) + sizeof(uint64_t) +
                    std::max((int64_t)size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(size)));
         } else {
@@ -147,7 +148,7 @@ public:
                               const int encode_level) {
         uint32_t size = sizeof(T) * column.size();
         buff = write_little_endian_32(size, buff);
-        if ((encode_level & 2) && size >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_integer(encode_level) && size >= ENCODE_SIZE_LIMIT) {
             if (sizeof(T) == 4 && sorted) { // only support sorted 32-bit integers
                 buff = encode_integers<true>(column.raw_data(), size, buff, encode_level);
             } else {
@@ -165,7 +166,7 @@ public:
         buff = read_little_endian_32(buff, &size);
         std::vector<T>& data = column->get_data();
         raw::make_room(&data, size / sizeof(T));
-        if ((encode_level & 2) && size >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_integer(encode_level) && size >= ENCODE_SIZE_LIMIT) {
             if (sizeof(T) == 4 && sorted) { // only support sorted 32-bit integers
                 buff = decode_integers<true>(buff, data.data(), size);
             } else {
@@ -186,13 +187,13 @@ public:
         const auto& offsets = column.get_offset();
         int64_t res = sizeof(T) * 2;
         int64_t offsets_size = offsets.size() * sizeof(typename vectorized::BinaryColumnBase<T>::Offset);
-        if ((encode_level & 2) && offsets_size >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_integer(encode_level) && offsets_size >= ENCODE_SIZE_LIMIT) {
             res += sizeof(uint64_t) +
                    std::max((int64_t)offsets_size, (int64_t)streamvbyte_max_compressedbytes(upper_int32(offsets_size)));
         } else {
             res += offsets_size;
         }
-        if ((encode_level & 4) && bytes.size() >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_string(encode_level) && bytes.size() >= ENCODE_SIZE_LIMIT) {
             res += sizeof(uint64_t) + std::max((int64_t)bytes.size(), (int64_t)LZ4_compressBound(bytes.size()));
         } else {
             res += bytes.size();
@@ -211,7 +212,7 @@ public:
         } else {
             buff = write_little_endian_64(bytes_size, buff);
         }
-        if ((encode_level & 4) && bytes_size >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_string(encode_level) && bytes_size >= ENCODE_SIZE_LIMIT) {
             buff = encode_string_lz4(bytes.data(), bytes_size, buff, encode_level);
         } else {
             buff = write_raw(bytes.data(), bytes_size, buff);
@@ -224,7 +225,7 @@ public:
         } else {
             buff = write_little_endian_64(offsets_size, buff);
         }
-        if ((encode_level & 2) && offsets_size >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_integer(encode_level) && offsets_size >= ENCODE_SIZE_LIMIT) {
             if (sizeof(T) == 4) { // only support sorted 32-bit integers
                 buff = encode_integers<true>(offsets.data(), offsets_size, buff, encode_level);
             } else {
@@ -246,7 +247,7 @@ public:
             buff = read_little_endian_64(buff, &bytes_size);
         }
         column->get_bytes().resize(bytes_size);
-        if ((encode_level & 4) && bytes_size >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_string(encode_level) && bytes_size >= ENCODE_SIZE_LIMIT) {
             buff = decode_string_lz4(buff, column->get_bytes().data(), bytes_size);
         } else {
             buff = read_raw(buff, column->get_bytes().data(), bytes_size);
@@ -259,7 +260,7 @@ public:
             buff = read_little_endian_64(buff, &offsets_size);
         }
         raw::make_room(&column->get_offset(), offsets_size / sizeof(typename vectorized::BinaryColumnBase<T>::Offset));
-        if ((encode_level & 2) && offsets_size >= ENCODE_SIZE_LIMIT) {
+        if (EncodeContext::enable_encode_integer(encode_level) && offsets_size >= ENCODE_SIZE_LIMIT) {
             if (sizeof(T) == 4) { // only support sorted 32-bit integers
                 buff = decode_integers<true>(buff, column->get_offset().data(), offsets_size);
             } else {

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -47,10 +47,10 @@ void EncodeContext::_adjust(const int col_id) {
         _column_encode_level[col_id] = 0;
     }
     if (old_level != _column_encode_level[col_id] || _session_encode_level < -1) {
-        VLOG_ROW << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
-                 << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
-                 << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
-                 << " higher than limit " << EncodeRatioLimit;
+        LOG(WARNING) << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
+                     << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
+                     << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
+                     << " higher than limit " << EncodeRatioLimit;
     }
     _encoded_bytes[col_id] = 0;
     _raw_bytes[col_id] = 0;

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -146,8 +146,8 @@ StatusOr<ChunkPB> ProtobufChunkSerde::serialize_without_meta(const vectorized::C
             buff = ColumnArraySerde::serialize(*chunk.columns()[i], buff, false, context->get_encode_level(i));
             if (UNLIKELY(buff == nullptr)) return Status::InternalError("has unsupported column");
             context->update(i, chunk.columns()[i]->byte_size(), buff - buff_begin);
-            if (context->get_encode_level(i) & 2) { // may be use streamvbyte
-                padding_size = 16;
+            if (EncodeContext::enable_encode_integer(context->get_encode_level(i))) { // may be use streamvbyte
+                padding_size = context->STREAMVBYTE_PADDING;
             }
         }
     }

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -47,10 +47,10 @@ void EncodeContext::_adjust(const int col_id) {
         _column_encode_level[col_id] = 0;
     }
     if (old_level != _column_encode_level[col_id] || _session_encode_level < -1) {
-        LOG(WARNING) << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
-                     << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
-                     << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
-                     << " higher than limit " << EncodeRatioLimit;
+        VLOG_ROW << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
+                 << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
+                 << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
+                 << " higher than limit " << EncodeRatioLimit;
     }
     _encoded_bytes[col_id] = 0;
     _raw_bytes[col_id] = 0;
@@ -134,6 +134,7 @@ StatusOr<ChunkPB> ProtobufChunkSerde::serialize_without_meta(const vectorized::C
     encode_fixed32_le(buff + 4, chunk.num_rows());
     buff = buff + 8;
 
+    int padding_size = 0; // as streamvbyte may read up to 16 extra bytes from the input.
     if (context == nullptr) {
         for (const auto& column : chunk.columns()) {
             buff = ColumnArraySerde::serialize(*column, buff);
@@ -145,10 +146,13 @@ StatusOr<ChunkPB> ProtobufChunkSerde::serialize_without_meta(const vectorized::C
             buff = ColumnArraySerde::serialize(*chunk.columns()[i], buff, false, context->get_encode_level(i));
             if (UNLIKELY(buff == nullptr)) return Status::InternalError("has unsupported column");
             context->update(i, chunk.columns()[i]->byte_size(), buff - buff_begin);
+            if (context->get_encode_level(i) & 2) { // may be use streamvbyte
+                padding_size = 16;
+            }
         }
     }
     chunk_pb.set_serialized_size(buff - reinterpret_cast<const uint8_t*>(serialized_data->data()));
-    serialized_data->resize(chunk_pb.serialized_size());
+    serialized_data->resize(chunk_pb.serialized_size() + padding_size);
     chunk_pb.set_uncompressed_size(serialized_data->size());
     if (context) {
         VLOG_ROW << "pb serialize data, memory bytes = " << chunk.bytes_usage()

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -147,7 +147,7 @@ StatusOr<ChunkPB> ProtobufChunkSerde::serialize_without_meta(const vectorized::C
             if (UNLIKELY(buff == nullptr)) return Status::InternalError("has unsupported column");
             context->update(i, chunk.columns()[i]->byte_size(), buff - buff_begin);
             if (EncodeContext::enable_encode_integer(context->get_encode_level(i))) { // may be use streamvbyte
-                padding_size = context->STREAMVBYTE_PADDING;
+                padding_size = context->STREAMVBYTE_PADDING_SIZE;
             }
         }
     }

--- a/be/src/serde/protobuf_serde.h
+++ b/be/src/serde/protobuf_serde.h
@@ -42,7 +42,16 @@ public:
 
     void set_encode_levels_in_pb(ChunkPB* const res);
 
+    static constexpr uint16_t STREAMVBYTE_PADDING = 16;
+
+    static bool enable_encode_integer(const int encode_code) { return encode_code & ENCODE_INTEGER; }
+
+    static bool enable_encode_string(const int encode_code) { return encode_code & ENCODE_STRING; }
+
 private:
+    static constexpr int ENCODE_INTEGER = 2;
+    static constexpr int ENCODE_STRING = 4;
+
     // if encode ratio < EncodeRatioLimit, encode it, otherwise not.
     void _adjust(const int col_id);
     const int _session_encode_level;

--- a/be/src/serde/protobuf_serde.h
+++ b/be/src/serde/protobuf_serde.h
@@ -45,9 +45,9 @@ public:
 
     static constexpr uint16_t STREAMVBYTE_PADDING_SIZE = STREAMVBYTE_PADDING;
 
-    static bool enable_encode_integer(const int encode_code) { return encode_code & ENCODE_INTEGER; }
+    static bool enable_encode_integer(const int encode_level) { return encode_level & ENCODE_INTEGER; }
 
-    static bool enable_encode_string(const int encode_code) { return encode_code & ENCODE_STRING; }
+    static bool enable_encode_string(const int encode_level) { return encode_level & ENCODE_STRING; }
 
 private:
     static constexpr int ENCODE_INTEGER = 2;

--- a/be/src/serde/protobuf_serde.h
+++ b/be/src/serde/protobuf_serde.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <streamvbyte.h>
 #include <string_view>
 #include <vector>
 
@@ -42,7 +43,7 @@ public:
 
     void set_encode_levels_in_pb(ChunkPB* const res);
 
-    static constexpr uint16_t STREAMVBYTE_PADDING = 16;
+    static constexpr uint16_t STREAMVBYTE_PADDING_SIZE = STREAMVBYTE_PADDING;
 
     static bool enable_encode_integer(const int encode_code) { return encode_code & ENCODE_INTEGER; }
 

--- a/be/src/serde/protobuf_serde.h
+++ b/be/src/serde/protobuf_serde.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <streamvbyte.h>
+
 #include <string_view>
 #include <vector>
 

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -154,13 +154,6 @@ inline void make_room(std::vector<T>* v, size_t n) {
     v->swap(reinterpret_cast<std::vector<T>&>(rv));
 }
 
-template <class T>
-inline void make_room_pad16(std::vector<T>* v, size_t n) {
-    RawVectorPad16<T> rv;
-    rv.resize(n);
-    v->swap(reinterpret_cast<std::vector<T>&>(rv));
-}
-
 inline void make_room(std::string* s, size_t n) {
     RawStringPad16 rs;
     rs.resize(n);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/StarRocksBenchmark/issues/273 
revert https://github.com/StarRocks/starrocks/pull/13062, as which just enlarge the decode buffer.
https://github.com/lemire/streamvbyte/pull/44 fix a error that streamvbyte's decode may read up to 16 extra bytes from the input (beyond the actual compressed data). Thus the users of this library, for safety, should ensure that there is allocated data 16 bytes beyond the compressed data.

SR can use `RawVectorPad16` to allocate vector with extra 16 bytes. So this PR introduces `make_room_pad16` to make room for decoding integers that encoded by streamvbyte.

by the way, refactor some codes.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
