### PR TITLE
[BugFix] [Branch-2.3] Older versions of Analyzer disable constant folding functions for smaller int types

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -4,6 +4,7 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -517,5 +518,11 @@ public class SetTest extends PlanTestBase {
                 "  |  order by: <slot 8> 8: expr ASC"));
         Assert.assertTrue(plan.contains("  2:Project\n" +
                 "  |  <slot 4> : 1: v1 + 2: v2"));
+    }
+
+    @Test
+    public void testSetExpression() throws Exception {
+        UtFrameUtils.parseAndAnalyzeStmt("set exec_mem_limit = 2 * 4", connectContext);
+        UtFrameUtils.parseAndAnalyzeStmt("set exec_mem_limit = 2 + 4 - 1 * 3", connectContext);
     }
 }


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13648 #4691

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
// Because branch 2.3 introduced a more refined four arithmetic type deduction in #4691,
// but there are some non-Query Statements that also require constant expression calculation.
// For example, SetStatement still uses the old Analyzer and the old version of constant calculation
// in 2.3, and the old version of the constant calculation does not support low-precision INT,
// so the old version of the constant calculation is adapted here.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
