### PR TITLE
[BugFix] Use MockUp to mock SystemInfoService

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -17,6 +17,8 @@ import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -82,26 +84,27 @@ public class ReportHandlerTest {
     @Test
     public void testHandleResourceUsageReport() {
         QueryQueueManager queryQueueManager = QueryQueueManager.getInstance();
-        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
         Backend backend = new Backend();
         long backendId = 0;
         int numRunningQueries = 1;
         long memLimitBytes = 3;
         long memUsedBytes = 2;
         int cpuUsedPermille = 300;
-        new Expectations(systemInfoService, queryQueueManager) {
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public Backend getBackend(long id) {
+                if (id == backendId) {
+                    return backend;
+                }
+                return null;
+            }
+        };
+
+        new Expectations(queryQueueManager) {
             {
                 queryQueueManager.maybeNotifyAfterLock();
                 times = 1;
-            }
-
-            {
-                systemInfoService.getBackend(backendId);
-                result = backend;
-            }
-            {
-                systemInfoService.getBackend(anyLong);
-                result = null;
             }
         };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The FE UT `testHandleResourceUsageReport` fails sometimes.

The reason is that it uses `Expectations` to mock `SystemInfoService`, but some daemon threads such as `SystemHandler` also uses `SystemInfoService::getInstance`, which causes it fails when they call some not mocked methods of `SystemInfoService`.



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
