### PR TITLE
[Enhancement] optimize connector io task

### DIFF
--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -212,9 +212,13 @@ Status NullableColumn::update_rows(const Column& src, const uint32_t* indexes) {
 
 size_t NullableColumn::filter_range(const Column::Filter& filter, size_t from, size_t to) {
     auto s1 = _data_column->filter_range(filter, from, to);
-    auto s2 = _null_column->filter_range(filter, from, to);
-    update_has_null();
-    DCHECK_EQ(s1, s2);
+    if (!_has_null) {
+        _null_column->resize(s1);
+    } else {
+        auto s2 = _null_column->filter_range(filter, from, to);
+        DCHECK_EQ(s1, s2);
+        update_has_null();
+    }
     return s1;
 }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -762,6 +762,8 @@ CONF_Int32(io_tasks_per_scan_operator, "4");
 CONF_Bool(connector_chunk_source_accumulate_chunk_enable, "true");
 CONF_Bool(connector_dynamic_chunk_buffer_limiter_enable, "true");
 CONF_Bool(connector_min_max_predicate_from_runtime_filter_enable, "true");
+CONF_Bool(scan_node_always_shared_scan, "false");
+CONF_Bool(connector_scan_node_always_shared_scan, "true");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -109,29 +109,33 @@ bool ScanOperator::has_output() const {
     // The default threshould of unpluging is BufferCapacity/DOP/4, and its range is [1, 16]
     // The overall strategy:
     // 1. If enough buffered chunks: pull_chunk, so return true
-    // 2. If not enough buffered chunks
-    //   2.1 Enough running io-tasks and buffer not full: wait some time for more chunks, so return false
-    //   2.1 Enough running io-tasks but buffer is full: pull_chunks, so return true
-    //   2.2 Not enough running io-tasks: submit io tasks, so return true
-    //   2.3 No more tasks: pull_chunk, so return true
+    // 2. If not enough buffered chunks (plug mode):
+    //   2.1 Buffer full: return true if has any chunk, else false
+    //   2.2 Enough running io-tasks: wait some time for more chunks, so return false
+    //   2.3 Not enough running io-tasks: submit io tasks, so return true
+    //   2.4 No more tasks: pull_chunk, so return true
+
+    size_t chunk_number = num_buffered_chunks();
     if (_unpluging) {
-        if (num_buffered_chunks() > 0) {
+        if (chunk_number > 0) {
             return true;
         }
         _unpluging = false;
     }
-    if (num_buffered_chunks() >= _buffer_unplug_threshold()) {
+    if (chunk_number >= _buffer_unplug_threshold()) {
         COUNTER_UPDATE(_buffer_unplug_counter, 1);
         _unpluging = true;
         return true;
     }
-    if (is_buffer_full() && num_buffered_chunks() > 0) {
-        return true;
+
+    DCHECK(!_unpluging);
+    bool buffer_full = is_buffer_full();
+    if (buffer_full) {
+        return chunk_number > 0;
     }
-    if (_num_running_io_tasks >= _io_tasks_per_scan_operator || is_buffer_full()) {
+    if (_num_running_io_tasks >= _io_tasks_per_scan_operator) {
         return false;
     }
-
     // Can pick up more morsels or submit more tasks
     if (!_morsel_queue->empty()) {
         return true;
@@ -241,6 +245,7 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     // Avoid uneven distribution when io tasks execute very fast, so we start
     // traverse the chunk_source array from last visit idx
     int cnt = _io_tasks_per_scan_operator;
+
     while (--cnt >= 0) {
         _chunk_source_idx = (_chunk_source_idx + 1) % _io_tasks_per_scan_operator;
         int i = _chunk_source_idx;
@@ -288,7 +293,6 @@ void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_sour
     _num_running_io_tasks--;
 
     DCHECK(_chunk_sources[chunk_source_index] != nullptr);
-
     {
         // - close() closes the chunk source which is not running.
         // - _finish_chunk_source_task() closes the chunk source conditionally and then make it as not running.
@@ -298,7 +302,6 @@ void ScanOperator::_finish_chunk_source_task(RuntimeState* state, int chunk_sour
         if (!_chunk_sources[chunk_source_index]->has_next_chunk() || _is_finished) {
             _close_chunk_source_unlocked(state, chunk_source_index);
         }
-
         _is_io_task_running[chunk_source_index] = false;
     }
 }
@@ -346,7 +349,6 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             int64_t prev_cpu_time = chunk_source->get_cpu_time_spent();
             int64_t prev_scan_rows = chunk_source->get_scan_rows();
             int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
-
             auto status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
             if (!status.ok() && !status.is_end_of_file()) {
                 _set_scan_status(status);

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -91,7 +91,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
         int io_parallelism = scan_dop * io_tasks_per_scan_operator();
 
         // If not so much morsels, try to assign morsel uniformly among operators to avoid data skew
-        if (scan_dop > 1 && dynamic_cast<pipeline::FixedMorselQueue*>(morsel_queue.get()) &&
+        if (!always_shared_scan() && scan_dop > 1 && dynamic_cast<pipeline::FixedMorselQueue*>(morsel_queue.get()) &&
             morsel_queue->num_original_morsels() <= io_parallelism) {
             auto morsel_queue_map = uniform_distribute_morsels(std::move(morsel_queue), scan_dop);
             return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(morsel_queue_map),

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -102,6 +102,7 @@ public:
     const std::string& name() const { return _name; }
 
     virtual int io_tasks_per_scan_operator() const { return config::io_tasks_per_scan_operator; }
+    virtual bool always_shared_scan() const { return config::scan_node_always_shared_scan; }
 
     // TODO: support more share_scan strategy
     void enable_shared_scan(bool enable);

--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -567,4 +567,8 @@ int ConnectorScanNode::io_tasks_per_scan_operator() const {
     return config::connector_io_tasks_per_scan_operator;
 }
 
+bool ConnectorScanNode::always_shared_scan() const {
+    return config::connector_scan_node_always_shared_scan;
+}
+
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/connector_scan_node.h
+++ b/be/src/exec/vectorized/connector_scan_node.h
@@ -37,6 +37,7 @@ public:
     connector::ConnectorType connector_type() { return _connector_type; }
 
     int io_tasks_per_scan_operator() const override;
+    bool always_shared_scan() const override;
 
 private:
     RuntimeState* _runtime_state = nullptr;

--- a/be/test/exec/vectorized/json_parser_test.cpp
+++ b/be/test/exec/vectorized/json_parser_test.cpp
@@ -448,7 +448,8 @@ PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
 PARALLEL_TEST(JsonParserTest, test_big_value) {
     simdjson::ondemand::parser simdjson_parser;
     // The padded_string would allocate memory with simdjson::SIMDJSON_PADDING bytes padding.
-    simdjson::padded_string input = simdjson::padded_string::load("./be/test/exec/test_data/json_scanner/big_value.json");
+    simdjson::padded_string input =
+            simdjson::padded_string::load("./be/test/exec/test_data/json_scanner/big_value.json");
 
     std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
 

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1095,7 +1095,7 @@ TEST_F(OrcChunkReaderTest, TestReadArrayDecimal) {
     type_array.children.emplace_back(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 9, 9));
 
     SlotDesc slot_descs[] = {
-            {"id",  TypeDescriptor::from_primtive_type(LogicalType::TYPE_INT)},
+            {"id", TypeDescriptor::from_primtive_type(LogicalType::TYPE_INT)},
             {"arr", type_array},
             {""},
     };


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR has done:
1. add option to always enable shared scan
2. add `has_output_when_running`. It's very like to `has_output` but without plug mechanism. It's called when source operator in executor queue. The reason behind it, is that if we have any chunk, we can run pipeline without waiting unplug, so in theory there will be less context switch.
3. optimize nullable column `filter_range`.


For ssb100g/q11 (with block cache), we spot a problem that there are skewed pipeline drivers 

![368ae06a-c1c2-4aa5-88b1-2ecc44a566bc](https://user-images.githubusercontent.com/1081215/204232188-9fe4eaf4-b7b3-4625-9b8c-4a85864793e2.jpeg)

And with `always_shared_scan = true`, we improve q11 from 1400ms down to 1182ms. We can get better out-of-box performance.

![2i3ubLEqxD](https://user-images.githubusercontent.com/1081215/204232416-a4966669-2e97-401e-8a96-9e03abb136b5.jpg)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
