### PR TITLE
[Enhancement] Eliminate bad cases of high cardinality group-by of agg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -39,6 +39,8 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.thrift.TAggregationNode;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TExpr;
@@ -307,10 +309,39 @@ public class AggregationNode extends PlanNode {
         return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
     }
 
+    private void disableCacheIfHighCardinalityGroupBy(FragmentNormalizer normalizer) {
+        if (ConnectContext.get() == null || getCardinality() == -1) {
+            return;
+        }
+        long cardinalityLimit = ConnectContext.get().getSessionVariable().getQueryCacheAggCardinalityLimit();
+        long cardinality = getCardinality();
+        if (cardinality < cardinalityLimit || aggInfo.getGroupingExprs().isEmpty()) {
+            return;
+        }
+        List<Expr> groupByExprs = aggInfo.getGroupingExprs();
+        if (groupByExprs.size() > 3) {
+            normalizer.setUncacheable(true);
+        }
+        List<SlotRef> slotRefs = groupByExprs.stream().filter(e -> e instanceof SlotRef && e.getType().isStringType())
+                .map(e -> (SlotRef) e).collect(Collectors.toList());
+        // we assume that if there exists a very high cardinality of string-typed group-by columns whose average length is
+        // greater than 24 bytes(it is equivalent to three bigint-typed group-by columns), then cache populating penalty
+        // is unacceptable.
+        List<ColumnStatistic> stringColumnStatistics = slotRefs.stream()
+                .map(slot -> columnStatistics.get(new ColumnRefOperator(slot.getSlotId().asInt(), null, null, false)))
+                .filter(stat -> stat != null && !stat.isUnknown() &&
+                        stat.getAverageRowSize() * stat.getDistinctValuesCount() > 24 * cardinalityLimit)
+                .collect(Collectors.toList());
+        if (!stringColumnStatistics.isEmpty()) {
+            normalizer.setUncacheable(true);
+        }
+    }
+
     @Override
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
+        disableCacheIfHighCardinalityGroupBy(normalizer);
         TNormalAggregationNode aggrNode = new TNormalAggregationNode();
-        TupleId tupleId = needsFinalize? aggInfo.getOutputTupleId():aggInfo.getIntermediateTupleId();
+        TupleId tupleId = needsFinalize ? aggInfo.getOutputTupleId() : aggInfo.getIntermediateTupleId();
         List<SlotId> slotIds = normalizer.getExecPlan().getDescTbl().getTupleDesc(tupleId).getSlots()
                 .stream().map(SlotDescriptor::getId).collect(Collectors.toList());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -299,6 +299,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // We assume that for PRIMARY_KEYS and UNIQUE_KEYS, the latest partitions are hot partitions that are updated
     // frequently, so it should not be cached in query cache since its disruptive cache invalidation.
     public static final String QUERY_CACHE_HOT_PARTITION_NUM = "query_cache_hot_partition_num";
+
+    public static final String QUERY_CACHE_AGG_CARDINALITY_LIMIT = "query_cache_agg_cardinality_limit";
     public static final String TRANSMISSION_ENCODE_LEVEL = "transmission_encode_level";
 
     public static final String NESTED_MV_REWRITE_MAX_LEVEL = "nested_mv_rewrite_max_level";
@@ -756,6 +758,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = QUERY_CACHE_HOT_PARTITION_NUM)
     private int queryCacheHotPartitionNum = 3;
+
+    @VarAttr(name = QUERY_CACHE_AGG_CARDINALITY_LIMIT)
+    private long queryCacheAggCardinalityLimit = 5000000;
 
     @VarAttr(name = NESTED_MV_REWRITE_MAX_LEVEL)
     private int nestedMvRewriteMaxLevel = 3;
@@ -1409,6 +1414,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getQueryCacheHotPartitionNum() {
         return queryCacheHotPartitionNum;
+    }
+
+    public void setQueryCacheAggCardinalityLimit(long limit) {
+        this.queryCacheAggCardinalityLimit = limit;
+    }
+
+    public long getQueryCacheAggCardinalityLimit() {
+        return queryCacheAggCardinalityLimit;
     }
 
     public void setEnableQueryCache(boolean on) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Aggregation has high cardinality group-by is bad cases for query cache populating operation, so we must eliminate these bad cases. How to define a high cardinality group-by aggregation?
1. cardinality of AggregationNode exceeds session variable query_cache_agg_high_cardinality_limit(5,000,000 in default), and
2. the number of group-by columns > 3 or the memory room that is occupied by one of string-typed group-by columns is too large and exceeds 24 * cardinality. Here the reason of chosing 24 * cardinality is assuming that aggregation on such a string-typed column have a highier cost that the same cardinality of three bigint-typed group-by columns.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
