### PR TITLE
[Enhancement] Remove sensitive info of create repo stmt from audit log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -43,6 +43,7 @@ import com.starrocks.mysql.privilege.Privilege;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.BaseGrantRevokePrivilegeStmt;
 import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.DefaultValueExpr;
@@ -138,6 +139,19 @@ public class AstToStringBuilder {
                 sb.append(stringStringPair.first + " = " + stringStringPair.second);
                 idx++;
             }
+            return sb.toString();
+        }
+
+        public String visitCreateRepositoryStatement(CreateRepositoryStmt stmt, Void context) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("CREATE REPOSITORY ").append(stmt.getName());
+            sb.append(" WITH BROKER ").append(stmt.getBrokerName());
+            sb.append(" ON LOCATION \"").append(stmt.getLocation()).append("\"");
+
+
+            sb.append(" PROPERTIES (");
+            sb.append(new PrintableMap<String, String>(stmt.getProperties(), "=", true, false, true));
+            sb.append(" )");
             return sb.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRepositoryStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRepositoryStmt.java
@@ -54,4 +54,9 @@ public class CreateRepositoryStmt extends DdlStmt {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitCreateRepositoryStatement(this, context);
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRepositoryStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRepositoryStmtTest.java
@@ -1,0 +1,45 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.UserException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AST2SQL;
+import com.starrocks.sql.ast.CreateRepositoryStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateRepositoryStmtTest {
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
+    @Test
+    public void testNormal() throws UserException {
+        String sql =
+                "CREATE REPOSITORY `hdfs_repo` WITH BROKER `hdfs_broker` ON LOCATION \"hdfs://hadoop-name-node:54310/path/to/repo/\" " +
+                        " PROPERTIES ( \"username\" = \"username1\", \"password\" = \"password1\" )";
+        CreateRepositoryStmt stmt = (CreateRepositoryStmt) com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        Assert.assertTrue(stmt.needAuditEncryption());
+        Assert.assertEquals("hdfs_broker", stmt.getBrokerName());
+        Assert.assertEquals("hdfs_repo", stmt.getName());
+        Assert.assertEquals("hdfs://hadoop-name-node:54310/path/to/repo/", stmt.getLocation());
+        Assert.assertNotNull(stmt.getProperties());
+    }
+
+    @Test
+    public void testToString() {
+        String sql =
+                "CREATE REPOSITORY `hdfs_repo` WITH BROKER `hdfs_broker` ON LOCATION \"hdfs://hadoop-name-node:54310/path/to/repo/\" " +
+                        " PROPERTIES ( \"username\" = \"username1\", \"password\" = \"password1\" )";
+        CreateRepositoryStmt stmt = (CreateRepositoryStmt) com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        Assert.assertEquals("CREATE REPOSITORY hdfs_repo WITH BROKER hdfs_broker ON LOCATION \"hdfs://hadoop-name-node:54310/path/to/repo/\" " +
+                "PROPERTIES (\"password\" = \"*XXX\", \"username\" = \"username1\" )", AST2SQL.toString(stmt));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRepositoryStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRepositoryStmtTest.java
@@ -4,7 +4,7 @@ package com.starrocks.analysis;
 
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.analyzer.AST2SQL;
+import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
@@ -40,6 +40,6 @@ public class CreateRepositoryStmtTest {
                         " PROPERTIES ( \"username\" = \"username1\", \"password\" = \"password1\" )";
         CreateRepositoryStmt stmt = (CreateRepositoryStmt) com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
         Assert.assertEquals("CREATE REPOSITORY hdfs_repo WITH BROKER hdfs_broker ON LOCATION \"hdfs://hadoop-name-node:54310/path/to/repo/\" " +
-                "PROPERTIES (\"password\" = \"*XXX\", \"username\" = \"username1\" )", AST2SQL.toString(stmt));
+                "PROPERTIES (\"password\" = \"***\", \"username\" = \"username1\" )", AstToStringBuilder.toString(stmt));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13324

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR removes access key/secret from audit log of create repo stmt. The new output would be like
```
2022-11-15 20:45:32,777 [query] |Client=127.0.0.1:56422|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=db0|State=ERR|ErrorCode=|Time=10|ScanBytes=0|ScanRows=0|ReturnRows=0|CpuCostNs=0|MemCostBytes=0|StmtId=3|QueryId=2834574d-64f4-11ed-bbf0-52243889412b|IsQuery=false|feIp=172.17.0.1|Stmt=CREATE REPOSITORY `hdfs_repo` WITH BROKER `hdfs_broker` ON LOCATION "hdfs://hadoop-name-node:54310/path/to/repo/" PROPERTIES ( "username" = "user", "password" = "*XXX" )|Dig
```
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
