### PR TITLE
[Enhancement] Optimize mem usage of partial update

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -204,7 +204,7 @@ Status DeltaWriter::_init() {
             // If tablet is a new created tablet and has no historical data, average_row_size is 0
             // And we use schema size as average row size. If there are complex type(i.e. BITMAP/ARRAY) or varchar,
             // we will consider it as 16 bytes.
-            average_row_size = _tablet->tablet_schema()->estimate_row_size(16);
+            average_row_size = _tablet->tablet_schema().estimate_row_size(16);
             _memtable_buffer_row = config::write_buffer_size / average_row_size;
         }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -184,10 +184,7 @@ Status DeltaWriter::_init() {
     // maybe partial update, change to partial tablet schema
     if (_tablet->tablet_schema().keys_type() == KeysType::PRIMARY_KEYS &&
         partial_cols_num < _tablet->tablet_schema().num_columns()) {
-        const TabletSchema& tablet_schema = _tablet->tablet_schema();
         writer_context.referenced_column_ids.reserve(partial_cols_num);
-        int64_t partial_cols_size = 0;
-        int64_t cols_size = 0;
         for (auto i = 0; i < partial_cols_num; ++i) {
             const auto& slot_col_name = (*_opt.slots)[i]->col_name();
             int32_t index = _tablet->field_index(slot_col_name);
@@ -198,17 +195,13 @@ Status DeltaWriter::_init() {
                 _set_state(kAborted, st);
                 return st;
             }
-            const TabletColumn& tablet_column = tablet_schema.column(static_cast<size_t>(index));
-            partial_cols_size += tablet_column.length();
             writer_context.referenced_column_ids.push_back(index);
         }
-        for (auto i = 0; i < tablet_schema.num_columns(); ++i) {
-            const TabletColumn& tablet_column = tablet_schema.column(i);
-            cols_size += tablet_column.length();
-        }
-
-        if (partial_cols_size != 0 && cols_size != 0) {
-            _memtable_buffer_size = config::write_buffer_size * partial_cols_size / cols_size;
+        int64_t average_row_size = _tablet->updates()->get_average_row_size();
+        if (average_row_size != 0) {
+            _memtable_buffer_row = config::write_buffer_size / average_row_size;
+        } else {
+            _memtable_buffer_row = 10240;
         }
 
         writer_context.partial_update_tablet_schema =
@@ -414,7 +407,7 @@ void DeltaWriter::_reset_mem_table() {
         _mem_table = std::make_unique<MemTable>(_tablet->tablet_id(), &_vectorized_schema, _opt.slots,
                                                 _mem_table_sink.get(), "", _mem_tracker);
     }
-    _mem_table->set_write_buffer_size(_memtable_buffer_size);
+    _mem_table->set_write_buffer_row(_memtable_buffer_row);
 }
 
 Status DeltaWriter::commit() {

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -201,7 +201,11 @@ Status DeltaWriter::_init() {
         if (average_row_size != 0) {
             _memtable_buffer_row = config::write_buffer_size / average_row_size;
         } else {
-            _memtable_buffer_row = 10240;
+            // If tablet is a new created tablet and has no historical data, average_row_size is 0
+            // And we use schema size as average row size. If there are complex type(i.e. BITMAP/ARRAY) or varchar,
+            // we will consider it as 16 bytes.
+            average_row_size = _tablet->tablet_schema()->estimate_row_size(16);
+            _memtable_buffer_row = config::write_buffer_size / average_row_size;
         }
 
         writer_context.partial_update_tablet_schema =

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -174,6 +174,7 @@ private:
     std::unique_ptr<FlushToken> _flush_token;
     std::unique_ptr<ReplicateToken> _replicate_token;
     bool _with_rollback_log;
+    int64_t _memtable_buffer_size = config::write_buffer_size;
 };
 
 } // namespace starrocks

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -174,7 +174,8 @@ private:
     std::unique_ptr<FlushToken> _flush_token;
     std::unique_ptr<ReplicateToken> _replicate_token;
     bool _with_rollback_log;
-    int64_t _memtable_buffer_size = config::write_buffer_size;
+    // initial value is max value
+    size_t _memtable_buffer_row = -1;
 };
 
 } // namespace starrocks

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -131,8 +131,12 @@ size_t MemTable::write_buffer_size() const {
     return _chunk_bytes_usage + _aggregator_bytes_usage;
 }
 
+size_t MemTable::write_buffer_rows() const {
+    return _total_rows - _merged_rows;
+}
+
 bool MemTable::is_full() const {
-    return write_buffer_size() >= _max_buffer_size;
+    return write_buffer_size() >= _max_buffer_size || write_buffer_rows() >= _max_buffer_row;
 }
 
 bool MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
@@ -162,6 +166,7 @@ bool MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from
     if (chunk.has_rows()) {
         _chunk_memory_usage += chunk.memory_usage() * size / chunk.num_rows();
         _chunk_bytes_usage += _chunk->bytes_usage(cur_row_count, size);
+        _total_rows += chunk.num_rows();
     }
 
     // if memtable is full, push it to the flush executor,
@@ -319,6 +324,7 @@ void MemTable::_aggregate(bool is_final) {
     // impossible finish
     DCHECK(!_aggregator->is_finish());
     DCHECK(_aggregator->source_exhausted());
+    _merged_rows = _aggregator->merged_rows();
 
     if (is_final) {
         _result_chunk.reset();

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -61,8 +61,9 @@ public:
 
     bool is_full() const;
 
-    static VectorizedSchema convert_schema(const TabletSchema* tablet_schema,
-                                           const std::vector<SlotDescriptor*>* slot_descs);
+    void set_write_buffer_size(size_t max_buffer_size) { _max_buffer_size = max_buffer_size; }
+
+    static Schema convert_schema(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>* slot_descs);
 
 private:
     void _merge();

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -51,6 +51,7 @@ public:
 
     // buffer memory usage for write segment
     size_t write_buffer_size() const;
+    size_t write_buffer_rows() const;
 
     // return true suggests caller should flush this memory table
     bool insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
@@ -62,6 +63,8 @@ public:
     bool is_full() const;
 
     void set_write_buffer_size(size_t max_buffer_size) { _max_buffer_size = max_buffer_size; }
+
+    void set_write_buffer_row(size_t max_buffer_row) { _max_buffer_row = max_buffer_row; }
 
     static VectorizedSchema convert_schema(const TabletSchema* tablet_schema,
                                            const std::vector<SlotDescriptor*>* slot_descs);
@@ -105,6 +108,10 @@ private:
     std::string _merge_condition;
 
     int64_t _max_buffer_size = config::write_buffer_size;
+    // initial value is max size
+    size_t _max_buffer_row = -1;
+    size_t _total_rows = 0;
+    size_t _merged_rows = 0;
 
     // memory statistic
     MemTracker* _mem_tracker = nullptr;

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -63,7 +63,8 @@ public:
 
     void set_write_buffer_size(size_t max_buffer_size) { _max_buffer_size = max_buffer_size; }
 
-    static Schema convert_schema(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>* slot_descs);
+    static VectorizedSchema convert_schema(const TabletSchema* tablet_schema,
+                                           const std::vector<SlotDescriptor*>* slot_descs);
 
 private:
     void _merge();

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -62,8 +62,6 @@ public:
 
     bool is_full() const;
 
-    void set_write_buffer_size(size_t max_buffer_size) { _max_buffer_size = max_buffer_size; }
-
     void set_write_buffer_row(size_t max_buffer_row) { _max_buffer_row = max_buffer_row; }
 
     static VectorizedSchema convert_schema(const TabletSchema* tablet_schema,

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -179,6 +179,24 @@ Status Rowset::reload() {
     return Status::OK();
 }
 
+Status Rowset::reload_segment(int32_t segment_id) {
+    DCHECK(_segments.size() > segment_id);
+    if (_segments.size() <= segment_id) {
+        LOG(WARNING) << "Error segment id: " << segment_id;
+        return Status::InternalError("Error segment id");
+    }
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_rowset_path));
+    size_t footer_size_hint = 16 * 1024;
+    std::string seg_path = segment_file_path(_rowset_path, rowset_id(), segment_id);
+    auto res = Segment::open(fs, seg_path, segment_id, _schema, &footer_size_hint);
+    if (!res.ok()) {
+        LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
+        return res.status();
+    }
+    _segments[segment_id] = std::move(res).value();
+    return Status::OK();
+}
+
 StatusOr<int64_t> Rowset::estimate_compaction_segment_iterator_num() {
     if (num_segments() == 0) {
         return 0;

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -151,6 +151,7 @@ public:
 
     // reload this rowset after the underlying segment file is changed
     Status reload();
+    Status reload_segment(int32_t segment_id);
 
     const TabletSchema& schema() const { return *_schema; }
     void set_schema(const TabletSchema* schema) { _schema = schema; }

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -331,7 +331,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
 
     DCHECK(_upserts[idx] != nullptr);
     auto read_column_schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema, read_column_ids);
-    std::vector<std::unique_ptr<vectorized::Column>> read_columns(read_column_ids.size());
+    std::vector<std::unique_ptr<Column>> read_columns(read_column_ids.size());
 
     _partial_update_states[idx].write_columns.resize(read_columns.size());
     _partial_update_states[idx].src_rss_rowids.resize(_upserts[idx]->size());
@@ -431,7 +431,7 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
     }
     if (!conflict_idxes.empty()) {
         total_conflicts += conflict_idxes.size();
-        std::vector<std::unique_ptr<vectorized::Column>> read_columns;
+        std::vector<std::unique_ptr<Column>> read_columns;
         read_columns.resize(_partial_update_states[segment_id].write_columns.size());
         for (uint32_t i = 0; i < read_columns.size(); ++i) {
             read_columns[i] = _partial_update_states[segment_id].write_columns[i]->clone_empty();
@@ -445,7 +445,7 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
                 tablet->updates()->get_column_values(read_column_ids, num_default > 0, rowids_by_rssid, &read_columns));
 
         for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
-            std::unique_ptr<vectorized::Column> new_write_column =
+            std::unique_ptr<Column> new_write_column =
                     _partial_update_states[segment_id].write_columns[col_idx]->clone_empty();
             new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0, read_idxes.size());
             RETURN_IF_ERROR(_partial_update_states[segment_id].write_columns[col_idx]->update_rows(

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -175,7 +175,8 @@ Status RowsetUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
     if (!_check_partial_update(rowset)) {
         return Status::OK();
     }
-    return _prepare_partial_update_states(tablet, rowset);
+
+    return _prepare_partial_update_states(tablet, rowset, 0, true);
 }
 
 Status RowsetUpdateState::load_deletes(Rowset* rowset, uint32_t idx) {
@@ -301,7 +302,16 @@ void RowsetUpdateState::plan_read_by_rssid(const vector<uint64_t>& rowids, size_
     }
 }
 
-Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset* rowset) {
+// Assume segment idx has been loaded and _upserts[idx] is not null
+Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx, bool need_lock) {
+    if (_partial_update_states.size() == 0) {
+        _partial_update_states.resize(rowset->num_segments());
+    }
+
+    if (_partial_update_states[idx].inited == true) {
+        return Status::OK();
+    }
+
     int64_t t_start = MonotonicMillis();
     const auto& txn_meta = rowset->rowset_meta()->get_meta_pb().txn_meta();
     const auto& tablet_schema = tablet->tablet_schema();
@@ -317,57 +327,51 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
         }
     }
 
+    DCHECK(_upserts[idx] != nullptr);
     auto read_column_schema = ChunkHelper::convert_schema_to_format_v2(tablet_schema, read_column_ids);
-    std::vector<std::unique_ptr<Column>> read_columns(read_column_ids.size());
-    size_t num_segments = rowset->num_segments();
-    _partial_update_states.resize(num_segments);
-    for (size_t i = 0; i < num_segments; i++) {
-        _partial_update_states[i].write_columns.resize(read_columns.size());
-        _partial_update_states[i].src_rss_rowids.resize(_upserts[i]->size());
-        for (uint32_t j = 0; j < read_columns.size(); ++j) {
-            auto column = ChunkHelper::column_from_field(*read_column_schema.field(j).get());
-            read_columns[j] = column->clone_empty();
-            _partial_update_states[i].write_columns[j] = column->clone_empty();
-        }
+    std::vector<std::unique_ptr<vectorized::Column>> read_columns(read_column_ids.size());
+
+    _partial_update_states[idx].write_columns.resize(read_columns.size());
+    _partial_update_states[idx].src_rss_rowids.resize(_upserts[idx]->size());
+    for (uint32_t i = 0; i < read_columns.size(); ++i) {
+        auto column = ChunkHelper::column_from_field(*read_column_schema.field(i).get());
+        read_columns[i] = column->clone_empty();
+        _partial_update_states[idx].write_columns[i] = column->clone_empty();
     }
 
     int64_t t_read_index = MonotonicMillis();
-    std::vector<std::vector<uint64_t>*> rss_rowids;
-    rss_rowids.resize(num_segments);
-    for (size_t i = 0; i < num_segments; ++i) {
-        rss_rowids[i] = &(_partial_update_states[i].src_rss_rowids);
+    if (need_lock) {
+        RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states(
+                tablet, _upserts[idx], &(_partial_update_states[idx].read_version),
+                &(_partial_update_states[idx].src_rss_rowids)));
+    } else {
+        RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states_unlock(
+                tablet, _upserts[idx], &(_partial_update_states[idx].read_version),
+                &(_partial_update_states[idx].src_rss_rowids)));
     }
-    DCHECK_EQ(_upserts.size(), num_segments);
-    RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states(tablet, _upserts, &_read_version, &_next_rowset_id,
-                                                                     &rss_rowids));
 
     int64_t t_read_values = MonotonicMillis();
     size_t total_rows = 0;
     // rows actually needed to be read, excluding rows with default values
-    size_t total_nondefault_rows = 0;
-    for (size_t i = 0; i < num_segments; i++) {
-        size_t num_default = 0;
-        std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
-        vector<uint32_t> idxes;
-        plan_read_by_rssid(_partial_update_states[i].src_rss_rowids, &num_default, &rowids_by_rssid, &idxes);
-        total_rows += _partial_update_states[i].src_rss_rowids.size();
-        total_nondefault_rows += _partial_update_states[i].src_rss_rowids.size() - num_default;
-        // get column values by rowid, also get default values if needed
-        RETURN_IF_ERROR(
-                tablet->updates()->get_column_values(read_column_ids, num_default > 0, rowids_by_rssid, &read_columns));
-        for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
-            _partial_update_states[i].write_columns[col_idx]->append_selective(*read_columns[col_idx], idxes.data(), 0,
-                                                                               idxes.size());
-            _memory_usage += _partial_update_states[i].write_columns[col_idx]->memory_usage();
-        }
+    size_t num_default = 0;
+    std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
+    vector<uint32_t> idxes;
+    plan_read_by_rssid(_partial_update_states[idx].src_rss_rowids, &num_default, &rowids_by_rssid, &idxes);
+    total_rows += _partial_update_states[idx].src_rss_rowids.size();
+    RETURN_IF_ERROR(
+            tablet->updates()->get_column_values(read_column_ids, num_default > 0, rowids_by_rssid, &read_columns));
+    for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
+        _partial_update_states[idx].write_columns[col_idx]->append_selective(*read_columns[col_idx], idxes.data(), 0,
+                                                                             idxes.size());
+        _memory_usage += _partial_update_states[idx].write_columns[col_idx]->memory_usage();
     }
     int64_t t_end = MonotonicMillis();
 
-    LOG(INFO) << strings::Substitute(
-            "prepare PartialUpdateState tablet:$0 read_version:$1 #segment:$2 #row:$3(#non-default:$4) #column:$5 "
-            "time:$6ms(index:$7/value:$8)",
-            _tablet_id, _read_version.to_string(), num_segments, total_rows, total_nondefault_rows, read_columns.size(),
-            t_end - t_start, t_read_values - t_read_index, t_end - t_read_values);
+    LOG(INFO) << Substitute(
+            "prepare PartialUpdateState tablet:$0 segment:$1 #row:$2(#non-default:$3) #column:$4 "
+            "time:$5ms(index:$6/value:$7)",
+            _tablet_id, idx, total_rows, total_rows - num_default, read_columns.size(), t_end - t_start,
+            t_read_values - t_read_index, t_end - t_read_values);
     return Status::OK();
 }
 
@@ -381,87 +385,83 @@ bool RowsetUpdateState::_check_partial_update(Rowset* rowset) {
 }
 
 Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* rowset, uint32_t rowset_id,
-                                                      EditVersion latest_applied_version,
+                                                      uint32_t segment_id, EditVersion latest_applied_version,
                                                       std::vector<uint32_t>& read_column_ids,
                                                       const PrimaryIndex& index) {
-    // _partial_update_states is empty which means write column is empty
-    if (_partial_update_states.empty()) {
-        return Status::InternalError("write column is empty");
+    if (_partial_update_states.size() <= segment_id || !_partial_update_states[segment_id].inited) {
+        std::string msg = Substitute(
+                "_check_and_reslove_conflict tablet:$0 rowset:$1 segment:$2 failed, partial_update_states size:$3",
+                tablet->tablet_id(), rowset_id, segment_id, _partial_update_states.size());
+        return Status::InternalError(msg);
     }
 
     // _read_version is equal to latest_applied_version which means there is no other rowset is applied
     // the data of write_columns can be write to segment file directly
-    if (latest_applied_version == _read_version) {
+    if (latest_applied_version == _partial_update_states[segment_id].read_version) {
         return Status::OK();
     }
 
     // get rss_rowids to identify conflict exist or not
     int64_t t_start = MonotonicMillis();
-    uint32_t num_segments = _upserts.size();
-    std::vector<std::vector<uint64_t>> new_rss_rowids;
-    new_rss_rowids.resize(num_segments);
-    for (uint32_t i = 0; i < num_segments; ++i) {
-        auto& pks = *_upserts[i];
-        new_rss_rowids[i].resize(pks.size());
-        index.get(pks, &new_rss_rowids[i]);
-    }
+    std::vector<uint64_t> new_rss_rowids(_upserts[segment_id]->size());
+    index.get(*_upserts[segment_id], &new_rss_rowids);
     int64_t t_read_index = MonotonicMillis();
 
     size_t total_conflicts = 0;
-    for (uint32_t i = 0; i < num_segments; ++i) {
-        uint32_t num_rows = new_rss_rowids[i].size();
-        std::vector<uint32_t> conflict_idxes;
-        std::vector<uint64_t> conflict_rowids;
-        DCHECK_EQ(num_rows, _partial_update_states[i].src_rss_rowids.size());
-        for (size_t j = 0; j < new_rss_rowids[i].size(); ++j) {
-            uint64_t new_rss_rowid = new_rss_rowids[i][j];
-            uint32_t new_rssid = new_rss_rowid >> 32;
-            uint64_t rss_rowid = _partial_update_states[i].src_rss_rowids[j];
-            uint32_t rssid = rss_rowid >> 32;
+    uint32_t num_rows = new_rss_rowids.size();
+    std::vector<uint32_t> conflict_idxes;
+    std::vector<uint64_t> conflict_rowids;
+    DCHECK_EQ(num_rows, _partial_update_states[segment_id].src_rss_rowids.size());
+    for (size_t i = 0; i < new_rss_rowids.size(); ++i) {
+        uint64_t new_rss_rowid = new_rss_rowids[i];
+        uint32_t new_rssid = new_rss_rowid >> 32;
+        uint64_t rss_rowid = _partial_update_states[segment_id].src_rss_rowids[i];
+        uint32_t rssid = rss_rowid >> 32;
 
-            if (rssid != new_rssid) {
-                conflict_idxes.emplace_back(j);
-                conflict_rowids.emplace_back(new_rss_rowid);
-            }
+        if (rssid != new_rssid) {
+            conflict_idxes.emplace_back(i);
+            conflict_rowids.emplace_back(new_rss_rowid);
         }
-        if (!conflict_idxes.empty()) {
-            total_conflicts += conflict_idxes.size();
-            std::vector<std::unique_ptr<Column>> read_columns;
-            read_columns.resize(_partial_update_states[i].write_columns.size());
-            for (uint32_t j = 0; j < read_columns.size(); ++j) {
-                read_columns[j] = _partial_update_states[i].write_columns[j]->clone_empty();
-            }
-            size_t num_default = 0;
-            std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
-            std::vector<uint32_t> read_idxes;
-            plan_read_by_rssid(conflict_rowids, &num_default, &rowids_by_rssid, &read_idxes);
-            DCHECK_EQ(conflict_idxes.size(), read_idxes.size());
-            RETURN_IF_ERROR(tablet->updates()->get_column_values(read_column_ids, num_default > 0, rowids_by_rssid,
-                                                                 &read_columns));
+    }
+    if (!conflict_idxes.empty()) {
+        total_conflicts += conflict_idxes.size();
+        std::vector<std::unique_ptr<vectorized::Column>> read_columns;
+        read_columns.resize(_partial_update_states[segment_id].write_columns.size());
+        for (uint32_t i = 0; i < read_columns.size(); ++i) {
+            read_columns[i] = _partial_update_states[segment_id].write_columns[i]->clone_empty();
+        }
+        size_t num_default = 0;
+        std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
+        std::vector<uint32_t> read_idxes;
+        plan_read_by_rssid(conflict_rowids, &num_default, &rowids_by_rssid, &read_idxes);
+        DCHECK_EQ(conflict_idxes.size(), read_idxes.size());
+        RETURN_IF_ERROR(
+                tablet->updates()->get_column_values(read_column_ids, num_default > 0, rowids_by_rssid, &read_columns));
 
-            for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
-                std::unique_ptr<Column> new_write_column =
-                        _partial_update_states[i].write_columns[col_idx]->clone_empty();
-                new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0, read_idxes.size());
-                RETURN_IF_ERROR(_partial_update_states[i].write_columns[col_idx]->update_rows(*new_write_column,
-                                                                                              conflict_idxes.data()));
-            }
+        for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
+            std::unique_ptr<vectorized::Column> new_write_column =
+                    _partial_update_states[segment_id].write_columns[col_idx]->clone_empty();
+            new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0, read_idxes.size());
+            RETURN_IF_ERROR(_partial_update_states[segment_id].write_columns[col_idx]->update_rows(
+                    *new_write_column, conflict_idxes.data()));
         }
     }
     int64_t t_end = MonotonicMillis();
-    LOG(INFO) << strings::Substitute(
-            "_check_and_resolve_conflict tablet:$0 rowset:$1 version:($2 $3) #conflict-row:$4 #column:$5 "
-            "time:$6ms(index:$7/value:$8)",
-            tablet->tablet_id(), rowset_id, _read_version.to_string(), latest_applied_version.to_string(),
-            total_conflicts, read_column_ids.size(), t_end - t_start, t_read_index - t_start, t_end - t_read_index);
+    LOG(INFO) << Substitute(
+            "_check_and_resolve_conflict tablet:$0 rowset:$1 segmet:$2 version:($3 $4) #conflict-row:$5 #column:$6 "
+            "time:$7ms(index:$8/value:$9)",
+            tablet->tablet_id(), rowset_id, segment_id, _partial_update_states[segment_id].read_version.to_string(),
+            latest_applied_version.to_string(), total_conflicts, read_column_ids.size(), t_end - t_start,
+            t_read_index - t_start, t_end - t_read_index);
 
     return Status::OK();
 }
 
-Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, EditVersion latest_applied_version,
-                                const PrimaryIndex& index) {
+Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, uint32_t segment_id,
+                                EditVersion latest_applied_version, const PrimaryIndex& index) {
     const auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
-    if (!_check_partial_update(rowset)) {
+    if (!rowset_meta_pb.has_txn_meta() || rowset->num_segments() == 0 ||
+        rowset_meta_pb.txn_meta().has_merge_condition()) {
         return Status::OK();
     }
     // currently assume it's a partial update
@@ -479,57 +479,40 @@ Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_
         }
     }
 
-    size_t num_segments = rowset->num_segments();
-    DCHECK(num_segments == _upserts.size());
-    vector<std::pair<string, string>> rewrite_files;
-    DeferOp clean_temp_files([&] {
-        for (auto& e : rewrite_files) {
-            FileSystem::Default()->delete_file(e.second);
-        }
-    });
-    bool is_rewrite = config::rewrite_partial_segment;
-    RETURN_IF_ERROR(
-            _check_and_resolve_conflict(tablet, rowset, rowset_id, latest_applied_version, read_column_ids, index));
+    DCHECK(_upserts[segment_id] != nullptr);
+    if (_partial_update_states.size() == 0 || !_partial_update_states[segment_id].inited) {
+        RETURN_IF_ERROR(_prepare_partial_update_states(tablet, rowset, segment_id, false));
+    } else {
+        // reslove conflict of segment
+        RETURN_IF_ERROR(_check_and_resolve_conflict(tablet, rowset, rowset_id, segment_id, latest_applied_version,
+                                                    read_column_ids, index));
+    }
 
-    for (size_t i = 0; i < num_segments; i++) {
-        auto src_path = Rowset::segment_file_path(tablet->schema_hash_path(), rowset->rowset_id(), i);
-        auto dest_path = Rowset::segment_temp_file_path(tablet->schema_hash_path(), rowset->rowset_id(), i);
-        rewrite_files.emplace_back(src_path, dest_path);
+    auto src_path = Rowset::segment_file_path(tablet->schema_hash_path(), rowset->rowset_id(), segment_id);
+    auto dest_path = Rowset::segment_temp_file_path(tablet->schema_hash_path(), rowset->rowset_id(), segment_id);
+    DeferOp clean_temp_files([&] { FileSystem::Default()->delete_file(dest_path); });
+    int64_t t_rewrite_start = MonotonicMillis();
+    FooterPointerPB partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
+    RETURN_IF_ERROR(SegmentRewriter::rewrite(src_path, dest_path, tablet->tablet_schema(), read_column_ids,
+                                             _partial_update_states[segment_id].write_columns, segment_id,
+                                             partial_rowset_footer));
+    int64_t t_rewrite_end = MonotonicMillis();
+    LOG(INFO) << Substitute("apply partial segment tablet:$0 rowset:$1 seg:$2 #column:$3 #rewrite:$4ms",
+                            tablet->tablet_id(), rowset_id, segment_id, read_column_ids.size(),
+                            t_rewrite_end - t_rewrite_start);
 
-        int64_t t_rewrite_start = MonotonicMillis();
-        FooterPointerPB partial_rowset_footer = txn_meta.partial_rowset_footers(i);
-        // if is_rewrite is true, rewrite partial segment file into dest_path first, then append write_columns
-        // if is_rewrite is false, append write_columns into src_path and rebuild segment footer
-        if (is_rewrite) {
-            RETURN_IF_ERROR(SegmentRewriter::rewrite(src_path, dest_path, tablet->tablet_schema(), read_column_ids,
-                                                     _partial_update_states[i].write_columns, i,
-                                                     partial_rowset_footer));
-        } else {
-            RETURN_IF_ERROR(SegmentRewriter::rewrite(src_path, tablet->tablet_schema(), read_column_ids,
-                                                     _partial_update_states[i].write_columns, i,
-                                                     partial_rowset_footer));
-        }
-        int64_t t_rewrite_end = MonotonicMillis();
-        LOG(INFO) << strings::Substitute("apply partial segment tablet:$0 rowset:$1 seg:$2 #column:$3 #rewrite:$4ms",
-                                         tablet->tablet_id(), rowset_id, i, read_column_ids.size(),
-                                         t_rewrite_end - t_rewrite_start);
+    // Assume all segment is rewrite
+    // TODO create a new function, finish_apply
+    if (segment_id == rowset->num_segments() - 1) {
+        RETURN_IF_ERROR(rowset->reload());
     }
-    if (is_rewrite) {
-        for (size_t i = 0; i < num_segments; i++) {
-            RETURN_IF_ERROR(FileSystem::Default()->rename_file(rewrite_files[i].second, rewrite_files[i].first));
+
+    for (size_t col_idx = 0; col_idx < _partial_update_states[segment_id].write_columns.size(); col_idx++) {
+        if (_partial_update_states[segment_id].write_columns[col_idx] != nullptr) {
+            _memory_usage -= _partial_update_states[segment_id].write_columns[col_idx]->memory_usage();
         }
     }
-    // clean this to prevent DeferOp clean files
-    rewrite_files.clear();
-    RETURN_IF_ERROR(rowset->reload());
-    for (size_t i = 0; i < _partial_update_states.size(); i++) {
-        for (size_t col_idx = 0; col_idx < _partial_update_states[i].write_columns.size(); col_idx++) {
-            if (_partial_update_states[i].write_columns[col_idx] != nullptr) {
-                _memory_usage -= _partial_update_states[i].write_columns[col_idx]->memory_usage();
-                _partial_update_states[i].write_columns[col_idx].reset();
-            }
-        }
-    }
+    _partial_update_states[segment_id].release();
     return Status::OK();
 }
 

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -506,10 +506,9 @@ Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_
                             tablet->tablet_id(), rowset_id, segment_id, read_column_ids.size(),
                             t_rewrite_end - t_rewrite_start);
 
-    // Assume all segment is rewrite
-    // TODO create a new function, finish_apply
-    /*
     FileSystem::Default()->rename_file(dest_path, src_path);
+    RETURN_IF_ERROR(rowset->reload_segment(segment_id));
+    /*
     if (segment_id == rowset->num_segments() - 1) {
         LOG(INFO) << "reload rowset: " << rowset_id << " segment_id: " << segment_id << " num_segment: " << rowset->num_segments();
         RETURN_IF_ERROR(rowset->reload());

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -83,8 +83,6 @@ public:
     void release_upserts(uint32_t idx);
     void release_deletes(uint32_t idx);
 
-    Status finish_apply(Tablet* tablet, Rowset* rowset);
-
 private:
     Status _load_deletes(Rowset* rowset, uint32_t delete_id, Column* pk_column);
     Status _load_upserts(Rowset* rowset, uint32_t upsert_id, Column* pk_column);

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -52,8 +52,6 @@ public:
 
     Status load(Tablet* tablet, Rowset* rowset);
 
-    //Status apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, EditVersion latest_applied_version,
-    //             const PrimaryIndex& index);
     Status apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, uint32_t segment_id,
                  EditVersion latest_applied_version, const PrimaryIndex& index);
 
@@ -89,12 +87,14 @@ private:
 
     Status _do_load(Tablet* tablet, Rowset* rowset);
 
-    //Status _prepare_partial_update_states(Tablet* tablet, Rowset* rowset);
+    // `need_lock` means whether the `_index_lock` in TabletUpdates needs to held.
+    // `index_lock` is used to avoid access the PrimaryIndex at the same time as the apply thread.
+    // This function will be called in two places, one is the commit phase and the other is the apply phase.
+    // In rowset commit phase, `need_lock` should be set as true to prevent concurrent access.
+    // In rowset apply phase, `_index_lock` is already held by apply thread, `need_lock` should be set as false
+    // to avoid dead lock.
     Status _prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx, bool need_lock);
 
-    //Status _check_and_resolve_conflict(Tablet* tablet, Rowset* rowset, uint32_t rowset_id,
-    //                                   EditVersion latest_applied_version, std::vector<uint32_t>& read_column_ids,
-    //                                   const PrimaryIndex& index);
     Status _check_and_resolve_conflict(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, uint32_t segment_id,
                                        EditVersion latest_applied_version, std::vector<uint32_t>& read_column_ids,
                                        const PrimaryIndex& index);
@@ -109,10 +109,6 @@ private:
     std::vector<ColumnUniquePtr> _deletes;
     size_t _memory_usage = 0;
     int64_t _tablet_id = 0;
-
-    // states for partial update
-    // EditVersion _read_version;
-    // uint32_t _next_rowset_id = 0;
 
     // TODO: dump to disk if memory usage is too large
     std::vector<PartialUpdateState> _partial_update_states;

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -83,6 +83,8 @@ public:
     void release_upserts(uint32_t idx);
     void release_deletes(uint32_t idx);
 
+    Status finish_apply(Tablet* tablet, Rowset* rowset);
+
 private:
     Status _load_deletes(Rowset* rowset, uint32_t delete_id, Column* pk_column);
     Status _load_upserts(Rowset* rowset, uint32_t upsert_id, Column* pk_column);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -910,6 +910,15 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
         }
         state.release_upserts(i);
     }
+    st = state.finish_apply(&_tablet, rowset.get());
+    if (!st.ok()) {
+        manager->update_state_cache().remove(state_entry);
+        std::string msg = Substitute("_apply_rowset_commit error: apply rowset update state failed: $0 $1",
+                                     st.to_string(), debug_string());
+        LOG(ERROR) << msg;
+        _set_error(msg);
+        return;
+    }
 
     for (uint32_t i = 0; i < rowset->num_delete_files(); i++) {
         state.load_deletes(rowset.get(), i);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2158,6 +2158,18 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     info->__set_data_size(total_size);
 }
 
+int64_t TabletUpdates::get_average_row_size() {
+    TTabletInfo info;
+    get_tablet_info_extra(&info);
+    int64_t total_row = info.row_count;
+    int64_t total_size = info.data_size;
+    if (total_row != 0) {
+        return total_size / total_row;
+    } else {
+        return 0;
+    }
+}
+
 std::string TabletUpdates::RowsetStats::to_string() const {
     return strings::Substitute("[seg:$0 row:$1 del:$2 bytes:$3 compaction:$4]", num_segments, num_rows, num_dels,
                                byte_size, compaction_score);

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -235,9 +235,16 @@ public:
                              std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                              vector<std::unique_ptr<Column>>* columns);
 
+    /*
     Status prepare_partial_update_states(Tablet* tablet, const std::vector<ColumnUniquePtr>& upserts,
                                          EditVersion* read_version, uint32_t* next_rowset_id,
                                          std::vector<std::vector<uint64_t>*>* rss_rowids);
+    */
+    Status prepare_partial_update_states(Tablet* tablet, const ColumnUniquePtr& upserts, EditVersion* read_version,
+                                         std::vector<uint64_t>* rss_rowids);
+
+    Status prepare_partial_update_states_unlock(Tablet* tablet, const ColumnUniquePtr& upserts,
+                                                EditVersion* read_version, std::vector<uint64_t>* rss_rowids);
 
     Status get_missing_version_ranges(std::vector<int64_t>& missing_version_ranges);
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -156,6 +156,9 @@ public:
     // get info's version, version_count, row_count, data_size
     void get_tablet_info_extra(TTabletInfo* info);
 
+    // get average row size
+    int64_t get_average_row_size();
+
     std::string debug_string() const;
 
     // Return nullptr if the delta rowset does not exist.

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -680,6 +680,7 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
     }
 
     auto rowset = rowset_writer->build().value();
+    rowset->set_schema(&tablet->tablet_schema());
     ASSERT_TRUE(rowset != nullptr);
     ASSERT_EQ(3, rowset->rowset_meta()->num_segments());
     ASSERT_EQ(rows_per_segment * 3, rowset->rowset_meta()->num_rows());

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -323,7 +323,7 @@ TEST_F(RowsetUpdateStateTest, check_conflict) {
     st = index.load(_tablet.get());
     std::vector<uint32_t> read_column_ids = {2};
     state.test_check_conflict(_tablet.get(), partial_rowset.get(), partial_rowset->rowset_meta()->get_rowset_seg_id(),
-                              latest_applied_version, read_column_ids, index);
+                              0, latest_applied_version, read_column_ids, index);
 
     // check data of write column
     const std::vector<PartialUpdateState>& new_parital_update_states = state.parital_update_states();

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -2140,6 +2140,7 @@ void TabletUpdatesTest::load_snapshot(const std::string& meta_dir, const TabletS
     ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(segment_path));
 
     ASSERT_TRUE(Segment::parse_segment_footer(read_file.get(), footer, nullptr, nullptr).ok());
+    LOG(INFO) << "parse segment footer success";
 }
 
 void TabletUpdatesTest::test_load_snapshot_incremental_with_partial_rowset_old(bool enable_persistent_index) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/11269

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We have partially optimized the primary key model for large import memory usage in this pr(https://github.com/StarRocks/starrocks/pull/12068), but the enhancement doesn't work if the load is partial update. And we also need a lot of memory if you do a large number of partial updates in one transaction. So this pr will try to reduce the memory usage of large partial update. 

There are two reasons for large memory usage during partial column updates:
1. The first one is that updating a few columns may increase the segment file size and we need to load all data of segment into memory which will cost a lot of memory.
2. The second one is that doing partial update requires reading data from other columns into memory, which can take up a lot of memory if the table has many columns.

In order to reduce memory usage,  the following two adjustments are made:
1. The first one is to estimate the length of the updated partial columns in each row when importing data, thus reducing the size of the segment file
2. The second one is don't load all the data of the rowset into memory at once, but to load them one by one according to the segment.

In my test env, one BE with two HDD, using StreamLoad, create a table with 65 column, 20 buckets:
```
CREATE TABLE `partial_test` (
  `col_1` bigint(20) NOT NULL COMMENT "",
  `col_2` bigint(20) NOT NULL COMMENT "",
  `col_3` bigint(20) NOT NULL COMMENT "",
  `col_4` varchar(150) NOT NULL COMMENT "",
  `col_5` varchar(150) NOT NULL COMMENT "",
  `col_6` varchar(150) NULL COMMENT "",
  `col_7` varchar(150) NULL COMMENT "",
  `col_8` varchar(1024) NULL COMMENT "",
  `col_9` varchar(120) NULL COMMENT "",
  `col_10` varchar(60) NULL COMMENT "",
  `col_11` varchar(10) NULL COMMENT "",
  `col_12` varchar(120) NULL COMMENT "",
  `col_13` varchar(524) NULL COMMENT "",
  `col_14` varchar(100) NULL COMMENT "",
  `col_15` varchar(150) NULL COMMENT "",
  `col_16` varchar(150) NULL COMMENT "",
  `col_17` varchar(150) NULL COMMENT "",
  `col_18` bigint(20) NULL COMMENT "",
  `col_19` varchar(500) NULL COMMENT "",
  `col_20` varchar(150) NULL COMMENT "",
  `col_21` tinyint(4) NULL COMMENT "",
  `col_22` int(11) NULL COMMENT "",
  `col_23` varchar(524) NULL COMMENT "",
  `col_24` bigint(20) NULL COMMENT "",
  `col_25` bigint(20) NULL COMMENT "",
  `col_26` varchar(8) NULL COMMENT "",
  `col_27` decimal64(18, 6) NULL COMMENT "",
  `col_28` decimal64(18, 6) NULL COMMENT "",
  `col_29` decimal64(18, 6) NULL COMMENT "",
  `col_30` decimal64(18, 6) NULL COMMENT "",
  `col_31` decimal64(18, 6) NULL COMMENT "",
  `col_32` decimal64(18, 6) NULL COMMENT "",
  `col_33` bigint(20) NULL COMMENT "",
  `col_34` decimal64(18, 6) NULL COMMENT "",
  `col_35` varchar(8) NULL COMMENT "",
  `col_36` decimal64(18, 6) NULL COMMENT "",
  `col_37` decimal64(18, 6) NULL COMMENT "",
  `col_38` varchar(8) NULL COMMENT "",
  `col_39` decimal64(18, 6) NULL COMMENT "",
  `col_40` decimal64(18, 6) NULL COMMENT "",
  `col_41` varchar(8) NULL COMMENT "",
  `col_42` decimal64(18, 6) NULL COMMENT "",
  `col_43` decimal64(18, 6) NULL COMMENT "",
  `col_44` decimal64(18, 6) NULL COMMENT "",
  `col_45` decimal64(18, 6) NULL COMMENT "",
  `col_46` int(11) NULL COMMENT "",
  `col_47` int(11) NOT NULL COMMENT "",
  `col_48` tinyint(4) NULL COMMENT "",
  `col_49` varchar(200) NULL COMMENT "",
  `col_50` tinyint(4) NULL COMMENT "",
  `col_51` varchar(200) NULL COMMENT "",
  `col_52` varchar(10) NULL COMMENT "",
  `col_53` tinyint(4) NULL COMMENT "",
  `col_54` tinyint(4) NULL COMMENT "",
  `col_55` varchar(150) NULL COMMENT "",
  `col_56` varchar(150) NULL COMMENT "",
  `col_57` varchar(500) NULL COMMENT "",
  `col_58` tinyint(4) NULL COMMENT "",
  `col_59` varchar(100) NULL COMMENT "",
  `col_60` varchar(150) NULL COMMENT "",
  `col_61` varchar(150) NULL COMMENT "",
  `col_62` varchar(150) NULL COMMENT "",
  `col_63` varchar(150) NULL COMMENT "",
  `col_64` datetime NULL COMMENT "",
  `col_65` datetime NULL COMMENT ""
) ENGINE=OLAP 
PRIMARY KEY(`col_1`, `col_2`, `col_3`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`col_1`, `col_2`) BUCKETS 20 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "V2",
"enable_persistent_index" = "true",
"compression" = "LZ4"
); 
```

|PrimaryKey Length| RowNum|BucketNum| Column Num| Partial ColumnNum | PartialUpdate RowsNum| Load time(s)| Apply time(ms)| Peak UpdateMemory usage | Note |
|---------------------|----------|------------|----------------|--------------------|------------------------------|----|-----|-----|----|
|12 Bytes| 300M | 20 |  65 | 5 | 100M | 135261 | 106693 | 78.9G | branch-main |
|12 Bytes| 300M | 20 |  65 | 5 | 100M | 166449| 149870 | 10.3G | branch-opt |
|12 Bytes| 300M | 20 |  65 | 5 | 100K | 2078 | 529 | 60.1M | branch-main |
|12 Bytes| 300M | 20 |  65 | 5 | 100K | 2211 | 541 | 60.2M | branch-opt |


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
