### PR TITLE
[BugFix] Fix query view failed when upgrade to 2.4/2.5

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
@@ -193,5 +193,6 @@ public class View extends Table {
         originalViewDef = Text.readString(in);
         originalViewDef = "";
         inlineViewDef = Text.readString(in);
+        inlineViewDef = inlineViewDef.replaceAll("default_cluster:", "");
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13516

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`default_cluster` is deprecated after 2.4, but the sql of view still remains default_cluster prefix for db, it will cause query failed. Remove the `default_cluster:` prefix when deserializing view.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
