### PR TITLE
[Enhancement] make create mv syntax more friendly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -481,11 +481,15 @@ submitTaskStatement
 createMaterializedViewStatement
     : CREATE MATERIALIZED VIEW (IF NOT EXISTS)? mvName=qualifiedName
     comment?
-    (PARTITION BY primaryExpression)?
-    distributionDesc?
-    refreshSchemeDesc?
-    properties?
+    materializedViewDesc*
     AS queryStatement
+    ;
+
+materializedViewDesc
+    : (PARTITION BY primaryExpression)
+    | distributionDesc
+    | refreshSchemeDesc
+    | properties
     ;
 
 showMaterializedViewStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -427,6 +427,28 @@ public class CreateMaterializedViewTest {
                 ")\n" +
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
         UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        sql = "create materialized view mv1\n" +
+                "distributed by hash(s2) buckets 10\n" +
+                "partition by date_trunc('month',k1)\n" +
+                "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                "') EVERY(INTERVAL 3 DAY)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "as select tb1.k1, k2 s2 from tbl1 tb1;";
+        UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        sql = "create materialized view mv1\n" +
+                "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                "') EVERY(INTERVAL 3 DAY)\n" +
+                "distributed by hash(s2) buckets 10\n" +
+                "partition by date_trunc('month',k1)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "as select tb1.k1, k2 s2 from tbl1 tb1;";
+        UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -248,7 +248,7 @@ public class CreateMaterializedViewTest {
     }
 
     private void dropTableForce(String tableName) throws Exception {
-        String sql = "drop table " + tableName +" force";
+        String sql = "drop table " + tableName + " force";
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statementBase);
         stmtExecutor.execute();
@@ -277,7 +277,7 @@ public class CreateMaterializedViewTest {
         return taskRuns;
     }
 
-    private void waitingRollupJobV2Finish() throws Exception{
+    private void waitingRollupJobV2Finish() throws Exception {
         // waiting alterJobV2 finish
         Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
         //Assert.assertEquals(1, alterJobs.size());
@@ -376,7 +376,7 @@ public class CreateMaterializedViewTest {
         String mvTaskName = TaskBuilder.getMvTaskName(materializedView.getId());
         List<TaskRunStatus> taskRuns = waitingTaskFinish();
         Assert.assertEquals(Constants.TaskRunState.SUCCESS, taskRuns.get(0).getState());
-        Collection<Partition> baseTablePartitions = ((OlapTable) baseTable).getPartitions();
+        Collection<Partition> baseTablePartitions = baseTable.getPartitions();
         Collection<Partition> mvPartitions = materializedView.getPartitions();
         Assert.assertEquals(2, mvPartitions.size());
         Assert.assertEquals(baseTablePartitions.size(), mvPartitions.size());
@@ -412,6 +412,50 @@ public class CreateMaterializedViewTest {
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+    }
+
+    @Test
+    public void testCreateAsyncMVWithDuplicatedProperty() {
+        LocalDateTime startTime = LocalDateTime.now().plusSeconds(3);
+        String sql = "create materialized view mv1\n" +
+                "partition by date_trunc('month',k1)\n" +
+                "partition by date_trunc('month',k1)\n" +
+                "distributed by hash(s2) buckets 10\n" +
+                "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                "') EVERY(INTERVAL 3 DAY)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "as select tb1.k1, k2 s2 from tbl1 tb1;";
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+
+        String sql2 = "create materialized view mv1\n" +
+                "partition by date_trunc('month',k1)\n" +
+                "distributed by hash(s2) buckets 10\n" +
+                "distributed by hash(s2) buckets 10\n" +
+                "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                "') EVERY(INTERVAL 3 DAY)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "as select tb1.k1, k2 s2 from tbl1 tb1;";
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(sql2, connectContext));
+
+        String sql3 = "create materialized view mv1\n" +
+                "partition by date_trunc('month',k1)\n" +
+                "distributed by hash(s2) buckets 10\n" +
+                "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                "') EVERY(INTERVAL 3 DAY)\n" +
+                "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                "') EVERY(INTERVAL 3 DAY)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "as select tb1.k1, k2 s2 from tbl1 tb1;";
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser(sql3, connectContext));
     }
 
     @Test
@@ -475,7 +519,7 @@ public class CreateMaterializedViewTest {
         CreateMaterializedViewStatement createMaterializedViewStatement = (CreateMaterializedViewStatement)
                 UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         RefreshSchemeDesc refreshSchemeDesc = createMaterializedViewStatement.getRefreshSchemeDesc();
-        Assert.assertEquals(MaterializedView.RefreshType.MANUAL,refreshSchemeDesc.getType());
+        Assert.assertEquals(MaterializedView.RefreshType.MANUAL, refreshSchemeDesc.getType());
     }
 
     @Test
@@ -806,7 +850,7 @@ public class CreateMaterializedViewTest {
             CreateMaterializedViewStatement createMaterializedViewStatement =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             ExpressionPartitionDesc partitionExpDesc = createMaterializedViewStatement.getPartitionExpDesc();
-            Assert.assertTrue(!partitionExpDesc.isFunction());
+            Assert.assertFalse(partitionExpDesc.isFunction());
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof SlotRef);
             Assert.assertEquals(partitionExpDesc.getExpr(), partitionExpDesc.getSlotRef());
             Assert.assertEquals("k1", partitionExpDesc.getSlotRef().getColumnName());
@@ -1430,7 +1474,8 @@ public class CreateMaterializedViewTest {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql2, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
         } catch (Exception e) {
-            Assert.assertEquals("Create materialized view from inactive materialized view: base_inactive_mv", e.getMessage());
+            Assert.assertEquals("Create materialized view from inactive materialized view: base_inactive_mv",
+                    e.getMessage());
         }
     }
 
@@ -1505,9 +1550,10 @@ public class CreateMaterializedViewTest {
                     "not supported nondeterministic function", e.getMessage());
         }
     }
+
     // ========== test colocate mv ==========
     @Test
-    public void testCreateColocateMvNormal() throws Exception{
+    public void testCreateColocateMvNormal() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.colocateTable\n" +
                 "(\n" +
                 "    k1 int,\n" +
@@ -1529,19 +1575,19 @@ public class CreateMaterializedViewTest {
             currentState.createMaterializedView((CreateMaterializedViewStmt) statementBase);
             waitingRollupJobV2Finish();
             ColocateTableIndex colocateTableIndex = currentState.getColocateTableIndex();
-            String fullGroupName = testDb.getId() +"_" + testDb.getFullName() +":" + "colocateMv";
+            String fullGroupName = testDb.getId() + "_" + testDb.getFullName() + ":" + "colocateMv";
             System.out.println(fullGroupName);
             long tableId = colocateTableIndex.getTableIdByGroup(fullGroupName);
-            Assert.assertNotEquals(-1,tableId);
+            Assert.assertNotEquals(-1, tableId);
 
             OlapTable table = (OlapTable) testDb.getTable("colocateTable");
-            Assert.assertEquals(1,table.getColocateMaterializedViewNames().size());
+            Assert.assertEquals(1, table.getColocateMaterializedViewNames().size());
             ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(tableId);
-            Assert.assertEquals(1,colocateTableIndex.getAllTableIds(groupId).size());
+            Assert.assertEquals(1, colocateTableIndex.getAllTableIds(groupId).size());
 
             dropMv("colocateMv");
             Assert.assertFalse(currentState.getColocateTableIndex().isColocateTable(tableId));
-            Assert.assertEquals(0,table.getColocateMaterializedViewNames().size());
+            Assert.assertEquals(0, table.getColocateMaterializedViewNames().size());
 
         } catch (Exception e) {
             Assert.fail(e.getMessage());
@@ -1551,7 +1597,7 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testCreateColocateMvToExitGroup() throws Exception{
+    public void testCreateColocateMvToExitGroup() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.colocateTable2\n" +
                 "(\n" +
                 "    k1 int,\n" +
@@ -1577,16 +1623,16 @@ public class CreateMaterializedViewTest {
             ColocateTableIndex colocateTableIndex = currentState.getColocateTableIndex();
             String fullGroupName = testDb.getId() + "_" + "group2";
             long tableId = colocateTableIndex.getTableIdByGroup(fullGroupName);
-            Assert.assertNotEquals(-1,tableId);
+            Assert.assertNotEquals(-1, tableId);
 
             OlapTable table = (OlapTable) testDb.getTable("colocateTable2");
-            Assert.assertEquals(1,table.getColocateMaterializedViewNames().size());
+            Assert.assertEquals(1, table.getColocateMaterializedViewNames().size());
             ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(tableId);
-            Assert.assertEquals(1,colocateTableIndex.getAllTableIds(groupId).size());
+            Assert.assertEquals(1, colocateTableIndex.getAllTableIds(groupId).size());
 
             dropMv("colocateMv2");
             Assert.assertTrue(currentState.getColocateTableIndex().isColocateTable(tableId));
-            Assert.assertEquals(0,table.getColocateMaterializedViewNames().size());
+            Assert.assertEquals(0, table.getColocateMaterializedViewNames().size());
 
         } catch (Exception e) {
             Assert.fail(e.getMessage());
@@ -1597,7 +1643,7 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testColocateMvAlterGroup() throws Exception{
+    public void testColocateMvAlterGroup() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.colocateTable3\n" +
                 "(\n" +
                 "    k1 int,\n" +
@@ -1624,7 +1670,7 @@ public class CreateMaterializedViewTest {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStmt) statementBase);
             waitingRollupJobV2Finish();
-            statementBase = UtFrameUtils.parseStmtWithNewParser(sql2,connectContext);
+            statementBase = UtFrameUtils.parseStmtWithNewParser(sql2, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStmt) statementBase);
             waitingRollupJobV2Finish();
 
@@ -1632,21 +1678,21 @@ public class CreateMaterializedViewTest {
             String fullGroupName = testDb.getId() + "_" + "group3";
             System.out.println(fullGroupName);
             long tableId = colocateTableIndex.getTableIdByGroup(fullGroupName);
-            Assert.assertNotEquals(-1,tableId);
+            Assert.assertNotEquals(-1, tableId);
 
             OlapTable table = (OlapTable) testDb.getTable("colocateTable3");
             Assert.assertFalse(table.isInColocateMvGroup());
-            Assert.assertEquals(2,table.getColocateMaterializedViewNames().size());
+            Assert.assertEquals(2, table.getColocateMaterializedViewNames().size());
             ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(tableId);
-            Assert.assertEquals(1,colocateTableIndex.getAllTableIds(groupId).size());
+            Assert.assertEquals(1, colocateTableIndex.getAllTableIds(groupId).size());
 
             sql = "alter table colocateTable3 set (\"colocate_with\" = \"groupNew\")";
             statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statementBase);
             stmtExecutor.execute();
 
-            Assert.assertEquals(2,table.getColocateMaterializedViewNames().size());
-            Assert.assertEquals("groupNew",table.getColocateGroup());
+            Assert.assertEquals(2, table.getColocateMaterializedViewNames().size());
+            Assert.assertEquals("groupNew", table.getColocateGroup());
             Assert.assertFalse(table.isInColocateMvGroup());
             Assert.assertTrue(colocateTableIndex.isColocateTable(tableId));
 
@@ -1658,10 +1704,10 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(colocateTableIndex.isColocateTable(tableId));
             Assert.assertTrue(table.isInColocateMvGroup());
             groupId = colocateTableIndex.getGroup(tableId);
-            Assert.assertNotEquals("group1",table.getColocateGroup());
+            Assert.assertNotEquals("group1", table.getColocateGroup());
 
             dropMv("colocateMv4");
-            Assert.assertEquals(1,table.getColocateMaterializedViewNames().size());
+            Assert.assertEquals(1, table.getColocateMaterializedViewNames().size());
             dropMv("colocateMv3");
             Assert.assertFalse(colocateTableIndex.isColocateTable(tableId));
 
@@ -2135,7 +2181,8 @@ public class CreateMaterializedViewTest {
         try {
             starRocksAssert.withMaterializedView(sql);
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Materialized view query statement only support direct query from table"));
+            Assert.assertTrue(
+                    e.getMessage().contains("Materialized view query statement only support direct query from table"));
         }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Behavior change:
- Allow description of create MV in arbitrary order
- The `partition by` clause, `distributed by` clause, `refresh` clause, `properties` clause could written in arbitrary order


Example:
```sql
create materialized view mv1
    partition by date_trunc('month', k1)
    distributed by hash(s2) buckets 10
    refresh async EVERY(INTERVAL 3 DAY)
    properties ("replication_num" = "1")
    AS select tb1.k1, k2 s2 from tbl1;
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
