### PR TITLE
[Enhancement][Cherry-Pick][Branch-2.5][Support Struct] Support Struct subfield materialize

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SubfieldExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SubfieldExpr.java
@@ -3,6 +3,7 @@
 package com.starrocks.analysis;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.AstVisitor;
@@ -37,6 +38,10 @@ public class SubfieldExpr extends Expr {
 
     public String getFieldName() {
         return fieldName;
+    }
+
+    public int getFieldPos(String fieldName) {
+        return ((StructType) (children.get(0).getType())).getFieldPos(fieldName);
     }
 
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
@@ -104,9 +104,9 @@ public class ArrayType extends Type {
     }
 
     @Override
-    public void selectAll() {
+    public void selectAllFields() {
         if (itemType.isComplexType()) {
-            itemType.selectAll();
+            itemType.selectAllFields();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -60,15 +60,15 @@ public class MapType extends Type {
             selectedFields[pos] = true;
         }
         if (needSetChildren && (pos == 1 || pos == -1) && valueType.isComplexType()) {
-            valueType.selectAll();
+            valueType.selectAllFields();
         }
     }
 
     @Override
-    public void selectAll() {
+    public void selectAllFields() {
         Arrays.fill(selectedFields, true);
         if (valueType.isComplexType()) {
-            valueType.selectAll();
+            valueType.selectAllFields();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -60,6 +60,8 @@ public class StructType extends Type {
                 fieldMap.put(field.getName(), field);
             }
         }
+        selectedFields = new Boolean[fields.size()];
+        Arrays.fill(selectedFields, false);
     }
 
     @Override
@@ -116,9 +118,25 @@ public class StructType extends Type {
         return fields.get(pos);
     }
 
-    public void clearFields() {
-        fields.clear();
-        fieldMap.clear();
+    @Override
+    public void setSelectedField(int pos, boolean needSetChildren) {
+        selectedFields[pos] = true;
+        if (needSetChildren) {
+            StructField structField = fields.get(pos);
+            if (structField.getType().isComplexType()) {
+                structField.getType().selectAllFields();
+            }
+        }
+    }
+
+    @Override
+    public void selectAllFields() {
+        Arrays.fill(selectedFields, true);
+        for (StructField structField : fields) {
+            if (structField.getType().isComplexType()) {
+                structField.getType().selectAllFields();
+            }
+        }
     }
 
     @Override
@@ -139,9 +157,7 @@ public class StructType extends Type {
         Preconditions.checkNotNull(!fields.isEmpty());
         node.setType(TTypeNodeType.STRUCT);
         node.setStruct_fields(new ArrayList<TStructField>());
-        //TODO(SmithCruise) Select all subfields now, partial subfield select will be implemented in next PR.
-        Boolean[] selectedFields = new Boolean[fields.size()];
-        Arrays.fill(selectedFields, true);
+        Preconditions.checkArgument(selectedFields.length == fields.size());
         node.setSelected_fields(Arrays.asList(selectedFields));
         for (StructField field : fields) {
             field.toThrift(container, node);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -549,8 +549,8 @@ public abstract class Type implements Cloneable {
     /**
      * Used for Nest Type
      */
-    public void selectAll() {
-        throw new IllegalStateException("selectAll() is not implemented for type " + toSql());
+    public void selectAllFields() {
+        throw new IllegalStateException("selectAllFields() is not implemented for type " + toSql());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 package com.starrocks.sql.optimizer.operator.scalar;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -22,9 +23,10 @@ public final class ColumnRefOperator extends ScalarOperator {
 
     private boolean isLambdaArgument;
 
+    // TODO(SmithCruise) Ugly code, remove it in future.
     // Empty list for default
     // If it's empty, means select all
-    private final List<List<Integer>> usedSubfieldPosGroup = new ArrayList<>();
+    private final List<ImmutableList<Integer>> usedSubfieldPosGroup = new ArrayList<>();
 
     public ColumnRefOperator(int id, Type type, String name, boolean nullable) {
         super(OperatorType.VARIABLE, type);
@@ -34,11 +36,11 @@ public final class ColumnRefOperator extends ScalarOperator {
         this.isLambdaArgument = false;
     }
 
-    public void addUsedSubfieldPos(List<Integer> usedNestFieldPos) {
+    public void addUsedSubfieldPos(ImmutableList<Integer> usedNestFieldPos) {
         this.usedSubfieldPosGroup.add(usedNestFieldPos);
     }
 
-    public List<List<Integer>> getUsedSubfieldPosGroup() {
+    public List<ImmutableList<Integer>> getUsedSubfieldPosGroup() {
         return this.usedSubfieldPosGroup;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SlotDescriptorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SlotDescriptorTest.java
@@ -1,9 +1,12 @@
 package com.starrocks.analysis;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.StructField;
+import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import org.junit.Assert;
@@ -12,6 +15,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 public class SlotDescriptorTest {
@@ -50,7 +54,7 @@ public class SlotDescriptorTest {
         // if the last one is complextype, select all child
         List<Integer> usedSubfieldPos = new ArrayList<>();
         usedSubfieldPos.add(1);
-        colRef.addUsedSubfieldPos(usedSubfieldPos);
+        colRef.addUsedSubfieldPos(ImmutableList.copyOf(usedSubfieldPos));
         slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
         Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
         Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
@@ -64,7 +68,7 @@ public class SlotDescriptorTest {
     public void testSetUsedSubfieldPosGroupLeaf() {
         // if the last one is a leaf
         List<Integer> usedSubfieldPos = Arrays.asList(1, 1);
-        colRef.addUsedSubfieldPos(usedSubfieldPos);
+        colRef.addUsedSubfieldPos(ImmutableList.copyOf(usedSubfieldPos));
         slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
         Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
         Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
@@ -77,9 +81,9 @@ public class SlotDescriptorTest {
     @Test
     public void testSetUsedSubfieldPosGroupTwoPos() {
         List<Integer> usedSubfieldPos1 = Arrays.asList(1, 1);
-        colRef.addUsedSubfieldPos(usedSubfieldPos1);
+        colRef.addUsedSubfieldPos(ImmutableList.copyOf(usedSubfieldPos1));
         List<Integer> usedSubfieldPos2 = Arrays.asList(1, 0);
-        colRef.addUsedSubfieldPos(usedSubfieldPos2);
+        colRef.addUsedSubfieldPos(ImmutableList.copyOf(usedSubfieldPos2));
         slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
         Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
         Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
@@ -93,7 +97,7 @@ public class SlotDescriptorTest {
     public void testSetUsedSubfieldPosGroupMapAllField() {
         // if the last one is a leaf
         List<Integer> usedSubfieldPos = Arrays.asList(1, -1);
-        colRef.addUsedSubfieldPos(usedSubfieldPos);
+        colRef.addUsedSubfieldPos(ImmutableList.copyOf(usedSubfieldPos));
         slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
         Assert.assertEquals(2, typeMapArrayMap.getSelectedFields().length);
         Assert.assertEquals(false, typeMapArrayMap.getSelectedFields()[0]);
@@ -106,7 +110,7 @@ public class SlotDescriptorTest {
         SlotDescriptor slot_new = new SlotDescriptor(SlotId.createGenerator().getNextId(), "clone_map", map_new, true);
         ColumnRefOperator colRef_new = new ColumnRefOperator(0, map_new, "clone_map", true);
         List<Integer> usedSubfield = Arrays.asList(-1);
-        colRef_new.addUsedSubfieldPos(usedSubfield);
+        colRef_new.addUsedSubfieldPos(ImmutableList.copyOf(usedSubfield));
         slot_new.setUsedSubfieldPosGroup(colRef_new.getUsedSubfieldPosGroup());
         Assert.assertEquals(2, map_new.getSelectedFields().length);
         // the cloned map selected 1, 1
@@ -121,8 +125,98 @@ public class SlotDescriptorTest {
     public void testSetUsedSubfieldPosGroupMapWrongField() {
         // if the last one is a leaf
         List<Integer> usedSubfieldPos = Arrays.asList(0, 0, 0);
-        colRef.addUsedSubfieldPos(usedSubfieldPos);
+        colRef.addUsedSubfieldPos(ImmutableList.copyOf(usedSubfieldPos));
         Assert.assertThrows(IllegalStateException.class, ()->slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup()));
     }
 
+    @Test
+    public void testStructSubfield() {
+        Type field1 = ScalarType.createType(PrimitiveType.INT);
+        Type field2Map = new MapType(ScalarType.createType(PrimitiveType.INT), ScalarType.createType(PrimitiveType.VARCHAR));
+        Type field2Str = ScalarType.createType(PrimitiveType.VARCHAR);
+        StructField structField1 = new StructField("subfield1", field2Map);
+        StructField structField2 = new StructField("subfield2", field2Str);
+        ArrayList<StructField> list1 = new ArrayList<>();
+        list1.add(structField1);
+        list1.add(structField2);
+        Type field2 = new StructType(list1);
+
+
+        StructField topLevel1 = new StructField("field1", field1);
+        StructField topLevel2 = new StructField("field2", field2);
+        ArrayList<StructField> list2 = new ArrayList<>();
+        list2.add(topLevel1);
+        list2.add(topLevel2);
+
+        StructType topType = new StructType(list2);
+
+        // type: {
+        //   "field1": INT
+        //   "field2": {
+        //      "subfield1": Map<INT, VARCHAR>,
+        //      "subfield2": VARCHAR
+        //   }
+        // }
+
+        {
+            StructType cloneType = topType.clone();
+            SlotDescriptor slot = new SlotDescriptor(SlotId.createGenerator().getNextId(),
+                    "struct_type", cloneType, true);
+            ColumnRefOperator colRef = new ColumnRefOperator(0, cloneType, "struct_type", true);
+            colRef.addUsedSubfieldPos(ImmutableList.copyOf(new LinkedList<>()));
+            slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
+
+            Assert.assertTrue(cloneType.getSelectedFields()[0]);
+            Assert.assertTrue(cloneType.getSelectedFields()[1]);
+
+            Type tmpType = cloneType.getField(1).getType();
+            Assert.assertTrue(tmpType.getSelectedFields()[0]);
+            Assert.assertTrue(tmpType.getSelectedFields()[1]);
+
+            tmpType = ((StructType) tmpType).getField(0).getType();
+            Assert.assertTrue(tmpType.getSelectedFields()[0]);
+            Assert.assertTrue(tmpType.getSelectedFields()[1]);
+        }
+
+        {
+            StructType cloneType = topType.clone();
+            SlotDescriptor slot = new SlotDescriptor(SlotId.createGenerator().getNextId(),
+                    "struct_type", cloneType, true);
+            ColumnRefOperator colRef = new ColumnRefOperator(0, cloneType, "struct_type", true);
+            colRef.addUsedSubfieldPos(ImmutableList.copyOf(Arrays.asList(1)));
+            slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
+
+            Assert.assertFalse(cloneType.getSelectedFields()[0]);
+            Assert.assertTrue(cloneType.getSelectedFields()[1]);
+
+            Type tmpType = cloneType.getField(1).getType();
+            Assert.assertTrue(tmpType.getSelectedFields()[0]);
+            Assert.assertTrue(tmpType.getSelectedFields()[1]);
+
+            tmpType = ((StructType) tmpType).getField(0).getType();
+            Assert.assertTrue(tmpType.getSelectedFields()[0]);
+            Assert.assertTrue(tmpType.getSelectedFields()[1]);
+        }
+
+        {
+            StructType cloneType = topType.clone();
+            SlotDescriptor slot = new SlotDescriptor(SlotId.createGenerator().getNextId(),
+                    "struct_type", cloneType, true);
+            ColumnRefOperator colRef = new ColumnRefOperator(0, cloneType, "struct_type", true);
+            colRef.addUsedSubfieldPos(ImmutableList.copyOf(Arrays.asList(1, 1)));
+            slot.setUsedSubfieldPosGroup(colRef.getUsedSubfieldPosGroup());
+
+            Assert.assertFalse(cloneType.getSelectedFields()[0]);
+            Assert.assertTrue(cloneType.getSelectedFields()[1]);
+
+            Type tmpType = cloneType.getField(1).getType();
+            Assert.assertFalse(tmpType.getSelectedFields()[0]);
+            Assert.assertTrue(tmpType.getSelectedFields()[1]);
+
+            tmpType = ((StructType) tmpType).getField(0).getType();
+            Assert.assertFalse(tmpType.getSelectedFields()[0]);
+            Assert.assertFalse(tmpType.getSelectedFields()[1]);
+        }
+
+    }
 }


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

This pr avoids reading redundant data in BE by determining the struct subfield that needs to be materialized in FE.
Cherry-Pick: #13401 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
