### PR TITLE
[BugFix][cherry-pick] Fix the `show_be_version.sh` script execute error due to the lack of cachelib dependency

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -142,3 +142,8 @@ export_shared_envvars() {
     # ===================================================================================
 }
 
+# Export cachelib libraries
+export_cachelib_lib_path() {
+    CACHELIB_DIR=$STARROCKS_HOME/lib/cachelib
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CACHELIB_DIR/lib:$CACHELIB_DIR/lib64:$CACHELIB_DIR/deps/lib:$CACHELIB_DIR/deps/lib64
+}

--- a/bin/show_be_version.sh
+++ b/bin/show_be_version.sh
@@ -18,4 +18,6 @@ else
     fi
 fi
 
+export_cachelib_lib_path
+
 ${STARROCKS_HOME}/lib/starrocks_be --version

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -76,8 +76,8 @@ else
     fi
 fi
 
-CACHELIB_DIR=$STARROCKS_HOME/lib/cachelib
-export LD_LIBRARY_PATH=$STARROCKS_HOME/lib/hadoop/native:$CACHELIB_DIR/lib:$CACHELIB_DIR/lib64:$CACHELIB_DIR/deps/lib:$CACHELIB_DIR/deps/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$STARROCKS_HOME/lib/hadoop/native:$LD_LIBRARY_PATH
+export_cachelib_lib_path
 
 # check java version and choose correct JAVA_OPTS
 JAVA_VERSION=$(jdk_version)

--- a/bin/start_cn.sh
+++ b/bin/start_cn.sh
@@ -77,6 +77,7 @@ else
 fi
 
 export LD_LIBRARY_PATH=$STARROCKS_HOME/lib/hadoop/native:$LD_LIBRARY_PATH
+export_cachelib_lib_path
 
 # HADOOP_CLASSPATH defined in $STARROCKS_HOME/conf/hadoop_env.sh
 # put $STARROCKS_HOME/conf ahead of $HADOOP_CLASSPATH so that custom config can replace the config in $HADOOP_CLASSPATH


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

StarRocks BE depends some cachelib dependency now, if not specify the library path, the binary may execute failed.

(cherry-pick from #13411)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
