### PR TITLE
[BugFix] Fixup reading the ensemble of rowsets instead of delta resets mistakenly

### DIFF
--- a/be/src/exec/query_cache/cache_operator.h
+++ b/be/src/exec/query_cache/cache_operator.h
@@ -9,6 +9,7 @@
 #include "exec/query_cache/cache_param.h"
 #include "exec/query_cache/lane_arbiter.h"
 #include "exec/query_cache/multilane_operator.h"
+#include "storage/rowset/rowset.h"
 namespace starrocks {
 namespace pipeline {
 class PipelineDriver;
@@ -37,6 +38,7 @@ public:
     Status reset_lane(RuntimeState* state, LaneOwnerType lane_owner);
     void populate_cache(int64_t tablet_id);
     int64_t cached_version(int64_t tablet_id);
+    std::tuple<int64_t, std::vector<RowsetSharedPtr>> delta_version_and_rowsets(int64_t tablet_id);
     Status push_chunk(RuntimeState* state, const vectorized::ChunkPtr& chunk) override;
     StatusOr<vectorized::ChunkPtr> pull_chunk(RuntimeState* state) override;
     bool has_output() const override;

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -392,7 +392,7 @@ StatusOr<TabletAndRowsets> TabletManager::capture_tablet_and_rowsets(TTabletId t
     std::shared_lock rlock(tablet->get_header_lock());
     std::vector<RowsetSharedPtr> rowsets;
     RETURN_IF_ERROR(tablet->capture_consistent_rowsets(Version{from_version, to_version}, &rowsets));
-    return std::make_tuple(std::move(tablet), std::move(rowsets));
+    return std::make_tuple(std::move(tablet), std::move(rowsets), std::make_shared<RowsetsAcqRel>(rowsets));
 }
 
 TabletSharedPtr TabletManager::_get_tablet_unlocked(TTabletId tablet_id, bool include_deleted, std::string* err) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Multiversion cache mechanism conflicts with this PR https://github.com/StarRocks/starrocks/pull/13937, and daily cases  evolving multiversion cache as follows fails:
1. test_query_cache_invalidated_by_new_ingestion_and_repopulate
2. test_query_cache_invalidated_by_new_ingestion
3. test_query_cache_multi_agg_partial_hit

So fix it by using delta rowsets instead of all of the resets when creating TabletReader.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
