### PR TITLE
[BugFix]Avoid BE crash when ORC's type can't convert to SlotDescriptor's type

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -49,11 +49,6 @@ const static std::unordered_map<orc::TypeKind, LogicalType> g_orc_starrocks_prim
 };
 
 // NOLINTNEXTLINE
-//const static std::set<orc::TypeKind> g_orc_int_type = {
-//        orc::BOOLEAN, orc::BYTE, orc::SHORT, orc::INT, orc::LONG, orc::FLOAT, orc::DOUBLE,
-//};
-
-// NOLINTNEXTLINE
 const static std::set<LogicalType> g_starrocks_int_type = {TYPE_BOOLEAN, TYPE_TINYINT,  TYPE_SMALLINT, TYPE_INT,
                                                            TYPE_BIGINT,  TYPE_LARGEINT, TYPE_FLOAT,    TYPE_DOUBLE};
 

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -30,7 +30,7 @@ namespace starrocks::vectorized {
 const FillColumnFunction& find_fill_func(LogicalType type, bool nullable);
 
 // NOLINTNEXTLINE
-const static std::unordered_map<orc::TypeKind, LogicalType> g_orc_starrocks_type_mapping = {
+const static std::unordered_map<orc::TypeKind, LogicalType> g_orc_starrocks_primitive_type_mapping = {
         {orc::BOOLEAN, TYPE_BOOLEAN},
         {orc::BYTE, TYPE_TINYINT},
         {orc::SHORT, TYPE_SMALLINT},
@@ -49,9 +49,9 @@ const static std::unordered_map<orc::TypeKind, LogicalType> g_orc_starrocks_type
 };
 
 // NOLINTNEXTLINE
-const static std::set<orc::TypeKind> g_orc_int_type = {
-        orc::BOOLEAN, orc::BYTE, orc::SHORT, orc::INT, orc::LONG, orc::FLOAT, orc::DOUBLE,
-};
+//const static std::set<orc::TypeKind> g_orc_int_type = {
+//        orc::BOOLEAN, orc::BYTE, orc::SHORT, orc::INT, orc::LONG, orc::FLOAT, orc::DOUBLE,
+//};
 
 // NOLINTNEXTLINE
 const static std::set<LogicalType> g_starrocks_int_type = {TYPE_BOOLEAN, TYPE_TINYINT,  TYPE_SMALLINT, TYPE_INT,
@@ -1459,8 +1459,8 @@ static Status _create_type_descriptor_by_orc(const TypeDescriptor& origin_type, 
         auto precision = (int)orc_type->getPrecision();
         auto scale = (int)orc_type->getScale();
         auto len = (int)orc_type->getMaximumLength();
-        auto iter = g_orc_starrocks_type_mapping.find(kind);
-        if (iter == g_orc_starrocks_type_mapping.end()) {
+        auto iter = g_orc_starrocks_primitive_type_mapping.find(kind);
+        if (iter == g_orc_starrocks_primitive_type_mapping.end()) {
             return Status::NotSupported("Unsupported ORC type: " + orc_type->toString());
         }
         result->type = iter->second;

--- a/be/src/formats/orc/orc_mapping.cpp
+++ b/be/src/formats/orc/orc_mapping.cpp
@@ -120,16 +120,12 @@ StatusOr<std::unique_ptr<OrcMapping>> OrcMappingFactory::build_mapping(
 Status OrcMappingFactory::_check_orc_type_can_converte_2_logical_type(const orc::Type& orc_source_type,
                                                                       const TypeDescriptor& slot_target_type) {
     bool can_convert = true;
-    if (slot_target_type.is_array_type()) {
-        can_convert = orc_source_type.getKind() == orc::TypeKind::LIST;
-    } else if (slot_target_type.is_map_type()) {
-        can_convert = orc_source_type.getKind() == orc::TypeKind::MAP;
-    } else if (slot_target_type.is_struct_type()) {
-        can_convert = orc_source_type.getKind() == orc::TypeKind::STRUCT;
-    } else if (slot_target_type.is_date_type()) {
-        can_convert = (orc_source_type.getKind() == orc::TypeKind::DATE) ||
-                      (orc_source_type.getKind() == orc::TypeKind::TIMESTAMP) ||
-                      (orc_source_type.getKind() == orc::TypeKind::TIMESTAMP_INSTANT);
+    if (orc_source_type.getKind() == orc::TypeKind::LIST) {
+        can_convert = slot_target_type.is_array_type();
+    } else if (orc_source_type.getKind() == orc::TypeKind::MAP) {
+        can_convert = slot_target_type.is_map_type();
+    } else if (orc_source_type.getKind() == orc::TypeKind::STRUCT) {
+        can_convert = slot_target_type.is_struct_type();
     }
 
     //TODO Other primitive type not check now!

--- a/be/src/formats/orc/orc_mapping.h
+++ b/be/src/formats/orc/orc_mapping.h
@@ -105,6 +105,9 @@ public:
                                                                const std::vector<std::string>* hive_column_names);
 
 private:
+    static Status _check_orc_type_can_converte_2_logical_type(const orc::Type& orc_source_type,
+                                                              const TypeDescriptor& slot_target_type);
+
     static Status _init_orc_mapping_with_orc_column_names(std::unique_ptr<OrcMapping>& mapping,
                                                           const std::vector<SlotDescriptor*>& slot_descs,
                                                           const orc::Type& orc_root_type, const bool case_sensitve);

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1598,7 +1598,7 @@ TEST_F(OrcChunkReaderTest, TestUnConvertableType) {
         reader.set_case_sensitive(true);
         auto input_stream = orc::readLocalFile(input_orc_file);
         Status st = reader.init(std::move(input_stream));
-        EXPECT_FALSE(!st.ok());
+        EXPECT_FALSE(st.ok());
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14156

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
