### PR TITLE
[BugFix] refresh finishChecker periodically to prevent table/partiton/index change

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -27,6 +27,7 @@ struct TabletPublishVersionTask {
     int64_t partition_id{0};
     int64_t tablet_id{0};
     int64_t version{0};
+    int64_t current_version{0};
     RowsetSharedPtr rowset;
     Status st;
     int64_t max_continuous_version{0}; // max continuous version after publish is done
@@ -85,10 +86,10 @@ void run_publish_version_task(ThreadPoolToken* token, const PublishVersionAgentT
                 }
                 TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(task.tablet_id);
                 if (!tablet) {
-                    task.st = Status::NotFound(
-                            fmt::format("Not found tablet to publish_version. tablet_id: {}, txn_id: {}",
-                                        task.tablet_id, task.txn_id));
-                    LOG(WARNING) << task.st;
+                    // tablet may get dropped, it's ok to ignore this situation
+                    LOG(WARNING) << fmt::format(
+                            "publish_version tablet not found tablet_id: {}, version: {} txn_id: {}", task.tablet_id,
+                            task.version, task.txn_id);
                     return;
                 }
                 {
@@ -107,7 +108,7 @@ void run_publish_version_task(ThreadPoolToken* token, const PublishVersionAgentT
                               << " partition:" << task.partition_id << " txn_id: " << task.txn_id
                               << " rowset:" << task.rowset->rowset_id();
                 }
-                task.version = tablet->max_continuous_version();
+                task.current_version = tablet->max_continuous_version();
             });
             if (st.is_service_unavailable()) {
                 int64_t retry_sleep_ms = 50 * retry_time;
@@ -141,10 +142,10 @@ void run_publish_version_task(ThreadPoolToken* token, const PublishVersionAgentT
                 st = task.st;
             }
         }
-        if (task.version > 0) {
+        if (task.current_version > 0) {
             auto& pair = tablet_versions.emplace_back();
             pair.__set_tablet_id(task.tablet_id);
-            pair.__set_version(task.version);
+            pair.__set_version(task.current_version);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -746,9 +746,9 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                         empty = false;
                     }
                     Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(replica.getBackendId());
-                    sb.append(String.format("[be:%s,version:%d%s]",
+                    sb.append(String.format(" %s:%d%s",
                             backend == null ? Long.toString(replica.getBackendId()) : backend.getHost(), replicaVersion,
-                            replica.getState() == ReplicaState.ALTER ? ",ALTER" : ""));
+                            replica.getState() == ReplicaState.ALTER ? "ALTER" : ""));
                 }
             }
             if (!empty) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1509,8 +1509,8 @@ public class StmtExecutor {
             String timeoutInfo = GlobalStateMgr.getCurrentGlobalTransactionMgr()
                     .getTxnPublishTimeoutDebugInfo(database.getId(), transactionId);
             LOG.warn("txn {} publish timeout {}", transactionId, timeoutInfo);
-            if (timeoutInfo.length() > 120) {
-                timeoutInfo = timeoutInfo.substring(0, 120) + "...";
+            if (timeoutInfo.length() > 240) {
+                timeoutInfo = timeoutInfo.substring(0, 240) + "...";
             }
             errMsg = "Publish timeout " + timeoutInfo;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1023,8 +1023,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             String timeoutInfo = GlobalStateMgr.getCurrentGlobalTransactionMgr()
                     .getTxnPublishTimeoutDebugInfo(db.getId(), request.getTxnId());
             LOG.warn("txn {} publish timeout {}", request.getTxnId(), timeoutInfo);
-            if (timeoutInfo.length() > 120) {
-                timeoutInfo = timeoutInfo.substring(0, 120) + "...";
+            if (timeoutInfo.length() > 240) {
+                timeoutInfo = timeoutInfo.substring(0, 240) + "...";
             }
             status.addToError_msgs("Publish timeout. The data will be visible after a while" + timeoutInfo);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -166,7 +166,7 @@ public class PublishVersionTask extends AgentTask {
             }
         }
         if (!droppedTablets.isEmpty()) {
-            LOG.warn("during publish version some tablets were dropped(maybe by alter), tabletIds={}", droppedTablets);
+            LOG.info("during publish version some tablets were dropped(maybe by alter), tabletIds={}", droppedTablets);
         }
         db.writeLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -159,6 +159,15 @@ public class PublishVersionTask extends AgentTask {
             LOG.warn("db not found dbid={}", dbId);
             return;
         }
+        List<Long> droppedTablets = new ArrayList<>();
+        for (int i = 0; i < tabletVersions.size(); i++) {
+            if (replicas.get(i) == null) {
+                droppedTablets.add(tabletVersions.get(i).tablet_id);
+            }
+        }
+        if (!droppedTablets.isEmpty()) {
+            LOG.warn("during publish version some tablets were dropped(maybe by alter), tabletIds={}", droppedTablets);
+        }
         db.writeLock();
         try {
             // TODO: persistent replica version
@@ -166,7 +175,6 @@ public class PublishVersionTask extends AgentTask {
                 TTabletVersionPair tabletVersion = tabletVersions.get(i);
                 Replica replica = replicas.get(i);
                 if (replica == null) {
-                    LOG.warn("replica not found backendid={} tabletid={}", backendId, tabletVersion.tablet_id);
                     continue;
                 }
                 replica.updateVersion(tabletVersion.version);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -175,7 +175,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
                         AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.PUBLISH_VERSION, task.getSignature());
                     }
                     // clear publish version tasks to reduce memory usage when state changed to visible.
-                    transactionState.clearPublishVersionTasks();
+                    transactionState.clearAfterPublished();
 
                     // Refresh materialized view when base table update transaction has been visible if necessary
                     refreshMvIfNecessary(transactionState);
@@ -203,7 +203,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
                         AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.PUBLISH_VERSION, task.getSignature());
                     }
                     // clear publish version tasks to reduce memory usage when state changed to visible.
-                    transactionState.clearPublishVersionTasks();
+                    transactionState.clearAfterPublished();
                     // Refresh materialized view when base table update transaction has been visible if necessary
                     refreshMvIfNecessary(transactionState);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -250,7 +250,7 @@ public class TransactionState implements Writable {
     // used for PublishDaemon to check whether this txn can be published
     // not persisted, so need to rebuilt if FE restarts
     private volatile TransactionChecker finishChecker = null;
-    private long checkTimes = 0;
+    private long checkerCreationTime = 0;
     private Span txnSpan = null;
     private String traceParent = null;
 
@@ -674,8 +674,9 @@ public class TransactionState implements Writable {
         return publishVersionTasks;
     }
 
-    public void clearPublishVersionTasks() {
+    public void clearAfterPublished() {
         publishVersionTasks.clear();
+        finishChecker = null;
     }
 
     @Override
@@ -901,18 +902,16 @@ public class TransactionState implements Writable {
 
     // Note: caller should hold db lock
     public void prepareFinishChecker(Database db) {
-        if (finishChecker == null) {
-            synchronized (this) {
-                if (finishChecker == null) {
-                    finishChecker = TransactionChecker.create(this, db);
-                }
-            }
+        synchronized (this) {
+            finishChecker = TransactionChecker.create(this, db);
+            checkerCreationTime = System.nanoTime();
         }
     }
 
     public boolean checkCanFinish() {
-        // this may happen if FE restarts
-        if (finishChecker == null) {
+        // finishChecker may be null if FE restarts
+        // finishChecker may require refresh if table/partition is dropped, or index is changed caused by Alter job
+        if (finishChecker == null || System.nanoTime() - checkerCreationTime > 10000000000L) {
             Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
             if (db == null) {
                 // consider txn finished if db is dropped
@@ -928,17 +927,18 @@ public class TransactionState implements Writable {
         if (finishState == null) {
             finishState = new TxnFinishState();
         }
-        checkTimes++;
         boolean ret = finishChecker.finished(finishState);
         if (ret) {
             txnSpan.addEvent("check_ok");
-            txnSpan.setAttribute("check_times", checkTimes);
         }
         return ret;
     }
 
     public String getPublishTimeoutDebugInfo() {
-        if (finishChecker != null) {
+        if (!hasSendTask()) {
+            return "txn has not sent publish tasks yet, maybe waiting previous txns on the same table(s) to finish, tableIds: " +
+                    Joiner.on(",").join(getTableIdList());
+        } else if (finishChecker != null) {
             return finishChecker.debugInfo();
         } else {
             return getErrMsg();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14148

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When using new publish mechanism and a txn is in the publish process, a DDL/schemachange occurs and the txn related table/partition/index changed, the finishchecker should be refreshed, or tablets in deleted index may still be checked for publish success(which will never happen), and the checker will never succeed. 

This PR fixes this by adding a periodic refresh(recreate actually) for finishchecker, so txn can finish even when DDL/schemachange occurs.

This PR also optimizes some logging issue found when debugging this bug.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
