### PR TITLE
[Refactor] reduce aggregator intermediate binary size

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -69,9 +69,7 @@ Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const vect
     if (!_aggregator->is_none_group_by_exprs()) {
         if (false) {
         }
-        TRY_CATCH_BAD_ALLOC(_aggregator->hash_map_variant().visit([&](auto& hash_map_with_key) {
-            _aggregator->build_hash_map(*hash_map_with_key, chunk_size, agg_group_by_with_limit);
-        }));
+        TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size, agg_group_by_with_limit));
         _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
     }

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.cpp
@@ -34,9 +34,7 @@ StatusOr<vectorized::ChunkPtr> AggregateBlockingSourceOperator::pull_chunk(Runti
     if (_aggregator->is_none_group_by_exprs()) {
         _aggregator->convert_to_chunk_no_groupby(&chunk);
     } else {
-        _aggregator->hash_map_variant().visit([&](auto& hash_map_with_key) {
-            _aggregator->convert_hash_map_to_chunk(*hash_map_with_key, chunk_size, &chunk);
-        });
+        _aggregator->convert_hash_map_to_chunk(chunk_size, &chunk);
     }
 
     size_t old_size = chunk->num_rows();

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -47,7 +47,7 @@ Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, co
     {
         SCOPED_TIMER(_aggregator->agg_compute_timer());
         bool limit_with_no_agg = _aggregator->limit() != -1;
-        _aggregator->build_hash_set(chunk->num_rows());
+        TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_set(chunk->num_rows()));
 
         _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -47,8 +47,7 @@ Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, co
     {
         SCOPED_TIMER(_aggregator->agg_compute_timer());
         bool limit_with_no_agg = _aggregator->limit() != -1;
-        TRY_CATCH_BAD_ALLOC(_aggregator->hash_set_variant().visit(
-                [&](auto& hash_set_with_key) { _aggregator->build_hash_set(*hash_set_with_key, chunk->num_rows()); }););
+        _aggregator->build_hash_set(chunk->num_rows());
 
         _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp
@@ -28,9 +28,7 @@ StatusOr<vectorized::ChunkPtr> AggregateDistinctBlockingSourceOperator::pull_chu
 
     int32_t chunk_size = state->chunk_size();
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
-    _aggregator->hash_set_variant().visit([&](auto& hash_set_with_key) {
-        _aggregator->convert_hash_set_to_chunk(*hash_set_with_key, chunk_size, &chunk);
-    });
+    _aggregator->convert_hash_set_to_chunk(chunk_size, &chunk);
 
     size_t old_size = chunk->num_rows();
     eval_runtime_bloom_filters(chunk.get());

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -83,7 +83,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t 
                                                       _aggregator->hash_set_variant().size())) {
         // hash table is not full or allow expand the hash table according reduction rate
         SCOPED_TIMER(_aggregator->agg_compute_timer());
-        _aggregator->build_hash_set(chunk_size);
+        TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_set(chunk_size));
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
         _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
@@ -91,7 +91,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t 
     } else {
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
-            _aggregator->build_hash_set_with_selection(chunk_size);
+            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_set_with_selection(chunk_size));
         }
 
         {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -62,8 +62,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_streaming() 
 Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_preaggregation(const size_t chunk_size) {
     SCOPED_TIMER(_aggregator->agg_compute_timer());
 
-    _aggregator->hash_set_variant().visit(
-            [&](auto& hash_set_with_key) { _aggregator->build_hash_set(*hash_set_with_key, chunk_size); });
+    _aggregator->build_hash_set(chunk_size);
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
@@ -84,8 +83,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t 
                                                       _aggregator->hash_set_variant().size())) {
         // hash table is not full or allow expand the hash table according reduction rate
         SCOPED_TIMER(_aggregator->agg_compute_timer());
-        TRY_CATCH_BAD_ALLOC(_aggregator->hash_set_variant().visit(
-                [&](auto& hash_set_with_key) { _aggregator->build_hash_set(*hash_set_with_key, chunk_size); }));
+        _aggregator->build_hash_set(chunk_size);
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
         _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
@@ -93,9 +91,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t 
     } else {
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
-            TRY_CATCH_BAD_ALLOC(_aggregator->hash_set_variant().visit([&](auto& hash_set_with_key) {
-                _aggregator->build_hash_set_with_selection(*hash_set_with_key, chunk_size);
-            }));
+            _aggregator->build_hash_set_with_selection(chunk_size);
         }
 
         {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -58,9 +58,7 @@ void AggregateDistinctStreamingSourceOperator::_output_chunk_from_hash_set(vecto
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
     }
 
-    _aggregator->hash_set_variant().visit([&](auto& hash_set_with_key) {
-        _aggregator->convert_hash_set_to_chunk(*hash_set_with_key, state->chunk_size(), chunk);
-    });
+    _aggregator->convert_hash_set_to_chunk(state->chunk_size(), chunk);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -60,9 +60,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_streaming() {
 
 Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(const size_t chunk_size) {
     SCOPED_TIMER(_aggregator->agg_compute_timer());
-    TRY_CATCH_BAD_ALLOC(_aggregator->hash_map_variant().visit(
-            [&](auto& hash_map_with_key) { _aggregator->build_hash_map(*hash_map_with_key, chunk_size); }));
-
+    TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
     if (_aggregator->is_none_group_by_exprs()) {
         _aggregator->compute_single_agg_state(chunk_size);
     } else {
@@ -88,8 +86,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const size_t chunk_si
                                                       _aggregator->hash_map_variant().size())) {
         // hash table is not full or allow expand the hash table according reduction rate
         SCOPED_TIMER(_aggregator->agg_compute_timer());
-        TRY_CATCH_BAD_ALLOC(_aggregator->hash_map_variant().visit(
-                [&](auto& hash_map_with_key) { _aggregator->build_hash_map(*hash_map_with_key, chunk_size); }));
+        TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
         if (_aggregator->is_none_group_by_exprs()) {
             _aggregator->compute_single_agg_state(chunk_size);
         } else {
@@ -103,9 +100,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const size_t chunk_si
     } else {
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
-            TRY_CATCH_BAD_ALLOC(_aggregator->hash_map_variant().visit([&](auto& hash_map_with_key) {
-                _aggregator->build_hash_map_with_selection(*hash_map_with_key, chunk_size);
-            }));
+            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map_with_selection(chunk_size));
         }
 
         size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection());

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -66,9 +66,7 @@ void AggregateStreamingSourceOperator::_output_chunk_from_hash_map(vectorized::C
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     }
 
-    _aggregator->hash_map_variant().visit([&](auto& hash_map_with_key) {
-        _aggregator->convert_hash_map_to_chunk(*hash_map_with_key, state->chunk_size(), chunk);
-    });
+    _aggregator->convert_hash_map_to_chunk(state->chunk_size(), chunk);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -68,9 +68,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
             if (!_aggregator->is_none_group_by_exprs()) {
                 TRY_CATCH_ALLOC_SCOPE_START()
-                _aggregator->hash_map_variant().visit([&](auto& hash_table_with_key) {
-                    _aggregator->build_hash_map(*hash_table_with_key, chunk_size, agg_group_by_with_limit);
-                });
+                _aggregator->build_hash_map(chunk_size, agg_group_by_with_limit);
                 _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
 
                 _aggregator->try_convert_to_two_level_map();
@@ -138,9 +136,7 @@ Status AggregateBlockingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
     if (_aggregator->is_none_group_by_exprs()) {
         _aggregator->convert_to_chunk_no_groupby(chunk);
     } else {
-        _aggregator->hash_map_variant().visit([&](auto& hash_map_with_key) {
-            _aggregator->convert_hash_map_to_chunk(*hash_map_with_key, chunk_size, chunk);
-        });
+        _aggregator->convert_hash_map_to_chunk(chunk_size, chunk);
     }
 
     size_t old_size = (*chunk)->num_rows();

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -54,9 +54,7 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
 
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
-            TRY_CATCH_BAD_ALLOC(_aggregator->hash_set_variant().visit([&](auto& hash_set_with_key) {
-                _aggregator->build_hash_set(*hash_set_with_key, chunk->num_rows());
-            }));
+            _aggregator->build_hash_set(chunk->num_rows());
             _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
             TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
@@ -99,9 +97,7 @@ Status DistinctBlockingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool
     }
     int32_t chunk_size = runtime_state()->chunk_size();
 
-    _aggregator->hash_set_variant().visit([&](auto& hash_set_with_key) {
-        _aggregator->convert_hash_set_to_chunk(*hash_set_with_key, chunk_size, chunk);
-    });
+    _aggregator->convert_hash_set_to_chunk(chunk_size, chunk);
 
     size_t old_size = (*chunk)->num_rows();
     eval_join_runtime_filters(chunk->get());

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -54,7 +54,7 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
 
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
-            _aggregator->build_hash_set(chunk->num_rows());
+            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_set(chunk->num_rows()));
             _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
             TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -68,9 +68,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
                 SCOPED_TIMER(_aggregator->agg_compute_timer());
                 TRY_CATCH_ALLOC_SCOPE_START()
 
-                _aggregator->hash_set_variant().visit([this, input_chunk_size](auto& hash_set_with_key) {
-                    _aggregator->build_hash_set(*hash_set_with_key, input_chunk_size);
-                });
+                _aggregator->build_hash_set(input_chunk_size);
 
                 COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
@@ -94,9 +92,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
                     SCOPED_TIMER(_aggregator->agg_compute_timer());
 
                     TRY_CATCH_ALLOC_SCOPE_START()
-                    _aggregator->hash_set_variant().visit([this, input_chunk_size](auto& hash_set_with_key) {
-                        _aggregator->build_hash_set(*hash_set_with_key, input_chunk_size);
-                    });
+                    _aggregator->build_hash_set(input_chunk_size);
 
                     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
                     _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
@@ -109,9 +105,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
                     {
                         SCOPED_TIMER(_aggregator->agg_compute_timer());
                         TRY_CATCH_ALLOC_SCOPE_START()
-                        _aggregator->hash_set_variant().visit([this, input_chunk_size](auto& hash_set_with_key) {
-                            _aggregator->build_hash_set_with_selection(*hash_set_with_key, input_chunk_size);
-                        });
+                        _aggregator->build_hash_set_with_selection(input_chunk_size);
                         TRY_CATCH_ALLOC_SCOPE_END()
                     }
 
@@ -166,9 +160,7 @@ void DistinctStreamingNode::_output_chunk_from_hash_set(ChunkPtr* chunk) {
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
     }
 
-    _aggregator->hash_set_variant().visit([&](auto& hash_set_with_key) {
-        _aggregator->convert_hash_set_to_chunk(*hash_set_with_key, runtime_state()->chunk_size(), chunk);
-    });
+    _aggregator->convert_hash_set_to_chunk(runtime_state()->chunk_size(), chunk);
 }
 
 std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctStreamingNode::decompose_to_pipeline(

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -104,9 +104,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
                 } else {
                     {
                         SCOPED_TIMER(_aggregator->agg_compute_timer());
-                        TRY_CATCH_ALLOC_SCOPE_START()
-                        _aggregator->build_hash_set_with_selection(input_chunk_size);
-                        TRY_CATCH_ALLOC_SCOPE_END()
+                        TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_set_with_selection(input_chunk_size));
                     }
 
                     {

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -1122,6 +1122,7 @@ void Aggregator::convert_hash_set_to_chunk(int32_t chunk_size, vectorized::Chunk
         *chunk = std::move(result_chunk);
     });
 }
+
 void Aggregator::_release_agg_memory() {
     // If all function states are of POD type,
     // then we don't have to traverse the hash table to call destroy method.

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -331,7 +331,7 @@ Status Aggregator::_reset_state(RuntimeState* state) {
             _agg_functions[i]->destroy(_agg_fn_ctxs[0], _single_agg_state + _agg_states_offsets[i]);
         }
     } else if (!_is_only_group_by_columns) {
-        _hash_map_variant.visit([this](auto& hash_map_with_key) { _release_agg_memory(hash_map_with_key.get()); });
+        _release_agg_memory();
     }
     _mem_pool->free_all();
 
@@ -371,7 +371,7 @@ void Aggregator::close(RuntimeState* state) {
                     _agg_functions[i]->destroy(_agg_fn_ctxs[0], _single_agg_state + _agg_states_offsets[i]);
                 }
             } else if (!_is_only_group_by_columns) {
-                _hash_map_variant.visit([&](auto& hash_map_with_key) { _release_agg_memory(hash_map_with_key.get()); });
+                _release_agg_memory();
             }
 
             _mem_pool->free_all();
@@ -936,4 +936,217 @@ void Aggregator::_init_agg_hash_variant(HashVariantType& hash_variant) {
         }
     });
 }
+
+void Aggregator::build_hash_map(size_t chunk_size, bool agg_group_by_with_limit) {
+    if (agg_group_by_with_limit) {
+        if (_hash_map_variant.size() >= _limit) {
+            build_hash_map_with_selection(chunk_size);
+            return;
+        } else {
+            _streaming_selection.assign(chunk_size, 0);
+        }
+    }
+
+    _hash_map_variant.visit([&](auto& hash_map_with_key) {
+        using MapType = std::remove_reference_t<decltype(*hash_map_with_key)>;
+        hash_map_with_key->compute_agg_states(chunk_size, _group_by_columns, _mem_pool.get(),
+                                              AllocateState<MapType>(this), &_tmp_agg_states);
+    });
+}
+
+void Aggregator::build_hash_map_with_selection(size_t chunk_size) {
+    _hash_map_variant.visit([&](auto& hash_map_with_key) {
+        using MapType = std::remove_reference_t<decltype(*hash_map_with_key)>;
+        hash_map_with_key->compute_agg_states(chunk_size, _group_by_columns, AllocateState<MapType>(this),
+                                              &_tmp_agg_states, &_streaming_selection);
+    });
+}
+
+void Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk) {
+    SCOPED_TIMER(_agg_stat->get_results_timer);
+
+    _hash_map_variant.visit([&](auto& variant_value) {
+        auto& hash_map_with_key = *variant_value;
+        using HashMapWithKey = std::remove_reference_t<decltype(hash_map_with_key)>;
+
+        auto it = std::any_cast<RawHashTableIterator>(_it_hash);
+        auto end = _state_allocator.end();
+
+        const auto hash_map_size = _hash_map_variant.size();
+        auto num_rows = std::min<size_t>(hash_map_size - _num_rows_processed, chunk_size);
+        vectorized::Columns group_by_columns = _create_group_by_columns(num_rows);
+        vectorized::Columns agg_result_columns = _create_agg_result_columns(num_rows);
+
+        auto use_intermediate = _use_intermediate_as_output();
+        int32_t read_index = 0;
+        {
+            SCOPED_TIMER(_agg_stat->iter_timer);
+            hash_map_with_key.results.resize(chunk_size);
+            // get key/value from hashtable
+            while ((it != end) & (read_index < chunk_size)) {
+                auto* value = it.value();
+                hash_map_with_key.results[read_index] = *reinterpret_cast<typename HashMapWithKey::KeyType*>(value);
+                _tmp_agg_states[read_index] = value;
+                ++read_index;
+                it.next();
+            }
+        }
+
+        {
+            SCOPED_TIMER(_agg_stat->group_by_append_timer);
+            hash_map_with_key.insert_keys_to_columns(hash_map_with_key.results, group_by_columns, read_index);
+        }
+
+        {
+            SCOPED_TIMER(_agg_stat->agg_append_timer);
+            if (!use_intermediate) {
+                for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+                    _agg_functions[i]->batch_finalize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
+                                                      _agg_states_offsets[i], agg_result_columns[i].get());
+                }
+            } else {
+                for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+                    _agg_functions[i]->batch_serialize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
+                                                       _agg_states_offsets[i], agg_result_columns[i].get());
+                }
+            }
+        }
+
+        _is_ht_eos = (it == end);
+
+        // If there is null key, output it last
+        if constexpr (HashMapWithKey::has_single_null_key) {
+            if (_is_ht_eos && hash_map_with_key.null_key_data != nullptr) {
+                // The output chunk size couldn't larger than _state->chunk_size()
+                if (read_index < _state->chunk_size()) {
+                    // For multi group by key, we don't need to special handle null key
+                    DCHECK(group_by_columns.size() == 1);
+                    DCHECK(group_by_columns[0]->is_nullable());
+                    group_by_columns[0]->append_default();
+
+                    if (!use_intermediate) {
+                        _finalize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns);
+                    } else {
+                        _serialize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns);
+                    }
+
+                    ++read_index;
+                } else {
+                    // Output null key in next round
+                    _is_ht_eos = false;
+                }
+            }
+        }
+
+        _it_hash = it;
+        auto result_chunk = _build_output_chunk(group_by_columns, agg_result_columns);
+        _num_rows_returned += read_index;
+        _num_rows_processed += read_index;
+        *chunk = std::move(result_chunk);
+    });
+}
+
+void Aggregator::build_hash_set(size_t chunk_size) {
+    _hash_set_variant.visit(
+            [&](auto& hash_set) { hash_set->build_set(chunk_size, _group_by_columns, _mem_pool.get()); });
+}
+
+void Aggregator::build_hash_set_with_selection(size_t chunk_size) {
+    _hash_set_variant.visit(
+            [&](auto& hash_set) { hash_set->build_set(chunk_size, _group_by_columns, &_streaming_selection); });
+}
+
+void Aggregator::convert_hash_set_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk) {
+    SCOPED_TIMER(_agg_stat->get_results_timer);
+
+    _hash_set_variant.visit([&](auto& variant_value) {
+        auto& hash_set = *variant_value;
+        using HashSetWithKey = std::remove_reference_t<decltype(hash_set)>;
+        using Iterator = typename HashSetWithKey::Iterator;
+        auto it = std::any_cast<Iterator>(_it_hash);
+        auto end = hash_set.hash_set.end();
+        const auto hash_set_size = _hash_set_variant.size();
+        auto num_rows = std::min<size_t>(hash_set_size - _num_rows_processed, chunk_size);
+        vectorized::Columns group_by_columns = _create_group_by_columns(num_rows);
+
+        // Computer group by columns and aggregate result column
+        int32_t read_index = 0;
+        hash_set.results.resize(chunk_size);
+        while (it != end && read_index < chunk_size) {
+            // hash_set.insert_key_to_columns(*it, group_by_columns);
+            hash_set.results[read_index] = *it;
+            ++read_index;
+            ++it;
+        }
+
+        {
+            SCOPED_TIMER(_agg_stat->group_by_append_timer);
+            hash_set.insert_keys_to_columns(hash_set.results, group_by_columns, read_index);
+        }
+
+        _is_ht_eos = (it == end);
+
+        // IF there is null key, output it last
+        if constexpr (HashSetWithKey::has_single_null_key) {
+            if (_is_ht_eos && hash_set.has_null_key) {
+                // The output chunk size couldn't larger than _state->chunk_size()
+                if (read_index < _state->chunk_size()) {
+                    // For multi group by key, we don't need to special handle null key
+                    DCHECK(group_by_columns.size() == 1);
+                    DCHECK(group_by_columns[0]->is_nullable());
+                    group_by_columns[0]->append_default();
+                    ++read_index;
+                } else {
+                    // Output null key in next round
+                    _is_ht_eos = false;
+                }
+            }
+        }
+
+        _it_hash = it;
+
+        vectorized::ChunkPtr result_chunk = std::make_shared<vectorized::Chunk>();
+        // For different agg phase, we should use different TupleDescriptor
+        auto use_intermediate = _use_intermediate_as_output();
+        if (!use_intermediate) {
+            for (size_t i = 0; i < group_by_columns.size(); i++) {
+                result_chunk->append_column(group_by_columns[i], _output_tuple_desc->slots()[i]->id());
+            }
+        } else {
+            for (size_t i = 0; i < group_by_columns.size(); i++) {
+                result_chunk->append_column(group_by_columns[i], _intermediate_tuple_desc->slots()[i]->id());
+            }
+        }
+        _num_rows_returned += read_index;
+        _num_rows_processed += read_index;
+        *chunk = std::move(result_chunk);
+    });
+}
+void Aggregator::_release_agg_memory() {
+    // If all function states are of POD type,
+    // then we don't have to traverse the hash table to call destroy method.
+    //
+    _hash_map_variant.visit([&](auto& hash_map_with_key) {
+        bool skip_destroy = std::all_of(_agg_functions.begin(), _agg_functions.end(),
+                                        [](auto* func) { return func->is_pod_state(); });
+        if (hash_map_with_key != nullptr && !skip_destroy) {
+            auto null_data_ptr = hash_map_with_key->get_null_key_data();
+            if (null_data_ptr != nullptr) {
+                for (int i = 0; i < _agg_functions.size(); i++) {
+                    _agg_functions[i]->destroy(_agg_fn_ctxs[i], null_data_ptr + _agg_states_offsets[i]);
+                }
+            }
+            auto it = _state_allocator.begin();
+            auto end = _state_allocator.end();
+
+            while (it != end) {
+                for (int i = 0; i < _agg_functions.size(); i++) {
+                    _agg_functions[i]->destroy(_agg_fn_ctxs[i], it.value() + _agg_states_offsets[i]);
+                }
+                it.next();
+            }
+        }
+    });
+}
+
 } // namespace starrocks

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <mutex>
 #include <queue>
+#include <type_traits>
 #include <utility>
 
 #include "column/chunk.h"
@@ -348,184 +349,18 @@ protected:
     AggStatistics* _agg_stat;
 
 public:
-    template <typename HashMapWithKey>
-    ATTRIBUTE_NOINLINE void build_hash_map(HashMapWithKey& hash_map_with_key, size_t chunk_size,
-                                           bool agg_group_by_with_limit = false) {
-        if (agg_group_by_with_limit) {
-            if (hash_map_with_key.hash_map.size() >= _limit) {
-                build_hash_map_with_selection(hash_map_with_key, chunk_size);
-                return;
-            } else {
-                _streaming_selection.assign(chunk_size, 0);
-            }
-        }
-        hash_map_with_key.compute_agg_states(chunk_size, _group_by_columns, _mem_pool.get(),
-                                             AllocateState<HashMapWithKey>(this), &_tmp_agg_states);
-    }
+    void build_hash_map(size_t chunk_size, bool agg_group_by_with_limit = false);
+    void build_hash_map_with_selection(size_t chunk_size);
+    void convert_hash_map_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk);
 
-    template <typename HashMapWithKey>
-    ATTRIBUTE_NOINLINE void build_hash_map_with_selection(HashMapWithKey& hash_map_with_key, size_t chunk_size) {
-        hash_map_with_key.compute_agg_states(chunk_size, _group_by_columns, AllocateState<HashMapWithKey>(this),
-                                             &_tmp_agg_states, &_streaming_selection);
-    }
-
-    template <typename HashSetWithKey>
-    ATTRIBUTE_NOINLINE void build_hash_set(HashSetWithKey& hash_set, size_t chunk_size) {
-        hash_set.build_set(chunk_size, _group_by_columns, _mem_pool.get());
-    }
-
-    template <typename HashSetWithKey>
-    ATTRIBUTE_NOINLINE void build_hash_set_with_selection(HashSetWithKey& hash_set, size_t chunk_size) {
-        hash_set.build_set(chunk_size, _group_by_columns, &_streaming_selection);
-    }
-
-    template <typename HashMapWithKey>
-    ATTRIBUTE_NOINLINE void convert_hash_map_to_chunk(HashMapWithKey& hash_map_with_key, int32_t chunk_size,
-                                                      vectorized::ChunkPtr* chunk) {
-        SCOPED_TIMER(_agg_stat->get_results_timer);
-
-        auto it = std::any_cast<RawHashTableIterator>(_it_hash);
-        auto end = _state_allocator.end();
-
-        const auto hash_map_size = _hash_map_variant.size();
-        auto num_rows = std::min<size_t>(hash_map_size - _num_rows_processed, chunk_size);
-        vectorized::Columns group_by_columns = _create_group_by_columns(num_rows);
-        vectorized::Columns agg_result_columns = _create_agg_result_columns(num_rows);
-
-        auto use_intermediate = _use_intermediate_as_output();
-        int32_t read_index = 0;
-        {
-            SCOPED_TIMER(_agg_stat->iter_timer);
-            hash_map_with_key.results.resize(chunk_size);
-            // get key/value from hashtable
-            while ((it != end) & (read_index < chunk_size)) {
-                auto* value = it.value();
-                hash_map_with_key.results[read_index] = *reinterpret_cast<typename HashMapWithKey::KeyType*>(value);
-                _tmp_agg_states[read_index] = value;
-                ++read_index;
-                it.next();
-            }
-        }
-
-        {
-            SCOPED_TIMER(_agg_stat->group_by_append_timer);
-            hash_map_with_key.insert_keys_to_columns(hash_map_with_key.results, group_by_columns, read_index);
-        }
-
-        {
-            SCOPED_TIMER(_agg_stat->agg_append_timer);
-            if (!use_intermediate) {
-                for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-                    _agg_functions[i]->batch_finalize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
-                                                      _agg_states_offsets[i], agg_result_columns[i].get());
-                }
-            } else {
-                for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-                    _agg_functions[i]->batch_serialize(_agg_fn_ctxs[i], read_index, _tmp_agg_states,
-                                                       _agg_states_offsets[i], agg_result_columns[i].get());
-                }
-            }
-        }
-
-        _is_ht_eos = (it == end);
-
-        // If there is null key, output it last
-        if constexpr (HashMapWithKey::has_single_null_key) {
-            if (_is_ht_eos && hash_map_with_key.null_key_data != nullptr) {
-                // The output chunk size couldn't larger than _state->chunk_size()
-                if (read_index < _state->chunk_size()) {
-                    // For multi group by key, we don't need to special handle null key
-                    DCHECK(group_by_columns.size() == 1);
-                    DCHECK(group_by_columns[0]->is_nullable());
-                    group_by_columns[0]->append_default();
-
-                    if (!use_intermediate) {
-                        _finalize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns);
-                    } else {
-                        _serialize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns);
-                    }
-
-                    ++read_index;
-                } else {
-                    // Output null key in next round
-                    _is_ht_eos = false;
-                }
-            }
-        }
-
-        _it_hash = it;
-        auto result_chunk = _build_output_chunk(group_by_columns, agg_result_columns);
-        _num_rows_returned += read_index;
-        _num_rows_processed += read_index;
-        *chunk = std::move(result_chunk);
-    }
-
-    template <typename HashSetWithKey>
-    ATTRIBUTE_NOINLINE void convert_hash_set_to_chunk(HashSetWithKey& hash_set, int32_t chunk_size,
-                                                      vectorized::ChunkPtr* chunk) {
-        SCOPED_TIMER(_agg_stat->get_results_timer);
-        using Iterator = typename HashSetWithKey::Iterator;
-        auto it = std::any_cast<Iterator>(_it_hash);
-        auto end = hash_set.hash_set.end();
-        const auto hash_set_size = _hash_set_variant.size();
-        auto num_rows = std::min<size_t>(hash_set_size - _num_rows_processed, chunk_size);
-        vectorized::Columns group_by_columns = _create_group_by_columns(num_rows);
-
-        // Computer group by columns and aggregate result column
-        int32_t read_index = 0;
-        hash_set.results.resize(chunk_size);
-        while (it != end && read_index < chunk_size) {
-            // hash_set.insert_key_to_columns(*it, group_by_columns);
-            hash_set.results[read_index] = *it;
-            ++read_index;
-            ++it;
-        }
-
-        {
-            SCOPED_TIMER(_agg_stat->group_by_append_timer);
-            hash_set.insert_keys_to_columns(hash_set.results, group_by_columns, read_index);
-        }
-
-        _is_ht_eos = (it == end);
-
-        // IF there is null key, output it last
-        if constexpr (HashSetWithKey::has_single_null_key) {
-            if (_is_ht_eos && hash_set.has_null_key) {
-                // The output chunk size couldn't larger than _state->chunk_size()
-                if (read_index < _state->chunk_size()) {
-                    // For multi group by key, we don't need to special handle null key
-                    DCHECK(group_by_columns.size() == 1);
-                    DCHECK(group_by_columns[0]->is_nullable());
-                    group_by_columns[0]->append_default();
-                    ++read_index;
-                } else {
-                    // Output null key in next round
-                    _is_ht_eos = false;
-                }
-            }
-        }
-
-        _it_hash = it;
-
-        vectorized::ChunkPtr result_chunk = std::make_shared<vectorized::Chunk>();
-        // For different agg phase, we should use different TupleDescriptor
-        auto use_intermediate = _use_intermediate_as_output();
-        if (!use_intermediate) {
-            for (size_t i = 0; i < group_by_columns.size(); i++) {
-                result_chunk->append_column(group_by_columns[i], _output_tuple_desc->slots()[i]->id());
-            }
-        } else {
-            for (size_t i = 0; i < group_by_columns.size(); i++) {
-                result_chunk->append_column(group_by_columns[i], _intermediate_tuple_desc->slots()[i]->id());
-            }
-        }
-        _num_rows_returned += read_index;
-        _num_rows_processed += read_index;
-        *chunk = std::move(result_chunk);
-    }
+    void build_hash_set(size_t chunk_size);
+    void build_hash_set_with_selection(size_t chunk_size);
+    void convert_hash_set_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk);
 
 protected:
-    bool _reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
+    bool _reached_limit() {
+        return _limit != -1 && _num_rows_returned >= _limit;
+    }
 
     bool _use_intermediate_as_input() {
         if (is_pending_reset_state()) {
@@ -559,12 +394,22 @@ protected:
     vectorized::ChunkPtr _build_output_chunk(const vectorized::Columns& group_by_columns,
                                              const vectorized::Columns& agg_result_columns);
 
-    void _set_passthrough(bool flag) { _is_passthrough = flag; }
-    bool is_passthrough() const { return _is_passthrough; }
+    void _set_passthrough(bool flag) {
+        _is_passthrough = flag;
+    }
+    bool is_passthrough() const {
+        return _is_passthrough;
+    }
 
-    void begin_pending_reset_state() { _is_pending_reset_state = true; }
-    void end_pending_reset_state() { _is_pending_reset_state = false; }
-    bool is_pending_reset_state() { return _is_pending_reset_state; }
+    void begin_pending_reset_state() {
+        _is_pending_reset_state = true;
+    }
+    void end_pending_reset_state() {
+        _is_pending_reset_state = false;
+    }
+    bool is_pending_reset_state() {
+        return _is_pending_reset_state;
+    }
 
     void _reset_exprs();
     Status _evaluate_exprs(vectorized::Chunk* chunk);
@@ -573,31 +418,8 @@ protected:
     template <typename HashVariantType>
     void _init_agg_hash_variant(HashVariantType& hash_variant);
 
-    template <typename HashMapWithKey>
-    ATTRIBUTE_NOINLINE void _release_agg_memory(HashMapWithKey* hash_map_with_key) {
-        // If all function states are of POD type,
-        // then we don't have to traverse the hash table to call destroy method.
-        //
-        bool skip_destroy = std::all_of(_agg_functions.begin(), _agg_functions.end(),
-                                        [](auto* func) { return func->is_pod_state(); });
-        if (hash_map_with_key != nullptr && !skip_destroy) {
-            auto null_data_ptr = hash_map_with_key->get_null_key_data();
-            if (null_data_ptr != nullptr) {
-                for (int i = 0; i < _agg_functions.size(); i++) {
-                    _agg_functions[i]->destroy(_agg_fn_ctxs[i], null_data_ptr + _agg_states_offsets[i]);
-                }
-            }
-            auto it = _state_allocator.begin();
-            auto end = _state_allocator.end();
+    void _release_agg_memory();
 
-            while (it != end) {
-                for (int i = 0; i < _agg_functions.size(); i++) {
-                    _agg_functions[i]->destroy(_agg_fn_ctxs[i], it.value() + _agg_states_offsets[i]);
-                }
-                it.next();
-            }
-        }
-    }
     template <class HashMapWithKey>
     friend struct AllocateState;
 };

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -2,14 +2,12 @@
 
 #pragma once
 
-#include <algorithm>
 #include <any>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <queue>
-#include <type_traits>
 #include <utility>
 
 #include "column/chunk.h"

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -356,9 +356,7 @@ public:
     void convert_hash_set_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk);
 
 protected:
-    bool _reached_limit() {
-        return _limit != -1 && _num_rows_returned >= _limit;
-    }
+    bool _reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
 
     bool _use_intermediate_as_input() {
         if (is_pending_reset_state()) {
@@ -392,22 +390,12 @@ protected:
     vectorized::ChunkPtr _build_output_chunk(const vectorized::Columns& group_by_columns,
                                              const vectorized::Columns& agg_result_columns);
 
-    void _set_passthrough(bool flag) {
-        _is_passthrough = flag;
-    }
-    bool is_passthrough() const {
-        return _is_passthrough;
-    }
+    void _set_passthrough(bool flag) { _is_passthrough = flag; }
+    bool is_passthrough() const { return _is_passthrough; }
 
-    void begin_pending_reset_state() {
-        _is_pending_reset_state = true;
-    }
-    void end_pending_reset_state() {
-        _is_pending_reset_state = false;
-    }
-    bool is_pending_reset_state() {
-        return _is_pending_reset_state;
-    }
+    void begin_pending_reset_state() { _is_pending_reset_state = true; }
+    void end_pending_reset_state() { _is_pending_reset_state = false; }
+    bool is_pending_reset_state() { return _is_pending_reset_state; }
 
     void _reset_exprs();
     Status _evaluate_exprs(vectorized::Chunk* chunk);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Many template functions in `Aggregator` cause duplicated template instantiation, which also amplify the binary size.

So we need to move these template function into `.cpp` from `.h`. This PR could reduce the `libExec.a` from 1.4GB to 1.3GB in debug build.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
