### PR TITLE
[BugFix] Disable tablet migration between local disks for pk table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -155,7 +155,7 @@ public class TabletInvertedIndex {
                                     tabletSyncMap.put(tabletMeta.getDbId(), tabletId);
                                 }
 
-                                // check and set path
+                                // check and set path,
                                 // path info of replica is only saved in Leader FE
                                 if (backendTabletInfo.isSetPath_hash() &&
                                         replica.getPathHash() != backendTabletInfo.getPath_hash()) {
@@ -181,7 +181,7 @@ public class TabletInvertedIndex {
                                     tabletRecoveryMap.put(tabletMeta.getDbId(), tabletId);
                                 }
 
-                                // check if need migration
+                                // check if tablet needs migration
                                 long partitionId = tabletMeta.getPartitionId();
                                 TStorageMedium storageMedium = storageMediumMap.get(partitionId);
                                 if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
@@ -201,7 +201,7 @@ public class TabletInvertedIndex {
                                         tabletMeta.setStorageMedium(storageMedium);
                                     }
                                 }
-                                // check if should clear transactions
+                                // check if we should clear transactions
                                 if (backendTabletInfo.isSetTransaction_ids()) {
                                     List<Long> transactionIds = backendTabletInfo.getTransaction_ids();
                                     GlobalTransactionMgr transactionMgr =
@@ -225,7 +225,7 @@ public class TabletInvertedIndex {
                                                  * This may happen as follows:
                                                  * 1. txn is committed on BE, and report commit info to FE
                                                  * 2. FE received report and begin to assemble partitionCommitInfos.
-                                                 * 3. At the same time, some of partitions have been dropped, so
+                                                 * 3. At the same time, some partitions have been dropped, so
                                                  *    partitionCommitInfos does not contain these partitions.
                                                  * 4. So we will not able to get partitionCommitInfo here.
                                                  *
@@ -254,13 +254,13 @@ public class TabletInvertedIndex {
                                     }
                                 } // end for txn id
 
-                                // update replicas's version count
+                                // update replica's version count
                                 // no need to write log, and no need to get db lock.
                                 if (backendTabletInfo.isSetVersion_count()) {
                                     replica.setVersionCount(backendTabletInfo.getVersion_count());
                                 }
                             } else {
-                                // tablet with invalid schemahash
+                                // tablet with invalid schema hash
                                 foundTabletsWithInvalidSchema.put(tabletId, backendTabletInfo);
                             } // end for be tablet info
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.LocalTablet.TabletStatus;
 import com.starrocks.catalog.MaterializedIndex;
@@ -912,6 +913,20 @@ public class ReportHandler extends Daemon {
             for (int i = 0; i < tabletMetaList.size(); i++) {
                 long tabletId = tabletIds.get(i);
                 TabletMeta tabletMeta = tabletMetaList.get(i);
+                Database db = GlobalStateMgr.getCurrentState().getDb(tabletMeta.getDbId());
+                if (db == null) {
+                    continue;
+                }
+                db.readLock();
+                try {
+                    OlapTable table = (OlapTable) db.getTable(tabletMeta.getTableId());
+                    if (table.getKeysType() == KeysType.PRIMARY_KEYS) {
+                        // Currently, primary key table doesn't support tablet migration between local disks.
+                        continue;
+                    }
+                } finally {
+                    db.readUnlock();
+                }
                 // always get old schema hash(as effective one)
                 int effectiveSchemaHash = tabletMeta.getOldSchemaHash();
                 StorageMediaMigrationTask task = new StorageMediaMigrationTask(backendId, tabletId,


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13097

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, primary key table doesn't support tablet migration between local disks.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
