### PR TITLE
[BugFix] Fix wrong validation of 'exec_mem_limit'

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -329,7 +329,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // Limitations
     // mem limit can't smaller than bufferpool's default page size
-    public static final int MIN_EXEC_MEM_LIMIT = 2097152;
+    public static final long MIN_EXEC_MEM_LIMIT = 2097152;
     // query timeout cannot greater than one month
     public static final int MAX_QUERY_TIMEOUT = 259200;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetVar.java
@@ -148,10 +148,10 @@ public class SetVar implements ParseNode {
             }
 
             if (getVariable().equalsIgnoreCase(SessionVariable.EXEC_MEM_LIMIT)) {
-                checkRangeLongVariable(SessionVariable.EXEC_MEM_LIMIT, (long) SessionVariable.MIN_EXEC_MEM_LIMIT, null);
                 this.expression = new StringLiteral(
                         Long.toString(ParseUtil.analyzeDataVolumn(getResolvedExpression().getStringValue())));
                 this.resolvedExpression = (LiteralExpr) this.expression;
+                checkRangeLongVariable(SessionVariable.EXEC_MEM_LIMIT, SessionVariable.MIN_EXEC_MEM_LIMIT, null);
             }
         } catch (UserException e) {
             throw new SemanticException(e.getMessage());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`exec_mem_limit` may exist in expr mode, such as `20g`、`20M`, etc., so we should check it's value after parse.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
