### PR TITLE
[Enhancement] change print throw exception's stack trace into LOG(WARNING) rather  than stderr

### DIFF
--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -68,9 +68,11 @@ void __wrap___cxa_throw(void* thrown_exception, void* info, void (*dest)(void*))
                              ToStringFromUnixMicros(GetCurrentTimeMicros()).c_str(), print_id(query_id).c_str(),
                              print_id(fragment_instance_id).c_str(), get_exception_name(info).c_str(),
                              get_stack_trace().c_str());
-
+#ifdef BE_TEST
+    // tests check message from stderr.
     std::cerr << stack << std::endl;
-    LOG(ERROR) << stack;
+#endif
+    LOG(WARNING) << stack;
 
     // call the real __cxa_throw():
     __real___cxa_throw(thrown_exception, info, dest);


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

print throw exception's stack trace into LOG(WARNING) rather than stderr
but be test should print the trace to stderr to capture exception info in tests.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [ ] I have checked the version labels which the pr will be auto backported to target branch
