### PR TITLE
[BugFix] concurrent export failed (#14201)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/PlannerProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/PlannerProfile.java
@@ -73,11 +73,9 @@ public class PlannerProfile {
         return timers.computeIfAbsent(name, (key) -> new ScopedTimer());
     }
 
-    private static final PlannerProfile DEFAULT_INSTANCE = new PlannerProfile();
-
     public static ScopedTimer getScopedTimer(String name) {
         // to avoid null.
-        PlannerProfile p = DEFAULT_INSTANCE;
+        PlannerProfile p = new PlannerProfile();
         ConnectContext ctx = ConnectContext.get();
         if (ctx != null) {
             p = ctx.getPlannerProfile();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14201

## Problem Summary(Required) ：
Problem:
This problem is cause by the following reason: Coordinator.exec may execute through different Coordinator instance. When they get a ScopedTimer, the same timer may be return to different thread in concurrent scenarios. This will cause the same ScopedTimer instance to be started and closed multiple times, and an exception will be thrown.

Solution:
New a new PlannerProfile to ensure that different Coordinator.exec get different timers when executing export(export don't set ConnectContext.threadLocalInfo, so we can use ConnectContext.get() to determine whether export is being executed).

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
