### PR TITLE
[Refactor] Change value of primitive type

### DIFF
--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -31,41 +31,40 @@
 
 namespace starrocks {
 
+// NOTE: This type will be merged with LogicalType in the future.
+// Because this type is not persisted in any format, so we keep the value
+// for each type equals with the type in LogicalType.
 enum PrimitiveType {
     INVALID_TYPE = 0,
-    TYPE_NULL,     /* 1 */
-    TYPE_BOOLEAN,  /* 2 */
-    TYPE_TINYINT,  /* 3 */
-    TYPE_SMALLINT, /* 4 */
-    TYPE_INT,      /* 5 */
-    TYPE_BIGINT,   /* 6 */
-    TYPE_LARGEINT, /* 7 */
-    TYPE_FLOAT,    /* 8 */
-    TYPE_DOUBLE,   /* 9 */
-    TYPE_VARCHAR,  /* 10 */
-    TYPE_DATE,     /* 11 */
-    TYPE_DATETIME, /* 12 */
-    TYPE_BINARY,
-    /* 13 */      // Not implemented
-    TYPE_DECIMAL, /* 14 */
-    TYPE_CHAR,    /* 15 */
-
-    TYPE_STRUCT,    /* 16 */
-    TYPE_ARRAY,     /* 17 */
-    TYPE_MAP,       /* 18 */
-    TYPE_HLL,       /* 19 */
-    TYPE_DECIMALV2, /* 20 */
-
-    TYPE_TIME,       /* 21 */
-    TYPE_OBJECT,     /* 22 */
-    TYPE_PERCENTILE, /* 23 */
-    TYPE_DECIMAL32,  /* 24 */
-    TYPE_DECIMAL64,  /* 25 */
-    TYPE_DECIMAL128, /* 26 */
-
-    TYPE_JSON,      /* 27 */
-    TYPE_FUNCTION,  /* 28 */
-    TYPE_VARBINARY, /* 29 */
+    TYPE_TINYINT = 1,
+    TYPE_SMALLINT = 3,
+    TYPE_INT = 5,
+    TYPE_BIGINT = 7,
+    TYPE_LARGEINT = 9,
+    TYPE_FLOAT = 10,
+    TYPE_DOUBLE = 11,
+    TYPE_CHAR = 13,
+    TYPE_DECIMAL = 16,
+    TYPE_VARCHAR = 17,
+    TYPE_STRUCT = 18,
+    TYPE_ARRAY = 19,
+    TYPE_MAP = 20,
+    TYPE_HLL = 23,
+    TYPE_BOOLEAN = 24,
+    TYPE_OBJECT = 25,
+    TYPE_NULL = 42,
+    TYPE_FUNCTION = 43,
+    TYPE_TIME = 44,
+    TYPE_BINARY = 45,
+    TYPE_VARBINARY = 46,
+    TYPE_DECIMAL32 = 47,
+    TYPE_DECIMAL64 = 48,
+    TYPE_DECIMAL128 = 49,
+    TYPE_DATE = 50,
+    TYPE_DATETIME = 51,
+    TYPE_DECIMALV2 = 52,
+    TYPE_PERCENTILE = 53,
+    TYPE_JSON = 54,
 };
 
 inline bool is_binary_type(PrimitiveType type) {

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -431,6 +431,10 @@ ColumnPredicate* new_column_in_predicate_generic(const TypeInfoPtr& type_info, C
     case LOGICAL_TYPE_OBJECT:
     case LOGICAL_TYPE_PERCENTILE:
     case LOGICAL_TYPE_JSON:
+    case LOGICAL_TYPE_NULL:
+    case LOGICAL_TYPE_FUNCTION:
+    case LOGCIAL_TYPE_TIME:
+    case LOGCIAL_TYPE_BINARY:
     case LOGICAL_TYPE_VARBINARY:
     case LOGICAL_TYPE_MAX_VALUE:
         return nullptr;

--- a/be/src/storage/column_not_in_predicate.cpp
+++ b/be/src/storage/column_not_in_predicate.cpp
@@ -331,6 +331,10 @@ ColumnPredicate* new_column_not_in_predicate(const TypeInfoPtr& type_info, Colum
     case LOGICAL_TYPE_OBJECT:
     case LOGICAL_TYPE_PERCENTILE:
     case LOGICAL_TYPE_JSON:
+    case LOGICAL_TYPE_NULL:
+    case LOGICAL_TYPE_FUNCTION:
+    case LOGCIAL_TYPE_TIME:
+    case LOGCIAL_TYPE_BINARY:
     case LOGICAL_TYPE_MAX_VALUE:
     case LOGICAL_TYPE_VARBINARY:
         return nullptr;

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -162,6 +162,10 @@ static ColumnPredicate* new_column_predicate(const TypeInfoPtr& type_info, Colum
     case LOGICAL_TYPE_OBJECT:
     case LOGICAL_TYPE_PERCENTILE:
     case LOGICAL_TYPE_JSON:
+    case LOGICAL_TYPE_NULL:
+    case LOGICAL_TYPE_FUNCTION:
+    case LOGCIAL_TYPE_TIME:
+    case LOGCIAL_TYPE_BINARY:
     case LOGICAL_TYPE_VARBINARY:
     case LOGICAL_TYPE_MAX_VALUE:
         return nullptr;

--- a/be/src/storage/convert_helper.cpp
+++ b/be/src/storage/convert_helper.cpp
@@ -1828,6 +1828,10 @@ const FieldConverter* get_field_converter(LogicalType from_type, LogicalType to_
         case LOGICAL_TYPE_STRUCT:
         case LOGICAL_TYPE_DISCRETE_DOUBLE:
         case LOGICAL_TYPE_NONE:
+        case LOGICAL_TYPE_NULL:
+        case LOGICAL_TYPE_FUNCTION:
+        case LOGCIAL_TYPE_TIME:
+        case LOGCIAL_TYPE_BINARY:
         case LOGICAL_TYPE_MAX_VALUE:
             return nullptr;
         }

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -157,6 +157,14 @@ std::string TabletColumn::get_string_by_field_type(LogicalType type) {
         return "UNKNOWN";
     case LOGICAL_TYPE_NONE:
         return "NONE";
+    case LOGICAL_TYPE_NULL:
+        return "NULL";
+    case LOGICAL_TYPE_FUNCTION:
+        return "FUNCTION";
+    case LOGCIAL_TYPE_TIME:
+        return "TIME";
+    case LOGCIAL_TYPE_BINARY:
+        return "BINARY";
     case LOGICAL_TYPE_MAX_VALUE:
         return "MAX_VALUE";
     case LOGICAL_TYPE_VARBINARY:
@@ -202,6 +210,10 @@ uint32_t TabletColumn::get_field_length_by_type(LogicalType type, uint32_t strin
     case LOGICAL_TYPE_STRUCT:
     case LOGICAL_TYPE_MAP:
     case LOGICAL_TYPE_NONE:
+    case LOGICAL_TYPE_NULL:
+    case LOGICAL_TYPE_FUNCTION:
+    case LOGCIAL_TYPE_TIME:
+    case LOGCIAL_TYPE_BINARY:
     case LOGICAL_TYPE_MAX_VALUE:
     case LOGICAL_TYPE_BOOL:
     case LOGICAL_TYPE_TINYINT:

--- a/be/src/storage/type_utils.h
+++ b/be/src/storage/type_utils.h
@@ -103,8 +103,12 @@ public:
             case LOGICAL_TYPE_DECIMAL_V2:
             case LOGICAL_TYPE_PERCENTILE:
             case LOGICAL_TYPE_JSON:
-            case LOGICAL_TYPE_MAX_VALUE:
+            case LOGICAL_TYPE_NULL:
+            case LOGICAL_TYPE_FUNCTION:
+            case LOGCIAL_TYPE_TIME:
+            case LOGCIAL_TYPE_BINARY:
             case LOGICAL_TYPE_VARBINARY:
+            case LOGICAL_TYPE_MAX_VALUE:
                 return type;
                 // no default by intention.
             }
@@ -124,6 +128,10 @@ public:
             case LOGICAL_TYPE_DECIMAL32:
             case LOGICAL_TYPE_DECIMAL64:
             case LOGICAL_TYPE_DECIMAL128:
+            case LOGICAL_TYPE_NULL:
+            case LOGICAL_TYPE_FUNCTION:
+            case LOGCIAL_TYPE_TIME:
+            case LOGCIAL_TYPE_BINARY:
             case LOGICAL_TYPE_VARBINARY:
                 return LOGICAL_TYPE_UNKNOWN;
             case LOGICAL_TYPE_TINYINT:

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -38,6 +38,10 @@ enum LogicalType {
 
     // Reserved some field for commutiy version
 
+    LOGICAL_TYPE_NULL = 42,
+    LOGICAL_TYPE_FUNCTION = 43,
+    LOGCIAL_TYPE_TIME = 44,
+    LOGCIAL_TYPE_BINARY = 45,
     LOGICAL_TYPE_VARBINARY = 46,
     // decimal v3 type
     LOGICAL_TYPE_DECIMAL32 = 47,

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -127,6 +127,14 @@ inline const char* field_type_to_string(LogicalType type) {
         return "PERCENTILE";
     case LOGICAL_TYPE_JSON:
         return "JSON";
+    case LOGICAL_TYPE_NULL:
+        return "NULL";
+    case LOGICAL_TYPE_FUNCTION:
+        return "FUNCTION";
+    case LOGCIAL_TYPE_TIME:
+        return "TIME";
+    case LOGCIAL_TYPE_BINARY:
+        return "BINARY";
     case LOGICAL_TYPE_VARBINARY:
         return "VARBINARY";
     case LOGICAL_TYPE_MAX_VALUE:

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -24,16 +24,16 @@ import static com.starrocks.utils.NativeMethodHelper.getAddrs;
 import static com.starrocks.utils.NativeMethodHelper.resizeStringData;
 
 public class UDFHelper {
-    public static final int TYPE_BOOLEAN = 2;
-    public static final int TYPE_TINYINT = 3;
-    public static final int TYPE_SMALLINT = 4;
+    public static final int TYPE_TINYINT = 1;
+    public static final int TYPE_SMALLINT = 3;
     public static final int TYPE_INT = 5;
-    public static final int TYPE_BIGINT = 6;
-    public static final int TYPE_FLOAT = 8;
-    public static final int TYPE_DOUBLE = 9;
-    public static final int TYPE_VARCHAR = 10;
-    public static final int TYPE_DATETIME = 12;
-    public static final int TYPE_ARRAY = 15;
+    public static final int TYPE_BIGINT = 7;
+    public static final int TYPE_FLOAT = 10;
+    public static final int TYPE_DOUBLE = 11;
+    public static final int TYPE_VARCHAR = 17;
+    public static final int TYPE_ARRAY = 19;
+    public static final int TYPE_BOOLEAN = 24;
+    public static final int TYPE_DATETIME = 51;
 
     private static final byte[] emptyBytes = new byte[0];
 


### PR DESCRIPTION
There are too many types there. It is difficult to understand and to tell the differences. Also, it is error-prone.
Most Primitive and LogicalType are the same, and there is no need to keep them.
So I plan to merge these two into one type.
Because in ColumnPB, starrocks use the value of LogicalType, we can't change the value of LogicalType.
But PrimitiveType's value is not persisted, so that we can change it according to the LogicalType value.
In this PR, I change the PrimitiveType value to its corresponding LogicalType.
In the following PR, I will make LogicalType have all PrimitiveType's functionality.
At last, I will make `using PrimitiveType = LogicalType`
Then there will be only LogicalType.