### PR TITLE
[BugFix] Fix morsel queue try_get

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -33,13 +33,7 @@ void _convert_morsels_to_olap_scan_ranges(const Morsels& morsels, std::vector<TI
 
 std::vector<TInternalScanRange*> FixedMorselQueue::olap_scan_ranges() const {
     std::vector<TInternalScanRange*> res;
-    if (_assign_morsels) {
-        for (auto& [_, morsels] : _morsels_per_operator) {
-            _convert_morsels_to_olap_scan_ranges(morsels, &res);
-        }
-    } else {
-        _convert_morsels_to_olap_scan_ranges(_morsels, &res);
-    }
+    _convert_morsels_to_olap_scan_ranges(_morsels, &res);
     return res;
 }
 
@@ -48,15 +42,14 @@ FixedMorselQueue::FixedMorselQueue(Morsels&& morsels, int dop)
     int io_parallelism = dop * ScanOperator::MAX_IO_TASKS_PER_OP;
     if (dop > 1 && _num_morsels <= io_parallelism) {
         for (int i = 0; i < dop; i++) {
-            _next_morsel_index_per_operator[i] = 0;
+            _next_idx_per_operator[i] = 0;
         }
         int operator_seq = 0;
         for (int i = 0; i < _morsels.size(); i++) {
-            _morsels_per_operator[operator_seq].push_back(std::move(_morsels[i]));
+            _morsel_idxs_per_operator[operator_seq].push_back(i);
             operator_seq = (operator_seq + 1) % _scan_dop;
         }
 
-        _morsels.clear();
         _assign_morsels = true;
     } else {
         _assign_morsels = false;
@@ -65,8 +58,8 @@ FixedMorselQueue::FixedMorselQueue(Morsels&& morsels, int dop)
 
 bool FixedMorselQueue::empty() const {
     if (_assign_morsels) {
-        for (auto& [seq, index] : _next_morsel_index_per_operator) {
-            if (index.load() < _morsels_per_operator.at(seq).size()) {
+        for (const auto& [seq, index] : _next_idx_per_operator) {
+            if (index.load() < _morsel_idxs_per_operator.at(seq).size()) {
                 return false;
             }
         }
@@ -78,21 +71,22 @@ bool FixedMorselQueue::empty() const {
 
 StatusOr<MorselPtr> FixedMorselQueue::try_get(int driver_seq) {
     if (_assign_morsels) {
-        auto& next_index = _next_morsel_index_per_operator[driver_seq];
-        auto& morsels = _morsels_per_operator[driver_seq];
+        auto& next_index = _next_idx_per_operator[driver_seq];
+        auto& morsel_idxs = _morsel_idxs_per_operator[driver_seq];
         int idx = next_index.load();
-        if (idx >= morsels.size()) {
+        if (idx >= morsel_idxs.size()) {
             return nullptr;
         }
         idx = next_index.fetch_add(1);
-        if (idx >= morsels.size()) {
+        if (idx >= morsel_idxs.size()) {
             return nullptr;
         }
 
+        int morsel_idx = morsel_idxs[idx];
         if (!_tablet_rowsets.empty()) {
-            _morsels[idx]->set_rowsets(std::move(_tablet_rowsets[idx]));
+            _morsels[morsel_idx]->set_rowsets(std::move(_tablet_rowsets[morsel_idx]));
         }
-        return std::move(morsels[idx]);
+        return std::move(_morsels[morsel_idx]);
     } else {
         auto idx = _pop_index.load();
         // prevent _num_morsels from superfluous addition

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -132,8 +132,8 @@ private:
 
     bool _assign_morsels = false;
     int _scan_dop;
-    std::map<int, Morsels> _morsels_per_operator;
-    std::map<int, std::atomic_size_t> _next_morsel_index_per_operator;
+    std::map<int, std::vector<int>> _morsel_idxs_per_operator;
+    std::map<int, std::atomic_size_t> _next_idx_per_operator;
 
     std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
 };


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix #14129.

`FixedMorselQueue ` in 2.3 has a strategy `_assign_morsels`, which splits _morsels to sub-morsels of each driver sequence. Therefore, the index of sub-morsels isn't identical to the index of morsels and rowset_per_tablets.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [x] 2.3
  - [ ] 2.2
