### PR TITLE
[BugFix] Fix show create table incorrect output order of order by.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2081,15 +2081,6 @@ public class GlobalStateMgr {
                 }
             }
             sb.append(Joiner.on(", ").join(keysColumnNames)).append(")");
-            MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexId());
-            if (index.getSortKeyIdxes() != null) {
-                sb.append("\nORDER BY(");
-                List<String> sortKeysColumnNames = Lists.newArrayList();
-                for (Integer i : index.getSortKeyIdxes()) {
-                    sortKeysColumnNames.add("`" + table.getBaseSchema().get(i).getName() + "`");
-                }
-                sb.append(Joiner.on(", ").join(sortKeysColumnNames)).append(")");
-            }
             if (!Strings.isNullOrEmpty(table.getComment())) {
                 sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
             }
@@ -2108,6 +2099,17 @@ public class GlobalStateMgr {
             // distribution
             DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
             sb.append("\n").append(distributionInfo.toSql());
+
+            // order by
+            MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexId());
+            if (index.getSortKeyIdxes() != null) {
+                sb.append("\nORDER BY(");
+                List<String> sortKeysColumnNames = Lists.newArrayList();
+                for (Integer i : index.getSortKeyIdxes()) {
+                    sortKeysColumnNames.add("`" + table.getBaseSchema().get(i).getName() + "`");
+                }
+                sb.append(Joiner.on(", ").join(sortKeysColumnNames)).append(")");
+            }
 
             // properties
             sb.append("\nPROPERTIES (\n");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13808

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

### Steps to reproduce the behavior (Required)
```
CREATE TABLE `primary_table_without_null` (
                `k1` date NOT NULL,
                `k2` datetime NOT NULL,
                `k3` varchar(20) NOT NULL,
                `k4` varchar(20) NOT NULL,
                `k5` boolean NOT NULL,
                `v1` tinyint NULL,
                `v2` smallint NULL,
                `v3` int NULL,
                `v4` bigint NULL,
                `v5` largeint NULL,
                `v6` float NULL,
                `v7` double NULL,
                `v8` decimal(27,9) NULL
            ) ENGINE=OLAP
            PRIMARY KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
            COMMENT "OLAP"
            DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3
            ORDER BY(`v5`, `v3`, `v1`)
            PROPERTIES (
                "replication_num" = "3",
                "enable_persistent_index" = "true",
                "storage_format" = "v2"
            );

> show create table primary_table_without_null;
```

### Expected behavior (Required)

```
> show create table primary_table_without_null;

CREATE TABLE `primary_table_without_null` (
  `k1` date NOT NULL COMMENT "",
  `k2` datetime NOT NULL COMMENT "",
  `k3` varchar(65533) NOT NULL COMMENT "",
  `k4` varchar(65533) NOT NULL COMMENT "",
  `k5` boolean NOT NULL COMMENT "",
  `v1` tinyint(4) NOT NULL COMMENT "",
  `v2` smallint(6) NOT NULL COMMENT "",
  `v3` int(11) NOT NULL COMMENT "",
  `v4` bigint(20) NOT NULL COMMENT "",
  `v5` largeint(40) NOT NULL COMMENT "",
  `v6` float NOT NULL COMMENT "",
  `v7` double NOT NULL COMMENT "",
  `v8` decimal128(27, 9) NOT NULL COMMENT ""
) ENGINE=OLAP 
PRIMARY KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3 
ORDER BY(`v5`, `v3`, `v1`)
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "V2",
"enable_persistent_index" = "false",
"compression" = "LZ4"
);
```

### Real behavior (Required)
```
CREATE TABLE `primary_table_without_null` (
  `k1` date NOT NULL COMMENT "",
  `k2` datetime NOT NULL COMMENT "",
  `k3` varchar(65533) NOT NULL COMMENT "",
  `k4` varchar(65533) NOT NULL COMMENT "",
  `k5` boolean NOT NULL COMMENT "",
  `v1` tinyint(4) NOT NULL COMMENT "",
  `v2` smallint(6) NOT NULL COMMENT "",
  `v3` int(11) NOT NULL COMMENT "",
  `v4` bigint(20) NOT NULL COMMENT "",
  `v5` largeint(40) NOT NULL COMMENT "",
  `v6` float NOT NULL COMMENT "",
  `v7` double NOT NULL COMMENT "",
  `v8` decimal128(27, 9) NOT NULL COMMENT ""
) ENGINE=OLAP 
PRIMARY KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
ORDER BY(`v5`, `v3`, `v1`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "V2",
"enable_persistent_index" = "false",
"compression" = "LZ4"
);
```



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
