### PR TITLE
[BugFix] Turn off the default block cache switch because compatibility issues with some linkers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -118,7 +118,7 @@ if [[ -z $(grep -o 'sse[^ ]*' /proc/cpuinfo) ]]; then
 fi
 
 if [[ -z ${WITH_BLOCK_CACHE} ]]; then
-	WITH_BLOCK_CACHE=ON
+	WITH_BLOCK_CACHE=OFF
 fi
 
 if [[ "${WITH_BLOCK_CACHE}" == "ON" && ! -f ${STARROCKS_THIRDPARTY}/installed/cachelib/lib/libcachelib_allocator.a ]]; then


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The cachelib dynamic output has some compatibility issues with some linkers, so temporarily turn off the default block cache switch until the problem be fixed.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
