### PR TITLE
[BugFix] Fix couldn't connect to ES external table with default https port URL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsNodeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/elasticsearch/EsNodeInfo.java
@@ -103,7 +103,7 @@ public class EsNodeInfo {
     public EsNodeInfo(String id, String seed) {
         this.id = id;
         String[] scratch = seed.split(":");
-        int port = 80;
+        int port = seed.startsWith("https") ? 443 : 80;
         if (scratch.length == 3) {
             port = Integer.parseInt(scratch[2]);
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13624 

## Problem Summary(Required) ：
the default port for https should be 443.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
