### PR TITLE
[WIP][Refactor] modify output column of SEMI/ANTI LogicalJoinOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
@@ -39,6 +39,10 @@ public class Projection {
         return new ArrayList<>(columnRefMap.keySet());
     }
 
+    public ColumnRefSet getOutputColumnRefSet() {
+        return new ColumnRefSet(columnRefMap.keySet());
+    }
+
     public Map<ColumnRefOperator, ScalarOperator> getColumnRefMap() {
         return columnRefMap;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOperator.java
@@ -4,8 +4,6 @@ package com.starrocks.sql.optimizer.operator.logical;
 
 import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.ExpressionContext;
-import com.starrocks.sql.optimizer.OptExpression;
-import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
@@ -14,6 +12,7 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -34,10 +33,10 @@ public abstract class LogicalOperator extends Operator {
 
     public abstract ColumnRefSet getOutputColumns(ExpressionContext expressionContext);
 
-    public ColumnRefOperator getSmallestColumn(ColumnRefFactory columnRefFactory, OptExpression opt) {
-        return Utils.findSmallestColumnRef(
-                getOutputColumns(new ExpressionContext(opt)).getStream().
-                        mapToObj(columnRefFactory::getColumnRef).collect(Collectors.toList()));
+    public List<ColumnRefOperator> getOutputColumnRefs(ExpressionContext expressionContext,
+                                                       ColumnRefFactory refFactory) {
+        return getOutputColumns(expressionContext).getStream().mapToObj(refFactory::getColumnRef)
+                .collect(Collectors.toList());
     }
 
     // lineage means the merge of operator's column ref map, which is used to track

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -300,9 +300,13 @@ public class ReorderJoinRule extends Rule {
             }
 
             if (childInputColumns.equals(outputColumns)) {
+                Map<ColumnRefOperator, ScalarOperator> columnMap =
+                        outputColumns.getStream().mapToObj(optimizerContext.getColumnRefFactory()::getColumnRef)
+                                .collect(Collectors.toMap(x -> x, x -> x));
+                Projection projection = new Projection(columnMap);
                 LogicalJoinOperator joinOperator = new LogicalJoinOperator.Builder().withOperator(
                                 (LogicalJoinOperator) optExpression.getOp())
-                        .setProjection(null).build();
+                        .setProjection(projection).build();
                 OptExpression joinOpt = OptExpression.create(joinOperator, Lists.newArrayList(left, right));
                 joinOpt.deriveLogicalPropertyItself();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
@@ -7,9 +7,9 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
-import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -50,9 +50,8 @@ public class PruneProjectColumnsRule extends TransformationRule {
         }));
 
         if (newMap.isEmpty()) {
-            OptExpression child = input.inputAt(0);
-            LogicalOperator childOp = (LogicalOperator) child.getOp();
-            ColumnRefOperator smallestColumn = childOp.getSmallestColumn(context.getColumnRefFactory(), child);
+            ColumnRefOperator smallestColumn =
+                    Utils.findSmallestColumnRef(input.inputAt(0), context.getColumnRefFactory());
             if (smallestColumn != null) {
                 ScalarOperator expr = projectOperator.getColumnRefMap().get(smallestColumn);
                 if (expr != null && !smallestColumn.equals(expr) && !expr.isVariable()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectRule.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
@@ -48,14 +49,11 @@ public class PruneProjectRule extends TransformationRule {
         if (((LogicalProjectOperator) input.getOp()).getColumnRefMap().isEmpty()) {
             Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
 
-            OptExpression child = input.inputAt(0);
-            LogicalOperator logicalOperator = (LogicalOperator) child.getOp();
+            LogicalOperator logicalOperator = (LogicalOperator) input.inputAt(0).getOp();
 
             ColumnRefOperator smallestColumn =
-                    logicalOperator.getSmallestColumn(context.getColumnRefFactory(), child);
-            if (smallestColumn != null) {
-                projectMap.put(smallestColumn, smallestColumn);
-            }
+                    Utils.findSmallestColumnRef(input.inputAt(0), context.getColumnRefFactory());
+            projectMap.put(smallestColumn, smallestColumn);
             return Lists.newArrayList(OptExpression
                     .create(new LogicalProjectOperator(projectMap, logicalOperator.getLimit()), input.getInputs()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
@@ -4,7 +4,6 @@ package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -165,10 +164,7 @@ public class RewriteGroupingSetsByCTERule extends TransformationRule {
         }
         // If there is no requiredColumns, we need to add least one column which is smallest
         if (consumeOutputMap.isEmpty()) {
-            List<ColumnRefOperator> outputColumns =
-                    produceOperator.getOutputColumns(new ExpressionContext(cteProduce)).getStream().
-                            mapToObj(factory::getColumnRef).collect(Collectors.toList());
-            ColumnRefOperator smallestColumn = Utils.findSmallestColumnRef(outputColumns);
+            ColumnRefOperator smallestColumn = Utils.findSmallestColumnRef(cteProduce, factory);
             ColumnRefOperator consumeOutput =
                     factory.create(smallestColumn, smallestColumn.getType(), smallestColumn.isNullable());
             consumeOutputMap.put(consumeOutput, smallestColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -11,7 +11,6 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
-import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -404,10 +403,7 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
         }
         // If there is no requiredColumns, we need to add least one column which is smallest
         if (consumeOutputMap.isEmpty()) {
-            List<ColumnRefOperator> outputColumns =
-                    produceOperator.getOutputColumns(new ExpressionContext(cteProduce)).getStream().
-                            mapToObj(factory::getColumnRef).collect(Collectors.toList());
-            ColumnRefOperator smallestColumn = Utils.findSmallestColumnRef(outputColumns);
+            ColumnRefOperator smallestColumn = Utils.findSmallestColumnRef(cteProduce, factory);
             ColumnRefOperator consumeOutput =
                     factory.create(smallestColumn, smallestColumn.getType(), smallestColumn.isNullable());
             consumeOutputMap.put(consumeOutput, smallestColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -18,7 +18,7 @@ public class Statistics {
     // This flag set true if get table row count from GlobalStateMgr LE 1
     // Table row count in FE depends on BE reporting，but FE may not get report from BE which just started，
     // this causes the table row count stored in FE to be inaccurate.
-    private boolean tableRowCountMayInaccurate;
+    private final boolean tableRowCountMayInaccurate;
 
     private Statistics(Builder builder) {
         this.outputRowCount = builder.outputRowCount;
@@ -53,7 +53,8 @@ public class Statistics {
 
     public ColumnStatistic getColumnStatistic(ColumnRefOperator column) {
         ColumnStatistic result = columnStatistics.get(column);
-        Preconditions.checkState(result != null);
+        Preconditions.checkNotNull(result,
+                String.format("miss column statistic for %s, all columns are %s", column, columnStatistics.keySet()));
         return result;
     }
 
@@ -121,6 +122,7 @@ public class Statistics {
         }
 
         public Builder addColumnStatistic(ColumnRefOperator column, ColumnStatistic statistic) {
+            Preconditions.checkNotNull(statistic);
             this.columnStatistics.put(column, statistic);
             return this;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -190,7 +190,16 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 statisticsBuilder.addColumnStatistic(columnRefOperator,
                         ExpressionStatisticCalculator.calculate(mapOperator, statisticsBuilder.build()));
             }
-
+        } else {
+            if (node instanceof LogicalOperator) {
+                LogicalOperator logical = (LogicalOperator) node;
+                Statistics input = statisticsBuilder.build();
+                for (ColumnRefOperator ref : logical.getOutputColumnRefs(context, columnRefFactory)) {
+                    statisticsBuilder.addColumnStatistic(ref, ExpressionStatisticCalculator.calculate(ref, input));
+                }
+            } else {
+                Preconditions.checkState(false, "TODO");
+            }
         }
         context.setStatistics(statisticsBuilder.build());
         return null;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -127,9 +127,10 @@ public class NestLoopJoinTest extends PlanTestBase {
                 "left anti join " +
                 " (select * from t3 where cast(v10 as string) like 'ss%' ) sub2" +
                 " on substr(cast(sub1.v7 as string), 1) = substr(cast(sub2.v10 as string), 1)";
-        assertPlanContains(sql, " 11:Project\n" +
-                "  |  <slot 14> : 14: substr\n" +
-                "  |  \n" +
+        assertPlanContains(sql, "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 11\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
                 "  10:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
@@ -140,9 +141,8 @@ public class NestLoopJoinTest extends PlanTestBase {
                 "from test_all_type_nullable t1 " +
                 "right anti join test_all_type_nullable2 t2 " +
                 "on t1.id_char = 0) as a;";
-        assertVerbosePlanContains(sql, "  4:Project\n" +
-                "  |  output columns:\n" +
-                "  |  28 <-> [28: id_tinyint, TINYINT, false]\n" +
+        assertVerbosePlanContains(sql, "  4:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: count[(*); args: ; result: BIGINT; args nullable: false; result nullable: false]\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  3:NESTLOOP JOIN\n" +
@@ -156,9 +156,9 @@ public class NestLoopJoinTest extends PlanTestBase {
                 "from test_all_type_nullable t1 " +
                 "right anti join test_all_type_nullable2 t2 " +
                 "on t1.id_char = 0) as a;";
-        assertVerbosePlanContains(sql, "  4:Project\n" +
-                "  |  output columns:\n" +
-                "  |  34 <-> [34: id_char, CHAR, false]\n" +
+        assertVerbosePlanContains(sql, "  4:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: count[([34: id_char, CHAR, false]); args: VARCHAR; " +
+                "result: BIGINT; args nullable: false; result nullable: false]\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  3:NESTLOOP JOIN\n" +
@@ -172,9 +172,8 @@ public class NestLoopJoinTest extends PlanTestBase {
                 "from test_all_type_nullable t1 " +
                 "left anti join test_all_type_nullable2 t2 " +
                 "on t1.id_char = 0) as a;";
-        assertVerbosePlanContains(sql, "  4:Project\n" +
-                "  |  output columns:\n" +
-                "  |  8 <-> [8: id_char, CHAR, false]\n" +
+        assertVerbosePlanContains(sql, "  4:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: count[(*); args: ; result: BIGINT; args nullable: false; result nullable: false]\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  3:NESTLOOP JOIN\n" +


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Modify `LogicalJoinOperator`'s output column, not output right table columns of `LEFT SEMI/ANTI JOIN` , to avoid propagate bugs.

Related changes:
1. Prune column with smallest column: avoid use right table's column for `LEFT SEMI/ANTI JOIN`, since it's not outputted
2. SemiJoinOrder: Build the correct projection for semi join
3. Physical property deriver


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
<!--Checkmate-->
- [ ] I have checked the version labels which the pr will be auto backported to target branch
