### PR TITLE
[BugFix] Fix nest CTE with join reorder bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1301,11 +1301,12 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         // The statistics of producer and children are equal theoretically, but statistics of children
         // plan maybe more accurate in actually
-        if (!produceStatisticsOp.isPresent() && context.getChildrenStatistics().isEmpty()) {
+        if (!produceStatisticsOp.isPresent() && (context.getChildrenStatistics().isEmpty() ||
+                context.getChildrenStatistics().stream().anyMatch(Objects::isNull))) {
             Preconditions.checkState(false, "Impossible cte statistics");
         }
 
-        if (!context.getChildrenStatistics().isEmpty()) {
+        if (!context.getChildrenStatistics().isEmpty() && context.getChildStatistics(0) != null) {
             //  use the statistics of children first
             context.setStatistics(context.getChildStatistics(0));
             Projection projection = node.getProjection();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -686,4 +686,20 @@ public class CTEPlanTest extends PlanTestBase {
                     "     TABLE: t0");
         }
     }
+
+
+    @Test
+    public void testNestCte() throws Exception {
+        String sql = "select /*+SET_VAR(cbo_max_reorder_node_use_exhaustive=1)*/* " +
+                "from t0 " +
+                "where (t0.v1 in (with c1 as (select 1 as v2) select x1.v2 from c1 x1 join c1 x2 join c1 x3)) is null;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  MultiCastDataSinks\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 15\n" +
+                "    RANDOM\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 21\n" +
+                "    RANDOM");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/13733

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For SQL
```
select /*+SET_VAR(cbo_max_reorder_node_use_exhaustive=1)*/* 
from t1 
where (t1.v1 in (
with c1 as (select 1 as v2) select x1.v2 from c1 x1 join c1 x2 join c1 x3)
) is null;
```

When compute FORCE CTE-2, use CTE-1  consume's statistics error, can't use children's statistics direct

```
LOGICAL
->  LogicalCTEAnchorOperator{cteId='2'}
    ->  LogicalCTEProduceOperator{cteId='2'}
        ->  LogicalCTEAnchorOperator{cteId='1'}
            ->  LogicalCTEProduceOperator{cteId='1'}
                ->  LOGICAL_VALUES
            ->  LOGICAL_JOIN {CROSS JOIN, onPredicate = null , Predicate = null}
                ->  LOGICAL_JOIN {CROSS JOIN, onPredicate = null , Predicate = null}
                    ->  LogicalCTEConsumeOperator{cteId='1', limit=-1, predicate=null}
                        ->  LOGICAL_VALUES
                    ->  LogicalCTEConsumeOperator{cteId='1', limit=-1, predicate=null}
                        ->  LOGICAL_VALUES
                ->  LogicalCTEConsumeOperator{cteId='1', limit=-1, predicate=null}
                    ->  LOGICAL_VALUES
    ->  LOGICAL_JOIN {INNER JOIN, onPredicate = CASE WHEN 16: countRows IS NULL OR 16: countRows = 0 THEN false WHEN 1: v1 IS NULL THEN null WHEN 14: cast IS NOT NULL THEN true WHEN 17: countNotNulls < 16: countRows THEN null ELSE false END IS NULL , Predicate = null}
        ->  LOGICAL_JOIN {LEFT OUTER JOIN, onPredicate = 1: v1 = 14: cast , Predicate = null}
            ->  LogicalOlapScanOperator {table=3036486, selectedPartitionId=[3061432], outputColumns=[1: v1, 2: v2, 3: v3], predicate=null, limit=-1}
            ->  LogicalAggregation {type=GLOBAL ,aggregations={} ,groupKeys=[14: cast]}
                ->  LogicalCTEConsumeOperator{cteId='2', limit=-1, predicate=null}
        ->  LogicalAggregation {type=GLOBAL ,aggregations={17: countNotNulls=count(15: cast), 16: countRows=count(1)} ,groupKeys=[]}
            ->  LogicalCTEConsumeOperator{cteId='2', limit=-1, predicate=null}

```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [ ] I have checked the version labels which the pr will be auto backported to target branch
