### PR TITLE
[BugFix] query whose group-by and having clause depends on agg columns of aggragate table/mv can not use multiversion cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.AggregateInfo;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.DescriptorTable;
@@ -34,7 +35,6 @@ import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleId;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
@@ -53,6 +53,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Optional;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -329,6 +330,10 @@ public class AggregationNode extends PlanNode {
         int numAggExprs = (aggExprs == null || aggExprs.isEmpty()) ? 0 : aggExprs.size();
         IntStream.range(0, numAggExprs).forEach(i ->
                 slotIdsAndAggExprs.put(slotIds.get(i + numGroupingExprs), aggExprs.get(i)));
+
+        normalizer.addAggColumnDependentSlotIds(slotIdsAndAggExprs);
+        normalizer.disableMultiversionIfExprsDependOnAggColumns(groupingExprs);
+
         Pair<List<Integer>, List<ByteBuffer>> remappedAggExprs =
                 normalizer.normalizeSlotIdsAndExprs(slotIdsAndAggExprs);
         aggrNode.setAggregate_functions(remappedAggExprs.second);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -25,7 +25,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.starrocks.analysis.AggregateInfo;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.DescriptorTable;
@@ -53,7 +52,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Optional;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -331,8 +329,8 @@ public class AggregationNode extends PlanNode {
         IntStream.range(0, numAggExprs).forEach(i ->
                 slotIdsAndAggExprs.put(slotIds.get(i + numGroupingExprs), aggExprs.get(i)));
 
-        normalizer.addAggColumnDependentSlotIds(slotIdsAndAggExprs);
-        normalizer.disableMultiversionIfExprsDependOnAggColumns(groupingExprs);
+        normalizer.addSlotsUseAggColumns(slotIdsAndAggExprs);
+        normalizer.disableMultiversionIfExprsUseAggColumns(groupingExprs);
 
         Pair<List<Integer>, List<ByteBuffer>> remappedAggExprs =
                 normalizer.normalizeSlotIdsAndExprs(slotIdsAndAggExprs);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
@@ -84,6 +84,7 @@ public class DecodeNode extends PlanNode {
                 .collect(Collectors.toList());
         decodeNode.setFrom_dict_ids(fromDictIds);
         decodeNode.setTo_string_ids(toStringIds);
+        normalizer.addAggColumnDependentSlotIds(stringFunctions);
         Pair<List<Integer>, List<ByteBuffer>> slotIdsAndExprs = normalizer.normalizeSlotIdsAndExprs(stringFunctions);
         decodeNode.setSlot_ids(slotIdsAndExprs.first);
         decodeNode.setString_functions(slotIdsAndExprs.second);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
@@ -84,7 +84,7 @@ public class DecodeNode extends PlanNode {
                 .collect(Collectors.toList());
         decodeNode.setFrom_dict_ids(fromDictIds);
         decodeNode.setTo_string_ids(toStringIds);
-        normalizer.addAggColumnDependentSlotIds(stringFunctions);
+        normalizer.addSlotsUseAggColumns(stringFunctions);
         Pair<List<Integer>, List<ByteBuffer>> slotIdsAndExprs = normalizer.normalizeSlotIdsAndExprs(stringFunctions);
         decodeNode.setSlot_ids(slotIdsAndExprs.first);
         decodeNode.setString_functions(slotIdsAndExprs.second);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -72,7 +72,7 @@ public class FragmentNormalizer {
 
     private KeysType keysType;
 
-    private Set<SlotId> aggColumnDependentSlotIds;
+    private Set<SlotId> slotsUseAggColumns;
 
     public FragmentNormalizer(ExecPlan execPlan, PlanFragment fragment) {
         this.execPlan = execPlan;
@@ -471,33 +471,33 @@ public class FragmentNormalizer {
         selectedPartitionIds.stream().forEach(id -> selectedRangeMap.put(id, "[]"));
     }
 
-    public Set<SlotId> getAggColumnDependentSlotIds() {
-        return aggColumnDependentSlotIds;
+    public Set<SlotId> getSlotsUseAggColumns() {
+        return slotsUseAggColumns;
     }
 
-    public void setAggColumnDependentSlotIds(Set<SlotId> aggColumnDependentSlotIds) {
-        this.aggColumnDependentSlotIds = aggColumnDependentSlotIds;
+    public void setSlotsUseAggColumns(Set<SlotId> slotsUseAggColumns) {
+        this.slotsUseAggColumns = slotsUseAggColumns;
     }
 
-    public void addAggColumnDependentSlotIds(Map<SlotId, Expr> exprs) {
+    public void addSlotsUseAggColumns(Map<SlotId, Expr> exprs) {
         exprs.forEach((slotId, expr) -> {
             List<SlotRef> slotRefs = Lists.newArrayList();
             expr.collect(SlotRef.class, slotRefs);
-            Set<SlotId> referenced = slotRefs.stream().map(SlotRef::getSlotId).collect(Collectors.toSet());
-            if (!Sets.intersection(this.aggColumnDependentSlotIds, referenced).isEmpty()) {
-                this.aggColumnDependentSlotIds.add(slotId);
+            Set<SlotId> usedColumnIds = slotRefs.stream().map(SlotRef::getSlotId).collect(Collectors.toSet());
+            if (!Sets.intersection(this.slotsUseAggColumns, usedColumnIds).isEmpty()) {
+                this.slotsUseAggColumns.add(slotId);
             }
         });
     }
 
-    public void disableMultiversionIfExprsDependOnAggColumns(List<Expr> exprs) {
+    public void disableMultiversionIfExprsUseAggColumns(List<Expr> exprs) {
         if (exprs == null || exprs.isEmpty()) {
             return;
         }
         List<SlotRef> slotRefs = Lists.newArrayList();
         exprs.forEach(e -> e.collect(SlotRef.class, slotRefs));
-        Set<SlotId> dependSlotIds = slotRefs.stream().map(SlotRef::getSlotId).collect(Collectors.toSet());
-        if (!Sets.intersection(dependSlotIds, this.aggColumnDependentSlotIds).isEmpty()) {
+        Set<SlotId> usedColumnIds = slotRefs.stream().map(SlotRef::getSlotId).collect(Collectors.toSet());
+        if (!Sets.intersection(usedColumnIds, this.slotsUseAggColumns).isEmpty()) {
             this.setCanUseMultiVersion(false);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -822,7 +822,7 @@ public class OlapScanNode extends ScanNode {
                 normalizer.getExecPlan().getDescTbl().getTupleDesc(tupleIds.get(0)).getSlots().stream()
                         .filter(s -> aggColumnNames.contains(s.getColumn().getName())).map(s -> s.getId())
                         .collect(Collectors.toSet());
-        normalizer.setAggColumnDependentSlotIds(aggColumnSlotIds);
+        normalizer.setSlotsUseAggColumns(aggColumnSlotIds);
 
         TNormalOlapScanNode scanNode = new TNormalOlapScanNode();
         scanNode.setTablet_id(olapTable.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -32,12 +32,10 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.sql.ast.PartitionNames;
-import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.TupleDescriptor;
-import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
@@ -59,11 +57,9 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
-import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.system.Backend;
 import com.starrocks.thrift.TExplainLevel;
@@ -799,11 +795,10 @@ public class OlapScanNode extends ScanNode {
     // of the tablet from merging the snapshot result in cache and the delta rowsets in disk.
     private boolean canUseMultiVersionCache() {
         switch (olapTable.getKeysType()) {
-            case DUP_KEYS:
-                return true;
             case PRIMARY_KEYS:
             case UNIQUE_KEYS:
                 return false;
+            case DUP_KEYS:
             case AGG_KEYS: {
                 List<Column> columns = selectedIndexId == -1 ? olapTable.getBaseSchema() :
                         olapTable.getSchemaByIndexId(selectedIndexId);
@@ -817,6 +812,18 @@ public class OlapScanNode extends ScanNode {
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
         normalizer.setKeysType(olapTable.getKeysType());
         normalizer.setCanUseMultiVersion(canUseMultiVersionCache());
+
+        List<Column> columns = selectedIndexId == -1 ? olapTable.getBaseSchema() :
+                olapTable.getSchemaByIndexId(selectedIndexId);
+
+        Set<String> aggColumnNames =
+                columns.stream().filter(Column::isAggregated).map(Column::getName).collect(Collectors.toSet());
+        Set<SlotId> aggColumnSlotIds =
+                normalizer.getExecPlan().getDescTbl().getTupleDesc(tupleIds.get(0)).getSlots().stream()
+                        .filter(s -> aggColumnNames.contains(s.getColumn().getName())).map(s -> s.getId())
+                        .collect(Collectors.toSet());
+        normalizer.setAggColumnDependentSlotIds(aggColumnSlotIds);
+
         TNormalOlapScanNode scanNode = new TNormalOlapScanNode();
         scanNode.setTablet_id(olapTable.getId());
         scanNode.setIndex_id(selectedIndexId);
@@ -844,7 +851,6 @@ public class OlapScanNode extends ScanNode {
         scanNode.setDict_int_ids(dictIntIds);
         planNode.setNode_type(TPlanNodeType.OLAP_SCAN_NODE);
         planNode.setOlap_scan_node(scanNode);
-
         normalizeConjuncts(normalizer, planNode, conjuncts);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -898,7 +898,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                 .collect(Collectors.toList());
         planNode.setNullable_tuples(nullable_tuples);
         toNormalForm(planNode, normalizer);
-        normalizer.disableMultiversionIfExprsDependOnAggColumns(conjuncts);
+        normalizer.disableMultiversionIfExprsUseAggColumns(conjuncts);
 
         return planNode;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -898,6 +898,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                 .collect(Collectors.toList());
         planNode.setNullable_tuples(nullable_tuples);
         toNormalForm(planNode, normalizer);
+        normalizer.disableMultiversionIfExprsDependOnAggColumns(conjuncts);
 
         return planNode;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -180,8 +180,8 @@ public class ProjectNode extends PlanNode {
     @Override
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
         TNormalProjectNode projectNode = new TNormalProjectNode();
-        normalizer.addAggColumnDependentSlotIds(commonSlotMap);
-        normalizer.addAggColumnDependentSlotIds(slotMap);
+        normalizer.addSlotsUseAggColumns(commonSlotMap);
+        normalizer.addSlotsUseAggColumns(slotMap);
         Pair<List<Integer>, List<ByteBuffer>> cseSlotIdsAndExprs = normalizer.normalizeSlotIdsAndExprs(commonSlotMap);
         projectNode.setCse_slot_ids(cseSlotIdsAndExprs.first);
         projectNode.setCse_exprs(cseSlotIdsAndExprs.second);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -180,6 +180,8 @@ public class ProjectNode extends PlanNode {
     @Override
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
         TNormalProjectNode projectNode = new TNormalProjectNode();
+        normalizer.addAggColumnDependentSlotIds(commonSlotMap);
+        normalizer.addAggColumnDependentSlotIds(slotMap);
         Pair<List<Integer>, List<ByteBuffer>> cseSlotIdsAndExprs = normalizer.normalizeSlotIdsAndExprs(commonSlotMap);
         projectNode.setCse_slot_ids(cseSlotIdsAndExprs.first);
         projectNode.setCse_exprs(cseSlotIdsAndExprs.second);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When a aggregation query is performed on AGGREGATE KEYS OlapTable or MV whose columns carrying aggregate functions and this query satisfies one of condtions as follows:
1. group-by clause of AggregationNode depends on aggr columns.
2. having clauseof AggregationNode depends on aggr columns.
3. conjuncts of PlanNodes below AggregationNode depends on aggr columns.

Then multiversion cache mechanism can not be leveraged to merge the snapshot result from the cache and the delta rowsets from the disk into final result of a tablet. To see the UT in FE, some queries are showed.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
