### PR TITLE
[Enhancement] Split tablets into small batches to decrease db lock occupation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -1359,7 +1359,11 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
 
         Catalog catalog = Catalog.getCurrentCatalog();
         Map<Pair<Long, Long>, PartitionStat> partitionStats = Maps.newHashMap();
+        long start = System.nanoTime();
+        long lockTotalTime = 0;
+        long lockStart;
         List<Long> dbIds = catalog.getDbIdsIncludeRecycleBin();
+        DATABASE:
         for (Long dbId : dbIds) {
             Database db = catalog.getDbIncludeRecycleBin(dbId);
             if (db == null) {
@@ -1370,8 +1374,13 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                 continue;
             }
 
+            // set the config to a local variable to avoid config params changed.
+            int partitionBatchNum = Config.tablet_checker_partition_batch_num;
+            int partitionChecked = 0;
             db.readLock();
+            lockStart = System.nanoTime();
             try {
+                TABLE:
                 for (Table table : catalog.getTablesIncludeRecycleBin(db)) {
                     // check table is olap table or colocate table
                     if (!table.needSchedule(isLocalBalance)) {
@@ -1380,6 +1389,25 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
 
                     OlapTable olapTbl = (OlapTable) table;
                     for (Partition partition : catalog.getAllPartitionsIncludeRecycleBin(olapTbl)) {
+                        partitionChecked++;
+                        if (partitionChecked % partitionBatchNum == 0) {
+                            lockTotalTime += System.nanoTime() - lockStart;
+                            // release lock, so that lock can be acquired by other threads.
+                            LOG.debug("partition checked reached batch value, release lock");
+                            db.readUnlock();
+                            db.readLock();
+                            LOG.debug("balancer get lock again");
+                            lockStart = System.nanoTime();
+                            if (catalog.getDbIncludeRecycleBin(dbId) == null) {
+                                continue DATABASE;
+                            }
+                            if (catalog.getTableIncludeRecycleBin(db, olapTbl.getId()) == null) {
+                                continue TABLE;
+                            }
+                            if (catalog.getPartitionIncludeRecycleBin(olapTbl, partition.getId()) == null) {
+                                continue;
+                            }
+                        }
                         if (partition.getState() != PartitionState.NORMAL) {
                             // when alter job is in FINISHING state, partition state will be set to NORMAL,
                             // and we can schedule the tablets in it.
@@ -1463,9 +1491,15 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                     }
                 }
             } finally {
+                lockTotalTime += System.nanoTime() - lockStart;
                 db.readUnlock();
             }
         }
+
+        long cost = (System.nanoTime() - start) / 1000000;
+        lockTotalTime = lockTotalTime / 1000000;
+        LOG.info("finished to calculate partition stats. cost: {} ms, in lock time: {} ms",
+                cost, lockTotalTime);
 
         return partitionStats;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -190,15 +190,17 @@ public class TabletChecker extends MasterDaemon {
     }
 
     private void checkTablets() {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         long totalTabletNum = 0;
         long unhealthyTabletNum = 0;
         long addToSchedulerTabletNum = 0;
         long tabletInScheduler = 0;
         long tabletNotReady = 0;
 
+        long lockTotalTime = 0;
+        long lockStart;
         List<Long> dbIds = catalog.getDbIdsIncludeRecycleBin();
-        OUT:
+        DATABASE:
         for (Long dbId : dbIds) {
             Database db = catalog.getDbIncludeRecycleBin(dbId);
             if (db == null) {
@@ -209,9 +211,14 @@ public class TabletChecker extends MasterDaemon {
                 continue;
             }
 
+            // set the config to a local variable to avoid config params changed.
+            int partitionBatchNum = Config.tablet_checker_partition_batch_num;
+            int partitionChecked = 0;
             db.readLock();
+            lockStart = System.nanoTime();
             try {
-                List<Long> aliveBeIdsInCluster = infoService.getClusterBackendIds(db.getClusterName(), true);
+                List<Long> aliveBeIdsInCluster = infoService.getBackendIds(true);
+                TABLE:
                 for (Table table : catalog.getTablesIncludeRecycleBin(db)) {
                     if (!table.needSchedule(false)) {
                         continue;
@@ -219,6 +226,25 @@ public class TabletChecker extends MasterDaemon {
 
                     OlapTable olapTbl = (OlapTable) table;
                     for (Partition partition : catalog.getAllPartitionsIncludeRecycleBin(olapTbl)) {
+                        partitionChecked++;
+                        if (partitionChecked % partitionBatchNum == 0) {
+                            LOG.debug("partition checked reached batch value, release lock");
+                            lockTotalTime += System.nanoTime() - lockStart;
+                            // release lock, so that lock can be acquired by other threads.
+                            db.readUnlock();
+                            db.readLock();
+                            LOG.debug("checker get lock again");
+                            lockStart = System.nanoTime();
+                            if (catalog.getDbIncludeRecycleBin(dbId) == null) {
+                                continue DATABASE;
+                            }
+                            if (catalog.getTableIncludeRecycleBin(db, olapTbl.getId()) == null) {
+                                continue TABLE;
+                            }
+                            if (catalog.getPartitionIncludeRecycleBin(olapTbl, partition.getId()) == null) {
+                                continue;
+                            }
+                        }
                         if (partition.getState() != PartitionState.NORMAL) {
                             // when alter job is in FINISHING state, partition state will be set to NORMAL,
                             // and we can schedule the tablets in it.
@@ -254,7 +280,7 @@ public class TabletChecker extends MasterDaemon {
 
                                 if (statusWithPrio.first == TabletStatus.HEALTHY) {
                                     // Only set last status check time when status is healthy.
-                                    localTablet.setLastStatusCheckTime(start);
+                                    localTablet.setLastStatusCheckTime(System.currentTimeMillis());
                                     continue;
                                 } else if (isInPrios) {
                                     statusWithPrio.second = TabletSchedCtx.Priority.VERY_HIGH;
@@ -282,7 +308,7 @@ public class TabletChecker extends MasterDaemon {
                                 if (res == AddResult.LIMIT_EXCEED) {
                                     LOG.info("number of scheduling tablets in tablet scheduler"
                                             + " exceed to limit. stop tablet checker");
-                                    break OUT;
+                                    break DATABASE;
                                 } else if (res == AddResult.ADDED) {
                                     addToSchedulerTabletNum++;
                                 }
@@ -300,19 +326,24 @@ public class TabletChecker extends MasterDaemon {
                     } // partitions
                 } // tables
             } finally {
+                lockTotalTime += System.nanoTime() - lockStart;
                 db.readUnlock();
             }
         } // end for dbs
 
-        long cost = System.currentTimeMillis() - start;
+        long cost = (System.nanoTime() - start) / 1000000;
+        lockTotalTime = lockTotalTime / 1000000;
 
         stat.counterTabletCheckCostMs.addAndGet(cost);
         stat.counterTabletChecked.addAndGet(totalTabletNum);
         stat.counterUnhealthyTabletNum.addAndGet(unhealthyTabletNum);
         stat.counterTabletAddToBeScheduled.addAndGet(addToSchedulerTabletNum);
 
-        LOG.info("finished to check tablets. unhealth/total/added/in_sched/not_ready: {}/{}/{}/{}/{}, cost: {} ms",
-                unhealthyTabletNum, totalTabletNum, addToSchedulerTabletNum, tabletInScheduler, tabletNotReady, cost);
+        LOG.info("finished to check tablets.  " +
+                        "unhealthy/total/added/in_sched/not_ready: {}/{}/{}/{}/{}, " +
+                        "cost: {} ms, in lock time: {} ms",
+                unhealthyTabletNum, totalTabletNum, addToSchedulerTabletNum,
+                tabletInScheduler, tabletNotReady, cost, lockTotalTime);
     }
 
     private boolean isInPrios(long dbId, long tblId, long partId) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1038,6 +1038,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int max_balancing_tablets = 100;
 
+    /**
+     * After checked tablet_checker_partition_batch_num partitions, db lock will be released,
+     * so that other threads can get the lock.
+     */
+    @ConfField(mutable = true)
+    public static int tablet_checker_partition_batch_num = 500;
+
     @Deprecated
     @ConfField(mutable = true)
     public static int report_queue_size = 100;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13069

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
TabletChecker/ColocateTableBalancer/DiskAndTabletLoadReBalancer scan all tablets to repair or balance tablet, and the db lock is occupied all the check time. If the number of tablet is large, lock conflicts can be frequent, and the writeLock request will have to wait for long time.
Divide all partitions into small batch to check tablets, so that db.readLock can be released between batches.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
