### PR TITLE
[BugFix] Use forward captured rowsets for query

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -87,6 +87,9 @@ StatusOr<MorselPtr> FixedMorselQueue::try_get() {
     }
     idx = _pop_index.fetch_add(1);
     if (idx < _num_morsels) {
+        if (!_tablet_rowsets.empty()) {
+            _morsels[idx]->set_rowsets(std::move(_tablet_rowsets[idx]));
+        }
         return std::move(_morsels[idx]);
     } else {
         return nullptr;
@@ -159,6 +162,7 @@ StatusOr<MorselPtr> PhysicalSplitMorselQueue::try_get() {
 
     MorselPtr morsel = std::make_unique<PhysicalSplitScanMorsel>(
             scan_morsel->get_plan_node_id(), *(scan_morsel->get_scan_range()), std::move(rowid_range));
+    morsel->set_rowsets(_tablet_rowsets[_tablet_idx]);
     _inc_num_splits(_is_last_split_of_current_morsel());
     return morsel;
 }
@@ -420,6 +424,7 @@ StatusOr<MorselPtr> LogicalSplitMorselQueue::try_get() {
     auto* scan_morsel = down_cast<ScanMorsel*>(_morsels[_tablet_idx].get());
     auto morsel = std::make_unique<LogicalSplitScanMorsel>(
             scan_morsel->get_plan_node_id(), *(scan_morsel->get_scan_range()), std::move(short_key_ranges));
+    morsel->set_rowsets(_tablet_rowsets[_tablet_idx]);
     _inc_num_splits(_is_last_split_of_current_morsel());
     return morsel;
 }

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -72,9 +72,14 @@ public:
     void set_from_version(int64_t from_version) { _from_version = from_version; }
     int64_t from_version() { return _from_version; }
 
+    void set_rowsets(std::vector<RowsetSharedPtr> rowsets) { _rowsets = std::move(rowsets); }
+    const std::vector<RowsetSharedPtr>& rowsets() const { return _rowsets; }
+
 private:
     int32_t _plan_node_id;
     int64_t _from_version = 0;
+
+    std::vector<RowsetSharedPtr> _rowsets;
 };
 
 class ScanMorsel : public Morsel {
@@ -213,6 +218,10 @@ public:
 
     std::vector<TInternalScanRange*> olap_scan_ranges() const override;
 
+    void set_tablet_rowsets(const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets) override {
+        _tablet_rowsets = tablet_rowsets;
+    }
+
     size_t num_original_morsels() const override { return _num_morsels; }
     size_t max_degree_of_parallelism() const override { return _num_morsels; }
     bool empty() const override { return _unget_morsel == nullptr && _pop_index >= _num_morsels; }
@@ -224,6 +233,7 @@ private:
     Morsels _morsels;
     const size_t _num_morsels;
     std::atomic<size_t> _pop_index;
+    std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
 };
 
 class SplitMorselQueue : public MorselQueue {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -263,7 +263,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
             ChunkHelper::convert_schema_to_format_v2(tablet_schema, reader_columns);
 
     _reader = std::make_shared<TabletReader>(_tablet, Version(_morsel->from_version(), _version),
-                                             std::move(child_schema));
+                                             std::move(child_schema), _morsel->rowsets());
     if (reader_columns.size() == scanner_columns.size()) {
         _prj_iter = _reader;
     } else {

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -66,6 +66,7 @@ void TabletReader::close() {
 Status TabletReader::prepare() {
     SCOPED_RAW_TIMER(&_stats.get_rowsets_ns);
     Status st = Status::OK();
+    // Non-empty rowsets indicate that it is captured before creating this TabletReader.
     if (_rowsets.empty()) {
         std::shared_lock l(_tablet->get_header_lock());
         st = _tablet->capture_consistent_rowsets(_version, &_rowsets);

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -21,6 +21,9 @@ class ColumnPredicate;
 class TabletReader final : public ChunkIterator {
 public:
     TabletReader(TabletSharedPtr tablet, const Version& version, VectorizedSchema schema);
+    // *captured_rowsets* is captured forward before creating TabletReader.
+    TabletReader(TabletSharedPtr tablet, const Version& version, VectorizedSchema schema,
+                 const std::vector<RowsetSharedPtr>& captured_rowsets);
     TabletReader(TabletSharedPtr tablet, const Version& version, VectorizedSchema schema, bool is_key,
                  RowSourceMaskBuffer* mask_buffer);
     ~TabletReader() override { close(); }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #3689.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The captured rowsets will still be deleted from `_version_graph` and `_rs_version_map`, and it just guarantee that the stale rowsets cannot be deleted and closed.

`TabletReader::prepare` will try to capture rowsets again and throw error when rowsets are stale.
Therefore, pass the forward captured rowsets to `TabletReader`.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [x] I have checked the version labels which the pr will be auto backported to target branch
