### PR TITLE
[Refactor] Delete unused global runtime profile

### DIFF
--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -45,7 +45,12 @@ Status ScanNode::prepare(RuntimeState* state) {
     _rows_read_counter = ADD_COUNTER(runtime_profile(), _s_rows_read_counter, TUnit::UNIT);
     _read_timer = ADD_TIMER(runtime_profile(), _s_total_read_timer);
 #ifndef BE_TEST
-    _total_throughput_counter = runtime_profile()->add_rate_counter(_s_total_throughput_counter, _bytes_read_counter);
+    _total_throughput_counter = runtime_profile()->add_derived_counter(
+            _s_total_throughput_counter, TUnit::BYTES_PER_SECOND,
+            [bytes_read_counter = _bytes_read_counter, total_time_countger = runtime_profile()->total_time_counter()] {
+                return RuntimeProfile::units_per_second(bytes_read_counter, total_time_countger);
+            },
+            "");
 #endif
     _materialize_tuple_timer =
             ADD_CHILD_TIMER(runtime_profile(), _s_materialize_tuple_timer, _s_scanner_thread_total_wallclock_time);

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -55,9 +55,6 @@ static const std::string THREAD_INVOLUNTARY_CONTEXT_SWITCHES = "InvoluntaryConte
 
 const std::string RuntimeProfile::ROOT_COUNTER = ""; // NOLINT
 
-// NOLINTNEXTLINE
-RuntimeProfile::PeriodicCounterUpdateState RuntimeProfile::_s_periodic_counter_update_state;
-
 const std::unordered_set<std::string> RuntimeProfile::NON_MERGE_COUNTER_NAMES = {
         "DegreeOfParallelism", "RuntimeBloomFilterNum",      "RuntimeInFilterNum",  "PushdownPredicates", "MemoryLimit",
         "ChunkBufferCapacity", "DefaultChunkBufferCapacity", "PeakChunkBufferSize", "TabletCount"};
@@ -72,23 +69,6 @@ RuntimeProfile::RuntimeProfile(std::string name, bool is_averaged_profile)
           _counter_total_time(TUnit::TIME_NS, 0),
           _local_time_percent(0) {
     _counter_map["TotalTime"] = std::make_pair(&_counter_total_time, ROOT_COUNTER);
-}
-
-RuntimeProfile::~RuntimeProfile() {
-    decltype(_counter_map)::iterator iter;
-
-    for (iter = _counter_map.begin(); iter != _counter_map.end(); ++iter) {
-        stop_rate_counters_updates(iter->second.first);
-        stop_sampling_counters_updates(iter->second.first);
-    }
-
-    std::set<std::vector<Counter*>*>::const_iterator buckets_iter;
-
-    for (buckets_iter = _bucketing_counters.begin(); buckets_iter != _bucketing_counters.end(); ++buckets_iter) {
-        // This is just a clean up. No need to perform conversion. Also, the underlying
-        // counters might be gone already.
-        stop_bucketing_counters_updates(*buckets_iter, false);
-    }
 }
 
 void RuntimeProfile::merge(RuntimeProfile* other) {
@@ -769,72 +749,6 @@ int64_t RuntimeProfile::units_per_second(const RuntimeProfile::Counter* total_co
     return value;
 }
 
-RuntimeProfile::Counter* RuntimeProfile::add_rate_counter(const std::string& name, Counter* src_counter) {
-    TUnit::type dst_type;
-
-    switch (src_counter->type()) {
-    case TUnit::BYTES:
-        dst_type = TUnit::BYTES_PER_SECOND;
-        break;
-
-    case TUnit::UNIT:
-        dst_type = TUnit::UNIT_PER_SECOND;
-        break;
-
-    default:
-        DCHECK(false) << "Unsupported src counter type: " << src_counter->type();
-        return nullptr;
-    }
-
-    Counter* dst_counter = add_counter(name, dst_type);
-    register_periodic_counter(src_counter, nullptr, dst_counter, RATE_COUNTER);
-    return dst_counter;
-}
-
-RuntimeProfile::Counter* RuntimeProfile::add_rate_counter(const std::string& name, SampleFn fn, TUnit::type dst_type) {
-    Counter* dst_counter = add_counter(name, dst_type);
-    register_periodic_counter(nullptr, std::move(fn), dst_counter, RATE_COUNTER);
-    return dst_counter;
-}
-
-RuntimeProfile::Counter* RuntimeProfile::add_sampling_counter(const std::string& name, Counter* src_counter) {
-    DCHECK(src_counter->type() == TUnit::UNIT);
-    Counter* dst_counter = add_counter(name, TUnit::DOUBLE_VALUE);
-    register_periodic_counter(src_counter, nullptr, dst_counter, SAMPLING_COUNTER);
-    return dst_counter;
-}
-
-RuntimeProfile::Counter* RuntimeProfile::add_sampling_counter(const std::string& name, SampleFn sample_fn) {
-    Counter* dst_counter = add_counter(name, TUnit::DOUBLE_VALUE);
-    register_periodic_counter(nullptr, std::move(sample_fn), dst_counter, SAMPLING_COUNTER);
-    return dst_counter;
-}
-
-void RuntimeProfile::add_bucketing_counters(const std::string& name, const std::string& parent_name,
-                                            Counter* src_counter, int num_buckets, std::vector<Counter*>* buckets) {
-    {
-        std::lock_guard<std::mutex> l(_counter_lock);
-        _bucketing_counters.insert(buckets);
-    }
-
-    for (int i = 0; i < num_buckets; ++i) {
-        std::stringstream counter_name;
-        counter_name << name << "=" << i;
-        buckets->push_back(add_counter(counter_name.str(), TUnit::DOUBLE_VALUE, parent_name));
-    }
-
-    std::lock_guard<std::mutex> l(_s_periodic_counter_update_state.lock);
-
-    if (_s_periodic_counter_update_state.update_thread == nullptr) {
-        _s_periodic_counter_update_state.update_thread =
-                std::make_unique<std::thread>(&RuntimeProfile::periodic_counter_update_loop);
-        Thread::set_thread_name(_s_periodic_counter_update_state.update_thread.get()->native_handle(), "rf_cnt_update");
-    }
-
-    BucketCountersInfo info{.src_counter = src_counter, .num_sampled = 0};
-    _s_periodic_counter_update_state.bucketing_counters[buckets] = info;
-}
-
 RuntimeProfile::EventSequence* RuntimeProfile::add_event_sequence(const std::string& name) {
     std::lock_guard<std::mutex> l(_event_sequences_lock);
     auto timer_it = _event_sequence_map.find(name);
@@ -846,140 +760,6 @@ RuntimeProfile::EventSequence* RuntimeProfile::add_event_sequence(const std::str
     EventSequence* timer = _pool->add(new EventSequence());
     _event_sequence_map[name] = timer;
     return timer;
-}
-
-void RuntimeProfile::register_periodic_counter(Counter* src_counter, SampleFn sample_fn, Counter* dst_counter,
-                                               PeriodicCounterType type) {
-    DCHECK(src_counter == nullptr || sample_fn == nullptr);
-
-    std::lock_guard<std::mutex> l(_s_periodic_counter_update_state.lock);
-
-    if (_s_periodic_counter_update_state.update_thread == nullptr) {
-        _s_periodic_counter_update_state.update_thread =
-                std::make_unique<std::thread>(&RuntimeProfile::periodic_counter_update_loop);
-        Thread::set_thread_name(_s_periodic_counter_update_state.update_thread.get()->native_handle(), "rf_cnt_update");
-    }
-
-    switch (type) {
-    case RATE_COUNTER: {
-        RateCounterInfo counter;
-        counter.src_counter = src_counter;
-        counter.sample_fn = std::move(sample_fn);
-        counter.elapsed_ms = 0;
-        _s_periodic_counter_update_state.rate_counters[dst_counter] = counter;
-        break;
-    }
-
-    case SAMPLING_COUNTER: {
-        SamplingCounterInfo counter;
-        counter.src_counter = src_counter;
-        counter.sample_fn = std::move(sample_fn);
-        counter.num_sampled = 0;
-        counter.total_sampled_value = 0;
-        _s_periodic_counter_update_state.sampling_counters[dst_counter] = counter;
-        break;
-    }
-
-    default:
-        DCHECK(false) << "Unsupported PeriodicCounterType:" << type;
-    }
-}
-
-void RuntimeProfile::stop_rate_counters_updates(Counter* rate_counter) {
-    std::lock_guard<std::mutex> l(_s_periodic_counter_update_state.lock);
-    _s_periodic_counter_update_state.rate_counters.erase(rate_counter);
-}
-
-void RuntimeProfile::stop_sampling_counters_updates(Counter* sampling_counter) {
-    std::lock_guard<std::mutex> l(_s_periodic_counter_update_state.lock);
-    _s_periodic_counter_update_state.sampling_counters.erase(sampling_counter);
-}
-
-void RuntimeProfile::stop_bucketing_counters_updates(std::vector<Counter*>* buckets, bool convert) {
-    int64_t num_sampled = 0;
-    {
-        std::lock_guard<std::mutex> l(_s_periodic_counter_update_state.lock);
-        auto itr = _s_periodic_counter_update_state.bucketing_counters.find(buckets);
-
-        if (itr != _s_periodic_counter_update_state.bucketing_counters.end()) {
-            num_sampled = itr->second.num_sampled;
-            _s_periodic_counter_update_state.bucketing_counters.erase(buckets);
-        }
-    }
-
-    if (convert && num_sampled > 0) {
-        for (Counter* counter : *buckets) {
-            double perc = 100.0 * counter->value() / (double)num_sampled;
-            counter->set(perc);
-        }
-    }
-}
-
-RuntimeProfile::PeriodicCounterUpdateState::PeriodicCounterUpdateState() = default;
-
-RuntimeProfile::PeriodicCounterUpdateState::~PeriodicCounterUpdateState() {
-    if (_s_periodic_counter_update_state.update_thread != nullptr) {
-        {
-            // Lock to ensure the update thread will see the update to _done
-            std::lock_guard<std::mutex> l(_s_periodic_counter_update_state.lock);
-            _done = true;
-        }
-        _s_periodic_counter_update_state.update_thread->join();
-    }
-}
-
-void RuntimeProfile::periodic_counter_update_loop() {
-    while (!_s_periodic_counter_update_state._done) {
-        auto before_time = MonotonicMillis();
-        SleepFor(MonoDelta::FromMilliseconds(config::periodic_counter_update_period_ms));
-        int64_t elapsed_ms = MonotonicMillis() - before_time;
-
-        std::lock_guard<std::mutex> l(_s_periodic_counter_update_state.lock);
-
-        for (auto it = _s_periodic_counter_update_state.rate_counters.begin();
-             it != _s_periodic_counter_update_state.rate_counters.end(); ++it) {
-            it->second.elapsed_ms += elapsed_ms;
-            int64_t value;
-
-            if (it->second.src_counter != nullptr) {
-                value = it->second.src_counter->value();
-            } else {
-                DCHECK(it->second.sample_fn != nullptr);
-                value = it->second.sample_fn();
-            }
-
-            int64_t rate = value * 1000 / (it->second.elapsed_ms);
-            it->first->set(rate);
-        }
-
-        for (auto it = _s_periodic_counter_update_state.sampling_counters.begin();
-             it != _s_periodic_counter_update_state.sampling_counters.end(); ++it) {
-            ++it->second.num_sampled;
-            int64_t value;
-
-            if (it->second.src_counter != nullptr) {
-                value = it->second.src_counter->value();
-            } else {
-                DCHECK(it->second.sample_fn != nullptr);
-                value = it->second.sample_fn();
-            }
-
-            it->second.total_sampled_value += value;
-            double average = static_cast<double>(it->second.total_sampled_value) / it->second.num_sampled;
-            it->first->set(average);
-        }
-
-        for (auto& bucketing_counter : _s_periodic_counter_update_state.bucketing_counters) {
-            int64_t val = bucketing_counter.second.src_counter->value();
-
-            if (val >= bucketing_counter.first->size()) {
-                val = bucketing_counter.first->size() - 1;
-            }
-
-            bucketing_counter.first->at(val)->update(1);
-            ++bucketing_counter.second.num_sampled;
-        }
-    }
 }
 
 void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& profiles) {

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -254,7 +254,7 @@ public:
     // Create a runtime profile object with 'name'.
     explicit RuntimeProfile(std::string name, bool is_averaged_profile = false);
 
-    ~RuntimeProfile();
+    ~RuntimeProfile() = default;
 
     RuntimeProfile* parent() const { return _parent; }
 
@@ -412,49 +412,10 @@ public:
     // Note: this function should not block (or take a long time).
     typedef std::function<int64_t()> SampleFn;
 
-    // Add a rate counter to the current profile based on src_counter with name.
-    // The rate counter is updated periodically based on the src counter.
-    // The rate counter has units in src_counter unit per second.
-    Counter* add_rate_counter(const std::string& name, Counter* src_counter);
-
-    // Same as 'add_rate_counter' above except values are taken by calling fn.
-    // The resulting counter will be of 'type'.
-    Counter* add_rate_counter(const std::string& name, SampleFn fn, TUnit::type type);
-
-    // Add a sampling counter to the current profile based on src_counter with name.
-    // The sampling counter is updated periodically based on the src counter by averaging
-    // the samples taken from the src counter.
-    // The sampling counter has the same unit as src_counter unit.
-    Counter* add_sampling_counter(const std::string& name, Counter* src_counter);
-
-    // Same as 'add_sampling_counter' above except the samples are taken by calling fn.
-    Counter* add_sampling_counter(const std::string& name, SampleFn fn);
-
-    // Add a bucket of counters to store the sampled value of src_counter.
-    // The src_counter is sampled periodically and the buckets are updated.
-    void add_bucketing_counters(const std::string& name, const std::string& parent_name, Counter* src_counter,
-                                int max_buckets, std::vector<Counter*>* buckets);
-
     /// Adds a high water mark counter to the runtime profile. Otherwise, same behavior
     /// as AddCounter().
     HighWaterMarkCounter* AddHighWaterMarkCounter(const std::string& name, TUnit::type unit,
                                                   const std::string& parent_name = "");
-
-    // stops updating the value of 'rate_counter'. Rate counters are updated
-    // periodically so should be removed as soon as the underlying counter is
-    // no longer going to change.
-    void stop_rate_counters_updates(Counter* rate_counter);
-
-    // stops updating the value of 'sampling_counter'. Sampling counters are updated
-    // periodically so should be removed as soon as the underlying counter is
-    // no longer going to change.
-    void stop_sampling_counters_updates(Counter* sampling_counter);
-
-    // stops updating the bucket counter.
-    // If convert is true, convert the buckets from count to percentage.
-    // Sampling counters are updated periodically so should be removed as soon as the
-    // underlying counter is no longer going to change.
-    void stop_bucketing_counters_updates(std::vector<Counter*>* buckets, bool convert);
 
     // Recursively compute the fraction of the 'total_time' spent in this profile and
     // its children.
@@ -535,65 +496,6 @@ private:
     // of the total time in the entire profile tree.
     double _local_time_percent;
 
-    enum PeriodicCounterType {
-        RATE_COUNTER = 0,
-        SAMPLING_COUNTER,
-    };
-
-    struct RateCounterInfo {
-        Counter* src_counter;
-        SampleFn sample_fn;
-        int64_t elapsed_ms;
-    };
-
-    struct SamplingCounterInfo {
-        Counter* src_counter; // the counter to be sampled
-        SampleFn sample_fn;
-        int64_t total_sampled_value; // sum of all sampled values;
-        int64_t num_sampled;         // number of samples taken
-    };
-
-    struct BucketCountersInfo {
-        Counter* src_counter; // the counter to be sampled
-        int64_t num_sampled;  // number of samples taken
-        // TODO: customize bucketing
-    };
-
-    // This is a static singleton object that is used to update all rate counters and
-    // sampling counters.
-    struct PeriodicCounterUpdateState {
-        PeriodicCounterUpdateState();
-
-        // Tears down the update thread.
-        ~PeriodicCounterUpdateState();
-
-        // Lock protecting state below
-        std::mutex lock;
-
-        // If true, tear down the update thread.
-        volatile bool _done{false};
-
-        // Thread performing asynchronous updates.
-        std::unique_ptr<std::thread> update_thread;
-
-        // A map of the dst (rate) counter to the src counter and elapsed time.
-        typedef std::map<Counter*, RateCounterInfo> RateCounterMap;
-        RateCounterMap rate_counters;
-
-        // A map of the dst (averages over samples) counter to the src counter (to be sampled)
-        // and number of samples taken.
-        typedef std::map<Counter*, SamplingCounterInfo> SamplingCounterMap;
-        SamplingCounterMap sampling_counters;
-
-        // Map from a bucket of counters to the src counter
-        typedef std::map<std::vector<Counter*>*, BucketCountersInfo> BucketCountersMap;
-        BucketCountersMap bucketing_counters;
-    };
-
-    // Singleton object that keeps track of all rate counters and the thread
-    // for updating them.
-    static PeriodicCounterUpdateState _s_periodic_counter_update_state; // NOLINT
-
     // update a subtree of profiles from nodes, rooted at *idx.
     // On return, *idx points to the node immediately following this subtree.
     void update(const std::vector<TRuntimeProfileNode>& nodes, int* idx);
@@ -602,18 +504,6 @@ private:
     // this profile and its children.
     // Called recusively.
     void compute_time_in_profile(int64_t total_time);
-
-    // Registers a periodic counter to be updated by the update thread.
-    // Either sample_fn or dst_counter must be non-NULL.  When the periodic counter
-    // is updated, it either gets the value from the dst_counter or calls the sample
-    // function to get the value.
-    // dst_counter/sample fn is assumed to be compatible types with src_counter.
-    static void register_periodic_counter(Counter* src_counter, SampleFn sample_fn, Counter* dst_counter,
-                                          PeriodicCounterType type);
-
-    // Loop for periodic counter update thread.  This thread wakes up once in a while
-    // and updates all the added rate counters and sampling counters.
-    static void periodic_counter_update_loop();
 
     // Print the child counters of the given counter name
     static void print_child_counters(const std::string& prefix, const std::string& counter_name,


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Global runtime profile is unused, and it locks lots of times in `~RuntimeProfile`. 
Therefore, 
- delete codes for global runtime profile.
- `ScanNode` uses `add_derived_counter` instead of global `add_rate_counter` to compute throughput bytes.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
