### PR TITLE
[Enhancement] Fix BE by Sonar

### DIFF
--- a/be/src/bench/runtime_filter_bench.cpp
+++ b/be/src/bench/runtime_filter_bench.cpp
@@ -106,7 +106,11 @@ static void do_benchmark_hash_partitioned(benchmark::State& state, TRuntimeFilte
         ASSERT_EQ(true_count, num_rows);
         total_evalute_time += MonotonicMillis() - t0;
     }
-    state.counters["evalute_time(ms)"] = total_evalute_time / iterate_times / num_column;
+    if (!num_column) {
+        state.counters["evalute_time(ms)"] = 0;
+    } else {
+        state.counters["evalute_time(ms)"] = total_evalute_time / iterate_times / num_column;
+    }
     state.PauseTiming();
 }
 

--- a/be/src/exprs/vectorized/array_functions.cpp
+++ b/be/src/exprs/vectorized/array_functions.cpp
@@ -402,6 +402,7 @@ private:
             size_t offset = offsets[i];
             size_t array_size = offsets[i + 1] - offsets[i];
             if constexpr (nullable) {
+                DCHECK(null_data != nullptr);
                 if (null_data[offset]) {
                     continue;
                 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
### 1. Division by zero
In `RuntimeFilterBench`, the divisor `num_column` may be zero.

### ~~2. convert `TSliceWithHash` to `Slice`~~
> Use pointer or reference to avoid slicing from "TSliceWithHash<starrocks::vectorized::PhmapSeed2>" to "Slice".

This is used to place result `Slice` into `hash_set.results`. It is OK to forcedly convert `TSliceWithHash` to `Slice`, because the field `hash` of child class `TSliceWithHash` doesn't need anymore and using object instead of pointer is friend to performance.
```C++
        hash_set.results.resize(chunk_size);
        while (it != end && read_index < chunk_size) {
            hash_set.results[read_index] = *it; // ***** here ******/
            ++read_index;
            ++it;
        }
```
### ~~3. Null pointer dereference~~
> `null_data` may be `nullptr`.

`null_data` dereference only occurs, when `nullable` is true. 
And the only caller `call_cum_sum` guarantee this.

```C++
    template <bool nullable, bool element_nullable>
    static void cumu_sum(ArrayColumn* arr_col, NullColumn* null_column) {
       // ...
       for (int i = 0; i < num_rows; ++i) {
            size_t offset = offsets[i];
            size_t array_size = offsets[i + 1] - offsets[i];
            if constexpr (nullable) {
                if (null_data[offset]) { // ***** here *****
                    continue;
                }
            }
       // ...
     }

    static void call_cum_sum(ArrayColumn* arr_col, NullColumn* null_column) {
        bool is_nullable = null_column != nullptr;
        bool element_nullable = arr_col->elements_column()->is_nullable();
        if (is_nullable && element_nullable) {
            cumu_sum<true, true>(arr_col, null_column);
        } else if (is_nullable && !element_nullable) {
            cumu_sum<true, false>(arr_col, null_column);
        } else if (!is_nullable && element_nullable) {
            cumu_sum<false, true>(arr_col, null_column);
        } else {
            cumu_sum<false, false>(arr_col, null_column);
        }
    }
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
