### PR TITLE
[Enhancement] support dynamic change max thread num of thread pool

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -306,7 +306,7 @@ CONF_Int32(cumulative_compaction_num_threads_per_disk, "1");
 // CONF_Int32(cumulative_compaction_write_mbytes_per_sec, "100");
 
 CONF_mInt32(update_compaction_check_interval_seconds, "60");
-CONF_Int32(update_compaction_num_threads_per_disk, "1");
+CONF_mInt32(update_compaction_num_threads_per_disk, "1");
 CONF_Int32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min
 CONF_mInt64(max_update_compaction_num_singleton_deltas, "1000");
 
@@ -324,7 +324,7 @@ CONF_mInt64(min_cmumulative_compaction_failure_interval_sec, "30"); // 30s
 //      C = (cumulative_compaction_num_threads_per_disk + base_compaction_num_threads_per_disk) * dir_num
 // set it to larger than C will be set to equal to C.
 // This config can be set to 0, which means to forbid any compaction, for some special cases.
-CONF_Int32(max_compaction_concurrency, "-1");
+CONF_mInt32(max_compaction_concurrency, "-1");
 
 // Threshold to logging compaction trace, in seconds.
 CONF_mInt32(compaction_trace_threshold, "60");
@@ -592,7 +592,7 @@ CONF_mInt32(storage_flood_stage_usage_percent, "95"); // 95%
 // The min bytes that should be left of a data dir
 CONF_mInt64(storage_flood_stage_left_capacity_bytes, "1073741824"); // 1GB
 // Number of thread for flushing memtable per store.
-CONF_Int32(flush_thread_num_per_store, "2");
+CONF_mInt32(flush_thread_num_per_store, "2");
 
 // Config for tablet meta checkpoint.
 CONF_mInt32(tablet_meta_checkpoint_min_new_rowsets_num, "10");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -49,7 +49,12 @@
 #include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/http_status.h"
+#include "storage/compaction_manager.h"
+#include "storage/memtable_flush_executor.h"
 #include "storage/page_cache.h"
+#include "storage/segment_flush_executor.h"
+#include "storage/segment_replicate_executor.h"
+#include "storage/storage_engine.h"
 #include "util/priority_thread_pool.hpp"
 
 namespace starrocks {
@@ -68,6 +73,22 @@ void UpdateConfigAction::handle(HttpRequest* req) {
             int64_t cache_limit = _exec_env->get_storage_page_cache_size();
             cache_limit = _exec_env->check_storage_page_cache_size(cache_limit);
             StoragePageCache::instance()->set_capacity(cache_limit);
+        });
+        _config_callback.emplace("max_compaction_concurrency", [&]() {
+            StorageEngine::instance()->compaction_manager()->update_max_threads(config::max_compaction_concurrency);
+        });
+        _config_callback.emplace("flush_thread_num_per_store", [&]() {
+            const size_t dir_cnt = StorageEngine::instance()->get_stores().size();
+            StorageEngine::instance()->memtable_flush_executor()->update_max_threads(
+                    config::flush_thread_num_per_store * dir_cnt);
+            StorageEngine::instance()->segment_replicate_executor()->update_max_threads(
+                    config::flush_thread_num_per_store * dir_cnt);
+            StorageEngine::instance()->segment_flush_executor()->update_max_threads(config::flush_thread_num_per_store *
+                                                                                    dir_cnt);
+        });
+        _config_callback.emplace("update_compaction_num_threads_per_disk", [&]() {
+            StorageEngine::instance()->increase_update_compaction_thread(
+                    config::update_compaction_num_threads_per_disk);
         });
     });
 

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -373,4 +373,12 @@ void CompactionManager::clear_tasks() {
     _data_dir_to_base_task_num_map.clear();
 }
 
+Status CompactionManager::update_max_threads(int max_threads) {
+    if (_compaction_pool != nullptr) {
+        return _compaction_pool->update_max_threads(max_threads);
+    } else {
+        return Status::InternalError("Thread pool not exist");
+    }
+}
+
 } // namespace starrocks

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -97,6 +97,8 @@ public:
 
     void schedule();
 
+    Status update_max_threads(int max_threads);
+
 private:
     CompactionManager(const CompactionManager& compaction_manager) = delete;
     CompactionManager(CompactionManager&& compaction_manager) = delete;

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -52,21 +52,21 @@ struct CompactionTaskInfo {
     uint64_t task_id{0};
     Version output_version;
     uint64_t elapsed_time{0};
-    int64_t tablet_id;
-    double compaction_score;
+    int64_t tablet_id{0};
+    double compaction_score{0};
     int64_t start_time{0};
     int64_t end_time{0};
-    size_t input_rows_num;
-    uint32_t input_rowsets_num;
-    size_t input_rowsets_size;
-    size_t input_segments_num;
-    uint32_t segment_iterator_num;
+    size_t input_rows_num{0};
+    uint32_t input_rowsets_num{0};
+    size_t input_rowsets_size{0};
+    size_t input_segments_num{0};
+    uint32_t segment_iterator_num{0};
     uint32_t output_segments_num{0};
     uint32_t output_rowset_size{0};
     size_t merged_rows{0};
     size_t filtered_rows{0};
     size_t output_num_rows{0};
-    CompactionType compaction_type;
+    CompactionType compaction_type{CompactionType::INVALID_COMPACTION};
 
     // for vertical compaction
     size_t column_group_size{0};

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -134,6 +134,14 @@ Status MemTableFlushExecutor::init(const std::vector<DataDir*>& data_dirs) {
             .build(&_flush_pool);
 }
 
+Status MemTableFlushExecutor::update_max_threads(int max_threads) {
+    if (_flush_pool != nullptr) {
+        return _flush_pool->update_max_threads(max_threads);
+    } else {
+        return Status::InternalError("Thread pool not exist");
+    }
+}
+
 std::unique_ptr<FlushToken> MemTableFlushExecutor::create_flush_token(ThreadPool::ExecutionMode execution_mode) {
     return std::make_unique<FlushToken>(_flush_pool->new_token(execution_mode));
 }

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -133,13 +133,15 @@ public:
     // because it needs path hash of each data dir.
     Status init(const std::vector<DataDir*>& data_dirs);
 
+    // dynamic update max threads num
+    Status update_max_threads(int max_threads);
+
     // NOTE: we use SERIAL mode here to ensure all mem-tables from one tablet are flushed in order.
     std::unique_ptr<FlushToken> create_flush_token(
             ThreadPool::ExecutionMode execution_mode = ThreadPool::ExecutionMode::SERIAL);
 
 private:
     std::unique_ptr<ThreadPool> _flush_pool;
-    std::unique_ptr<ThreadPool> _replicate_pool;
 };
 
 } // namespace starrocks

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -105,6 +105,14 @@ Status SegmentFlushExecutor::init(const std::vector<DataDir*>& data_dirs) {
             .build(&_flush_pool);
 }
 
+Status SegmentFlushExecutor::update_max_threads(int max_threads) {
+    if (_flush_pool != nullptr) {
+        return _flush_pool->update_max_threads(max_threads);
+    } else {
+        return Status::InternalError("Thread pool not exist");
+    }
+}
+
 std::unique_ptr<SegmentFlushToken> SegmentFlushExecutor::create_flush_token(
         const std::shared_ptr<starrocks::vectorized::DeltaWriter>& delta_writer,
         ThreadPool::ExecutionMode execution_mode) {

--- a/be/src/storage/segment_flush_executor.h
+++ b/be/src/storage/segment_flush_executor.h
@@ -68,6 +68,8 @@ public:
     // because it needs path hash of each data dir.
     Status init(const std::vector<DataDir*>& data_dirs);
 
+    Status update_max_threads(int max_threads);
+
     std::unique_ptr<SegmentFlushToken> create_flush_token(
             const std::shared_ptr<starrocks::vectorized::DeltaWriter>& delta_writer,
             ThreadPool::ExecutionMode execution_mode = ThreadPool::ExecutionMode::CONCURRENT);

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -327,6 +327,14 @@ Status SegmentReplicateExecutor::init(const std::vector<DataDir*>& data_dirs) {
             .build(&_replicate_pool);
 }
 
+Status SegmentReplicateExecutor::update_max_threads(int max_threads) {
+    if (_replicate_pool != nullptr) {
+        return _replicate_pool->update_max_threads(max_threads);
+    } else {
+        return Status::InternalError("Thread pool not exist");
+    }
+}
+
 std::unique_ptr<ReplicateToken> SegmentReplicateExecutor::create_replicate_token(
         const DeltaWriterOptions* opt, ThreadPool::ExecutionMode execution_mode) {
     return std::make_unique<ReplicateToken>(_replicate_pool->new_token(execution_mode), opt);

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -144,6 +144,8 @@ public:
     // because it needs path hash of each data dir.
     Status init(const std::vector<DataDir*>& data_dirs);
 
+    Status update_max_threads(int max_threads);
+
     // NOTE: we use SERIAL mode here to ensure all segment from one tablet are synced in order.
     std::unique_ptr<ReplicateToken> create_replicate_token(
             const DeltaWriterOptions* opt,

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1119,6 +1119,27 @@ bool StorageEngine::check_rowset_id_in_unused_rowsets(const RowsetId& rowset_id)
     return search != _unused_rowsets.end();
 }
 
+void StorageEngine::increase_update_compaction_thread(const int num_threads_per_disk) {
+    // convert store map to vector
+    std::vector<DataDir*> data_dirs;
+    for (auto& tmp_store : _store_map) {
+        data_dirs.push_back(tmp_store.second);
+    }
+    const auto data_dir_num = static_cast<int32_t>(data_dirs.size());
+    const int32_t cur_threads_per_disk = _update_compaction_threads.size() / data_dir_num;
+    if (num_threads_per_disk <= cur_threads_per_disk) {
+        LOG(WARNING) << fmt::format("not support decrease update compaction thread, from {} to {}",
+                                    cur_threads_per_disk, num_threads_per_disk);
+        return;
+    }
+    for (uint32_t i = 0; i < data_dir_num * (num_threads_per_disk - cur_threads_per_disk); ++i) {
+        _update_compaction_threads.emplace_back([this, data_dir_num, data_dirs, i] {
+            _update_compaction_thread_callback(nullptr, data_dirs[i % data_dir_num]);
+        });
+        Thread::set_thread_name(_update_compaction_threads.back(), "update_compact");
+    }
+}
+
 DummyStorageEngine::DummyStorageEngine(const EngineOptions& options)
         : StorageEngine(options), _conf_path(options.conf_path) {
     _s_instance = this;

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -207,6 +207,8 @@ public:
 
     void do_manual_compact(bool force_compact);
 
+    void increase_update_compaction_thread(const int num_threads_per_disk);
+
 protected:
     static StorageEngine* _s_instance;
 

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -363,12 +363,20 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     }
 
     // Size limit check.
-    int64_t capacity_remaining = static_cast<int64_t>(_max_threads) - _active_threads +
-                                 static_cast<int64_t>(_max_queue_size) - _total_queued_tasks;
+    int64_t capacity_remaining = 0;
+    const int cur_max_threads = _max_threads.load();
+    if (cur_max_threads >= _active_threads) {
+        capacity_remaining = static_cast<int64_t>(cur_max_threads) - _active_threads +
+                             static_cast<int64_t>(_max_queue_size) - _total_queued_tasks;
+    } else {
+        // dynamic decrease _max_threads
+        capacity_remaining = static_cast<int64_t>(_max_queue_size) - _total_queued_tasks;
+    }
+
     if (capacity_remaining < 1) {
         return Status::ServiceUnavailable(strings::Substitute(
                 "Thread pool is at capacity ($0/$1 tasks running, $2/$3 tasks queued)",
-                _num_threads + _num_threads_pending_start, _max_threads, _total_queued_tasks, _max_queue_size));
+                _num_threads + _num_threads_pending_start, _max_threads.load(), _total_queued_tasks, _max_queue_size));
     }
 
     // Should we create another thread?
@@ -391,7 +399,7 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     int inactive_threads = _num_threads + _num_threads_pending_start - _active_threads;
     int additional_threads = static_cast<int>(_queue.size()) + threads_from_this_submit - inactive_threads;
     bool need_a_thread = false;
-    if (additional_threads > 0 && _num_threads + _num_threads_pending_start < _max_threads) {
+    if (additional_threads > 0 && _num_threads + _num_threads_pending_start < _max_threads.load()) {
         need_a_thread = true;
         _num_threads_pending_start++;
     }
@@ -455,6 +463,19 @@ bool ThreadPool::wait_for(const MonoDelta& delta) {
     check_not_pool_thread_unlocked();
     return _idle_cond.wait_for(l, std::chrono::nanoseconds(delta.ToNanoseconds()),
                                [&]() { return _total_queued_tasks <= 0 && _active_threads <= 0; });
+}
+
+Status ThreadPool::update_max_threads(int max_threads) {
+    if (max_threads < this->_min_threads) {
+        std::string err_msg = strings::Substitute("invalid max threads num $0 :  min threads num: $1",
+                                                  std::to_string(max_threads), std::to_string(this->_min_threads));
+        LOG(WARNING) << err_msg;
+        return Status::InvalidArgument(err_msg);
+    } else {
+        _max_threads.store(max_threads);
+        LOG(INFO) << "ThreadPool " << _name << " update max threads : " << _max_threads.load();
+    }
+    return Status::OK();
 }
 
 void ThreadPool::dispatch_thread() {

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/list_hook.hpp>
 #include <condition_variable>
@@ -199,6 +200,9 @@ public:
     // Returns true if the pool reached the idle state, false otherwise.
     bool wait_for(const MonoDelta& delta);
 
+    // dynamic update max threads num
+    Status update_max_threads(int max_threads);
+
     // Allocates a new token for use in token-based task submission. All tokens
     // must be destroyed before their ThreadPool is destroyed.
     //
@@ -268,7 +272,7 @@ private:
 
     const std::string _name;
     const int _min_threads;
-    const int _max_threads;
+    std::atomic<int> _max_threads;
     const int _max_queue_size;
     const MonoDelta _idle_timeout;
 

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -217,7 +217,7 @@ TEST_F(ThreadPoolTest, TestRace) {
         CountDownLatch l(1);
         // CountDownLatch::count_down has multiple overloaded version,
         // so an cast is needed to use std::bind
-        ASSERT_TRUE(_pool->submit_func(std::bind((void (CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
+        ASSERT_TRUE(_pool->submit_func(std::bind((void(CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
         l.wait();
         // Sleeping a different amount in each iteration makes it more likely to hit
         // the bug.
@@ -251,6 +251,59 @@ TEST_F(ThreadPoolTest, TestVariableSizeThreadPool) {
     latch.count_down();
     _pool->wait();
     ASSERT_EQ(0, _pool->_active_threads);
+    _pool->shutdown();
+    ASSERT_EQ(0, _pool->num_threads());
+}
+
+TEST_F(ThreadPoolTest, TestIncMaxThreadPool) {
+    ASSERT_TRUE(rebuild_pool_with_builder(ThreadPoolBuilder(kDefaultPoolName)
+                                                  .set_min_threads(1)
+                                                  .set_max_threads(4)
+                                                  .set_idle_timeout(MonoDelta::FromMilliseconds(1)))
+                        .ok());
+
+    // There is 1 thread to start with.
+    ASSERT_EQ(1, _pool->num_threads());
+    // We get up to 4 threads when submitting work.
+    CountDownLatch latch(1);
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch)).ok());
+    ASSERT_EQ(1, _pool->num_threads());
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch)).ok());
+    ASSERT_EQ(2, _pool->num_threads());
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch)).ok());
+    ASSERT_EQ(3, _pool->num_threads());
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch)).ok());
+    ASSERT_EQ(4, _pool->num_threads());
+    // The 5th piece of work gets queued.
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch)).ok());
+    ASSERT_EQ(4, _pool->num_threads());
+    // Finish all work
+    latch.count_down();
+    _pool->wait();
+    ASSERT_EQ(0, _pool->_active_threads);
+    // inc max threads to 6
+    _pool->update_max_threads(6);
+    CountDownLatch latch2(1);
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch2)).ok());
+    ASSERT_EQ(4, _pool->num_threads());
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch2)).ok());
+    ASSERT_EQ(4, _pool->num_threads());
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch2)).ok());
+    ASSERT_EQ(4, _pool->num_threads());
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch2)).ok());
+    ASSERT_EQ(4, _pool->num_threads());
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch2)).ok());
+    ASSERT_EQ(5, _pool->num_threads());
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch2)).ok());
+    ASSERT_EQ(6, _pool->num_threads());
+    // The 7th piece of work gets queued.
+    ASSERT_TRUE(_pool->submit(SlowTask::new_slow_task(&latch2)).ok());
+    ASSERT_EQ(6, _pool->num_threads());
+    // Finish all work
+    latch2.count_down();
+    _pool->wait();
+    ASSERT_EQ(0, _pool->_active_threads);
+
     _pool->shutdown();
     ASSERT_EQ(0, _pool->num_threads());
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13723

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When we want to update `max_compaction_concurrency` and `flush_thread_num_per_store` in be.conf, we can use http request to update them and not need to restart be.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
