### PR TITLE
[cherry-pick][branch-2.3][Enhancement] Flush l0 when index file large in case of the l0 index file keep growing.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -785,4 +785,7 @@ CONF_Int64(max_length_for_bitmap_function, "1000000");
 
 // Used to limit buffer size of tablet send channel.
 CONF_mInt64(send_channel_buffer_limit, "67108864");
+
+CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
+
 } // namespace starrocks::config

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -169,11 +169,13 @@ public:
     Status check_not_exist(size_t n, const void* keys);
 
     // get Immutable index file size;
-    void file_size(uint64_t* file_size) {
+    uint64_t file_size() {
         if (_file != nullptr) {
             auto res = _file->get_size();
             CHECK(res.ok()) << res.status(); // FIXME: no abort
-            *file_size = *res;
+            return *res;
+        } else {
+            return 0;
         }
     }
 
@@ -269,6 +271,14 @@ public:
 
     // apply modification
     Status on_commited();
+
+    uint64_t l0_file_size() {
+        if (_index_file != nullptr) {
+            return _index_file->size();
+        } else {
+            return 0;
+        }
+    }
 
     // batch index operations
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
