### PR TITLE
[Enhancement] set exception_stack_level and white/black lists

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -893,6 +893,6 @@ CONF_mInt64(send_channel_buffer_limit, "67108864");
 // other value means the default value
 CONF_Int32(exception_stack_level, "1");
 CONF_String(exception_stack_white_list, "std::");
-CONF_String(exception_stack_black_list, "apache::thrift::,ue2::");
+CONF_String(exception_stack_black_list, "apache::thrift::,ue2::,arangodb::");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -884,4 +884,17 @@ CONF_Int64(query_cache_capacity, "536870912");
 
 // Used to limit buffer size of tablet send channel.
 CONF_mInt64(send_channel_buffer_limit, "67108864");
+
+// exception_stack_level controls when to print exception's stack
+// -1, enable print all exceptions' stack
+// 0, disable print exceptions' stack
+// 1, print the white list's exceptions' stack (default)
+// 2, print all exceptions' stack that is not in black_lists
+// other value means the default value
+CONF_Int32(exception_stack_level, "1");
+CONF_String(exception_stack_white_list,
+            "bad_alloc,runtime_error,logic_error,length_error,out_of_range,range_error,overflow_error,bad_typeid,bad_"
+            "cast,system_error");
+CONF_String(exception_stack_black_list, "apache::thrift::,ue2::");
+
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -892,9 +892,7 @@ CONF_mInt64(send_channel_buffer_limit, "67108864");
 // 2, print all exceptions' stack that is not in black_lists
 // other value means the default value
 CONF_Int32(exception_stack_level, "1");
-CONF_String(exception_stack_white_list,
-            "bad_alloc,runtime_error,logic_error,length_error,out_of_range,range_error,overflow_error,bad_typeid,bad_"
-            "cast,system_error");
+CONF_String(exception_stack_white_list, "std::");
 CONF_String(exception_stack_black_list, "apache::thrift::,ue2::");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -888,8 +888,8 @@ CONF_mInt64(send_channel_buffer_limit, "67108864");
 // exception_stack_level controls when to print exception's stack
 // -1, enable print all exceptions' stack
 // 0, disable print exceptions' stack
-// 1, print the white list's exceptions' stack (default)
-// 2, print all exceptions' stack that is not in black_lists
+// 1, print exceptions' stack whose prefix is in the white list(default)
+// 2, print exceptions' stack whose prefix is not in the black list
 // other value means the default value
 CONF_Int32(exception_stack_level, "1");
 CONF_String(exception_stack_white_list, "std::");

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -88,6 +88,7 @@ public:
 private:
     ExceptionStackContext() {
         _level = starrocks::config::exception_stack_level;
+        // other values mean the default value.
         if (_level < -1 || _level > 2) {
             _level = 1;
         }

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -20,8 +20,10 @@
 #include <cxxabi.h>
 #include <fmt/format.h>
 
-#include <string>
+#include <exception>
 
+#include "common/config.h"
+#include "gutil/strings/split.h"
 #include "runtime/current_thread.h"
 #include "util/time.h"
 
@@ -37,45 +39,98 @@ std::string get_stack_trace() {
     return s;
 }
 
-// as exception' name is not large, so we can think there are no exceptions.
-std::string get_exception_name(const void* info) {
-    auto* exception_info = (std::type_info*)info;
-    int demangle_status;
-    char* demangled_exception_name;
-    std::string exception_name = "unknown";
-    if (exception_info != nullptr) {
-        // Demangle the name of the exception using the GNU C++ ABI:
-        demangled_exception_name = abi::__cxa_demangle(exception_info->name(), nullptr, nullptr, &demangle_status);
-        if (demangled_exception_name != nullptr) {
-            exception_name = std::string(demangled_exception_name);
-            // Free the memory from __cxa_demangle():
-            free(demangled_exception_name);
-        } else {
-            // NOTE: if the demangle fails, we do nothing, so the
-            // non-demangled name will be printed. That's ok.
-            exception_name = std::string(exception_info->name());
+class ExceptionStackContext {
+public:
+    static ExceptionStackContext* get_instance() {
+        static ExceptionStackContext context;
+        return &context;
+    }
+    // as exception' name is not large, so we can think there are no exceptions.
+    static std::string get_exception_name(const void* info) {
+        auto* exception_info = (std::type_info*)info;
+        int demangle_status;
+        char* demangled_exception_name;
+        std::string exception_name = "unknown";
+        if (exception_info != nullptr) {
+            // Demangle the name of the exception using the GNU C++ ABI:
+            demangled_exception_name = abi::__cxa_demangle(exception_info->name(), nullptr, nullptr, &demangle_status);
+            if (demangled_exception_name != nullptr) {
+                exception_name = std::string(demangled_exception_name);
+                // Free the memory from __cxa_demangle():
+                free(demangled_exception_name);
+            } else {
+                // NOTE: if the demangle fails, we do nothing, so the
+                // non-demangled name will be printed. That's ok.
+                exception_name = std::string(exception_info->name());
+            }
+        }
+        return exception_name;
+    }
+    bool in_black_list(const string& exception) {
+        for (auto const& str : _black_list) {
+            if (exception.find(str) != exception.npos) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool in_white_list(const string& exception) {
+        for (auto const& str : _white_list) {
+            if (exception.find(str) != exception.npos) {
+                return true;
+            }
+        }
+        return false;
+    }
+    int get_level() { return _level; }
+
+private:
+    ExceptionStackContext() {
+        _level = starrocks::config::exception_stack_level;
+        if (_level < -1 || _level > 2) {
+            _level = 1;
+        }
+        _white_list = strings::Split(starrocks::config::exception_stack_white_list, ",");
+        _black_list = strings::Split(starrocks::config::exception_stack_black_list, ",");
+    }
+    ~ExceptionStackContext() = default;
+    std::vector<string> _white_list;
+    std::vector<string> _black_list;
+    int _level;
+};
+
+// wrap libc's _cxa_throw that must not throw exceptions again, otherwise causing crash.
+#ifdef __clang__
+void __wrap___cxa_throw(void* thrown_exception, std::type_info* info, void (*dest)(void*)) {
+#elif defined(__GNUC__)
+void __wrap___cxa_throw(void* thrown_exception, void* info, void (*dest)(void*)) {
+#endif
+    auto print_level = ExceptionStackContext::get_instance()->get_level();
+    if (print_level != 0) {
+        string exception_name = ExceptionStackContext::get_exception_name((void*)info);
+        if ((print_level == 1 && ExceptionStackContext::get_instance()->in_white_list(exception_name)) ||
+            print_level == -1 ||
+            (print_level == 2 && !ExceptionStackContext::get_instance()->in_black_list(exception_name))) {
+            auto query_id = CurrentThread::current().query_id();
+            auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
+            auto stack = fmt::format("{}, query_id={}, fragment_instance_id={} throws exception: {}, trace:\n {} \n",
+                                     ToStringFromUnixMicros(GetCurrentTimeMicros()).c_str(), print_id(query_id).c_str(),
+                                     print_id(fragment_instance_id).c_str(), exception_name.c_str(),
+                                     get_stack_trace().c_str());
+#ifdef BE_TEST
+            // tests check message from stderr.
+            std::cerr << stack << std::endl;
+#endif
+            LOG(WARNING) << stack;
         }
     }
-    return exception_name;
-}
-
-#if defined(__GNUC__)
-// wrap libc's _cxa_throw that must not throw exceptions again, otherwise causing crash.
-void __wrap___cxa_throw(void* thrown_exception, void* info, void (*dest)(void*)) {
-    auto query_id = CurrentThread::current().query_id();
-    auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
-    auto stack = fmt::format("{}, query_id={}, fragment_instance_id={} throws exception: {}, trace:\n {} \n",
-                             ToStringFromUnixMicros(GetCurrentTimeMicros()).c_str(), print_id(query_id).c_str(),
-                             print_id(fragment_instance_id).c_str(), get_exception_name(info).c_str(),
-                             get_stack_trace().c_str());
-#ifdef BE_TEST
-    // tests check message from stderr.
-    std::cerr << stack << std::endl;
-#endif
-    LOG(WARNING) << stack;
-
     // call the real __cxa_throw():
+#ifdef __clang__
     __real___cxa_throw(thrown_exception, info, dest);
-}
+#elif defined(__GNUC__)
+    __real___cxa_throw(thrown_exception, info, dest);
 #endif
+}
+
 } // namespace starrocks

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -66,18 +66,18 @@ public:
         }
         return exception_name;
     }
-    bool in_black_list(const string& exception) {
+    bool prefix_in_black_list(const string& exception) {
         for (auto const& str : _black_list) {
-            if (exception.find(str) != exception.npos) {
+            if (exception.rfind(str, 0) == 0) {
                 return true;
             }
         }
         return false;
     }
 
-    bool in_white_list(const string& exception) {
+    bool prefix_in_white_list(const string& exception) {
         for (auto const& str : _white_list) {
-            if (exception.find(str) != exception.npos) {
+            if (exception.rfind(str, 0) == 0) {
                 return true;
             }
         }
@@ -110,9 +110,9 @@ void __wrap___cxa_throw(void* thrown_exception, void* info, void (*dest)(void*))
     auto print_level = ExceptionStackContext::get_instance()->get_level();
     if (print_level != 0) {
         string exception_name = ExceptionStackContext::get_exception_name((void*)info);
-        if ((print_level == 1 && ExceptionStackContext::get_instance()->in_white_list(exception_name)) ||
+        if ((print_level == 1 && ExceptionStackContext::get_instance()->prefix_in_white_list(exception_name)) ||
             print_level == -1 ||
-            (print_level == 2 && !ExceptionStackContext::get_instance()->in_black_list(exception_name))) {
+            (print_level == 2 && !ExceptionStackContext::get_instance()->prefix_in_black_list(exception_name))) {
             auto query_id = CurrentThread::current().query_id();
             auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
             auto stack = fmt::format("{}, query_id={}, fragment_instance_id={} throws exception: {}, trace:\n {} \n",

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -30,10 +30,12 @@ std::string get_stack_trace();
 extern "C" {
 #ifdef __clang__
 void __real___cxa_throw(void* thrown_exception, std::type_info* info, void (*dest)(void*));
-void __wrap___cxa_throw(void* thrown_exception, std::type_info* info, void (*dest)(void*));
+__attribute__((no_sanitize("address"))) void __wrap___cxa_throw(void* thrown_exception, std::type_info* info,
+                                                                void (*dest)(void*));
 #elif defined(__GNUC__)
 void __real___cxa_throw(void* thrown_exception, void* infov, void (*dest)(void*));
-void __wrap___cxa_throw(void* thrown_exception, void* infov, void (*dest)(void*));
+__attribute__((no_sanitize("address"))) void __wrap___cxa_throw(void* thrown_exception, void* infov,
+                                                                void (*dest)(void*));
 #endif
 }
 

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -26,13 +26,15 @@ namespace starrocks {
 // for recursive calls.
 std::string get_stack_trace();
 
-#if defined(__GNUC__)
 // wrap libc's _cxa_throw to print stack trace of exceptions
 extern "C" {
+#ifdef __clang__
+void __real___cxa_throw(void* thrown_exception, std::type_info* info, void (*dest)(void*));
+void __wrap___cxa_throw(void* thrown_exception, std::type_info* info, void (*dest)(void*));
+#elif defined(__GNUC__)
 void __real___cxa_throw(void* thrown_exception, void* infov, void (*dest)(void*));
-
 void __wrap___cxa_throw(void* thrown_exception, void* infov, void (*dest)(void*));
-}
 #endif
+}
 
 } // namespace starrocks


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/StarRocksTest/issues/1495

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add `exception_stack_level` to control when to print exception's stack
1. -1, enable print all exceptions' stack
2. 0, disable print exceptions' stack
3. 1, print the white list's exceptions' stack (default)
4.  2, print all exceptions' stack that is not in black_lists
5.  other value means the default value

### results
```
mysql> select get_json_int('{"a": "str"}', '$.a');
+-------------------------------------+
| get_json_int('{"a": "str"}', '$.a') |
+-------------------------------------+
|                                NULL |
+-------------------------------------+
```
default parameters (unit: ns)
```
print exception stack cost time = 4779
print exception stack cost time = 5143
print exception stack cost time = 4650
print exception stack cost time = 4107
print exception stack cost time = 3230
print exception stack cost time = 3287
print exception stack cost time = 3515
print exception stack cost time = 6829
print exception stack cost time = 6565
print exception stack cost time = 8008
print exception stack cost time = 6212
print exception stack cost time = 5614
print exception stack cost time = 5532
print exception stack cost time = 6493
print exception stack cost time = 6325
```
-1 (print all stack) (unit: ns)

```
print exception stack cost time = 57949400
print exception stack cost time = 56149434
print exception stack cost time = 56165425
print exception stack cost time = 57021296
print exception stack cost time = 56560388
print exception stack cost time = 56647435
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
