### PR TITLE
[Enhancement] Support size tiered compaction strategy

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -322,6 +322,11 @@ CONF_Int64(vertical_compaction_max_columns_per_group, "5");
 
 CONF_Bool(enable_event_based_compaction_framework, "true");
 
+CONF_Bool(enable_size_tiered_compaction_strategy, "true");
+CONF_mInt64(size_tiered_min_level_size, "131072");
+CONF_mInt64(size_tiered_level_multiple, "5");
+CONF_mInt64(size_tiered_level_num, "7");
+
 CONF_Bool(enable_check_string_lengths, "true");
 // 5GB
 CONF_mInt64(min_cumulative_compaction_size, "5368709120");

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -157,6 +157,7 @@ add_library(Storage STATIC
     vertical_compaction_task.cpp
     compaction_task_factory.cpp
     default_compaction_policy.cpp
+    size_tiered_compaction_policy.cpp
     cluster_id_mgr.cpp
     push_utils.cpp
     lake/async_delta_writer.cpp

--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -14,7 +14,7 @@ namespace starrocks {
 struct CompactionCandidate {
     TabletSharedPtr tablet;
     CompactionType type;
-    int64_t score = 0;
+    double score = 0;
 
     CompactionCandidate() : tablet(nullptr), type(INVALID_COMPACTION) {}
 

--- a/be/src/storage/compaction_context.h
+++ b/be/src/storage/compaction_context.h
@@ -16,7 +16,7 @@ namespace starrocks {
 class CompactionPolicy;
 
 struct CompactionContext {
-    int64_t score = 0;
+    double score = 0;
     CompactionType type = INVALID_COMPACTION;
     std::unique_ptr<CompactionPolicy> policy;
 };

--- a/be/src/storage/compaction_policy.h
+++ b/be/src/storage/compaction_policy.h
@@ -14,7 +14,7 @@ public:
     virtual ~CompactionPolicy() = default;
 
     // used to judge whether a tablet should do compaction or not
-    virtual bool need_compaction(int64_t* score, CompactionType* type) = 0;
+    virtual bool need_compaction(double* score, CompactionType* type) = 0;
 
     // used to generate a CompactionTask for tablet
     virtual std::shared_ptr<CompactionTask> create_compaction(TabletSharedPtr tablet) = 0;

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -228,9 +228,9 @@ protected:
     Status _validate_compaction(const Statistics& stats) {
         // check row number
         DCHECK(_output_rowset) << "_output_rowset is null";
-        LOG(INFO) << "validate compaction, _input_rows_num:" << _task_info.input_rows_num
-                  << ", output rowset rows:" << _output_rowset->num_rows() << ", merged_rows:" << stats.merged_rows
-                  << ", filtered_rows:" << stats.filtered_rows;
+        VLOG(1) << "validate compaction, _input_rows_num:" << _task_info.input_rows_num
+                << ", output rowset rows:" << _output_rowset->num_rows() << ", merged_rows:" << stats.merged_rows
+                << ", filtered_rows:" << stats.filtered_rows;
         if (_task_info.input_rows_num != _output_rowset->num_rows() + stats.merged_rows + stats.filtered_rows) {
             LOG(WARNING) << "row_num does not match between cumulative input and output! "
                          << "input_row_num=" << _task_info.input_rows_num << ", merged_row_num=" << stats.merged_rows
@@ -254,9 +254,9 @@ protected:
         _tablet->modify_rowsets({_output_rowset}, _input_rowsets);
         _tablet->save_meta();
         Rowset::close_rowsets(_input_rowsets);
-        LOG(INFO) << "commit compaction. output version:" << _task_info.output_version
-                  << ", output rowset version:" << _output_rowset->version()
-                  << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size();
+        VLOG(1) << "commit compaction. output version:" << _task_info.output_version
+                << ", output rowset version:" << _output_rowset->version()
+                << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size();
     }
 
     void _success_callback();

--- a/be/src/storage/default_compaction_policy.h
+++ b/be/src/storage/default_compaction_policy.h
@@ -16,19 +16,19 @@ public:
     DefaultCumulativeBaseCompactionPolicy& operator=(const DefaultCumulativeBaseCompactionPolicy&) = delete;
 
     // used to judge whether a tablet should do compaction or not
-    bool need_compaction(int64_t* score, CompactionType* type) override;
+    bool need_compaction(double* score, CompactionType* type) override;
 
     // used to generate a CompactionTask for tablet
     std::shared_ptr<CompactionTask> create_compaction(TabletSharedPtr tablet) override;
 
 protected:
-    Status _pick_rowsets_to_cumulative_compact(std::vector<RowsetSharedPtr>* input_rowsets, int64_t* score);
-    Status _pick_rowsets_to_base_compact(std::vector<RowsetSharedPtr>* input_rowsets, int64_t* score);
+    Status _pick_rowsets_to_cumulative_compact(std::vector<RowsetSharedPtr>* input_rowsets, double* score);
+    Status _pick_rowsets_to_base_compact(std::vector<RowsetSharedPtr>* input_rowsets, double* score);
 
     // _check_version_continuity_with_cumulative_point checks whether the input rowsets is continuous with cumulative point.
     Status _check_version_continuity_with_cumulative_point(const std::vector<RowsetSharedPtr>& rowsets);
 
-    bool _fit_compaction_condition(const std::vector<RowsetSharedPtr>& rowsets, int64_t compaction_score);
+    bool _fit_compaction_condition(const std::vector<RowsetSharedPtr>& rowsets, double compaction_score);
 
     Status _check_rowset_overlapping(const std::vector<RowsetSharedPtr>& rowsets);
     Status _check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);
@@ -37,8 +37,8 @@ protected:
     Tablet* _tablet;
     std::vector<RowsetSharedPtr> _cumulative_rowsets;
     std::vector<RowsetSharedPtr> _base_rowsets;
-    int64_t _cumulative_score = 0;
-    int64_t _base_score = 0;
+    double _cumulative_score = 0;
+    double _base_score = 0;
     CompactionType _compaction_type = INVALID_COMPACTION;
 };
 

--- a/be/src/storage/size_tiered_compaction_policy.cpp
+++ b/be/src/storage/size_tiered_compaction_policy.cpp
@@ -1,0 +1,277 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "storage/size_tiered_compaction_policy.h"
+
+#include "runtime/current_thread.h"
+#include "storage/compaction_task_factory.h"
+#include "util/defer_op.h"
+#include "util/starrocks_metrics.h"
+#include "util/time.h"
+#include "util/trace.h"
+
+namespace starrocks::vectorized {
+
+SizeTieredCompactionPolicy::SizeTieredCompactionPolicy(Tablet* tablet) : _tablet(tablet) {
+    _max_level_size =
+            config::size_tiered_min_level_size * pow(config::size_tiered_level_multiple, config::size_tiered_level_num);
+}
+
+bool SizeTieredCompactionPolicy::need_compaction(double* score, CompactionType* type) {
+    auto st = _pick_rowsets_to_size_tiered_compact(&_rowsets, &_score);
+
+    if (st.ok()) {
+        if (_rowsets[0]->start_version() == 0) {
+            _compaction_type = BASE_COMPACTION;
+        } else {
+            _compaction_type = CUMULATIVE_COMPACTION;
+        }
+        *score = _score;
+    } else {
+        _compaction_type = INVALID_COMPACTION;
+        *score = 0;
+    }
+    *type = _compaction_type;
+
+    return _compaction_type != INVALID_COMPACTION;
+}
+
+std::shared_ptr<CompactionTask> SizeTieredCompactionPolicy::create_compaction(TabletSharedPtr tablet) {
+    if (_compaction_type != INVALID_COMPACTION) {
+        Version output_version;
+        output_version.first = (*_rowsets.begin())->start_version();
+        output_version.second = (*_rowsets.rbegin())->end_version();
+
+        CompactionTaskFactory factory(output_version, tablet, std::move(_rowsets), _score, _compaction_type);
+        std::shared_ptr<CompactionTask> compaction_task = factory.create_compaction_task();
+        _compaction_type = INVALID_COMPACTION;
+        return compaction_task;
+    }
+    return nullptr;
+}
+
+double SizeTieredCompactionPolicy::_cal_compaction_score(int64_t segment_num, int64_t level_size, int64_t total_size,
+                                                         KeysType keys_type, bool reached_max_version) {
+    double score = 0;
+    if (keys_type == KeysType::DUP_KEYS) {
+        // duplicate keys only has write amplification, so that we use more aggressive size-tiered strategy
+        score = segment_num + ((double)(total_size - level_size) / level_size) * 2;
+    } else {
+        // agg/unique key also has read amplification, segment num occupies a greater weight
+        score = segment_num + (segment_num - 1) * 2 + ((double)(total_size - level_size) / level_size);
+    }
+
+    // level bonus: The lower the level means the smaller the data volume of the compaction, the higher the execution priority
+    int64_t level_bonus = 0;
+    for (int64_t v = level_size; v < _max_level_size && level_bonus <= 7; ++level_bonus) {
+        v = v * config::size_tiered_level_multiple;
+    }
+    score += level_bonus;
+
+    // version limit bonus: The version num of the tablet is about to exceed the limit, we let it perform compaction faster and reduce the version num
+    if (reached_max_version) {
+        score *= 2;
+    }
+
+    return score;
+}
+
+Status SizeTieredCompactionPolicy::_pick_rowsets_to_size_tiered_compact(std::vector<RowsetSharedPtr>* input_rowsets,
+                                                                        double* score) {
+    input_rowsets->clear();
+    *score = 0;
+    std::vector<RowsetSharedPtr> candidate_rowsets;
+    _tablet->pick_all_candicate_rowsets(&candidate_rowsets);
+
+    if (candidate_rowsets.size() <= 1) {
+        return Status::NotFound("compaction no suitable version error.");
+    }
+
+    std::sort(candidate_rowsets.begin(), candidate_rowsets.end(), Rowset::comparator);
+
+    if (candidate_rowsets.size() == 2 && candidate_rowsets[0]->end_version() == 1) {
+        // the tablet is with rowset: [0-1], [2-y]
+        // and [0-1] has no data. in this situation, no need to do base compaction.
+        return Status::NotFound("compaction no suitable version error.");
+    }
+
+    struct SizeTieredLevel {
+        SizeTieredLevel(std::vector<RowsetSharedPtr> r, int64_t s, int64_t l, int64_t t, double sc)
+                : rowsets(std::move(r)), segment_num(s), level_size(l), total_size(t), score(sc) {}
+
+        std::vector<RowsetSharedPtr> rowsets;
+        int64_t segment_num;
+        int64_t level_size;
+        int64_t total_size;
+        double score;
+    };
+
+    struct LevelComparator {
+        bool operator()(const SizeTieredLevel* left, const SizeTieredLevel* right) const {
+            return left->score > right->score ||
+                   (left->score == right->score &&
+                    left->rowsets[0]->start_version() > right->rowsets[0]->start_version());
+        }
+    };
+
+    std::vector<std::unique_ptr<SizeTieredLevel>> order_levels;
+    std::set<SizeTieredLevel*, LevelComparator> priority_levels;
+    std::vector<RowsetSharedPtr> transient_rowsets;
+    size_t segment_num = 0;
+    int64_t level_multiple = config::size_tiered_level_multiple;
+    auto keys_type = _tablet->keys_type();
+
+    bool force_base_compaction = false;
+    if (time(nullptr) - candidate_rowsets[0]->creation_time() >
+        config::base_compaction_interval_seconds_since_last_operation) {
+        force_base_compaction = true;
+    }
+
+    bool reached_max_version = false;
+    if (candidate_rowsets.size() > config::tablet_max_versions / 10 * 9) {
+        reached_max_version = true;
+    }
+
+    int64_t level_size = -1;
+    int64_t total_size = 0;
+    int64_t prev_end_version = -1;
+    for (auto rowset : candidate_rowsets) {
+        int64_t rowset_size = rowset->data_disk_size() > 0 ? rowset->data_disk_size() : 1;
+        if (level_size == -1) {
+            level_size = rowset_size < _max_level_size ? rowset_size : _max_level_size;
+            total_size = 0;
+        }
+
+        // meet missed version
+        if (rowset->start_version() != prev_end_version + 1) {
+            if (!transient_rowsets.empty()) {
+                auto level = std::make_unique<SizeTieredLevel>(
+                        transient_rowsets, segment_num, level_size, total_size,
+                        _cal_compaction_score(segment_num, level_size, total_size, keys_type, reached_max_version));
+                priority_levels.emplace(level.get());
+                order_levels.emplace_back(std::move(level));
+            }
+            level_size = rowset_size < _max_level_size ? rowset_size : _max_level_size;
+            segment_num = 0;
+            total_size = 0;
+            transient_rowsets.clear();
+        }
+
+        if (_tablet->version_for_delete_predicate(rowset->version())) {
+            // meet a delete version
+            // base compaction can handle delete condition
+            if (!transient_rowsets.empty() && transient_rowsets[0]->start_version() == 0) {
+            } else {
+                // if upper level only has one rowset, we can merge into one level
+                int64_t i = order_levels.size() - 1;
+                while (i >= 0) {
+                    if (order_levels[i]->rowsets.size() == 1 &&
+                        transient_rowsets[0]->start_version() == order_levels[i]->rowsets[0]->end_version() + 1 &&
+                        !_tablet->version_for_delete_predicate(order_levels[i]->rowsets[0]->version())) {
+                        transient_rowsets.insert(transient_rowsets.begin(), order_levels[i]->rowsets[0]);
+                        auto rs = order_levels[i]->rowsets[0]->data_disk_size() > 0
+                                          ? order_levels[i]->rowsets[0]->data_disk_size()
+                                          : 1;
+                        level_size = rs < _max_level_size ? rs : _max_level_size;
+                        segment_num += order_levels[i]->segment_num;
+                        total_size += level_size;
+                        priority_levels.erase(order_levels[i].get());
+                        i--;
+                    } else {
+                        break;
+                    }
+                }
+                order_levels.resize(i + 1);
+
+                // after merge, check if we match base compaction condition
+                if (!transient_rowsets.empty() && transient_rowsets[0]->start_version() != 0) {
+                    auto level = std::make_unique<SizeTieredLevel>(
+                            transient_rowsets, segment_num, level_size, total_size,
+                            _cal_compaction_score(segment_num, level_size, total_size, keys_type, reached_max_version));
+                    priority_levels.emplace(level.get());
+                    order_levels.emplace_back(std::move(level));
+                }
+
+                if (transient_rowsets.empty() ||
+                    (!transient_rowsets.empty() && transient_rowsets[0]->start_version() != 0)) {
+                    segment_num = 0;
+                    transient_rowsets.clear();
+                    level_size = -1;
+                    continue;
+                }
+            }
+        } else if (!force_base_compaction && level_size > config::size_tiered_min_level_size &&
+                   rowset_size < level_size && level_size / rowset_size > (level_multiple - 1)) {
+            if (!transient_rowsets.empty()) {
+                auto level = std::make_unique<SizeTieredLevel>(
+                        transient_rowsets, segment_num, level_size, total_size,
+                        _cal_compaction_score(segment_num, level_size, total_size, keys_type, reached_max_version));
+                priority_levels.emplace(level.get());
+                order_levels.emplace_back(std::move(level));
+            }
+            segment_num = 0;
+            transient_rowsets.clear();
+            level_size = rowset_size < _max_level_size ? rowset_size : _max_level_size;
+            total_size = 0;
+        }
+
+        segment_num += rowset->rowset_meta()->get_compaction_score();
+        total_size += rowset_size;
+        transient_rowsets.emplace_back(rowset);
+        prev_end_version = rowset->end_version();
+    }
+
+    if (!transient_rowsets.empty()) {
+        auto level = std::make_unique<SizeTieredLevel>(
+                transient_rowsets, segment_num, level_size, total_size,
+                _cal_compaction_score(segment_num, level_size, total_size, keys_type, reached_max_version));
+        priority_levels.emplace(level.get());
+        order_levels.emplace_back(std::move(level));
+    }
+
+    for (auto& level : order_levels) {
+        *score += level->score;
+    }
+
+    SizeTieredLevel* selected_level = nullptr;
+    if (!priority_levels.empty()) {
+        selected_level = *priority_levels.begin();
+        if (selected_level->rowsets.size() > 1) {
+            *input_rowsets = selected_level->rowsets;
+        }
+    }
+
+    // Cumulative compaction will process with at least 1 rowset.
+    // So when there is no rowset being chosen, we should return Status::NotFound("cumulative compaction no suitable version error.");
+    if (input_rowsets->empty()) {
+        return Status::NotFound("cumulative compaction no suitable version error.");
+    }
+
+    RETURN_IF_ERROR(_check_version_continuity(*input_rowsets));
+
+    LOG(INFO) << "pick tablet " << _tablet->tablet_id()
+              << " for size-tiered compaction rowset version=" << input_rowsets->front()->start_version() << "-"
+              << input_rowsets->back()->end_version() << " score=" << selected_level->score
+              << " level_size=" << selected_level->level_size << " total_size=" << selected_level->total_size
+              << " segment_num=" << selected_level->segment_num << " force_base_compaction=" << force_base_compaction
+              << " reached_max_versions=" << reached_max_version;
+
+    return Status::OK();
+}
+
+Status SizeTieredCompactionPolicy::_check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets) {
+    RowsetSharedPtr prev_rowset = rowsets.front();
+    for (size_t i = 1; i < rowsets.size(); ++i) {
+        const RowsetSharedPtr& rowset = rowsets[i];
+        if (rowset->start_version() != prev_rowset->end_version() + 1) {
+            LOG(WARNING) << "There are missed versions among rowsets. "
+                         << "prev_rowset version=" << prev_rowset->start_version() << "-" << prev_rowset->end_version()
+                         << ", rowset version=" << rowset->start_version() << "-" << rowset->end_version();
+            return Status::InternalError("cumulative compaction miss version error.");
+        }
+        prev_rowset = rowset;
+    }
+
+    return Status::OK();
+}
+
+} // namespace starrocks::vectorized

--- a/be/src/storage/size_tiered_compaction_policy.h
+++ b/be/src/storage/size_tiered_compaction_policy.h
@@ -1,0 +1,37 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#pragma once
+
+#include <string>
+
+#include "storage/compaction_policy.h"
+
+namespace starrocks::vectorized {
+
+class SizeTieredCompactionPolicy : public CompactionPolicy {
+public:
+    SizeTieredCompactionPolicy(Tablet* tablet);
+
+    SizeTieredCompactionPolicy(const SizeTieredCompactionPolicy&) = delete;
+    SizeTieredCompactionPolicy& operator=(const SizeTieredCompactionPolicy&) = delete;
+
+    // used to judge whether a tablet should do compaction or not
+    bool need_compaction(double* score, CompactionType* type) override;
+
+    // used to generate a CompactionTask for tablet
+    std::shared_ptr<CompactionTask> create_compaction(TabletSharedPtr tablet) override;
+
+protected:
+    Status _pick_rowsets_to_size_tiered_compact(std::vector<RowsetSharedPtr>* input_rowsets, double* score);
+    double _cal_compaction_score(int64_t segment_num, int64_t level_size, int64_t total_size, KeysType keys_type,
+                                 bool reached_max_version);
+    Status _check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);
+
+    Tablet* _tablet;
+    std::vector<RowsetSharedPtr> _rowsets;
+    double _score;
+    CompactionType _compaction_type;
+    int64_t _max_level_size;
+};
+
+} // namespace starrocks::vectorized

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -205,7 +205,7 @@ public:
 
     void pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
     void pick_candicate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
-    void pick_all_candicate_rowsets(vector<RowsetSharedPtr>* candidate_rowsets);
+    void pick_all_candicate_rowsets(std::vector<RowsetSharedPtr>* candidate_rowsets);
 
     void calculate_cumulative_point();
 
@@ -230,7 +230,7 @@ public:
     // do not do compaction
     bool need_compaction();
 
-    int64_t compaction_score();
+    double compaction_score();
     CompactionType compaction_type();
 
     void set_compaction_context(std::unique_ptr<CompactionContext>& context);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -209,7 +209,8 @@ set(EXEC_FILES
         ./storage/update_manager_test.cpp
         ./storage/compaction_utils_test.cpp
         ./storage/compaction_manager_test.cpp
-	./storage/default_compaction_policy_test.cpp
+        ./storage/default_compaction_policy_test.cpp
+        ./storage/size_tiered_compaction_policy_test.cpp
         ./storage/aggregate_iterator_test.cpp
         ./storage/chunk_aggregator_test.cpp
         ./storage/chunk_helper_test.cpp
@@ -218,7 +219,7 @@ set(EXEC_FILES
         ./storage/conjunctive_predicates_test.cpp
         ./storage/convert_helper_test.cpp
         ./storage/merge_iterator_test.cpp
-	    ./storage/memtable_flush_executor_test.cpp
+        ./storage/memtable_flush_executor_test.cpp
         ./storage/memtable_test.cpp
         ./storage/projection_iterator_test.cpp
         ./storage/push_handler_test.cpp

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -28,6 +28,7 @@ TEST(CompactionManagerTest, test_candidates) {
         tablet->set_tablet_meta(tablet_meta);
         tablet->set_data_dir(&data_dir);
         tablet->set_tablet_state(TABLET_RUNNING);
+
         // for i == 9 and i == 10, compaction scores are equal
         CompactionCandidate candidate;
         candidate.tablet = tablet;

--- a/be/test/storage/size_tiered_compaction_policy_test.cpp
+++ b/be/test/storage/size_tiered_compaction_policy_test.cpp
@@ -1,0 +1,1158 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "storage/cumulative_compaction.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdlib>
+#include <ctime>
+#include <memory>
+
+#include "column/schema.h"
+#include "fs/fs_util.h"
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
+#include "storage/chunk_helper.h"
+#include "storage/compaction.h"
+#include "storage/compaction_context.h"
+#include "storage/compaction_manager.h"
+#include "storage/compaction_utils.h"
+#include "storage/size_tiered_compaction_policy.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_meta.h"
+#include "testutil/assert.h"
+
+namespace starrocks::vectorized {
+
+class SizeTieredCompactionPolicyTest : public testing::Test {
+public:
+    ~SizeTieredCompactionPolicyTest() override {
+        if (_engine) {
+            _engine->stop();
+            delete _engine;
+            _engine = nullptr;
+        }
+    }
+
+    void rowset_writer_add_rows(std::unique_ptr<RowsetWriter>& writer, int64_t level) {
+        std::srand(std::time(nullptr));
+        std::vector<std::string> test_data;
+        auto schema = ChunkHelper::convert_schema_to_format_v2(*_tablet_schema);
+        auto chunk = ChunkHelper::new_chunk(schema, 1024);
+        for (size_t i = 0; i < 24576 * pow(config::size_tiered_level_multiple + 1, level - 2); ++i) {
+            test_data.push_back("well" + std::to_string(std::rand()));
+            auto& cols = chunk->columns();
+            cols[0]->append_datum(vectorized::Datum(static_cast<int32_t>(std::rand())));
+            Slice field_1(test_data[i]);
+            cols[1]->append_datum(vectorized::Datum(field_1));
+            cols[2]->append_datum(vectorized::Datum(static_cast<int32_t>(10000 + std::rand())));
+        }
+        CHECK_OK(writer->add_chunk(*chunk));
+    }
+
+    void write_new_version(TabletMetaSharedPtr tablet_meta, int64_t level = 2) {
+        RowsetWriterContext rowset_writer_context;
+        create_rowset_writer_context(&rowset_writer_context, _version);
+        _version++;
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &rowset_writer).ok());
+
+        rowset_writer_add_rows(rowset_writer, level);
+
+        rowset_writer->flush();
+        RowsetSharedPtr src_rowset = *rowset_writer->build();
+        ASSERT_TRUE(src_rowset != nullptr);
+        LOG(INFO) << "rowset version " << src_rowset->start_version() << " size " << src_rowset->data_disk_size();
+
+        tablet_meta->add_rs_meta(src_rowset->rowset_meta());
+    }
+
+    void write_specify_version(TabletSharedPtr tablet, int64_t version, int64_t level = 2) {
+        RowsetWriterContext rowset_writer_context;
+        create_rowset_writer_context(&rowset_writer_context, version);
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &rowset_writer).ok());
+
+        rowset_writer_add_rows(rowset_writer, level);
+
+        rowset_writer->flush();
+        RowsetSharedPtr src_rowset = *rowset_writer->build();
+        ASSERT_TRUE(src_rowset != nullptr);
+        LOG(INFO) << "rowset version " << src_rowset->start_version() << " size " << src_rowset->data_disk_size();
+
+        ASSERT_TRUE(tablet->add_rowset(src_rowset).ok());
+    }
+
+    void write_delete_version(TabletMetaSharedPtr tablet_meta, int64_t version) {
+        RowsetWriterContext rowset_writer_context;
+        create_rowset_writer_context(&rowset_writer_context, version);
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &rowset_writer).ok());
+
+        rowset_writer->flush();
+        RowsetSharedPtr src_rowset = *rowset_writer->build();
+        ASSERT_TRUE(src_rowset != nullptr);
+        ASSERT_EQ(0, src_rowset->num_rows());
+
+        auto* delete_predicate = src_rowset->rowset_meta()->mutable_delete_predicate();
+        delete_predicate->set_version(version);
+        auto* in_pred = delete_predicate->add_in_predicates();
+        in_pred->set_column_name("k1");
+        in_pred->set_is_not_in(false);
+        in_pred->add_values("0");
+
+        tablet_meta->add_rs_meta(src_rowset->rowset_meta());
+    }
+
+    void create_rowset_writer_context(RowsetWriterContext* rowset_writer_context, int64_t version) {
+        RowsetId rowset_id;
+        rowset_id.init(_rowset_id++);
+        rowset_writer_context->rowset_id = rowset_id;
+        rowset_writer_context->tablet_id = 12345;
+        rowset_writer_context->tablet_schema_hash = 1111;
+        rowset_writer_context->partition_id = 10;
+        rowset_writer_context->rowset_path_prefix = config::storage_root_path + "/data/0/12345/1111";
+        rowset_writer_context->rowset_state = VISIBLE;
+        rowset_writer_context->tablet_schema = _tablet_schema.get();
+        rowset_writer_context->version.first = version;
+        rowset_writer_context->version.second = version;
+    }
+
+    void create_tablet_schema(KeysType keys_type) {
+        TabletSchemaPB tablet_schema_pb;
+        tablet_schema_pb.set_keys_type(keys_type);
+        tablet_schema_pb.set_num_short_key_columns(2);
+        tablet_schema_pb.set_num_rows_per_row_block(1024);
+        tablet_schema_pb.set_next_column_unique_id(4);
+
+        ColumnPB* column_1 = tablet_schema_pb.add_column();
+        column_1->set_unique_id(1);
+        column_1->set_name("k1");
+        column_1->set_type("INT");
+        column_1->set_is_key(true);
+        column_1->set_length(4);
+        column_1->set_index_length(4);
+        column_1->set_is_nullable(false);
+        column_1->set_is_bf_column(false);
+
+        ColumnPB* column_2 = tablet_schema_pb.add_column();
+        column_2->set_unique_id(2);
+        column_2->set_name("k2");
+        column_2->set_type("VARCHAR");
+        column_2->set_length(20);
+        column_2->set_index_length(20);
+        column_2->set_is_key(true);
+        column_2->set_is_nullable(false);
+        column_2->set_is_bf_column(false);
+
+        ColumnPB* column_3 = tablet_schema_pb.add_column();
+        column_3->set_unique_id(3);
+        column_3->set_name("v1");
+        column_3->set_type("INT");
+        column_3->set_length(4);
+        column_3->set_is_key(false);
+        column_3->set_is_nullable(false);
+        column_3->set_is_bf_column(false);
+        column_3->set_aggregation("SUM");
+
+        _tablet_schema = std::make_unique<TabletSchema>(tablet_schema_pb);
+    }
+
+    void create_tablet_meta(TabletMeta* tablet_meta) {
+        TabletMetaPB tablet_meta_pb;
+        tablet_meta_pb.set_table_id(10000);
+        tablet_meta_pb.set_tablet_id(12345);
+        tablet_meta_pb.set_schema_hash(1111);
+        tablet_meta_pb.set_partition_id(10);
+        tablet_meta_pb.set_shard_id(0);
+        tablet_meta_pb.set_creation_time(1575020449);
+        tablet_meta_pb.set_tablet_state(PB_RUNNING);
+        PUniqueId* tablet_uid = tablet_meta_pb.mutable_tablet_uid();
+        tablet_uid->set_hi(10);
+        tablet_uid->set_lo(10);
+
+        TabletSchemaPB* tablet_schema_pb = tablet_meta_pb.mutable_schema();
+        _tablet_schema->to_schema_pb(tablet_schema_pb);
+
+        tablet_meta->init_from_pb(&tablet_meta_pb);
+    }
+
+    void init_compaction_context(TabletSharedPtr tablet) {
+        std::unique_ptr<CompactionContext> compaction_context = std::make_unique<CompactionContext>();
+        compaction_context->policy = std::make_unique<SizeTieredCompactionPolicy>(tablet.get());
+        tablet->set_compaction_context(compaction_context);
+    }
+
+    Status compact(TabletSharedPtr tablet) {
+        if (!tablet->need_compaction()) {
+            LOG(WARNING) << "no need compact";
+            return Status::InternalError("no need compact");
+        }
+
+        auto task = tablet->create_compaction_task();
+        if (task == nullptr) {
+            LOG(WARNING) << "task is null";
+            return Status::InternalError("task is null");
+        }
+
+        task->run();
+        if (task->compaction_task_state() == COMPACTION_FAILED) {
+            LOG(WARNING) << "task fail";
+            return Status::InternalError("task fail");
+        }
+
+        return Status::OK();
+    }
+
+    void SetUp() override {
+        config::min_cumulative_compaction_num_singleton_deltas = 2;
+        config::max_cumulative_compaction_num_singleton_deltas = 5;
+        config::max_compaction_concurrency = 1;
+        config::min_base_compaction_num_singleton_deltas = 10;
+        Compaction::init(config::max_compaction_concurrency);
+
+        config::storage_root_path = std::filesystem::current_path().string() + "/data_test_cumulative_compaction";
+        fs::remove_all(config::storage_root_path);
+        ASSERT_TRUE(fs::create_directories(config::storage_root_path).ok());
+        std::vector<StorePath> paths;
+        paths.emplace_back(config::storage_root_path);
+
+        starrocks::EngineOptions options;
+        options.store_paths = paths;
+        options.compaction_mem_tracker = _compaction_mem_tracker.get();
+        if (_engine == nullptr) {
+            Status s = starrocks::StorageEngine::open(options, &_engine);
+            ASSERT_TRUE(s.ok()) << s.to_string();
+        }
+
+        _engine->compaction_manager()->_disable_update_tablet = true;
+
+        _schema_hash_path = fmt::format("{}/data/0/12345/1111", config::storage_root_path);
+        ASSERT_OK(fs::create_directories(_schema_hash_path));
+
+        _metadata_mem_tracker = std::make_unique<MemTracker>(-1);
+        _mem_pool = std::make_unique<MemPool>();
+
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+
+        _rowset_id = 10000;
+        _version = 0;
+    }
+
+    void TearDown() override {
+        if (fs::path_exist(config::storage_root_path)) {
+            ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
+        }
+    }
+
+protected:
+    StorageEngine* _engine = nullptr;
+    std::unique_ptr<TabletSchema> _tablet_schema;
+    std::string _schema_hash_path;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
+    std::unique_ptr<MemTracker> _compaction_mem_tracker;
+    std::unique_ptr<MemPool> _mem_pool;
+
+    int64_t _rowset_id;
+    int64_t _version;
+};
+
+TEST_F(SizeTieredCompactionPolicyTest, test_init_succeeded) {
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
+    init_compaction_context(tablet);
+    ASSERT_FALSE(compact(tablet).ok());
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_candidate_rowsets_empty) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+    TabletMetaSharedPtr tablet_meta(new TabletMeta());
+    tablet_meta->set_tablet_schema(schema);
+
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_FALSE(compact(tablet).ok());
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_min_compaction) {
+    LOG(INFO) << "test_min_cumulative_compaction";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    auto res = compact(tablet);
+    ASSERT_FALSE(res.ok());
+
+    ASSERT_EQ(1, tablet->version_count());
+    std::vector<Version> versions;
+    tablet->list_versions(&versions);
+    ASSERT_EQ(1, versions.size());
+    ASSERT_EQ(0, versions[0].first);
+    ASSERT_EQ(0, versions[0].second);
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_max_compaction) {
+    LOG(INFO) << "test_max_cumulative_compaction";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 6; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    auto res = compact(tablet);
+    ASSERT_TRUE(res.ok());
+
+    ASSERT_EQ(1, tablet->version_count());
+    std::vector<Version> versions;
+    tablet->list_versions(&versions);
+    ASSERT_EQ(1, versions.size());
+    ASSERT_EQ(0, versions[0].first);
+    ASSERT_EQ(5, versions[0].second);
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_missed_first_version) {
+    LOG(INFO) << "test_missed_first_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+    _version++;
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    {
+        auto res = compact(tablet);
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_missed_version_after_cumulative_point) {
+    LOG(INFO) << "test_missed_version_after_cumulative_point";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+    _version++;
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    // compaction 3-4
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(4, versions[2].second);
+    }
+
+    // compaction 1-2
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(4, versions[1].second);
+    }
+
+    // write 2
+    {
+        write_specify_version(tablet, 2);
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(4, versions[2].second);
+    }
+
+    // compaction 2
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(4, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_missed_two_version) {
+    LOG(INFO) << "test_missed_two_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+    _version += 2;
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    // compaction 4-5
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+
+    // compaction 0-1
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(4, versions[1].first);
+        ASSERT_EQ(5, versions[1].second);
+    }
+
+    // write version 2
+    {
+        write_specify_version(tablet, 2);
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+
+    // compaction 0-2
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(2, versions[0].second);
+        ASSERT_EQ(4, versions[1].first);
+        ASSERT_EQ(5, versions[1].second);
+    }
+
+    // write version 3
+    {
+        write_specify_version(tablet, 3);
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(2, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+
+    // compaction 0-5
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(5, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_delete_version) {
+    LOG(INFO) << "test_delete_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+    _version++;
+    write_delete_version(tablet_meta, 1);
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(3, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(2, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_missed_and_delete_version) {
+    LOG(INFO) << "test_missed_delete_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+    _version += 2;
+    write_delete_version(tablet_meta, 3);
+
+    _version += 2;
+    for (int i = 0; i < 2; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(5, tablet->version_count());
+
+    // compaction 6-7
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(4, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+        ASSERT_EQ(6, versions[3].first);
+        ASSERT_EQ(7, versions[3].second);
+    }
+
+    // compaction 0-1
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(6, versions[2].first);
+        ASSERT_EQ(7, versions[2].second);
+    }
+
+    // write version 2
+    {
+        write_specify_version(tablet, 2);
+        ASSERT_EQ(4, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+        ASSERT_EQ(6, versions[3].first);
+        ASSERT_EQ(7, versions[3].second);
+    }
+
+    // compaction 0-3
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(3, versions[0].second);
+        ASSERT_EQ(6, versions[1].first);
+        ASSERT_EQ(7, versions[1].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_two_delete_version) {
+    LOG(INFO) << "test_two_delete_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+    _version++;
+    write_delete_version(tablet_meta, 1);
+    _version++;
+    write_delete_version(tablet_meta, 2);
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(3, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_two_delete_missed_version) {
+    LOG(INFO) << "test_two_delete_missed_version";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+    _version++;
+    _version++;
+    write_delete_version(tablet_meta, 2);
+    _version++;
+    write_delete_version(tablet_meta, 3);
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(4, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+        ASSERT_EQ(4, versions[3].first);
+        ASSERT_EQ(4, versions[3].second);
+    }
+
+    // write version 1
+    {
+        write_specify_version(tablet, 1);
+        ASSERT_EQ(5, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(5, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(2, versions[2].first);
+        ASSERT_EQ(2, versions[2].second);
+        ASSERT_EQ(3, versions[3].first);
+        ASSERT_EQ(3, versions[3].second);
+        ASSERT_EQ(4, versions[4].first);
+        ASSERT_EQ(4, versions[4].second);
+    }
+
+    // compaction 0-4
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(4, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_write_descending_order_level_size) {
+    LOG(INFO) << "test_write_descending_order_level_size";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 4);
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 2);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(3, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(2, versions[2].first);
+        ASSERT_EQ(2, versions[2].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_write_order_level_size) {
+    LOG(INFO) << "test_write_order_level_size";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 2);
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 4);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(3, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(2, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_write_multi_descending_order_level_size) {
+    LOG(INFO) << "test_write_multi_descending_order_level_size";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 4);
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 2);
+    write_new_version(tablet_meta, 2);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(5, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(4, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(2, versions[2].first);
+        ASSERT_EQ(2, versions[2].second);
+        ASSERT_EQ(3, versions[3].first);
+        ASSERT_EQ(4, versions[3].second);
+    }
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(4, versions[1].second);
+    }
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(4, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_base_compaction) {
+    LOG(INFO) << "test_backtrace_base_compaction";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 2);
+    write_delete_version(tablet_meta, 2);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(3, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(2, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_base_and_backtrace_compaction) {
+    LOG(INFO) << "test_base_and_backtrace_compaction";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 2);
+    write_delete_version(tablet_meta, 3);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(2, versions[1].second);
+        ASSERT_EQ(3, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+    }
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(3, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_cumulative_compaction) {
+    LOG(INFO) << "test_backtrace_cumulative_compaction";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 4);
+    write_new_version(tablet_meta, 4);
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 2);
+    write_delete_version(tablet_meta, 4);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(5, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(4, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(2, versions[2].first);
+        ASSERT_EQ(3, versions[2].second);
+        ASSERT_EQ(4, versions[3].first);
+        ASSERT_EQ(4, versions[3].second);
+    }
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(1, versions[0].second);
+        ASSERT_EQ(2, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(4, versions[2].second);
+    }
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(4, versions[0].second);
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_no_backtrace_compaction) {
+    LOG(INFO) << "test_no_backtrace_compaction";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 3);
+    _version++;
+    _version++;
+    write_delete_version(tablet_meta, 2);
+    write_new_version(tablet_meta, 2);
+    _version++;
+    write_delete_version(tablet_meta, 4);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_FALSE(res.ok());
+        ASSERT_EQ(4, tablet->version_count());
+    }
+}
+
+TEST_F(SizeTieredCompactionPolicyTest, test_force_base_compaction) {
+    LOG(INFO) << "test_force_base_compaction";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 4);
+    write_new_version(tablet_meta, 3);
+    write_new_version(tablet_meta, 2);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(3, tablet->version_count());
+
+    {
+        auto res = compact(tablet);
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(3, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(1, versions[1].second);
+        ASSERT_EQ(2, versions[2].first);
+        ASSERT_EQ(2, versions[2].second);
+    }
+
+    sleep(1);
+
+    config::base_compaction_interval_seconds_since_last_operation = 1;
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(2, versions[0].second);
+    }
+
+    config::base_compaction_interval_seconds_since_last_operation = 86400;
+}
+
+} // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The basic idea of ​​the `Size-Tiered` compaction strategy is to allow rowsets with similar data volumes to perform compaction as much as possible, so as to avoid `write amplification` caused by compaction.

Therefore, we divide the data of a tablet into `size_tiered_level_num` levels, among which the size of the minium level is `size_tiered_min_level_size`, and the size increases by `size_tiered_level_multiple` times for each level that increases.

When a new rowset is generated, it will be marked to the corresponding Level according to the amount of data. Size-Tiered compaction will calculate the `compaction score` of each level based on the `number of segments` and `data volume of the rowset` of each level, and the `Duplicate Key` will give more Data volume is weighted to avoid write amplification as much as possible, and `Aggreation/Unique Key` will weight the number of segments to reduce read amplification and space enlargement. Then the level with the highest compaction score will perform compaction on the rowsets of the same level, and the newly generated rowsets will also be marked to the corresponding level according to the amount of data.

![image](https://user-images.githubusercontent.com/1292236/204206297-6e4efb02-a968-431f-b32f-45e91d9fefc7.png)

The above figure assumes `size_tiered_level_num=3` `size_tiered_level_multiple=2`
Initially, there are Rowset [0-10], [11-12], [13-13]. After writing [14-14], first enter level 1 and execute cumulative compaction to generate [13-14]. Because size=2 meets the requirements of level 2, then execute cumulative compaction with [11-12] of level 2 to generate [11-14], and finally enter level 3, execute Base compaction with [0-10] to generate [0-14].


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
