### PR TITLE
[Enhancement] limit fetch partitions size of per rpc when manual refreshing external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1508,6 +1508,12 @@ public class Config extends ConfigBase {
     public static long remote_file_cache_ttl_s = 3600 * 36L;
 
     /**
+     * The maximum number of partitions to fetch from the metastore in one RPC.
+     */
+    @ConfField
+    public static int max_hive_partitions_per_rpc = 1000;
+
+    /**
      * The interval of lazy refreshing remote file's metadata cache
      */
     @ConfField


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
