### PR TITLE
[BugFix][cherry-pick] Fix incorrect dla query results for parquet with case-sensitive predicates

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -32,7 +32,7 @@ Status FileReader::init(vectorized::HdfsScannerContext* ctx) {
     RETURN_IF_ERROR(_parse_footer());
 
     std::unordered_set<std::string> names;
-    _file_metadata->schema().get_field_names(&names);
+    _file_metadata->schema().get_field_names(&names, _scanner_ctx->case_sensitive);
     _scanner_ctx->set_columns_from_file(names);
     ASSIGN_OR_RETURN(_is_file_filtered, _scanner_ctx->should_skip_by_evaluating_not_existed_slots());
     if (_is_file_filtered) {

--- a/be/src/formats/parquet/schema.cpp
+++ b/be/src/formats/parquet/schema.cpp
@@ -2,6 +2,8 @@
 
 #include "formats/parquet/schema.h"
 
+#include <boost/algorithm/string.hpp>
+
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h"
 
@@ -365,10 +367,11 @@ int SchemaDescriptor::get_column_index(const std::string& column, bool case_sens
     return -1;
 }
 
-void SchemaDescriptor::get_field_names(std::unordered_set<std::string>* names) const {
+void SchemaDescriptor::get_field_names(std::unordered_set<std::string>* names, bool case_sensitive) const {
     names->clear();
     for (const ParquetField& f : _fields) {
-        names->emplace(f.name);
+        std::string name = case_sensitive ? f.name : boost::algorithm::to_lower_copy(f.name);
+        names->emplace(std::move(name));
     }
 }
 

--- a/be/src/formats/parquet/schema.h
+++ b/be/src/formats/parquet/schema.h
@@ -79,7 +79,7 @@ public:
         return nullptr;
     }
 
-    void get_field_names(std::unordered_set<std::string>* names) const;
+    void get_field_names(std::unordered_set<std::string>* names, bool case_sensitive) const;
 
 private:
     void leaf_to_field(const tparquet::SchemaElement& t_schema, const LevelInfo& cur_level_info, bool is_nullable,

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -51,7 +51,8 @@ private:
     HdfsScannerContext* _create_context_for_late_materialization();
 
     HdfsScannerContext* _create_file4_base_context();
-    HdfsScannerContext* _create_context_for_struct_solumn();
+    HdfsScannerContext* _create_context_for_struct_column();
+    HdfsScannerContext* _create_context_for_upper_pred();
 
     HdfsScannerContext* _create_file5_base_context();
     HdfsScannerContext* _create_file6_base_context();
@@ -408,11 +409,19 @@ HdfsScannerContext* FileReaderTest::_create_file5_base_context() {
     return ctx;
 }
 
-HdfsScannerContext* FileReaderTest::_create_context_for_struct_solumn() {
+HdfsScannerContext* FileReaderTest::_create_context_for_struct_column() {
     auto* ctx = _create_file4_base_context();
     // create conjuncts
     // c3 = "c", c2 is not in slots, so the slot_id=1
     _create_string_conjunct_ctxs(TExprOpcode::EQ, 1, "c", &ctx->conjunct_ctxs_by_slot[1]);
+    return ctx;
+}
+
+HdfsScannerContext* FileReaderTest::_create_context_for_upper_pred() {
+    auto* ctx = _create_file4_base_context();
+    // create conjuncts
+    // B1 = "C", c2,c4 is not in slots, so the slot_id=2
+    _create_string_conjunct_ctxs(TExprOpcode::EQ, 2, "C", &ctx->conjunct_ctxs_by_slot[2]);
     return ctx;
 }
 
@@ -848,7 +857,7 @@ TEST_F(FileReaderTest, TestReadStructColumns) {
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
                                                     std::filesystem::file_size(_file4_path));
     // init
-    auto* ctx = _create_context_for_struct_solumn();
+    auto* ctx = _create_context_for_struct_column();
     Status status = file_reader->init(ctx);
     ASSERT_TRUE(status.ok());
 
@@ -869,6 +878,36 @@ TEST_F(FileReaderTest, TestReadStructColumns) {
     Slice s = col->get(0).get_slice();
     std::string res(s.data, s.size);
     EXPECT_EQ(res, "c");
+}
+
+TEST_F(FileReaderTest, TestReadWithUpperPred) {
+    auto file = _create_file(_file4_path);
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                                    std::filesystem::file_size(_file4_path));
+
+    // init
+    auto* ctx = _create_context_for_upper_pred();
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok());
+
+    // get next
+    auto chunk = _create_struct_chunk();
+    status = file_reader->get_next(&chunk);
+    ASSERT_TRUE(status.ok());
+    LOG(ERROR) << "status: " << status.get_error_msg();
+    ASSERT_EQ(3, chunk->num_rows());
+    for (int i = 0; i < chunk->num_rows(); ++i) {
+        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
+    }
+
+    ColumnPtr int_col = chunk->get_column_by_slot_id(0);
+    int i = int_col->get(0).get_int32();
+    EXPECT_EQ(i, 3);
+
+    ColumnPtr char_col = chunk->get_column_by_slot_id(2);
+    Slice s = char_col->get(0).get_slice();
+    std::string res(s.data, s.size);
+    EXPECT_EQ(res, "C");
 }
 
 TEST_F(FileReaderTest, TestReadArray2dColumn) {
@@ -936,7 +975,7 @@ TEST_F(FileReaderTest, TestReadStructUpperColumns) {
                                                     std::filesystem::file_size(_file4_path));;
 
 	// init
-	auto* ctx = _create_context_for_struct_solumn();
+	auto* ctx = _create_context_for_struct_column();
 	Status status = file_reader->init(ctx);
 	ASSERT_TRUE(status.ok());
 


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For lake source which is case sensitive, the column names may be upper-case. When querying the parquet file only with an upper predicate, as we didn't deal with the predicate cases completely, it will be treated as `not_existed_slots` and the query will be skipped, which causes an empty result.

(cherry-pick from #13698)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [ ] I have checked the version labels which the pr will be auto backported to target branch
