### PR TITLE
[Enhancement] Optimize creation of scan mv in register mv (#13970)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/PlannerProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/PlannerProfile.java
@@ -218,8 +218,8 @@ public class PlannerProfile {
                 getTime("Optimizer.CostBaseOptimize", times), 2));
         trace.append(print("Optimizer.PhysicalRewrite",
                 getTime("Optimizer.PhysicalRewrite", times), 2));
-        trace.append(print("Optimizer.registerMvs",
-                getTime("Optimizer.registerMvs", times), 2));
+        trace.append(print("Optimizer.preprocessMvs",
+                getTime("Optimizer.preprocessMvs", times), 2));
         trace.append(print("ExecPlanBuild", getTime("ExecPlanBuild", times), 1));
 
         return trace.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -7,7 +7,7 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
-import java.util.List;
+import java.util.Map;
 
 public class MaterializationContext {
     private MaterializedView mv;
@@ -18,12 +18,6 @@ public class MaterializationContext {
 
     private ColumnRefFactory mvColumnRefFactory;
 
-    // output expressions of mv define sql
-    private List<ColumnRefOperator> mvOutputExpressions;
-
-    // output expressions of select * from mv
-    private List<ColumnRefOperator> scanMvOutputExpressions;
-
     // logical OptExpression for query
     private OptExpression queryExpression;
 
@@ -31,14 +25,16 @@ public class MaterializationContext {
 
     private OptimizerContext optimizerContext;
 
+    private Map<ColumnRefOperator, ColumnRefOperator> outputMapping;
+
     public MaterializationContext(MaterializedView mv,
                                   OptExpression mvExpression,
-                                  ColumnRefFactory columnRefFactory,
-                                  List<ColumnRefOperator> mvOutputExpressions) {
+                                  ColumnRefFactory queryColumnRefFactory,
+                                  ColumnRefFactory mvColumnRefFactory) {
         this.mv = mv;
         this.mvExpression = mvExpression;
-        this.mvColumnRefFactory = columnRefFactory;
-        this.mvOutputExpressions = mvOutputExpressions;
+        this.queryRefFactory = queryColumnRefFactory;
+        this.mvColumnRefFactory = mvColumnRefFactory;
     }
 
     public MaterializedView getMv() {
@@ -59,18 +55,6 @@ public class MaterializationContext {
 
     public ColumnRefFactory getMvColumnRefFactory() {
         return mvColumnRefFactory;
-    }
-
-    public List<ColumnRefOperator> getMvOutputExpressions() {
-        return mvOutputExpressions;
-    }
-
-    public List<ColumnRefOperator> getScanMvOutputExpressions() {
-        return scanMvOutputExpressions;
-    }
-
-    public void setScanMvOutputExpressions(List<ColumnRefOperator> scanMvOutputExpressions) {
-        this.scanMvOutputExpressions = scanMvOutputExpressions;
     }
 
     public OptExpression getQueryExpression() {
@@ -95,5 +79,13 @@ public class MaterializationContext {
 
     public void setOptimizerContext(OptimizerContext optimizerContext) {
         this.optimizerContext = optimizerContext;
+    }
+
+    public Map<ColumnRefOperator, ColumnRefOperator> getOutputMapping() {
+        return outputMapping;
+    }
+
+    public void setOutputMapping(Map<ColumnRefOperator, ColumnRefOperator> outputMapping) {
+        this.outputMapping = outputMapping;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -1,0 +1,167 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.PartitionNames;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.HashDistributionDesc;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MvRewritePreprocessor {
+    private final ConnectContext connectContext;
+    private final ColumnRefFactory queryColumnRefFactory;
+    private final OptimizerContext context;
+    private final OptExpression logicOperatorTree;
+
+    public MvRewritePreprocessor(ConnectContext connectContext,
+                                 ColumnRefFactory queryColumnRefFactory,
+                                 OptimizerContext context,
+                                 OptExpression logicOperatorTree) {
+        this.connectContext = connectContext;
+        this.queryColumnRefFactory = queryColumnRefFactory;
+        this.context = context;
+        this.logicOperatorTree = logicOperatorTree;
+    }
+
+    public void prepareMvCandidatesForPlan() {
+        List<Table> tables = MvUtils.getAllTables(logicOperatorTree);
+
+        // get all related materialized views, include nested mvs
+        Set<MaterializedView> relatedMvs =
+                MvUtils.getRelatedMvs(connectContext.getSessionVariable().getNestedMvRewriteMaxLevel(), tables);
+
+        for (MaterializedView mv : relatedMvs) {
+            if (!mv.isActive()) {
+                continue;
+            }
+            Set<String> partitionNamesToRefresh = mv.getPartitionNamesToRefreshForMv();
+            PartitionInfo partitionInfo = mv.getPartitionInfo();
+            if (partitionInfo instanceof SinglePartitionInfo) {
+                if (!partitionNamesToRefresh.isEmpty()) {
+                    continue;
+                }
+            } else if (partitionNamesToRefresh.containsAll(mv.getPartitionNames())) {
+                // if the mv is partitioned, and all partitions need refresh,
+                // then it can not be an candidate
+                continue;
+            }
+
+            // 1. build mv query logical plan
+            ColumnRefFactory mvColumnRefFactory = new ColumnRefFactory();
+            MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
+            OptExpression mvPlan = mvOptimizer.optimize(mv, mvColumnRefFactory, connectContext);
+            if (!MvUtils.isValidMVPlan(mvPlan)) {
+                continue;
+            }
+
+            List<ColumnRefOperator> mvOutputColumns = mvOptimizer.getOutputExpressions();
+            MaterializationContext materializationContext =
+                    new MaterializationContext(mv, mvPlan, queryColumnRefFactory, mvColumnRefFactory);
+            // generate scan mv plan here to reuse it in rule applications
+            LogicalOlapScanOperator scanMvOp = createScanMvExpression(materializationContext);
+            materializationContext.setScanMvOperator(scanMvOp);
+            String dbName = connectContext.getGlobalStateMgr().getDb(mv.getDbId()).getFullName();
+            connectContext.getDumpInfo().addTable(dbName, mv);
+            // should keep the sequence of schema
+            List<ColumnRefOperator> scanMvOutputColumns = Lists.newArrayList();
+            for (Column column : mv.getFullSchema()) {
+                scanMvOutputColumns.add(scanMvOp.getColumnReference(column));
+            }
+            Preconditions.checkState(mvOutputColumns.size() == scanMvOutputColumns.size());
+
+            // construct output column mapping from mv sql to mv scan operator
+            // eg: for mv1 sql define: select a, (b + 1) as c2, (a * b) as c3 from table;
+            // select sql plan output columns:    a, b + 1, a * b
+            //                                    |    |      |
+            //                                    v    v      V
+            // mv scan operator output columns:  a,   c2,    c3
+            Map<ColumnRefOperator, ColumnRefOperator> outputMapping = Maps.newHashMap();
+            for (int i = 0; i < mvOutputColumns.size(); i++) {
+                outputMapping.put(mvOutputColumns.get(i), scanMvOutputColumns.get(i));
+            }
+            materializationContext.setOutputMapping(outputMapping);
+            context.addCandidateMvs(materializationContext);
+        }
+    }
+
+    private LogicalOlapScanOperator createScanMvExpression(MaterializationContext materializationContext) {
+        MaterializedView mv = materializationContext.getMv();
+
+        ImmutableMap.Builder<ColumnRefOperator, Column> colRefToColumnMetaMapBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<Column, ColumnRefOperator> columnMetaToColRefMapBuilder = ImmutableMap.builder();
+        ImmutableList.Builder<ColumnRefOperator> outputVariablesBuilder = ImmutableList.builder();
+
+        ColumnRefFactory columnRefFactory = materializationContext.getQueryRefFactory();
+        int relationId = columnRefFactory.getNextRelationId();
+        for (Column column : mv.getFullSchema()) {
+            ColumnRefOperator columnRef = columnRefFactory.create(column.getName(),
+                    column.getType(),
+                    column.isAllowNull());
+            columnRefFactory.updateColumnToRelationIds(columnRef.getId(), relationId);
+            columnRefFactory.updateColumnRefToColumns(columnRef, column, mv);
+            outputVariablesBuilder.add(columnRef);
+            colRefToColumnMetaMapBuilder.put(columnRef, column);
+            columnMetaToColRefMapBuilder.put(column, columnRef);
+        }
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = columnMetaToColRefMapBuilder.build();
+        DistributionInfo distributionInfo = mv.getDefaultDistributionInfo();
+        Preconditions.checkState(distributionInfo instanceof HashDistributionInfo);
+        HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
+        List<Column> distributedColumns = hashDistributionInfo.getDistributionColumns();
+        List<Integer> hashDistributeColumns = new ArrayList<>();
+        for (Column distributedColumn : distributedColumns) {
+            hashDistributeColumns.add(columnMetaToColRefMap.get(distributedColumn).getId());
+        }
+
+        HashDistributionDesc hashDistributionDesc =
+                new HashDistributionDesc(hashDistributeColumns, HashDistributionDesc.SourceType.LOCAL);
+
+        List<Long> selectPartitionIds = Lists.newArrayList();
+        Set<String> excludedPartitions = mv.getPartitionNamesToRefreshForMv();
+        List<String> selectedPartitionNames = mv.getPartitionNames()
+                .stream().filter(name -> !excludedPartitions.contains(name)).collect(Collectors.toList());
+        for (Partition p : mv.getPartitions()) {
+            if (selectedPartitionNames.contains(p.getName())) {
+                selectPartitionIds.add(p.getId());
+            }
+        }
+        PartitionNames partitionNames = new PartitionNames(false, selectedPartitionNames);
+        LogicalOlapScanOperator scanOperator = new LogicalOlapScanOperator(mv,
+                colRefToColumnMetaMapBuilder.build(),
+                columnMetaToColRefMap,
+                DistributionSpec.createHashDistributionSpec(hashDistributionDesc),
+                Operator.DEFAULT_LIMIT,
+                null,
+                mv.getBaseIndexId(),
+                selectPartitionIds,
+                partitionNames,
+                Lists.newArrayList(),
+                Lists.newArrayList());
+        return scanOperator;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -4,14 +4,7 @@ package com.starrocks.sql.optimizer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.starrocks.analysis.TableName;
-import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.PartitionInfo;
-import com.starrocks.catalog.SinglePartitionInfo;
-import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.Explain;
@@ -22,7 +15,6 @@ import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.cost.CostEstimate;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
@@ -43,7 +35,6 @@ import com.starrocks.sql.optimizer.rule.transformation.PushLimitAndFilterToCTEPr
 import com.starrocks.sql.optimizer.rule.transformation.RemoveAggregationFromAggTable;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteGroupingSetsByCTERule;
 import com.starrocks.sql.optimizer.rule.transformation.SemiReorderRule;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule;
 import com.starrocks.sql.optimizer.rule.tree.ExchangeSortToMergeRule;
 import com.starrocks.sql.optimizer.rule.tree.PreAggregateTurnOnRule;
@@ -56,13 +47,11 @@ import com.starrocks.sql.optimizer.rule.tree.UseSortAggregateRule;
 import com.starrocks.sql.optimizer.task.OptimizeGroupTask;
 import com.starrocks.sql.optimizer.task.RewriteTreeTask;
 import com.starrocks.sql.optimizer.task.TaskContext;
-import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Optimizer's entrance class
@@ -196,63 +185,11 @@ public class Optimizer {
         if (Config.enable_experimental_mv
                 && connectContext.getSessionVariable().isEnableMaterializedViewRewrite()
                 && !optimizerConfig.isRuleBased()) {
-            try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Optimizer.registerMvs")) {
-                registerMaterializedViews(logicOperatorTree, connectContext);
+            try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Optimizer.preprocessMvs")) {
+                MvRewritePreprocessor preprocessor =
+                        new MvRewritePreprocessor(connectContext, columnRefFactory, context, logicOperatorTree);
+                preprocessor.prepareMvCandidatesForPlan();
             }
-        }
-    }
-
-    private void registerMaterializedViews(OptExpression logicOperatorTree, ConnectContext connectContext) {
-        List<Table> tables = MvUtils.getAllTables(logicOperatorTree);
-
-        // get all related materialized views, include nested mvs
-        Set<MaterializedView> relatedMvs =
-                MvUtils.getRelatedMvs(connectContext.getSessionVariable().getNestedMvRewriteMaxLevel(), tables);
-
-        for (MaterializedView mv : relatedMvs) {
-            if (!mv.isActive()) {
-                continue;
-            }
-            Set<String> partitionNamesToRefresh = mv.getPartitionNamesToRefreshForMv();
-            PartitionInfo partitionInfo = mv.getPartitionInfo();
-            if (partitionInfo instanceof SinglePartitionInfo) {
-                if (!partitionNamesToRefresh.isEmpty()) {
-                    continue;
-                }
-            } else if (partitionNamesToRefresh.containsAll(mv.getPartitionNames())) {
-                // if the mv is partitioned, and all partitions need refresh,
-                // then it can not be an candidate
-                continue;
-            }
-
-            // 1. build mv query logical plan
-            ColumnRefFactory columnRefFactory = new ColumnRefFactory();
-            MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
-            OptExpression mvPlan = mvOptimizer.optimize(mv, columnRefFactory, connectContext);
-            if (!MvUtils.isValidMVPlan(mvPlan)) {
-                continue;
-            }
-
-            List<ColumnRefOperator> outputExpressions = mvOptimizer.getOutputExpressions();
-            MaterializationContext materializationContext = new MaterializationContext(
-                    mv, mvPlan, columnRefFactory, outputExpressions);
-
-            // generate scan mv plan
-            Database db = context.getCatalog().getDb(mv.getDbId());
-            TableName tableName = new TableName(db.getFullName(), mv.getName());
-            String selectMvSql = "select * from " + tableName.toSql();
-            Pair<OptExpression, LogicalPlan> scanMvPlans =
-                    MvUtils.getRuleOptimizedLogicalPlan(selectMvSql, context.getColumnRefFactory(), connectContext);
-            OptExpression scanMvPlan = scanMvPlans.first;
-            if (!MvUtils.isLogicalSPJ(scanMvPlan)) {
-                continue;
-            }
-            if (!(scanMvPlan.getOp() instanceof LogicalOlapScanOperator)) {
-                continue;
-            }
-            materializationContext.setScanMvOperator(scanMvPlan.getOp());
-            materializationContext.setScanMvOutputExpressions(scanMvPlans.second.getOutputColumn());
-            context.addCandidateMvs(materializationContext);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.optimizer.base.EquivalenceClasses;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -108,18 +109,6 @@ public class MaterializedViewRewriter {
             return Lists.newArrayList();
         }
 
-        // construct output column mapping from mv sql to mv scan operator
-        // eg: for mv1 sql define: select a, (b + 1) as c2, (a * b) as c3 from table;
-        // select sql plan output columns:    a, b + 1, a * b
-        //                                    |    |      |
-        //                                    v    v      V
-        // mv scan operator output columns:  a,   c2,    c3
-        Map<ColumnRefOperator, ColumnRefOperator> outputMapping = Maps.newHashMap();
-        for (int i = 0; i < materializationContext.getMvOutputExpressions().size(); i++) {
-            outputMapping.put(materializationContext.getMvOutputExpressions().get(i),
-                    materializationContext.getScanMvOutputExpressions().get(i));
-        }
-
         Map<ColumnRefOperator, ScalarOperator> mvLineage =
                 getLineage(mvExpression, materializationContext.getMvColumnRefFactory());
         ReplaceColumnRefRewriter mvColumnRefRewriter = new ReplaceColumnRefRewriter(mvLineage, true);
@@ -145,14 +134,17 @@ public class MaterializedViewRewriter {
                 queryTables, queryExpression, materializationContext.getMvColumnRefFactory(), mvTables, mvExpression);
 
         // used to judge whether query scalar ops can be rewritten
+        List<ColumnRefOperator> scanMvOutputColumns =
+                ((LogicalOlapScanOperator) materializationContext.getScanMvOperator()).getOutputColumns();
         Set<ColumnRefOperator> queryColumnSet = queryRelationIdToColumns.values()
                 .stream().flatMap(List::stream)
-                .filter(columnRef -> !materializationContext.getScanMvOutputExpressions().contains(columnRef))
+                .filter(columnRef -> !scanMvOutputColumns.contains(columnRef))
                 .collect(Collectors.toSet());
         RewriteContext rewriteContext = new RewriteContext(queryExpression, queryPredicateSplit, queryEc,
                 queryRelationIdToColumns, materializationContext.getQueryRefFactory(),
                 queryColumnRefRewriter, mvExpression, mvPredicateSplit, mvRelationIdToColumns,
-                materializationContext.getMvColumnRefFactory(), mvColumnRefRewriter, outputMapping, queryColumnSet);
+                materializationContext.getMvColumnRefFactory(), mvColumnRefRewriter,
+                materializationContext.getOutputMapping(), queryColumnSet);
         List<OptExpression> results = Lists.newArrayList();
         for (BiMap<Integer, Integer> relationIdMapping : relationIdMappings) {
             rewriteContext.setQueryToMvRelationIdMapping(relationIdMapping);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -29,7 +29,6 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         List<OptExpression> results = Lists.newArrayList();
         for (MaterializationContext mvContext : context.getCandidateMvs()) {
             mvContext.setQueryExpression(queryExpression);
-            mvContext.setQueryRefFactory(context.getColumnRefFactory());
             mvContext.setOptimizerContext(context);
             MaterializedViewRewriter rewriter = getMaterializedViewRewrite(mvContext);
             List<OptExpression> rewritten = rewriter.rewrite();


### PR DESCRIPTION
* The creation of scan mv in register mv during mv query rewrite can be optimized. Originally the creation of scan mv is based on sql,which can be enhanced by constructing LogicalOlapScanOperator directly.

* move preparation logic to MvRewritePreprocessor

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13969 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
[Enhancement] Optimize creation of scan mv in register mv (#13970)

    * The creation of scan mv in register mv during mv query rewrite can be optimized.
    Originally the creation of scan mv is based on sql,which can be enhanced
    by constructing LogicalOlapScanOperator directly.

    * move preparation logic to MvRewritePreprocessor
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
