### PR TITLE
[BugFix] add FORBID_INVALID_DATA sql_mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -280,7 +280,13 @@ public enum ErrorCode {
     ERR_PRIVILEGE_ACCESS_TABLE_DENIED(5088, new byte[] {'4', '2', '0', '0', '0'},
             "Access denied for user '%s' to table '%s' when checking privilege"),
     ERR_PRIVILEGE_ROUTINELODE_JOB_NOT_FOUND(5089, new byte[] {'4', '2', '0', '0', '0'},
-            "Routine load job [%s] not found when checking privilege");
+            "Routine load job [%s] not found when checking privilege"),
+
+    ERR_PLAN_VALIDATE_ERROR(6000, new byte[] {'0', '7', '0', '0', '0'},
+            "Incorrect logical plan found in operator: %s. Invalid reason: %s"),
+    ERR_INVALID_DATE_ERROR(6001, new byte[] {'2', '2', '0', '0', '0'}, "Incorrect %s value %s");
+
+
 
     ErrorCode(int code, byte[] sqlState, String errorMsg) {
         this.code = code;

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
@@ -23,6 +23,8 @@ package com.starrocks.common;
 
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.optimizer.validate.ValidateException;
 
 // Used to report error happened when execute SQL of user
 public class ErrorReport {
@@ -78,6 +80,10 @@ public class ErrorReport {
     public static void reportDdlException(String pattern, ErrorCode errorCode, Object... objs)
             throws DdlException {
         throw new DdlException(reportCommon(pattern, errorCode, objs));
+    }
+
+    public static void reportValidateException(ErrorCode errorCode, ErrorType errorType, Object... objs) {
+        throw new ValidateException(errorCode.formatErrorMsg(objs), errorType);
     }
 
     public interface DdlExecutor {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SqlModeHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SqlModeHelper.java
@@ -53,6 +53,8 @@ public class SqlModeHelper {
     public static final long MODE_ONLY_FULL_GROUP_BY = 1L << 5;
     public static final long MODE_NO_UNSIGNED_SUBTRACTION = 1L << 6;
     public static final long MODE_NO_DIR_IN_CREATE = 1L << 7;
+
+    public static final long MODE_FORBID_INVALID_DATE = 1L << 8;
     public static final long MODE_ALLOW_THROW_EXCEPTION = 1L << 9;
     public static final long MODE_DOUBLE_LITERAL = 1L << 17;
     public static final long MODE_ANSI = 1L << 18;
@@ -80,7 +82,8 @@ public class SqlModeHelper {
     public static final long MODE_ALLOWED_MASK =
             (MODE_REAL_AS_FLOAT | MODE_PIPES_AS_CONCAT | MODE_ANSI_QUOTES |
                     MODE_IGNORE_SPACE | MODE_NOT_USED | MODE_ONLY_FULL_GROUP_BY |
-                    MODE_NO_UNSIGNED_SUBTRACTION | MODE_NO_DIR_IN_CREATE | MODE_ALLOW_THROW_EXCEPTION | MODE_DOUBLE_LITERAL |
+                    MODE_NO_UNSIGNED_SUBTRACTION | MODE_NO_DIR_IN_CREATE | MODE_DOUBLE_LITERAL |
+                    MODE_FORBID_INVALID_DATE | MODE_ALLOW_THROW_EXCEPTION |
                     MODE_NO_AUTO_VALUE_ON_ZERO | MODE_NO_BACKSLASH_ESCAPES |
                     MODE_STRICT_TRANS_TABLES | MODE_STRICT_ALL_TABLES | MODE_NO_ZERO_IN_DATE |
                     MODE_NO_ZERO_DATE | MODE_INVALID_DATES | MODE_ERROR_FOR_DIVISION_BY_ZERO |
@@ -102,6 +105,7 @@ public class SqlModeHelper {
         SQL_MODE_SET.put("NO_UNSIGNED_SUBTRACTION", MODE_NO_UNSIGNED_SUBTRACTION);
         SQL_MODE_SET.put("NO_DIR_IN_CREATE", MODE_NO_DIR_IN_CREATE);
         SQL_MODE_SET.put("ALLOW_THROW_EXCEPTION", MODE_ALLOW_THROW_EXCEPTION);
+        SQL_MODE_SET.put("FORBID_INVALID_DATE", MODE_FORBID_INVALID_DATE);
         SQL_MODE_SET.put("MODE_DOUBLE_LITERAL", MODE_DOUBLE_LITERAL);
         SQL_MODE_SET.put("ANSI", MODE_ANSI);
         SQL_MODE_SET.put("NO_AUTO_VALUE_ON_ZERO", MODE_NO_AUTO_VALUE_ON_ZERO);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
@@ -1,0 +1,263 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.validate;
+
+import com.starrocks.catalog.Type;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
+
+import java.util.List;
+import java.util.Map;
+
+public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, Void> {
+
+    private final boolean needValidate;
+
+    private final long sqlMode;
+
+    public OptExpressionValidator() {
+        needValidate = needValidate();
+        sqlMode = ConnectContext.get() == null ? 0 : ConnectContext.get().getSessionVariable().getSqlMode();
+    }
+
+    @Override
+    public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalProject(OptExpression optExpression, Void context) {
+        if (needValidate) {
+            Map<ColumnRefOperator, ScalarOperator> map = ((LogicalProjectOperator) optExpression.getOp())
+                    .getColumnRefMap();
+            validateProjectionMap(map);
+        }
+        validateChildOpt(optExpression);
+        return optExpression;
+    }
+
+    @Override
+    public OptExpression visitLogicalFilter(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalLimit(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalAggregate(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalTopN(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalJoin(OptExpression optExpression, Void context) {
+        if (needValidate) {
+            LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();
+            validateScalarOperator(joinOperator.getOnPredicate());
+        }
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalApply(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalAssertOneRow(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalWindow(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalUnion(OptExpression optExpression, Void context) {
+        LogicalUnionOperator unionOperator = (LogicalUnionOperator) optExpression.getOp();
+        List<ColumnRefOperator> resultCols = unionOperator.getOutputColumnRefOp();
+        for (List<ColumnRefOperator> childCols : unionOperator.getChildOutputColumns()) {
+            if (resultCols.size() != childCols.size()) {
+                ErrorReport.reportValidateException(ErrorCode.ERR_PLAN_VALIDATE_ERROR,
+                        ErrorType.INTERNAL_ERROR, optExpression, "input cols size not equal with output cols size");
+            }
+            for (int i = 0; i < resultCols.size(); i++) {
+                Type outputType = resultCols.get(i).getType();
+                Type inputType = childCols.get(i).getType();
+                if (outputType.getPrimitiveType() != inputType.getPrimitiveType()) {
+                    ErrorReport.reportValidateException(ErrorCode.ERR_PLAN_VALIDATE_ERROR,
+                            ErrorType.INTERNAL_ERROR, optExpression, "input cols type not equal with output cols type");
+                }
+            }
+        }
+        validateChildOpt(optExpression);
+        return optExpression;
+    }
+
+    @Override
+    public OptExpression visitLogicalExcept(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+
+    @Override
+    public OptExpression visitLogicalIntersect(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalValues(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+
+    @Override
+    public OptExpression visitLogicalRepeat(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalTableFunction(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalTreeAnchor(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalCTEAnchor(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalCTEProduce(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    @Override
+    public OptExpression visitLogicalCTEConsume(OptExpression optExpression, Void context) {
+        return commonValidate(optExpression);
+    }
+
+    private OptExpression commonValidate(OptExpression optExpression) {
+        if (needValidate) {
+            validateOperator(optExpression.getOp());
+        }
+        validateChildOpt(optExpression);
+        return optExpression;
+    }
+
+    private void validateChildOpt(OptExpression optExpression) {
+        for (int i = 0; i < optExpression.arity(); i++) {
+            OptExpression childOpt = optExpression.inputAt(i);
+            childOpt.getOp().accept(this, childOpt, null);
+        }
+    }
+
+
+    private void validateOperator(Operator operator) {
+        if (operator.getProjection() != null) {
+            Map<ColumnRefOperator, ScalarOperator> map = operator.getProjection().getColumnRefMap();
+            validateProjectionMap(map);
+        }
+        validateScalarOperator(operator.getPredicate());
+    }
+
+    private void validateProjectionMap(Map<ColumnRefOperator, ScalarOperator> map) {
+        for (ScalarOperator scalarOperator : map.values()) {
+            validateScalarOperator(scalarOperator);
+        }
+    }
+
+    private void validateScalarOperator(ScalarOperator scalarOperator) {
+        if (scalarOperator == null) {
+            return;
+        }
+
+        TypeValidator typeValidator = new TypeValidator();
+        scalarOperator.accept(typeValidator, null);
+    }
+
+
+    private class TypeValidator extends BaseScalarOperatorShuttle {
+
+        @Override
+        public ScalarOperator visitCall(CallOperator call, Void context) {
+            String fnName = call.getFnName();
+            if (needDateValidate()
+                    && ("str_to_date".equals(fnName) || "str2date".equals(fnName))
+                    && call.getChild(0).isConstantRef()) {
+                checkDateType((ConstantOperator) call.getChild(0), Type.DATETIME);
+            } else {
+                super.visitCall(call, context);
+            }
+            return call;
+        }
+
+        @Override
+        public ScalarOperator visitCastOperator(CastOperator operator, Void context) {
+            ScalarOperator child = operator.getChild(0);
+            if (needDateValidate()
+                    && child.isConstantRef()
+                    && operator.getType().isDateType()) {
+                checkDateType((ConstantOperator) child, operator.getType());
+            } else {
+                super.visitCastOperator(operator, context);
+            }
+            return operator;
+        }
+
+        private void checkDateType(ConstantOperator constant, Type toType) {
+            try {
+                constant.castTo(toType);
+            } catch (Exception e) {
+                ErrorReport.reportValidateException(ErrorCode.ERR_INVALID_DATE_ERROR,
+                        ErrorType.USER_ERROR, toType, constant.getValue());
+            }
+        }
+    }
+
+    private boolean needValidate() {
+        if (ConnectContext.get() == null) {
+            return false;
+        }
+
+        long sqlMode = ConnectContext.get().getSessionVariable().getSqlMode();
+        if ((sqlMode & SqlModeHelper.MODE_FORBID_INVALID_DATE) > 0) {
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
+    private boolean needDateValidate() {
+        return (sqlMode & SqlModeHelper.MODE_FORBID_INVALID_DATE) > 0;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
@@ -244,7 +244,6 @@ public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, 
         private boolean needDateValidate() {
             return (sqlMode & SqlModeHelper.MODE_FORBID_INVALID_DATE) > 0;
         }
-
     }
 
     private boolean needValidate() {
@@ -252,7 +251,6 @@ public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, 
             return false;
         }
 
-        long sqlMode = ConnectContext.get().getSessionVariable().getSqlMode();
-        return (sqlMode & SqlModeHelper.MODE_FORBID_INVALID_DATE) > 0;
+        return (ConnectContext.get().getSessionVariable().getSqlMode() & SqlModeHelper.MODE_FORBID_INVALID_DATE) > 0;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
@@ -240,6 +240,11 @@ public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, 
                         ErrorType.USER_ERROR, toType, constant.getValue());
             }
         }
+
+        private boolean needDateValidate() {
+            return (sqlMode & SqlModeHelper.MODE_FORBID_INVALID_DATE) > 0;
+        }
+
     }
 
     private boolean needValidate() {
@@ -248,16 +253,6 @@ public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, 
         }
 
         long sqlMode = ConnectContext.get().getSessionVariable().getSqlMode();
-        if ((sqlMode & SqlModeHelper.MODE_FORBID_INVALID_DATE) > 0) {
-            return true;
-        } else {
-            return false;
-        }
-
-    }
-
-    private boolean needDateValidate() {
         return (sqlMode & SqlModeHelper.MODE_FORBID_INVALID_DATE) > 0;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/ValidateException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/ValidateException.java
@@ -1,0 +1,14 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.validate;
+
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
+
+public class ValidateException extends StarRocksPlannerException {
+
+    public ValidateException(String message, ErrorType type) {
+        super(message, type);
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ValidatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ValidatePlanTest.java
@@ -1,0 +1,64 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.SqlModeHelper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.fail;
+
+class ValidatePlanTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("invalidDateSqlList")
+    void invalidDateSqlTest(String sql) {
+        FeConstants.runningUnitTest = false;
+        connectContext.getSessionVariable().setSqlMode(SqlModeHelper.MODE_FORBID_INVALID_DATE);
+        String plan = "";
+        try {
+            plan = getFragmentPlan(sql);
+            fail("sql cannot execute with validation, but plan is: " + plan);
+        } catch (Exception e) {
+            assertContains(e.getMessage(), "Incorrect");
+        }
+
+        connectContext.getSessionVariable().setSqlMode(0);
+        try {
+            getFragmentPlan(sql);
+        } catch (Exception e) {
+            fail("sql can execute without validation, but error happens: " + plan);
+        }
+    }
+
+
+    private static Stream<Arguments> invalidDateSqlList() {
+        List<String> sqlList = Lists.newArrayList();
+        sqlList.add("select cast('a' as date)");
+        sqlList.add("select cast('a' as datetime)");
+        sqlList.add("select cast(20221131 as date)");
+        sqlList.add("select cast('2021-12-32' as date) from t1");
+        sqlList.add("select * from test_all_type where id_date > '2021-11-31'");
+        sqlList.add("select * from test_all_type where id_date > '2021-11-29' or id_date < '2021-09-00'");
+        sqlList.add("select * from test_all_type t1 join test_all_type t2 on t1.id_date > " +
+                "t2.id_date + str2date('2021-09-00', 'yyyy-MM-dd')");
+        sqlList.add("select * from test_all_type where id_date > '2021-11-30' or id_date < " +
+                "cast(str_to_date('2021-11-31', 'yyyy-MM-dd') as int)");
+        sqlList.add("select *, cast(20211131 as date) from t1 union all select *, cast(20211130 as date) from t2");
+        return sqlList.stream().map(e -> Arguments.of(e));
+    }
+
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For predicate like `date > '2021-09-31'`, we need cast `2021-09-31` to date. However the resutl of this cast expression is null because of the date is invalid, making the predicate result is unknown. It's reasonable but a little confuzed to users, becuase they think rows with date greater than `2021-09-31` like `2021-10-11` should return or a error to tell them it's a invalid date. 
So, we add a FORBID_INVALID_DATA sqlMode. When turn it on, any invalid date literal will throw an expcetion in validation phase.  When call operator need a date type argument, we add cast to the argument if it not satisified. So we check a value if it's a valid date in cast operator and str_to_date(it only need varchar type argument, but the varchar should be a valid date) call operator is enough.

BTW, `DATE '2021-09-31'` is invalid in parser phase. We only need to consider other types cast to date/datetime scenes in plan phase.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
