### PR TITLE
[Refactor] make Expr::evaluate return status

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -678,7 +678,7 @@ StatusOr<size_t> ExecNode::eval_conjuncts_into_filter(const std::vector<ExprCont
         return 0;
     }
     for (auto* ctx : ctxs) {
-        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate_with_filter(chunk, filter->data()));
+        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate(chunk, filter->data()));
         size_t true_count = vectorized::ColumnHelper::count_true_with_notnull(column);
 
         if (true_count == column->size()) {

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -351,7 +351,8 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
                 conjuncts.push_back(it2->root());
             }
         }
-        _orc_reader->set_conjuncts_and_runtime_filters(conjuncts, _scanner_params.runtime_filter_collector);
+        RETURN_IF_ERROR(
+                _orc_reader->set_conjuncts_and_runtime_filters(conjuncts, _scanner_params.runtime_filter_collector));
     }
     _orc_reader->set_hive_column_names(_scanner_params.hive_column_names);
     _orc_reader->set_case_sensitive(_scanner_params.case_sensitive);

--- a/be/src/exec/vectorized/json_scanner.h
+++ b/be/src/exec/vectorized/json_scanner.h
@@ -39,7 +39,7 @@ private:
     static Status _parse_json_paths(const std::string& jsonpath, std::vector<std::vector<SimpleJsonPath>>* path_vecs);
     Status _create_src_chunk(ChunkPtr* chunk);
     Status _open_next_reader();
-    ChunkPtr _cast_chunk(const ChunkPtr& src_chunk);
+    StatusOr<ChunkPtr> _cast_chunk(const ChunkPtr& src_chunk);
 
     friend class JsonReader;
 

--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -97,7 +97,7 @@ StatusOr<ChunkPtr> ORCScanner::get_next() {
             break;
         }
     }
-    auto cast_chunk = _transfer_chunk(tmp_chunk);
+    ASSIGN_OR_RETURN(auto cast_chunk, _transfer_chunk(tmp_chunk));
     // use base class implementation. they are the SAME!!!
     return materialize(tmp_chunk, cast_chunk);
 }
@@ -124,9 +124,9 @@ StatusOr<ChunkPtr> ORCScanner::_next_orc_chunk() {
     return Status::InternalError("unreachable path");
 }
 
-ChunkPtr ORCScanner::_transfer_chunk(starrocks::vectorized::ChunkPtr& src) {
+StatusOr<ChunkPtr> ORCScanner::_transfer_chunk(starrocks::vectorized::ChunkPtr& src) {
     SCOPED_RAW_TIMER(&_counter->cast_chunk_ns);
-    ChunkPtr cast_chunk = _orc_reader->cast_chunk(&src);
+    ASSIGN_OR_RETURN(ChunkPtr cast_chunk, _orc_reader->cast_chunk(&src));
     auto range = _scan_range.ranges.at(_next_range - 1);
     if (range.__isset.num_of_columns_from_file) {
         for (int i = 0; i < range.columns_from_path.size(); ++i) {

--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -126,7 +126,7 @@ StatusOr<ChunkPtr> ORCScanner::_next_orc_chunk() {
 
 StatusOr<ChunkPtr> ORCScanner::_transfer_chunk(starrocks::vectorized::ChunkPtr& src) {
     SCOPED_RAW_TIMER(&_counter->cast_chunk_ns);
-    ASSIGN_OR_RETURN(ChunkPtr cast_chunk, _orc_reader->cast_chunk(&src));
+    ASSIGN_OR_RETURN(ChunkPtr cast_chunk, _orc_reader->cast_chunk_checked(&src));
     auto range = _scan_range.ranges.at(_next_range - 1);
     if (range.__isset.num_of_columns_from_file) {
         for (int i = 0; i < range.columns_from_path.size(); ++i) {

--- a/be/src/exec/vectorized/orc_scanner.h
+++ b/be/src/exec/vectorized/orc_scanner.h
@@ -35,7 +35,7 @@ private:
 
     ChunkPtr _create_src_chunk();
 
-    ChunkPtr _transfer_chunk(ChunkPtr& src);
+    StatusOr<ChunkPtr> _transfer_chunk(ChunkPtr& src);
 
     ChunkPtr _materialize(ChunkPtr& src, ChunkPtr& cast);
 

--- a/be/src/exec/vectorized/parquet_scanner.cpp
+++ b/be/src/exec/vectorized/parquet_scanner.cpp
@@ -120,7 +120,7 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
                 continue;
             }
 
-            auto column = _cast_exprs[i]->evaluate(nullptr, (*chunk).get());
+            ASSIGN_OR_RETURN(auto column, _cast_exprs[i]->evaluate_checked(nullptr, (*chunk).get()));
             column = ColumnHelper::unfold_const_column(slot_desc->type(), (*chunk)->num_rows(), column);
             cast_chunk->append_column(column, slot_desc->id());
         }

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -600,12 +600,8 @@ StatusOr<ColumnPtr> Expr::evaluate_const(ExprContext* context) {
     return _constant_column;
 }
 
-ColumnPtr Expr::evaluate(ExprContext* context, vectorized::Chunk* ptr) {
-    return nullptr;
-}
-
-ColumnPtr Expr::evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) {
-    return evaluate(context, ptr);
+StatusOr<ColumnPtr> Expr::evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) {
+    return evaluate_checked(context, ptr);
 }
 
 vectorized::ColumnRef* Expr::get_column_ref() {

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -190,8 +190,12 @@ public:
     // for vector query engine
     virtual StatusOr<ColumnPtr> evaluate_const(ExprContext* context);
 
-    virtual ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr);
-    virtual ColumnPtr evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter);
+    // TODO: check error in expression and return error status, instead of return null column
+    virtual StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) = 0;
+    virtual StatusOr<ColumnPtr> evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter);
+
+    // // TODO:(murphy) remove this unchecked evaluate
+    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) { return evaluate_checked(context, ptr).value(); }
 
     // get the first column ref in expr
     vectorized::ColumnRef* get_column_ref();

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -194,7 +194,7 @@ public:
     virtual StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) = 0;
     virtual StatusOr<ColumnPtr> evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter);
 
-    // // TODO:(murphy) remove this unchecked evaluate
+    // TODO:(murphy) remove this unchecked evaluate
     ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) { return evaluate_checked(context, ptr).value(); }
 
     // get the first column ref in expr

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -181,11 +181,7 @@ std::string ExprContext::get_error_msg() const {
     return "";
 }
 
-StatusOr<ColumnPtr> ExprContext::evaluate(vectorized::Chunk* chunk) {
-    return evaluate(_root, chunk, nullptr);
-}
-
-StatusOr<ColumnPtr> ExprContext::evaluate_with_filter(vectorized::Chunk* chunk, uint8_t* filter) {
+StatusOr<ColumnPtr> ExprContext::evaluate(vectorized::Chunk* chunk, uint8_t* filter) {
     return evaluate(_root, chunk, filter);
 }
 
@@ -202,9 +198,9 @@ StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, vectorized::Chunk* chunk, uin
     try {
         ColumnPtr ptr = nullptr;
         if (filter == nullptr) {
-            ptr = e->evaluate(this, chunk);
+            ASSIGN_OR_RETURN(ptr, e->evaluate_checked(this, chunk));
         } else {
-            ptr = e->evaluate_with_filter(this, chunk, filter);
+            ASSIGN_OR_RETURN(ptr, e->evaluate_with_filter(this, chunk, filter));
         }
         DCHECK(ptr != nullptr);
         if (chunk != nullptr && 0 != chunk->num_columns() && ptr->is_constant()) {

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -116,10 +116,7 @@ public:
 
     std::string get_error_msg() const;
 
-    // vector query engine
-    StatusOr<ColumnPtr> evaluate(vectorized::Chunk* chunk);
-    StatusOr<ColumnPtr> evaluate_with_filter(vectorized::Chunk* chunk, uint8_t* filter);
-
+    StatusOr<ColumnPtr> evaluate(vectorized::Chunk* chunk, uint8_t* filter = nullptr);
     StatusOr<ColumnPtr> evaluate(Expr* expr, vectorized::Chunk* chunk, uint8_t* filter = nullptr);
 
 private:

--- a/be/src/exprs/vectorized/arithmetic_expr.cpp
+++ b/be/src/exprs/vectorized/arithmetic_expr.cpp
@@ -52,21 +52,27 @@ public:
         if (lhs_pt_opt.has_value() && rhs_pt_opt.has_value()) {
             auto lhs_pt = lhs_pt_opt.value();
             auto rhs_pt = rhs_pt_opt.value();
-            ASSIGN_OR_RETURN(auto l, _children[0]->get_child(0)->evaluate_checked(context, chunk));
-            ASSIGN_OR_RETURN(auto r, _children[1]->get_child(0)->evaluate_checked(context, chunk));
             if (lhs_pt == TYPE_DECIMAL64 && rhs_pt == TYPE_DECIMAL64 && Type == TYPE_DECIMAL128) {
+                ASSIGN_OR_RETURN(auto l, _children[0]->get_child(0)->evaluate_checked(context, chunk));
+                ASSIGN_OR_RETURN(auto r, _children[1]->get_child(0)->evaluate_checked(context, chunk));
                 return VectorizedStrictDecimalBinaryFunction<MulOp64x64_128, false>::template evaluate<
                         TYPE_DECIMAL64, TYPE_DECIMAL64, Type>(l, r);
             }
             if (lhs_pt == TYPE_DECIMAL32 && rhs_pt == TYPE_DECIMAL64 && Type == TYPE_DECIMAL128) {
+                ASSIGN_OR_RETURN(auto l, _children[0]->get_child(0)->evaluate_checked(context, chunk));
+                ASSIGN_OR_RETURN(auto r, _children[1]->get_child(0)->evaluate_checked(context, chunk));
                 return VectorizedStrictDecimalBinaryFunction<MulOp32x64_128, false>::template evaluate<
                         TYPE_DECIMAL32, TYPE_DECIMAL64, Type>(l, r);
             }
             if (lhs_pt == TYPE_DECIMAL64 && rhs_pt == TYPE_DECIMAL32 && Type == TYPE_DECIMAL128) {
+                ASSIGN_OR_RETURN(auto l, _children[0]->get_child(0)->evaluate_checked(context, chunk));
+                ASSIGN_OR_RETURN(auto r, _children[1]->get_child(0)->evaluate_checked(context, chunk));
                 return VectorizedStrictDecimalBinaryFunction<MulOp32x64_128, false>::template evaluate<
                         TYPE_DECIMAL32, TYPE_DECIMAL64, Type>(r, l);
             }
             if (lhs_pt == TYPE_DECIMAL32 && rhs_pt == TYPE_DECIMAL32 && Type == TYPE_DECIMAL128) {
+                ASSIGN_OR_RETURN(auto l, _children[0]->get_child(0)->evaluate_checked(context, chunk));
+                ASSIGN_OR_RETURN(auto r, _children[1]->get_child(0)->evaluate_checked(context, chunk));
                 return VectorizedStrictDecimalBinaryFunction<MulOp32x32_128, false>::template evaluate<
                         TYPE_DECIMAL32, TYPE_DECIMAL32, Type>(r, l);
             }

--- a/be/src/exprs/vectorized/arithmetic_expr.cpp
+++ b/be/src/exprs/vectorized/arithmetic_expr.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 
 #include "common/object_pool.h"
+#include "common/statusor.h"
 #include "exprs/vectorized/arithmetic_operation.h"
 #include "exprs/vectorized/binary_function.h"
 #include "exprs/vectorized/decimal_binary_function.h"
@@ -45,51 +46,45 @@ class VectorizedArithmeticExpr final : public Expr {
 public:
     DEFINE_CLASS_CONSTRUCTOR(VectorizedArithmeticExpr);
 
-    std::optional<ColumnPtr> evaluate_decimal_fast_mul(ExprContext* context, vectorized::Chunk* chunk) {
+    StatusOr<ColumnPtr> evaluate_decimal_fast_mul(ExprContext* context, vectorized::Chunk* chunk) {
         auto lhs_pt_opt = eliminate_trivial_cast_for_decimal_mul(_children[0]);
         auto rhs_pt_opt = eliminate_trivial_cast_for_decimal_mul(_children[1]);
         if (lhs_pt_opt.has_value() && rhs_pt_opt.has_value()) {
             auto lhs_pt = lhs_pt_opt.value();
             auto rhs_pt = rhs_pt_opt.value();
+            ASSIGN_OR_RETURN(auto l, _children[0]->get_child(0)->evaluate_checked(context, chunk));
+            ASSIGN_OR_RETURN(auto r, _children[1]->get_child(0)->evaluate_checked(context, chunk));
             if (lhs_pt == TYPE_DECIMAL64 && rhs_pt == TYPE_DECIMAL64 && Type == TYPE_DECIMAL128) {
-                auto l = _children[0]->get_child(0)->evaluate(context, chunk);
-                auto r = _children[1]->get_child(0)->evaluate(context, chunk);
                 return VectorizedStrictDecimalBinaryFunction<MulOp64x64_128, false>::template evaluate<
                         TYPE_DECIMAL64, TYPE_DECIMAL64, Type>(l, r);
             }
             if (lhs_pt == TYPE_DECIMAL32 && rhs_pt == TYPE_DECIMAL64 && Type == TYPE_DECIMAL128) {
-                auto l = _children[0]->get_child(0)->evaluate(context, chunk);
-                auto r = _children[1]->get_child(0)->evaluate(context, chunk);
                 return VectorizedStrictDecimalBinaryFunction<MulOp32x64_128, false>::template evaluate<
                         TYPE_DECIMAL32, TYPE_DECIMAL64, Type>(l, r);
             }
             if (lhs_pt == TYPE_DECIMAL64 && rhs_pt == TYPE_DECIMAL32 && Type == TYPE_DECIMAL128) {
-                auto l = _children[0]->get_child(0)->evaluate(context, chunk);
-                auto r = _children[1]->get_child(0)->evaluate(context, chunk);
                 return VectorizedStrictDecimalBinaryFunction<MulOp32x64_128, false>::template evaluate<
                         TYPE_DECIMAL32, TYPE_DECIMAL64, Type>(r, l);
             }
             if (lhs_pt == TYPE_DECIMAL32 && rhs_pt == TYPE_DECIMAL32 && Type == TYPE_DECIMAL128) {
-                auto l = _children[0]->get_child(0)->evaluate(context, chunk);
-                auto r = _children[1]->get_child(0)->evaluate(context, chunk);
                 return VectorizedStrictDecimalBinaryFunction<MulOp32x32_128, false>::template evaluate<
                         TYPE_DECIMAL32, TYPE_DECIMAL32, Type>(r, l);
             }
         }
-        return {};
+        return nullptr;
     }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
 #if defined(__x86_64__) && defined(__GNUC__)
         if constexpr (is_mul_op<OP> && pt_is_decimal<Type>) {
-            auto opt_result = evaluate_decimal_fast_mul(context, ptr);
-            if (opt_result.has_value()) {
-                return opt_result.value();
+            ASSIGN_OR_RETURN(auto opt_result, evaluate_decimal_fast_mul(context, ptr));
+            if (opt_result != nullptr) {
+                return opt_result;
             }
         }
 #endif
-        auto l = _children[0]->evaluate(context, ptr);
-        auto r = _children[1]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
+        ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
         if constexpr (pt_is_decimal<Type>) {
             // Enable overflow checking in decimal arithmetic
             return VectorizedStrictDecimalBinaryFunction<OP, true>::template evaluate<Type>(l, r);
@@ -113,20 +108,20 @@ template <LogicalType Type, typename Op>
 class VectorizedDivArithmeticExpr final : public Expr {
 public:
     DEFINE_CLASS_CONSTRUCTOR(VectorizedDivArithmeticExpr);
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         if constexpr (is_intdiv_op<Op> && pt_is_bigint<Type>) {
             using CastFunction = VectorizedUnaryFunction<DecimalTo<true>>;
             switch (_children[0]->type().type) {
             case TYPE_DECIMAL32: {
-                auto column = evaluate_internal<TYPE_DECIMAL32>(context, ptr);
+                ASSIGN_OR_RETURN(auto column, evaluate_internal<TYPE_DECIMAL32>(context, ptr));
                 return CastFunction::evaluate<TYPE_DECIMAL32, LogicalType::TYPE_BIGINT>(column);
             }
             case TYPE_DECIMAL64: {
-                auto column = evaluate_internal<TYPE_DECIMAL64>(context, ptr);
+                ASSIGN_OR_RETURN(auto column, evaluate_internal<TYPE_DECIMAL64>(context, ptr));
                 return CastFunction::evaluate<TYPE_DECIMAL64, LogicalType::TYPE_BIGINT>(column);
             }
             case TYPE_DECIMAL128: {
-                auto column = evaluate_internal<TYPE_DECIMAL128>(context, ptr);
+                ASSIGN_OR_RETURN(auto column, evaluate_internal<TYPE_DECIMAL128>(context, ptr));
                 return CastFunction::evaluate<TYPE_DECIMAL128, LogicalType::TYPE_BIGINT>(column);
             }
             default:
@@ -139,9 +134,9 @@ public:
 
 private:
     template <LogicalType LType>
-    ColumnPtr evaluate_internal(ExprContext* context, vectorized::Chunk* ptr) {
-        auto l = _children[0]->evaluate(context, ptr);
-        auto r = _children[1]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_internal(ExprContext* context, vectorized::Chunk* ptr) {
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
+        ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
         if constexpr (pt_is_decimal<LType>) {
             using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<LType, DivOp, true>;
             return VectorizedDiv::template evaluate<LType>(l, r);
@@ -158,9 +153,9 @@ template <LogicalType Type>
 class VectorizedModArithmeticExpr final : public Expr {
 public:
     DEFINE_CLASS_CONSTRUCTOR(VectorizedModArithmeticExpr);
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        auto l = _children[0]->evaluate(context, ptr);
-        auto r = _children[1]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
+        ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
 
         if constexpr (pt_is_decimal<Type>) {
             using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<Type, ModOp, true>;
@@ -178,8 +173,8 @@ template <LogicalType Type>
 class VectorizedBitNotArithmeticExpr final : public Expr {
 public:
     DEFINE_CLASS_CONSTRUCTOR(VectorizedBitNotArithmeticExpr);
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        auto l = _children[0]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
         using ArithmeticBitNot = ArithmeticUnaryOperator<BitNotOp, Type>;
         return VectorizedStrictUnaryFunction<ArithmeticBitNot>::template evaluate<Type>(l);
     }

--- a/be/src/exprs/vectorized/array_element_expr.cpp
+++ b/be/src/exprs/vectorized/array_element_expr.cpp
@@ -17,11 +17,11 @@ public:
     ArrayElementExpr(const ArrayElementExpr&) = default;
     ArrayElementExpr(ArrayElementExpr&&) = default;
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* chunk) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* chunk) override {
         DCHECK_EQ(2, _children.size());
         DCHECK_EQ(_type, _children[0]->type().children[0]);
-        ColumnPtr arg0 = _children[0]->evaluate(context, chunk);
-        ColumnPtr arg1 = _children[1]->evaluate(context, chunk);
+        ASSIGN_OR_RETURN(ColumnPtr arg0, _children[0]->evaluate_checked(context, chunk));
+        ASSIGN_OR_RETURN(ColumnPtr arg1, _children[1]->evaluate_checked(context, chunk));
         size_t num_rows = std::max(arg0->size(), arg1->size());
         // No optimization for const column now.
         arg0 = ColumnHelper::unfold_const_column(_children[0]->type(), num_rows, arg0);

--- a/be/src/exprs/vectorized/array_expr.cpp
+++ b/be/src/exprs/vectorized/array_expr.cpp
@@ -17,7 +17,7 @@ public:
     ArrayExpr(const ArrayExpr&) = default;
     ArrayExpr(ArrayExpr&&) = default;
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* chunk) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* chunk) override {
         const TypeDescriptor& element_type = _type.children[0];
         const size_t num_elements = _children.size();
 
@@ -30,7 +30,7 @@ public:
         std::vector<ColumnPtr> element_columns(num_elements);
         std::vector<Column*> element_raw_ptrs(num_elements);
         for (size_t i = 0; i < num_elements; i++) {
-            auto col = _children[i]->evaluate(context, chunk);
+            ASSIGN_OR_RETURN(auto col, _children[i]->evaluate_checked(context, chunk));
             num_rows = std::max(num_rows, col->size());
             element_columns[i] = std::move(col);
         }

--- a/be/src/exprs/vectorized/array_map_expr.cpp
+++ b/be/src/exprs/vectorized/array_map_expr.cpp
@@ -34,7 +34,7 @@ inline bool offsets_equal(const UInt32Column::Ptr& array1, const UInt32Column::P
 // The input array column maybe nullable, so first remove the wrap of nullable property.
 // The result of lambda expressions do not change the offsets of the current array and the null map.
 // NOTE the return column must be of the return type.
-ColumnPtr ArrayMapExpr::evaluate(ExprContext* context, Chunk* chunk) {
+StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* chunk) {
     std::vector<ColumnPtr> inputs;
     NullColumnPtr input_null_map = nullptr;
     std::shared_ptr<ArrayColumn> input_array = nullptr;

--- a/be/src/exprs/vectorized/array_map_expr.h
+++ b/be/src/exprs/vectorized/array_map_expr.h
@@ -24,6 +24,6 @@ public:
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new ArrayMapExpr(*this)); }
 
-    ColumnPtr evaluate(ExprContext* context, Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 };
 } // namespace starrocks::vectorized

--- a/be/src/exprs/vectorized/binary_predicate.cpp
+++ b/be/src/exprs/vectorized/binary_predicate.cpp
@@ -54,8 +54,8 @@ public:
     Expr* clone(ObjectPool* pool) const override { return pool->add(new VectorizedBinaryPredicate(*this)); }
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
-        auto l = _children[0]->evaluate(context, ptr);
-        auto r = _children[1]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
+        ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
         return VectorizedStrictBinaryFunction<OP>::template evaluate<Type, TYPE_BOOLEAN>(l, r);
     }
 };

--- a/be/src/exprs/vectorized/binary_predicate.cpp
+++ b/be/src/exprs/vectorized/binary_predicate.cpp
@@ -53,7 +53,7 @@ public:
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new VectorizedBinaryPredicate(*this)); }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         auto l = _children[0]->evaluate(context, ptr);
         auto r = _children[1]->evaluate(context, ptr);
         return VectorizedStrictBinaryFunction<OP>::template evaluate<Type, TYPE_BOOLEAN>(l, r);
@@ -72,9 +72,9 @@ public:
     // if v1 null and v2 not null = false
     // if v1 not null and v2 null = false
     // if v1 not null and v2 not null = v1 OP v2
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        auto l = _children[0]->evaluate(context, ptr);
-        auto r = _children[1]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
+        ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
 
         ColumnViewer<Type> v1(l);
         ColumnViewer<Type> v2(r);

--- a/be/src/exprs/vectorized/case_expr.cpp
+++ b/be/src/exprs/vectorized/case_expr.cpp
@@ -84,15 +84,15 @@ private:
     //   If ALL `WHEN` is null, return NULL
     //   If `CASE` equals `WHEN`, return `THEN`
     //   If `CASE` can't match ANY `WHEN`, return NULL
-    ColumnPtr evaluate_case(ExprContext* context, vectorized::Chunk* chunk) {
+    StatusOr<ColumnPtr> evaluate_case(ExprContext* context, vectorized::Chunk* chunk) {
         ColumnPtr else_column = nullptr;
         if (!_has_else_expr) {
             else_column = ColumnHelper::create_const_null_column(chunk != nullptr ? chunk->num_rows() : 1);
         } else {
-            else_column = _children[_children.size() - 1]->evaluate(context, chunk);
+            ASSIGN_OR_RETURN(else_column, _children[_children.size() - 1]->evaluate_checked(context, chunk));
         }
 
-        ColumnPtr case_column = _children[0]->evaluate(context, chunk);
+        ASSIGN_OR_RETURN(ColumnPtr case_column, _children[0]->evaluate_checked(context, chunk));
         if (ColumnHelper::count_nulls(case_column) == case_column->size()) {
             return else_column->clone();
         }
@@ -112,14 +112,14 @@ private:
         then_viewers.reserve(loop_end);
 
         for (int i = 1; i < loop_end; i += 2) {
-            ColumnPtr when_column = _children[i]->evaluate(context, chunk);
+            ASSIGN_OR_RETURN(ColumnPtr when_column, _children[i]->evaluate_checked(context, chunk));
 
             // skip if all null
             if (ColumnHelper::count_nulls(when_column) == when_column->size()) {
                 continue;
             }
 
-            ColumnPtr then_column = _children[i + 1]->evaluate(context, chunk);
+            ASSIGN_OR_RETURN(ColumnPtr then_column, _children[i + 1]->evaluate_checked(context, chunk));
 
             when_viewers.emplace_back(when_column);
             then_viewers.emplace_back(then_column);
@@ -195,12 +195,12 @@ private:
     //  Special CASE-WHEN statment, and `WHEN` clause must be boolean.
     //  If all `WHEN` is null/false, return NULL
     //  If `WHEN` is not null and true, return `THEN`
-    ColumnPtr evaluate_no_case(ExprContext* context, vectorized::Chunk* chunk) {
+    StatusOr<ColumnPtr> evaluate_no_case(ExprContext* context, vectorized::Chunk* chunk) {
         ColumnPtr else_column = nullptr;
         if (!_has_else_expr) {
             else_column = ColumnHelper::create_const_null_column(chunk != nullptr ? chunk->num_rows() : 1);
         } else {
-            else_column = _children[_children.size() - 1]->evaluate(context, chunk);
+            ASSIGN_OR_RETURN(else_column, _children[_children.size() - 1]->evaluate_checked(context, chunk));
         }
 
         int loop_end = _children.size() - 1;
@@ -218,7 +218,7 @@ private:
         then_viewers.reserve(loop_end);
 
         for (int i = 0; i < loop_end; i += 2) {
-            ColumnPtr when_column = _children[i]->evaluate(context, chunk);
+            ASSIGN_OR_RETURN(ColumnPtr when_column, _children[i]->evaluate_checked(context, chunk));
 
             size_t trues_count = ColumnHelper::count_true_with_notnull(when_column);
 
@@ -227,7 +227,7 @@ private:
                 continue;
             }
 
-            ColumnPtr then_column = _children[i + 1]->evaluate(context, chunk);
+            ASSIGN_OR_RETURN(ColumnPtr then_column, _children[i + 1]->evaluate_checked(context, chunk));
 
             // direct return if first when is all true
             if (when_viewers.empty() && trues_count == when_column->size()) {

--- a/be/src/exprs/vectorized/case_expr.cpp
+++ b/be/src/exprs/vectorized/case_expr.cpp
@@ -55,7 +55,7 @@ public:
         return _children.size() % 2 == 1 ? Status::OK() : Status::InvalidArgument("case when children is error!");
     }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* chunk) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* chunk) override {
         if (_has_case_expr) {
             return evaluate_case(context, chunk);
         } else {

--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -1050,8 +1050,8 @@ template <LogicalType FromType, LogicalType ToType, bool AllowThrowException>
 class VectorizedCastExpr final : public Expr {
 public:
     DEFINE_CAST_CONSTRUCT(VectorizedCastExpr);
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        ColumnPtr column = _children[0]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
         if (ColumnHelper::count_nulls(column) == column->size() && column->size() != 0) {
             return ColumnHelper::create_const_null_column(column->size());
         }
@@ -1126,8 +1126,8 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(timeToDatetime, date, time) {
             return Status::OK();                                                                                \
         }                                                                                                       \
                                                                                                                 \
-        ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {                             \
-            ColumnPtr column = _children[0]->evaluate(context, ptr);                                            \
+        StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {           \
+            ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));                   \
             if (ColumnHelper::count_nulls(column) == column->size() && column->size() != 0) {                   \
                 return ColumnHelper::create_const_null_column(column->size());                                  \
             }                                                                                                   \
@@ -1240,8 +1240,8 @@ template <LogicalType Type, bool AllowThrowException>
 class VectorizedCastToStringExpr final : public Expr {
 public:
     DEFINE_CAST_CONSTRUCT(VectorizedCastToStringExpr);
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        ColumnPtr column = _children[0]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
         if (ColumnHelper::count_nulls(column) == column->size() && column->size() != 0) {
             return ColumnHelper::create_const_null_column(column->size());
         }

--- a/be/src/exprs/vectorized/cast_expr.h
+++ b/be/src/exprs/vectorized/cast_expr.h
@@ -40,7 +40,7 @@ public:
 
     ~VectorizedCastArrayExpr() override = default;
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new VectorizedCastArrayExpr(*this)); }
 
@@ -54,7 +54,7 @@ public:
     CastStringToArray(const TExprNode& node, Expr* cast_element, TypeDescriptor type_desc)
             : Expr(node), _cast_elements_expr(cast_element), _cast_to_type_desc(std::move(type_desc)) {}
     ~CastStringToArray() override = default;
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* input_chunk) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* input_chunk) override;
     Expr* clone(ObjectPool* pool) const override { return pool->add(new CastStringToArray(*this)); }
 
 private:
@@ -71,7 +71,7 @@ public:
             : Expr(node), _cast_elements_expr(cast_element), _cast_to_type_desc(std::move(type_desc)) {}
     ~CastJsonToArray() override = default;
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* input_chunk) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* input_chunk) override;
     Expr* clone(ObjectPool* pool) const override { return pool->add(new CastJsonToArray(*this)); }
 
 private:

--- a/be/src/exprs/vectorized/cast_expr_array.cpp
+++ b/be/src/exprs/vectorized/cast_expr_array.cpp
@@ -16,8 +16,8 @@ namespace starrocks::vectorized {
 
 static const char* kArrayDelimeter = ",";
 
-ColumnPtr VectorizedCastArrayExpr::evaluate(ExprContext* context, vectorized::Chunk* ptr) {
-    ColumnPtr column = _children[0]->evaluate(context, ptr);
+StatusOr<ColumnPtr> VectorizedCastArrayExpr::evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) {
+    ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
     if (ColumnHelper::count_nulls(column) == column->size()) {
         return ColumnHelper::create_const_null_column(column->size());
     }
@@ -48,7 +48,7 @@ ColumnPtr VectorizedCastArrayExpr::evaluate(ExprContext* context, vectorized::Ch
     auto column_ref = _cast_element_expr->get_child(0);
     SlotId slot_id = (reinterpret_cast<ColumnRef*>(column_ref))->slot_id();
     chunk->append_column(src_col, slot_id);
-    ColumnPtr dest_col = _cast_element_expr->evaluate(nullptr, chunk.get());
+    ASSIGN_OR_RETURN(ColumnPtr dest_col, _cast_element_expr->evaluate_checked(nullptr, chunk.get()));
     dest_col = ColumnHelper::unfold_const_column(column_ref->type(), chunk->num_rows(), dest_col);
 
     if (src_col->is_nullable() && !dest_col->is_nullable()) {
@@ -62,8 +62,8 @@ ColumnPtr VectorizedCastArrayExpr::evaluate(ExprContext* context, vectorized::Ch
 };
 
 // Cast string to array<ANY>
-ColumnPtr CastStringToArray::evaluate(ExprContext* context, vectorized::Chunk* input_chunk) {
-    ColumnPtr column = _children[0]->evaluate(context, input_chunk);
+StatusOr<ColumnPtr> CastStringToArray::evaluate_checked(ExprContext* context, vectorized::Chunk* input_chunk) {
+    ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, input_chunk));
     if (column->only_null()) {
         return ColumnHelper::create_const_null_column(column->size());
     }
@@ -117,7 +117,8 @@ ColumnPtr CastStringToArray::evaluate(ExprContext* context, vectorized::Chunk* i
         ChunkPtr chunk = std::make_shared<Chunk>();
         SlotId slot_id = down_cast<ColumnRef*>(_cast_elements_expr->get_child(0))->slot_id();
         chunk->append_column(elements, slot_id);
-        elements = ColumnHelper::cast_to_nullable_column(_cast_elements_expr->evaluate(context, chunk.get()));
+        ASSIGN_OR_RETURN(auto cast_res, _cast_elements_expr->evaluate_checked(context, chunk.get()));
+        elements = ColumnHelper::cast_to_nullable_column(cast_res);
     }
 
     // 3. Assemble elements into array column
@@ -143,8 +144,8 @@ Slice CastStringToArray::_unquote(Slice slice) {
     return slice;
 }
 
-ColumnPtr CastJsonToArray::evaluate(ExprContext* context, vectorized::Chunk* input_chunk) {
-    ColumnPtr column = _children[0]->evaluate(context, input_chunk);
+StatusOr<ColumnPtr> CastJsonToArray::evaluate_checked(ExprContext* context, vectorized::Chunk* input_chunk) {
+    ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, input_chunk));
     if (column->only_null()) {
         return ColumnHelper::create_const_null_column(column->size());
     }
@@ -185,7 +186,8 @@ ColumnPtr CastJsonToArray::evaluate(ExprContext* context, vectorized::Chunk* inp
         ChunkPtr chunk = std::make_shared<Chunk>();
         SlotId slot_id = down_cast<ColumnRef*>(_cast_elements_expr->get_child(0))->slot_id();
         chunk->append_column(elements, slot_id);
-        elements = ColumnHelper::cast_to_nullable_column(_cast_elements_expr->evaluate(context, chunk.get()));
+        ASSIGN_OR_RETURN(auto cast_res, _cast_elements_expr->evaluate_checked(context, chunk.get()));
+        elements = ColumnHelper::cast_to_nullable_column(cast_res);
     }
 
     // 3. Assemble elements into array column

--- a/be/src/exprs/vectorized/clone_expr.h
+++ b/be/src/exprs/vectorized/clone_expr.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "column/column.h"
 #include "exprs/expr.h"
 
 namespace starrocks::vectorized {
@@ -14,8 +15,8 @@ public:
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new CloneExpr(*this)); }
 
-    ColumnPtr evaluate(ExprContext* context, Chunk* ptr) override {
-        ColumnPtr column = get_child(0)->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
+        ASSIGN_OR_RETURN(ColumnPtr column, get_child(0)->evaluate_checked(context, ptr));
         return column->clone_shared();
     }
 };

--- a/be/src/exprs/vectorized/column_ref.cpp
+++ b/be/src/exprs/vectorized/column_ref.cpp
@@ -35,7 +35,7 @@ std::string ColumnRef::debug_string() const {
     return out.str();
 }
 
-ColumnPtr ColumnRef::evaluate(ExprContext* context, Chunk* ptr) {
+StatusOr<ColumnPtr> ColumnRef::evaluate_checked(ExprContext* context, Chunk* ptr) {
     return get_column(this, ptr);
 }
 

--- a/be/src/exprs/vectorized/column_ref.h
+++ b/be/src/exprs/vectorized/column_ref.h
@@ -37,7 +37,7 @@ public:
     std::string debug_string() const override;
 
     // vector query engine
-    vectorized::ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
 
     static vectorized::ColumnPtr& get_column(Expr* expr, vectorized::Chunk* chunk);
 

--- a/be/src/exprs/vectorized/compound_predicate.cpp
+++ b/be/src/exprs/vectorized/compound_predicate.cpp
@@ -31,8 +31,8 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(AndImpl, l_value, r_value) {
 class VectorizedAndCompoundPredicate final : public Predicate {
 public:
     DEFINE_COMPOUND_CONSTRUCT(VectorizedAndCompoundPredicate);
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        auto l = _children[0]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
         int l_falses = ColumnHelper::count_false_with_notnull(l);
 
         // left all false and not null
@@ -40,7 +40,7 @@ public:
             return l->clone();
         }
 
-        auto r = _children[1]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
 
         return VectorizedLogicPredicateBinaryFunction<AndNullImpl, AndImpl>::template evaluate<TYPE_BOOLEAN>(l, r);
     }
@@ -63,8 +63,8 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(OrImpl, l_value, r_value) {
 class VectorizedOrCompoundPredicate final : public Predicate {
 public:
     DEFINE_COMPOUND_CONSTRUCT(VectorizedOrCompoundPredicate);
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        auto l = _children[0]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
 
         int l_trues = ColumnHelper::count_true_with_notnull(l);
         // left all true and not null
@@ -72,7 +72,7 @@ public:
             return l->clone();
         }
 
-        auto r = _children[1]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
 
         return VectorizedLogicPredicateBinaryFunction<OrNullImpl, OrImpl>::template evaluate<TYPE_BOOLEAN>(l, r);
     }
@@ -85,8 +85,8 @@ DEFINE_UNARY_FN_WITH_IMPL(CompoundPredNot, l) {
 class VectorizedNotCompoundPredicate final : public Predicate {
 public:
     DEFINE_COMPOUND_CONSTRUCT(VectorizedNotCompoundPredicate);
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        auto l = _children[0]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
 
         return VectorizedStrictUnaryFunction<CompoundPredNot>::template evaluate<TYPE_BOOLEAN>(l);
     }

--- a/be/src/exprs/vectorized/condition_expr.cpp
+++ b/be/src/exprs/vectorized/condition_expr.cpp
@@ -108,12 +108,12 @@ public:
 
     // NullIF: return null if lhs == rhs else return lhs
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
-        auto lhs = _children[0]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(auto lhs, _children[0]->evaluate_checked(context, ptr));
         if (ColumnHelper::count_nulls(lhs) == lhs->size()) {
             return ColumnHelper::create_const_null_column(lhs->size());
         }
 
-        auto rhs = _children[1]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(auto rhs, _children[1]->evaluate_checked(context, ptr));
         if (ColumnHelper::count_nulls(rhs) == rhs->size()) {
             return lhs->clone();
         }
@@ -278,7 +278,7 @@ public:
         std::vector<ColumnViewer<Type>> viewers;
         std::vector<ColumnPtr> columns;
         for (int i = 0; i < _children.size(); ++i) {
-            auto value = _children[i]->evaluate(context, ptr);
+            ASSIGN_OR_RETURN(auto value, _children[i]->evaluate_checked(context, ptr));
             auto null_count = ColumnHelper::count_nulls(value);
 
             // 1.return if first column is all not null.

--- a/be/src/exprs/vectorized/dictmapping_expr.cpp
+++ b/be/src/exprs/vectorized/dictmapping_expr.cpp
@@ -5,14 +5,14 @@
 namespace starrocks::vectorized {
 DictMappingExpr::DictMappingExpr(const TExprNode& node) : Expr(node, false) {}
 
-ColumnPtr DictMappingExpr::evaluate(ExprContext* context, Chunk* ptr) {
+StatusOr<ColumnPtr> DictMappingExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
     // If dict_func_expr is nullptr, then it means that this DictExpr has not been rewritten.
     // But in some cases we need to evaluate the original expression directly
     // (usually column_expr_predicate).
     if (dict_func_expr == nullptr) {
-        return get_child(1)->evaluate(context, ptr);
+        return get_child(1)->evaluate_checked(context, ptr);
     } else {
-        return dict_func_expr->evaluate(context, ptr);
+        return dict_func_expr->evaluate_checked(context, ptr);
     }
 }
 

--- a/be/src/exprs/vectorized/dictmapping_expr.h
+++ b/be/src/exprs/vectorized/dictmapping_expr.h
@@ -27,7 +27,7 @@ public:
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new DictMappingExpr(*this)); }
 
-    ColumnPtr evaluate(ExprContext* context, Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
     template <class Rewrite>
     Status rewrite(Rewrite&& rewriter) {

--- a/be/src/exprs/vectorized/function_call_expr.cpp
+++ b/be/src/exprs/vectorized/function_call_expr.cpp
@@ -82,7 +82,7 @@ Status VectorizedFunctionCallExpr::open(starrocks::RuntimeState* state, starrock
     //  output in row engine, but we need set output scale in vectorized engine?
     if (_fn.name.function_name == "round" && _type.type == TYPE_DOUBLE) {
         if (_children[1]->is_constant()) {
-            ColumnPtr ptr = _children[1]->evaluate(context, nullptr);
+            ASSIGN_OR_RETURN(ColumnPtr ptr, _children[1]->evaluate_checked(context, nullptr));
             _output_scale =
                     std::static_pointer_cast<Int32Column>(std::static_pointer_cast<ConstColumn>(ptr)->data_column())
                             ->get_data()[0];
@@ -114,7 +114,8 @@ bool VectorizedFunctionCallExpr::is_constant() const {
     return Expr::is_constant();
 }
 
-ColumnPtr VectorizedFunctionCallExpr::evaluate(starrocks::ExprContext* context, vectorized::Chunk* ptr) {
+StatusOr<ColumnPtr> VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext* context,
+                                                                 vectorized::Chunk* ptr) {
     FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
 
     Columns args;

--- a/be/src/exprs/vectorized/function_call_expr.h
+++ b/be/src/exprs/vectorized/function_call_expr.h
@@ -25,7 +25,7 @@ protected:
 
     bool is_constant() const override;
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
 
 private:
     const FunctionDescriptor* _fn_desc;

--- a/be/src/exprs/vectorized/in_const_predicate.hpp
+++ b/be/src/exprs/vectorized/in_const_predicate.hpp
@@ -272,7 +272,7 @@ public:
     }
 
     StatusOr<ColumnPtr> evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) override {
-        ColumnPtr lhs = _children[0]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(ColumnPtr lhs, _children[0]->evaluate_checked(context, ptr));
         if (!_eq_null && ColumnHelper::count_nulls(lhs) == lhs->size()) {
             return ColumnHelper::create_const_null_column(lhs->size());
         }

--- a/be/src/exprs/vectorized/in_const_predicate.hpp
+++ b/be/src/exprs/vectorized/in_const_predicate.hpp
@@ -132,7 +132,7 @@ public:
                 return Status::InternalError("VectorizedInPredicate type not same");
             }
 
-            ColumnPtr value = _children[i]->evaluate(context, nullptr);
+            ASSIGN_OR_RETURN(ColumnPtr value, _children[i]->evaluate_checked(context, nullptr));
             if (!value->is_constant() && !value->only_null()) {
                 return Status::InternalError("VectorizedInPredicate value not const");
             }
@@ -271,7 +271,7 @@ public:
         return result;
     }
 
-    ColumnPtr evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) override {
+    StatusOr<ColumnPtr> evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) override {
         ColumnPtr lhs = _children[0]->evaluate(context, ptr);
         if (!_eq_null && ColumnHelper::count_nulls(lhs) == lhs->size()) {
             return ColumnHelper::create_const_null_column(lhs->size());
@@ -307,7 +307,7 @@ public:
         }
     }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         return evaluate_with_filter(context, ptr, nullptr);
     }
 

--- a/be/src/exprs/vectorized/info_func.cpp
+++ b/be/src/exprs/vectorized/info_func.cpp
@@ -26,7 +26,7 @@ VectorizedInfoFunc::VectorizedInfoFunc(const TExprNode& node) : Expr(node) {
     }
 }
 
-ColumnPtr VectorizedInfoFunc::evaluate(ExprContext* context, vectorized::Chunk* ptr) {
+StatusOr<ColumnPtr> VectorizedInfoFunc::evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) {
     ColumnPtr column = _value->clone_empty();
     column->append(*_value, 0, 1);
     if (ptr != nullptr) {

--- a/be/src/exprs/vectorized/info_func.h
+++ b/be/src/exprs/vectorized/info_func.h
@@ -15,7 +15,7 @@ public:
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new VectorizedInfoFunc(*this)); }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
 
     std::string debug_string() const override;
 

--- a/be/src/exprs/vectorized/is_null_predicate.cpp
+++ b/be/src/exprs/vectorized/is_null_predicate.cpp
@@ -22,8 +22,8 @@ class VectorizedIsNullPredicate final : public Predicate {
 public:
     DEFINE_CLASS_CONSTRUCT_FN(VectorizedIsNullPredicate);
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        ColumnPtr column = _children[0]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
 
         if (column->only_null()) {
             return ColumnHelper::create_const_column<TYPE_BOOLEAN>(true, column->size());
@@ -46,8 +46,8 @@ class VectorizedIsNotNullPredicate final : public Predicate {
 public:
     DEFINE_CLASS_CONSTRUCT_FN(VectorizedIsNotNullPredicate);
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
-        ColumnPtr column = _children[0]->evaluate(context, ptr);
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
+        ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
 
         if (column->only_null()) {
             return ColumnHelper::create_const_column<TYPE_BOOLEAN>(false, column->size());

--- a/be/src/exprs/vectorized/java_function_call_expr.cpp
+++ b/be/src/exprs/vectorized/java_function_call_expr.cpp
@@ -82,11 +82,11 @@ struct UDFFunctionCallHelper {
 
 JavaFunctionCallExpr::JavaFunctionCallExpr(const TExprNode& node) : Expr(node) {}
 
-ColumnPtr JavaFunctionCallExpr::evaluate(ExprContext* context, vectorized::Chunk* ptr) {
+StatusOr<ColumnPtr> JavaFunctionCallExpr::evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) {
     Columns columns(children().size());
 
     for (int i = 0; i < _children.size(); ++i) {
-        columns[i] = _children[i]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(columns[i], _children[i]->evaluate_checked(context, ptr));
     }
     ColumnPtr res;
     auto call_udf = [&]() {

--- a/be/src/exprs/vectorized/java_function_call_expr.h
+++ b/be/src/exprs/vectorized/java_function_call_expr.h
@@ -17,7 +17,7 @@ public:
     ~JavaFunctionCallExpr() override;
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new JavaFunctionCallExpr(*this)); }
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
     Status prepare(RuntimeState* state, ExprContext* context) override;
     Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
     void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;

--- a/be/src/exprs/vectorized/lambda_function.cpp
+++ b/be/src/exprs/vectorized/lambda_function.cpp
@@ -47,8 +47,8 @@ Status LambdaFunction::prepare(starrocks::RuntimeState* state, starrocks::ExprCo
     return Status::OK();
 }
 
-ColumnPtr LambdaFunction::evaluate(ExprContext* context, Chunk* ptr) {
-    return get_child(0)->evaluate(context, ptr);
+StatusOr<ColumnPtr> LambdaFunction::evaluate_checked(ExprContext* context, Chunk* ptr) {
+    return get_child(0)->evaluate_checked(context, ptr);
 }
 
 void LambdaFunction::close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {

--- a/be/src/exprs/vectorized/lambda_function.h
+++ b/be/src/exprs/vectorized/lambda_function.h
@@ -25,7 +25,7 @@ public:
 
     Status prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) override;
 
-    ColumnPtr evaluate(ExprContext* context, Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
     // the slot ids of lambda expression may be originally from the arguments of this lambda function
     // or its parent lambda functions, or captured columns, remove the first one.

--- a/be/src/exprs/vectorized/literal.cpp
+++ b/be/src/exprs/vectorized/literal.cpp
@@ -142,7 +142,7 @@ VectorizedLiteral::VectorizedLiteral(ColumnPtr&& value, const TypeDescriptor& ty
 
 #undef CASE_TYPE_COLUMN
 
-ColumnPtr VectorizedLiteral::evaluate(ExprContext* context, vectorized::Chunk* ptr) {
+StatusOr<ColumnPtr> VectorizedLiteral::evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) {
     ColumnPtr column = _value->clone_empty();
     column->append(*_value, 0, 1);
     if (ptr != nullptr) {

--- a/be/src/exprs/vectorized/literal.h
+++ b/be/src/exprs/vectorized/literal.h
@@ -16,7 +16,7 @@ public:
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new VectorizedLiteral(*this)); }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
 
     std::string debug_string() const override;
 

--- a/be/src/exprs/vectorized/map_element_expr.cpp
+++ b/be/src/exprs/vectorized/map_element_expr.cpp
@@ -17,12 +17,12 @@ public:
     MapElementExpr(const MapElementExpr&) = default;
     MapElementExpr(MapElementExpr&&) = default;
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* chunk) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* chunk) override {
         DCHECK_EQ(2, _children.size());
         // check the map's value type is the same as the expr's type
         DCHECK_EQ(_type, _children[0]->type().children[1]);
-        ColumnPtr arg0 = _children[0]->evaluate(context, chunk);
-        ColumnPtr arg1 = _children[1]->evaluate(context, chunk);
+        ASSIGN_OR_RETURN(ColumnPtr arg0, _children[0]->evaluate_checked(context, chunk));
+        ASSIGN_OR_RETURN(ColumnPtr arg1, _children[1]->evaluate_checked(context, chunk));
         size_t num_rows = std::max(arg0->size(), arg1->size());
         // No optimization for const column now.
         arg0 = ColumnHelper::unfold_const_column(_children[0]->type(), num_rows, arg0);

--- a/be/src/exprs/vectorized/placeholder_ref.cpp
+++ b/be/src/exprs/vectorized/placeholder_ref.cpp
@@ -7,7 +7,7 @@
 namespace starrocks::vectorized {
 PlaceHolderRef::PlaceHolderRef(const TExprNode& node) : Expr(node, true), _column_id(node.vslot_ref.slot_id) {}
 
-ColumnPtr PlaceHolderRef::evaluate(ExprContext* context, Chunk* ptr) {
+StatusOr<ColumnPtr> PlaceHolderRef::evaluate_checked(ExprContext* context, Chunk* ptr) {
     ColumnPtr& column = (ptr)->get_column_by_slot_id(_column_id);
     return column;
 }

--- a/be/src/exprs/vectorized/placeholder_ref.h
+++ b/be/src/exprs/vectorized/placeholder_ref.h
@@ -13,7 +13,7 @@ namespace starrocks::vectorized {
 class PlaceHolderRef final : public Expr {
 public:
     PlaceHolderRef(const TExprNode& node);
-    vectorized::ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override;
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override;
     bool is_constant() const override { return false; }
     Expr* clone(ObjectPool* pool) const override { return pool->add(new PlaceHolderRef(*this)); }
     int get_slot_ids(std::vector<SlotId>* slot_ids) const override {

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -631,7 +631,7 @@ public:
     bool is_constant() const override { return false; }
     bool is_bound(const std::vector<TupleId>& tuple_ids) const override { return false; }
 
-    ColumnPtr evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) override {
+    StatusOr<ColumnPtr> evaluate_with_filter(ExprContext* context, vectorized::Chunk* ptr, uint8_t* filter) override {
         const vectorized::ColumnPtr col = ptr->get_column_by_slot_id(_slot_id);
         size_t size = col->size();
 
@@ -683,7 +683,7 @@ public:
         return result;
     }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         return evaluate_with_filter(context, ptr, nullptr);
     }
 

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -56,7 +56,7 @@ public:
     // copy from cvb to chunk
     Status fill_chunk(ChunkPtr* chunk);
     // some type cast & conversion.
-    ChunkPtr cast_chunk(ChunkPtr* chunk);
+    StatusOr<ChunkPtr> cast_chunk(ChunkPtr* chunk);
     // call them before calling init.
     void set_read_chunk_size(uint64_t v) { _read_chunk_size = v; }
     void set_row_reader_filter(std::shared_ptr<orc::RowReaderFilter> filter);
@@ -124,7 +124,8 @@ public:
 private:
     ChunkPtr _create_chunk(const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);
     Status _fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);
-    ChunkPtr _cast_chunk(ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);
+    StatusOr<ChunkPtr> _cast_chunk(ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slots,
+                                   const std::vector<int>* indices);
 
     bool _ok_to_add_conjunct(const Expr* conjunct);
     void _add_conjunct(const Expr* conjunct, std::unique_ptr<orc::SearchArgumentBuilder>& builder);

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -56,13 +56,14 @@ public:
     // copy from cvb to chunk
     Status fill_chunk(ChunkPtr* chunk);
     // some type cast & conversion.
-    StatusOr<ChunkPtr> cast_chunk(ChunkPtr* chunk);
+    StatusOr<ChunkPtr> cast_chunk_checked(ChunkPtr* chunk);
+    ChunkPtr cast_chunk(ChunkPtr* chunk) { return cast_chunk_checked(chunk).value(); }
     // call them before calling init.
     void set_read_chunk_size(uint64_t v) { _read_chunk_size = v; }
     void set_row_reader_filter(std::shared_ptr<orc::RowReaderFilter> filter);
-    void set_conjuncts(const std::vector<Expr*>& conjuncts);
-    void set_conjuncts_and_runtime_filters(const std::vector<Expr*>& conjuncts,
-                                           const RuntimeFilterProbeCollector* rf_collector);
+    Status set_conjuncts(const std::vector<Expr*>& conjuncts);
+    Status set_conjuncts_and_runtime_filters(const std::vector<Expr*>& conjuncts,
+                                             const RuntimeFilterProbeCollector* rf_collector);
     Status set_timezone(const std::string& tz);
     size_t num_columns() const { return _src_slot_descriptors.size(); }
 
@@ -128,7 +129,7 @@ private:
                                    const std::vector<int>* indices);
 
     bool _ok_to_add_conjunct(const Expr* conjunct);
-    void _add_conjunct(const Expr* conjunct, std::unique_ptr<orc::SearchArgumentBuilder>& builder);
+    Status _add_conjunct(const Expr* conjunct, std::unique_ptr<orc::SearchArgumentBuilder>& builder);
     bool _add_runtime_filter(const SlotDescriptor* slot_desc, const JoinRuntimeFilter* rf,
                              std::unique_ptr<orc::SearchArgumentBuilder>& builder);
 

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -49,7 +49,7 @@ public:
         }
     }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         size_t num_rows = ptr->num_rows();
         if (_always_null) {
             return ColumnHelper::create_const_null_column(num_rows);

--- a/be/test/exprs/vectorized/array_element_expr_test.cpp
+++ b/be/test/exprs/vectorized/array_element_expr_test.cpp
@@ -16,7 +16,7 @@ class FakeConstExpr : public starrocks::Expr {
 public:
     explicit FakeConstExpr(const TExprNode& dummy) : Expr(dummy) {}
 
-    ColumnPtr evaluate(ExprContext*, Chunk*) override { return _column; }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { return _column; }
 
     Expr* clone(ObjectPool*) const override { return nullptr; }
 

--- a/be/test/exprs/vectorized/condition_expr_test.cpp
+++ b/be/test/exprs/vectorized/condition_expr_test.cpp
@@ -127,7 +127,7 @@ template <LogicalType Type>
 class RandomValueExpr final : public Expr {
 public:
     RandomValueExpr(const TExprNode& t, size_t size, std::default_random_engine& re) : Expr(t), _re(re) { _init(size); }
-    ColumnPtr evaluate(ExprContext*, Chunk*) override { return col; }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { return col; }
 
     typename RunTimeColumnType<Type>::Container get_data() { return col->get_data(); }
 
@@ -160,7 +160,7 @@ template <LogicalType Type>
 class MakeNullableExpr final : public Expr {
 public:
     MakeNullableExpr(const TExprNode& t, size_t size, Expr* inner) : Expr(t), _inner(inner) { init(); }
-    ColumnPtr evaluate(ExprContext*, Chunk*) override { return _col; }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { return _col; }
     Expr* clone(ObjectPool* pool) const override { return nullptr; }
 
     ColumnPtr get_col_ptr() { return _col; }

--- a/be/test/exprs/vectorized/decimal_cast_expr_test_helper.h
+++ b/be/test/exprs/vectorized/decimal_cast_expr_test_helper.h
@@ -22,7 +22,7 @@ template <LogicalType Type>
 class VerbatimVectorizedExpr : public MockCostExpr {
 public:
     VerbatimVectorizedExpr(const TExprNode& t, ColumnPtr column) : MockCostExpr(t), column(column) {}
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override { return column; }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override { return column; }
 
 private:
     ColumnPtr column;

--- a/be/test/exprs/vectorized/lambda_function_expr_test.cpp
+++ b/be/test/exprs/vectorized/lambda_function_expr_test.cpp
@@ -26,7 +26,7 @@ class FakeConstExpr : public starrocks::Expr {
 public:
     explicit FakeConstExpr(const TExprNode& dummy) : Expr(dummy) {}
 
-    ColumnPtr evaluate(ExprContext*, Chunk*) override { return _column; }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { return _column; }
 
     Expr* clone(ObjectPool*) const override { return nullptr; }
 

--- a/be/test/exprs/vectorized/map_element_expr_test.cpp
+++ b/be/test/exprs/vectorized/map_element_expr_test.cpp
@@ -15,7 +15,7 @@ class FakeConstExpr : public starrocks::Expr {
 public:
     explicit FakeConstExpr(const TExprNode& dummy) : Expr(dummy) {}
 
-    ColumnPtr evaluate(ExprContext*, Chunk*) override { return _column; }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { return _column; }
 
     Expr* clone(ObjectPool*) const override { return nullptr; }
 

--- a/be/test/exprs/vectorized/mock_vectorized_expr.h
+++ b/be/test/exprs/vectorized/mock_vectorized_expr.h
@@ -36,6 +36,7 @@ class MockCostExpr : public Expr {
 public:
     explicit MockCostExpr(const TExprNode& t) : Expr(t) {}
 
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { DCHECK(false); }
     Expr* clone(ObjectPool* pool) const override { return pool->add(new MockCostExpr(*this)); }
 
     int64_t cost_ns() { return _ns; }

--- a/be/test/exprs/vectorized/mock_vectorized_expr.h
+++ b/be/test/exprs/vectorized/mock_vectorized_expr.h
@@ -24,7 +24,7 @@ class MockExpr : public starrocks::Expr {
 public:
     explicit MockExpr(const TExprNode& dummy, ColumnPtr result) : Expr(dummy), _column(std::move(result)) {}
 
-    ColumnPtr evaluate(ExprContext*, Chunk*) override { return _column; }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { return _column; }
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new MockExpr(*this)); }
 
@@ -71,7 +71,7 @@ public:
     MockVectorizedExpr(const TExprNode& t, size_t size, RunTimeCppType<Type> value)
             : MockCostExpr(t), size(size), value(value) {}
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         start();
         ColumnPtr col;
         if constexpr (pt_is_decimal<Type>) {
@@ -99,7 +99,7 @@ public:
     MockMultiVectorizedExpr(const TExprNode& t, size_t size, RunTimeCppType<Type> num1, RunTimeCppType<Type> num2)
             : MockCostExpr(t), size(size), num1(num1), num2(num2) {}
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         start();
         auto col = RunTimeColumnType<Type>::create();
         col->reserve(size);
@@ -129,7 +129,7 @@ public:
     MockNullVectorizedExpr(const TExprNode& t, size_t size, RunTimeCppType<Type> value, bool only_null)
             : MockCostExpr(t), only_null(only_null), flag(0), size(size), value(value) {}
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         start();
         if (only_null) {
             return ColumnHelper::create_const_null_column(1);
@@ -175,7 +175,7 @@ public:
         col = ColumnHelper::create_const_column<Type>(value, 1);
     }
 
-    ColumnPtr evaluate(ExprContext* context, vectorized::Chunk* ptr) override {
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, vectorized::Chunk* ptr) override {
         start();
         stop();
         return col;

--- a/be/test/exprs/vectorized/subfield_expr_test.cpp
+++ b/be/test/exprs/vectorized/subfield_expr_test.cpp
@@ -14,7 +14,7 @@ class FakeConstExpr : public starrocks::Expr {
 public:
     explicit FakeConstExpr(const TExprNode& dummy) : Expr(dummy) {}
 
-    ColumnPtr evaluate(ExprContext*, Chunk*) override { return _column; }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { return _column; }
 
     Expr* clone(ObjectPool*) const override { return nullptr; }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

https://github.com/StarRocks/starrocks/issues/13199

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Refactor the `StatusOr<ColumnPtr> Expr::evaluate` to make it return error when evaluating failed. 


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
