### PR TITLE
[Enhancement] Add catch bad alloc for serialize/finalize/transmit_chunk

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -34,7 +34,7 @@ StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(Runti
     if (_aggregator->is_none_group_by_exprs()) {
         RETURN_IF_ERROR(_aggregator->convert_to_chunk_no_groupby(&chunk));
     } else {
-        RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(chunk_size, &chunk))
+        RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(chunk_size, &chunk));
     }
 
     size_t old_size = chunk->num_rows();

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -32,9 +32,9 @@ StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(Runti
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
 
     if (_aggregator->is_none_group_by_exprs()) {
-        _aggregator->convert_to_chunk_no_groupby(&chunk);
+        RETURN_IF_ERROR(_aggregator->convert_to_chunk_no_groupby(&chunk));
     } else {
-        _aggregator->convert_hash_map_to_chunk(chunk_size, &chunk);
+        RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(chunk_size, &chunk))
     }
 
     size_t old_size = chunk->num_rows();

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -53,20 +53,21 @@ StatusOr<vectorized::ChunkPtr> AggregateStreamingSourceOperator::pull_chunk(Runt
     // Even if it is streaming mode, the purpose of reading from hash table is to
     // correctly process the state of hash table(_is_ht_eos)
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
-    _output_chunk_from_hash_map(&chunk, state);
+    RETURN_IF_ERROR(_output_chunk_from_hash_map(&chunk, state));
     eval_runtime_bloom_filters(chunk.get());
     DCHECK_CHUNK(chunk);
     return std::move(chunk);
 }
 
-void AggregateStreamingSourceOperator::_output_chunk_from_hash_map(vectorized::ChunkPtr* chunk, RuntimeState* state) {
+Status AggregateStreamingSourceOperator::_output_chunk_from_hash_map(vectorized::ChunkPtr* chunk, RuntimeState* state) {
     if (!_aggregator->it_hash().has_value()) {
         _aggregator->hash_map_variant().visit(
                 [&](auto& hash_map_with_key) { _aggregator->it_hash() = _aggregator->_state_allocator.begin(); });
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     }
 
-    _aggregator->convert_hash_map_to_chunk(state->chunk_size(), chunk);
+    RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), chunk));
+    return Status::OK();
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.h
@@ -28,7 +28,7 @@ public:
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    void _output_chunk_from_hash_map(vectorized::ChunkPtr* chunk, RuntimeState* state);
+    Status _output_chunk_from_hash_map(vectorized::ChunkPtr* chunk, RuntimeState* state);
 
     // It is used to perform aggregation algorithms shared by
     // AggregateStreamingSinkOperator. It is

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -242,7 +242,7 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(RuntimeState* state, const 
         int64_t attachment_physical_bytes = _parent->construct_brpc_attachment(_chunk_request, attachment);
         TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment,
                                   attachment_physical_bytes};
-        _parent->_buffer->add_request(info);
+        RETURN_IF_ERROR(_parent->_buffer->add_request(info));
         _current_request_bytes = 0;
         _chunk_request.reset();
         *is_real_sent = true;
@@ -269,7 +269,7 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(RuntimeState* state, PT
 
     TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment,
                               attachment_physical_bytes};
-    _parent->_buffer->add_request(info);
+    RETURN_IF_ERROR(_parent->_buffer->add_request(info));
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -637,12 +637,14 @@ Status ExchangeSinkOperator::serialize_chunk(const vectorized::Chunk* src, Chunk
         // We only serialize chunk meta for first chunk
         if (*is_first_chunk) {
             _encode_context = serde::EncodeContext::get_encode_context_shared_ptr(src->columns().size(), _encode_level);
-            StatusOr<ChunkPB> res = serde::ProtobufChunkSerde::serialize(*src, _encode_context);
+            StatusOr<ChunkPB> res = Status::OK();
+            TRY_CATCH_BAD_ALLOC(res = serde::ProtobufChunkSerde::serialize(*src, _encode_context));
             RETURN_IF_ERROR(res);
             res->Swap(dst);
             *is_first_chunk = false;
         } else {
-            StatusOr<ChunkPB> res = serde::ProtobufChunkSerde::serialize_without_meta(*src, _encode_context);
+            StatusOr<ChunkPB> res = Status::OK();
+            TRY_CATCH_BAD_ALLOC(res = serde::ProtobufChunkSerde::serialize_without_meta(*src, _encode_context));
             RETURN_IF_ERROR(res);
             res->Swap(dst);
         }

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -59,10 +59,10 @@ SinkBuffer::~SinkBuffer() {
     _buffers.clear();
 }
 
-void SinkBuffer::add_request(TransmitChunkInfo& request) {
+Status SinkBuffer::add_request(TransmitChunkInfo& request) {
     DCHECK(_num_remaining_eos > 0);
     if (_is_finishing) {
-        return;
+        return Status::OK();
     }
     if (!request.attachment.empty()) {
         _bytes_enqueued += request.attachment.size();
@@ -70,8 +70,10 @@ void SinkBuffer::add_request(TransmitChunkInfo& request) {
     }
     {
         auto& instance_id = request.fragment_instance_id;
-        _try_to_send_rpc(instance_id, [&]() { _buffers[instance_id.lo].push(request); });
+        RETURN_IF_ERROR(_try_to_send_rpc(instance_id, [&]() { _buffers[instance_id.lo].push(request); }));
     }
+
+    return Status::OK();
 }
 
 bool SinkBuffer::is_full() const {
@@ -215,7 +217,7 @@ void SinkBuffer::_process_send_window(const TUniqueId& instance_id, const int64_
     }
 }
 
-void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::function<void()>& pre_works) {
+Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::function<void()>& pre_works) {
     std::lock_guard<Mutex> l(*_mutexes[instance_id.lo]);
     pre_works();
 
@@ -224,7 +226,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::funct
 
     for (;;) {
         if (_is_finishing) {
-            return;
+            return Status::OK();
         }
 
         auto& buffer = _buffers[instance_id.lo];
@@ -241,7 +243,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::funct
             too_much_brpc_process = _num_in_flight_rpcs[instance_id.lo] >= config::pipeline_sink_brpc_dop;
         }
         if (buffer.empty() || too_much_brpc_process) {
-            return;
+            return Status::OK();
         }
 
         TransmitChunkInfo& request = buffer.front();
@@ -263,7 +265,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::funct
         // But we must guarantee that first packet must be received first
         if (_num_finished_rpcs[instance_id.lo] == 0 && _num_in_flight_rpcs[instance_id.lo] > 0) {
             need_wait = true;
-            return;
+            return Status::OK();
         }
         if (request.params->eos()) {
             DeferOp eos_defer([this, &instance_id, &need_wait]() {
@@ -290,7 +292,7 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::funct
                 // But we must guarantee that eos packent must be the last packet
                 if (_num_in_flight_rpcs[instance_id.lo] > 0) {
                     need_wait = true;
-                    return;
+                    return Status::OK();
                 }
             }
         }
@@ -355,15 +357,19 @@ void SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::funct
         closure->cntl.request_attachment().append(request.attachment);
 
         if (bthread_self()) {
-            request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
+            TRY_CATCH_BAD_ALLOC(
+                    request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure));
         } else {
             // When the driver worker thread sends request and creates the protobuf request,
             // also use process_mem_tracker to record the memory of the protobuf request.
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
-            request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
+            TRY_CATCH_BAD_ALLOC(
+                    request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure));
         }
 
-        return;
+        return Status::OK();
     }
+
+    return Status::OK();
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -70,7 +70,7 @@ public:
                bool is_dest_merge, size_t num_sinkers);
     ~SinkBuffer();
 
-    void add_request(TransmitChunkInfo& request);
+    Status add_request(TransmitChunkInfo& request);
     bool is_full() const;
 
     void set_finishing();
@@ -96,7 +96,7 @@ private:
 
     // Try to send rpc if buffer is not empty and channel is not busy
     // And we need to put this function and other extra works(pre_works) together as an atomic operation
-    void _try_to_send_rpc(const TUniqueId& instance_id, const std::function<void()>& pre_works);
+    Status _try_to_send_rpc(const TUniqueId& instance_id, const std::function<void()>& pre_works);
 
     // Roughly estimate network time which is defined as the time between sending a and receiving a packet,
     // and the processing time of both sides are excluded

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -287,7 +287,8 @@ Status NodeChannel::_serialize_chunk(const vectorized::Chunk* src, ChunkPB* dst)
 
     {
         SCOPED_RAW_TIMER(&_serialize_batch_ns);
-        StatusOr<ChunkPB> res = serde::ProtobufChunkSerde::serialize(*src);
+        StatusOr<ChunkPB> res = Status::OK();
+        TRY_CATCH_BAD_ALLOC(res = serde::ProtobufChunkSerde::serialize(*src));
         if (!res.ok()) {
             _cancelled = true;
             _err_st = res.status();

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -134,9 +134,9 @@ Status AggregateBlockingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
     int32_t chunk_size = runtime_state()->chunk_size();
 
     if (_aggregator->is_none_group_by_exprs()) {
-        _aggregator->convert_to_chunk_no_groupby(chunk);
+        RETURN_IF_ERROR(_aggregator->convert_to_chunk_no_groupby(chunk));
     } else {
-        _aggregator->convert_hash_map_to_chunk(chunk_size, chunk);
+        RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(chunk_size, chunk));
     }
 
     size_t old_size = (*chunk)->num_rows();

--- a/be/src/exec/vectorized/aggregate/aggregate_streaming_node.h
+++ b/be/src/exec/vectorized/aggregate/aggregate_streaming_node.h
@@ -21,6 +21,6 @@ public:
             pipeline::PipelineBuilderContext* context) override;
 
 private:
-    void _output_chunk_from_hash_map(ChunkPtr* chunk);
+    Status _output_chunk_from_hash_map(ChunkPtr* chunk);
 };
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -967,7 +967,7 @@ void Aggregator::build_hash_map_with_selection(size_t chunk_size) {
 Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk) {
     SCOPED_TIMER(_agg_stat->get_results_timer);
 
-    _hash_map_variant.visit([&](auto& variant_value) {
+    RETURN_IF_ERROR(_hash_map_variant.visit([&](auto& variant_value) {
         auto& hash_map_with_key = *variant_value;
         using HashMapWithKey = std::remove_reference_t<decltype(hash_map_with_key)>;
 
@@ -1004,12 +1004,14 @@ Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::Chu
             if (!use_intermediate) {
                 for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
                     TRY_CATCH_BAD_ALLOC(_agg_functions[i]->batch_finalize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
-                                                      _agg_states_offsets[i], agg_result_columns[i].get()));
+                                                                          _agg_states_offsets[i],
+                                                                          agg_result_columns[i].get()));
                 }
             } else {
                 for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
                     TRY_CATCH_BAD_ALLOC(_agg_functions[i]->batch_serialize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
-                                                       _agg_states_offsets[i], agg_result_columns[i].get()));
+                                                                           _agg_states_offsets[i],
+                                                                           agg_result_columns[i].get()));
                 }
             }
         }
@@ -1045,7 +1047,11 @@ Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::Chu
         _num_rows_returned += read_index;
         _num_rows_processed += read_index;
         *chunk = std::move(result_chunk);
-    });
+
+        return Status::OK();
+    }));
+
+    return Status::OK();
 }
 
 void Aggregator::build_hash_set(size_t chunk_size) {

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -513,15 +513,15 @@ Status Aggregator::_evaluate_const_columns(int i) {
     return Status::OK();
 }
 
-void Aggregator::convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk) {
+Status Aggregator::convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk) {
     SCOPED_TIMER(_agg_stat->get_results_timer);
     // TODO(kks): we should approve memory allocate here
     vectorized::Columns agg_result_column = _create_agg_result_columns(1);
     auto use_intermediate = _use_intermediate_as_output();
     if (!use_intermediate) {
-        _finalize_to_chunk(_single_agg_state, agg_result_column);
+        TRY_CATCH_BAD_ALLOC(_finalize_to_chunk(_single_agg_state, agg_result_column));
     } else {
-        _serialize_to_chunk(_single_agg_state, agg_result_column);
+        TRY_CATCH_BAD_ALLOC(_serialize_to_chunk(_single_agg_state, agg_result_column));
     }
 
     // For agg function column is non-nullable and table is empty
@@ -545,6 +545,8 @@ void Aggregator::convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk) {
     ++_num_rows_processed;
     *chunk = std::move(result_chunk);
     _is_ht_eos = true;
+
+    return Status::OK();
 }
 
 void Aggregator::process_limit(vectorized::ChunkPtr* chunk) {
@@ -962,7 +964,7 @@ void Aggregator::build_hash_map_with_selection(size_t chunk_size) {
     });
 }
 
-void Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk) {
+Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk) {
     SCOPED_TIMER(_agg_stat->get_results_timer);
 
     _hash_map_variant.visit([&](auto& variant_value) {
@@ -1001,13 +1003,13 @@ void Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::Chunk
             SCOPED_TIMER(_agg_stat->agg_append_timer);
             if (!use_intermediate) {
                 for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-                    _agg_functions[i]->batch_finalize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
-                                                      _agg_states_offsets[i], agg_result_columns[i].get());
+                    TRY_CATCH_BAD_ALLOC(_agg_functions[i]->batch_finalize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
+                                                      _agg_states_offsets[i], agg_result_columns[i].get()));
                 }
             } else {
                 for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-                    _agg_functions[i]->batch_serialize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
-                                                       _agg_states_offsets[i], agg_result_columns[i].get());
+                    TRY_CATCH_BAD_ALLOC(_agg_functions[i]->batch_serialize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
+                                                       _agg_states_offsets[i], agg_result_columns[i].get()));
                 }
             }
         }
@@ -1025,9 +1027,9 @@ void Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::Chunk
                     group_by_columns[0]->append_default();
 
                     if (!use_intermediate) {
-                        _finalize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns);
+                        TRY_CATCH_BAD_ALLOC(_finalize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns));
                     } else {
-                        _serialize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns);
+                        TRY_CATCH_BAD_ALLOC(_serialize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns));
                     }
 
                     ++read_index;

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -357,9 +357,7 @@ public:
     void convert_hash_set_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk);
 
 protected:
-    bool _reached_limit() {
-        return _limit != -1 && _num_rows_returned >= _limit;
-    }
+    bool _reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
 
     bool _use_intermediate_as_input() {
         if (is_pending_reset_state()) {
@@ -393,22 +391,12 @@ protected:
     vectorized::ChunkPtr _build_output_chunk(const vectorized::Columns& group_by_columns,
                                              const vectorized::Columns& agg_result_columns);
 
-    void _set_passthrough(bool flag) {
-        _is_passthrough = flag;
-    }
-    bool is_passthrough() const {
-        return _is_passthrough;
-    }
+    void _set_passthrough(bool flag) { _is_passthrough = flag; }
+    bool is_passthrough() const { return _is_passthrough; }
 
-    void begin_pending_reset_state() {
-        _is_pending_reset_state = true;
-    }
-    void end_pending_reset_state() {
-        _is_pending_reset_state = false;
-    }
-    bool is_pending_reset_state() {
-        return _is_pending_reset_state;
-    }
+    void begin_pending_reset_state() { _is_pending_reset_state = true; }
+    void end_pending_reset_state() { _is_pending_reset_state = false; }
+    bool is_pending_reset_state() { return _is_pending_reset_state; }
 
     void _reset_exprs();
     Status _evaluate_exprs(vectorized::Chunk* chunk);

--- a/be/src/exec/vectorized/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/vectorized/sorted_streaming_aggregator.cpp
@@ -398,12 +398,12 @@ void SortedStreamingAggregator::_get_agg_result_columns(size_t chunk_size, const
                                                         vectorized::Columns& agg_result_columns) {
     SCOPED_TIMER(_agg_stat->get_results_timer);
     if (_cmp_vector[0] != 0 && _last_state) {
-        _finalize_to_chunk(_last_state, agg_result_columns);
+        TRY_CATCH_BAD_ALLOC(_finalize_to_chunk(_last_state, agg_result_columns));
     }
 
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-        _agg_functions[i]->batch_finalize_with_selection(_agg_fn_ctxs[i], chunk_size, _tmp_agg_states,
-                                                         _agg_states_offsets[i], agg_result_columns[i].get(), selector);
+        TRY_CATCH_BAD_ALLOC(_agg_functions[i]->batch_finalize_with_selection(_agg_fn_ctxs[i], chunk_size, _tmp_agg_states,
+                                                         _agg_states_offsets[i], agg_result_columns[i].get(), selector));
     }
 }
 
@@ -444,7 +444,7 @@ StatusOr<vectorized::ChunkPtr> SortedStreamingAggregator::pull_eos_chunk() {
     auto agg_result_columns = _create_agg_result_columns(1);
     auto group_by_columns = _last_columns;
 
-    _finalize_to_chunk(_last_state, agg_result_columns);
+    TRY_CATCH_BAD_ALLOC(_finalize_to_chunk(_last_state, agg_result_columns));
     _destroy_state(_last_state);
     _last_state = nullptr;
     _last_columns.clear();

--- a/be/src/exec/vectorized/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/vectorized/sorted_streaming_aggregator.cpp
@@ -395,15 +395,16 @@ Status SortedStreamingAggregator::_update_states(size_t chunk_size) {
 }
 
 Status SortedStreamingAggregator::_get_agg_result_columns(size_t chunk_size, const std::vector<uint8_t>& selector,
-                                                        vectorized::Columns& agg_result_columns) {
+                                                          vectorized::Columns& agg_result_columns) {
     SCOPED_TIMER(_agg_stat->get_results_timer);
     if (_cmp_vector[0] != 0 && _last_state) {
         TRY_CATCH_BAD_ALLOC(_finalize_to_chunk(_last_state, agg_result_columns));
     }
 
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-        TRY_CATCH_BAD_ALLOC(_agg_functions[i]->batch_finalize_with_selection(_agg_fn_ctxs[i], chunk_size, _tmp_agg_states,
-                                                         _agg_states_offsets[i], agg_result_columns[i].get(), selector));
+        TRY_CATCH_BAD_ALLOC(_agg_functions[i]->batch_finalize_with_selection(_agg_fn_ctxs[i], chunk_size,
+                                                                             _tmp_agg_states, _agg_states_offsets[i],
+                                                                             agg_result_columns[i].get(), selector));
     }
     return Status::OK();
 }

--- a/be/src/exec/vectorized/sorted_streaming_aggregator.h
+++ b/be/src/exec/vectorized/sorted_streaming_aggregator.h
@@ -26,7 +26,7 @@ private:
 
     Status _update_states(size_t chunk_size);
 
-    void _get_agg_result_columns(size_t chunk_size, const std::vector<uint8_t>& selector,
+    Status _get_agg_result_columns(size_t chunk_size, const std::vector<uint8_t>& selector,
                                  vectorized::Columns& agg_result_columns);
     void _close_group_by(size_t chunk_size, const std::vector<uint8_t>& selector);
 

--- a/be/src/exec/vectorized/sorted_streaming_aggregator.h
+++ b/be/src/exec/vectorized/sorted_streaming_aggregator.h
@@ -27,7 +27,7 @@ private:
     Status _update_states(size_t chunk_size);
 
     Status _get_agg_result_columns(size_t chunk_size, const std::vector<uint8_t>& selector,
-                                 vectorized::Columns& agg_result_columns);
+                                   vectorized::Columns& agg_result_columns);
     void _close_group_by(size_t chunk_size, const std::vector<uint8_t>& selector);
 
     Status _build_group_by_columns(size_t chunk_size, size_t selected_size, const std::vector<uint8_t>& selector,

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -680,12 +680,14 @@ Status DataStreamSender::serialize_chunk(const vectorized::Chunk* src, ChunkPB* 
         SCOPED_TIMER(_serialize_chunk_timer);
         // We only serialize chunk meta for first chunk
         if (*is_first_chunk) {
-            StatusOr<ChunkPB> res = serde::ProtobufChunkSerde::serialize(*src);
+            StatusOr<ChunkPB> res = Status::OK();
+            TRY_CATCH_BAD_ALLOC(res = serde::ProtobufChunkSerde::serialize(*src));
             if (!res.ok()) return res.status();
             res->Swap(dst);
             *is_first_chunk = false;
         } else {
-            StatusOr<ChunkPB> res = serde::ProtobufChunkSerde::serialize_without_meta(*src);
+            StatusOr<ChunkPB> res = Status::OK();
+            TRY_CATCH_BAD_ALLOC(res = serde::ProtobufChunkSerde::serialize_without_meta(*src));
             if (!res.ok()) return res.status();
             res->Swap(dst);
         }

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -35,6 +35,7 @@
 #include "gen_cpp/BackendService.h"
 #include "gen_cpp/Types_types.h"
 #include "runtime/client_cache.h"
+#include "runtime/current_thread.h"
 #include "runtime/data_stream_mgr.h"
 #include "runtime/descriptors.h"
 #include "runtime/dpp_sink_internal.h"
@@ -282,7 +283,8 @@ Status DataStreamSender::Channel::_do_send_chunk_rpc(PTransmitChunkParams* reque
     _chunk_closure->cntl.Reset();
     _chunk_closure->cntl.set_timeout_ms(_brpc_timeout_ms);
     _chunk_closure->cntl.request_attachment().append(attachment);
-    _brpc_stub->transmit_chunk(&_chunk_closure->cntl, request, &_chunk_closure->result, _chunk_closure);
+    TRY_CATCH_BAD_ALLOC(
+            _brpc_stub->transmit_chunk(&_chunk_closure->cntl, request, &_chunk_closure->result, _chunk_closure));
     _request_seq++;
     return Status::OK();
 }

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -256,7 +256,8 @@ Status LoadChannel::_deserialize_chunk(const ChunkPB& pchunk, vectorized::Chunk&
             TRY_CATCH_BAD_ALLOC({
                 std::string_view buff(reinterpret_cast<const char*>(uncompressed_buffer->data()), uncompressed_size);
                 serde::ProtobufChunkDeserializer des(_chunk_meta);
-                StatusOr<vectorized::Chunk> res = des.deserialize(buff);
+                StatusOr<vectorized::Chunk> res = Status::OK();
+                TRY_CATCH_BAD_ALLOC(res = des.deserialize(buff));
                 if (!res.ok()) return res.status();
                 chunk = std::move(res).value();
             });

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -6,6 +6,7 @@
 
 #include "column/column_helper.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
 #include "serde/column_array_serde.h"
 #include "util/coding.h"
@@ -174,7 +175,8 @@ StatusOr<vectorized::Chunk> ProtobufChunkSerde::deserialize(const RowDescriptor&
     }
     int64_t deserialized_size = 0;
     ProtobufChunkDeserializer deserializer(*res, &chunk_pb, encode_level);
-    StatusOr<vectorized::Chunk> chunk = deserializer.deserialize(chunk_pb.data(), &deserialized_size);
+    StatusOr<vectorized::Chunk> chunk = Status::OK();
+    TRY_CATCH_BAD_ALLOC(chunk = deserializer.deserialize(chunk_pb.data(), &deserialized_size));
     if (!chunk.ok()) return chunk;
 
     // The logic is a bit confusing here.


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
It appear when We execute sql with two-phase aggregate and massive datas:
```
select window_funnel(100 , time, 0 , [event_type = '浏览', event_type = '点击', event_type = '下单' ]) from window_funnel;
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When we use window_funnel for two-phase aggregate(**update-serialize=>merge-finalize**), It will collect records through serialization to second phase, If there records are massive and overflow available memory, It will throw bad alloc exception, and we missed it. **So we should catch it.**

Add TRY_CATCH_BAD_ALLOC for serialize_to_column for bad alloc.
