### PR TITLE
[Enhancement] check max_user_connections must less than qe_max_connection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -1449,7 +1449,7 @@ public class Auth implements Writable {
             throws DdlException {
         writeLock();
         try {
-            propertyMgr.updateUserProperty(user, properties);
+            propertyMgr.updateUserProperty(user, properties, isReplay);
             if (!isReplay) {
                 UserPropertyInfo propertyInfo = new UserPropertyInfo(user, properties);
                 GlobalStateMgr.getCurrentState().getEditLog().logUpdateUserProperty(propertyInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserProperty.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.AccessPrivilege;
 import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.Pair;
@@ -144,7 +145,7 @@ public class UserProperty implements Writable {
         whiteList.removeDomain(domain);
     }
 
-    public void update(List<Pair<String, String>> properties) throws DdlException {
+    public void update(List<Pair<String, String>> properties, boolean isReplay) throws DdlException {
         // copy
         long newMaxConn = maxConn;
 
@@ -168,6 +169,12 @@ public class UserProperty implements Writable {
 
                 if (newMaxConn <= 0 || newMaxConn > 10000) {
                     throw new DdlException(PROP_MAX_USER_CONNECTIONS + " is not valid, must between 1 and 10000");
+                }
+
+                if (!isReplay && newMaxConn > Config.qe_max_connection) {
+                    throw new DdlException(
+                            PROP_MAX_USER_CONNECTIONS + " is not valid, must less than qe_max_connection " +
+                                    Config.qe_max_connection);
                 }
             } else {
                 throw new DdlException("Unknown user property(" + key + ")");

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPropertyMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/UserPropertyMgr.java
@@ -91,13 +91,13 @@ public class UserPropertyMgr implements Writable {
         }
     }
 
-    public void updateUserProperty(String user, List<Pair<String, String>> properties) throws DdlException {
+    public void updateUserProperty(String user, List<Pair<String, String>> properties, boolean isReplay) throws DdlException {
         UserProperty property = propertyMap.get(user);
         if (property == null) {
             throw new DdlException("Unknown user(" + user + ")");
         }
 
-        property.update(properties);
+        property.update(properties, isReplay);
     }
 
     public long getMaxConn(String qualifiedUser) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/UserPropertyTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.util.List;
 
 public class UserPropertyTest {
-    private FakeGlobalStateMgr fakeGlobalStateMgr;
 
     @Test
     public void testUpdate() throws DdlException {
@@ -39,7 +38,7 @@ public class UserPropertyTest {
         properties.add(Pair.create("MAX_USER_CONNECTIONS", "100"));
 
         UserProperty userProperty = new UserProperty();
-        userProperty.update(properties);
+        userProperty.update(properties, false);
         Assert.assertEquals(100, userProperty.getMaxConn());
 
         // fetch property
@@ -52,5 +51,9 @@ public class UserPropertyTest {
                 Assert.assertEquals("100", value);
             }
         }
+
+        properties.get(0).second = "1025";
+        Assert.assertThrows("max_user_connections is not valid, must less than qe_max_connection 1024",
+                DdlException.class, () -> userProperty.update(properties, false));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] Enhancement

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In theory, `max_user_connections` greater than `qe_max_connection` is invalid, so we should check in SET phase.
In order to compatible with old config, skip check in replay phase.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
