### PR TITLE
[BugFix] Fix bug mysql display large int type in mysql-client 8.x

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1576,6 +1576,8 @@ public abstract class Type implements Cloneable {
             case VARCHAR:
             case HLL:
             case BITMAP:
+            // Because mysql does not have a large int type, mysql will treat it as hex after exceeding bigint
+            case LARGEINT:
                 return CHARSET_UTF8;
             default:
                 return CHARSET_BINARY;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1578,6 +1578,7 @@ public abstract class Type implements Cloneable {
             case BITMAP:
             // Because mysql does not have a large int type, mysql will treat it as hex after exceeding bigint
             case LARGEINT:
+            case JSON:
                 return CHARSET_UTF8;
             default:
                 return CHARSET_BINARY;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -125,6 +125,13 @@ public class TypeTest {
         Assert.assertEquals(0, type.getMysqlResultSetFieldDecimals());
         Assert.assertEquals(33, type.getMysqlResultSetFieldCharsetIndex());
 
+        // hll
+        type = Type.JSON;
+        // default 20 * 3
+        Assert.assertEquals(60, type.getMysqlResultSetFieldLength());
+        Assert.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assert.assertEquals(33, type.getMysqlResultSetFieldCharsetIndex());
+
         // array
         ArrayType arrayType = new ArrayType(Type.INT);
         // default 20 * 3

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -55,7 +55,7 @@ public class TypeTest {
         type = Type.LARGEINT;
         Assert.assertEquals(40, type.getMysqlResultSetFieldLength());
         Assert.assertEquals(0, type.getMysqlResultSetFieldDecimals());
-        Assert.assertEquals(63, type.getMysqlResultSetFieldCharsetIndex());
+        Assert.assertEquals(33, type.getMysqlResultSetFieldCharsetIndex());
 
         // date
         type = Type.DATE;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14127

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
