### PR TITLE
[BugFix] control running_queries via RAII

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -172,7 +172,7 @@ Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams&
             wg = WorkGroupManager::instance()->get_default_workgroup();
         }
         DCHECK(wg != nullptr);
-        RETURN_IF_ERROR(_query_ctx->init_query(wg.get()));
+        RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get()));
         _wg = wg;
     }
     DCHECK(!_fragment_ctx->enable_resource_group() || _wg != nullptr);
@@ -663,11 +663,7 @@ void FragmentExecutor::_fail_cleanup() {
         }
         if (_query_ctx->count_down_fragments()) {
             auto query_id = _query_ctx->query_id();
-            if (ExecEnv::GetInstance()->query_context_mgr()->remove(query_id)) {
-                if (_wg) {
-                    _wg->decr_num_queries();
-                }
-            }
+            ExecEnv::GetInstance()->query_context_mgr()->remove(query_id);
         }
     }
 }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -415,25 +415,9 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
         if (_query_ctx->count_down_fragments()) {
             auto query_id = _query_ctx->query_id();
             DCHECK(!this->is_still_pending_finish());
-
-            auto frag_id = _fragment_ctx->fragment_instance_id();
-            int active_fragments = _query_ctx->num_active_fragments();
-            int active_drivers = _fragment_ctx->num_drivers();
-
             // Acquire the pointer to avoid be released when removing query
             auto query_trace = _query_ctx->shared_query_trace();
-            auto wg = _workgroup;
-            auto fragment_ctx_ptr = uintptr_t(_fragment_ctx);
-            auto query_ctx_ptr = uintptr_t(_query_ctx);
-            if (ExecEnv::GetInstance()->query_context_mgr()->remove(query_id)) {
-                if (wg) {
-                    LOG(INFO) << "decrease num running queries in workgroup " << wg->id()
-                              << " query_id=" << print_id(query_id) << ", fragment_ctx address=" << fragment_ctx_ptr
-                              << ", fragment_instance_id=" << print_id(frag_id) << ", active_drivers=" << active_drivers
-                              << ", active_fragments=" << active_fragments << ", query_ctx address=" << query_ctx_ptr;
-                    wg->decr_num_queries();
-                }
-            }
+            ExecEnv::GetInstance()->query_context_mgr()->remove(query_id);
             QUERY_TRACE_END("finalize", _driver_name);
             // @TODO(silverbullet233): if necessary, remove the dump from the execution thread
             // considering that this feature is generally used for debugging,

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -25,6 +25,7 @@ using std::chrono::seconds;
 using std::chrono::milliseconds;
 using std::chrono::steady_clock;
 using std::chrono::duration_cast;
+
 // The context for all fragment of one query in one BE
 class QueryContext : public std::enable_shared_from_this<QueryContext> {
 public:
@@ -61,7 +62,7 @@ public:
         return now > _query_deadline;
     }
 
-    bool is_dead() { return _num_active_fragments == 0 && _num_fragments == _total_fragments; }
+    bool is_dead() const { return _num_active_fragments == 0 && _num_fragments == _total_fragments; }
     // add expired seconds to deadline
     void extend_delivery_lifetime() {
         _delivery_deadline =
@@ -100,7 +101,7 @@ public:
     void init_mem_tracker(int64_t bytes_limit, MemTracker* parent);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
 
-    Status init_query(workgroup::WorkGroup* wg);
+    Status init_query_once(workgroup::WorkGroup* wg);
 
     // Some statistic about the query, including cpu, scan_rows, scan_bytes
     int64_t mem_cost_bytes() const { return _mem_tracker->peak_consumption(); }
@@ -180,6 +181,7 @@ private:
     std::shared_ptr<QueryStatisticsRecvr> _sub_plan_query_statistics_recvr; // For receive
 
     int64_t _scan_limit = 0;
+    workgroup::RunningQueryTokenPtr _wg_running_query_token_ptr;
 };
 
 class QueryContextManager {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -28,7 +28,11 @@ bool WorkGroupSchedEntity<Q>::is_sq_wg() const {
 template class WorkGroupSchedEntity<pipeline::DriverQueue>;
 template class WorkGroupSchedEntity<ScanTaskQueue>;
 
-///WorkGroup.
+/// WorkGroup.
+RunningQueryToken::~RunningQueryToken() {
+    wg->decr_num_queries();
+}
+
 WorkGroup::WorkGroup(std::string name, int64_t id, int64_t version, size_t cpu_limit, double memory_limit,
                      size_t concurrency, WorkGroupType type)
         : _name(std::move(name)),
@@ -149,7 +153,7 @@ void WorkGroup::decr_num_running_drivers() {
     }
 }
 
-Status WorkGroup::try_incr_num_queries() {
+StatusOr<RunningQueryTokenPtr> WorkGroup::acquire_running_query_token() {
     int64_t old = _num_running_queries.fetch_add(1);
     if (_concurrency_limit != ABSENT_CONCURRENCY_LIMIT && old >= _concurrency_limit) {
         _num_running_queries.fetch_sub(1);
@@ -157,7 +161,7 @@ Status WorkGroup::try_incr_num_queries() {
         return Status::TooManyTasks(fmt::format("Exceed concurrency limit: {}", _concurrency_limit));
     }
     _num_total_queries++;
-    return Status::OK();
+    return std::make_unique<RunningQueryToken>(shared_from_this());
 }
 
 void WorkGroup::decr_num_queries() {

--- a/be/src/exec/workgroup/work_group_fwd.h
+++ b/be/src/exec/workgroup/work_group_fwd.h
@@ -11,6 +11,8 @@ class DriverQueue;
 namespace starrocks::workgroup {
 
 class WorkGroup;
+using WorkGroupPtr = std::shared_ptr<WorkGroup>;
+
 class ScanTaskQueue;
 
 template <typename Q>
@@ -21,6 +23,7 @@ using WorkGroupScanSchedEntity = WorkGroupSchedEntity<ScanTaskQueue>;
 class WorkGroupManager;
 class ScanExecutor;
 
-using WorkGroupPtr = std::shared_ptr<WorkGroup>;
+struct RunningQueryToken;
+using RunningQueryTokenPtr = std::unique_ptr<RunningQueryToken>;
 
 } // namespace starrocks::workgroup

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -4,9 +4,12 @@
 #include <random>
 
 #include "exec/pipeline/query_context.h"
+#include "exec/workgroup/work_group.h"
 #include "gtest/gtest.h"
+#include "testutil/assert.h"
 
 namespace starrocks::pipeline {
+
 TEST(QueryContextManagerTest, testSingleThreadOperations) {
     auto parent_mem_tracker = std::make_shared<MemTracker>(MemTracker::QUERY_POOL, 1073741824L, "parent", nullptr);
     {
@@ -205,4 +208,78 @@ TEST(QueryContextManagerTest, testMulitiThreadOperations) {
     query_ctx_mgr->remove(query_id);
     ASSERT_TRUE(query_ctx_mgr->get(query_id) == nullptr);
 }
+
+QueryContext* gen_query_ctx(MemTracker* parent_mem_tracker, QueryContextManager* query_ctx_mgr, int64_t query_id_hi,
+                            int64_t query_id_lo, size_t total_fragments, size_t delivery_expire_seconds,
+                            size_t query_expire_seconds) {
+    TUniqueId query_id;
+    query_id.hi = query_id_hi;
+    query_id.lo = query_id_lo;
+
+    auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+    query_ctx->set_total_fragments(total_fragments);
+    query_ctx->set_delivery_expire_seconds(delivery_expire_seconds);
+    query_ctx->set_query_expire_seconds(query_expire_seconds);
+    query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker);
+    query_ctx->extend_delivery_lifetime();
+    query_ctx->extend_query_lifetime();
+    query_ctx->count_down_fragments();
+
+    return query_ctx;
+}
+
+TEST(QueryContextManagerTest, testSetWorkgroup) {
+    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTracker::QUERY_POOL, 1073741824L, "parent", nullptr);
+    auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
+    ASSERT_TRUE(query_ctx_mgr->init().ok());
+
+    workgroup::WorkGroupPtr wg = std::make_shared<workgroup::WorkGroup>("wg1", 1, 1, 1, 1, 1 /* concurrency_limit */,
+                                                                        workgroup::WorkGroupType::WG_NORMAL);
+
+    auto* query_ctx1 = gen_query_ctx(parent_mem_tracker.get(), query_ctx_mgr.get(), 0, 1, 3, 60, 300);
+    auto* query_ctx_overloaded = gen_query_ctx(parent_mem_tracker.get(), query_ctx_mgr.get(), 1, 2, 3, 60, 300);
+    const auto query_id1 = query_ctx1->query_id();
+
+    /// Case 1: When all the fragments have come and finished, wg.num_running_queries should become to zero.
+    ASSERT_OK(query_ctx1->init_query_once(wg.get()));
+    ASSERT_OK(query_ctx1->init_query_once(wg.get()));    // None-first invocations have no side-effects.
+    ASSERT_ERROR(query_ctx_overloaded->init_query_once(wg.get())); // Exceed concurrency_limit.
+    ASSERT_EQ(1, wg->num_running_queries());
+    ASSERT_EQ(1, wg->concurrency_overflow_count());
+    // All the fragments comes.
+    for (int i = 1; i < query_ctx1->total_fragments(); ++i) {
+        auto* cur_query_ctx = query_ctx_mgr->get_or_register(query_id1);
+        ASSERT_EQ(query_ctx1, cur_query_ctx);
+    }
+    while (!query_ctx1->has_no_active_instances()) {
+        query_ctx1->count_down_fragments();
+    }
+    ASSERT_TRUE(query_ctx1->is_dead()); // All the fragments have come and finished.
+    query_ctx_mgr->remove(query_id1);
+    ASSERT_TRUE(query_ctx_mgr->get(query_id1) == nullptr);
+    ASSERT_EQ(0, wg->num_running_queries());
+
+    /// Case 2: When some fragments don't come but delivery timeout has expired,
+    /// wg.num_running_queries should also become to zero.
+    auto* query_ctx2 =
+            gen_query_ctx(parent_mem_tracker.get(), query_ctx_mgr.get(), 3, 4, 3, 0 /* delivery_timeout */, 300);
+    const auto query_id2 = query_ctx2->query_id();
+    ASSERT_OK(query_ctx2->init_query_once(wg.get()));
+    ASSERT_OK(query_ctx2->init_query_once(wg.get())); // None-first invocations have no side-effects.
+    ASSERT_EQ(1, wg->num_running_queries());
+    for (int i = 2; i < query_ctx2->total_fragments(); ++i) {
+        auto* cur_query_ctx = query_ctx_mgr->get_or_register(query_id2);
+        ASSERT_EQ(query_ctx2, cur_query_ctx);
+    }
+    while (!query_ctx2->has_no_active_instances()) {
+        query_ctx2->count_down_fragments();
+    }
+    ASSERT_FALSE(query_ctx2->is_dead());
+    query_ctx_mgr->remove(query_id2);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ASSERT_FALSE(query_ctx_mgr->remove(query_id2)); // Trigger _clean_slot.
+    ASSERT_EQ(0, wg->num_running_queries());
+}
+
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
As for the concurrency control of workgroup, `wg.running_queries` will be count down, when `query_ctx->remove()` returns true.

However, `query_ctx->remove()`  returns true, only when all the fragments have been delivered and finished. If some fragments fail to be delivered due to overload of BE or FE, then `running_queries` will never be count down.

Therefore, we use a RAII class `RunningQueryToken` to control it. `query_ctx` hold a token when increasing `running_queries`, and will always release this token in desctructor.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [x] I have checked the version labels which the pr will be auto backported to target branch
