### PR TITLE
[Enhancement] Always write down version file

### DIFF
--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -58,7 +58,7 @@ def get_java_version():
         return out.decode('utf-8').replace("\"", "\\\"").strip()
     return "unknown jdk"
 
-def write_file(file_name, file_content, commit_hash):
+def write_file(file_name, file_content):
     with open(file_name, 'w') as fh:
         fh.write(file_content)
 
@@ -89,7 +89,7 @@ public class Version {{
     d = os.path.dirname(file_name)
     if not os.path.exists(d):
         os.makedirs(d)
-    skip_write_if_commit_unchanged(file_name, file_content, commit_hash)
+    write_file(file_name, file_content)
 
 def generate_cpp_file(cpp_path, version, commit_hash, build_type, build_time, user, host):
     file_format = '''
@@ -116,7 +116,7 @@ const char* STARROCKS_BUILD_HOST = "{BUILD_HOST}";
     d = os.path.dirname(file_name)
     if not os.path.exists(d):
         os.makedirs(d)
-    skip_write_if_commit_unchanged(file_name, file_content, commit_hash)
+    write_file(file_name, file_content)
 
 def main():
     parser = argparse.ArgumentParser()

--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -58,16 +58,7 @@ def get_java_version():
         return out.decode('utf-8').replace("\"", "\\\"").strip()
     return "unknown jdk"
 
-def skip_write_if_commit_unchanged(file_name, file_content, commit_hash):
-    if os.path.exists(file_name):
-        with open(file_name) as fh:
-            data = fh.read()
-            import re
-            m = re.search("COMMIT_HASH: (?P<commit_hash>\w+)", data)
-            old_commit_hash = m.group('commit_hash') if m else None
-            print('gen_build_version.py {}: old commit = {}, new commit = {}'.format(file_name, old_commit_hash, commit_hash))
-            if old_commit_hash == commit_hash:
-                return
+def write_file(file_name, file_content, commit_hash):
     with open(file_name, 'w') as fh:
         fh.write(file_content)
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In old time, version file is skipped written to avoid re-compile when commit is not changed. 

But now since we have ccache, we can write down version file anyway. 

The good side of writing donw version file always, is because sometimes we might change compiler parameters like BUILD_TYPE = DEBUG/RELEASE, but new build type is not written down into version file.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
