### PR TITLE
[Enhancement] metric cpu_use_ratio uses growth value

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -371,7 +371,7 @@ void WorkGroupDriverQueue::_enqueue_workgroup(workgroup::WorkGroupDriverSchedEnt
             int64_t diff_vruntime_ns = new_vruntime_ns - wg_entity->vruntime_ns();
             if (diff_vruntime_ns > 0) {
                 DCHECK(_wg_entities.find(wg_entity) == _wg_entities.end());
-                wg_entity->incr_runtime_ns(diff_vruntime_ns * wg_entity->cpu_limit());
+                wg_entity->adjust_runtime_ns(diff_vruntime_ns * wg_entity->cpu_limit());
             }
         }
     }

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -176,7 +176,7 @@ void WorkGroupScanTaskQueue::_enqueue_workgroup(workgroup::WorkGroupScanSchedEnt
         int64_t diff_vruntime_ns = new_vruntime_ns - wg_entity->vruntime_ns();
         if (diff_vruntime_ns > 0) {
             DCHECK(_wg_entities.find(wg_entity) == _wg_entities.end());
-            wg_entity->incr_runtime_ns(diff_vruntime_ns * wg_entity->cpu_limit());
+            wg_entity->adjust_runtime_ns(diff_vruntime_ns * wg_entity->cpu_limit());
         }
     }
 

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -25,6 +25,17 @@ bool WorkGroupSchedEntity<Q>::is_sq_wg() const {
     return _workgroup->is_sq_wg();
 }
 
+template <typename Q>
+void WorkGroupSchedEntity<Q>::incr_runtime_ns(int64_t runtime_ns) {
+    _vruntime_ns += runtime_ns / cpu_limit();
+    _unadjusted_runtime_ns += runtime_ns;
+}
+
+template <typename Q>
+void WorkGroupSchedEntity<Q>::adjust_runtime_ns(int64_t runtime_ns) {
+    _vruntime_ns += runtime_ns / cpu_limit();
+}
+
 template class WorkGroupSchedEntity<pipeline::DriverQueue>;
 template class WorkGroupSchedEntity<ScanTaskQueue>;
 
@@ -301,15 +312,33 @@ void WorkGroupManager::add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockTy
     _wg_metrics[wg->name()] = wg->unique_id();
 }
 
+double _calculate_ratio(int64_t curr_value, int64_t sum_value) {
+    if (sum_value <= 0) {
+        return 0;
+    }
+    return double(curr_value) / sum_value;
+}
+
 void WorkGroupManager::update_metrics_unlocked() {
     int64_t sum_cpu_runtime_ns = 0;
     int64_t sum_scan_runtime_ns = 0;
     int64_t sum_connector_scan_runtime_ns = 0;
     for (const auto& [_, wg] : _workgroups) {
-        sum_cpu_runtime_ns += wg->driver_sched_entity()->runtime_ns();
-        sum_scan_runtime_ns += wg->scan_sched_entity()->runtime_ns();
-        sum_connector_scan_runtime_ns += wg->connector_scan_sched_entity()->runtime_ns();
+        wg->driver_sched_entity()->mark_curr_runtime_ns();
+        wg->scan_sched_entity()->mark_curr_runtime_ns();
+        wg->connector_scan_sched_entity()->mark_curr_runtime_ns();
+
+        sum_cpu_runtime_ns += wg->driver_sched_entity()->growth_runtime_ns();
+        sum_scan_runtime_ns += wg->scan_sched_entity()->growth_runtime_ns();
+        sum_connector_scan_runtime_ns += wg->connector_scan_sched_entity()->growth_runtime_ns();
     }
+    DeferOp mark_last_runtime_op([this] {
+        for (const auto& [_, wg] : _workgroups) {
+            wg->driver_sched_entity()->mark_last_runtime_ns();
+            wg->scan_sched_entity()->mark_last_runtime_ns();
+            wg->connector_scan_sched_entity()->mark_last_runtime_ns();
+        }
+    });
 
     for (const auto& [name, wg_id] : _wg_metrics) {
         auto wg_it = _workgroups.find(wg_id);
@@ -317,15 +346,11 @@ void WorkGroupManager::update_metrics_unlocked() {
             const auto& wg = wg_it->second;
             VLOG(2) << "workgroup update_metrics " << name;
 
-            double cpu_expected_use_ratio = _sum_cpu_limit == 0 ? 0 : double(wg->cpu_limit()) / _sum_cpu_limit;
-            double cpu_use_ratio =
-                    sum_cpu_runtime_ns <= 0 ? 0 : double(wg->driver_sched_entity()->runtime_ns()) / sum_cpu_runtime_ns;
-            double scan_use_ratio =
-                    sum_scan_runtime_ns <= 0 ? 0 : double(wg->scan_sched_entity()->runtime_ns()) / sum_scan_runtime_ns;
-            double connector_scan_use_ratio =
-                    sum_connector_scan_runtime_ns <= 0
-                            ? 0
-                            : double(wg->connector_scan_sched_entity()->runtime_ns()) / sum_connector_scan_runtime_ns;
+            double cpu_expected_use_ratio = _calculate_ratio(wg->cpu_limit(), _sum_cpu_limit);
+            double cpu_use_ratio = _calculate_ratio(wg->driver_sched_entity()->growth_runtime_ns(), sum_cpu_runtime_ns);
+            double scan_use_ratio = _calculate_ratio(wg->scan_sched_entity()->growth_runtime_ns(), sum_scan_runtime_ns);
+            double connector_scan_use_ratio = _calculate_ratio(wg->connector_scan_sched_entity()->growth_runtime_ns(),
+                                                               sum_connector_scan_runtime_ns);
 
             _wg_cpu_limit_metrics[name]->set_value(cpu_expected_use_ratio);
             _wg_cpu_metrics[name]->set_value(cpu_use_ratio);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13734.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The metric `cpu_use_ratio` of workgroup shows the cpu usage proportion for the **accumulated** cpu runtime, but it is expected to show the proportion for an interval.

Therefore, modify it to calculate the proportion for the interval between two calls to `update_metric`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
