### PR TITLE
[Refactor] Remove Field dependency in ZoneMap

### DIFF
--- a/be/src/storage/decimal_type_info.cpp
+++ b/be/src/storage/decimal_type_info.cpp
@@ -196,7 +196,7 @@ TypeInfoPtr get_decimal_type_info(LogicalType type, int precision, int scale) {
     }
 }
 
-std::string get_decimal_zone_map_string(TypeInfo* type_info, const char* value) {
+std::string get_decimal_zone_map_string(TypeInfo* type_info, const void* value) {
     switch (type_info->type()) {
     case TYPE_DECIMAL32: {
         auto* decimal_type_info = down_cast<DecimalTypeInfo<TYPE_DECIMAL32>*>(type_info);

--- a/be/src/storage/decimal_type_info.h
+++ b/be/src/storage/decimal_type_info.h
@@ -8,6 +8,6 @@ namespace starrocks {
 
 TypeInfoPtr get_decimal_type_info(LogicalType type, int precision, int scale);
 
-std::string get_decimal_zone_map_string(TypeInfo* type_info, const char* value);
+std::string get_decimal_zone_map_string(TypeInfo* type_info, const void* value);
 
 } // namespace starrocks

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -369,7 +369,7 @@ Status ScalarColumnWriter::init() {
     }
     if (_opts.need_zone_map) {
         _has_index_builder = true;
-        _zone_map_index_builder = ZoneMapIndexWriter::create(get_field());
+        _zone_map_index_builder = ZoneMapIndexWriter::create(get_field()->type_info().get(), get_field()->length());
     }
     if (_opts.need_bitmap_index) {
         _has_index_builder = true;

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -41,41 +41,28 @@ struct ZoneMapDatumBase {
     using CppType = typename TypeTraits<type>::CppType;
     CppType value;
 
-    void init([[maybe_unused]] TypeInfo* type_info, [[maybe_unused]] int length) {
-    }
-    void set_to_max(TypeInfo* type_info) {
-        type_info->set_to_max(&value);
-    }
-    void set_to_min(TypeInfo* type_info) {
-        type_info->set_to_min(&value);
-    }
-    std::string to_zone_map_string(TypeInfo* type_info) const {
-        return type_info->to_string(&value);
-    }
+    void init([[maybe_unused]] TypeInfo* type_info, [[maybe_unused]] int length) {}
+    void set_to_max(TypeInfo* type_info) { type_info->set_to_max(&value); }
+    void set_to_min(TypeInfo* type_info) { type_info->set_to_min(&value); }
+    std::string to_zone_map_string(TypeInfo* type_info) const { return type_info->to_string(&value); }
 };
 
 template <LogicalType type>
-struct ZoneMapDatum : public ZoneMapDatumBase<type> { };
+struct ZoneMapDatum : public ZoneMapDatumBase<type> {};
 
 template <>
 struct ZoneMapDatum<TYPE_DECIMAL32> : public ZoneMapDatumBase<TYPE_DECIMAL32> {
-    std::string to_zone_map_string(TypeInfo* type_info) const {
-        return get_decimal_zone_map_string(type_info, &value);
-    }
+    std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
 };
 
 template <>
 struct ZoneMapDatum<TYPE_DECIMAL64> : public ZoneMapDatumBase<TYPE_DECIMAL64> {
-    std::string to_zone_map_string(TypeInfo* type_info) const {
-        return get_decimal_zone_map_string(type_info, &value);
-    }
+    std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
 };
 
 template <>
 struct ZoneMapDatum<TYPE_DECIMAL128> : public ZoneMapDatumBase<TYPE_DECIMAL128> {
-    std::string to_zone_map_string(TypeInfo* type_info) const {
-        return get_decimal_zone_map_string(type_info, &value);
-    }
+    std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
 };
 
 template <>
@@ -90,9 +77,7 @@ struct ZoneMapDatum<TYPE_CHAR> : public ZoneMapDatumBase<TYPE_CHAR> {
         value.size = _length;
         memset(value.data, 0xFF, value.size);
     }
-    void set_to_min([[maybe_unused]] TypeInfo* type_info) {
-        value.size = 0;
-    }
+    void set_to_min([[maybe_unused]] TypeInfo* type_info) { value.size = 0; }
     int _length;
     std::string _value_container;
 };

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -25,7 +25,6 @@
 
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
-#include "runtime/mem_pool.h"
 #include "storage/chunk_helper.h"
 #include "storage/olap_define.h"
 #include "storage/olap_type_infra.h"
@@ -37,11 +36,76 @@
 
 namespace starrocks {
 
+template <LogicalType type>
+struct ZoneMapDatumBase {
+    using CppType = typename TypeTraits<type>::CppType;
+    CppType value;
+
+    void init([[maybe_unused]] TypeInfo* type_info, [[maybe_unused]] int length) {
+    }
+    void set_to_max(TypeInfo* type_info) {
+        type_info->set_to_max(&value);
+    }
+    void set_to_min(TypeInfo* type_info) {
+        type_info->set_to_min(&value);
+    }
+    std::string to_zone_map_string(TypeInfo* type_info) const {
+        return type_info->to_string(&value);
+    }
+};
+
+template <LogicalType type>
+struct ZoneMapDatum : public ZoneMapDatumBase<type> { };
+
+template <>
+struct ZoneMapDatum<TYPE_DECIMAL32> : public ZoneMapDatumBase<TYPE_DECIMAL32> {
+    std::string to_zone_map_string(TypeInfo* type_info) const {
+        return get_decimal_zone_map_string(type_info, &value);
+    }
+};
+
+template <>
+struct ZoneMapDatum<TYPE_DECIMAL64> : public ZoneMapDatumBase<TYPE_DECIMAL64> {
+    std::string to_zone_map_string(TypeInfo* type_info) const {
+        return get_decimal_zone_map_string(type_info, &value);
+    }
+};
+
+template <>
+struct ZoneMapDatum<TYPE_DECIMAL128> : public ZoneMapDatumBase<TYPE_DECIMAL128> {
+    std::string to_zone_map_string(TypeInfo* type_info) const {
+        return get_decimal_zone_map_string(type_info, &value);
+    }
+};
+
+template <>
+struct ZoneMapDatum<TYPE_CHAR> : public ZoneMapDatumBase<TYPE_CHAR> {
+    void init([[maybe_unused]] TypeInfo* type_info_, int length) {
+        _length = length;
+        raw::make_room(&_value_container, length);
+        value.data = (char*)_value_container.c_str();
+        value.size = length;
+    }
+    void set_to_max([[maybe_unused]] TypeInfo* type_info) {
+        value.size = _length;
+        memset(value.data, 0xFF, value.size);
+    }
+    void set_to_min([[maybe_unused]] TypeInfo* type_info) {
+        value.size = 0;
+    }
+    int _length;
+    std::string _value_container;
+};
+
+template <>
+struct ZoneMapDatum<TYPE_VARCHAR> : public ZoneMapDatum<TYPE_CHAR> {};
+
+template <LogicalType type>
 struct ZoneMap {
     // min value of zone
-    char* min_value = nullptr;
+    ZoneMapDatum<type> min_value;
     // max value of zone
-    char* max_value = nullptr;
+    ZoneMapDatum<type> max_value;
 
     // if both has_null and has_not_null is false, means no rows.
     // if has_null is true and has_not_null is false, means all rows is null.
@@ -52,9 +116,9 @@ struct ZoneMap {
     // has_not_null means whether zone has none-null value
     bool has_not_null = false;
 
-    void to_proto(ZoneMapPB* dst, Field* field) const {
-        dst->set_min(field->to_zone_map_string(min_value));
-        dst->set_max(field->to_zone_map_string(max_value));
+    void to_proto(ZoneMapPB* dst, TypeInfo* type_info) const {
+        dst->set_min(min_value.to_zone_map_string(type_info));
+        dst->set_max(max_value.to_zone_map_string(type_info));
         dst->set_has_null(has_null);
         dst->set_has_not_null(has_not_null);
     }
@@ -65,7 +129,9 @@ class ZoneMapIndexWriterImpl final : public ZoneMapIndexWriter {
     using CppType = typename TypeTraits<type>::CppType;
 
 public:
-    explicit ZoneMapIndexWriterImpl(starrocks::Field* field);
+    // TypeInfo is used for all kinds of types. It is used to change the content of datum of the max/min value.
+    // length is only used for CHAR/VARCHAR, and used to allocate enough memory for min/max value.
+    explicit ZoneMapIndexWriterImpl(TypeInfo* type_info, int length);
 
     void add_values(const void* values, size_t count) override;
 
@@ -79,21 +145,18 @@ public:
     uint64_t size() const override { return _estimated_size; }
 
 private:
-    void _reset_zone_map(ZoneMap* zone_map) {
+    void _reset_zone_map(ZoneMap<type>* zone_map) {
         // we should allocate max varchar length and set to max for min value
-        _field->set_to_max(zone_map->min_value);
-        _field->set_to_min(zone_map->max_value);
+        zone_map->min_value.set_to_max(_type_info);
+        zone_map->max_value.set_to_min(_type_info);
         zone_map->has_null = false;
         zone_map->has_not_null = false;
     }
 
-    Field* _field;
+    TypeInfo* _type_info;
     // memory will be managed by MemPool
-    ZoneMap _page_zone_map;
-    ZoneMap _segment_zone_map;
-    // TODO(zc): we should replace this memory pool later, we only allocate min/max
-    // for field. But MemPool allocate 4KB least, it will a waste for most cases.
-    MemPool _pool;
+    ZoneMap<type> _page_zone_map;
+    ZoneMap<type> _segment_zone_map;
 
     // serialized ZoneMapPB for each data page
     std::vector<std::string> _values;
@@ -101,12 +164,12 @@ private:
 };
 
 template <LogicalType type>
-ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(Field* field) : _field(field) {
-    _page_zone_map.min_value = _field->allocate_value(&_pool);
-    _page_zone_map.max_value = _field->allocate_value(&_pool);
+ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(TypeInfo* type_info, int length) : _type_info(type_info) {
+    _page_zone_map.min_value.init(_type_info, length);
+    _page_zone_map.max_value.init(_type_info, length);
     _reset_zone_map(&_page_zone_map);
-    _segment_zone_map.min_value = _field->allocate_value(&_pool);
-    _segment_zone_map.max_value = _field->allocate_value(&_pool);
+    _segment_zone_map.min_value.init(_type_info, length);
+    _segment_zone_map.max_value.init(_type_info, length);
     _reset_zone_map(&_segment_zone_map);
 }
 
@@ -116,11 +179,11 @@ void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) 
         _page_zone_map.has_not_null = true;
         const auto* vals = reinterpret_cast<const CppType*>(values);
         auto [pmin, pmax] = std::minmax_element(vals, vals + count);
-        if (unaligned_load<CppType>(pmin) < unaligned_load<CppType>(_page_zone_map.min_value)) {
-            _field->type_info()->direct_copy(_page_zone_map.min_value, pmin, nullptr);
+        if (unaligned_load<CppType>(pmin) < _page_zone_map.min_value.value) {
+            _type_info->direct_copy(&_page_zone_map.min_value.value, pmin, nullptr);
         }
-        if (unaligned_load<CppType>(pmax) > unaligned_load<CppType>(_page_zone_map.max_value)) {
-            _field->type_info()->direct_copy(_page_zone_map.max_value, pmax, nullptr);
+        if (unaligned_load<CppType>(pmax) > _page_zone_map.max_value.value) {
+            _type_info->direct_copy(&_page_zone_map.max_value.value, pmax, nullptr);
         }
     }
 }
@@ -128,11 +191,11 @@ void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) 
 template <LogicalType type>
 Status ZoneMapIndexWriterImpl<type>::flush() {
     // Update segment zone map.
-    if (_field->compare(_segment_zone_map.min_value, _page_zone_map.min_value) > 0) {
-        _field->type_info()->direct_copy(_segment_zone_map.min_value, _page_zone_map.min_value, nullptr);
+    if (_page_zone_map.min_value.value < _segment_zone_map.min_value.value) {
+        _type_info->direct_copy(&_segment_zone_map.min_value.value, &_page_zone_map.min_value.value, nullptr);
     }
-    if (_field->compare(_segment_zone_map.max_value, _page_zone_map.max_value) < 0) {
-        _field->type_info()->direct_copy(_segment_zone_map.max_value, _page_zone_map.max_value, nullptr);
+    if (_page_zone_map.min_value.value > _segment_zone_map.min_value.value) {
+        _type_info->direct_copy(&_segment_zone_map.max_value.value, &_page_zone_map.max_value.value, nullptr);
     }
     if (_page_zone_map.has_null) {
         _segment_zone_map.has_null = true;
@@ -142,7 +205,7 @@ Status ZoneMapIndexWriterImpl<type>::flush() {
     }
 
     ZoneMapPB zone_map_pb;
-    _page_zone_map.to_proto(&zone_map_pb, _field);
+    _page_zone_map.to_proto(&zone_map_pb, _type_info);
     _reset_zone_map(&_page_zone_map);
 
     std::string serialized_zone_map;
@@ -157,13 +220,13 @@ Status ZoneMapIndexWriterImpl<type>::flush() {
 
 struct ZoneMapIndexWriterBuilder {
     template <LogicalType ftype>
-    std::unique_ptr<ZoneMapIndexWriter> operator()(Field* field) {
-        return std::make_unique<ZoneMapIndexWriterImpl<ftype>>(field);
+    std::unique_ptr<ZoneMapIndexWriter> operator()(TypeInfo* type_info, int length) {
+        return std::make_unique<ZoneMapIndexWriterImpl<ftype>>(type_info, length);
     }
 };
 
-std::unique_ptr<ZoneMapIndexWriter> ZoneMapIndexWriter::create(starrocks::Field* field) {
-    return field_type_dispatch_zonemap_index(field->type(), ZoneMapIndexWriterBuilder(), field);
+std::unique_ptr<ZoneMapIndexWriter> ZoneMapIndexWriter::create(TypeInfo* type_info, int length) {
+    return field_type_dispatch_zonemap_index(type_info->type(), ZoneMapIndexWriterBuilder(), type_info, length);
 }
 
 template <LogicalType type>
@@ -171,7 +234,7 @@ Status ZoneMapIndexWriterImpl<type>::finish(WritableFile* wfile, ColumnIndexMeta
     index_meta->set_type(ZONE_MAP_INDEX);
     ZoneMapIndexPB* meta = index_meta->mutable_zone_map_index();
     // store segment zone map
-    _segment_zone_map.to_proto(meta->mutable_segment_zone_map(), _field);
+    _segment_zone_map.to_proto(meta->mutable_segment_zone_map(), _type_info);
 
     // write out zone map for each data pages
     TypeInfoPtr typeinfo = get_type_info(TYPE_OBJECT);

--- a/be/src/storage/rowset/zone_map_index.h
+++ b/be/src/storage/rowset/zone_map_index.h
@@ -46,7 +46,7 @@ class WritableFile;
 // reader can prune an entire segment without reading pages.
 class ZoneMapIndexWriter {
 public:
-    static std::unique_ptr<ZoneMapIndexWriter> create(starrocks::Field* field);
+    static std::unique_ptr<ZoneMapIndexWriter> create(TypeInfo* type_info, int length);
 
     virtual ~ZoneMapIndexWriter() = default;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -370,16 +370,16 @@ TARGET_LINK_LIBRARIES(bytes_test
 
 # =================================================
 # test cases must be compiled as a standalone binary
-ADD_BE_TEST(http/metrics_action_test)
-ADD_BE_TEST(http/http_client_test)
-
-ADD_BE_TEST(runtime/routine_load_task_executor_test)
-ADD_BE_TEST(runtime/small_file_mgr_test)
-ADD_BE_TEST(runtime/user_function_cache_test)
-
-ADD_BE_TEST(storage/delete_handler_test)
-ADD_BE_TEST(storage/options_test)
-ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
+# ADD_BE_TEST(http/metrics_action_test)
+# ADD_BE_TEST(http/http_client_test)
+# 
+# ADD_BE_TEST(runtime/routine_load_task_executor_test)
+# ADD_BE_TEST(runtime/small_file_mgr_test)
+# ADD_BE_TEST(runtime/user_function_cache_test)
+# 
+# ADD_BE_TEST(storage/delete_handler_test)
+# ADD_BE_TEST(storage/options_test)
+# ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
 
 # you can simply add test case as single binary without adding `main`
 # ADD_BE_TEST(exec/vectorized/sorting_test)

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -370,16 +370,16 @@ TARGET_LINK_LIBRARIES(bytes_test
 
 # =================================================
 # test cases must be compiled as a standalone binary
-# ADD_BE_TEST(http/metrics_action_test)
-# ADD_BE_TEST(http/http_client_test)
-# 
-# ADD_BE_TEST(runtime/routine_load_task_executor_test)
-# ADD_BE_TEST(runtime/small_file_mgr_test)
-# ADD_BE_TEST(runtime/user_function_cache_test)
-# 
-# ADD_BE_TEST(storage/delete_handler_test)
-# ADD_BE_TEST(storage/options_test)
-# ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
+ADD_BE_TEST(http/metrics_action_test)
+ADD_BE_TEST(http/http_client_test)
+
+ADD_BE_TEST(runtime/routine_load_task_executor_test)
+ADD_BE_TEST(runtime/small_file_mgr_test)
+ADD_BE_TEST(runtime/user_function_cache_test)
+
+ADD_BE_TEST(storage/delete_handler_test)
+ADD_BE_TEST(storage/options_test)
+ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
 
 # you can simply add test case as single binary without adding `main`
 # ADD_BE_TEST(exec/vectorized/sorting_test)

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -49,7 +49,8 @@ protected:
     void test_string(const std::string& testname, Field* field) {
         std::string filename = kTestDir + "/" + testname;
 
-        std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(field->type_info().get(), field->length());
+        std::unique_ptr<ZoneMapIndexWriter> builder =
+                ZoneMapIndexWriter::create(field->type_info().get(), field->length());
         std::vector<std::string> values1 = {"aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff"};
         for (auto& value : values1) {
             Slice slice(value);

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -49,7 +49,7 @@ protected:
     void test_string(const std::string& testname, Field* field) {
         std::string filename = kTestDir + "/" + testname;
 
-        std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(field);
+        std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(field->type_info().get(), field->length());
         std::vector<std::string> values1 = {"aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff"};
         for (auto& value : values1) {
             Slice slice(value);
@@ -107,7 +107,7 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
     TabletColumn int_column = create_int_key(0);
     Field* field = FieldFactory::create(int_column);
 
-    std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(field);
+    std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(field->type_info().get(), field->length());
     std::vector<int> values1 = {1, 10, 11, 20, 21, 22};
     for (auto value : values1) {
         builder->add_values((const uint8_t*)&value, 1);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Before this CL, ZoneMap uses Field to visit a raw memory as the min/max state for the writing page and segment.

To speed-up writing performance for CHAR/VARCHAR, Zone Map writer will allocate memory before, then when the value is updated, it can copy the content directly without allocating new memory content. So it needs the CHAR/VARCHAR length information in its corresponding Field.

Because we want to delete the Field struct, I introduce the ZoneMapDatum struct in this PR. This struct is a self-contained struct, for string type, it will allocate memory through std::string member rather than MemPool.

Because ZoneMap is already a template class, so I implement ZoneMapDatum in a template way too, which will have better performance and easier accessing way.

The original unit test pass and I tested it with some designed case, both works fine.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [ ] I have checked the version labels which the pr will be auto backported to target branch
