### PR TITLE
[BugFix] move non-deterministic func check into expr reuse phase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -147,11 +147,6 @@ public class CallOperator extends ScalarOperator {
         }
         CallOperator other = (CallOperator) obj;
 
-        //Non-deterministic functions cannot be equal by default, and expression reuse is disabled
-        if (FunctionSet.nonDeterministicFunctions.contains(fnName)) {
-            return false;
-        }
-
         return isDistinct == other.isDistinct &&
                 Objects.equals(fnName, other.fnName) &&
                 Objects.equals(type, other.type) &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -219,7 +219,7 @@ public class ScalarOperatorsReuse {
 
         private int collectCommonOperatorsByDepth(int depth, ScalarOperator operator) {
             Set<ScalarOperator> operators = getOperatorsByDepth(depth, operatorsByDepth);
-            if (operators.contains(operator)) {
+            if (!isNonDeterministicFuncExist(operator) && operators.contains(operator)) {
                 Set<ScalarOperator> commonOperators = getOperatorsByDepth(depth, commonOperatorsByDepth);
                 commonOperators.add(operator);
             }
@@ -235,7 +235,7 @@ public class ScalarOperatorsReuse {
 
         @Override
         public Integer visit(ScalarOperator scalarOperator, Void context) {
-            if (isNonDeterministicFuncExist(scalarOperator) || scalarOperator.getChildren().isEmpty()) {
+            if (scalarOperator.getChildren().isEmpty()) {
                 return 0;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 public class ScalarOperatorsReuseRule implements TreeRewriteRule {
-    public static final ReuseVisitor HANDLER = new ReuseVisitor();
+    private static final ReuseVisitor HANDLER = new ReuseVisitor();
 
     @Override
     public OptExpression rewrite(OptExpression root, TaskContext taskContext) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -2,11 +2,14 @@
 
 package com.starrocks.sql.optimizer.rewrite;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import org.junit.Assert;
 import org.junit.Before;
@@ -922,5 +925,13 @@ public class ScalarOperatorFunctionsTest {
         ConstantOperator date =
                 ScalarOperatorFunctions.fromUnixTime(O_INT_10, ConstantOperator.createVarchar("%Y-%m-%d %H:%i:%s"));
         assertTrue(date.toString().matches("1970-01-01 0.*:00:10"));
+    }
+
+    @Test
+    public void testNonDeterministicFuncComp() {
+        // In logical phash, the new operator cloned from the original one should equal with the original one.
+        CallOperator random = new CallOperator(FunctionSet.RANDOM, Type.DOUBLE, Lists.newArrayList());
+        CallOperator randomCopy = (CallOperator) random.clone();
+        assertEquals(random, randomCopy);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In logical plan optimize phase, a scalar operator and its copy should be regarded as the same thing.
So, it's better move this special non-deterministic func check logic into expr reuse phase.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
