### PR TITLE
[Enhancement][Lake] Compaction scheduling based on compaction score (3/3)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CompactionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CompactionsProcDir.java
@@ -43,7 +43,7 @@ public class CompactionsProcDir implements ProcDirInterface {
         ConcurrentHashMap<PartitionIdentifier, CompactionContext> runningCompactions = compactionManager.getRunningCompactions();
         for (CompactionContext context : runningCompactions.values()) {
             List<String> row = new ArrayList<>();
-            row.add(String.valueOf(context.getPartitionName()));
+            row.add(String.valueOf(context.getFullPartitionName()));
             row.add(String.valueOf(context.getTxnId()));
             row.add(TimeUtils.longToTimeString(context.getStartTs()));
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CompactionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CompactionsProcDir.java
@@ -1,0 +1,54 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.common.proc;
+
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.lake.compaction.CompactionContext;
+import com.starrocks.lake.compaction.CompactionManager;
+import com.starrocks.lake.compaction.PartitionIdentifier;
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CompactionsProcDir implements ProcDirInterface {
+    private List<String> titles = new ArrayList<>();
+
+    public CompactionsProcDir() {
+        titles.add("Partition");
+        titles.add("TxnID");
+        titles.add("StartTime");
+    }
+
+    @Override
+    public boolean register(String name, ProcNodeInterface node) {
+        return false;
+    }
+
+    @Override
+    public ProcNodeInterface lookup(String name) throws AnalysisException {
+        return null;
+    }
+
+    @Override
+    public ProcResult fetchResult() throws AnalysisException {
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(titles);
+        CompactionManager compactionManager = GlobalStateMgr.getCurrentState().getCompactionManager();
+        if (compactionManager == null) {
+            return result;
+        }
+        ConcurrentHashMap<PartitionIdentifier, CompactionContext> runningCompactions = compactionManager.getRunningCompactions();
+        for (CompactionContext context : runningCompactions.values()) {
+            List<String> row = new ArrayList<>();
+            row.add(String.valueOf(context.getPartitionName()));
+            row.add(String.valueOf(context.getTxnId()));
+            row.add(TimeUtils.longToTimeString(context.getStartTs()));
+
+            result.addRow(row);
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CompactionsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CompactionsProcNode.java
@@ -13,23 +13,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class CompactionsProcDir implements ProcDirInterface {
+public class CompactionsProcNode implements ProcNodeInterface {
     private List<String> titles = new ArrayList<>();
 
-    public CompactionsProcDir() {
+    public CompactionsProcNode() {
         titles.add("Partition");
         titles.add("TxnID");
         titles.add("StartTime");
-    }
-
-    @Override
-    public boolean register(String name, ProcNodeInterface node) {
-        return false;
-    }
-
-    @Override
-    public ProcNodeInterface lookup(String name) throws AnalysisException {
-        return null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -50,8 +50,11 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.OrderByPair;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.lake.StorageCacheInfo;
+import com.starrocks.lake.compaction.PartitionIdentifier;
+import com.starrocks.lake.compaction.PartitionStatistics;
+import com.starrocks.lake.compaction.Quantiles;
 import com.starrocks.monitor.unit.ByteSizeValue;
+import com.starrocks.server.GlobalStateMgr;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -68,38 +71,53 @@ public class PartitionsProcDir implements ProcDirInterface {
     private final PartitionType partitionType;
     private ImmutableList<String> titleNames;
     private Database db;
-    private OlapTable olapTable;
+    private OlapTable table;
     private boolean isTempPartition = false;
 
-    public PartitionsProcDir(Database db, OlapTable olapTable, boolean isTempPartition) {
+    public PartitionsProcDir(Database db, OlapTable table, boolean isTempPartition) {
         this.db = db;
-        this.olapTable = olapTable;
+        this.table = table;
         this.isTempPartition = isTempPartition;
-        this.partitionType = olapTable.getPartitionInfo().getType();
+        this.partitionType = table.getPartitionInfo().getType();
         this.createTitleNames();
     }
 
     private void createTitleNames() {
-        ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
-                .add("PartitionId").add("PartitionName")
-                .add("VisibleVersion").add("VisibleVersionTime").add("VisibleVersionHash")
-                .add("State").add("PartitionKey");
-
-        if (this.partitionType == PartitionType.LIST) {
-            builder.add("List");
+        if (table.isLakeTable()) {
+            ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
+                    .add("PartitionId")
+                    .add("PartitionName")
+                    .add("CompactVersion")
+                    .add("VisibleVersion")
+                    .add("NextVersion")
+                    .add("State")
+                    .add("DataSize")
+                    .add("RowCount")
+                    .add("AvgCS") // Average compaction score
+                    .add("P50CS") // 50th percentile compaction score
+                    .add("MaxCS"); // Maximum compaction score
+            this.titleNames = builder.build();
         } else {
-            builder.add("Range");
+            ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
+                    .add("PartitionId")
+                    .add("PartitionName")
+                    .add("VisibleVersion")
+                    .add("VisibleVersionTime")
+                    .add("VisibleVersionHash")
+                    .add("State")
+                    .add("PartitionKey")
+                    .add(partitionType == PartitionType.LIST ? "List" : "Range")
+                    .add("DistributionKey")
+                    .add("Buckets")
+                    .add("ReplicationNum")
+                    .add("StorageMedium")
+                    .add("CooldownTime")
+                    .add("LastConsistencyCheckTime")
+                    .add("DataSize")
+                    .add("IsInMemory")
+                    .add("RowCount");
+            this.titleNames = builder.build();
         }
-
-        builder.add("DistributionKey").add("Buckets").add("ReplicationNum");
-        if (olapTable.isLakeTable()) {
-            builder.add("EnableStorageCache").add("StorageCacheTtlSecond").add("AllowAsyncWriteBack")
-                    .add("DataSize").add("RowCount");
-        } else {
-            builder.add("StorageMedium").add("CooldownTime").add("LastConsistencyCheckTime").add("DataSize")
-                    .add("IsInMemory").add("RowCount");
-        }
-        this.titleNames = builder.build();
     }
 
     public boolean filter(String columnName, Comparable element, Map<String, Expr> filterMap) throws AnalysisException {
@@ -222,16 +240,20 @@ public class PartitionsProcDir implements ProcDirInterface {
     }
 
     private List<List<Comparable>> getPartitionInfos() {
+        return table.isLakeTable() ? getLakePartitionInfos() : getOlapPartitionInfos();
+    }
+
+    private List<List<Comparable>> getOlapPartitionInfos() {
         Preconditions.checkNotNull(db);
-        Preconditions.checkNotNull(olapTable);
-        Preconditions.checkState(olapTable.isNativeTable());
+        Preconditions.checkNotNull(table);
+        Preconditions.checkState(table.isNativeTable());
 
         // get info
         List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
         db.readLock();
         try {
             List<Long> partitionIds;
-            PartitionInfo tblPartitionInfo = olapTable.getPartitionInfo();
+            PartitionInfo tblPartitionInfo = table.getPartitionInfo();
 
             // for range partitions, we return partitions in ascending range order by default.
             // this is to be consistent with the behaviour before 0.12
@@ -241,74 +263,123 @@ public class PartitionsProcDir implements ProcDirInterface {
                         .map(Map.Entry::getKey).collect(Collectors.toList());
             } else {
                 Collection<Partition> partitions =
-                        isTempPartition ? olapTable.getTempPartitions() : olapTable.getPartitions();
+                        isTempPartition ? table.getTempPartitions() : table.getPartitions();
                 partitionIds = partitions.stream().map(Partition::getId).collect(Collectors.toList());
             }
 
-            Joiner joiner = Joiner.on(", ");
             for (Long partitionId : partitionIds) {
-                Partition partition = olapTable.getPartition(partitionId);
-
-                List<Comparable> partitionInfo = new ArrayList<Comparable>();
-                String partitionName = partition.getName();
-                partitionInfo.add(partitionId);
-                partitionInfo.add(partitionName);
-                partitionInfo.add(partition.getVisibleVersion());
-                partitionInfo.add(TimeUtils.longToTimeString(partition.getVisibleVersionTime()));
-                partitionInfo.add(0);
-                partitionInfo.add(partition.getState());
-
-                // partition key , range or list value
-                partitionInfo.add(joiner.join(this.findPartitionColNames(tblPartitionInfo)));
-                partitionInfo.add(this.findRangeOrListValues(tblPartitionInfo, partitionId));
-
-                // distribution
-                DistributionInfo distributionInfo = partition.getDistributionInfo();
-                if (distributionInfo.getType() == DistributionInfoType.HASH) {
-                    HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
-                    List<Column> distributionColumns = hashDistributionInfo.getDistributionColumns();
-                    StringBuilder sb = new StringBuilder();
-                    for (int i = 0; i < distributionColumns.size(); i++) {
-                        if (i != 0) {
-                            sb.append(", ");
-                        }
-                        sb.append(distributionColumns.get(i).getName());
-                    }
-                    partitionInfo.add(sb.toString());
-                } else {
-                    partitionInfo.add("ALL KEY");
-                }
-
-                partitionInfo.add(distributionInfo.getBucketNum());
-
-                short replicationNum = tblPartitionInfo.getReplicationNum(partitionId);
-                partitionInfo.add(String.valueOf(replicationNum));
-
-                long dataSize = partition.getDataSize();
-                ByteSizeValue byteSizeValue = new ByteSizeValue(dataSize);
-                if (olapTable.isLakeTable()) {
-                    StorageCacheInfo storageCacheInfo = tblPartitionInfo.getStorageCacheInfo(partitionId);
-                    partitionInfo.add(storageCacheInfo.isEnableStorageCache());
-                    partitionInfo.add(storageCacheInfo.getStorageCacheTtlS());
-                    partitionInfo.add(storageCacheInfo.isAllowAsyncWriteBack());
-                    partitionInfo.add(byteSizeValue);
-                    partitionInfo.add(partition.getRowCount());
-                } else {
-                    DataProperty dataProperty = tblPartitionInfo.getDataProperty(partitionId);
-                    partitionInfo.add(dataProperty.getStorageMedium().name());
-                    partitionInfo.add(TimeUtils.longToTimeString(dataProperty.getCooldownTimeMs()));
-                    partitionInfo.add(TimeUtils.longToTimeString(partition.getLastCheckTime()));
-                    partitionInfo.add(byteSizeValue);
-                    partitionInfo.add(tblPartitionInfo.getIsInMemory(partitionId));
-                    partitionInfo.add(partition.getRowCount());
-                }
-
-                partitionInfos.add(partitionInfo);
+                partitionInfos.add(getOlapPartitionInfo(tblPartitionInfo, table.getPartition(partitionId)));
             }
         } finally {
             db.readUnlock();
         }
         return partitionInfos;
+    }
+
+    private List<List<Comparable>> getLakePartitionInfos() {
+        Preconditions.checkNotNull(db);
+        Preconditions.checkNotNull(table);
+        Preconditions.checkState(table.isNativeTable());
+
+        // get info
+        List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
+        db.readLock();
+        try {
+            List<Long> partitionIds;
+            PartitionInfo tblPartitionInfo = table.getPartitionInfo();
+
+            // for range partitions, we return partitions in ascending range order by default.
+            // this is to be consistent with the behaviour before 0.12
+            if (tblPartitionInfo.getType() == PartitionType.RANGE) {
+                RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) tblPartitionInfo;
+                partitionIds = rangePartitionInfo.getSortedRangeMap(isTempPartition).stream()
+                        .map(Map.Entry::getKey).collect(Collectors.toList());
+            } else {
+                Collection<Partition> partitions =
+                        isTempPartition ? table.getTempPartitions() : table.getPartitions();
+                partitionIds = partitions.stream().map(Partition::getId).collect(Collectors.toList());
+            }
+
+            for (Long partitionId : partitionIds) {
+                partitionInfos.add(getLakePartitionInfo(tblPartitionInfo, table.getPartition(partitionId)));
+            }
+        } finally {
+            db.readUnlock();
+        }
+        return partitionInfos;
+    }
+
+    private List<Comparable> getOlapPartitionInfo(PartitionInfo tblPartitionInfo, Partition partition) {
+        List<Comparable> partitionInfo = new ArrayList<Comparable>();
+        partitionInfo.add(partition.getId()); // PartitionId
+        partitionInfo.add(partition.getName()); // PartitionName
+        partitionInfo.add(partition.getVisibleVersion()); // VisibleVersion
+        partitionInfo.add(TimeUtils.longToTimeString(partition.getVisibleVersionTime())); // VisibleVersionTime
+        partitionInfo.add(0); // VisibleVersionHash
+        partitionInfo.add(partition.getState()); // State
+
+        // partition key , range or list value
+        Joiner joiner = Joiner.on(", ");
+        partitionInfo.add(joiner.join(this.findPartitionColNames(tblPartitionInfo)));
+        partitionInfo.add(this.findRangeOrListValues(tblPartitionInfo, partition.getId()));
+
+        // distribution
+        DistributionInfo distributionInfo = partition.getDistributionInfo();
+        if (distributionInfo.getType() == DistributionInfoType.HASH) {
+            HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
+            List<Column> distributionColumns = hashDistributionInfo.getDistributionColumns();
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < distributionColumns.size(); i++) {
+                if (i != 0) {
+                    sb.append(", ");
+                }
+                sb.append(distributionColumns.get(i).getName());
+            }
+            partitionInfo.add(sb.toString());
+        } else {
+            partitionInfo.add("ALL KEY");
+        }
+
+        partitionInfo.add(distributionInfo.getBucketNum());
+
+        short replicationNum = tblPartitionInfo.getReplicationNum(partition.getId());
+        partitionInfo.add(String.valueOf(replicationNum));
+
+        long dataSize = partition.getDataSize();
+        ByteSizeValue byteSizeValue = new ByteSizeValue(dataSize);
+        DataProperty dataProperty = tblPartitionInfo.getDataProperty(partition.getId());
+        partitionInfo.add(dataProperty.getStorageMedium().name());
+        partitionInfo.add(TimeUtils.longToTimeString(dataProperty.getCooldownTimeMs()));
+        partitionInfo.add(TimeUtils.longToTimeString(partition.getLastCheckTime()));
+        partitionInfo.add(byteSizeValue);
+        partitionInfo.add(tblPartitionInfo.getIsInMemory(partition.getId()));
+        partitionInfo.add(partition.getRowCount());
+
+        return partitionInfo;
+    }
+
+    private List<Comparable> getLakePartitionInfo(PartitionInfo tblPartitionInfo, Partition partition) {
+        PartitionIdentifier identifier = new PartitionIdentifier(db.getId(), table.getId(), partition.getId());
+        PartitionStatistics statistics = GlobalStateMgr.getCurrentState().getCompactionManager().getStatistics(identifier);
+        Quantiles compactionScore = statistics != null ? statistics.getCompactionScore() : null;
+
+        List<Comparable> partitionInfo = new ArrayList<Comparable>();
+
+        partitionInfo.add(partition.getId()); // PartitionId
+        partitionInfo.add(partition.getName()); // PartitionName
+        partitionInfo.add(statistics != null ? statistics.getCompactionVersion().getVersion() : 0); // CompactVersion
+        partitionInfo.add(partition.getVisibleVersion()); // VisibleVersion
+        partitionInfo.add(partition.getNextVersion()); // NextVersion
+        partitionInfo.add(partition.getState()); // State
+
+        long dataSize = partition.getDataSize();
+        ByteSizeValue byteSizeValue = new ByteSizeValue(dataSize);
+        partitionInfo.add(byteSizeValue); // DataSize
+        partitionInfo.add(partition.getRowCount()); // RowCount
+        partitionInfo.add(String.format("%.2f", compactionScore != null ? compactionScore.getAvg() : 0.0)); // AvgCS
+        partitionInfo.add(String.format("%.2f", compactionScore != null ? compactionScore.getP50() : 0.0)); // P50CS
+        partitionInfo.add(String.format("%.2f", compactionScore != null ? compactionScore.getMax() : 0.0)); // MaxCS
+        return partitionInfo;
     }
 
     private List<String> findPartitionColNames(PartitionInfo partitionInfo) {
@@ -320,7 +391,7 @@ public class PartitionsProcDir implements ProcDirInterface {
         } else {
             partitionColumns = new ArrayList<>();
         }
-        return partitionColumns.stream().map(column -> column.getName()).collect(Collectors.toList());
+        return partitionColumns.stream().map(Column::getName).collect(Collectors.toList());
     }
 
     private String findRangeOrListValues(PartitionInfo partitionInfo, long partitionId) {
@@ -348,19 +419,19 @@ public class PartitionsProcDir implements ProcDirInterface {
     public ProcNodeInterface lookup(String partitionIdStr) throws AnalysisException {
         long partitionId = -1L;
         try {
-            partitionId = Long.valueOf(partitionIdStr);
+            partitionId = Long.parseLong(partitionIdStr);
         } catch (NumberFormatException e) {
             throw new AnalysisException("Invalid partition id format: " + partitionIdStr);
         }
 
         db.readLock();
         try {
-            Partition partition = olapTable.getPartition(partitionId);
+            Partition partition = table.getPartition(partitionId);
             if (partition == null) {
                 throw new AnalysisException("Partition[" + partitionId + "] does not exist");
             }
 
-            return new IndicesProcDir(db, olapTable, partition);
+            return new IndicesProcDir(db, table, partition);
         } finally {
             db.readUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcDirInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcDirInterface.java
@@ -24,7 +24,7 @@ package com.starrocks.common.proc;
 import com.starrocks.common.AnalysisException;
 
 public interface ProcDirInterface extends ProcNodeInterface {
-    public boolean register(String name, ProcNodeInterface node);
+    boolean register(String name, ProcNodeInterface node);
 
-    public ProcNodeInterface lookup(String name) throws AnalysisException;
+    ProcNodeInterface lookup(String name) throws AnalysisException;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcService.java
@@ -56,7 +56,7 @@ public final class ProcService {
         root.register("stream_loads", new StreamLoadsProcDir());
         root.register("colocation_group", new ColocationGroupProcDir());
         root.register("catalog", GlobalStateMgr.getCurrentState().getCatalogMgr().getProcNode());
-        root.register("compactions", new CompactionsProcDir());
+        root.register("compactions", new CompactionsProcNode());
     }
 
     // Get the corresponding PROC Node by the specified path

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcService.java
@@ -56,6 +56,7 @@ public final class ProcService {
         root.register("stream_loads", new StreamLoadsProcDir());
         root.register("colocation_group", new ColocationGroupProcDir());
         root.register("catalog", GlobalStateMgr.getCurrentState().getCatalogMgr().getProcNode());
+        root.register("compactions", new CompactionsProcDir());
     }
 
     // Get the corresponding PROC Node by the specified path

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionContext.java
@@ -94,11 +94,11 @@ public class CompactionContext {
         return visibleTs;
     }
 
-    public void setPartitionName(String partitionName) {
+    public void setFullPartitionName(String partitionName) {
         this.partitionName = partitionName;
     }
 
-    public String getPartitionName() {
+    public String getFullPartitionName() {
         return partitionName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -246,7 +246,7 @@ public class CompactionScheduler extends Daemon {
         context.setTxnId(txnId);
         context.setBeToTablets(beToTablets);
         context.setStartTs(System.currentTimeMillis());
-        context.setPartitionName(String.format("%s.%s.%s", db.getFullName(), table.getName(), partition.getName()));
+        context.setFullPartitionName(String.format("%s.%s.%s", db.getFullName(), table.getName(), partition.getName()));
 
         long nextCompactionInterval = MIN_COMPACTION_INTERVAL_MS_ON_SUCCESS;
         try {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -160,17 +160,6 @@ message RestoreSnapshotsResponse {
     optional int32 pad = 1;
 }
 
-message CheckCompactionRequest {
-    // Calculate the compaction score for each of the following tablets
-    repeated int64 tablet_ids = 1;
-    optional int64 version = 2;
-}
-
-message CheckCompactionResponse {
-    // Mapping from tablet id to copmaction score
-    map<int64, double> compaction_scores = 1;
-}
-
 service LakeService {
     rpc publish_version(PublishVersionRequest) returns (PublishVersionResponse);
     rpc publish_log_version(PublishLogVersionRequest) returns (PublishLogVersionResponse);
@@ -184,6 +173,5 @@ service LakeService {
     rpc unlock_tablet_metadata(UnlockTabletMetadataRequest) returns (UnlockTabletMetadataResponse);
     rpc upload_snapshots(UploadSnapshotsRequest) returns (UploadSnapshotsResponse);
     rpc restore_snapshots(RestoreSnapshotsRequest) returns (RestoreSnapshotsResponse);
-    rpc check_compaction(CheckCompactionRequest) returns (CheckCompactionResponse);
 }
 


### PR DESCRIPTION
This PR mainly to give users better insight into the scheduling of compaction tasks:
- Show compaction scores in the output of command `show partitions from table`, if the table is a lake table
- Add `show proc /compactions` to show current running compaction tasks

Example output of `show partitions from table`:
```
+-------------+---------------+----------------+----------------+-------------+--------+--------------+-------------------------------------------------------------------------+-----------------+---------+----------+----------+----------+------------+-------+-------+-------+
| PartitionId | PartitionName | CompactVersion | VisibleVersion | NextVersion | State  | PartitionKey | Range                                                                   | DistributionKey | Buckets | DataSize | RowCount | CacheTTL | AsyncWrite | AvgCS | P50CS | MaxCS |
+-------------+---------------+----------------+----------------+-------------+--------+--------------+-------------------------------------------------------------------------+-----------------+---------+----------+----------+----------+------------+-------+-------+-------+
| 10444       | p1            | 1              | 101            | 102         | NORMAL | lo_orderdate | [types: [INT]; keys: [-2147483648]; ..types: [INT]; keys: [19930101]; ) | lo_orderkey     | 48      | 2.2GB    | 91248844 | 0        | false      | 0.00  | 0.00  | 0.00  |
| 10445       | p2            | 1              | 101            | 102         | NORMAL | lo_orderdate | [types: [INT]; keys: [19930101]; ..types: [INT]; keys: [19940101]; )    | lo_orderkey     | 48      | 2.2GB    | 91007488 | 0        | false      | 0.00  | 0.00  | 0.00  |
| 10446       | p3            | 1              | 101            | 102         | NORMAL | lo_orderdate | [types: [INT]; keys: [19940101]; ..types: [INT]; keys: [19950101]; )    | lo_orderkey     | 48      | 2.2GB    | 91044214 | 0        | false      | 0.00  | 0.00  | 0.00  |
| 10447       | p4            | 1              | 101            | 102         | NORMAL | lo_orderdate | [types: [INT]; keys: [19950101]; ..types: [INT]; keys: [19960101]; )    | lo_orderkey     | 48      | 2.2GB    | 91016436 | 0        | false      | 0.00  | 0.00  | 0.00  |
| 10448       | p5            | 1              | 101            | 102         | NORMAL | lo_orderdate | [types: [INT]; keys: [19960101]; ..types: [INT]; keys: [19970101]; )    | lo_orderkey     | 48      | 2.2GB    | 91301792 | 0        | false      | 0.00  | 0.00  | 0.00  |
| 10449       | p6            | 1              | 101            | 102         | NORMAL | lo_orderdate | [types: [INT]; keys: [19970101]; ..types: [INT]; keys: [19980101]; )    | lo_orderkey     | 48      | 2.2GB    | 91050840 | 0        | false      | 0.00  | 0.00  | 0.00  |
| 10450       | p7            | 1              | 101            | 102         | NORMAL | lo_orderdate | [types: [INT]; keys: [19980101]; ..types: [INT]; keys: [19990101]; )    | lo_orderkey     | 48      | 1.3GB    | 53368288 | 0        | false      | 0.00  | 0.00  | 0.00  |
+-------------+---------------+----------------+----------------+-------------+--------+--------------+-------------------------------------------------------------------------+-----------------+---------+----------+----------+----------+------------+-------+-------+-------+
```
`AvgCS` is the average compaction score of the partition;
`P50CS` is the 50th percentile compaction score of the partition;
`MaxCS` is the maximum compaction score of the partition.

Example output of `show proc /compactions`:
```
StarRocks > show proc "/compactions";
+----------------------------+-------+---------------------+
| Partition                  | TxnID | StartTime           |
+----------------------------+-------+---------------------+
| ssb_lake_100g.lineorder.p3 | 25    | 2022-11-25 11:56:05 |
+----------------------------+-------+---------------------+
```

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [ ] I have checked the version labels which the pr will be auto backported to target branch
