### PR TITLE
[Enhancement] QueryCache support primary_key and unique_key (#13349)

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -327,6 +327,8 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
             cache_param.slot_remapping[slot] = remapped_slot;
             cache_param.reverse_slot_remapping[remapped_slot] = slot;
         }
+        cache_param.can_use_multiversion = tcache_param.can_use_multiversion;
+        cache_param.keys_type = tcache_param.keys_type;
         _fragment_ctx->set_enable_cache(true);
     }
 
@@ -358,14 +360,14 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
                         continue;
                     }
                     const auto& region = tcache_param.region_map.at(partition_id);
-                    std::string cache_suffix_key;
-                    cache_suffix_key.reserve(sizeof(partition_id) + region.size() + sizeof(tablet_id));
-                    cache_suffix_key.insert(cache_suffix_key.end(), (uint8_t*)&partition_id,
+                    std::string cache_prefix_key;
+                    cache_prefix_key.reserve(sizeof(partition_id) + region.size() + sizeof(tablet_id));
+                    cache_prefix_key.insert(cache_prefix_key.end(), (uint8_t*)&partition_id,
                                             ((uint8_t*)&partition_id) + sizeof(partition_id));
-                    cache_suffix_key.insert(cache_suffix_key.end(), region.begin(), region.end());
-                    cache_suffix_key.insert(cache_suffix_key.end(), (uint8_t*)&tablet_id,
+                    cache_prefix_key.insert(cache_prefix_key.end(), region.begin(), region.end());
+                    cache_prefix_key.insert(cache_prefix_key.end(), (uint8_t*)&tablet_id,
                                             ((uint8_t*)&tablet_id) + sizeof(tablet_id));
-                    _fragment_ctx->cache_param().cache_key_prefixes[tablet_id] = std::move(cache_suffix_key);
+                    _fragment_ctx->cache_param().cache_key_prefixes[tablet_id] = std::move(cache_prefix_key);
                 }
             }
         }

--- a/be/src/exec/query_cache/cache_operator.h
+++ b/be/src/exec/query_cache/cache_operator.h
@@ -53,6 +53,10 @@ private:
     void _update_probe_metrics(int64_t, const std::vector<vectorized::ChunkPtr>& chunks);
     void _handle_stale_cache_value(int64_t tablet_id, CacheValue& cache_value, PerLaneBufferPtr& buffer,
                                    int64_t version);
+    void _handle_stale_cache_value_for_non_pk(int64_t tablet_id, CacheValue& cache_value, PerLaneBufferPtr& buffer,
+                                              int64_t version);
+    void _handle_stale_cache_value_for_pk(int64_t tablet_id, CacheValue& cache_value, PerLaneBufferPtr& buffer,
+                                          int64_t version);
     bool _should_passthrough(size_t num_rows, size_t num_bytes);
     vectorized::ChunkPtr _pull_chunk_from_per_lane_buffer(PerLaneBufferPtr& buffer);
     CacheManagerRawPtr _cache_mgr;

--- a/be/src/exec/query_cache/cache_param.h
+++ b/be/src/exec/query_cache/cache_param.h
@@ -3,21 +3,23 @@
 
 #include <string>
 #include <unordered_map>
-namespace starrocks {
-namespace query_cache {
 
-using CacheKeySuffixMap = std::unordered_map<int64_t, std::string>;
+#include "gen_cpp/Types_types.h"
+namespace starrocks::query_cache {
+
+using CacheKeyPrefixMap = std::unordered_map<int64_t, std::string>;
 using SlotRemapping = std::unordered_map<int32_t, int32_t>;
 struct CacheParam {
     int num_lanes;
     int32_t plan_node_id;
     std::string digest;
-    CacheKeySuffixMap cache_key_prefixes;
+    CacheKeyPrefixMap cache_key_prefixes;
     SlotRemapping slot_remapping;
     SlotRemapping reverse_slot_remapping;
     bool force_populate;
     size_t entry_max_bytes;
     size_t entry_max_rows;
+    bool can_use_multiversion;
+    TKeysType::type keys_type;
 };
-} // namespace query_cache
-} // namespace starrocks
+} // namespace starrocks::query_cache

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -142,10 +142,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     private boolean hasJoinNode = false;
     private boolean hasOlapScanNode = false;
 
-    private PlanNodeId cachePlanNodeId = null;
-    private ByteBuffer digest = null;
-    private Map<Integer, Integer> slotRemapping = Maps.newHashMap();
-    private Map<Long, String> rangeMap = Maps.newHashMap();
+    private TCacheParam cacheParam = null;
     private boolean hasOlapTableSink = false;
     private boolean forceSetTableSinkDop = false;
     private boolean forceAssignScanRangesPerDriverSeq = false;
@@ -292,38 +289,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.outputExprs = Expr.cloneList(outputExprs, null);
     }
 
-    public void setCachePlanNodeId(PlanNodeId cachePlanNodeId) {
-        this.cachePlanNodeId = cachePlanNodeId;
-    }
-
-    public PlanNodeId getCachePlanNodeId() {
-        return cachePlanNodeId;
-    }
-
-    public ByteBuffer getDigest() {
-        return digest;
-    }
-
-    public void setDigest(ByteBuffer digest) {
-        this.digest = digest;
-    }
-
-    public Map<Integer, Integer> getSlotRemapping() {
-        return slotRemapping;
-    }
-
-    public void setSlotRemapping(Map<Integer, Integer> slotRemapping) {
-        this.slotRemapping = slotRemapping;
-    }
-
-    public Map<Long, String> getRangeMap() {
-        return rangeMap;
-    }
-
-    public void setRangeMap(Map<Long, String> rangeMap) {
-        this.rangeMap = rangeMap;
-    }
-
     /**
      * Finalize plan tree and create stream sink, if needed.
      */
@@ -381,12 +346,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         if (!loadGlobalDicts.isEmpty()) {
             result.setLoad_global_dicts(dictToThrift(loadGlobalDicts));
         }
-        if (cachePlanNodeId != null && cachePlanNodeId.isValid()) {
-            TCacheParam cacheParam = new TCacheParam();
-            cacheParam.setId(getCachePlanNodeId().asInt());
-            cacheParam.setDigest(getDigest());
-            cacheParam.setRegion_map(getRangeMap());
-            cacheParam.setSlot_remapping(getSlotRemapping());
+        if (cacheParam != null) {
             if (ConnectContext.get() != null) {
                 SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
                 cacheParam.setForce_populate(sessionVariable.isQueryCacheForcePopulate());
@@ -664,5 +624,13 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public boolean hasOlapScanNode() {
         return hasOlapScanNode;
+    }
+
+    public TCacheParam getCacheParam() {
+        return cacheParam;
+    }
+
+    public void setCacheParam(TCacheParam cacheParam) {
+        this.cacheParam = cacheParam;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -294,6 +294,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
     public static final String QUERY_CACHE_ENTRY_MAX_BYTES = "query_cache_entry_max_bytes";
     public static final String QUERY_CACHE_ENTRY_MAX_ROWS = "query_cache_entry_max_rows";
+
+    // We assume that for PRIMARY_KEYS and UNIQUE_KEYS, the latest partitions are hot partitions that are updated
+    // frequently, so it should not be cached in query cache since its disruptive cache invalidation.
+    public static final String QUERY_CACHE_HOT_PARTITION_NUM = "query_cache_hot_partition_num";
     public static final String TRANSMISSION_ENCODE_LEVEL = "transmission_encode_level";
 
     public static final String NESTED_MV_REWRITE_MAX_LEVEL = "nested_mv_rewrite_max_level";
@@ -744,6 +748,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = QUERY_CACHE_ENTRY_MAX_ROWS)
     private long queryCacheEntryMaxRows = 409600;
+
+    @VarAttr(name = QUERY_CACHE_HOT_PARTITION_NUM)
+    private int queryCacheHotPartitionNum = 3;
 
     @VarAttr(name = NESTED_MV_REWRITE_MAX_LEVEL)
     private int nestedMvRewriteMaxLevel = 3;
@@ -1372,6 +1379,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getQueryCacheEntryMaxRows() {
         return queryCacheEntryMaxRows;
+    }
+
+    public void setQueryCacheHotPartitionNum(int n) {
+        queryCacheHotPartitionNum = n;
+    }
+
+    public int getQueryCacheHotPartitionNum() {
+        return queryCacheHotPartitionNum;
     }
 
     public void setEnableQueryCache(boolean on) {

--- a/gensrc/thrift/Planner.thrift
+++ b/gensrc/thrift/Planner.thrift
@@ -37,6 +37,8 @@ struct TCacheParam {
 5: optional bool force_populate;
 6: optional i64 entry_max_bytes;
 7: optional i64 entry_max_rows;
+8: optional bool can_use_multiversion;
+10:optional Types.TKeysType keys_type;
 }
 
 // TPlanFragment encapsulates info needed to execute a particular


### PR DESCRIPTION
Query cache support data models of UNIQUE_KEYS and PRIMARY_KEYS. now query cache support all data models. different models have different policies to support multiversion:

1. support multiversion cache: DUP_KEYS, AGG_KEYS(contains no replace aggfunc)
2. not support multiversion cache: UNIQUE_KEYS, PRIMARY_KEYS, AGG(contains replace aggfunc). Althrough these scenarios do not support multiversion cache, but if cache contains a stale cache value and the delta version has not data, the cache can be hit totally.

cherry-pick: https://github.com/StarRocks/starrocks/pull/13349