### PR TITLE
[Enhancement] Make config::{min,max}garbage_sweep_interval mutable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -253,8 +253,8 @@ CONF_mInt32(inc_rowset_expired_sec, "1800");
 // inc_rowset snapshot rs sweep time interval
 CONF_mInt32(tablet_rowset_stale_sweep_time_sec, "1800");
 // garbage sweep policy
-CONF_Int32(max_garbage_sweep_interval, "3600");
-CONF_Int32(min_garbage_sweep_interval, "180");
+CONF_mInt32(max_garbage_sweep_interval, "3600");
+CONF_mInt32(min_garbage_sweep_interval, "180");
 CONF_mInt32(snapshot_expire_time_sec, "172800");
 CONF_mInt32(trash_file_expire_time_sec, "259200");
 // check row nums for BE/CE and schema change. true is open, false is closed.

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -536,11 +536,11 @@ int32_t GarbageSweepIntervalCalculator::curr_interval() const {
     // when disk usage =90%, ratio is about 0.0057
     double ratio = (1.1 * (M_PI / 2 - std::atan(_disk_usage * 100 / 5 - 14)) - 0.28) / M_PI;
     ratio = std::max(0.0, ratio);
-    ratio = std::min(1.0, ratio);
     int32_t curr_interval = _max_interval * ratio;
     // when usage < 60%,curr_interval is about max_interval,
     // when usage > 80%, curr_interval is close to min_interval
     curr_interval = std::max(curr_interval, _min_interval);
+    curr_interval = std::min(curr_interval, _max_interval);
 
     return curr_interval;
 }

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -381,4 +381,37 @@ public:
     Status start_bg_threads() override { return Status::OK(); };
 };
 
+/// Load min_garbage_sweep_interval and max_garbage_sweep_interval from config,
+/// and calculate a proper sweep interval according to the disk usage and min/max interval.
+///
+/// *maybe_interval_updated* can be used to check and update min/max interval from config.
+/// All the methods are not thread-safe.
+class GarbageSweepIntervalCalculator {
+public:
+    GarbageSweepIntervalCalculator();
+
+    DISALLOW_COPY(GarbageSweepIntervalCalculator);
+    DISALLOW_MOVE(GarbageSweepIntervalCalculator);
+
+    double& mutable_disk_usage() { return _disk_usage; }
+
+    // Return true and update min and max interval, if the value from config is changed.
+    bool maybe_interval_updated();
+    // Calculate the interval according to the disk usage and min/max interval.
+    int32_t curr_interval() const;
+
+private:
+    void _normalize_min_max();
+
+    // The value read from config.
+    int32_t _original_min_interval;
+    int32_t _original_max_interval;
+    // The value after normalized.
+    int32_t _min_interval;
+    int32_t _max_interval;
+
+    // Value is in [0, 1].
+    double _disk_usage = 1.0;
+};
+
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -230,6 +230,7 @@ set(EXEC_FILES
         ./storage/base_compaction_test.cpp
         ./storage/rowset_merger_test.cpp
         ./storage/schema_change_test.cpp
+        ./storage/storage_engine_test.cpp
         ./runtime/buffer_control_block_test.cpp
         ./runtime/datetime_value_test.cpp
         ./runtime/decimalv2_value_test.cpp

--- a/be/test/storage/storage_engine_test.cpp
+++ b/be/test/storage/storage_engine_test.cpp
@@ -1,0 +1,48 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "storage/storage_engine.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/parallel_test.h"
+
+namespace starrocks {
+
+PARALLEL_TEST(StorageEngineTest, test_garbage_sweep_interval_calculator) {
+    config::min_garbage_sweep_interval = 100;
+    config::max_garbage_sweep_interval = 10000;
+    GarbageSweepIntervalCalculator calculator;
+
+    struct TestCase {
+        TestCase(int32_t original_min, int32_t original_max, bool expected_changed, int32_t expected_min,
+                 int32_t expected_max)
+                : original_min(original_min),
+                  original_max(original_max),
+                  expected_changed(expected_changed),
+                  expected_min(expected_min),
+                  expected_max(expected_max) {}
+
+        const int32_t original_min;
+        const int32_t original_max;
+
+        const bool expected_changed;
+        const int32_t expected_min;
+        const int32_t expected_max;
+    };
+    TestCase test_cases[] = {{100, 2, true, 1, 2},  {-1, 4, true, 1, 4},  {-10, -2, true, 1, 1},
+                             {0, 4, true, 1, 4},    {0, 0, true, 1, 1},   {2, 10, true, 2, 10},
+                             {2, 10, false, 2, 10}, {3, 10, true, 3, 10}, {3, 11, true, 3, 11}};
+
+    for (const auto& c : test_cases) {
+        config::min_garbage_sweep_interval = c.original_min;
+        config::max_garbage_sweep_interval = c.original_max;
+        ASSERT_EQ(c.expected_changed, calculator.maybe_interval_updated());
+
+        calculator.mutable_disk_usage() = 1000; // Make disk usage large enough to use min_interval as curr_interval.
+        ASSERT_EQ(c.expected_min, calculator.curr_interval());
+        calculator.mutable_disk_usage() = -1; // Make disk usage small enough to use max_interval as curr_interval.
+        ASSERT_EQ(c.expected_max, calculator.curr_interval());
+    }
+}
+
+} // namespace starrocks

--- a/be/test/storage/storage_engine_test.cpp
+++ b/be/test/storage/storage_engine_test.cpp
@@ -42,6 +42,13 @@ PARALLEL_TEST(StorageEngineTest, test_garbage_sweep_interval_calculator) {
         ASSERT_EQ(c.expected_min, calculator.curr_interval());
         calculator.mutable_disk_usage() = -1; // Make disk usage small enough to use max_interval as curr_interval.
         ASSERT_EQ(c.expected_max, calculator.curr_interval());
+
+        for (double usage = -1; usage <= 2.0; usage += 0.1) {
+            calculator.mutable_disk_usage() = usage;
+            int32_t curr = calculator.curr_interval();
+            ASSERT_GE(curr, c.expected_min);
+            ASSERT_LE(curr, c.expected_max);
+        }
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In order to trigger gc stale rowsets in daily case, make `config::{min,max}garbage_sweep_interval` mutable.
In `_garbage_sweeper_thread_callback` thread, check whether they are changed and update interval every 1 second.

BTW, there are some bugs about calculating interval and disk usage.
The disk usage is 1, 1e2, 1e4, etc. after each gc in `_garbage_sweeper_thread_callback`, but it should be in range `[0, 1]`, which causes `curr_interval` is always `min_garbage_sweep_interval` regardless of disk usage.



## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
