### PR TITLE
[BugFix] Give a default value to eliminate the DCHECK error in debug mode

### DIFF
--- a/be/src/exprs/anyval_util.cpp
+++ b/be/src/exprs/anyval_util.cpp
@@ -97,6 +97,11 @@ FunctionContext::TypeDesc AnyValUtil::column_type_to_type_desc(const TypeDescrip
         // here we can return any value.
         out.type = TYPE_NULL;
         break;
+    case TYPE_MAP:
+        // reaching here means we are executing a vectorized built-in function and the return type is unused,
+        // so here we can return any value.
+        out.type = TYPE_NULL;
+        break;
     case TYPE_DECIMAL32:
         out.type = TYPE_DECIMAL32;
         out.precision = type.precision;


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Build-in function will use column_type_to_type_desc to create context, but for map type and map functions the type is not useful so we can just give a default type value.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
