### PR TITLE
[BugFix] Fix BE's GC module cannot delete expired txn logs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -590,7 +590,7 @@ public class GlobalTransactionMgr implements Writable {
             DatabaseTransactionMgr dbTransactionMgr = entry.getValue();
             result = min(result, dbTransactionMgr.getMinActiveTxnId());
         }
-        return result == Long.MAX_VALUE ? null : result;
+        return result == Long.MAX_VALUE ? idGenerator.peekNextTransactionId() : result;
     }
 
     public TransactionState getTransactionState(long dbId, long transactionId) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionIdGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionIdGenerator.java
@@ -54,6 +54,10 @@ public class TransactionIdGenerator {
         }
     }
 
+    public synchronized long peekNextTransactionId() {
+        return nextId + 1;
+    }
+
     public synchronized void initTransactionId(long id) {
         if (id > batchEndId) {
             batchEndId = id;


### PR DESCRIPTION
BE's GC module can only delete txn log whose id is smaller than the `min_active_txn_id` field of the heartbeat request, and the value of `min_active_txn_id` is calculated from
GlobalTransactionMgr::getMinActiveTxnId().

In the original implementation, GlobalTransactionMgr::getMinActiveTxnId() would return null, if there are no running transactions, then `min_active_txn_id` would be 0, which in turn prevents BE's GC module from deleting any TxnLog.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
