### PR TITLE
[BugFix] Validate query_timeout at analyze stage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -70,6 +70,9 @@ public class LeaderOpExecutor {
         // set thriftTimeoutMs to query_timeout + thrift_rpc_timeout_ms
         // so that we can return an execution timeout instead of a network timeout
         this.thriftTimeoutMs = ctx.getSessionVariable().getQueryTimeoutS() * 1000 + Config.thrift_rpc_timeout_ms;
+        if (this.thriftTimeoutMs < 0) {
+            this.thriftTimeoutMs = ctx.getSessionVariable().getQueryTimeoutS() * 1000;
+        }
         this.parsedStmt = parsedStmt;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -115,8 +115,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String SQL_SAFE_UPDATES = "sql_safe_updates";
     public static final String NET_BUFFER_LENGTH = "net_buffer_length";
     public static final String CODEGEN_LEVEL = "codegen_level";
-    // mem limit can't smaller than bufferpool's default page size
-    public static final int MIN_EXEC_MEM_LIMIT = 2097152;
     public static final String BATCH_SIZE = "batch_size";
     public static final String CHUNK_SIZE = "chunk_size";
     public static final String DISABLE_STREAMING_PREAGGREGATIONS = "disable_streaming_preaggregations";
@@ -293,7 +291,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_SCAN_BLOCK_CACHE = "enable_scan_block_cache";
     public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
 
-
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
     public static final String QUERY_CACHE_ENTRY_MAX_BYTES = "query_cache_entry_max_bytes";
@@ -303,8 +300,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String NESTED_MV_REWRITE_MAX_LEVEL = "nested_mv_rewrite_max_level";
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE = "enable_materialized_view_rewrite";
     public static final String ENABLE_MATERIALIZED_VIEW_UNION_REWRITE = "enable_materialized_view_union_rewrite";
-    public static final String ENABLE_RULE_BASED_MATERIALIZED_VIEW_REWRITE = "enable_rule_based_materialized_view_rewrite";
-    public static final String ENABLE_COST_BASED_MATERIALIZED_VIEW_REWRITE = "enable_cost_based_materialized_view_rewrite";
+    public static final String ENABLE_RULE_BASED_MATERIALIZED_VIEW_REWRITE =
+            "enable_rule_based_materialized_view_rewrite";
+    public static final String ENABLE_COST_BASED_MATERIALIZED_VIEW_REWRITE =
+            "enable_cost_based_materialized_view_rewrite";
 
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
@@ -327,6 +326,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             .add("vectorized_insert_enable")
             .add("prefer_join_method")
             .add("rewrite_count_distinct_to_bitmap_hll").build();
+
+    // Limitations
+    // mem limit can't smaller than bufferpool's default page size
+    public static final int MIN_EXEC_MEM_LIMIT = 2097152;
+    // query timeout cannot greater than one month
+    public static final int MAX_QUERY_TIMEOUT = 259200;
 
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE, alias = ENABLE_PIPELINE_ENGINE, show = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = true;
@@ -724,7 +729,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableSortAggregate(boolean enableSortAggregate) {
         this.enableSortAggregate = enableSortAggregate;
     }
-    
+
     @VariableMgr.VarAttr(name = ENABLE_SCAN_BLOCK_CACHE)
     private boolean useScanBlockCache = false;
 
@@ -887,16 +892,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public long getSqlSelectLimit() {
-        if (sqlSelectLimit < 0) {
-            return DEFAULT_SELECT_LIMIT;
-        }
         return sqlSelectLimit;
     }
 
     public void setSqlSelectLimit(long limit) {
-        if (limit < 0) {
-            return;
-        }
         this.sqlSelectLimit = limit;
     }
 
@@ -917,11 +916,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setMaxExecMemByte(long maxExecMemByte) {
-        if (maxExecMemByte < MIN_EXEC_MEM_LIMIT) {
-            this.maxExecMemByte = MIN_EXEC_MEM_LIMIT;
-        } else {
-            this.maxExecMemByte = maxExecMemByte;
-        }
+        this.maxExecMemByte = maxExecMemByte;
     }
 
     public void setLoadMemLimit(long loadMemLimit) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetVar.java
@@ -95,8 +95,7 @@ public class SetVar implements ParseNode {
             if (!GlobalStateMgr.getCurrentState().isUsingNewPrivilege()) {
                 if (!GlobalStateMgr.getCurrentState().getAuth()
                         .checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
-                    ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                                                        "ADMIN");
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
                 }
             }
         }
@@ -133,11 +132,11 @@ public class SetVar implements ParseNode {
 
         // Check variable load_mem_limit value is valid
         if (getVariable().equalsIgnoreCase(SessionVariable.LOAD_MEM_LIMIT)) {
-            checkNonNegativeLongVariable(SessionVariable.LOAD_MEM_LIMIT);
+            checkRangeLongVariable(SessionVariable.LOAD_MEM_LIMIT, 0L, null);
         }
 
         if (getVariable().equalsIgnoreCase(SessionVariable.QUERY_MEM_LIMIT)) {
-            checkNonNegativeLongVariable(SessionVariable.QUERY_MEM_LIMIT);
+            checkRangeLongVariable(SessionVariable.QUERY_MEM_LIMIT, 0L, null);
         }
 
         try {
@@ -149,6 +148,7 @@ public class SetVar implements ParseNode {
             }
 
             if (getVariable().equalsIgnoreCase(SessionVariable.EXEC_MEM_LIMIT)) {
+                checkRangeLongVariable(SessionVariable.EXEC_MEM_LIMIT, (long) SessionVariable.MIN_EXEC_MEM_LIMIT, null);
                 this.expression = new StringLiteral(
                         Long.toString(ParseUtil.analyzeDataVolumn(getResolvedExpression().getStringValue())));
                 this.resolvedExpression = (LiteralExpr) this.expression;
@@ -158,13 +158,22 @@ public class SetVar implements ParseNode {
         }
 
         if (getVariable().equalsIgnoreCase(SessionVariable.SQL_SELECT_LIMIT)) {
-            checkNonNegativeLongVariable(SessionVariable.SQL_SELECT_LIMIT);
+            checkRangeLongVariable(SessionVariable.SQL_SELECT_LIMIT, 0L, null);
+        }
+
+        if (getVariable().equalsIgnoreCase(SessionVariable.QUERY_TIMEOUT)) {
+            checkRangeLongVariable(SessionVariable.QUERY_TIMEOUT, 1L, (long) SessionVariable.MAX_QUERY_TIMEOUT);
+        }
+
+        if (getVariable().equalsIgnoreCase(SessionVariable.NEW_PLANNER_OPTIMIZER_TIMEOUT)) {
+            checkRangeLongVariable(SessionVariable.NEW_PLANNER_OPTIMIZER_TIMEOUT, 1L, null);
         }
 
         if (getVariable().equalsIgnoreCase(SessionVariable.RESOURCE_GROUP)) {
             String wgName = getResolvedExpression().getStringValue();
             if (!StringUtils.isEmpty(wgName)) {
-                ResourceGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByName(wgName);
+                ResourceGroup wg =
+                        GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByName(wgName);
                 if (wg == null) {
                     throw new SemanticException("resource group not exists: " + wgName);
                 }
@@ -176,12 +185,15 @@ public class SetVar implements ParseNode {
         }
     }
 
-    private void checkNonNegativeLongVariable(String field) {
+    private void checkRangeLongVariable(String field, Long min, Long max) {
         String value = getResolvedExpression().getStringValue();
         try {
             long num = Long.parseLong(value);
-            if (num < 0) {
-                throw new SemanticException(field + " must be equal or greater than 0.");
+            if (min != null && num < min) {
+                throw new SemanticException(String.format("%s must be equal or greater than %d.", field, min));
+            }
+            if (max != null && num > max) {
+                throw new SemanticException(String.format("%s must be equal or smaller than %d.", field, max));
             }
         } catch (NumberFormatException ex) {
             throw new SemanticException(field + " is not a number");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -108,12 +108,12 @@ public class VariableMgrTest {
         }
 
         // Set global variable
-        SetVar setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));
+        SetVar setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(12999934L));
         setVar.analyze();
         VariableMgr.setVar(var, setVar, false);
-        Assert.assertEquals(1234L, var.getMaxExecMemByte());
+        Assert.assertEquals(12999934L, var.getMaxExecMemByte());
         var = VariableMgr.newSessionVariable();
-        Assert.assertEquals(1234L, var.getMaxExecMemByte());
+        Assert.assertEquals(12999934L, var.getMaxExecMemByte());
 
         SetVar setVar2 = new SetVar(SetType.GLOBAL, "parallel_fragment_exec_instance_num", new IntLiteral(5L));
         setVar2.analyze();
@@ -137,18 +137,18 @@ public class VariableMgrTest {
         Assert.assertEquals("CST", var.getTimeZone());
 
         // Set session variable
-        setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(1234L));
+        setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(12999934L));
         setVar.analyze();
         VariableMgr.setVar(var, setVar, false);
-        Assert.assertEquals(1234L, var.getMaxExecMemByte());
+        Assert.assertEquals(12999934L, var.getMaxExecMemByte());
 
         // onlySessionVar
-        setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(4321L));
+        setVar = new SetVar(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(12999935L));
         setVar.analyze();
         VariableMgr.setVar(var, setVar, true);
-        Assert.assertEquals(4321L, var.getMaxExecMemByte());
+        Assert.assertEquals(12999935L, var.getMaxExecMemByte());
         var = VariableMgr.newSessionVariable();
-        Assert.assertEquals(1234L, var.getMaxExecMemByte());
+        Assert.assertEquals(12999934L, var.getMaxExecMemByte());
 
         setVar3 = new SetVar(SetType.SESSION, "time_zone", new StringLiteral("Asia/Jakarta"));
         setVar3.analyze();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -421,7 +421,7 @@ public class LimitTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("limit: 8888"));
         connectContext.getSessionVariable().setSqlSelectLimit(SessionVariable.DEFAULT_SELECT_LIMIT);
 
-        connectContext.getSessionVariable().setSqlSelectLimit(-100);
+        connectContext.getSessionVariable().setSqlSelectLimit(0);
         sql = "select * from test_all_type";
         plan = getFragmentPlan(sql);
         Assert.assertFalse(plan.contains("limit"));


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13695

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Validate `query_timeout` in analyze stage, with maximum value to `259200`

After this pr, you will get error message when setting `query_timeout` with an illegal value.

```
> set global query_timeout=360000000;
(1064, 'query_timeout must be equal or smaller than 259200.')
> set global query_timeout=0;
(1064, 'query_timeout must be equal or greater than 1.')
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
