### PR TITLE
[Feature] Support CTE for update and delete statements

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -83,6 +83,9 @@ public class UpdateAnalyzer {
         }
         SelectRelation selectRelation =
                 new SelectRelation(selectList, relation, updateStmt.getWherePredicate(), null, null);
+        if (updateStmt.getCommonTableExpressions() != null) {
+            updateStmt.getCommonTableExpressions().forEach(selectRelation::addCTERelation);
+        }
         QueryStatement queryStatement = new QueryStatement(selectRelation);
         queryStatement.setIsExplain(updateStmt.isExplain(), updateStmt.getExplainLevel());
         new QueryAnalyzer(session).analyze(queryStatement);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DeleteStmt.java
@@ -34,6 +34,7 @@ public class DeleteStmt extends DmlStmt {
     private final PartitionNames partitionNames;
     private final List<Relation> usingRelations;
     private final Expr wherePredicate;
+    private final List<CTERelation> commonTableExpressions;
 
     // fields for new planer, primary key table
     private Table table;
@@ -46,14 +47,16 @@ public class DeleteStmt extends DmlStmt {
     private long jobId = -1;
 
     public DeleteStmt(TableName tableName, PartitionNames partitionNames, Expr wherePredicate) {
-        this(tableName, partitionNames, null, wherePredicate);
+        this(tableName, partitionNames, null, wherePredicate, null);
     }
 
-    public DeleteStmt(TableName tableName, PartitionNames partitionNames, List<Relation> usingRelations, Expr wherePredicate) {
+    public DeleteStmt(TableName tableName, PartitionNames partitionNames, List<Relation> usingRelations, Expr wherePredicate,
+                      List<CTERelation> commonTableExpressions) {
         this.tblName = tableName;
         this.partitionNames = partitionNames;
         this.usingRelations = usingRelations;
         this.wherePredicate = wherePredicate;
+        this.commonTableExpressions = commonTableExpressions;
         this.deleteConditions = Lists.newLinkedList();
     }
 
@@ -72,6 +75,10 @@ public class DeleteStmt extends DmlStmt {
 
     public Expr getWherePredicate() {
         return wherePredicate;
+    }
+
+    public List<CTERelation> getCommonTableExpressions() {
+        return commonTableExpressions;
     }
 
     public List<String> getPartitionNamesList() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
@@ -12,16 +12,18 @@ public class UpdateStmt extends DmlStmt {
     private final List<ColumnAssignment> assignments;
     private final List<Relation> fromRelations;
     private final Expr wherePredicate;
+    private final List<CTERelation> commonTableExpressions;
 
     private Table table;
     private QueryStatement queryStatement;
 
     public UpdateStmt(TableName tableName, List<ColumnAssignment> assignments, List<Relation> fromRelations,
-                      Expr wherePredicate) {
+                      Expr wherePredicate, List<CTERelation> commonTableExpressions) {
         this.tableName = tableName;
         this.assignments = assignments;
         this.fromRelations = fromRelations;
         this.wherePredicate = wherePredicate;
+        this.commonTableExpressions = commonTableExpressions;
     }
 
     @Override
@@ -39,6 +41,10 @@ public class UpdateStmt extends DmlStmt {
 
     public Expr getWherePredicate() {
         return wherePredicate;
+    }
+
+    public List<CTERelation> getCommonTableExpressions() {
+        return commonTableExpressions;
     }
 
     public void setTable(Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1326,7 +1326,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
         }
         Expr where = context.where != null ? (Expr) visit(context.where) : null;
-        UpdateStmt ret = new UpdateStmt(targetTableName, assignments, fromRelations, where);
+        List<CTERelation> ctes = null;
+        if (context.withClause() != null) {
+            ctes = visit(context.withClause().commonTableExpression(), CTERelation.class);
+        }
+        UpdateStmt ret = new UpdateStmt(targetTableName, assignments, fromRelations, where, ctes);
         if (context.explainDesc() != null) {
             ret.setIsExplain(true, getExplainType(context.explainDesc()));
         }
@@ -1343,7 +1347,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
         List<Relation> usingRelations = context.using != null ? visit(context.using.relation(), Relation.class) : null;
         Expr where = context.where != null ? (Expr) visit(context.where) : null;
-        DeleteStmt ret = new DeleteStmt(targetTableName, partitionNames, usingRelations, where);
+        List<CTERelation> ctes = null;
+        if (context.withClause() != null) {
+            ctes = visit(context.withClause().commonTableExpression(), CTERelation.class);
+        }
+        DeleteStmt ret = new DeleteStmt(targetTableName, partitionNames, usingRelations, where, ctes);
         if (context.explainDesc() != null) {
             ret.setIsExplain(true, getExplainType(context.explainDesc()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -751,11 +751,11 @@ insertStatement
     ;
 
 updateStatement
-    : explainDesc? UPDATE qualifiedName SET assignmentList fromClause (WHERE where=expression)?
+    : explainDesc? withClause? UPDATE qualifiedName SET assignmentList fromClause (WHERE where=expression)?
     ;
 
 deleteStatement
-    : explainDesc? DELETE FROM qualifiedName partitionNames? (USING using=relations)? (WHERE where=expression)?
+    : explainDesc? withClause? DELETE FROM qualifiedName partitionNames? (USING using=relations)? (WHERE where=expression)?
     ;
 
 // ------------------------------------------- Routine Statement -----------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
@@ -88,4 +88,11 @@ public class AnalyzeDeleteTest {
                 "delete from tprimary using tprimary2 tp2 join t0 where tprimary.pk = tp2.pk " +
                         "and tp2.pk = t0.v1 and t0.v2 > 0");
     }
+
+    @Test
+    public void testCTE() {
+        analyzeSuccess(
+                "with tp2cte as (select * from tprimary2 where v2 < 10) delete from tprimary using " +
+                        "tp2cte where tprimary.pk = tp2cte.pk");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUpdateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUpdateTest.java
@@ -55,4 +55,11 @@ public class AnalyzeUpdateTest {
                 "update tprimary set v2 = tp2.v2 from tprimary2 tp2 join t0 where tprimary.pk = tp2.pk " +
                         "and tp2.pk = t0.v1 and t0.v2 > 0");
     }
+
+    @Test
+    public void testCTE() {
+        analyzeSuccess(
+                "with tp2cte as (select * from tprimary2 where v2 < 10) update tprimary set v2 = tp2cte.v2 " +
+                        "from tp2cte where tprimary.pk = tp2cte.pk");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13879

## Problem Summary(Required) ：
Support CTE for update and delete statements, like:

```
WITH acme_accounts as (SELECT * from accounts where WHERE accounts.name = 'Acme Corporation')
UPDATE employees SET sales_count = sales_count + 1 FROM acme_accounts 
WHERE employees.id = acme_accounts.sales_person;

WITH foo_producers as (SELECT * from producers where producers.name = 'foo')
DELETE FROM films USING foo_producers
  WHERE producer_id = foo_producers.id;
```

Example:
```
mysql> create table t0 (pk bigint NOT NULL, v0 string not null, v1 int not null) primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
Query OK, 0 rows affected (0.06 sec)

mysql> insert into t0 values (1,"1", 1), (2,"2",2), (3,"3",3);
Query OK, 3 rows affected (0.27 sec)
{'label':'insert_49448e70-6c70-11ed-9c75-0242db56f0f5', 'status':'VISIBLE', 'txnId':'1002'}

mysql> 
mysql> create table t1 (pk bigint NOT NULL, v0 string not null, v1 int not null) primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
Query OK, 0 rows affected (0.02 sec)

mysql> insert into t1 values (2,"21", 21);
Query OK, 1 row affected (0.04 sec)
{'label':'insert_4970a782-6c70-11ed-9c75-0242db56f0f5', 'status':'VISIBLE', 'txnId':'1003'}

mysql> with t1w as (select * from t1 where v1=21) update t0 set v1=t1w.v1 from t1w where t0.pk = t1w.pk; 
Query OK, 1 row affected (0.16 sec)
{'label':'update_4d41acb3-6c70-11ed-9c75-0242db56f0f5', 'status':'VISIBLE', 'txnId':'1004'}

mysql> explain with t1w as (select * from t1 where v1=21) update t0 set v1=t1w.v1 from t1w where t0.pk = t1w.pk;
+--------------------------------------------+
| Explain String                             |
+--------------------------------------------+
| PLAN FRAGMENT 0                            |
|  OUTPUT EXPRS:4: pk | 5: v0 | 9: v1        |
|   PARTITION: RANDOM                        |
|                                            |
|   OLAP TABLE SINK                          |
|     TABLE: t0                              |
|     TUPLE ID: 3                            |
|     RANDOM                                 |
|                                            |
|   4:Project                                |
|   |  <slot 4> : 4: pk                      |
|   |  <slot 5> : 5: v0                      |
|   |  <slot 9> : 9: v1                      |
|   |                                        |
|   3:HASH JOIN                              |
|   |  join op: INNER JOIN (BUCKET_SHUFFLE)  |
|   |  colocate: false, reason:              |
|   |  equal join conjunct: 4: pk = 7: pk    |
|   |                                        |
|   |----2:EXCHANGE                          |
|   |                                        |
|   0:OlapScanNode                           |
|      TABLE: t0                             |
|      PREAGGREGATION: ON                    |
|      partitions=1/1                        |
|      rollup: t0                            |
|      tabletRatio=1/1                       |
|      tabletList=11004                      |
|      cardinality=1                         |
|      avgRowSize=2.0                        |
|      numNodes=0                            |
|                                            |
| PLAN FRAGMENT 1                            |
|  OUTPUT EXPRS:                             |
|   PARTITION: RANDOM                        |
|                                            |
|   STREAM DATA SINK                         |
|     EXCHANGE ID: 02                        |
|     BUCKET_SHUFFLE_HASH_PARTITIONED: 7: pk |
|                                            |
|   1:OlapScanNode                           |
|      TABLE: t1                             |
|      PREAGGREGATION: ON                    |
|      PREDICATES: 9: v1 = 21                |
|      partitions=1/1                        |
|      rollup: t1                            |
|      tabletRatio=1/1                       |
|      tabletList=11010                      |
|      cardinality=1                         |
|      avgRowSize=2.0                        |
|      numNodes=0                            |
+--------------------------------------------+
51 rows in set (0.01 sec)

mysql> explain with t1w as (select * from t1 where v1=21) delete from t0 using t1w where t0.pk = t1w.pk; 
+--------------------------------------------+
| Explain String                             |
+--------------------------------------------+
| PLAN FRAGMENT 0                            |
|  OUTPUT EXPRS:4: pk | 10: expr             |
|   PARTITION: RANDOM                        |
|                                            |
|   OLAP TABLE SINK                          |
|     TABLE: t0                              |
|     TUPLE ID: 4                            |
|     RANDOM                                 |
|                                            |
|   5:Project                                |
|   |  <slot 4> : 4: pk                      |
|   |  <slot 10> : 1                         |
|   |                                        |
|   4:HASH JOIN                              |
|   |  join op: INNER JOIN (BUCKET_SHUFFLE)  |
|   |  colocate: false, reason:              |
|   |  equal join conjunct: 4: pk = 7: pk    |
|   |                                        |
|   |----3:EXCHANGE                          |
|   |                                        |
|   0:OlapScanNode                           |
|      TABLE: t0                             |
|      PREAGGREGATION: ON                    |
|      partitions=1/1                        |
|      rollup: t0                            |
|      tabletRatio=1/1                       |
|      tabletList=11004                      |
|      cardinality=1                         |
|      avgRowSize=1.0                        |
|      numNodes=0                            |
|                                            |
| PLAN FRAGMENT 1                            |
|  OUTPUT EXPRS:                             |
|   PARTITION: RANDOM                        |
|                                            |
|   STREAM DATA SINK                         |
|     EXCHANGE ID: 03                        |
|     BUCKET_SHUFFLE_HASH_PARTITIONED: 7: pk |
|                                            |
|   2:Project                                |
|   |  <slot 7> : 7: pk                      |
|   |                                        |
|   1:OlapScanNode                           |
|      TABLE: t1                             |
|      PREAGGREGATION: ON                    |
|      PREDICATES: 9: v1 = 21                |
|      partitions=1/1                        |
|      rollup: t1                            |
|      tabletRatio=1/1                       |
|      tabletList=11010                      |
|      cardinality=1                         |
|      avgRowSize=2.0                        |
|      numNodes=0                            |
+--------------------------------------------+
53 rows in set (0.02 sec)

mysql> with t1w as (select * from t1 where v1=21) delete from t0 using t1w where t0.pk = t1w.pk;
Query OK, 1 row affected (0.07 sec)
{'label':'delete_8e3db8d8-6c70-11ed-9c75-0242db56f0f5', 'status':'VISIBLE', 'txnId':'1005'}

mysql> select * from t0;
+------+------+------+
| pk   | v0   | v1   |
+------+------+------+
|    1 | 1    |    1 |
|    3 | 3    |    3 |
+------+------+------+
2 rows in set (0.01 sec)

```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
