### PR TITLE
[Refactor] Refactor build_hash_map and build_set to remove duplicated codes

### DIFF
--- a/be/src/exec/vectorized/aggregate/agg_hash_set.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_set.h
@@ -67,26 +67,27 @@ struct AggHashSetOfOneNumberKey {
     static_assert(sizeof(FieldType) <= sizeof(KeyType), "hash set key size needs to be larger than the actual element");
 
     AggHashSetOfOneNumberKey(int32_t chunk_size) {}
-    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
-        DCHECK(!key_columns[0]->is_nullable());
-        auto* column = down_cast<ColumnType*>(key_columns[0].get());
-        const size_t row_num = column->size();
-        for (size_t i = 0; i < row_num; ++i) {
-            hash_set.emplace(column->get_data()[i]);
-        }
-    }
 
+    // When compute_and_allocate=false:
     // Elements queried in HashSet will be added to HashSet
     // elements that cannot be queried are not processed,
     // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
-    void build_set(size_t chunk_size, const Columns& key_columns, std::vector<uint8_t>* not_founds) {
+    template <bool compute_and_allocate>
+    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool, std::vector<uint8_t>* not_founds) {
         DCHECK(!key_columns[0]->is_nullable());
-        auto* column = ColumnHelper::as_raw_column<ColumnType>(key_columns[0]);
+        if constexpr (!compute_and_allocate) {
+            DCHECK(not_founds);
+            not_founds->assign(chunk_size, 0);
+        }
+        auto* column = down_cast<ColumnType*>(key_columns[0].get());
+        const size_t row_num = column->size();
         auto& keys = column->get_data();
-        not_founds->resize(chunk_size);
-
-        for (size_t i = 0; i < chunk_size; ++i) {
-            (*not_founds)[i] = !hash_set.contains(keys[i]);
+        for (size_t i = 0; i < row_num; ++i) {
+            if constexpr (compute_and_allocate) {
+                hash_set.emplace(keys[i]);
+            } else {
+                (*not_founds)[i] = !hash_set.contains(keys[i]);
+            }
         }
     }
 
@@ -111,7 +112,17 @@ struct AggHashSetOfOneNullableNumberKey {
     static_assert(sizeof(FieldType) <= sizeof(KeyType), "hash set key size needs to be larger than the actual element");
 
     AggHashSetOfOneNullableNumberKey(int32_t chunk_size) {}
-    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
+
+    // When compute_and_allocate=false:
+    // Elements queried in HashSet will be added to HashSet
+    // elements that cannot be queried are not processed,
+    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
+    template <bool compute_and_allocate>
+    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool, std::vector<uint8_t>* not_founds) {
+        if constexpr (!compute_and_allocate) {
+            DCHECK(not_founds);
+            not_founds->assign(chunk_size, 0);
+        }
         if (key_columns[0]->only_null()) {
             has_null_key = true;
         } else {
@@ -119,6 +130,7 @@ struct AggHashSetOfOneNullableNumberKey {
             auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
             auto* data_column = down_cast<ColumnType*>(nullable_column->data_column().get());
             const auto& null_data = nullable_column->null_column_data();
+            auto& keys = data_column->get_data();
 
             size_t row_num = nullable_column->size();
             if (nullable_column->has_null()) {
@@ -126,42 +138,20 @@ struct AggHashSetOfOneNullableNumberKey {
                     if (null_data[i]) {
                         has_null_key = true;
                     } else {
-                        hash_set.emplace(data_column->get_data()[i]);
+                        if constexpr (compute_and_allocate) {
+                            hash_set.emplace(keys[i]);
+                        } else {
+                            (*not_founds)[i] = !hash_set.contains(keys[i]);
+                        }
                     }
                 }
             } else {
                 for (size_t i = 0; i < row_num; ++i) {
-                    hash_set.emplace(data_column->get_data()[i]);
-                }
-            }
-        }
-    }
-
-    // Elements queried in HashSet will be added to HashSet
-    // elements that cannot be queried are not processed,
-    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
-    void build_set(size_t chunk_size, const Columns& key_columns, std::vector<uint8_t>* not_founds) {
-        not_founds->assign(chunk_size, 0);
-        if (key_columns[0]->only_null()) {
-            has_null_key = true;
-        } else {
-            DCHECK(key_columns[0]->is_nullable());
-            auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0]);
-            auto* data_column = ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column());
-            const auto& null_data = nullable_column->null_column_data();
-            auto& keys = data_column->get_data();
-
-            if (nullable_column->has_null()) {
-                for (size_t i = 0; i < chunk_size; ++i) {
-                    if (null_data[i]) {
-                        has_null_key = true;
+                    if constexpr (compute_and_allocate) {
+                        hash_set.emplace(keys[i]);
                     } else {
                         (*not_founds)[i] = !hash_set.contains(keys[i]);
                     }
-                }
-            } else {
-                for (size_t i = 0; i < chunk_size; ++i) {
-                    (*not_founds)[i] = !hash_set.contains(keys[i]);
                 }
             }
         }
@@ -188,35 +178,33 @@ struct AggHashSetOfOneStringKey {
 
     AggHashSetOfOneStringKey(int32_t chunk_size) {}
 
-    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
+    // When compute_and_allocate=false:
+    // Elements queried in HashSet will be added to HashSet
+    // elements that cannot be queried are not processed,
+    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
+    template <bool compute_and_allocate>
+    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool, std::vector<uint8_t>* not_founds) {
         DCHECK(key_columns[0]->is_binary());
         auto* column = down_cast<BinaryColumn*>(key_columns[0].get());
+        if constexpr (!compute_and_allocate) {
+            DCHECK(not_founds);
+            not_founds->assign(chunk_size, 0);
+        }
 
         size_t row_num = column->size();
         for (size_t i = 0; i < row_num; ++i) {
             auto tmp = column->get_slice(i);
-            KeyType key(tmp);
-
-            hash_set.lazy_emplace(key, [&](const auto& ctor) {
-                // we must persist the slice before insert
-                uint8_t* pos = pool->allocate(key.size);
-                memcpy(pos, key.data, key.size);
-                ctor(pos, key.size, key.hash);
-            });
-        }
-    }
-
-    // Elements queried in HashSet will be added to HashSet
-    // elements that cannot be queried are not processed,
-    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
-    void build_set(size_t chunk_size, const Columns& key_columns, std::vector<uint8_t>* not_founds) {
-        DCHECK(key_columns[0]->is_binary());
-        auto* column = ColumnHelper::as_raw_column<BinaryColumn>(key_columns[0]);
-        not_founds->assign(chunk_size, 0);
-
-        for (size_t i = 0; i < chunk_size; ++i) {
-            auto key = column->get_slice(i);
-            (*not_founds)[i] = !hash_set.contains(key);
+            if constexpr (compute_and_allocate) {
+                KeyType key(tmp);
+                hash_set.lazy_emplace(key, [&](const auto& ctor) {
+                    // we must persist the slice before insert
+                    uint8_t* pos = pool->allocate(key.size);
+                    memcpy(pos, key.data, key.size);
+                    ctor(pos, key.size, key.hash);
+                });
+            } else {
+                (*not_founds)[i] = !hash_set.contains(tmp);
+            }
         }
     }
 
@@ -239,7 +227,16 @@ struct AggHashSetOfOneNullableStringKey {
 
     AggHashSetOfOneNullableStringKey(int32_t chunk_size) {}
 
-    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
+    // When compute_and_allocate=false:
+    // Elements queried in HashSet will be added to HashSet
+    // elements that cannot be queried are not processed,
+    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
+    template <bool compute_and_allocate>
+    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool, std::vector<uint8_t>* not_founds) {
+        if constexpr (!compute_and_allocate) {
+            DCHECK(not_founds);
+            not_founds->assign(chunk_size, 0);
+        }
         if (key_columns[0]->only_null()) {
             has_null_key = true;
         } else if (key_columns[0]->is_nullable()) {
@@ -253,47 +250,27 @@ struct AggHashSetOfOneNullableStringKey {
                     if (null_data[i]) {
                         has_null_key = true;
                     } else {
-                        _handle_data_key_column(data_column, i, pool);
+                        if constexpr (compute_and_allocate) {
+                            _handle_data_key_column(data_column, i, pool, not_founds);
+                        } else {
+                            _handle_data_key_column(data_column, i, not_founds);
+                        }
                     }
                 }
             } else {
                 for (size_t i = 0; i < row_num; ++i) {
-                    _handle_data_key_column(data_column, i, pool);
-                }
-            }
-        }
-    }
-
-    // Elements queried in HashSet will be added to HashSet
-    // elements that cannot be queried are not processed,
-    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
-    void build_set(size_t chunk_size, const Columns& key_columns, std::vector<uint8_t>* not_founds) {
-        not_founds->assign(chunk_size, 0);
-        if (key_columns[0]->only_null()) {
-            has_null_key = true;
-        } else {
-            DCHECK(key_columns[0]->is_nullable());
-            auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0]);
-            auto* data_column = ColumnHelper::as_raw_column<BinaryColumn>(nullable_column->data_column());
-            const auto& null_data = nullable_column->null_column_data();
-
-            if (nullable_column->has_null()) {
-                for (size_t i = 0; i < chunk_size; ++i) {
-                    if (null_data[i]) {
-                        has_null_key = true;
+                    if constexpr (compute_and_allocate) {
+                        _handle_data_key_column(data_column, i, pool, not_founds);
                     } else {
                         _handle_data_key_column(data_column, i, not_founds);
                     }
                 }
-            } else {
-                for (size_t i = 0; i < chunk_size; ++i) {
-                    _handle_data_key_column(data_column, i, not_founds);
-                }
             }
         }
     }
 
-    void _handle_data_key_column(BinaryColumn* data_column, size_t row, MemPool* pool) {
+    void _handle_data_key_column(BinaryColumn* data_column, size_t row, MemPool* pool,
+                                 std::vector<uint8_t>* not_founds) {
         auto tmp = data_column->get_slice(row);
         KeyType key(tmp);
 
@@ -335,8 +312,17 @@ struct AggHashSetOfSerializedKey {
               _buffer(_mem_pool->allocate(max_one_row_size * chunk_size)),
               _chunk_size(chunk_size) {}
 
-    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
+    // When compute_and_allocate=false:
+    // Elements queried in HashSet will be added to HashSet
+    // elements that cannot be queried are not processed,
+    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
+    template <bool compute_and_allocate>
+    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool, std::vector<uint8_t>* not_founds) {
         slice_sizes.assign(_chunk_size, 0);
+        if constexpr (!compute_and_allocate) {
+            DCHECK(not_founds);
+            not_founds->assign(chunk_size, 0);
+        }
 
         size_t cur_max_one_row_size = get_max_serialize_size(key_columns);
         if (UNLIKELY(cur_max_one_row_size > max_one_row_size)) {
@@ -353,38 +339,17 @@ struct AggHashSetOfSerializedKey {
 
         for (size_t i = 0; i < chunk_size; ++i) {
             Slice tmp = {_buffer + i * max_one_row_size, slice_sizes[i]};
-            KeyType key(tmp);
-
-            hash_set.lazy_emplace(key, [&](const auto& ctor) {
-                // we must persist the slice before insert
-                uint8_t* pos = pool->allocate(key.size);
-                memcpy(pos, key.data, key.size);
-                ctor(pos, key.size, key.hash);
-            });
-        }
-    }
-
-    // Elements queried in HashSet will be added to HashSet
-    // elements that cannot be queried are not processed,
-    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
-    void build_set(size_t chunk_size, const Columns& key_columns, std::vector<uint8_t>* not_founds) {
-        slice_sizes.assign(_chunk_size, 0);
-
-        size_t cur_max_one_row_size = get_max_serialize_size(key_columns);
-        if (UNLIKELY(cur_max_one_row_size > max_one_row_size)) {
-            max_one_row_size = cur_max_one_row_size;
-            _mem_pool->clear();
-            _buffer = _mem_pool->allocate(max_one_row_size * _chunk_size);
-        }
-
-        for (const auto& key_column : key_columns) {
-            key_column->serialize_batch(_buffer, slice_sizes, chunk_size, max_one_row_size);
-        }
-
-        not_founds->assign(chunk_size, 0);
-        for (size_t i = 0; i < chunk_size; ++i) {
-            Slice key = {_buffer + i * max_one_row_size, slice_sizes[i]};
-            (*not_founds)[i] = !hash_set.contains(key);
+            if constexpr (compute_and_allocate) {
+                KeyType key(tmp);
+                hash_set.lazy_emplace(key, [&](const auto& ctor) {
+                    // we must persist the slice before insert
+                    uint8_t* pos = pool->allocate(key.size);
+                    memcpy(pos, key.data, key.size);
+                    ctor(pos, key.size, key.hash);
+                });
+            } else {
+                (*not_founds)[i] = !hash_set.contains(tmp);
+            }
         }
     }
 
@@ -448,9 +413,18 @@ struct AggHashSetOfSerializedKeyFixedSize {
         memset(buffer, 0x0, max_fixed_size * _chunk_size);
     }
 
-    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {
+    // When compute_and_allocate=false:
+    // Elements queried in HashSet will be added to HashSet
+    // elements that cannot be queried are not processed,
+    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
+    template <bool compute_and_allocate>
+    void build_set(size_t chunk_size, const Columns& key_columns, MemPool* pool, std::vector<uint8_t>* not_founds) {
         DCHECK(fixed_byte_size != -1);
         slice_sizes.assign(chunk_size, 0);
+        if constexpr (!compute_and_allocate) {
+            DCHECK(not_founds);
+            not_founds->assign(chunk_size, 0);
+        }
 
         if (has_null_column) {
             memset(buffer, 0x0, max_fixed_size * chunk_size);
@@ -469,39 +443,10 @@ struct AggHashSetOfSerializedKeyFixedSize {
         }
 
         for (size_t i = 0; i < chunk_size; ++i) {
-            hash_set.insert(key[i]);
-        }
-    }
-
-    // Elements queried in HashSet will be added to HashSet
-    // elements that cannot be queried are not processed,
-    // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
-    void build_set(size_t chunk_size, const Columns& key_columns, std::vector<uint8_t>* not_founds) {
-        DCHECK(fixed_byte_size != -1);
-        slice_sizes.assign(chunk_size, 0);
-
-        if (has_null_column) {
-            memset(buffer, 0x0, max_fixed_size * chunk_size);
-        }
-
-        for (const auto& key_column : key_columns) {
-            key_column->serialize_batch(buffer, slice_sizes, chunk_size, max_fixed_size);
-        }
-
-        not_founds->assign(chunk_size, 0);
-
-        FixedSizeSliceKey key;
-
-        if (!has_null_column) {
-            for (size_t i = 0; i < chunk_size; ++i) {
-                memcpy(key.u.data, buffer + i * max_fixed_size, max_fixed_size);
-                (*not_founds)[i] = !hash_set.contains(key);
-            }
-        } else {
-            for (size_t i = 0; i < chunk_size; ++i) {
-                memcpy(key.u.data, buffer + i * max_fixed_size, max_fixed_size);
-                key.u.size = slice_sizes[i];
-                (*not_founds)[i] = !hash_set.contains(key);
+            if constexpr (compute_and_allocate) {
+                hash_set.insert(key[i]);
+            } else {
+                (*not_founds)[i] = !hash_set.contains(key[i]);
             }
         }
     }

--- a/be/src/exec/vectorized/aggregate/agg_hash_set.h
+++ b/be/src/exec/vectorized/aggregate/agg_hash_set.h
@@ -55,6 +55,17 @@ using SliceAggTwoLevelHashSet =
                                       phmap::priv::Allocator<Slice>, 4>;
 
 // ==============================================================
+
+#define AGG_HASH_SET_COMMON_METHODS()                                                                \
+    void build_hash_set(size_t chunk_size, const Columns& key_columns, MemPool* pool) {              \
+        return build_set<true>(chunk_size, key_columns, pool, nullptr);                              \
+    }                                                                                                \
+                                                                                                     \
+    void build_hash_set_with_selection(size_t chunk_size, const Columns& key_columns, MemPool* pool, \
+                                       std::vector<uint8_t>* not_founds) {                           \
+        return build_set<false>(chunk_size, key_columns, pool, not_founds);                          \
+    }
+
 // handle one number hash key
 template <LogicalType primitive_type, typename HashSet>
 struct AggHashSetOfOneNumberKey {
@@ -67,6 +78,8 @@ struct AggHashSetOfOneNumberKey {
     static_assert(sizeof(FieldType) <= sizeof(KeyType), "hash set key size needs to be larger than the actual element");
 
     AggHashSetOfOneNumberKey(int32_t chunk_size) {}
+
+    AGG_HASH_SET_COMMON_METHODS()
 
     // When compute_and_allocate=false:
     // Elements queried in HashSet will be added to HashSet
@@ -112,6 +125,8 @@ struct AggHashSetOfOneNullableNumberKey {
     static_assert(sizeof(FieldType) <= sizeof(KeyType), "hash set key size needs to be larger than the actual element");
 
     AggHashSetOfOneNullableNumberKey(int32_t chunk_size) {}
+
+    AGG_HASH_SET_COMMON_METHODS()
 
     // When compute_and_allocate=false:
     // Elements queried in HashSet will be added to HashSet
@@ -178,6 +193,8 @@ struct AggHashSetOfOneStringKey {
 
     AggHashSetOfOneStringKey(int32_t chunk_size) {}
 
+    AGG_HASH_SET_COMMON_METHODS()
+
     // When compute_and_allocate=false:
     // Elements queried in HashSet will be added to HashSet
     // elements that cannot be queried are not processed,
@@ -226,6 +243,8 @@ struct AggHashSetOfOneNullableStringKey {
     HashSet hash_set;
 
     AggHashSetOfOneNullableStringKey(int32_t chunk_size) {}
+
+    AGG_HASH_SET_COMMON_METHODS()
 
     // When compute_and_allocate=false:
     // Elements queried in HashSet will be added to HashSet
@@ -311,6 +330,8 @@ struct AggHashSetOfSerializedKey {
             : _mem_pool(std::make_unique<MemPool>()),
               _buffer(_mem_pool->allocate(max_one_row_size * chunk_size)),
               _chunk_size(chunk_size) {}
+
+    AGG_HASH_SET_COMMON_METHODS()
 
     // When compute_and_allocate=false:
     // Elements queried in HashSet will be added to HashSet
@@ -412,6 +433,8 @@ struct AggHashSetOfSerializedKeyFixedSize {
               _chunk_size(chunk_size) {
         memset(buffer, 0x0, max_fixed_size * _chunk_size);
     }
+
+    AGG_HASH_SET_COMMON_METHODS()
 
     // When compute_and_allocate=false:
     // Elements queried in HashSet will be added to HashSet

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -1069,14 +1069,13 @@ Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::Chu
 }
 
 void Aggregator::build_hash_set(size_t chunk_size) {
-    _hash_set_variant.visit([&](auto& hash_set) {
-        hash_set->template build_set<true>(chunk_size, _group_by_columns, _mem_pool.get(), nullptr);
-    });
+    _hash_set_variant.visit(
+            [&](auto& hash_set) { hash_set->build_hash_set(chunk_size, _group_by_columns, _mem_pool.get()); });
 }
 
 void Aggregator::build_hash_set_with_selection(size_t chunk_size) {
     _hash_set_variant.visit([&](auto& hash_set) {
-        hash_set->template build_set<false>(chunk_size, _group_by_columns, _mem_pool.get(), &_streaming_selection);
+        hash_set->build_hash_set_with_selection(chunk_size, _group_by_columns, _mem_pool.get(), &_streaming_selection);
     });
 }
 

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -969,7 +969,7 @@ void Aggregator::build_hash_map_with_selection(size_t chunk_size) {
     });
 }
 
-void Aggregator::build_hash_map_allocate_and_with_selection(size_t chunk_size) {
+void Aggregator::build_hash_map_allocate_and_with_selection(size_t chunk_size, bool agg_group_by_with_limit) {
     _hash_map_variant.visit([&](auto& hash_map_with_key) {
         using MapType = std::remove_reference_t<decltype(*hash_map_with_key)>;
         using Func = decltype(AllocateState<MapType>(this));

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -350,7 +350,7 @@ protected:
 public:
     void build_hash_map(size_t chunk_size, bool agg_group_by_with_limit = false);
     void build_hash_map_with_selection(size_t chunk_size);
-    void build_hash_map_allocate_and_with_selection(size_t chunk_size, bool agg_group_by_with_limit = false);
+    void build_hash_map_with_selection_and_allocation(size_t chunk_size, bool agg_group_by_with_limit = false);
     Status convert_hash_map_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk);
 
     void build_hash_set(size_t chunk_size);

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -350,6 +350,7 @@ protected:
 public:
     void build_hash_map(size_t chunk_size, bool agg_group_by_with_limit = false);
     void build_hash_map_with_selection(size_t chunk_size);
+    void build_hash_map_allocate_and_with_selection(size_t chunk_size, bool agg_group_by_with_limit = false);
     Status convert_hash_map_to_chunk(int32_t chunk_size, vectorized::ChunkPtr* chunk);
 
     void build_hash_set(size_t chunk_size);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13880

- Use template to refactor build_hash_map and build_set to remove duplicated codes;
- Add `build_hash_map_allocate_and_with_selection` method to be used in StreamMV later.

```
// When meets not found group keys, mark the first pos into `_streaming_selection` and insert into the hashmap
// so the following group keys(same as the first not found group keys) are not marked as non-founded.
// This can be used for stream mv so no need to find multi times for the same non-found group keys.
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
