### PR TITLE
[BugFix]lambda arguments cannot be seen as normal column ref

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
@@ -47,7 +47,7 @@ public class ColumnRefFactory {
         } else if (expression instanceof CastExpr) {
             nameHint = "cast";
         }
-        return create(nextId++, nameHint, type, nullable);
+        return create(nextId++, nameHint, type, nullable, false);
     }
 
     public ColumnRefOperator create(ScalarOperator operator, Type type, boolean nullable) {
@@ -63,15 +63,19 @@ public class ColumnRefFactory {
                 nameHint = ((CallOperator) operator).getFnName();
             }
         }
-        return create(nextId++, nameHint, type, nullable);
+        return create(nextId++, nameHint, type, nullable, false);
     }
 
     public ColumnRefOperator create(String name, Type type, boolean nullable) {
-        return create(nextId++, name, type, nullable);
+        return create(nextId++, name, type, nullable, false);
     }
 
-    private ColumnRefOperator create(int id, String name, Type type, boolean nullable) {
-        ColumnRefOperator columnRef = new ColumnRefOperator(id, type, name, nullable);
+    public ColumnRefOperator create(String name, Type type, boolean nullable, boolean isLambdaArg) {
+        return create(nextId++, name, type, nullable, isLambdaArg);
+    }
+
+    private ColumnRefOperator create(int id, String name, Type type, boolean nullable, boolean isLambdaArg) {
+        ColumnRefOperator columnRef = new ColumnRefOperator(id, type, name, nullable, isLambdaArg);
         columnRefs.add(columnRef);
         return columnRef;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorType.java
@@ -100,6 +100,7 @@ public enum OperatorType {
     DICT_MAPPING,
     CLONE,
     LAMBDA_FUNCTION,
+    LAMBDA_ARGUMENT,
     SUBQUERY,
     SUBFIELD,
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -21,8 +21,6 @@ public final class ColumnRefOperator extends ScalarOperator {
     private final String name;
     private boolean nullable;
 
-    private boolean isLambdaArgument;
-
     // TODO(SmithCruise) Ugly code, remove it in future.
     // Empty list for default
     // If it's empty, means select all
@@ -34,7 +32,6 @@ public final class ColumnRefOperator extends ScalarOperator {
         this.id = id;
         this.name = requireNonNull(name, "name is null");
         this.nullable = nullable;
-        this.isLambdaArgument = false;
     }
 
     public void addUsedSubfieldPos(ImmutableList<Integer> usedNestFieldPos) {
@@ -46,11 +43,11 @@ public final class ColumnRefOperator extends ScalarOperator {
     }
 
     public ColumnRefOperator(int id, Type type, String name, boolean nullable, boolean isLambdaArgument) {
-        super(OperatorType.VARIABLE, type);
+        // lambda arguments cannot be seen by outer scopes, so set it a different operator type.
+        super(isLambdaArgument ? OperatorType.LAMBDA_ARGUMENT : OperatorType.VARIABLE, type);
         this.id = id;
         this.name = requireNonNull(name, "name is null");
         this.nullable = nullable;
-        this.isLambdaArgument = isLambdaArgument;
     }
 
     public int getId() {
@@ -96,7 +93,7 @@ public final class ColumnRefOperator extends ScalarOperator {
     }
 
     public ColumnRefSet getUsedColumns() {
-        if (isLambdaArgument) {
+        if (getOpType().equals(OperatorType.LAMBDA_ARGUMENT)) {
             return new ColumnRefSet();
         }
         return new ColumnRefSet(id);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -384,8 +384,8 @@ public final class SqlToScalarOperatorTranslator {
         }
 
         @Override
-        public ScalarOperator visitLambdaArguments(LambdaArgument node, Context context) {
-            return columnRefFactory.create(node.getName(), node.getType(), node.isNullable());
+        public ScalarOperator visitLambdaArguments(LambdaArgument node, Context context) { // set isLambda
+            return columnRefFactory.create(node.getName(), node.getType(), node.isNullable(), true);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -384,7 +384,7 @@ public final class SqlToScalarOperatorTranslator {
         }
 
         @Override
-        public ScalarOperator visitLambdaArguments(LambdaArgument node, Context context) { // set isLambda
+        public ScalarOperator visitLambdaArguments(LambdaArgument node, Context context) {
             return columnRefFactory.create(node.getName(), node.getType(), node.isNullable(), true);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -499,6 +499,17 @@ public class ExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testLambdaPredicateOnScan() throws Exception {
+        starRocksAssert.withTable("create table test_lambda_on_scan" +
+                "(c0 INT, c2 array<int>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+        String sql = "select * from test_lambda_on_scan where array_map(x -> x, c2) is not null";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("array_map"));
+    }
+
+    @Test
     public void testInPredicateNormalize() throws Exception {
         starRocksAssert.withTable("create table test_in_pred_norm" +
                 "(c0 INT, c1 INT, c2 INT, c3 INT, c4 DATE, c5 DATE) " +


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/starrocks/issues/13524

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

lambda arguments cannot be seen as normal column ref, which is just used within lambda functions.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
