### PR TITLE
[Enhancement] support unpartitioned and multi-column partitioned table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -183,7 +183,7 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
             case INT:
             case BIGINT: {
                 IntLiteral intLiteral = (IntLiteral) literal;
-                final long maxValue = 1L << ((type.getSlotSize() << 3) - 1) - 1L;
+                final long maxValue = (1L << ((type.getSlotSize() << 3) - 1)) - 1L;
                 long succ = intLiteral.getValue();
                 succ += succ < maxValue ? 1L : 0L;
                 key.pushColumn(new IntLiteral(succ, Type.fromPrimitiveType(type)), type);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -39,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -460,5 +461,12 @@ public class FragmentNormalizer {
             remainConjuncts.addAll(boundOtherExprs);
             return remainConjuncts;
         }
+    }
+
+    // For partition that not support partition column range predicates' decomposition, we
+    // just create a simple selectedRangeMap which is used to construct cache key in BE.
+    public void createSimpleRangeMap(Collection<Long> selectedPartitionIds) {
+        selectedRangeMap = Maps.newHashMap();
+        selectedPartitionIds.stream().forEach(id -> selectedRangeMap.put(id, "[]"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FragmentNormalizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FragmentNormalizerTest.java
@@ -4,30 +4,30 @@ package com.starrocks.planner;
 
 import com.google.common.collect.Range;
 import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.LargeIntLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 public class FragmentNormalizerTest {
-    @Test
-    public void testToClosedAndOpenRange() throws AnalysisException {
-        Column partitionColumn = new Column("dt", Type.fromPrimitiveType(PrimitiveType.DATE));
+
+    private void testHelper(Column partitionColumn, LiteralExpr lower, LiteralExpr lowerSucc, LiteralExpr upper,
+                            LiteralExpr upperSucc)
+            throws AnalysisException {
         List<Column> partitionColumns = Arrays.asList(partitionColumn);
         PartitionKey minKey = PartitionKey.createInfinityPartitionKey(partitionColumns, false);
         PartitionKey maxKey = PartitionKey.createInfinityPartitionKey(partitionColumns, true);
-
-        LiteralExpr lower = new DateLiteral(2022, 1, 1);
-        LiteralExpr lowerSucc = new DateLiteral(2022, 1, 2);
-        LiteralExpr upper = new DateLiteral(2022, 1, 10);
-        LiteralExpr upperSucc = new DateLiteral(2022, 1, 11);
-
         PartitionKey lowerKey = new PartitionKey();
         PartitionKey lowerSuccKey = new PartitionKey();
         PartitionKey upperKey = new PartitionKey();
@@ -56,5 +56,58 @@ public class FragmentNormalizerTest {
             Range<PartitionKey> targetRange = (Range<PartitionKey>) tc[1];
             Assert.assertEquals(targetRange, FragmentNormalizer.toClosedOpenRange(range));
         }
+    }
+
+    @Test
+    public void testToClosedAndOpenRangeForDate() throws AnalysisException {
+        Column partitionColumn = new Column("dt", Type.fromPrimitiveType(PrimitiveType.DATE));
+        LiteralExpr lower = new DateLiteral(2022, 1, 1);
+        LiteralExpr lowerSucc = new DateLiteral(2022, 1, 2);
+        LiteralExpr upper = new DateLiteral(2022, 1, 10);
+        LiteralExpr upperSucc = new DateLiteral(2022, 1, 11);
+        testHelper(partitionColumn, lower, lowerSucc, upper, upperSucc);
+    }
+
+    @Test
+    public void testToClosedAndOpenRangeForDatetime() throws AnalysisException {
+        Column partitionColumn = new Column("ts", Type.fromPrimitiveType(PrimitiveType.DATETIME));
+        LiteralExpr lower = new DateLiteral(2022, 1, 1, 11, 23, 59);
+        LiteralExpr lowerSucc = new DateLiteral(2022, 1, 1, 11, 24, 0);
+        LiteralExpr upper = new DateLiteral(2022, 1, 10, 23, 59, 59);
+        LiteralExpr upperSucc = new DateLiteral(2022, 1, 11, 0, 0, 0);
+        testHelper(partitionColumn, lower, lowerSucc, upper, upperSucc);
+
+    }
+
+    @Test
+    public void testToClosedAndOpenRangeForInteger() throws AnalysisException {
+        PrimitiveType[] integerPtypes = new PrimitiveType[] {
+                PrimitiveType.BIGINT,
+                PrimitiveType.INT,
+                PrimitiveType.SMALLINT,
+                PrimitiveType.TINYINT,
+        };
+        for (PrimitiveType ptype : integerPtypes) {
+            Type type = Type.fromPrimitiveType(ptype);
+            long secondMaxValue = (1L << (ptype.getTypeSize() * 8 - 1)) - 2;
+            Column partitionColumn = new Column("k0", type);
+            LiteralExpr lower = new IntLiteral(1, type);
+            LiteralExpr lowerSucc = new IntLiteral(2, type);
+            LiteralExpr upper = new IntLiteral(secondMaxValue, type);
+            LiteralExpr upperSucc = new IntLiteral(secondMaxValue + 1, type);
+            testHelper(partitionColumn, lower, lowerSucc, upper, upperSucc);
+        }
+    }
+
+    @Test
+    public void testToClosedAndOpenRangeForLargeInt() throws AnalysisException {
+        Column partitionColumn = new Column("k0", Type.fromPrimitiveType(PrimitiveType.LARGEINT));
+        LiteralExpr lower = new LargeIntLiteral("1");
+        LiteralExpr lowerSucc = new LargeIntLiteral("2");
+        LiteralExpr upper =
+                new LargeIntLiteral(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.valueOf(2)).toString());
+        LiteralExpr upperSucc =
+                new LargeIntLiteral(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.valueOf(1)).toString());
+        testHelper(partitionColumn, lower, lowerSucc, upper, upperSucc);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Previous version of query cache only support single-column partitioned OlapTable, this PR introduces:
1. unpartitioned OlapTable support.
2. multi-column partitioned OlapTable support. however, predicates on multi-column partition is hard to decomposition, it is will be support in future instead of present.
3. fixup bugs of predicates' decomposition of integer-typed single-column partition.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2

