### PR TITLE
[BugFix] Fix the bug of slow execution of show frontends

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -5229,10 +5229,10 @@ public class Catalog {
             }
             frontends.put(fe.getNodeName(), fe);
             if (fe.getRole() == FrontendNodeType.FOLLOWER || fe.getRole() == FrontendNodeType.REPLICA) {
-                // DO NOT add helper sockets here, cause BDBHA is not instantiated yet.
-                // helper sockets will be added after start BDBHA
-                // But add to helperNodes, just for show
                 helperNodes.add(Pair.create(fe.getHost(), fe.getEditLogPort()));
+                if (!Catalog.isCheckpointThread()) {
+                    ((BDBHA) haProtocol).addHelperSocket(fe.getHost(), fe.getEditLogPort());
+                }
             }
         } finally {
             unlock();
@@ -5250,6 +5250,9 @@ public class Catalog {
             if (removedFe.getRole() == FrontendNodeType.FOLLOWER
                     || removedFe.getRole() == FrontendNodeType.REPLICA) {
                 helperNodes.remove(Pair.create(removedFe.getHost(), removedFe.getEditLogPort()));
+                if (!Catalog.isCheckpointThread()) {
+                    ((BDBHA) haProtocol).removeHelperSocket(removedFe.getHost(), removedFe.getEditLogPort());
+                }
             }
 
             removedFrontends.add(removedFe.getNodeName());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13339

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When executing `show frontends` command, FE will get node info from bdb using ReplicationGroupAdmin. But FE only add/remove the fe host to/from ReplicationGroupAdmin in leader node. This will leave some unreachable host in non-leader node. It will cause the slow problem.
To fix this bug,  add/remove fe node from ReplicationGroupAdmin client in the non-leader FE.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
