### PR TITLE
[Refactor] Remove duplicate function

### DIFF
--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -171,7 +171,7 @@ static Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, 
         TScalarType scalar = curr_type_node.scalar_type;
 
         LogicalType field_type = t_primitive_type_to_field_type(scalar.type, v);
-        column_pb->set_type(TabletColumn::get_string_by_field_type(field_type));
+        column_pb->set_type(logical_type_to_string(field_type));
         column_pb->set_length(TabletColumn::get_field_length_by_type(field_type, scalar.len));
         column_pb->set_index_length(column_pb->length());
         column_pb->set_frac(curr_type_node.scalar_type.scale);
@@ -189,7 +189,7 @@ static Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, 
         return Status::OK();
     }
     case TTypeNodeType::ARRAY:
-        column_pb->set_type(TabletColumn::get_string_by_field_type(LOGICAL_TYPE_ARRAY));
+        column_pb->set_type(logical_type_to_string(LOGICAL_TYPE_ARRAY));
         column_pb->set_length(TabletColumn::get_field_length_by_type(LOGICAL_TYPE_ARRAY, sizeof(Collection)));
         column_pb->set_index_length(column_pb->length());
         return t_column_to_pb_column(kFakeUniqueId, t_column, v, column_pb->add_children_columns(), depth + 1);

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -329,7 +329,7 @@ Status PrimaryKeyEncoder::create_column(const vectorized::Schema& schema, std::u
             *pcolumn = vectorized::TimestampColumn::create_mutable();
             break;
         default:
-            return Status::NotSupported(StringPrintf("primary key type not support: %s", field_type_to_string(type)));
+            return Status::NotSupported(StringPrintf("primary key type not support: %s", logical_type_to_string(type)));
         }
     } else {
         // composite keys encoding to binary
@@ -404,7 +404,7 @@ static void prepare_ops_datas(const vectorized::Schema& schema, const vectorized
             break;
         default:
             CHECK(false) << "type not supported for primary key encoding "
-                         << field_type_to_string(schema.field(j)->type()->type());
+                         << logical_type_to_string(schema.field(j)->type()->type());
         }
     }
 }

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -545,7 +545,7 @@ Status compaction_merge_rowsets(Tablet& tablet, int64_t version, const vector<Ro
         merger = std::make_unique<RowsetMergerImpl<int64_t>>();
         break;
     default:
-        return Status::NotSupported(StringPrintf("primary key type not support: %s", field_type_to_string(key_type)));
+        return Status::NotSupported(StringPrintf("primary key type not support: %s", logical_type_to_string(key_type)));
     }
     return merger->do_merge(tablet, version, schema, rowsets, writer, cfg);
 }

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -70,8 +70,8 @@ ColumnMapping* ChunkChanger::get_mutable_column_mapping(size_t column_index) {
             TYPE_REINTERPRET_CAST(from_type, double);                               \
         default:                                                                    \
             LOG(WARNING) << "the column type which was altered to was unsupported." \
-                         << " origin_type=" << logical_type_to_string(ref_type)       \
-                         << ", alter_type=" << logical_type_to_string(new_type);      \
+                         << " origin_type=" << logical_type_to_string(ref_type)     \
+                         << ", alter_type=" << logical_type_to_string(new_type);    \
             return false;                                                           \
         }                                                                           \
         break;                                                                      \

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -70,8 +70,8 @@ ColumnMapping* ChunkChanger::get_mutable_column_mapping(size_t column_index) {
             TYPE_REINTERPRET_CAST(from_type, double);                               \
         default:                                                                    \
             LOG(WARNING) << "the column type which was altered to was unsupported." \
-                         << " origin_type=" << field_type_to_string(ref_type)       \
-                         << ", alter_type=" << field_type_to_string(new_type);      \
+                         << " origin_type=" << logical_type_to_string(ref_type)       \
+                         << ", alter_type=" << logical_type_to_string(new_type);      \
             return false;                                                           \
         }                                                                           \
         break;                                                                      \
@@ -280,8 +280,8 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
                 Status st = converter->convert_column(ref_field.type().get(), *base_col, new_field.type().get(),
                                                       new_col.get(), mem_pool);
                 if (!st.ok()) {
-                    LOG(WARNING) << "failed to convert " << field_type_to_string(ref_type) << " to "
-                                 << field_type_to_string(new_type);
+                    LOG(WARNING) << "failed to convert " << logical_type_to_string(ref_type) << " to "
+                                 << logical_type_to_string(new_type);
                     return false;
                 }
             } else {
@@ -311,8 +311,8 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
                 if (new_type < ref_type) {
                     LOG(INFO) << "type degraded while altering column. "
                               << "column=" << new_tablet_meta->tablet_schema().column(i).name()
-                              << ", origin_type=" << field_type_to_string(ref_type)
-                              << ", alter_type=" << field_type_to_string(new_type);
+                              << ", origin_type=" << logical_type_to_string(ref_type)
+                              << ", alter_type=" << logical_type_to_string(new_type);
                 }
             }
         } else {
@@ -382,8 +382,8 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                 Status st = converter->convert_column(ref_type_info.get(), *base_col, new_type_info.get(),
                                                       new_col.get(), mem_pool);
                 if (!st.ok()) {
-                    LOG(WARNING) << "failed to convert " << field_type_to_string(ref_type) << " to "
-                                 << field_type_to_string(new_type);
+                    LOG(WARNING) << "failed to convert " << logical_type_to_string(ref_type) << " to "
+                                 << logical_type_to_string(new_type);
                     return false;
                 }
             } else {
@@ -413,8 +413,8 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                 if (new_type < ref_type) {
                     LOG(INFO) << "type degraded while altering column. "
                               << "column=" << new_schema.field(i)->name()
-                              << ", origin_type=" << field_type_to_string(ref_type)
-                              << ", alter_type=" << field_type_to_string(new_type);
+                              << ", origin_type=" << logical_type_to_string(ref_type)
+                              << ", alter_type=" << logical_type_to_string(new_type);
                 }
             }
         } else {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -33,45 +33,6 @@
 
 namespace starrocks {
 
-LogicalType TabletColumn::get_field_type_by_string(const std::string& type_str) {
-    std::string upper_type_str = type_str;
-    std::transform(type_str.begin(), type_str.end(), upper_type_str.begin(), ::toupper);
-    if (upper_type_str == "TINYINT") return LOGICAL_TYPE_TINYINT;
-    if (upper_type_str == "SMALLINT") return LOGICAL_TYPE_SMALLINT;
-    if (upper_type_str == "INT") return LOGICAL_TYPE_INT;
-    if (upper_type_str == "BIGINT") return LOGICAL_TYPE_BIGINT;
-    if (upper_type_str == "LARGEINT") return LOGICAL_TYPE_LARGEINT;
-    if (upper_type_str == "UNSIGNED_TINYINT") return LOGICAL_TYPE_UNSIGNED_TINYINT;
-    if (upper_type_str == "UNSIGNED_SMALLINT") return LOGICAL_TYPE_UNSIGNED_SMALLINT;
-    if (upper_type_str == "UNSIGNED_INT") return LOGICAL_TYPE_UNSIGNED_INT;
-    if (upper_type_str == "UNSIGNED_BIGINT") return LOGICAL_TYPE_UNSIGNED_BIGINT;
-    if (upper_type_str == "FLOAT") return LOGICAL_TYPE_FLOAT;
-    if (upper_type_str == "DISCRETE_DOUBLE") return LOGICAL_TYPE_DISCRETE_DOUBLE;
-    if (upper_type_str == "DOUBLE") return LOGICAL_TYPE_DOUBLE;
-    if (upper_type_str == "CHAR") return LOGICAL_TYPE_CHAR;
-    if (upper_type_str == "DATE_V2") return LOGICAL_TYPE_DATE_V2;
-    if (upper_type_str == "DATE") return LOGICAL_TYPE_DATE;
-    if (upper_type_str == "DATETIME") return LOGICAL_TYPE_DATETIME;
-    if (upper_type_str == "TIMESTAMP") return LOGICAL_TYPE_TIMESTAMP;
-    if (upper_type_str == "DECIMAL_V2") return LOGICAL_TYPE_DECIMAL_V2;
-    if (upper_type_str == "DECIMAL") return LOGICAL_TYPE_DECIMAL;
-    if (upper_type_str == "VARCHAR") return LOGICAL_TYPE_VARCHAR;
-    if (upper_type_str == "BOOLEAN") return LOGICAL_TYPE_BOOL;
-    if (upper_type_str == "HLL") return LOGICAL_TYPE_HLL;
-    if (upper_type_str == "STRUCT") return LOGICAL_TYPE_STRUCT;
-    if (upper_type_str == "ARRAY") return LOGICAL_TYPE_ARRAY;
-    if (upper_type_str == "MAP") return LOGICAL_TYPE_MAP;
-    if (upper_type_str == "OBJECT") return LOGICAL_TYPE_OBJECT;
-    if (upper_type_str == "PERCENTILE") return LOGICAL_TYPE_PERCENTILE;
-    if (upper_type_str == "DECIMAL32") return LOGICAL_TYPE_DECIMAL32;
-    if (upper_type_str == "DECIMAL64") return LOGICAL_TYPE_DECIMAL64;
-    if (upper_type_str == "DECIMAL128") return LOGICAL_TYPE_DECIMAL128;
-    if (upper_type_str == "JSON") return LOGICAL_TYPE_JSON;
-    if (upper_type_str == "VARBINARY") return LOGICAL_TYPE_VARBINARY;
-    LOG(WARNING) << "invalid type string. [type='" << type_str << "']";
-    return LOGICAL_TYPE_UNKNOWN;
-}
-
 FieldAggregationMethod TabletColumn::get_aggregation_type_by_string(const std::string& str) {
     std::string upper_str = str;
     std::transform(str.begin(), str.end(), upper_str.begin(), ::toupper);
@@ -87,90 +48,6 @@ FieldAggregationMethod TabletColumn::get_aggregation_type_by_string(const std::s
     if (upper_str == "PERCENTILE_UNION") return OLAP_FIELD_AGGREGATION_PERCENTILE_UNION;
     LOG(WARNING) << "invalid aggregation type string. [aggregation='" << str << "']";
     return OLAP_FIELD_AGGREGATION_UNKNOWN;
-}
-
-std::string TabletColumn::get_string_by_field_type(LogicalType type) {
-    switch (type) {
-    case LOGICAL_TYPE_TINYINT:
-        return "TINYINT";
-    case LOGICAL_TYPE_UNSIGNED_TINYINT:
-        return "UNSIGNED_TINYINT";
-    case LOGICAL_TYPE_SMALLINT:
-        return "SMALLINT";
-    case LOGICAL_TYPE_UNSIGNED_SMALLINT:
-        return "UNSIGNED_SMALLINT";
-    case LOGICAL_TYPE_INT:
-        return "INT";
-    case LOGICAL_TYPE_UNSIGNED_INT:
-        return "UNSIGNED_INT";
-    case LOGICAL_TYPE_BIGINT:
-        return "BIGINT";
-    case LOGICAL_TYPE_LARGEINT:
-        return "LARGEINT";
-    case LOGICAL_TYPE_UNSIGNED_BIGINT:
-        return "UNSIGNED_BIGINT";
-    case LOGICAL_TYPE_FLOAT:
-        return "FLOAT";
-    case LOGICAL_TYPE_DOUBLE:
-        return "DOUBLE";
-    case LOGICAL_TYPE_DISCRETE_DOUBLE:
-        return "DISCRETE_DOUBLE";
-    case LOGICAL_TYPE_CHAR:
-        return "CHAR";
-    case LOGICAL_TYPE_DATE:
-        return "DATE";
-    case LOGICAL_TYPE_DATE_V2:
-        return "DATE_V2";
-    case LOGICAL_TYPE_DATETIME:
-        return "DATETIME";
-    case LOGICAL_TYPE_TIMESTAMP:
-        return "TIMESTAMP";
-    case LOGICAL_TYPE_DECIMAL:
-        return "DECIMAL";
-    case LOGICAL_TYPE_DECIMAL_V2:
-        return "DECIMAL_V2";
-    case LOGICAL_TYPE_DECIMAL32:
-        return "DECIMAL32";
-    case LOGICAL_TYPE_DECIMAL64:
-        return "DECIMAL64";
-    case LOGICAL_TYPE_DECIMAL128:
-        return "DECIMAL128";
-    case LOGICAL_TYPE_VARCHAR:
-        return "VARCHAR";
-    case LOGICAL_TYPE_BOOL:
-        return "BOOLEAN";
-    case LOGICAL_TYPE_HLL:
-        return "HLL";
-    case LOGICAL_TYPE_STRUCT:
-        return "STRUCT";
-    case LOGICAL_TYPE_ARRAY:
-        return "ARRAY";
-    case LOGICAL_TYPE_MAP:
-        return "MAP";
-    case LOGICAL_TYPE_OBJECT:
-        return "OBJECT";
-    case LOGICAL_TYPE_PERCENTILE:
-        return "PERCENTILE";
-    case LOGICAL_TYPE_JSON:
-        return "JSON";
-    case LOGICAL_TYPE_UNKNOWN:
-        return "UNKNOWN";
-    case LOGICAL_TYPE_NONE:
-        return "NONE";
-    case LOGICAL_TYPE_NULL:
-        return "NULL";
-    case LOGICAL_TYPE_FUNCTION:
-        return "FUNCTION";
-    case LOGCIAL_TYPE_TIME:
-        return "TIME";
-    case LOGCIAL_TYPE_BINARY:
-        return "BINARY";
-    case LOGICAL_TYPE_MAX_VALUE:
-        return "MAX_VALUE";
-    case LOGICAL_TYPE_VARBINARY:
-        return "VARBINARY";
-    }
-    return "";
 }
 
 std::string TabletColumn::get_string_by_aggregation_type(FieldAggregationMethod type) {
@@ -336,7 +213,7 @@ TabletColumn& TabletColumn::operator=(TabletColumn&& rhs) noexcept {
 void TabletColumn::init_from_pb(const ColumnPB& column) {
     _unique_id = column.unique_id();
     _col_name.assign(column.name());
-    _type = TabletColumn::get_field_type_by_string(column.type());
+    _type = string_to_logical_type(column.type());
 
     _set_flag(kIsKeyShift, column.is_key());
     _set_flag(kIsNullableShift, column.is_nullable());
@@ -378,7 +255,7 @@ void TabletColumn::init_from_pb(const ColumnPB& column) {
 void TabletColumn::to_schema_pb(ColumnPB* column) const {
     column->mutable_name()->assign(_col_name.data(), _col_name.size());
     column->set_unique_id(_unique_id);
-    column->set_type(get_string_by_field_type(_type));
+    column->set_type(logical_type_to_string(_type));
     column->set_is_key(is_key());
     column->set_is_nullable(is_nullable());
     if (has_default_value()) {
@@ -552,7 +429,7 @@ std::unique_ptr<TabletSchema> TabletSchema::convert_to_format(DataFormatVersion 
         }
         if (t1 != t2) {
             auto* type_info = get_scalar_type_info(t2);
-            col_pb->set_type(TabletColumn::get_string_by_field_type(t2));
+            col_pb->set_type(logical_type_to_string(t2));
             col_pb->set_length(type_info->size());
             col_pb->set_index_length(type_info->size());
         }

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -135,9 +135,7 @@ public:
     friend bool operator==(const TabletColumn& a, const TabletColumn& b);
     friend bool operator!=(const TabletColumn& a, const TabletColumn& b);
 
-    static std::string get_string_by_field_type(LogicalType type);
     static std::string get_string_by_aggregation_type(FieldAggregationMethod aggregation_type);
-    static LogicalType get_field_type_by_string(const std::string& str);
     static FieldAggregationMethod get_aggregation_type_by_string(const std::string& str);
     size_t estimate_field_size(size_t variable_length) const;
     static uint32_t get_field_length_by_type(LogicalType type, uint32_t string_length);

--- a/be/src/types/CMakeLists.txt
+++ b/be/src/types/CMakeLists.txt
@@ -7,5 +7,6 @@ add_library(Types STATIC
     bitmap_value.cpp
     date_value.cpp
     hll.cpp
+    logical_type.cpp
     timestamp_value.cpp
 )

--- a/be/src/types/logical_type.cpp
+++ b/be/src/types/logical_type.cpp
@@ -131,4 +131,4 @@ const char* logical_type_to_string(LogicalType type) {
     return "";
 }
 
-}
+} // namespace starrocks

--- a/be/src/types/logical_type.cpp
+++ b/be/src/types/logical_type.cpp
@@ -1,0 +1,134 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "types/logical_type.h"
+
+#include <algorithm>
+
+#include "common/logging.h"
+
+namespace starrocks {
+
+LogicalType string_to_logical_type(const std::string& type_str) {
+    std::string upper_type_str = type_str;
+    std::transform(type_str.begin(), type_str.end(), upper_type_str.begin(), ::toupper);
+    if (upper_type_str == "TINYINT") return LOGICAL_TYPE_TINYINT;
+    if (upper_type_str == "SMALLINT") return LOGICAL_TYPE_SMALLINT;
+    if (upper_type_str == "INT") return LOGICAL_TYPE_INT;
+    if (upper_type_str == "BIGINT") return LOGICAL_TYPE_BIGINT;
+    if (upper_type_str == "LARGEINT") return LOGICAL_TYPE_LARGEINT;
+    if (upper_type_str == "UNSIGNED_TINYINT") return LOGICAL_TYPE_UNSIGNED_TINYINT;
+    if (upper_type_str == "UNSIGNED_SMALLINT") return LOGICAL_TYPE_UNSIGNED_SMALLINT;
+    if (upper_type_str == "UNSIGNED_INT") return LOGICAL_TYPE_UNSIGNED_INT;
+    if (upper_type_str == "UNSIGNED_BIGINT") return LOGICAL_TYPE_UNSIGNED_BIGINT;
+    if (upper_type_str == "FLOAT") return LOGICAL_TYPE_FLOAT;
+    if (upper_type_str == "DISCRETE_DOUBLE") return LOGICAL_TYPE_DISCRETE_DOUBLE;
+    if (upper_type_str == "DOUBLE") return LOGICAL_TYPE_DOUBLE;
+    if (upper_type_str == "CHAR") return LOGICAL_TYPE_CHAR;
+    if (upper_type_str == "DATE_V2") return LOGICAL_TYPE_DATE_V2;
+    if (upper_type_str == "DATE") return LOGICAL_TYPE_DATE;
+    if (upper_type_str == "DATETIME") return LOGICAL_TYPE_DATETIME;
+    if (upper_type_str == "TIMESTAMP") return LOGICAL_TYPE_TIMESTAMP;
+    if (upper_type_str == "DECIMAL_V2") return LOGICAL_TYPE_DECIMAL_V2;
+    if (upper_type_str == "DECIMAL") return LOGICAL_TYPE_DECIMAL;
+    if (upper_type_str == "VARCHAR") return LOGICAL_TYPE_VARCHAR;
+    if (upper_type_str == "BOOLEAN") return LOGICAL_TYPE_BOOL;
+    if (upper_type_str == "HLL") return LOGICAL_TYPE_HLL;
+    if (upper_type_str == "STRUCT") return LOGICAL_TYPE_STRUCT;
+    if (upper_type_str == "ARRAY") return LOGICAL_TYPE_ARRAY;
+    if (upper_type_str == "MAP") return LOGICAL_TYPE_MAP;
+    if (upper_type_str == "OBJECT") return LOGICAL_TYPE_OBJECT;
+    if (upper_type_str == "PERCENTILE") return LOGICAL_TYPE_PERCENTILE;
+    if (upper_type_str == "DECIMAL32") return LOGICAL_TYPE_DECIMAL32;
+    if (upper_type_str == "DECIMAL64") return LOGICAL_TYPE_DECIMAL64;
+    if (upper_type_str == "DECIMAL128") return LOGICAL_TYPE_DECIMAL128;
+    if (upper_type_str == "JSON") return LOGICAL_TYPE_JSON;
+    if (upper_type_str == "VARBINARY") return LOGICAL_TYPE_VARBINARY;
+    LOG(WARNING) << "invalid type string. [type='" << type_str << "']";
+    return LOGICAL_TYPE_UNKNOWN;
+}
+
+const char* logical_type_to_string(LogicalType type) {
+    switch (type) {
+    case LOGICAL_TYPE_TINYINT:
+        return "TINYINT";
+    case LOGICAL_TYPE_UNSIGNED_TINYINT:
+        return "UNSIGNED_TINYINT";
+    case LOGICAL_TYPE_SMALLINT:
+        return "SMALLINT";
+    case LOGICAL_TYPE_UNSIGNED_SMALLINT:
+        return "UNSIGNED_SMALLINT";
+    case LOGICAL_TYPE_INT:
+        return "INT";
+    case LOGICAL_TYPE_UNSIGNED_INT:
+        return "UNSIGNED_INT";
+    case LOGICAL_TYPE_BIGINT:
+        return "BIGINT";
+    case LOGICAL_TYPE_LARGEINT:
+        return "LARGEINT";
+    case LOGICAL_TYPE_UNSIGNED_BIGINT:
+        return "UNSIGNED_BIGINT";
+    case LOGICAL_TYPE_FLOAT:
+        return "FLOAT";
+    case LOGICAL_TYPE_DOUBLE:
+        return "DOUBLE";
+    case LOGICAL_TYPE_DISCRETE_DOUBLE:
+        return "DISCRETE_DOUBLE";
+    case LOGICAL_TYPE_CHAR:
+        return "CHAR";
+    case LOGICAL_TYPE_DATE:
+        return "DATE";
+    case LOGICAL_TYPE_DATE_V2:
+        return "DATE_V2";
+    case LOGICAL_TYPE_DATETIME:
+        return "DATETIME";
+    case LOGICAL_TYPE_TIMESTAMP:
+        return "TIMESTAMP";
+    case LOGICAL_TYPE_DECIMAL:
+        return "DECIMAL";
+    case LOGICAL_TYPE_DECIMAL_V2:
+        return "DECIMAL_V2";
+    case LOGICAL_TYPE_DECIMAL32:
+        return "DECIMAL32";
+    case LOGICAL_TYPE_DECIMAL64:
+        return "DECIMAL64";
+    case LOGICAL_TYPE_DECIMAL128:
+        return "DECIMAL128";
+    case LOGICAL_TYPE_VARCHAR:
+        return "VARCHAR";
+    case LOGICAL_TYPE_BOOL:
+        return "BOOLEAN";
+    case LOGICAL_TYPE_HLL:
+        return "HLL";
+    case LOGICAL_TYPE_STRUCT:
+        return "STRUCT";
+    case LOGICAL_TYPE_ARRAY:
+        return "ARRAY";
+    case LOGICAL_TYPE_MAP:
+        return "MAP";
+    case LOGICAL_TYPE_OBJECT:
+        return "OBJECT";
+    case LOGICAL_TYPE_PERCENTILE:
+        return "PERCENTILE";
+    case LOGICAL_TYPE_JSON:
+        return "JSON";
+    case LOGICAL_TYPE_UNKNOWN:
+        return "UNKNOWN";
+    case LOGICAL_TYPE_NONE:
+        return "NONE";
+    case LOGICAL_TYPE_NULL:
+        return "NULL";
+    case LOGICAL_TYPE_FUNCTION:
+        return "FUNCTION";
+    case LOGCIAL_TYPE_TIME:
+        return "TIME";
+    case LOGCIAL_TYPE_BINARY:
+        return "BINARY";
+    case LOGICAL_TYPE_MAX_VALUE:
+        return "MAX_VALUE";
+    case LOGICAL_TYPE_VARBINARY:
+        return "VARBINARY";
+    }
+    return "";
+}
+
+}

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -104,4 +104,3 @@ inline std::ostream& operator<<(std::ostream& os, starrocks::LogicalType type) {
     os << starrocks::logical_type_to_string(type);
     return os;
 }
-

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -59,95 +59,6 @@ enum LogicalType {
     LOGICAL_TYPE_MAX_VALUE = 55
 };
 
-inline const char* field_type_to_string(LogicalType type) {
-    switch (type) {
-    case LOGICAL_TYPE_TINYINT:
-        return "TINYINT";
-    case LOGICAL_TYPE_UNSIGNED_TINYINT:
-        return "UNSIGNED TINYINT";
-    case LOGICAL_TYPE_SMALLINT:
-        return "SMALLINT";
-    case LOGICAL_TYPE_UNSIGNED_SMALLINT:
-        return "UNSIGNED SMALLINT";
-    case LOGICAL_TYPE_INT:
-        return "INT";
-    case LOGICAL_TYPE_UNSIGNED_INT:
-        return "UNSIGNED INT";
-    case LOGICAL_TYPE_BIGINT:
-        return "BIGINT";
-    case LOGICAL_TYPE_UNSIGNED_BIGINT:
-        return "UNSIGNED BIGINT";
-    case LOGICAL_TYPE_LARGEINT:
-        return "LARGEINT";
-    case LOGICAL_TYPE_FLOAT:
-        return "FLOAT";
-    case LOGICAL_TYPE_DOUBLE:
-        return "DOUBLE";
-    case LOGICAL_TYPE_DISCRETE_DOUBLE:
-        return "DISCRETE DOUBLE";
-    case LOGICAL_TYPE_CHAR:
-        return "CHAR";
-    case LOGICAL_TYPE_DATE:
-        return "DATE";
-    case LOGICAL_TYPE_DATETIME:
-        return "DATETIME";
-    case LOGICAL_TYPE_DECIMAL:
-        return "DECIMAL";
-    case LOGICAL_TYPE_VARCHAR:
-        return "VARCHAR";
-    case LOGICAL_TYPE_STRUCT:
-        return "STRUCT";
-    case LOGICAL_TYPE_ARRAY:
-        return "ARRAY";
-    case LOGICAL_TYPE_MAP:
-        return "MAP";
-    case LOGICAL_TYPE_UNKNOWN:
-        return "UNKNOWN";
-    case LOGICAL_TYPE_NONE:
-        return "NONE";
-    case LOGICAL_TYPE_HLL:
-        return "HLL";
-    case LOGICAL_TYPE_BOOL:
-        return "BOOL";
-    case LOGICAL_TYPE_OBJECT:
-        return "OBJECT";
-    case LOGICAL_TYPE_DECIMAL32:
-        return "DECIMAL32";
-    case LOGICAL_TYPE_DECIMAL64:
-        return "DECIMAL64";
-    case LOGICAL_TYPE_DECIMAL128:
-        return "DECIMAL128";
-    case LOGICAL_TYPE_DATE_V2:
-        return "DATE V2";
-    case LOGICAL_TYPE_TIMESTAMP:
-        return "TIMESTAMP";
-    case LOGICAL_TYPE_DECIMAL_V2:
-        return "DECIMAL V2";
-    case LOGICAL_TYPE_PERCENTILE:
-        return "PERCENTILE";
-    case LOGICAL_TYPE_JSON:
-        return "JSON";
-    case LOGICAL_TYPE_NULL:
-        return "NULL";
-    case LOGICAL_TYPE_FUNCTION:
-        return "FUNCTION";
-    case LOGCIAL_TYPE_TIME:
-        return "TIME";
-    case LOGCIAL_TYPE_BINARY:
-        return "BINARY";
-    case LOGICAL_TYPE_VARBINARY:
-        return "VARBINARY";
-    case LOGICAL_TYPE_MAX_VALUE:
-        return "MAX VALUE";
-    }
-    return "";
-}
-
-inline std::ostream& operator<<(std::ostream& os, LogicalType type) {
-    os << field_type_to_string(type);
-    return os;
-}
-
 // TODO(lism): support varbinary for zone map.
 inline bool is_zone_map_key_type(LogicalType type) {
     return type != LOGICAL_TYPE_CHAR && type != LOGICAL_TYPE_VARCHAR && type != LOGICAL_TYPE_JSON &&
@@ -184,4 +95,13 @@ inline bool is_decimalv3_field_type(LogicalType type) {
     return type == LOGICAL_TYPE_DECIMAL32 || type == LOGICAL_TYPE_DECIMAL64 || type == LOGICAL_TYPE_DECIMAL128;
 }
 
+LogicalType string_to_logical_type(const std::string& type_str);
+const char* logical_type_to_string(LogicalType type);
+
 } // namespace starrocks
+
+inline std::ostream& operator<<(std::ostream& os, starrocks::LogicalType type) {
+    os << starrocks::logical_type_to_string(type);
+    return os;
+}
+

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -110,7 +110,7 @@ protected:
     template <typename T>
     void test_convert_to_varchar(LogicalType type, int type_size, T val, const std::string& expect_val) {
         auto src_tablet_schema =
-                SetTabletSchema("SrcColumn", field_type_to_string(type), "REPLACE", type_size, false, false);
+                SetTabletSchema("SrcColumn", logical_type_to_string(type), "REPLACE", type_size, false, false);
         auto dst_tablet_schema = SetTabletSchema("VarcharColumn", "VARCHAR", "REPLACE", 255, false, false);
 
         Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
@@ -131,7 +131,7 @@ protected:
     void test_convert_from_varchar(LogicalType type, int type_size, std::string val, T expect_val) {
         auto src_tablet_schema = SetTabletSchema("VarcharColumn", "VARCHAR", "REPLACE", 255, false, false);
         auto dst_tablet_schema =
-                SetTabletSchema("DstColumn", field_type_to_string(type), "REPLACE", type_size, false, false);
+                SetTabletSchema("DstColumn", logical_type_to_string(type), "REPLACE", type_size, false, false);
 
         Field f = ChunkHelper::convert_field_to_format_v2(0, src_tablet_schema->column(0));
         Field f2 = ChunkHelper::convert_field_to_format_v2(0, dst_tablet_schema->column(0));


### PR DESCRIPTION
TabletColumn::get_string_by_field_type is the same as field_type_to_string. So in this CL, I replace field_type_to_string with TabletColumn::get_string_by_field_type. Because TabletColumn::get_string_by_field_type is used by metadata serialization.  So we can't change its implementation.
I rename TabletColumn::get_string_by_field_type to logical_type_to_string in this CL too.