### PR TITLE
[Enhancement] Avoid FixedMorselQueue::empty returns false-positive

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -56,14 +56,11 @@ FixedMorselQueue::FixedMorselQueue(Morsels&& morsels, int dop)
     }
 }
 
-bool FixedMorselQueue::empty() const {
+bool FixedMorselQueue::empty(int driver_seq) const {
     if (_assign_morsels) {
-        for (const auto& [seq, index] : _next_idx_per_operator) {
-            if (index.load() < _morsel_idxs_per_operator.at(seq).size()) {
-                return false;
-            }
-        }
-        return true;
+        const auto& next_index = _next_idx_per_operator.at(driver_seq);
+        const auto& morsel_idxs = _morsel_idxs_per_operator.at(driver_seq);
+        return next_index >= morsel_idxs.size();
     } else {
         return _pop_index >= _num_morsels;
     }

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -132,8 +132,8 @@ private:
 
     bool _assign_morsels = false;
     int _scan_dop;
-    std::map<int, std::vector<int>> _morsel_idxs_per_operator;
-    std::map<int, std::atomic_size_t> _next_idx_per_operator;
+    std::vector<std::vector<int>> _morsel_idxs_per_operator;
+    std::vector<std::atomic_size_t> _next_idx_per_operator;
 
     std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
 };

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -98,7 +98,7 @@ public:
 
     virtual size_t num_original_morsels() const = 0;
     virtual size_t max_degree_of_parallelism() const = 0;
-    virtual bool empty() const = 0;
+    virtual bool empty(int driver_seq) const = 0;
     virtual StatusOr<MorselPtr> try_get(int driver_seq) = 0;
 
     virtual std::string name() const = 0;
@@ -120,7 +120,7 @@ public:
 
     size_t num_original_morsels() const override { return _num_morsels; }
     size_t max_degree_of_parallelism() const override { return _num_morsels; }
-    bool empty() const override;
+    bool empty(int driver_seq) const override;
     StatusOr<MorselPtr> try_get(int driver_seq) override;
 
     std::string name() const override { return "fixed_morsel_queue"; }
@@ -157,7 +157,7 @@ public:
 
     size_t num_original_morsels() const override { return _morsels.size(); }
     size_t max_degree_of_parallelism() const override { return _degree_of_parallelism; }
-    bool empty() const override { return _tablet_idx >= _tablets.size(); }
+    bool empty(int driver_seq) const override { return _tablet_idx >= _tablets.size(); }
     StatusOr<MorselPtr> try_get(int driver_seq) override;
 
     std::string name() const override { return "physical_split_morsel_queue"; }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -149,7 +149,7 @@ bool ScanOperator::has_output() const {
     // return true if more i/o tasks can be committed.
 
     // Can pick up more morsels.
-    if (!_morsel_queue->empty()) {
+    if (!_morsel_queue->empty(_driver_sequence)) {
         return true;
     }
 
@@ -178,7 +178,7 @@ bool ScanOperator::is_finished() const {
     }
 
     // Any io task is running or needs to run.
-    if (_num_running_io_tasks > 0 || !_morsel_queue->empty()) {
+    if (_num_running_io_tasks > 0 || !_morsel_queue->empty(_driver_sequence)) {
         return false;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`FixedMorselQueue::empty` may return false-positive. 
As for the strategy `_assign_morsels` which splits morsels to sub-morsels of each driver sequence. However, `empty` returns true, if any sub-morsel is not empty.



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [x] 2.3
  - [ ] 2.2
