### PR TITLE
[Bugfix] change the default value of case_sensitive to true

### DIFF
--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -104,7 +104,7 @@ private:
     bool _has_partition_columns = false;
 
     std::vector<std::string> _hive_column_names;
-    bool _case_sensitive = false;
+    bool _case_sensitive = true;
     const HiveTableDescriptor* _hive_table = nullptr;
 
     // ======================================

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -124,7 +124,7 @@ struct HdfsScannerParams {
 
     std::vector<std::string>* hive_column_names = nullptr;
 
-    bool case_sensitive = false;
+    bool case_sensitive = true;
 
     HdfsScanProfile* profile = nullptr;
 
@@ -175,7 +175,7 @@ struct HdfsScannerContext {
     // runtime filters.
     const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
 
-    bool case_sensitive = false;
+    bool case_sensitive = true;
 
     std::string timezone;
 

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -167,7 +167,7 @@ private:
     std::shared_ptr<Column::Filter> _broker_load_filter;
     size_t _num_rows_filtered;
     const std::vector<std::string>* _hive_column_names = nullptr;
-    bool _case_sensitive = false;
+    bool _case_sensitive = true;
     std::unordered_map<std::string, int> _name_to_column_id;
     RuntimeState* _state;
     SlotDescriptor* _current_slot;

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -22,7 +22,7 @@ struct ColumnReaderContext {
 
 struct ColumnReaderOptions {
     std::string timezone;
-    bool case_sensitive = false;
+    bool case_sensitive = true;
     int chunk_size = 0;
     vectorized::HdfsScanStats* stats = nullptr;
     RandomAccessFile* file = nullptr;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -61,7 +61,7 @@ struct GroupReaderParam {
 
     FileMetaData* file_metadata = nullptr;
 
-    bool case_sensitive = false;
+    bool case_sensitive = true;
 };
 
 class GroupReader {


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

it's introduced in this PR: https://github.com/StarRocks/starrocks/pull/9744.

A column of a iceberg table is capitalized. When we use this column as a filter condition, the returned result is empty.

https://github.com/StarRocks/starrocks/pull/9744 introduced a case sensitive flag, but, it changes the previous logic, we should set case sensitive to true to keep backward-compatiblity.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
