### PR TITLE
[Enhancement] Add BE down tolerate time for colcoate balance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -743,7 +743,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
             // 1. BE is dead for a long time
             // 2. BE is under decommission
             if ((!be.isAlive() &&
-                    (currTime - be.getLastUpdateMs()) > Config.tablet_sched_repair_delay_factor_second * 1000 * 2)
+                    (currTime - be.getLastUpdateMs()) > Config.tablet_sched_colocate_be_down_tolerate_time_s * 1000)
                     || be.isDecommissioned()) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1097,6 +1097,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, aliases = {"disable_colocate_balance"})
     public static boolean tablet_sched_disable_colocate_balance = false;
 
+    /**
+     * If BE is down beyond this time, tablets on that BE of colcoate table will be migrated to other available BEs
+     */
+    @ConfField(mutable = true)
+    public static int tablet_sched_colocate_be_down_tolerate_time_s = 12 * 3600;
+
     @ConfField(aliases = {"tablet_balancer_strategy"})
     public static String tablet_sched_balancer_strategy = "disk_and_tablet";
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1101,7 +1101,7 @@ public class Config extends ConfigBase {
      * If BE is down beyond this time, tablets on that BE of colcoate table will be migrated to other available BEs
      */
     @ConfField(mutable = true)
-    public static int tablet_sched_colocate_be_down_tolerate_time_s = 12 * 3600;
+    public static long tablet_sched_colocate_be_down_tolerate_time_s = 12 * 3600;
 
     @ConfField(aliases = {"tablet_balancer_strategy"})
     public static String tablet_sched_balancer_strategy = "disk_and_tablet";

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -554,7 +554,7 @@ public class ColocateTableBalancerTest {
                 result = false;
                 minTimes = 0;
                 myBackend3.getLastUpdateMs();
-                result = System.currentTimeMillis() - Config.tablet_sched_repair_delay_factor_second * 1000 * 20;
+                result = System.currentTimeMillis() - Config.tablet_sched_colocate_be_down_tolerate_time_s * 1000;
                 minTimes = 0;
 
                 // backend4 not available, and dead for a short time
@@ -635,7 +635,7 @@ public class ColocateTableBalancerTest {
                 result = false;
                 minTimes = 0;
                 myBackend3.getLastUpdateMs();
-                result = System.currentTimeMillis() - Config.tablet_sched_repair_delay_factor_second * 1000 * 20;
+                result = System.currentTimeMillis() - Config.tablet_sched_colocate_be_down_tolerate_time_s * 1000;
                 minTimes = 0;
 
                 // backend4 available, not alive but dead for a short time


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Colocate balance is very time-and-resource-consuming, but when BE is down for a little time, colcoate balance will be triggered. We should avoid colocate balance as much as possible. So add a config param `tablet_sched_colocate_be_down_tolerate_time_s`, if BE is down beyond this time, tablets on that BE of colcoate table will be migrated to other available BEs.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
