### PR TITLE
[Enhancement] Reduce lock contention of query context

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -530,6 +530,7 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
                 driver->set_morsel_queue(morsel_queue_factory->create(i));
                 if (auto* scan_operator = driver->source_scan_operator()) {
                     scan_operator->set_workgroup(_wg);
+                    scan_operator->set_query_ctx(_query_ctx->get_shared_ptr());
                     if (dynamic_cast<ConnectorScanOperator*>(scan_operator) != nullptr) {
                         if (_wg != nullptr) {
                             scan_operator->set_scan_executor(exec_env->connector_scan_executor_with_workgroup());

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -186,7 +186,7 @@ void QueryContextManager::_clean_func(QueryContextManager* manager) {
 }
 
 size_t QueryContextManager::_slot_idx(const TUniqueId& query_id) {
-    return std::hash<size_t>()(query_id.lo) & _slot_mask;
+    return HashUtil::hash(&query_id.hi, sizeof(query_id.hi), 0) & _slot_mask;
 }
 
 QueryContextManager::~QueryContextManager() {

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -25,7 +25,7 @@ using std::chrono::milliseconds;
 using std::chrono::steady_clock;
 using std::chrono::duration_cast;
 // The context for all fragment of one query in one BE
-class QueryContext {
+class QueryContext : public std::enable_shared_from_this<QueryContext> {
 public:
     QueryContext();
     ~QueryContext();
@@ -135,6 +135,8 @@ public:
     std::shared_ptr<QueryStatisticsRecvr> maintained_query_recv();
     bool is_result_sink() const { return _is_result_sink; }
     void set_result_sink(bool value) { _is_result_sink = value; }
+
+    QueryContextPtr get_shared_ptr() { return shared_from_this(); }
 
 public:
     static constexpr int DEFAULT_EXPIRE_SECONDS = 300;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -312,10 +312,6 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     _num_running_io_tasks++;
     _is_io_task_running[chunk_source_index] = true;
 
-    // to avoid holding mutex in bthread, we choose to initialize lazily here instead of in prepare
-    if (is_uninitialized(_query_ctx)) {
-        _query_ctx = state->exec_env()->query_context_mgr()->get(state->query_id());
-    }
     starrocks::debug::QueryTraceContext query_trace_ctx = starrocks::debug::tls_trace_ctx;
     query_trace_ctx.id = reinterpret_cast<int64_t>(_chunk_sources[chunk_source_index].get());
     int32_t driver_id = CurrentThread::current().get_driver_id();
@@ -454,6 +450,10 @@ void ScanOperator::_merge_chunk_source_profiles() {
 
     _unique_metrics->copy_all_info_strings_from(merged_profile);
     _unique_metrics->copy_all_counters_from(merged_profile);
+}
+
+void ScanOperator::set_query_ctx(std::shared_ptr<QueryContext> query_ctx) {
+    _query_ctx = std::move(query_ctx);
 }
 
 // ========== ScanOperatorFactory ==========

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -452,7 +452,7 @@ void ScanOperator::_merge_chunk_source_profiles() {
     _unique_metrics->copy_all_counters_from(merged_profile);
 }
 
-void ScanOperator::set_query_ctx(const std::shared_ptr<QueryContext>& query_ctx) {
+void ScanOperator::set_query_ctx(const QueryContextPtr& query_ctx) {
     _query_ctx = query_ctx;
 }
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -452,8 +452,8 @@ void ScanOperator::_merge_chunk_source_profiles() {
     _unique_metrics->copy_all_counters_from(merged_profile);
 }
 
-void ScanOperator::set_query_ctx(std::shared_ptr<QueryContext> query_ctx) {
-    _query_ctx = std::move(query_ctx);
+void ScanOperator::set_query_ctx(const std::shared_ptr<QueryContext>& query_ctx) {
+    _query_ctx = query_ctx;
 }
 
 // ========== ScanOperatorFactory ==========

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -62,6 +62,8 @@ public:
     void set_cache_operator(const query_cache::CacheOperatorPtr& cache_operator) { _cache_operator = cache_operator; }
     void set_ticket_checker(query_cache::TicketCheckerPtr& ticket_checker) { _ticket_checker = ticket_checker; }
 
+    void set_query_ctx(std::shared_ptr<QueryContext> query_ctx);
+
 protected:
     static constexpr size_t kIOTaskBatchSize = 64;
 

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -62,7 +62,7 @@ public:
     void set_cache_operator(const query_cache::CacheOperatorPtr& cache_operator) { _cache_operator = cache_operator; }
     void set_ticket_checker(query_cache::TicketCheckerPtr& ticket_checker) { _ticket_checker = ticket_checker; }
 
-    void set_query_ctx(const std::shared_ptr<QueryContext>& query_ctx);
+    void set_query_ctx(const QueryContextPtr& query_ctx);
 
 protected:
     static constexpr size_t kIOTaskBatchSize = 64;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -62,7 +62,7 @@ public:
     void set_cache_operator(const query_cache::CacheOperatorPtr& cache_operator) { _cache_operator = cache_operator; }
     void set_ticket_checker(query_cache::TicketCheckerPtr& ticket_checker) { _ticket_checker = ticket_checker; }
 
-    void set_query_ctx(std::shared_ptr<QueryContext> query_ctx);
+    void set_query_ctx(const std::shared_ptr<QueryContext>& query_ctx);
 
 protected:
     static constexpr size_t kIOTaskBatchSize = 64;

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -280,6 +280,9 @@ public:
     WritableFile() = default;
     virtual ~WritableFile() = default;
 
+    // No copying allowed
+    DISALLOW_COPY(WritableFile);
+
     // Append data to the end of the file
     virtual Status append(const Slice& data) = 0;
 
@@ -316,11 +319,6 @@ public:
 
     // Returns the filename provided when the WritableFile was constructed.
     virtual const std::string& filename() const = 0;
-
-private:
-    // No copying allowed
-    WritableFile(const WritableFile&) = delete;
-    void operator=(const WritableFile&) = delete;
 };
 
 } // namespace starrocks

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -24,7 +24,7 @@ namespace starrocks {
 class RandomAccessFile;
 class WritableFile;
 class SequentialFile;
-class ResultFileOptions;
+struct ResultFileOptions;
 class TUploadReq;
 class TDownloadReq;
 struct WritableFileOptions;

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -235,6 +235,7 @@ void PipeLineFileScanNodeTest::prepare_pipeline() {
                         std::make_shared<PipelineDriver>(std::move(operators), _query_ctx, _fragment_ctx, driver_id++);
                 driver->set_morsel_queue(morsel_queue_factory->create(i));
                 if (auto* scan_operator = driver->source_scan_operator()) {
+                    scan_operator->set_query_ctx(_query_ctx->get_shared_ptr());
                     if (dynamic_cast<starrocks::pipeline::ConnectorScanOperator*>(scan_operator) != nullptr) {
                         scan_operator->set_scan_executor(_exec_env->connector_scan_executor_without_workgroup());
                     } else {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Set `query_ctx` to `ScanOperator` at preparing fragment.
    The first invocation of `ScanOperator::pull_chunk` uses `query_context_mgr()->get` to get `query_ctx`. As for the high-concurrency scenario, this read lock contention is pretty heavy.
2. Use `fnv_hash(hi)` instead of `std::hash(lo)`, because the `lo` of different query ids are the same, and `std::hash(hi) & mask` produces the same hash value for the query ids generated in a short duration. An example is as follows.


| query_id.hi          | std::hash(hi)        | std::hash(hi)                                                | Std::hash(hi)   & 0b111111 |
| -------------------- | -------------------- | ------------------------------------------------------------ | -------------------------- |
| -4652227574547738131 | 13794516499161813485 | 0b1011111101101111111101111010101101100100110011100001000111101101 | 45                         |
| -4652227570252770835 | 13794516503456780781 | 0b1011111101101111111101111010110001100100110011100001000111101101 | 45                         |
| -4652227557367868947 | 13794516516341682669 | 0b1011111101101111111101111010111101100100110011100001000111101101 | 45                         |
| -4652184603399941651 | 13794559470309609965 | 0b1011111101110000000111101100000001100100110011100001000111101101 | 45                         |
| -4652055750086094355 | 13794688323623457261 | 0b1011111101110000100100111111000101100100110011100001000111101101 | 45                         |
| -4652012787528232467 | 13794731286181319149 | 0b1011111101110000101110110000010001100100110011100001000111101101 | 45                         |
| -4651969833560305171 | 13794774240149246445 | 0b1011111101110000111000100001010101100100110011100001000111101101 | 45                         |
| -4651926879592377875 | 13794817194117173741 | 0b1011111101110001000010010010011001100100110011100001000111101101 | 45                         |
| -4651883925624450579 | 13794860148085101037 | 0b1011111101110001001100000011011101100100110011100001000111101101 | 45                         |
| -4651883921329483283 | 13794860152380068333 | 0b1011111101110001001100000011100001100100110011100001000111101101 | 45                         |
| -4651840967361555987 | 13794903106347995629 | 0b1011111101110001010101110100100101100100110011100001000111101101 | 45                         |
| -4651840963066588691 | 13794903110642962925 | 0b1011111101110001010101110100101001100100110011100001000111101101 | 45                         |
| -4689422231849266707 | 13757321841860284909 | 0b1011111011101011110100110101001101100100110011100001000111101101 | 45                         |
| -4689594060605877779 | 13757150013103673837 | 0b1011111011101011001101110000110001100100110011100001000111101101 | 45                         |
| -4651798009098661395 | 13794946064610890221 | 0b1011111101110001011111100101101101100100110011100001000111101101 | 45                         |
| -4651798004803694099 | 13794946068905857517 | 0b1011111101110001011111100101110001100100110011100001000111101101 | 45                         |
| -4689594064900845075 | 13757150008808706541 | 0b1011111011101011001101110000101101100100110011100001000111101101 | 45                         |
| -4651755050835766803 | 13794989022873784813 | 0b1011111101110001101001010110110101100100110011100001000111101101 | 45                         |
| -4651712096867839507 | 13795031976841712109 | 0b1011111101110001110011000111111001100100110011100001000111101101 | 45                         |
| -4651669142899912211 | 13795074930809639405 | 0b1011111101110001111100111000111101100100110011100001000111101101 | 45                         |
| -4652227565957803539 | 13794516507751748077 | 0b1011111101101111111101111010110101100100110011100001000111101101 | 45                         |







## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
