### PR TITLE
[BugFix]  Be maybe crash if upgrade from version 2.2 to version 2.4 

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -436,10 +436,12 @@ StatusOr<std::vector<vectorized::ChunkIteratorPtr>> Rowset::get_segment_iterator
     for (int64_t i = 0; i < num_segments(); i++) {
         auto& seg_ptr = segments()[i];
         if (seg_ptr->num_rows() == 0) {
+            seg_iterators[i] = new_empty_iterator(schema, config::vector_chunk_size);
             continue;
         }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
+            seg_iterators[i] = new_empty_iterator(schema, config::vector_chunk_size);
             continue;
         }
         if (!res.ok()) {

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -75,7 +75,12 @@ struct MergeEntry {
         rowset_release_guard.reset();
     }
 
-    Status init() { return next(); }
+    Status init() {
+        if (segment_itr == nullptr) {
+            return Status::EndOfFile("End of merge entry iterator");
+        }
+        return next();
+    }
 
     Status next() {
         DCHECK(pk_cur == nullptr || pk_cur > pk_last);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13699

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If you upgrade directly from version 2.2 to 2.4, the PrimaryKey table compaction may cause be crash. Because in version 2.2, a pure delete data load of primary key will create a empty rowset with empty segment and version 2.4 will get a NPE while doing update compaction.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
