### PR TITLE
[BugFix][Cherry-pick][Branch-2.2] Fix the bug of not locking when cleaning txn_meta (#13285)

### DIFF
--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -415,20 +415,7 @@ Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_
     rewrite_files.clear();
     auto beta_rowset = down_cast<BetaRowset*>(rowset);
     RETURN_IF_ERROR(beta_rowset->reload());
-    // Be may crash during the rewrite or after the rewrite
-    // So the data at the end of the segment_file may be illegal
-    // We use partial_rowset_footers to locate the partial_footer so that
-    // the segment can be read normally after be crash during rewrite
-    // If rewrite is finished, the partial_segment_footer should be removed from rowset_meta
-    // to make sure the new full rowset could be read normally after be restarted
-    RETURN_IF_ERROR(_update_rowset_meta(tablet, rowset));
     return Status::OK();
-}
-
-Status RowsetUpdateState::_update_rowset_meta(Tablet* tablet, Rowset* rowset) {
-    rowset->rowset_meta()->clear_txn_meta();
-    auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
-    return TabletMetaManager::write_rowset_meta(tablet->data_dir(), tablet->tablet_id(), rowset_meta_pb, string());
 }
 
 std::string RowsetUpdateState::to_string() const {

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -59,8 +59,6 @@ private:
                                        EditVersion latest_applied_version, std::vector<uint32_t>& read_column_ids,
                                        const PrimaryIndex& index);
 
-    Status _update_rowset_meta(Tablet* tablet, Rowset* rowset);
-
     std::once_flag _load_once_flag;
     Status _status;
     // one for each segment file

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -485,11 +485,7 @@ Status SnapshotManager::make_snapshot_on_tablet_meta(SnapshotTypePB snapshot_typ
     snapshot_meta.set_snapshot_format(snapshot_format);
     snapshot_meta.set_snapshot_type(snapshot_type);
     snapshot_meta.set_snapshot_version(snapshot_version);
-    snapshot_meta.rowset_metas().reserve(rowset_metas.size());
-    for (const auto& rowset_meta : rowset_metas) {
-        RowsetMetaPB& meta_pb = snapshot_meta.rowset_metas().emplace_back();
-        rowset_meta->to_rowset_pb(&meta_pb);
-    }
+    tablet->updates()->to_rowset_meta_pb(rowset_metas, snapshot_meta.rowset_metas());
     if (snapshot_type == SNAPSHOT_TYPE_FULL) {
         auto meta_store = tablet->data_dir()->get_meta();
         uint32_t new_rsid = 0;

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -804,7 +804,8 @@ Status TabletMetaManager::rowset_iterate(DataDir* store, TTabletId tablet_id, co
 
 Status TabletMetaManager::apply_rowset_commit(DataDir* store, TTabletId tablet_id, int64_t logid,
                                               const EditVersion& version,
-                                              vector<std::pair<uint32_t, DelVectorPtr>>& delvecs) {
+                                              vector<std::pair<uint32_t, DelVectorPtr>>& delvecs,
+                                              const RowsetMetaPB* rowset_meta) {
     WriteBatch batch;
     auto handle = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
     string logkey = encode_meta_log_key(tablet_id, logid);
@@ -827,6 +828,16 @@ Status TabletMetaManager::apply_rowset_commit(DataDir* store, TTabletId tablet_i
         auto dv_key = encode_del_vector_key(tsid.tablet_id, tsid.segment_id, version.major());
         auto dv_value = rssid_delvec.second->save();
         st = batch.Put(handle, dv_key, dv_value);
+        if (!st.ok()) {
+            LOG(WARNING) << "rowset_commit failed, rocksdb.batch.put failed";
+            return to_status(st);
+        }
+    }
+
+    if (rowset_meta != nullptr) {
+        string rowset_key = encode_meta_rowset_key(tablet_id, rowset_meta->rowset_seg_id());
+        auto rowset_value = rowset_meta->SerializeAsString();
+        st = batch.Put(handle, rowset_key, rowset_value);
         if (!st.ok()) {
             LOG(WARNING) << "rowset_commit failed, rocksdb.batch.put failed";
             return to_status(st);

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -144,7 +144,8 @@ public:
 
     // update meta after state of a rowset commit is applied
     static Status apply_rowset_commit(DataDir* store, TTabletId tablet_id, int64_t logid, const EditVersion& version,
-                                      std::vector<std::pair<uint32_t, DelVectorPtr>>& delvecs);
+                                      std::vector<std::pair<uint32_t, DelVectorPtr>>& delvecs,
+                                      const starrocks::RowsetMetaPB* rowset_meta);
 
     // traverse all the op logs for a tablet
     static Status traverse_meta_logs(DataDir* store, TTabletId tablet_id,

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -874,7 +874,16 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     {
         std::lock_guard wl(_lock);
         // 4. write meta
-        st = TabletMetaManager::apply_rowset_commit(_tablet.data_dir(), tablet_id, _next_log_id, version, new_del_vecs);
+        const auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
+        if (rowset_meta_pb.has_txn_meta()) {
+            rowset->rowset_meta()->clear_txn_meta();
+            st = TabletMetaManager::apply_rowset_commit(_tablet.data_dir(), tablet_id, _next_log_id, version,
+                                                        new_del_vecs, &(rowset->rowset_meta()->get_meta_pb()));
+        } else {
+            st = TabletMetaManager::apply_rowset_commit(_tablet.data_dir(), tablet_id, _next_log_id, version,
+                                                        new_del_vecs, nullptr);
+        }
+
         if (!st.ok()) {
             std::string msg = Substitute("_apply_rowset_commit error: write meta failed: $0 $1", st.to_string(),
                                          _debug_string(false));
@@ -1222,7 +1231,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         std::lock_guard wl(_lock);
         // 3. write meta
         st = TabletMetaManager::apply_rowset_commit(_tablet.data_dir(), tablet_id, _next_log_id, version_info.version,
-                                                    delvecs);
+                                                    delvecs, nullptr);
         if (!st.ok()) {
             manager->index_cache().release(index_entry);
             std::string msg = Substitute("_apply_compaction_commit error: write meta failed: $0 $1", st.to_string(),
@@ -2675,6 +2684,16 @@ Status TabletUpdates::prepare_partial_update_states(Tablet* tablet, const std::v
     manager->index_cache().release(index_entry);
 
     return Status::OK();
+}
+
+void TabletUpdates::to_rowset_meta_pb(const std::vector<RowsetMetaSharedPtr>& rowset_metas,
+                                      std::vector<RowsetMetaPB>& rowset_metas_pb) {
+    std::lock_guard wl(_lock);
+    rowset_metas_pb.reserve(rowset_metas.size());
+    for (const auto& rowset_meta : rowset_metas) {
+        RowsetMetaPB& meta_pb = rowset_metas_pb.emplace_back();
+        rowset_meta->to_rowset_pb(&meta_pb);
+    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -214,6 +214,9 @@ public:
         return _get_latest_applied_version(latest_applied_version);
     }
 
+    void to_rowset_meta_pb(const std::vector<RowsetMetaSharedPtr>& rowset_metas,
+                           std::vector<RowsetMetaPB>& rowset_metas_pb);
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13283

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When we do apply of partial rowset, we will clear txn_meta at last, but this operation is not locked. So if the clone operation happens at the same time, the incomplete rowset_meta may be read which will cause the following error.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
