### PR TITLE
[Enhancement] Add --with-bench option in build.sh and don't compile bench dir by default

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -75,6 +75,8 @@ option(WITH_COMPRESS "Build binary with compresss debug section" ON)
 
 option(WITH_BLOCK_CACHE "Build binary with block cache feature" OFF)
 
+option(WITH_BENCH "Build binary with bench" OFF)
+
 option(USE_STAROS "Use StarOS to manager tablet info" OFF)
 
 # Check gcc
@@ -743,32 +745,28 @@ FUNCTION(ADD_BE_TEST TEST_NAME)
 ENDFUNCTION()
 
 # Add a benchmark to BE
-FUNCTION(ADD_BE_BENCH TEST_NAME)
-
-    if (WITH_BENCH STREQUAL "OFF")
-        return()
-    endif()
-
+FUNCTION(ADD_BE_BENCH BENCH_NAME)
+    message(STATUS "Add Be Bench")
     set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/")
     # This gets the directory where the test is from (e.g. 'exprs' or 'runtime')
     get_filename_component(DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-    get_filename_component(TEST_DIR_NAME ${TEST_NAME} PATH)
-    get_filename_component(TEST_FILE_NAME ${TEST_NAME} NAME)
-
+    get_filename_component(BENCH_DIR_NAME ${BENCH_NAME} PATH)
+    set(BENCH_OUTPUT_DIR_NAME "output")
+    get_filename_component(BENCH_FILE_NAME ${BENCH_NAME} NAME)
+    
     find_package(benchmark REQUIRED)
-    ADD_EXECUTABLE(${TEST_FILE_NAME} ${TEST_NAME}.cpp)
-    TARGET_LINK_LIBRARIES(${TEST_FILE_NAME} ${TEST_LINK_LIBS} benchmark benchmark_main)
+    ADD_EXECUTABLE(${BENCH_FILE_NAME} ${BENCH_NAME}.cpp)
+    TARGET_LINK_LIBRARIES(${BENCH_FILE_NAME} ${TEST_LINK_LIBS} benchmark benchmark_main)
 
-    SET_TARGET_PROPERTIES(${TEST_FILE_NAME} PROPERTIES COMPILE_FLAGS "-fno-access-control")
-    SET_TARGET_PROPERTIES(${TEST_FILE_NAME} PROPERTIES COMPILE_FLAGS ${CXX_FLAGS_RELEASE})
-    if (NOT "${TEST_DIR_NAME}" STREQUAL "")
-        SET_TARGET_PROPERTIES(${TEST_FILE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}/${TEST_DIR_NAME}")
+    SET_TARGET_PROPERTIES(${BENCH_FILE_NAME} PROPERTIES COMPILE_FLAGS "-fno-access-control")
+    SET_TARGET_PROPERTIES(${BENCH_FILE_NAME} PROPERTIES COMPILE_FLAGS ${CXX_FLAGS_RELEASE})
+    if (NOT "${BENCH_OUTPUT_DIR_NAME}" STREQUAL "")
+        SET_TARGET_PROPERTIES(${BENCH_FILE_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}/${BENCH_OUTPUT_DIR_NAME}")
     endif()
-    ADD_TEST(${TEST_FILE_NAME} "${BUILD_OUTPUT_ROOT_DIRECTORY}/${TEST_NAME}")
+    ADD_TEST(${BENCH_FILE_NAME} "${BUILD_OUTPUT_ROOT_DIRECTORY}/${BENCH_NAME}")
 ENDFUNCTION()
 
 add_subdirectory(${SRC_DIR}/agent)
-add_subdirectory(${SRC_DIR}/bench)
 add_subdirectory(${SRC_DIR}/common)
 add_subdirectory(${SRC_DIR}/connector)
 add_subdirectory(${SRC_DIR}/column)
@@ -791,6 +789,11 @@ add_subdirectory(${SRC_DIR}/udf)
 
 add_subdirectory(${SRC_DIR}/tools)
 add_subdirectory(${SRC_DIR}/util)
+
+if (WITH_BENCH STREQUAL "ON")
+     message(STATUS "Build binary with bench")
+    add_subdirectory(${SRC_DIR}/bench)
+endif()
 
 if (${WITH_BLOCK_CACHE} STREQUAL "ON")
     add_subdirectory(${SRC_DIR}/block_cache)

--- a/be/src/bench/README.md
+++ b/be/src/bench/README.md
@@ -1,0 +1,7 @@
+### Usage
+```
+sh build.sh --with-bench
+
+find . -name 'runtime_filter_bench'
+./build_Release/src/bench/output/runtime_filter_bench
+```

--- a/build.sh
+++ b/build.sh
@@ -61,6 +61,7 @@ Usage: $0 <options>
      --use-staros       build Backend with staros
      --with-gcov        build Backend with gcov, has an impact on performance
      --without-gcov     build Backend without gcov(default)
+     --with-bench       build Backend with bench(default without bench)
      -j                 build Backend parallel
 
   Eg.
@@ -83,6 +84,7 @@ OPTS=$(getopt \
   -l 'spark-dpp' \
   -l 'clean' \
   -l 'with-gcov' \
+  -l 'with-bench' \
   -l 'without-gcov' \
   -l 'use-staros' \
   -o 'j:' \
@@ -101,6 +103,7 @@ BUILD_SPARK_DPP=
 CLEAN=
 RUN_UT=
 WITH_GCOV=OFF
+WITH_BENCH=OFF
 USE_STAROS=OFF
 if [[ -z ${USE_AVX2} ]]; then
     USE_AVX2=ON
@@ -166,6 +169,7 @@ else
             --with-gcov) WITH_GCOV=ON; shift ;;
             --without-gcov) WITH_GCOV=OFF; shift ;;
             --use-staros) USE_STAROS=ON; shift ;;
+            --with-bench) WITH_BENCH=ON; shift ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
             -j) PARALLEL=$2; shift 2 ;;
@@ -193,6 +197,7 @@ echo "Get params:
     CLEAN               -- $CLEAN
     RUN_UT              -- $RUN_UT
     WITH_GCOV           -- $WITH_GCOV
+    WITH_BENCH          -- $WITH_BENCH
     USE_STAROS          -- $USE_STAROS
     USE_AVX2            -- $USE_AVX2
     PARALLEL            -- $PARALLEL
@@ -249,6 +254,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DUSE_JEMALLOC=$USE_JEMALLOC \
                     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                     -DUSE_STAROS=${USE_STAROS} \
+                    -DWITH_BENCH=${WITH_BENCH} \
                     -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
                     -Dprotobuf_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/protobuf \
                     -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
@@ -265,6 +271,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
                     -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE \
                     -DUSE_JEMALLOC=$USE_JEMALLOC \
+                    -DWITH_BENCH=${WITH_BENCH} \
                     -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
                     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  ..
     fi

--- a/run-ut.sh
+++ b/run-ut.sh
@@ -78,7 +78,6 @@ RUN=0
 TEST_FILTER=*
 HELP=0
 WITH_AWS=OFF
-WITH_BENCH=OFF
 USE_STAROS=OFF
 WITH_BLOCK_CACHE=OFF
 WITH_GCOV=OFF
@@ -89,7 +88,6 @@ while true; do
         --gtest_filter) TEST_FILTER=$2 ; shift 2;; 
         --help) HELP=1 ; shift ;; 
         --with-aws) WITH_AWS=ON; shift ;;
-        --with-bench) WITH_BENCH=ON; shift ;;
         --with-gcov) WITH_GCOV=ON; shift ;;
         --use-staros) USE_STAROS=ON; shift ;;
         -j) PARALLEL=$2; shift 2 ;;
@@ -136,7 +134,7 @@ if [ "${USE_STAROS}" == "ON"  ]; then
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DMAKE_TEST=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
               -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
-              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DWITH_BENCH=${WITH_BENCH}  \
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
               -DUSE_STAROS=${USE_STAROS} -DWITH_GCOV=${WITH_GCOV} \
               -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
               -Dprotobuf_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/protobuf \
@@ -153,7 +151,7 @@ else
               -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
               -DWITH_GCOV=${WITH_GCOV} \
               -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
-              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DWITH_BENCH=${WITH_BENCH} ../
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
 fi
 time ${BUILD_SYSTEM} -j${PARALLEL}
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

- Move --with-bench from run-ut.sh to build.sh because benchmark is tested in release mode(by default).
- don't compile bench dir by default to decrease compile time.
- optimize benchmark binary output dir.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [ ] I have checked the version labels which the pr will be auto backported to target branch
