### PR TITLE
[Refactor] Fix clang-format-11 compatible with clang-format-10.3

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,7 @@ PointerAlignment: Left
 ReflowComments: false
 SortUsingDeclarations: false
 SpacesBeforeTrailingComments: 1
+AllowShortFunctionsOnASingleLine: Inline
 ---
 Language: Java
 BasedOnStyle: Google

--- a/be/src/runtime/int128_arithmetics_x86_64.h
+++ b/be/src/runtime/int128_arithmetics_x86_64.h
@@ -50,6 +50,7 @@ inline constexpr bool is_bit64<uint64_t> = true;
 template <class T, class U, std::enable_if_t<is_bit64<T>, T> = 0, std::enable_if_t<is_bit64<U>, U> = 0>
 static inline int asm_add(T x, U y, T& res) {
     int8_t overflow = 0;
+    // clang-format off
     // x and y are two signed int64_t
     // SF|CF == 1 indicates overflow of abs(x) + abs(y);
     // SF^CF == 1 indicates overflow of a + y;
@@ -64,31 +65,33 @@ static inline int asm_add(T x, U y, T& res) {
                 "setc %b[overflow]\n\t"
                 "sets %%r8b\n\t"
                 "or %%r8b, %b[overflow]"
-                : [ res ] "+r"(res), [ overflow ] "+r"(overflow)
-                : [ x ] "r"(x), [ y ] "r"(y)
+                : [res] "+r"(res), [overflow] "+r"(overflow)
+                : [x] "r"(x), [y] "r"(y)
                 : "cc", "r8");
     } else {
         __asm__ __volatile__(
                 "mov %[x], %[res]\n\t"
                 "add %[y], %[res]"
-                : [ res ] "+r"(res), "=@cco"(overflow)
-                : [ x ] "r"(x), [ y ] "r"(y)
+                : [res] "+r"(res), "=@cco"(overflow)
+                : [x] "r"(x), [y] "r"(y)
                 : "cc");
     }
+    // clang-format on
     return overflow;
 }
 
 template <class T, class U, std::enable_if_t<is_bit64<T>, T> = 0, std::enable_if_t<is_bit64<U>, U> = 0>
 static int asm_mul(T x, U y, Int128Wrapper& res) {
     int8_t overflow;
+    // clang-format off
     if constexpr (std::is_unsigned<T>::value && std::is_unsigned<U>::value) {
         __asm__ __volatile__(
                 "mov %[x], %%rax\n\t"
                 "mul %[y]\n\t"
                 "mov %%rdx, %[high]\n\t"
                 "mov %%rax, %[low]"
-                : [ high ] "=r"(res.u.high), [ low ] "=r"(res.u.low), "=@cco"(overflow)
-                : [ x ] "r"(x), [ y ] "r"(y)
+                : [high] "=r"(res.u.high), [low] "=r"(res.u.low), "=@cco"(overflow)
+                : [x] "r"(x), [y] "r"(y)
                 : "cc", "rdx", "rax");
     } else {
         __asm__ __volatile__(
@@ -96,10 +99,11 @@ static int asm_mul(T x, U y, Int128Wrapper& res) {
                 "imul %[y]\n\t"
                 "mov %%rdx, %[high]\n\t"
                 "mov %%rax, %[low]"
-                : [ high ] "=r"(res.s.high), [ low ] "=r"(res.s.low), "=@cco"(overflow)
-                : [ x ] "r"(x), [ y ] "r"(y)
+                : [high] "=r"(res.s.high), [low] "=r"(res.s.low), "=@cco"(overflow)
+                : [x] "r"(x), [y] "r"(y)
                 : "cc", "rdx", "rax");
     }
+    // clang-format on
     return overflow;
 }
 
@@ -116,14 +120,16 @@ static int64_t asm_mul32(int32_t x, int32_t y) {
 #endif
         } s;
     } z;
+    // clang-format off
     __asm__ __volatile__(
             "mov %[x], %%eax\n\t"
             "imul %[y]\n\t"
             "mov %%edx, %[high]\n\t"
             "mov %%eax, %[low]"
-            : [ high ] "=r"(z.s.high), [ low ] "=r"(z.s.low)
-            : [ x ] "r"(x), [ y ] "r"(y)
+            : [high] "=r"(z.s.high), [low] "=r"(z.s.low)
+            : [x] "r"(x), [y] "r"(y)
             : "cc", "rax", "rdx");
+    // clang-format on
     return z.i64;
 }
 
@@ -132,14 +138,16 @@ static inline bool asm_add_overflow(int128_t x, int128_t y, int128_t* z) {
     auto& yw = reinterpret_cast<Int128Wrapper&>(y);
     auto& zw = reinterpret_cast<Int128Wrapper&>(*z);
     int8_t overflow = 0;
+    // clang-format off
     __asm__ __volatile__(
             "mov %[xl], %[zl]\n\t"
             "mov %[xh], %[zh]\n\t"
             "add %[yl], %[zl]\n\t"
             "adc %[yh], %[zh]\n\t"
-            : [ zl ] "+r"(zw.s.low), [ zh ] "+r"(zw.s.high), "=@cco"(overflow)
-            : [ xl ] "r"(xw.s.low), [ yl ] "r"(yw.s.low), [ xh ] "r"(xw.s.high), [ yh ] "r"(yw.s.high)
+            : [zl] "+r"(zw.s.low), [zh] "+r"(zw.s.high), "=@cco"(overflow)
+            : [xl] "r"(xw.s.low), [yl] "r"(yw.s.low), [xh] "r"(xw.s.high), [yh] "r"(yw.s.high)
             : "cc");
+    // clang-format on
     return overflow;
 }
 
@@ -148,14 +156,16 @@ static inline bool asm_sub_overflow(int128_t x, int128_t y, int128_t* z) {
     auto& yw = reinterpret_cast<Int128Wrapper&>(y);
     auto& zw = reinterpret_cast<Int128Wrapper&>(*z);
     int8_t overflow = 0;
+    // clang-format off
     __asm__ __volatile__(
             "mov %[xl], %[zl]\n\t"
             "mov %[xh], %[zh]\n\t"
             "sub %[yl], %[zl]\n\t"
             "sbb %[yh], %[zh]\n\t"
-            : [ zl ] "+r"(zw.s.low), [ zh ] "+r"(zw.s.high), "=@cco"(overflow)
-            : [ xl ] "r"(xw.s.low), [ yl ] "r"(yw.s.low), [ xh ] "r"(xw.s.high), [ yh ] "r"(yw.s.high)
+            : [zl] "+r"(zw.s.low), [zh] "+r"(zw.s.high), "=@cco"(overflow)
+            : [xl] "r"(xw.s.low), [yl] "r"(yw.s.low), [xh] "r"(xw.s.high), [yh] "r"(yw.s.high)
             : "cc");
+    // clang-format on
     return overflow;
 }
 
@@ -211,7 +221,7 @@ static inline int multi3(const int128_t& x, const int128_t& y, int128_t& res) {
 // udiv128by64to64 and udivmodti4 come from llvm-project/compiler-rt/lib/builtins/udivmodti4.c
 static inline uint64_t udiv128by64to64(uint64_t u1, uint64_t u0, uint64_t v, uint64_t* r) {
     uint64_t result;
-    __asm__("divq %[v]" : "=a"(result), "=d"(*r) : [ v ] "r"(v), "a"(u0), "d"(u1));
+    __asm__("divq %[v]" : "=a"(result), "=d"(*r) : [v] "r"(v), "a"(u0), "d"(u1));
     return result;
 }
 

--- a/be/src/runtime/int128_arithmetics_x86_64.h
+++ b/be/src/runtime/int128_arithmetics_x86_64.h
@@ -221,7 +221,9 @@ static inline int multi3(const int128_t& x, const int128_t& y, int128_t& res) {
 // udiv128by64to64 and udivmodti4 come from llvm-project/compiler-rt/lib/builtins/udivmodti4.c
 static inline uint64_t udiv128by64to64(uint64_t u1, uint64_t u0, uint64_t v, uint64_t* r) {
     uint64_t result;
+    // clang-format off
     __asm__("divq %[v]" : "=a"(result), "=d"(*r) : [v] "r"(v), "a"(u0), "d"(u1));
+    // clang-format on
     return result;
 }
 

--- a/be/src/util/phmap/btree.h
+++ b/be/src/util/phmap/btree.h
@@ -972,9 +972,9 @@ private:
     // padding.
     constexpr static size_type NodeTargetValues(const int begin, const int end) {
         return begin == end ? begin
-                            : SizeWithNValues((begin + end) / 2 + 1) > params_type::kTargetNodeSize
-                       ? (NodeTargetValues(begin, (begin + end) / 2)
-                          : NodeTargetValues((begin + end) / 2 + 1, end));
+                            : (SizeWithNValues((begin + end) / 2 + 1) > params_type::kTargetNodeSize
+                                       ? NodeTargetValues(begin, (begin + end) / 2)
+                                       : NodeTargetValues((begin + end) / 2 + 1, end));
     }
 
     enum {

--- a/be/src/util/phmap/btree.h
+++ b/be/src/util/phmap/btree.h
@@ -597,7 +597,7 @@ constexpr bool do_less_than_comparison(const Compare& compare, const K& x, const
 template <typename Int, phmap::enable_if_t<std::is_same<int, Int>::value, int> = 0>
 constexpr phmap::weak_ordering compare_result_as_ordering(const Int c) {
     return c < 0 ? phmap::weak_ordering::less
-                 : c == 0 ? phmap::weak_ordering::equivalent : phmap::weak_ordering::greater;
+                 : (c == 0 ? phmap::weak_ordering::equivalent : phmap::weak_ordering::greater);
 }
 constexpr phmap::weak_ordering compare_result_as_ordering(const phmap::weak_ordering c) {
     return c;
@@ -612,7 +612,7 @@ template <typename Compare, typename K, typename LK,
           phmap::enable_if_t<std::is_same<bool, phmap::invoke_result_t<Compare, const K&, const LK&>>::value, int> = 0>
 constexpr phmap::weak_ordering do_three_way_comparison(const Compare& compare, const K& x, const LK& y) {
     return compare(x, y) ? phmap::weak_ordering::less
-                         : compare(y, x) ? phmap::weak_ordering::greater : phmap::weak_ordering::equivalent;
+                         : (compare(y, x) ? phmap::weak_ordering::greater : phmap::weak_ordering::equivalent);
 }
 
 } // namespace compare_internal
@@ -973,8 +973,8 @@ private:
     constexpr static size_type NodeTargetValues(const int begin, const int end) {
         return begin == end ? begin
                             : SizeWithNValues((begin + end) / 2 + 1) > params_type::kTargetNodeSize
-                                      ? NodeTargetValues(begin, (begin + end) / 2)
-                                      : NodeTargetValues((begin + end) / 2 + 1, end);
+                       ? (NodeTargetValues(begin, (begin + end) / 2)
+                          : NodeTargetValues((begin + end) / 2 + 1, end));
     }
 
     enum {

--- a/be/src/util/phmap/phmap_base.h
+++ b/be/src/util/phmap/phmap_base.h
@@ -1836,16 +1836,16 @@ template <typename T>
 constexpr copy_traits get_ctor_copy_traits() {
     return std::is_copy_constructible<T>::value
                    ? copy_traits::copyable
-                   : std::is_move_constructible<T>::value ? copy_traits::movable : copy_traits::non_movable;
+                   : (std::is_move_constructible<T>::value ? copy_traits::movable : copy_traits::non_movable);
 }
 
 template <typename T>
 constexpr copy_traits get_assign_copy_traits() {
     return phmap::is_copy_assignable<T>::value && std::is_copy_constructible<T>::value
                    ? copy_traits::copyable
-                   : phmap::is_move_assignable<T>::value && std::is_move_constructible<T>::value
-                             ? copy_traits::movable
-                             : copy_traits::non_movable;
+                   : (phmap::is_move_assignable<T>::value && std::is_move_constructible<T>::value
+                              ? copy_traits::movable
+                              : copy_traits::non_movable);
 }
 
 // Whether T is constructible or convertible from optional<U>.
@@ -2332,7 +2332,7 @@ constexpr auto operator==(const optional<T>& x, const optional<U>& y)
         -> decltype(optional_internal::convertible_to_bool(*x == *y)) {
     return static_cast<bool>(x) != static_cast<bool>(y)
                    ? false
-                   : static_cast<bool>(x) == false ? true : static_cast<bool>(*x == *y);
+                   : (static_cast<bool>(x) == false ? true : static_cast<bool>(*x == *y));
 }
 
 // Returns: If bool(x) != bool(y), true; otherwise, if bool(x) == false, false;
@@ -2342,7 +2342,7 @@ constexpr auto operator!=(const optional<T>& x, const optional<U>& y)
         -> decltype(optional_internal::convertible_to_bool(*x != *y)) {
     return static_cast<bool>(x) != static_cast<bool>(y)
                    ? true
-                   : static_cast<bool>(x) == false ? false : static_cast<bool>(*x != *y);
+                   : (static_cast<bool>(x) == false ? false : static_cast<bool>(*x != *y));
 }
 // Returns: If !y, false; otherwise, if !x, true; otherwise *x < *y.
 template <typename T, typename U>


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

clang-format-11 has some different behavior from clang-format-10.3 which StarRocks CI/CD environment uses by default, so it is very inconvenient for developers who have only clang-format-11 in their development environment.

So in this CL, I refactored the code to make both clang-format-11 and clang-format-10.3 will generate the same result. The key changes include:
1. add `AllowShortFunctionsOnASingleLine: Inline` in clang-format configuration to tell clang-format what we need actually. Actually, this is not necessary for clang-format-11, but it is useful for higher version clang-format, so I kept this change.
2. Disable clang-format for ASM code. I don't know which clang-format option can control the behavior.
3. Add brackets to two continuous ternary operators, which make clang-format-11 generate the same result as the older one. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
