### PR TITLE
[BugFix] Fix Java UDF open method may call multi times in predicate

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -42,12 +42,14 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const vec
     RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
 
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {
-        return _push_chunk_by_force_streaming();
+        RETURN_IF_ERROR(_push_chunk_by_force_streaming());
     } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_PREAGGREGATION) {
-        return _push_chunk_by_force_preaggregation(chunk->num_rows());
+        RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk->num_rows()));
     } else {
-        return _push_chunk_by_auto(chunk->num_rows());
+        RETURN_IF_ERROR(_push_chunk_by_auto(chunk->num_rows()));
     }
+    RETURN_IF_ERROR(_aggregator->check_has_error());
+    return Status::OK();
 }
 
 Status AggregateStreamingSinkOperator::_push_chunk_by_force_streaming() {
@@ -73,7 +75,6 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(const
     TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
-    RETURN_IF_ERROR(_aggregator->check_has_error());
     return Status::OK();
 }
 

--- a/be/src/exec/vectorized/olap_scan_prepare.cpp
+++ b/be/src/exec/vectorized/olap_scan_prepare.cpp
@@ -643,7 +643,8 @@ Status OlapScanConjunctsManager::get_column_predicates(PredicateParser* parser,
         auto& expr_ctxs = iter.second;
         const SlotDescriptor* slot_desc = slots[slot_index];
         for (ExprContext* ctx : expr_ctxs) {
-            std::unique_ptr<ColumnPredicate> p(parser->parse_expr_ctx(*slot_desc, runtime_state, ctx));
+            ASSIGN_OR_RETURN(auto tmp, parser->parse_expr_ctx(*slot_desc, runtime_state, ctx));
+            std::unique_ptr<ColumnPredicate> p(std::move(tmp));
             if (p == nullptr) {
                 std::stringstream ss;
                 ss << "invalid filter, slot=" << slot_desc->debug_string();

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -12,8 +12,10 @@
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
+#include "common/status.h"
 #include "exprs/agg/aggregate.h"
 #include "gutil/casts.h"
+#include "jni.h"
 #include "runtime/primitive_type.h"
 #include "udf/java/java_data_converter.h"
 #include "udf/java/java_udf.h"
@@ -99,24 +101,37 @@ public:
         // 1 convert input as state
         // 1.1 create state list
         auto rets = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->create->method.handle(), batch_size);
+        RETURN_IF_UNLIKELY_NULL(rets, (void)0);
         // 1.2 convert input as input array
         int num_cols = ctx->get_num_args();
         std::vector<DirectByteBuffer> buffers;
         std::vector<jobject> args;
+        DeferOp defer = DeferOp([&]() {
+            // clean up arrays
+            for (auto& arg : args) {
+                if (arg) {
+                    env->DeleteLocalRef(arg);
+                }
+            }
+        });
         args.emplace_back(rets);
         std::vector<const Column*> raw_input_ptrs(src.size());
         for (int i = 0; i < src.size(); ++i) {
             raw_input_ptrs[i] = src[i].get();
         }
-        JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, raw_input_ptrs.data(), num_cols, batch_size,
-                                                      &args);
+        auto st = JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, raw_input_ptrs.data(), num_cols,
+                                                                batch_size, &args);
+        RETURN_IF_UNLIKELY(!st.ok(), (void)0);
+
         // 2 batch call update
         helper.batch_update_state(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
                                   ctx->impl()->udaf_ctxs()->update->method.handle(), args.data(), args.size());
         // 3 get serialize size
         auto serialize_szs = (jintArray)helper.int_batch_call(
                 ctx, rets, ctx->impl()->udaf_ctxs()->serialize_size->method.handle(), batch_size);
+        RETURN_IF_UNLIKELY_NULL(serialize_szs, (void)0);
         LOCAL_REF_GUARD_ENV(env, serialize_szs);
+
         int length = env->GetArrayLength(serialize_szs);
         std::vector<int> slice_sz(length);
         helper.getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
@@ -127,12 +142,14 @@ public:
                 std::make_unique<DirectByteBuffer>(udf_ctxs->buffer_data.data(), udf_ctxs->buffer_data.size());
         // chunk size
         auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), batch_size);
+        RETURN_IF_UNLIKELY_NULL(buffer_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         jobject state_and_buffer[2] = {rets, buffer_array};
         helper.batch_update_state(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
                                   ctx->impl()->udaf_ctxs()->serialize->method.handle(), state_and_buffer, 2);
-        std::vector<Slice> slices(batch_size);
+
         // 5 ready
+        std::vector<Slice> slices(batch_size);
         int offsets = 0;
         for (int i = 0; i < batch_size; ++i) {
             slices[i] = Slice(udf_ctxs->buffer_data.data() + offsets, slice_sz[i]);
@@ -140,10 +157,6 @@ public:
         }
         // append result to dst column
         CHECK((*dst)->append_strings(slices));
-        // 6 clean up arrays
-        for (auto& arg : args) {
-            env->DeleteLocalRef(arg);
-        }
     }
 
     // State Data
@@ -175,14 +188,18 @@ public:
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
         helper.getEnv()->PushLocalFrame(num_cols * 3 + 1);
+        auto defer = DeferOp([&helper]() { helper.getEnv()->PopLocalFrame(nullptr); });
+
         {
-            auto states_arr = JavaDataTypeConverter::convert_to_states(states, state_offset, batch_size);
-            JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_cols, batch_size, &args);
+            auto states_arr = JavaDataTypeConverter::convert_to_states(ctx, states, state_offset, batch_size);
+            RETURN_IF_UNLIKELY_NULL(states_arr, (void)0);
+            auto st =
+                    JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_cols, batch_size, &args);
+            RETURN_IF_UNLIKELY(!st.ok(), (void)0);
             helper.batch_update(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
                                 ctx->impl()->udaf_ctxs()->update->method.handle(), states_arr, args.data(),
                                 args.size());
         }
-        helper.getEnv()->PopLocalFrame(nullptr);
     }
 
     void update_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
@@ -193,9 +210,12 @@ public:
         int num_cols = ctx->get_num_args();
         helper.getEnv()->PushLocalFrame(num_cols * 3 + 1);
         {
-            auto states_arr = JavaDataTypeConverter::convert_to_states_with_filter(states, state_offset, filter.data(),
-                                                                                   batch_size);
-            JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_cols, batch_size, &args);
+            auto states_arr = JavaDataTypeConverter::convert_to_states_with_filter(ctx, states, state_offset,
+                                                                                   filter.data(), batch_size);
+            RETURN_IF_UNLIKELY_NULL(states_arr, (void)0);
+            auto st =
+                    JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_cols, batch_size, &args);
+            RETURN_IF_UNLIKELY(!st.ok(), (void)0);
             helper.batch_update_if_not_null(ctx, ctx->impl()->udaf_ctxs()->handle.handle(),
                                             ctx->impl()->udaf_ctxs()->update->method.handle(), states_arr, args.data(),
                                             args.size());
@@ -212,7 +232,9 @@ public:
         int num_cols = ctx->get_num_args();
         env->PushLocalFrame(num_cols * 3 + 1);
         {
-            JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_cols, batch_size, &args);
+            auto st =
+                    JavaDataTypeConverter::convert_to_boxed_array(ctx, &buffers, columns, num_cols, batch_size, &args);
+            RETURN_IF_UNLIKELY(!st.ok(), (void)0);
 
             auto* stub = ctx->impl()->udaf_ctxs()->update_batch_call_stub.get();
             auto state_handle = this->data(state).handle;
@@ -228,6 +250,7 @@ public:
         auto* env = helper.getEnv();
         // get state lists
         auto state_array = states_provider();
+        RETURN_IF_UNLIKELY_NULL(state_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, state_array);
 
         // prepare buffer
@@ -238,6 +261,7 @@ public:
         auto& serialized_bytes = serialized_column->get_bytes();
         auto buffer = std::make_unique<DirectByteBuffer>(serialized_bytes.data(), serialized_bytes.size());
         auto buffer_array = helper.create_object_array(buffer->handle(), batch_size);
+        RETURN_IF_UNLIKELY_NULL(buffer_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
 
         // batch call merge
@@ -251,7 +275,8 @@ public:
         auto* env = helper.getEnv();
 
         auto provider = [&]() {
-            auto state_id_list = JavaDataTypeConverter::convert_to_states(states, state_offset, batch_size);
+            auto state_id_list = JavaDataTypeConverter::convert_to_states(ctx, states, state_offset, batch_size);
+            RETURN_IF_UNLIKELY_NULL(state_id_list, state_id_list);
             LOCAL_REF_GUARD_ENV(env, state_id_list);
             auto state_array = helper.convert_handles_to_jobjects(ctx, state_id_list);
             return state_array;
@@ -270,7 +295,7 @@ public:
         auto& helper = JVMFunctionHelper::getInstance();
 
         auto provider = [&]() {
-            auto state_id_list = JavaDataTypeConverter::convert_to_states_with_filter(states, state_offset,
+            auto state_id_list = JavaDataTypeConverter::convert_to_states_with_filter(ctx, states, state_offset,
                                                                                       filter.data(), batch_size);
             return state_id_list;
         };
@@ -307,16 +332,31 @@ public:
         auto* env = helper.getEnv();
         auto* udf_ctxs = ctx->impl()->udaf_ctxs();
 
+        const size_t origin_chunk_size = to->size();
+        auto defer = DeferOp([&]() {
+            // we must keep column num_rows equals with expected numbers
+            if (to->size() != batch_size + origin_chunk_size) {
+                DCHECK(ctx->has_error());
+                to->append_default(origin_chunk_size + batch_size - to->size());
+            }
+        });
+
         // step 1 get state lists
         auto states = const_cast<AggDataPtr*>(agg_states.data());
-        auto state_id_list = JavaDataTypeConverter::convert_to_states(states, state_offset, batch_size);
+        auto state_id_list = JavaDataTypeConverter::convert_to_states(ctx, states, state_offset, batch_size);
+        RETURN_IF_UNLIKELY_NULL(state_id_list, (void)0);
         LOCAL_REF_GUARD_ENV(env, state_id_list);
+
         auto state_array = helper.convert_handles_to_jobjects(ctx, state_id_list);
+        RETURN_IF_UNLIKELY_NULL(state_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, state_array);
+
         // step 2 serialize size
         auto serialize_szs = (jintArray)helper.int_batch_call(
                 ctx, state_array, ctx->impl()->udaf_ctxs()->serialize_size->method.handle(), batch_size);
+        RETURN_IF_UNLIKELY_NULL(serialize_szs, (void)0);
         LOCAL_REF_GUARD_ENV(env, serialize_szs);
+
         int length = env->GetArrayLength(serialize_szs);
         std::vector<int> slice_sz(length);
         helper.getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
@@ -348,18 +388,32 @@ public:
         auto* env = helper.getEnv();
         auto* udf_ctxs = ctx->impl()->udaf_ctxs();
 
+        const size_t origin_chunk_size = to->size();
+        auto defer = DeferOp([&]() {
+            // we must keep column num_rows equals with expected numbers
+            if (to->size() != batch_size + origin_chunk_size) {
+                DCHECK(ctx->has_error());
+                to->append_default(origin_chunk_size + batch_size - to->size());
+            }
+        });
+
         // 1. get state list
         auto states = const_cast<AggDataPtr*>(agg_states.data());
-        auto state_id_list = JavaDataTypeConverter::convert_to_states(states, state_offset, batch_size);
+        auto state_id_list = JavaDataTypeConverter::convert_to_states(ctx, states, state_offset, batch_size);
+        RETURN_IF_UNLIKELY_NULL(state_id_list, (void)0);
         LOCAL_REF_GUARD_ENV(env, state_id_list);
+
         auto state_array = helper.convert_handles_to_jobjects(ctx, state_id_list);
+        RETURN_IF_UNLIKELY_NULL(state_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, state_array);
         // 2. batch call finalize
         CHECK(to->empty());
         // 3. get result from column
         auto res = helper.batch_call(ctx, udf_ctxs->handle.handle(), udf_ctxs->finalize->method.handle(), &state_array,
                                      1, batch_size);
+        RETURN_IF_UNLIKELY_NULL(res, (void)0);
         LOCAL_REF_GUARD_ENV(env, res);
+
         LogicalType type = udf_ctxs->finalize->method_desc[0].type;
         if (!to->is_nullable()) {
             ColumnPtr wrapper(const_cast<Column*>(to), [](auto p) {});

--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -129,7 +129,6 @@ Status JavaFunctionCallExpr::prepare(RuntimeState* state, ExprContext* context) 
     context->fn_context(_fn_context_index)->set_is_udf(true);
 
     _func_desc = std::make_shared<JavaUDFContext>();
-
     // TODO:
     _is_returning_random_value = false;
     return Status::OK();
@@ -222,7 +221,9 @@ Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
         }
         return Status::OK();
     };
-    RETURN_IF_ERROR(call_function_in_pthread(state, open_state)->get_future().get());
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
+        RETURN_IF_ERROR(call_function_in_pthread(state, open_state)->get_future().get());
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -6,6 +6,8 @@
 #include <utility>
 
 #include "column/column_helper.h"
+#include "common/status.h"
+#include "common/statusor.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/binary_predicate.h"
@@ -20,12 +22,20 @@
 namespace starrocks::vectorized {
 
 ColumnExprPredicate::ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state,
-                                         ExprContext* expr_ctx, const SlotDescriptor* slot_desc)
+                                         const SlotDescriptor* slot_desc)
         : ColumnPredicate(std::move(type_info), column_id), _state(state), _slot_desc(slot_desc), _monotonic(true) {
+    _is_expr_predicate = true;
+}
+
+StatusOr<ColumnExprPredicate*> ColumnExprPredicate::make_column_expr_predicate(TypeInfoPtr type_info,
+                                                                               ColumnId column_id, RuntimeState* state,
+                                                                               ExprContext* expr_ctx,
+                                                                               const SlotDescriptor* slot_desc) {
+    auto* expr_predicate = new ColumnExprPredicate(std::move(type_info), column_id, state, slot_desc);
     // note: conjuncts would be shared by multiple scanners
     // so here we have to clone one to keep thread safe.
-    _add_expr_ctx(expr_ctx);
-    _is_expr_predicate = true;
+    RETURN_IF_ERROR(expr_predicate->_add_expr_ctx(expr_ctx));
+    return expr_predicate;
 }
 
 ColumnExprPredicate::~ColumnExprPredicate() {
@@ -34,13 +44,14 @@ ColumnExprPredicate::~ColumnExprPredicate() {
     }
 }
 
-void ColumnExprPredicate::_add_expr_ctxs(const std::vector<ExprContext*>& expr_ctxs) {
+Status ColumnExprPredicate::_add_expr_ctxs(const std::vector<ExprContext*>& expr_ctxs) {
     for (auto& expr : expr_ctxs) {
-        _add_expr_ctx(expr);
+        RETURN_IF_ERROR(_add_expr_ctx(expr));
     }
+    return Status::OK();
 }
 
-void ColumnExprPredicate::_add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx) {
+Status ColumnExprPredicate::_add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx) {
     if (expr_ctx != nullptr) {
         DCHECK(expr_ctx->opened());
         // Transfer the ownership to object pool
@@ -48,9 +59,10 @@ void ColumnExprPredicate::_add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx) {
         _expr_ctxs.emplace_back(ctx);
         _monotonic &= ctx->root()->is_monotonic();
     }
+    return Status::OK();
 }
 
-void ColumnExprPredicate::_add_expr_ctx(ExprContext* expr_ctx) {
+Status ColumnExprPredicate::_add_expr_ctx(ExprContext* expr_ctx) {
     if (expr_ctx != nullptr) {
         DCHECK(expr_ctx->opened());
         ExprContext* ctx = nullptr;
@@ -58,6 +70,7 @@ void ColumnExprPredicate::_add_expr_ctx(ExprContext* expr_ctx) {
         _expr_ctxs.emplace_back(ctx);
         _monotonic &= ctx->root()->is_monotonic();
     }
+    return Status::OK();
 }
 
 Status ColumnExprPredicate::evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const {
@@ -181,10 +194,11 @@ Status ColumnExprPredicate::convert_to(const ColumnPredicate** output, const Typ
     RETURN_IF_ERROR(cast_expr_ctx->prepare(_state));
     RETURN_IF_ERROR(cast_expr_ctx->open(_state));
 
-    ColumnExprPredicate* pred =
-            obj_pool->add(new ColumnExprPredicate(target_type_info, _column_id, _state, nullptr, _slot_desc));
-    pred->_add_expr_ctxs(_expr_ctxs);
-    pred->_add_expr_ctx(std::move(cast_expr_ctx));
+    ASSIGN_OR_RETURN(auto pred, ColumnExprPredicate::make_column_expr_predicate(target_type_info, _column_id, _state,
+                                                                                nullptr, _slot_desc));
+
+    RETURN_IF_ERROR(pred->_add_expr_ctxs(_expr_ctxs));
+    RETURN_IF_ERROR(pred->_add_expr_ctx(std::move(cast_expr_ctx)));
     *output = pred;
     return Status::OK();
 }
@@ -249,9 +263,9 @@ Status ColumnExprPredicate::try_to_rewrite_for_zone_map_filter(starrocks::Object
         auto expr_rewrite = std::make_unique<ExprContext>(expr);
         RETURN_IF_ERROR(expr_rewrite->prepare(_state));
         RETURN_IF_ERROR(expr_rewrite->open(_state));
-
-        ColumnExprPredicate* new_pred =
-                pool->add(new ColumnExprPredicate(_type_info, _column_id, _state, nullptr, _slot_desc));
+        ASSIGN_OR_RETURN(ColumnExprPredicate * new_pred, ColumnExprPredicate::make_column_expr_predicate(
+                                                                 _type_info, _column_id, _state, nullptr, _slot_desc));
+        new_pred = pool->add(new_pred);
         new_pred->_add_expr_ctx(std::move(expr_rewrite));
         for (int i = 1; i < _expr_ctxs.size(); i++) {
             new_pred->_add_expr_ctx(_expr_ctxs[i]);

--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -34,8 +34,9 @@ class Column;
 // And that task is almost impossible.
 class ColumnExprPredicate : public ColumnPredicate {
 public:
-    ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state, ExprContext* expr_ctx,
-                        const SlotDescriptor* slot_desc);
+    static StatusOr<ColumnExprPredicate*> make_column_expr_predicate(TypeInfoPtr type_info, ColumnId column_id,
+                                                                     RuntimeState* state, ExprContext* expr_ctx,
+                                                                     const SlotDescriptor* slot_desc);
 
     ~ColumnExprPredicate() override;
 
@@ -62,13 +63,16 @@ public:
                                               std::vector<const ColumnExprPredicate*>* output) const;
 
 private:
-    void _add_expr_ctxs(const std::vector<ExprContext*>& expr_ctxs);
+    ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state,
+                        const SlotDescriptor* slot_desc);
+
+    Status _add_expr_ctxs(const std::vector<ExprContext*>& expr_ctxs);
 
     // Take ownership of this expression, not necessary to clone
-    void _add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx);
+    Status _add_expr_ctx(std::unique_ptr<ExprContext> expr_ctx);
 
     // Share the ownership, is necessary to clone it
-    void _add_expr_ctx(ExprContext* expr_ctx);
+    Status _add_expr_ctx(ExprContext* expr_ctx);
 
     ObjectPool _pool;
     RuntimeState* _state;

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -13,6 +13,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/config.h"
 #include "common/object_pool.h"
+#include "common/statusor.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/in_const_predicate.hpp"
 #include "exprs/vectorized/runtime_filter_bank.h"
@@ -346,7 +347,8 @@ StatusOr<bool> ColumnPredicateRewriter::_rewrite_expr_predicate(ObjectPool* pool
 
     DCHECK_IF_ERROR(filter->prepare(state));
     DCHECK_IF_ERROR(filter->open(state));
-    *ptr = new ColumnExprPredicate(get_type_info(kDictCodeType), pred->column_id(), state, filter, pred->slot_desc());
+    ASSIGN_OR_RETURN(*ptr, ColumnExprPredicate::make_column_expr_predicate(
+                                   get_type_info(kDictCodeType), pred->column_id(), state, filter, pred->slot_desc()))
     filter->close(state);
 
     return true;

--- a/be/src/storage/predicate_parser.cpp
+++ b/be/src/storage/predicate_parser.cpp
@@ -72,8 +72,8 @@ ColumnPredicate* PredicateParser::parse_thrift_cond(const TCondition& condition)
     return pred;
 }
 
-ColumnPredicate* PredicateParser::parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState* state,
-                                                 ExprContext* expr_ctx) const {
+StatusOr<ColumnPredicate*> PredicateParser::parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState* state,
+                                                           ExprContext* expr_ctx) const {
     const size_t column_id = _schema.field_index(slot_desc.col_name());
     RETURN_IF(column_id >= _schema.num_columns(), nullptr);
     const TabletColumn& col = _schema.column(column_id);
@@ -81,7 +81,7 @@ ColumnPredicate* PredicateParser::parse_expr_ctx(const SlotDescriptor& slot_desc
     auto scale = col.scale();
     auto type = TypeUtils::to_storage_format_v2(col.type());
     auto&& type_info = get_type_info(type, precision, scale);
-    return new ColumnExprPredicate(type_info, column_id, state, expr_ctx, &slot_desc);
+    return ColumnExprPredicate::make_column_expr_predicate(type_info, column_id, state, expr_ctx, &slot_desc);
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/storage/predicate_parser.h
+++ b/be/src/storage/predicate_parser.h
@@ -4,6 +4,8 @@
 
 #include <string>
 
+#include "common/statusor.h"
+
 namespace starrocks {
 
 class TabletSchema;
@@ -29,7 +31,8 @@ public:
     // return nullptr if parse failed.
     ColumnPredicate* parse_thrift_cond(const TCondition& condition) const;
 
-    ColumnPredicate* parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*, ExprContext* expr_ctx) const;
+    StatusOr<ColumnPredicate*> parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*,
+                                              ExprContext* expr_ctx) const;
 
 private:
     const TabletSchema& _schema;

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -7,6 +7,8 @@
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "column/type_traits.h"
+#include "common/compiler_util.h"
+#include "common/status.h"
 
 #define APPLY_FOR_NUMBERIC_TYPE(M) \
     M(TYPE_BOOLEAN)                \
@@ -220,11 +222,17 @@ Status ConvertDirectBufferVistor::do_visit(const BinaryColumn& column) {
     return Status::OK();
 }
 
-jobject JavaDataTypeConverter::convert_to_states(uint8_t** data, size_t offset, int num_rows) {
+#define RETURN_NULL_WITH_REPORT_ERROR(cond, ctx, msg) \
+    if (UNLIKELY(cond)) {                             \
+        ctx->set_error(msg);                          \
+    }
+
+jobject JavaDataTypeConverter::convert_to_states(FunctionContext* ctx, uint8_t** data, size_t offset, int num_rows) {
     auto& helper = JVMFunctionHelper::getInstance();
     auto* env = helper.getEnv();
     int inputs[num_rows];
     jintArray arr = env->NewIntArray(num_rows);
+    RETURN_NULL_WITH_REPORT_ERROR(arr == nullptr, ctx, "OOM may happened in Java Heap");
     for (int i = 0; i < num_rows; ++i) {
         inputs[i] = reinterpret_cast<JavaUDAFState*>(data[i] + offset)->handle;
     }
@@ -232,12 +240,13 @@ jobject JavaDataTypeConverter::convert_to_states(uint8_t** data, size_t offset, 
     return arr;
 }
 
-jobject JavaDataTypeConverter::convert_to_states_with_filter(uint8_t** data, size_t offset, const uint8_t* filter,
-                                                             int num_rows) {
+jobject JavaDataTypeConverter::convert_to_states_with_filter(FunctionContext* ctx, uint8_t** data, size_t offset,
+                                                             const uint8_t* filter, int num_rows) {
     auto& helper = JVMFunctionHelper::getInstance();
     auto* env = helper.getEnv();
     int inputs[num_rows];
     jintArray arr = env->NewIntArray(num_rows);
+    RETURN_NULL_WITH_REPORT_ERROR(arr == nullptr, ctx, "OOM may happened in Java Heap");
     for (int i = 0; i < num_rows; ++i) {
         if (filter[i] == 0) {
             inputs[i] = reinterpret_cast<JavaUDAFState*>(data[i] + offset)->handle;
@@ -249,9 +258,9 @@ jobject JavaDataTypeConverter::convert_to_states_with_filter(uint8_t** data, siz
     return arr;
 }
 
-void JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, std::vector<DirectByteBuffer>* buffers,
-                                                   const Column** columns, int num_cols, int num_rows,
-                                                   std::vector<jobject>* res) {
+Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, std::vector<DirectByteBuffer>* buffers,
+                                                     const Column** columns, int num_cols, int num_rows,
+                                                     std::vector<jobject>* res) {
     auto& helper = JVMFunctionHelper::getInstance();
     JNIEnv* env = helper.getEnv();
     ConvertDirectBufferVistor vistor(*buffers);
@@ -275,7 +284,14 @@ void JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, std::ve
                                             buffers_sz);
         }
 
+        if (arg == nullptr) {
+            std::string err_msg = "OOM may happened in Java Heap";
+            ctx->set_error(err_msg.c_str());
+            return Status::InternalError(err_msg);
+        }
+
         res->emplace_back(arg);
     }
+    return Status::OK();
 }
 } // namespace starrocks::vectorized

--- a/be/src/udf/java/java_data_converter.h
+++ b/be/src/udf/java/java_data_converter.h
@@ -51,13 +51,12 @@ private:
 
 class JavaDataTypeConverter {
 public:
-    static jobject convert_to_states(uint8_t** data, size_t offset, int num_rows);
-    static jobject convert_to_states_with_filter(uint8_t** data, size_t offset, const uint8_t* filter, int num_rows);
+    static jobject convert_to_states(FunctionContext* ctx, uint8_t** data, size_t offset, int num_rows);
+    static jobject convert_to_states_with_filter(FunctionContext* ctx, uint8_t** data, size_t offset,
+                                                 const uint8_t* filter, int num_rows);
 
-    static void convert_to_boxed_array(FunctionContext* ctx, std::vector<DirectByteBuffer>* buffers,
-                                       const Column** columns, int num_cols, int num_rows, std::vector<jobject>* res);
-    static void convert_to_native_array(FunctionContext* ctx, std::vector<DirectByteBuffer>* buffers,
-                                        const Column** columns, int num_cols, int num_rows, std::vector<jobject>* res);
+    static Status convert_to_boxed_array(FunctionContext* ctx, std::vector<DirectByteBuffer>* buffers,
+                                         const Column** columns, int num_cols, int num_rows, std::vector<jobject>* res);
 };
 
 template <bool handle_null>


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #13787
Fixes #13817

1. 
when we enable enable_column_expr_predicate.
we will call clone for ExprContext, which will call multi times for JavaFunctionCall::open.
so we should only call open when scope equals FragmentLocal
```
    #5 0x10743b82 in _M_invoke /usr/include/c++/11/bits/std_function.h:291
    #6 0x13067f7d in std::function<starrocks::Status ()>::operator()() const /usr/include/c++/11/bits/std_function.h:590
    #7 0x13064be5 in starrocks::call_function_in_pthread(starrocks::RuntimeState*, std::function<starrocks::Status ()> const&) /home/disk5/fha/Do
risDB/be/src/udf/java/utils.cpp:27
    #8 0x10741f81 in starrocks::vectorized::JavaFunctionCallExpr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks_udf::Function
Context::FunctionStateScope) /stdpain/starrocks/be/src/exprs/vectorized/java_function_call_expr.cpp:225
    #9 0xf3bed68 in starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks_udf::FunctionContext::FunctionStateScope) 
/stdpain/starrocks/be/src/exprs/expr.cpp:434
    #10 0xf3b2498 in starrocks::ExprContext::clone(starrocks::RuntimeState*, starrocks::ObjectPool*, starrocks::ExprContext**) /home/disk5/fha/Do
risDB/be/src/exprs/expr_context.cpp:129
    #11 0x12762f89 in starrocks::vectorized::ColumnExprPredicate::_add_expr_ctx(starrocks::ExprContext*) /stdpain/starrocks/be/src/storage/c
olumn_expr_predicate.cpp:69
    #12 0x127620eb in starrocks::vectorized::ColumnExprPredicate::make_column_expr_predicate(std::shared_ptr<starrocks::TypeInfo>, unsigned int, 
starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::SlotDescriptor const*) /stdpain/starrocks/be/src/storage/column_expr_predicate
.cpp:37
    #13 0x127ed051 in starrocks::vectorized::PredicateParser::parse_expr_ctx(starrocks::SlotDescriptor const&, starrocks::RuntimeState*, starrock
s::ExprContext*) const /stdpain/starrocks/be/src/storage/predicate_parser.cpp:84
    #14 0xcc28e7e in starrocks::vectorized::OlapScanConjunctsManager::get_column_predicates(starrocks::vectorized::PredicateParser*, std::vector<
std::unique_ptr<starrocks::vectorized::ColumnPredicate, std::default_delete<starrocks::vectorized::ColumnPredicate> >, std::allocator<std::unique
_ptr<starrocks::vectorized::ColumnPredicate, std::default_delete<starrocks::vectorized::ColumnPredicate> > > >*) /stdpain/starrocks/be/src/e
xec/vectorized/olap_scan_prepare.cpp:646
```

2. we should check return value from create_xxx_array.


## Problem Summary(Required) ：
https://github.com/StarRocks/StarRocksTest/pull/1467

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
