### PR TITLE
[BugFix] Remove access null pointer dereference

### DIFF
--- a/be/src/types/hll.cpp
+++ b/be/src/types/hll.cpp
@@ -42,10 +42,9 @@ using std::stringstream;
 namespace starrocks {
 
 std::string HyperLogLog::empty() {
-    static HyperLogLog hll;
     std::string buf;
     buf.resize(HLL_EMPTY_SIZE);
-    hll.serialize((uint8_t*)buf.c_str());
+    (*(uint8_t*)buf.c_str()) = HLL_DATA_EMPTY;
     return buf;
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Remove 
```
Array access (via field 'data') results in a null pointer dereference
```
report by sonar. Caused by serialize with HLL_DATA_FULL.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
