### PR TITLE
[BugFix] unify array_filter(array, null) to return empty array when the null value from const value or column

### DIFF
--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -1070,6 +1070,15 @@ private:
         size_t chunk_size = columns[0]->size();
         ColumnPtr src_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[0]);
         ColumnPtr dest_column = src_column->clone_empty();
+        if (columns[1]->only_null()) { // return empty array for non-null array by design.
+            auto data_column = dest_column;
+            if (dest_column->is_nullable()) {
+                data_column = down_cast<const NullableColumn*>(dest_column.get())->data_column();
+            }
+            data_column->append_default(chunk_size);
+            return dest_column;
+        }
+
         ColumnPtr bool_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[1]);
 
         if (src_column->is_nullable()) {

--- a/be/src/exprs/vectorized/array_functions.tpp
+++ b/be/src/exprs/vectorized/array_functions.tpp
@@ -1053,6 +1053,8 @@ private:
     }
 };
 
+// by design array_filter(array, bool_array), if bool_array is null, return an empty array. We do not return null, as
+// it will change the null property of return results which keeps the same with the first argument array.
 class ArrayFilter {
 public:
     static ColumnPtr process([[maybe_unused]] FunctionContext* ctx, const Columns& columns) {
@@ -1061,7 +1063,9 @@ public:
 
 private:
     static ColumnPtr _array_filter(const Columns& columns) {
-        RETURN_IF_COLUMNS_ONLY_NULL(columns);
+        if (columns[0]->only_null()) {
+            return columns[0];
+        }
 
         size_t chunk_size = columns[0]->size();
         ColumnPtr src_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[0]);

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -4649,7 +4649,7 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
     ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
 
-    ASSERT_TRUE(dest_column->only_null());
+    ASSERT_TRUE(dest_column->get(0).get_array().empty());
 }
 
 TEST_F(ArrayFunctionsTest, array_distinct_only_null) {

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -4650,7 +4650,6 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
     ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
     ASSERT_TRUE(dest_column->get(0).get_array().empty());
-
     // array is null
     dest_column = filter.process(nullptr, {src_column2, src_column});
     ASSERT_TRUE(dest_column->only_null());

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -4646,10 +4646,18 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
 
     auto src_column2 = ColumnHelper::create_const_null_column(1);
 
+    // bool_array is null
     ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
-
     ASSERT_TRUE(dest_column->get(0).get_array().empty());
+
+    // array is null
+    dest_column = filter.process(nullptr, {src_column2, src_column});
+    ASSERT_TRUE(dest_column->only_null());
+
+    // all null
+    dest_column = filter.process(nullptr, {src_column2, src_column2});
+    ASSERT_TRUE(dest_column->only_null());
 }
 
 TEST_F(ArrayFunctionsTest, array_distinct_only_null) {


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/13915

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

currently, array_filter(array, null) will return null, if null is a const value, but return [] if null from a column. this behavior is not consistent.

unify array_filter(array, null) to return empty array when the null value from const value or column.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [ ] I have checked the version labels which the pr will be auto backported to target branch
