### PR TITLE
[BugFix] Variable chunk's column types

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -163,11 +163,6 @@ public:
         if (src_column->is_nullable()) {
             return src_column;
         }
-
-        // const column should not be casted to nullable column.
-        if (src_column->is_constant()) {
-            return ColumnHelper::create_const_null_column(src_column->size());
-        }
         return NullableColumn::create(src_column, NullColumn::create(src_column->size(), 0));
     }
 

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -163,6 +163,11 @@ public:
         if (src_column->is_nullable()) {
             return src_column;
         }
+
+        // const column should not be casted to nullable column.
+        if (src_column->is_constant()) {
+            return src_column;
+        }
         return NullableColumn::create(src_column, NullColumn::create(src_column->size(), 0));
     }
 

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -166,7 +166,7 @@ public:
 
         // const column should not be casted to nullable column.
         if (src_column->is_constant()) {
-            return src_column;
+            return ColumnHelper::create_const_null_column(src_column->size());
         }
         return NullableColumn::create(src_column, NullColumn::create(src_column->size(), 0));
     }

--- a/be/src/exec/vectorized/csv_scanner.cpp
+++ b/be/src/exec/vectorized/csv_scanner.cpp
@@ -181,7 +181,7 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
 
         fill_columns_from_path(src_chunk, _num_fields_in_csv, _scan_range.ranges[_curr_file_index].columns_from_path,
                                src_chunk->num_rows());
-        ASSIGN_OR_RETURN(chunk, _materialize(src_chunk));
+        ASSIGN_OR_RETURN(chunk, materialize(nullptr, src_chunk));
     } while ((chunk)->num_rows() == 0);
     return std::move(chunk);
 }
@@ -272,43 +272,6 @@ ChunkPtr CSVScanner::_create_chunk(const std::vector<SlotDescriptor*>& slots) {
         chunk->append_column(std::move(column), slots[i]->id());
     }
     return chunk;
-}
-
-// TODO(zhuming): move this function to `FileScanner` or `FileScanNode`
-StatusOr<ChunkPtr> CSVScanner::_materialize(ChunkPtr& src_chunk) {
-    SCOPED_RAW_TIMER(&_counter->materialize_ns);
-
-    if (src_chunk->num_rows() == 0) {
-        return src_chunk;
-    }
-
-    ChunkPtr dest_chunk = std::make_shared<Chunk>();
-
-    // CREATE ROUTINE LOAD routine_load_job_1
-    // on table COLUMNS (k1,k2,k3=k1)
-    // The column k3 and k1 will pointer to the same entity.
-    // The k3 should be copied to avoid this case.
-    // column_pointers is a hashset to check the repeatability.
-    HashSet<uintptr_t> column_pointers;
-    int ctx_index = 0;
-    int src_rows = src_chunk->num_rows();
-    for (const auto& slot : _dest_tuple_desc->slots()) {
-        if (!slot->is_materialized()) {
-            continue;
-        }
-
-        int dest_index = ctx_index++;
-        ASSIGN_OR_RETURN(auto dst_col, _dest_expr_ctx[dest_index]->evaluate(src_chunk.get()));
-        auto col_pointer = reinterpret_cast<uintptr_t>(dst_col.get());
-        if (column_pointers.contains(col_pointer)) {
-            dst_col = dst_col->clone();
-        } else {
-            column_pointers.emplace(col_pointer);
-        }
-        dst_col = ColumnHelper::unfold_const_column(slot->type(), src_rows, dst_col);
-        dest_chunk->append_column(dst_col, slot->id());
-    }
-    return dest_chunk;
 }
 
 void CSVScanner::_report_error(const std::string& line, const std::string& err_msg) {

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -172,13 +172,14 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::vectorized::ChunkPt
             column_pointers.emplace(col_pointer);
         }
 
+        col = ColumnHelper::unfold_const_column(slot->type(), cast->num_rows(), col);
+
         // The column builder in ctx->evaluate may build column as non-nullable.
         // See be/src/column/column_builder.h#L79.
         if (!col->is_nullable() && slot->is_nullable()) {
             col = ColumnHelper::cast_to_nullable_column(col);
         }
 
-        col = ColumnHelper::unfold_const_column(slot->type(), cast->num_rows(), col);
         dest_chunk->append_column(col, slot->id());
 
         if (src != nullptr && col->is_nullable() && col->has_null()) {

--- a/be/src/exec/vectorized/file_scanner.cpp
+++ b/be/src/exec/vectorized/file_scanner.cpp
@@ -139,6 +139,11 @@ void FileScanner::fill_columns_from_path(starrocks::vectorized::ChunkPtr& chunk,
 StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::vectorized::ChunkPtr& src,
                                             starrocks::vectorized::ChunkPtr& cast) {
     SCOPED_RAW_TIMER(&_counter->materialize_ns);
+
+    if (cast->num_rows() == 0) {
+        return cast;
+    }
+
     // materialize
     ChunkPtr dest_chunk = std::make_shared<Chunk>();
 
@@ -166,10 +171,17 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::vectorized::ChunkPt
         } else {
             column_pointers.emplace(col_pointer);
         }
+
+        // The column builder in ctx->evaluate may build column as non-nullable.
+        // See be/src/column/column_builder.h#L79.
+        if (!col->is_nullable() && slot->is_nullable()) {
+            col = ColumnHelper::cast_to_nullable_column(col);
+        }
+
         col = ColumnHelper::unfold_const_column(slot->type(), cast->num_rows(), col);
         dest_chunk->append_column(col, slot->id());
 
-        if (col->is_nullable() && col->has_null()) {
+        if (src != nullptr && col->is_nullable() && col->has_null()) {
             if (_strict_mode && _dest_slot_desc_mappings[dest_index] != nullptr) {
                 ColumnPtr& src_col = src->get_column_by_slot_id(_dest_slot_desc_mappings[dest_index]->id());
 

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -24,22 +24,12 @@ protected:
         builder.append(Slice("v1"), true);
         return builder.build(false);
     }
-
-    ColumnPtr create_const_column() {
-        ColumnBuilder<TYPE_VARCHAR> builder(1);
-        builder.append(Slice("v1"));
-        return builder.build(true);
-    }
 };
 
 TEST_F(ColumnHelperTest, cast_to_nullable_column) {
     auto col = ColumnHelper::cast_to_nullable_column(create_column());
     ASSERT_TRUE(col->is_nullable());
     ASSERT_FALSE(col->is_constant());
-
-    col = ColumnHelper::cast_to_nullable_column(create_const_column());
-    ASSERT_TRUE(col->is_nullable());
-    ASSERT_TRUE(col->is_constant());
 
     col = ColumnHelper::cast_to_nullable_column(create_nullable_column());
     ASSERT_TRUE(col->is_nullable());

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -38,7 +38,7 @@ TEST_F(ColumnHelperTest, cast_to_nullable_column) {
     ASSERT_FALSE(col->is_constant());
 
     col = ColumnHelper::cast_to_nullable_column(create_const_column());
-    ASSERT_FALSE(col->is_nullable());
+    ASSERT_TRUE(col->is_nullable());
     ASSERT_TRUE(col->is_constant());
 
     col = ColumnHelper::cast_to_nullable_column(create_nullable_column());

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -30,13 +30,6 @@ protected:
         builder.append(Slice("v1"));
         return builder.build(true);
     }
-
-    ColumnPtr create_const_nullable_column() {
-        ColumnBuilder<TYPE_VARCHAR> builder(1);
-        builder.append(Slice("v1"), true);
-        return builder.build(true);
-    }
-
 };
 
 TEST_F(ColumnHelperTest, cast_to_nullable_column) {
@@ -44,9 +37,13 @@ TEST_F(ColumnHelperTest, cast_to_nullable_column) {
     ASSERT_TRUE(col->is_nullable());
     ASSERT_FALSE(col->is_constant());
 
-    auto col = ColumnHelper::cast_to_nullable_column(create_const_column());
-    ASSERT_TRUE(col->is_nullable());
+    col = ColumnHelper::cast_to_nullable_column(create_const_column());
+    ASSERT_FALSE(col->is_nullable());
     ASSERT_TRUE(col->is_constant());
+
+    col = ColumnHelper::cast_to_nullable_column(create_nullable_column());
+    ASSERT_TRUE(col->is_nullable());
+    ASSERT_FALSE(col->is_constant());
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -1,6 +1,7 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
 #include "column/column_helper.h"
+#include "column/column_builder.h"
 
 #include "gtest/gtest.h"
 
@@ -10,6 +11,42 @@ class ColumnHelperTest : public testing::Test {
 public:
     void SetUp() override {}
     void TearDown() override {}
+
+protected:
+    ColumnPtr create_column() {
+        ColumnBuilder<TYPE_VARCHAR> builder(1);
+        builder.append(Slice("v1"));
+        return builder.build(false);
+    }
+
+    ColumnPtr create_nullable_column() {
+        ColumnBuilder<TYPE_VARCHAR> builder(1);
+        builder.append(Slice("v1"), true);
+        return builder.build(false);
+    }
+
+    ColumnPtr create_const_column() {
+        ColumnBuilder<TYPE_VARCHAR> builder(1);
+        builder.append(Slice("v1"));
+        return builder.build(true);
+    }
+
+    ColumnPtr create_const_nullable_column() {
+        ColumnBuilder<TYPE_VARCHAR> builder(1);
+        builder.append(Slice("v1"), true);
+        return builder.build(true);
+    }
+
 };
+
+TEST_F(ColumnHelperTest, cast_to_nullable_column) {
+    auto col = ColumnHelper::cast_to_nullable_column(create_column());
+    ASSERT_TRUE(col->is_nullable());
+    ASSERT_FALSE(col->is_constant());
+
+    auto col = ColumnHelper::cast_to_nullable_column(create_const_column());
+    ASSERT_TRUE(col->is_nullable());
+    ASSERT_TRUE(col->is_constant());
+}
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13053

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The column type like `datetime` is casted from `varchar` in the file scanner. `cast_from_string_to_datetime_fn` would build a column as nullable when there're nulls in the column, while it would build a column as non-nullable when there's no null in the column. So, the column types of different chunks may be different. 
The exchange node gets the chunk schema according to the first chunk it receives, and then parses the chunk according to the schema. In this way, the exchange node cannot handle the variable column type.
This PR corrects the columns returned by the `cast_from_string_to_datetime_fn` according to the actual schema. 
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function










