### PR TITLE
[BugFix] Use std::abs instead of abs

### DIFF
--- a/be/src/geo/geo_types.cpp
+++ b/be/src/geo/geo_types.cpp
@@ -30,6 +30,7 @@
 #include <s2/util/coding/coder.h>
 #include <s2/util/units/length-units.h>
 
+#include <cmath>
 #include <cstdio>
 #include <iomanip>
 #include <memory>
@@ -46,7 +47,7 @@ void print_s2point(std::ostream& os, const S2Point& point) {
 }
 
 static inline bool is_valid_lng_lat(double lng, double lat) {
-    return abs(lng) <= 180 && abs(lat) <= 90;
+    return std::abs(lng) <= 180 && std::abs(lat) <= 90;
 }
 
 // Return GEO_PARSE_OK, if and only if this can be converted to a valid S2Point

--- a/be/src/runtime/decimalv3.h
+++ b/be/src/runtime/decimalv3.h
@@ -4,6 +4,7 @@
 
 #include <fmt/format.h>
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -75,8 +76,8 @@ public:
         // [b/2] == r means round half to up.
         // carry depends on sign of a^b.
         Type carry = ((a ^ b) >> (sizeof(Type) * 8 - 1)) | 1;
-        Type abs_b = abs(b);
-        Type abs_r = abs(r);
+        Type abs_b = std::abs(b);
+        Type abs_r = std::abs(r);
         bool need_carry = ((abs_b >> 1) + (abs_b & 1)) <= abs_r;
         *c += carry & -Type(need_carry);
         return false;
@@ -211,9 +212,9 @@ public:
             return (*dec_value == float_lower_overflow_indicator<To>) ||
                    (*dec_value == float_upper_overflow_indicator<To>);
         } else if constexpr (is_decimal128<To>) {
-            // abs(value)<1.0 -> 0: Acceptable
-            // abs(value)>=1.0 -> 0 or different sign: Overflow!!
-            return abs(value) >= From(1) && (*dec_value == To(0) || ((value < From(0)) ^ (*dec_value < To(0))));
+            // std::abs(value)<1.0 -> 0: Acceptable
+            // std::abs(value)>=1.0 -> 0 or different sign: Overflow!!
+            return std::abs(value) >= From(1) && (*dec_value == To(0) || ((value < From(0)) ^ (*dec_value < To(0))));
         } else {
             static_assert(is_decimal<To>, "invalid decimal type");
         }
@@ -272,7 +273,7 @@ public:
 
         if constexpr (rule == ROUND_HALF_UP || rule == ROUND_HALF_EVEN) {
             //TODO(by satanson): ROUND_HALF_UP is different from ROUND_HALF_EVEN
-            need_round = abs(remainder) >= (divisor >> 1);
+            need_round = std::abs(remainder) >= (divisor >> 1);
         } else if constexpr (rule == ROUND_FLOOR) {
             need_round = remainder > 0 && quotient > 0;
         } else if constexpr (rule == ROUND_CEILING) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2,6 +2,7 @@
 
 #include "storage/tablet_updates.h"
 
+#include <cmath>
 #include <ctime>
 #include <memory>
 
@@ -2195,7 +2196,7 @@ void TabletUpdates::_print_rowsets(std::vector<uint32_t>& rowsets, std::string* 
                 auto& stats = *itr->second;
                 string bytes = PrettyPrinter::print(stats.byte_size, TUnit::BYTES);
                 // PrettyPrinter doesn't support negative value
-                string compaction = PrettyPrinter::print(abs(stats.compaction_score), TUnit::BYTES);
+                string compaction = PrettyPrinter::print(std::abs(stats.compaction_score), TUnit::BYTES);
                 const char* cprefix = "";
                 if (stats.compaction_score < 0) {
                     cprefix = "-";

--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -714,7 +714,7 @@ inline T StringParser::string_to_decimal(const char* s, int len, int type_precis
                 if (LIKELY(divisor >= 0)) {
                     T remainder = value % divisor;
                     value /= divisor;
-                    if (abs(remainder) >= (divisor >> 1)) {
+                    if (std::abs(remainder) >= (divisor >> 1)) {
                         value += 1;
                     }
                 } else {

--- a/be/src/util/time.cpp
+++ b/be/src/util/time.cpp
@@ -18,6 +18,7 @@
 #include "util/time.h"
 
 #include <chrono>
+#include <cmath>
 #include <cstdlib>
 #include <iomanip>
 #include <sstream>
@@ -53,20 +54,20 @@ static string TimepointToString(const chrono::system_clock::time_point& t, bool 
 // Format the sub-second part of the input time point object 't', at the
 // precision specified by 'p'. The returned string is meant to be appended to
 // the string returned by TimePointToString() above.
-// Note the use of abs(). This is to make sure we correctly format negative times,
+// Note the use of std::abs(). This is to make sure we correctly format negative times,
 // i.e., times before the Unix epoch.
 static string FormatSubSecond(const chrono::system_clock::time_point& t, TimePrecision p) {
     std::stringstream ss;
     auto frac = t.time_since_epoch();
     if (p == TimePrecision::Millisecond) {
         auto subsec = chrono::duration_cast<chrono::milliseconds>(frac) % MILLIS_PER_SEC;
-        ss << "." << std::setfill('0') << std::setw(3) << abs(subsec.count());
+        ss << "." << std::setfill('0') << std::setw(3) << std::abs(subsec.count());
     } else if (p == TimePrecision::Microsecond) {
         auto subsec = chrono::duration_cast<chrono::microseconds>(frac) % MICROS_PER_SEC;
-        ss << "." << std::setfill('0') << std::setw(6) << abs(subsec.count());
+        ss << "." << std::setfill('0') << std::setw(6) << std::abs(subsec.count());
     } else if (p == TimePrecision::Nanosecond) {
         auto subsec = chrono::duration_cast<chrono::nanoseconds>(frac) % NANOS_PER_SEC;
-        ss << "." << std::setfill('0') << std::setw(9) << abs(subsec.count());
+        ss << "." << std::setfill('0') << std::setw(9) << std::abs(subsec.count());
     } else {
         // 1-second precision or unknown unit. Return empty string.
         DCHECK_EQ(TimePrecision::Second, p);

--- a/be/test/exec/query_cache/query_cache_test.cpp
+++ b/be/test/exec/query_cache/query_cache_test.cpp
@@ -472,7 +472,7 @@ static ValidateFuncGenerator eq_validator_gen = [](double expect) {
 
 static ValidateFuncGenerator approx_validator_gen = [](double expect) {
     return [expect](double actual) {
-        auto abs_value = std::max(std::abs(expect), abs(actual));
+        auto abs_value = std::max(std::abs(expect), std::abs(actual));
         LOG(INFO) << strings::Substitute("approx_validate: expect=$0, actual=$1", expect, actual);
         ASSERT_TRUE(abs_value == 0.0 || std::abs(expect - actual) / abs_value < 0.001);
     };

--- a/be/test/exec/query_cache/query_cache_test.cpp
+++ b/be/test/exec/query_cache/query_cache_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <thread>
 #include <utility>
@@ -471,9 +472,9 @@ static ValidateFuncGenerator eq_validator_gen = [](double expect) {
 
 static ValidateFuncGenerator approx_validator_gen = [](double expect) {
     return [expect](double actual) {
-        auto abs_value = std::max(abs(expect), abs(actual));
+        auto abs_value = std::max(std::abs(expect), abs(actual));
         LOG(INFO) << strings::Substitute("approx_validate: expect=$0, actual=$1", expect, actual);
-        ASSERT_TRUE(abs_value == 0.0 || abs(expect - actual) / abs_value < 0.001);
+        ASSERT_TRUE(abs_value == 0.0 || std::abs(expect - actual) / abs_value < 0.001);
     };
 };
 

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -284,7 +284,7 @@ void test_agg_variance_function(FunctionContext* ctx, const AggregateFunction* f
     func->serialize_to_column(ctx, state->state(), serde_column.get());
     func->merge(ctx, serde_column.get(), state2->state(), 0);
     func->finalize_to_column(ctx, state2->state(), result_column.get());
-    ASSERT_TRUE(abs(merge_result - result_column->get_data()[2]) < 1e-8);
+    ASSERT_TRUE(std::abs(merge_result - result_column->get_data()[2]) < 1e-8);
 }
 
 TEST_F(AggregateTest, test_count) {

--- a/be/test/exprs/vectorized/decimal_cast_expr_test_helper.h
+++ b/be/test/exprs/vectorized/decimal_cast_expr_test_helper.h
@@ -1,8 +1,9 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
 #pragma once
-
 #include <gtest/gtest.h>
+
+#include <cmath>
 
 #include "butil/time.h"
 #include "column/column_helper.h"
@@ -189,7 +190,7 @@ void assert_equal(std::string const& expect, std::string const& actual, [[maybe_
         auto expect_value = cast_value<TYPE_VARCHAR, Type>(expect, -1, -1, precision, scale);
         auto actual_value = cast_value<TYPE_VARCHAR, Type>(actual, -1, -1, precision, scale);
         auto delta = (expect_value - actual_value);
-        double epsilon = abs(double(delta)) / double(expect_value + (expect_value == CppType(0)));
+        double epsilon = std::abs(double(delta)) / double(expect_value + (expect_value == CppType(0)));
         ASSERT_TRUE(epsilon < 0.0000001);
     } else {
         compare_decimal_string(expect, actual, scale);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

/be/ut_build_ASAN/test/starrocks_test  --gtest_filter=*testCastFromDoubleToDecimal128p35s30Abnormal* fails in https://github.com/StarRocks/starrocks/pull/13435.
The reason is that:
![image](https://user-images.githubusercontent.com/1721321/202111017-3cb36ff8-9ac0-4234-bfe7-4b1000b59f91.png)
The line in red rectangular gives the wrong answers. abs(int32) is used instead fo abs(double)

```
0x000000000c4b2a94        216                    return abs(value) >= From(1) && (*dec_value == To(0) || ((value < From(0)) ^ (*dec_value < To(0))));
   0x000000000c4b2a8b <_ZN9starrocks13DecimalV3Cast10from_floatIdnEEbNSt9enable_ifIX19is_floating_point_vIT_EES3_E4typeERKNS2_IX29is_underlying_type_of_decimalIT0_EES6_E4typeEPS8_+166>:        c5 fb 10 45 e8        vmovsd -0x18(%rbp),%xmm0
   0x000000000c4b2a90 <_ZN9starrocks13DecimalV3Cast10from_floatIdnEEbNSt9enable_ifIX19is_floating_point_vIT_EES3_E4typeERKNS2_IX29is_underlying_type_of_decimalIT0_EES6_E4typeEPS8_+171>:        c5 fb 2c c0        vcvttsd2si %xmm0,%eax
=> 0x000000000c4b2a94 <_ZN9starrocks13DecimalV3Cast10from_floatIdnEEbNSt9enable_ifIX19is_floating_point_vIT_EES3_E4typeERKNS2_IX29is_underlying_type_of_decimalIT0_EES6_E4typeEPS8_+175>:        89 c2        mov    %eax,%edx
   0x000000000c4b2a96 <_ZN9starrocks13DecimalV3Cast10from_floatIdnEEbNSt9enable_ifIX19is_floating_point_vIT_EES3_E4typeERKNS2_IX29is_underlying_type_of_decimalIT0_EES6_E4typeEPS8_+177>:        f7 da        neg    %edx
   0x000000000c4b2a98 <_ZN9starrocks13DecimalV3Cast10from_floatIdnEEbNSt9enable_ifIX19is_floating_point_vIT_EES3_E4typeERKNS2_IX29is_underlying_type_of_decimalIT0_EES6_E4typeEPS8_+179>:        0f 49 c2        cmovns %edx,%eax
```
vcvttsd2si truncates the double into int32_t, so use std::abs instead of abs