### PR TITLE
[Enhancement] don't use default value of table comment to unpartition hive/hudi table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/TableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/TableFactory.java
@@ -90,10 +90,10 @@ public class TableFactory {
         HiveTable hiveTable = tableBuilder.build();
 
         // partition key, commented for show partition key
-        String partitionCmt = "PARTITION BY (" + String.join(", ", hiveTable.getPartitionColumnNames()) + ")";
-        if (Strings.isNullOrEmpty(stmt.getComment())) {
+        if (Strings.isNullOrEmpty(stmt.getComment()) && hiveTable.getPartitionColumnNames().size() > 0) {
+            String partitionCmt = "PARTITION BY (" + String.join(", ", hiveTable.getPartitionColumnNames()) + ")";
             hiveTable.setComment(partitionCmt);
-        } else {
+        } else if (!Strings.isNullOrEmpty(stmt.getComment())) {
             hiveTable.setComment(stmt.getComment());
         }
         return hiveTable;
@@ -163,10 +163,10 @@ public class TableFactory {
         HudiTable hudiTable = tableBuilder.build();
 
         // partition key, commented for show partition key
-        String partitionCmt = "PARTITION BY (" + String.join(", ", hudiTable.getPartitionColumnNames()) + ")";
-        if (Strings.isNullOrEmpty(stmt.getComment())) {
+        if (Strings.isNullOrEmpty(stmt.getComment()) && hudiTable.getPartitionColumnNames().size() > 0) {
+            String partitionCmt = "PARTITION BY (" + String.join(", ", hudiTable.getPartitionColumnNames()) + ")";
             hudiTable.setComment(partitionCmt);
-        } else {
+        } else if (!Strings.isNullOrEmpty(stmt.getComment())) {
             hudiTable.setComment(stmt.getComment());
         }
         return hudiTable;


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
If we don't set table comment when creating external table. we use the partition info as comment. but current display is ambiguous for unpartitioned table. like:

select TABLE_COMMENT  from information_schema.tables limit 2;
+----------------------------------+
| TABLE_COMMENT                    |
+----------------------------------+
| PARTITION BY (col_date, col_int) |
| PARTITION BY ()                  |
-------------------------------

so we remove the default partition info on unpartitioned table.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
