### PR TITLE
[Enhancement] Remove sensitive info from audit log of create resource stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -45,6 +45,7 @@ public class PrintableMap<K, V> {
         SENSITIVE_KEY.add("fs.cosn.userinfo.secretId");
         SENSITIVE_KEY.add("fs.cosn.userinfo.secretKey");
         SENSITIVE_KEY.add("property.sasl.password");
+        SENSITIVE_KEY.add("broker.password");
     }
 
     public PrintableMap(Map<K, V> map, String keyValueSaperator,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -58,6 +58,7 @@ import com.starrocks.sql.ast.BaseGrantRevokePrivilegeStmt;
 import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.DataDescription;
+import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.DefaultValueExpr;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.ExceptRelation;
@@ -151,6 +152,16 @@ public class AstToStringBuilder {
                 sb.append(stringStringPair.first + " = " + stringStringPair.second);
                 idx++;
             }
+            return sb.toString();
+        }
+
+        public String visitCreateResourceStatement(CreateResourceStmt stmt, Void context) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("CREATE EXTERNAL RESOURCE ").append(stmt.getResourceName());
+
+            sb.append(" PROPERTIES (");
+            sb.append(new PrintableMap<String, String>(stmt.getProperties(), "=", true, false, true));
+            sb.append(")");
             return sb.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateResourceStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateResourceStmt.java
@@ -59,5 +59,10 @@ public class CreateResourceStmt extends DdlStmt {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitCreateResourceStatement(this, context);
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return true;
+    }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ResourceStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ResourceStmtTest.java
@@ -93,4 +93,11 @@ public class ResourceStmtTest {
         // bad case for resource name
         analyzeFail("drop resource 01hive");
     }
+
+    @Test
+    public void testCreateResourceStmtToString() {
+        CreateResourceStmt stmt = (CreateResourceStmt) analyzeSuccess(
+                "CREATE EXTERNAL RESOURCE \"spark0\" PROPERTIES ( \"type\" = \"spark\", \"spark.master\" = \"yarn\", \"spark.submit.deployMode\" = \"cluster\", \"spark.jars\" = \"xxx.jar,yyy.jar\", \"spark.files\" = \"/tmp/aaa,/tmp/bbb\", \"spark.executor.memory\" = \"1g\", \"spark.yarn.queue\" = \"queue0\", \"spark.hadoop.yarn.resourcemanager.address\" = \"resourcemanager_host:8032\", \"spark.hadoop.fs.defaultFS\" = \"hdfs://namenode_host:9000\", \"working_dir\" = \"hdfs://namenode_host:9000/tmp/starrocks\", \"broker\" = \"broker0\", \"broker.username\" = \"user0\", \"broker.password\" = \"password0\" )");
+        Assert.assertEquals("CREATE EXTERNAL RESOURCE spark0 PROPERTIES (\"spark.executor.memory\" = \"1g\", \"spark.master\" = \"yarn\", \"working_dir\" = \"hdfs://namenode_host:9000/tmp/starrocks\", \"broker.password\" = \"***\", \"spark.submit.deployMode\" = \"cluster\", \"type\" = \"spark\", \"broker\" = \"broker0\", \"spark.hadoop.yarn.resourcemanager.address\" = \"resourcemanager_host:8032\", \"spark.files\" = \"/tmp/aaa,/tmp/bbb\", \"spark.hadoop.fs.defaultFS\" = \"hdfs://namenode_host:9000\", \"spark.yarn.queue\" = \"queue0\", \"broker.username\" = \"user0\", \"spark.jars\" = \"xxx.jar,yyy.jar\")", AstToStringBuilder.toString(stmt));;
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13324

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR removes access key/secret from audit log of create resource stmt. The new output would be like
```
2022-11-16 10:28:26,584 [query] |Client=127.0.0.1:41444|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=db0|State=ERR|ErrorCode=|Time=17|ScanBytes=0|ScanRows=0|ReturnRows=0|CpuCostNs=0|MemCostBytes=0|StmtId=4|QueryId=59bf85c0-6556-11ed-8e50-52243889412b|IsQuery=false|feIp=172.17.0.1|Stmt=CREATE EXTERNAL RESOURCE "spark0" PROPERTIES (     "type" = "spark",     "spark.master" = "yarn",     "spark.submit.deployMode" = "cluster",     "spark.jars" = "xxx.jar,yyy.jar",     "spark.files" = "/tmp/aaa,/tmp/bbb",     "spark.executor.memory" = "1g",     "spark.yarn.queue" = "queue0",     "spark.hadoop.yarn.resourcemanager.address" = "resourcemanager_host:8032",     "spark.hadoop.fs.defaultFS" = "hdfs://namenode_host:9000",     "working_dir" = "hdfs://namenode_host:9000/tmp/starrocks",     "broker" = "broker0",     "broker.username" = "user0",     "broker.password" = "*XXX" )|Digest=|PlanCpuCost=0.0|PlanMemCost=0.0|PendingTimeMs=0
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
