### PR TITLE
[Enhancement][Lake] Drop disk cache after GC

### DIFF
--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -22,9 +22,21 @@ inline StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const std::
     return fs->new_sequential_file(path);
 }
 
+inline StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const SequentialFileOptions& opts,
+                                                                     const std::string& path) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
+    return fs->new_sequential_file(opts, path);
+}
+
 inline StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const std::string& path) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
     return fs->new_random_access_file(path);
+}
+
+inline StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,
+                                                                          const std::string& path) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
+    return fs->new_random_access_file(opts, path);
 }
 
 inline StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const std::string& path) {

--- a/be/src/fs/rapidjson_stream_adapter.h
+++ b/be/src/fs/rapidjson_stream_adapter.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-// #include <rapidjson/stream.h>
-
 #include "common/logging.h"
 #include "fs/fs.h"
 

--- a/be/src/fs/rapidjson_stream_adapter.h
+++ b/be/src/fs/rapidjson_stream_adapter.h
@@ -56,6 +56,8 @@ public:
         Read();
     }
 
+    DISALLOW_COPY_AND_MOVE(RapidJSONReadStreamAdapter);
+
     Ch Peek() const { return *_current; }
     Ch Take() {
         Ch c = *_current;

--- a/be/src/fs/rapidjson_stream_adapter.h
+++ b/be/src/fs/rapidjson_stream_adapter.h
@@ -1,0 +1,197 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#pragma once
+
+// #include <rapidjson/stream.h>
+
+#include "common/logging.h"
+#include "fs/fs.h"
+
+namespace starrocks {
+
+/**
+ * Example usage:
+ * ```
+ * #include <rapidjson/document.h> // will include "rapidjson/rapidjson.h" 
+ * #include "fs/fs_util.h"
+ * // ...
+ * ASSIGN_OR_RETURN(auto f = fs::new_sequential_file("1.json"));
+ * char buffer[65536];
+ * RapidJSONReadStreamAdapter adapter(f.get(), buffer, sizeof(buffer));
+ * rapidjson::Document d;
+ * d.ParseStream(adapter); 
+ * ```
+ **/
+class RapidJSONReadStreamAdapter {
+public:
+    typedef char Ch; //!< Character type (byte).
+
+    // Constructor
+    //  |fp| file pointer opened for read.
+    //  |buffer| user-supplied buffer.
+    //  |buffer_size| size of buffer in bytes. Must >=4 bytes.
+    RapidJSONReadStreamAdapter(SequentialFile* fp, char* buffer, size_t buffer_size)
+            : RapidJSONReadStreamAdapter(fp->stream(), buffer, buffer_size) {}
+
+    // Constructor
+    //  |fp| file pointer opened for read.
+    //  |buffer| user-supplied buffer.
+    //  |buffer_size| size of buffer in bytes. Must >=4 bytes.
+    RapidJSONReadStreamAdapter(RandomAccessFile* fp, char* buffer, size_t buffer_size)
+            : RapidJSONReadStreamAdapter(fp->stream(), buffer, buffer_size) {}
+
+    // Constructor
+    //  |is| input stream opened for read.
+    //  |buffer| user-supplied buffer.
+    //  |buffer_size| size of buffer in bytes. Must >=4 bytes.
+    RapidJSONReadStreamAdapter(std::shared_ptr<io::InputStream> is, char* buffer, size_t buffer_size)
+            : _is(std::move(is)),
+              _buffer(buffer),
+              _buffer_size(buffer_size),
+              _buffer_last(0),
+              _current(_buffer),
+              _read_count(0),
+              _count(0),
+              _eof(false) {
+        DCHECK(_is != nullptr);
+        DCHECK(buffer_size >= 4);
+        Read();
+    }
+
+    Ch Peek() const { return *_current; }
+    Ch Take() {
+        Ch c = *_current;
+        Read();
+        return c;
+    }
+    size_t Tell() const { return _count + static_cast<size_t>(_current - _buffer); }
+
+    // Not implemented
+    void Put(Ch) { DCHECK(false); }
+    void Flush() { DCHECK(false); }
+    Ch* PutBegin() {
+        DCHECK(false);
+        return 0;
+    }
+    size_t PutEnd(Ch*) {
+        DCHECK(false);
+        return 0;
+    }
+
+    // For encoding detection only.
+    const Ch* Peek4() const { return (_current + 4 - !_eof <= _buffer_last) ? _current : 0; }
+
+    Status status() const { return _status; }
+
+private:
+    void Read() {
+        if (_current < _buffer_last) {
+            ++_current;
+        } else if (!_eof) {
+            _count += _read_count;
+            auto read_count_or = _is->read(_buffer, _buffer_size);
+            _status.update(read_count_or.status());
+            _read_count = read_count_or.ok() ? *read_count_or : 0;
+            _buffer_last = _buffer + _read_count - 1;
+            _current = _buffer;
+            if (_read_count == 0) {
+                _buffer[_read_count] = '\0';
+                ++_buffer_last;
+                _eof = true;
+            }
+        }
+    }
+
+    std::shared_ptr<io::InputStream> _is;
+    Ch* _buffer;
+    size_t _buffer_size;
+    Ch* _buffer_last;
+    Ch* _current;
+    size_t _read_count;
+    size_t _count; // Number of characters read
+    Status _status;
+    bool _eof;
+};
+
+class RapidJSONWriteStreamAdapter {
+public:
+    typedef char Ch; // Character type. Only support char.
+
+    RapidJSONWriteStreamAdapter(WritableFile* wf, char* buffer, size_t bufferSize)
+            : _wf(wf), _buffer(buffer), _buffer_end(buffer + bufferSize), _current(_buffer) {
+        DCHECK(_wf != nullptr);
+    }
+
+    DISALLOW_COPY_AND_MOVE(RapidJSONWriteStreamAdapter);
+
+    void Put(char c) {
+        if (_current >= _buffer_end) Flush();
+
+        *_current++ = c;
+    }
+
+    void PutN(char c, size_t n) {
+        size_t avail = static_cast<size_t>(_buffer_end - _current);
+        while (n > avail) {
+            std::memset(_current, c, avail);
+            _current += avail;
+            Flush();
+            n -= avail;
+            avail = static_cast<size_t>(_buffer_end - _current);
+        }
+
+        if (n > 0) {
+            std::memset(_current, c, n);
+            _current += n;
+        }
+    }
+
+    void Flush() {
+        if (_current != _buffer) {
+            _status.update(_wf->append({_buffer, static_cast<size_t>(_current - _buffer)}));
+            _current = _buffer;
+        }
+    }
+
+    // Not implemented
+    char Peek() const {
+        DCHECK(false);
+        return 0;
+    }
+    char Take() {
+        DCHECK(false);
+        return 0;
+    }
+    size_t Tell() const {
+        DCHECK(false);
+        return 0;
+    }
+    char* PutBegin() {
+        DCHECK(false);
+        return 0;
+    }
+    size_t PutEnd(char*) {
+        DCHECK(false);
+        return 0;
+    }
+
+    Status status() const { return _status; }
+
+private:
+    WritableFile* _wf;
+    char* _buffer;
+    char* _buffer_end;
+    char* _current;
+    Status _status;
+};
+
+} // namespace starrocks
+
+namespace rapidjson {
+//! Implement specialized version of PutN() with memset() for better performance.
+template <>
+inline void PutN(starrocks::RapidJSONWriteStreamAdapter& stream, char c, size_t n) {
+    stream.PutN(c, n);
+}
+
+} // namespace rapidjson

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -74,7 +74,7 @@ absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::get_shard_files
         std::shared_lock l(_mtx);
         auto it = _shards.find(id);
         if (it == _shards.end()) {
-            return absl::NotFoundError(fmt::format("failed to get shardinfo {}", id));
+            return absl::InternalError(fmt::format("failed to get shardinfo {}", id));
         }
         if (it->second.fs) {
             return it->second.fs;
@@ -86,7 +86,7 @@ absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::get_shard_files
         auto shard_iter = _shards.find(id);
         // could be possibly shards removed or fs get created during unlock-lock
         if (shard_iter == _shards.end()) {
-            return absl::NotFoundError(fmt::format("failed to get shardinfo {}", id));
+            return absl::InternalError(fmt::format("failed to get shardinfo {}", id));
         }
         if (shard_iter->second.fs) {
             return shard_iter->second.fs;

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -17,7 +17,7 @@ constexpr static const int kTxnLogFilenameLength = 37;
 constexpr static const int kTabletMetadataLockFilenameLength = 55;
 constexpr static const int kSegmentFileNameLength = 40;
 
-constexpr static const char* const kOrphanListFileName = "orphans.json";
+constexpr static const char* const kGCFileName = "GC.json";
 
 inline bool is_segment(std::string_view file_name) {
     return HasSuffixString(file_name, ".dat");

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -17,7 +17,7 @@ constexpr static const int kTxnLogFilenameLength = 37;
 constexpr static const int kTabletMetadataLockFilenameLength = 55;
 constexpr static const int kSegmentFileNameLength = 40;
 
-constexpr static const char* const kOrphanListFileName = "orphans";
+constexpr static const char* const kOrphanListFileName = "orphans.txt";
 
 inline bool is_segment(std::string_view file_name) {
     return HasSuffixString(file_name, ".dat");

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -8,12 +8,16 @@
 
 #include "gutil/strings/util.h"
 #include "util/string_parser.hpp"
+#include "util/uid_util.h"
 
 namespace starrocks::lake {
 
 constexpr static const int kTabletMetadataFilenameLength = 38;
 constexpr static const int kTxnLogFilenameLength = 37;
 constexpr static const int kTabletMetadataLockFilenameLength = 55;
+constexpr static const int kSegmentFileNameLength = 40;
+
+constexpr static const char* const kOrphanListFileName = "orphans";
 
 inline bool is_segment(std::string_view file_name) {
     return HasSuffixString(file_name, ".dat");
@@ -49,6 +53,12 @@ inline std::string txn_vlog_filename(int64_t tablet_id, int64_t version) {
 
 inline std::string tablet_metadata_lock_filename(int64_t tablet_id, int64_t version, int64_t expire_time) {
     return fmt::format("{:016X}_{:016X}_{:016X}.lock", tablet_id, version, expire_time);
+}
+
+inline std::string random_segment_filename() {
+    auto name = fmt::format("{}.dat", generate_uuid_string());
+    DCHECK_EQ(kSegmentFileNameLength, name.size());
+    return name;
 }
 
 // Return value: <tablet id, tablet version>

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -17,7 +17,7 @@ constexpr static const int kTxnLogFilenameLength = 37;
 constexpr static const int kTabletMetadataLockFilenameLength = 55;
 constexpr static const int kSegmentFileNameLength = 40;
 
-constexpr static const char* const kOrphanListFileName = "orphans.txt";
+constexpr static const char* const kOrphanListFileName = "orphans.json";
 
 inline bool is_segment(std::string_view file_name) {
     return HasSuffixString(file_name, ".dat");

--- a/be/src/storage/lake/fixed_location_provider.h
+++ b/be/src/storage/lake/fixed_location_provider.h
@@ -22,6 +22,8 @@ public:
     // No usage now.
     DISALLOW_COPY_AND_MOVE(FixedLocationProvider);
 
+    std::set<int64_t> owned_tablets() const override { return {}; }
+
     std::string root_location(int64_t tablet_id) const override { return _root; }
 
     Status list_root_locations(std::set<std::string>* roots) const override {

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -38,6 +38,7 @@ static Status read_orphan_list_file(RandomAccessFile* file, std::vector<std::str
     DCHECK_EQ(0, size % (kSegmentFileNameLength + 1));
     raw::RawVector<char> buff;
     buff.resize(size); // TODO: streaming read
+    RETURN_IF_ERROR(file->read_fully(buff.data(), size));
     orphans->reserve(size / (kSegmentFileNameLength + 1));
     for (auto offset = 0L; offset < size; offset += (kSegmentFileNameLength + 1)) {
         orphans->emplace_back(&buff[offset], kSegmentFileNameLength);

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -13,146 +13,160 @@
 #include "storage/lake/location_provider.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_metadata.h"
+#include "util/raw_container.h"
 
 namespace starrocks::lake {
 
-static std::string format_time(time_t ts) {
-    struct tm tm {};
-    char buffer[32];
-    // Format: 2009-06-06 20:20:00 UTC
-    auto len = std::strftime(buffer, sizeof(buffer), "%Y.%m.%d %H:%M:%S UTC", gmtime_r(&ts, &tm));
-    return {buffer, len};
+static Status write_orphan_list_file(const std::set<std::string>& orphans, WritableFile* file) {
+    for (const auto& s : orphans) {
+        RETURN_IF_ERROR(file->append(s));
+        RETURN_IF_ERROR(file->append("\n"));
+    }
+    DCHECK_EQ((kSegmentFileNameLength + 1) * orphans.size(), file->size());
+    return Status::OK();
 }
 
-Status metadata_gc(std::string_view root_location, TabletManager* tablet_mgr, int64_t min_active_txn_id) {
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_location));
+static Status read_orphan_list_file(RandomAccessFile* file, std::vector<std::string>* orphans) {
+    auto stream = file->stream();
+    auto size_or = stream->get_size();
+    if (size_or.status().is_not_found()) { // File does not exist
+        return Status::OK();
+    } else if (!size_or.ok()) {
+        return size_or.status();
+    }
+    auto size = *size_or;
+    DCHECK_EQ(0, size % (kSegmentFileNameLength + 1));
+    raw::RawVector<char> buff;
+    buff.resize(size); // TODO: streaming read
+    orphans->reserve(size / (kSegmentFileNameLength + 1));
+    for (auto offset = 0L; offset < size; offset += (kSegmentFileNameLength + 1)) {
+        orphans->emplace_back(&buff[offset], kSegmentFileNameLength);
+        DCHECK_EQ('\n', buff[offset + kSegmentFileNameLength + 1]);
+    }
+    return Status::OK();
+}
 
+static Status delete_tablet_metadata(std::string_view root_location, const std::set<int64_t>& owned_tablets) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_location));
     const auto max_versions = config::lake_gc_metadata_max_versions;
     if (UNLIKELY(max_versions < 1)) {
         return Status::InternalError("invalid config 'lake_gc_metadata_max_versions': value must be no less than 1");
     }
 
-    const auto metadata_root_location = join_path(root_location, kMetadataDirectoryName);
-    const auto txn_log_root_location = join_path(root_location, kTxnLogDirectoryName);
-
     std::unordered_map<int64_t, std::vector<int64_t>> tablet_metadatas;
-    std::vector<std::string> txn_logs;
     std::unordered_map<int64_t, std::unordered_set<int64_t>> locked_tablet_metadatas;
 
     auto start_time = std::time(nullptr);
-    {
-        auto iter_st = fs->iterate_dir(metadata_root_location, [&](std::string_view name) {
-            if (is_tablet_metadata(name)) {
-                auto [tablet_id, version] = parse_tablet_metadata_filename(name);
+    auto metadata_root_location = join_path(root_location, kMetadataDirectoryName);
+    auto iter_st = fs->iterate_dir(metadata_root_location, [&](std::string_view name) {
+        if (is_tablet_metadata(name)) {
+            auto [tablet_id, version] = parse_tablet_metadata_filename(name);
+            if (owned_tablets.count(tablet_id) > 0) {
                 tablet_metadatas[tablet_id].emplace_back(version);
             }
-            if (is_tablet_metadata_lock(name)) {
-                auto [tablet_id, version, expire_time] = parse_tablet_metadata_lock_filename(name);
-                if (start_time < expire_time) {
-                    locked_tablet_metadatas[tablet_id].insert(version);
-                }
-            }
-            return true;
-        });
-
-        if (iter_st.is_not_found()) {
-            // ignore this error
-            return Status::OK();
         }
-
-        if (!iter_st.ok()) {
-            return iter_st;
-        }
-
-        for (auto& [tablet_id, versions] : tablet_metadatas) {
-            if (versions.size() <= max_versions) {
-                continue;
-            }
-            // TODO: batch delete
-            // Keep the latest 10 versions.
-            // If the tablet metadata is locked, the correspoding version will be kept.
-            std::sort(versions.begin(), versions.end());
-            for (size_t i = 0, sz = versions.size() - max_versions; i < sz; i++) {
-                if (locked_tablet_metadatas.count(tablet_id)) {
-                    const auto& locked_tablet_metadata = locked_tablet_metadatas[tablet_id];
-                    if (locked_tablet_metadata.count(versions[i])) {
-                        continue;
-                    }
-                }
-                auto path = join_path(metadata_root_location, tablet_metadata_filename(tablet_id, versions[i]));
-                LOG(INFO) << "Deleting " << path;
-                auto st = fs->delete_file(path);
-                LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << path << ": " << st;
+        if (is_tablet_metadata_lock(name)) {
+            auto [tablet_id, version, expire_time] = parse_tablet_metadata_lock_filename(name);
+            if (start_time < expire_time && owned_tablets.count(tablet_id) > 0) {
+                locked_tablet_metadatas[tablet_id].insert(version);
             }
         }
+        return true;
+    });
+
+    if (!iter_st.ok()) {
+        return iter_st;
     }
 
-    // delete expired txn logs
-    {
-        auto iter_st = fs->iterate_dir(txn_log_root_location, [&](std::string_view name) {
-            if (is_txn_log(name)) {
-                auto [tablet_id, txn_id] = parse_txn_log_filename(name);
-                if (txn_id < min_active_txn_id) {
-                    txn_logs.emplace_back(name);
+    for (auto& [tablet_id, versions] : tablet_metadatas) {
+        if (versions.size() <= max_versions) {
+            continue;
+        }
+        // TODO: batch delete
+        // Keep the latest 10 versions.
+        // If the tablet metadata is locked, the correspoding version will be kept.
+        std::sort(versions.begin(), versions.end());
+        for (size_t i = 0, sz = versions.size() - max_versions; i < sz; i++) {
+            if (locked_tablet_metadatas.count(tablet_id)) {
+                const auto& locked_tablet_metadata = locked_tablet_metadatas[tablet_id];
+                if (locked_tablet_metadata.count(versions[i])) {
+                    continue;
                 }
             }
-            return true;
-        });
-        if (iter_st.is_not_found()) {
-            // ignore this error
-            return Status::OK();
-        }
-
-        if (!iter_st.ok()) {
-            return iter_st;
-        }
-
-        for (const auto& filename : txn_logs) {
-            auto location = join_path(txn_log_root_location, filename);
-            auto st = fs->delete_file(location);
-            LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << location << ": " << st;
+            auto path = join_path(metadata_root_location, tablet_metadata_filename(tablet_id, versions[i]));
+            LOG(INFO) << "Deleting " << path;
+            auto st = fs->delete_file(path);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << path << ": " << st;
         }
     }
-
     return Status::OK();
 }
 
-Status segment_gc(std::string_view root_location, TabletManager* tablet_mgr) {
+static Status delete_txn_log(std::string_view root_location, const std::set<int64_t>& owned_tablets,
+                             int64_t min_active_txn_id) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_location));
+    auto txn_log_root_location = join_path(root_location, kTxnLogDirectoryName);
+    auto iter_st = fs->iterate_dir(txn_log_root_location, [&](std::string_view name) {
+        if (is_txn_log(name)) {
+            auto [tablet_id, txn_id] = parse_txn_log_filename(name);
+            if (txn_id < min_active_txn_id && owned_tablets.count(tablet_id) > 0) {
+                VLOG(2) << "Deleting " << name;
+                auto location = join_path(txn_log_root_location, name);
+                auto st = fs->delete_file(location);
+                LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << name << ": " << st;
+            }
+        }
+        return true;
+    });
+    return iter_st.is_not_found() ? Status::OK() : iter_st;
+}
 
+static Status drop_disk_cache(std::string_view root_location) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_location));
+    auto segment_root_location = join_path(root_location, kSegmentDirectoryName);
+    auto orphan_list_location = join_path(root_location, kOrphanListFileName);
+    auto file_or = fs->new_random_access_file(orphan_list_location);
+    if (file_or.status().is_not_found()) {
+        return Status::OK();
+    } else if (!file_or.ok()) {
+        return file_or.status();
+    }
+    std::vector<std::string> orphan_segments;
+    RETURN_IF_ERROR(read_orphan_list_file(file_or->get(), &orphan_segments));
+    for (const auto& seg : orphan_segments) {
+        VLOG(3) << "Dropping disk cache of " << seg;
+        auto location = join_path(segment_root_location, seg);
+        // TODO: Add a new interface for dropping disk cache
+        auto st = fs->delete_file(location);
+        LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to drop cache of " << seg << ": " << st;
+    }
+    return Status::OK();
+}
+
+Status metadata_gc(std::string_view root_location, TabletManager* tablet_mgr, int64_t min_active_txn_id) {
+    const auto owned_tablets = tablet_mgr->owned_tablets();
+    Status ret;
+    ret.update(delete_tablet_metadata(root_location, owned_tablets));
+    ret.update(delete_txn_log(root_location, owned_tablets, min_active_txn_id));
+    ret.update(drop_disk_cache(root_location));
+    return ret;
+}
+
+static StatusOr<std::set<std::string>> find_orphan_segments(TabletManager* tablet_mgr, std::string_view root_location,
+                                                            const std::vector<std::string>& tablet_metadatas,
+                                                            const std::vector<std::string>& txn_logs) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_location));
     const auto metadata_root_location = join_path(root_location, kMetadataDirectoryName);
     const auto txn_log_root_location = join_path(root_location, kTxnLogDirectoryName);
     const auto segment_root_location = join_path(root_location, kSegmentDirectoryName);
 
-    std::vector<std::string> tablet_metadatas;
-    std::vector<std::string> txn_logs;
-    std::unordered_set<std::string> segments;
+    std::set<std::string> segments;
 
     // List segment
     auto iter_st = fs->iterate_dir(segment_root_location, [&](std::string_view name) {
         if (LIKELY(is_segment(name))) {
             segments.emplace(name);
         }
-        return true;
-    });
-    if (!iter_st.ok() && !iter_st.is_not_found()) {
-        return iter_st;
-    }
-
-    // List tablet meatadata
-    iter_st = fs->iterate_dir(metadata_root_location, [&](std::string_view name) {
-        if (is_tablet_metadata(name)) {
-            tablet_metadatas.emplace_back(name);
-        }
-        return true;
-    });
-    if (!iter_st.ok() && !iter_st.is_not_found()) {
-        return iter_st;
-    }
-
-    // List txn log
-    iter_st = fs->iterate_dir(txn_log_root_location, [&](std::string_view name) {
-        txn_logs.emplace_back(name);
         return true;
     });
     if (!iter_st.ok() && !iter_st.is_not_found()) {
@@ -210,22 +224,80 @@ Status segment_gc(std::string_view root_location, TabletManager* tablet_mgr) {
 
     auto now = std::time(nullptr);
 
-    for (auto& seg : segments) {
-        auto location = join_path(segment_root_location, seg);
+    for (auto it = segments.begin(); it != segments.end(); /**/) {
+        auto location = join_path(segment_root_location, *it);
         auto res = fs->get_file_modified_time(location);
         if (!res.ok()) {
             LOG_IF(WARNING, !res.status().is_not_found())
                     << "Fail to get modified time of " << location << ": " << res.status();
-            continue;
-        } else if ((now < *res) || (now - *res < config::lake_gc_segment_expire_seconds)) {
-            //     ^^^^^^^^^^^^ This is necessary because (now - *res) is an unsigned value.
-            continue;
+            it = segments.erase(it);
+        } else if (now < *res + config::lake_gc_segment_expire_seconds) {
+            it = segments.erase(it);
+        } else {
+            ++it;
         }
+    }
 
-        LOG(INFO) << "Deleting orphan segment " << location << ". mtime=" << format_time(static_cast<time_t>(*res));
+    return segments;
+}
 
+Status segment_gc(std::string_view root_location, TabletManager* tablet_mgr) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_location));
+
+    const auto owned_tablets = tablet_mgr->owned_tablets();
+    const auto metadata_root_location = join_path(root_location, kMetadataDirectoryName);
+    const auto txn_log_root_location = join_path(root_location, kTxnLogDirectoryName);
+    const auto segment_root_location = join_path(root_location, kSegmentDirectoryName);
+
+    int64_t min_tablet_id = INT64_MAX;
+    std::vector<std::string> tablet_metadatas;
+
+    // List tablet meatadata
+    auto iter_st = fs->iterate_dir(metadata_root_location, [&](std::string_view name) {
+        if (!is_tablet_metadata(name)) {
+            return true;
+        }
+        auto [tablet_id, version] = parse_tablet_metadata_filename(name);
+        min_tablet_id = std::min(min_tablet_id, tablet_id);
+        tablet_metadatas.emplace_back(name);
+        return true;
+    });
+    if (!iter_st.ok()) {
+        return iter_st;
+    }
+
+    if (min_tablet_id == INT64_MAX) {
+        LOG(INFO) << "Skiped segment GC of " << root_location << " because there is no tablet metadata";
+        return Status::OK();
+    }
+
+    if (owned_tablets.count(min_tablet_id) == 0) {
+        // The tablet with the smallest ID is not managed by the current process, skip segment GC
+        return Status::OK();
+    }
+
+    // List txn log
+    std::vector<std::string> txn_logs;
+    iter_st = fs->iterate_dir(txn_log_root_location, [&](std::string_view name) {
+        txn_logs.emplace_back(name);
+        return true;
+    });
+    if (!iter_st.ok() && !iter_st.is_not_found()) {
+        return iter_st;
+    }
+
+    // Find orphan segments
+    ASSIGN_OR_RETURN(auto orphan_segments, find_orphan_segments(tablet_mgr, root_location, tablet_metadatas, txn_logs));
+    // Write orphan segment list file
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    ASSIGN_OR_RETURN(auto orphan_list_file, fs->new_writable_file(opts, join_path(root_location, kOrphanListFileName)));
+    RETURN_IF_ERROR(write_orphan_list_file(orphan_segments, orphan_list_file.get()));
+    // Delete orphan segment files
+    for (auto& seg : orphan_segments) {
+        LOG(INFO) << "Deleting orphan segment " << seg;
+        auto location = join_path(segment_root_location, seg);
         auto st = fs->delete_file(location);
-        LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << location << ": " << st;
+        LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << seg << ": " << st;
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -23,7 +23,7 @@ static Status write_orphan_list_file(const std::set<std::string>& orphans, Writa
         RETURN_IF_ERROR(file->append("\n"));
     }
     DCHECK_EQ((kSegmentFileNameLength + 1) * orphans.size(), file->size());
-    return Status::OK();
+    return file->close();
 }
 
 static Status read_orphan_list_file(RandomAccessFile* file, std::vector<std::string>* orphans) {
@@ -289,7 +289,7 @@ Status segment_gc(std::string_view root_location, TabletManager* tablet_mgr) {
     // Find orphan segments
     ASSIGN_OR_RETURN(auto orphan_segments, find_orphan_segments(tablet_mgr, root_location, tablet_metadatas, txn_logs));
     // Write orphan segment list file
-    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    WritableFileOptions opts{.sync_on_close = false, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     ASSIGN_OR_RETURN(auto orphan_list_file, fs->new_writable_file(opts, join_path(root_location, kOrphanListFileName)));
     RETURN_IF_ERROR(write_orphan_list_file(orphan_segments, orphan_list_file.get()));
     // Delete orphan segment files

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -148,7 +148,7 @@ static Status delete_txn_log(std::string_view root_location, const std::set<int6
 static Status drop_disk_cache(std::string_view root_location) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_location));
     auto segment_root_location = join_path(root_location, kSegmentDirectoryName);
-    auto orphan_list_location = join_path(root_location, kOrphanListFileName);
+    auto orphan_list_location = join_path(root_location, kGCFileName);
     auto file_or = fs->new_random_access_file(orphan_list_location);
     if (file_or.status().is_not_found()) {
         return Status::OK();
@@ -314,7 +314,7 @@ Status segment_gc(std::string_view root_location, TabletManager* tablet_mgr) {
     ASSIGN_OR_RETURN(auto orphan_segments, find_orphan_segments(tablet_mgr, root_location, tablet_metadatas, txn_logs));
     // Write orphan segment list file
     WritableFileOptions opts{.sync_on_close = false, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-    ASSIGN_OR_RETURN(auto orphan_list_file, fs->new_writable_file(opts, join_path(root_location, kOrphanListFileName)));
+    ASSIGN_OR_RETURN(auto orphan_list_file, fs->new_writable_file(opts, join_path(root_location, kGCFileName)));
     RETURN_IF_ERROR(write_orphan_list_file(orphan_segments, orphan_list_file.get()));
     // Delete orphan segment files
     for (auto& seg : orphan_segments) {

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -174,7 +174,7 @@ static StatusOr<std::set<std::string>> find_orphan_segments(TabletManager* table
     }
 
     if (segments.empty()) {
-        return Status::OK();
+        return segments;
     }
 
     auto check_rowset = [&](const RowsetMetadata& rowset) {

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -7,8 +7,8 @@
 #include "column/chunk.h"
 #include "common/config.h"
 #include "fs/fs_util.h"
+#include "storage/lake/filenames.h"
 #include "storage/rowset/segment_writer.h"
-#include "util/uid_util.h"
 
 namespace starrocks::lake {
 
@@ -63,7 +63,7 @@ Status GeneralTabletWriter::reset_segment_writer() {
     if (_schema == nullptr) {
         ASSIGN_OR_RETURN(_schema, _tablet.get_schema());
     }
-    auto name = fmt::format("{}.dat", generate_uuid_string());
+    auto name = random_segment_filename();
     ASSIGN_OR_RETURN(auto of, fs::new_writable_file(_tablet.segment_location(name)));
     SegmentWriterOptions opts;
     auto w = std::make_unique<SegmentWriter>(std::move(of), _seg_id++, _schema.get(), opts);

--- a/be/src/storage/lake/location_provider.h
+++ b/be/src/storage/lake/location_provider.h
@@ -21,6 +21,9 @@ class LocationProvider {
 public:
     virtual ~LocationProvider() = default;
 
+    // TODO: move this method to another class.
+    virtual std::set<int64_t> owned_tablets() const = 0;
+
     // The result should be guaranteed to not end with "/"
     virtual std::string root_location(int64_t tablet_id) const = 0;
 

--- a/be/src/storage/lake/starlet_location_provider.cpp
+++ b/be/src/storage/lake/starlet_location_provider.cpp
@@ -43,5 +43,16 @@ Status StarletLocationProvider::list_root_locations(std::set<std::string>* roots
     return Status::OK();
 }
 
+std::set<int64_t> StarletLocationProvider::owned_tablets() const {
+    std::set<int64_t> ret;
+    if (g_worker != nullptr) {
+        auto shards = g_worker->shards();
+        for (const auto& s : shards) {
+            ret.insert(s.id);
+        }
+    }
+    return ret;
+}
+
 } // namespace starrocks::lake
 #endif // USE_STAROS

--- a/be/src/storage/lake/starlet_location_provider.h
+++ b/be/src/storage/lake/starlet_location_provider.h
@@ -18,6 +18,8 @@ public:
 
     DISALLOW_COPY_AND_MOVE(StarletLocationProvider);
 
+    std::set<int64_t> owned_tablets() const override;
+
     std::string root_location(int64_t tablet_id) const override;
 
     Status list_root_locations(std::set<std::string>* roots) const override;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -767,6 +767,10 @@ Status TabletManager::delete_tablet_metadata_lock(int64_t tablet_id, int64_t ver
     return st.is_not_found() ? Status::OK() : st;
 }
 
+std::set<int64_t> TabletManager::owned_tablets() {
+    return _location_provider->owned_tablets();
+}
+
 void TabletManager::start_gc() {
     int r = bthread_start_background(&_metadata_gc_tid, nullptr, metadata_gc_trigger, this);
     PLOG_IF(FATAL, r != 0) << "Fail to call bthread_start_background";

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -128,8 +128,8 @@ private:
 
     StatusOr<TabletSchemaPtr> get_tablet_schema(int64_t tablet_id);
 
-    StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location);
-    StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location);
+    StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_cache);
+    StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
 
     /// Cache operations
     bool fill_metacache(std::string_view key, CacheValue* ptr, int size);

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -117,6 +117,9 @@ public:
 
     void start_gc();
 
+    // Return a set of tablet that owned by this TabletManager.
+    std::set<int64_t> owned_tablets();
+
 private:
     using CacheValue = std::variant<TabletMetadataPtr, TxnLogPtr, TabletSchemaPtr, SegmentPtr>;
 

--- a/be/test/storage/lake/gc_test.cpp
+++ b/be/test/storage/lake/gc_test.cpp
@@ -252,7 +252,7 @@ TEST_F(GCTest, test_segment_gc) {
         }
     }
     {
-        auto orphan_list = join_path(kTestDir, kOrphanListFileName);
+        auto orphan_list = join_path(kTestDir, kGCFileName);
         auto st = fs->path_exists(orphan_list);
         ASSERT_OK(st);
     }

--- a/be/test/storage/lake/gc_test.cpp
+++ b/be/test/storage/lake/gc_test.cpp
@@ -23,226 +23,115 @@ namespace starrocks::lake {
 
 class TestLocationProvider : public LocationProvider {
 public:
-    explicit TestLocationProvider(LocationProvider* lp) : _lp(lp) {}
+    explicit TestLocationProvider(std::string dir) : _dir(dir) {}
 
-    std::string root_location(int64_t tablet_id) const override {
-        if (_owned_shards.count(tablet_id) > 0) {
-            return _lp->root_location(tablet_id);
-        } else {
-            return "/path/to/nonexist/directory/";
-        }
+    std::set<int64_t> owned_tablets() const override { return _owned_shards; }
+
+    std::string root_location(int64_t tablet_id) const override { return _dir; }
+
+    Status list_root_locations(std::set<std::string>* roots) const override {
+        roots->insert(_dir);
+        return Status::OK();
     }
 
-    Status list_root_locations(std::set<std::string>* roots) const override { return _lp->list_root_locations(roots); }
-
     std::set<int64_t> _owned_shards;
-    LocationProvider* _lp;
+    std::string _dir;
 };
 
 class GCTest : public ::testing::Test {
 public:
-    static void SetUpTestCase() {
+    void SetUp() override {
         CHECK_OK(fs::create_directories(join_path(kTestDir, kMetadataDirectoryName)));
         CHECK_OK(fs::create_directories(join_path(kTestDir, kTxnLogDirectoryName)));
         CHECK_OK(fs::create_directories(join_path(kTestDir, kSegmentDirectoryName)));
-
-        s_location_provider = std::make_unique<FixedLocationProvider>(kTestDir);
-        s_tablet_manager = std::make_unique<lake::TabletManager>(s_location_provider.get(), 16384);
     }
 
-    static void TearDownTestCase() { (void)FileSystem::Default()->delete_dir_recursive(kTestDir); }
+    void TearDown() override { (void)FileSystem::Default()->delete_dir_recursive(kTestDir); }
 
 protected:
     constexpr static const char* const kTestDir = "./lake_gc_test";
-    inline static std::unique_ptr<lake::LocationProvider> s_location_provider;
-    inline static std::unique_ptr<TabletManager> s_tablet_manager;
 };
 
 // NOLINTNEXTLINE
 TEST_F(GCTest, test_metadata_gc) {
     auto fs = FileSystem::Default();
-    auto tablet_id = next_id();
-    auto version_count = config::lake_gc_metadata_max_versions + 4;
-    int64_t txn_id = 1;
-    auto expire_time = std::time(nullptr) + 100000;
-    for (int i = 0; i < version_count; i++) {
-        auto metadata = std::make_shared<TabletMetadata>();
-        // leave scheme and rowset unsetted.
-        metadata->set_id(tablet_id);
-        metadata->set_version(i + 1);
-        metadata->set_next_rowset_id(i + 1);
-
-        if (i == 0 || i == 1) {
-            ASSERT_OK(s_tablet_manager->put_tablet_metadata_lock(tablet_id, i + 1, expire_time));
-            ++txn_id;
-        }
-
-        ASSERT_OK(s_tablet_manager->put_tablet_metadata(metadata));
-        ASSERT_OK(metadata_gc(kTestDir, s_tablet_manager.get(), 0));
-    }
-
-    // Ensure all metadata are still exist.
-    for (int i = 0; i < version_count; i++) {
-        // Version 1 and 2 will be kept because their metadata are locked.
-        if (i == 2 || i == 3) {
-            auto location = s_tablet_manager->tablet_metadata_location(tablet_id, i + 1);
-            auto st = fs->path_exists(location);
-            ASSERT_TRUE(st.is_not_found()) << st;
-        } else {
-            auto location = s_tablet_manager->tablet_metadata_location(tablet_id, i + 1);
-            ASSERT_OK(fs->path_exists(location));
-        }
-    }
-
-    // txn log
-    int64_t min_active_txn_log_id = 100;
-    {
-        for (int i = 0; i < 5; i++) {
-            auto txn_log = std::make_shared<lake::TxnLog>();
-            txn_log->set_tablet_id(tablet_id);
-            txn_log->set_txn_id(i);
-            ASSERT_OK(s_tablet_manager->put_txn_log(txn_log));
-        }
-        ASSERT_OK(metadata_gc(kTestDir, s_tablet_manager.get(), min_active_txn_log_id));
-
-        for (int i = 0; i < 5; i++) {
-            auto txn = s_tablet_manager->txn_log_location(tablet_id, i);
-            auto st = fs->path_exists(txn);
-            ASSERT_TRUE(st.is_not_found()) << st;
-        }
-    }
-
-    {
-        for (int i = 100; i < 105; i++) {
-            auto txn_log = std::make_shared<lake::TxnLog>();
-            txn_log->set_tablet_id(tablet_id);
-            txn_log->set_txn_id(i);
-            ASSERT_OK(s_tablet_manager->put_txn_log(txn_log));
-        }
-        ASSERT_OK(metadata_gc(kTestDir, s_tablet_manager.get(), min_active_txn_log_id));
-
-        for (int i = 100; i < 105; i++) {
-            auto location = s_tablet_manager->txn_log_location(tablet_id, i);
-            ASSERT_OK(fs->path_exists(location));
-        }
-    }
-}
-
-// NOLINTNEXTLINE
-TEST_F(GCTest, segment_metadata_gc) {
-    auto fs = FileSystem::Default();
-    auto tablet_id = next_id();
-    auto segments = std::vector<std::string>();
-    for (int i = 0; i < 10; i++) {
-        segments.emplace_back(fmt::format("{}.dat", generate_uuid_string()));
-        auto location = s_tablet_manager->segment_location(tablet_id, segments.back());
-        ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(location));
-        ASSERT_OK(wf->close());
-    }
-    auto valid_segment_cnt = 0;
-
-    {
-        auto metadata = std::make_shared<TabletMetadata>();
-        metadata->set_id(tablet_id);
-        metadata->set_version(1);
-        metadata->set_next_rowset_id(1);
-        auto rowset = metadata->add_rowsets();
-        rowset->add_segments(segments[valid_segment_cnt++]);
-        rowset->add_segments(segments[valid_segment_cnt++]);
-        ASSERT_OK(s_tablet_manager->put_tablet_metadata(metadata));
-    }
-    {
-        auto log_write = std::make_shared<TxnLog>();
-        log_write->set_tablet_id(tablet_id);
-        log_write->set_txn_id(next_id());
-
-        auto rowset = log_write->mutable_op_write()->mutable_rowset();
-        rowset->add_segments(segments[valid_segment_cnt++]);
-        rowset->add_segments(segments[valid_segment_cnt++]);
-        ASSERT_OK(s_tablet_manager->put_txn_log(log_write));
-    }
-    {
-        auto log_compaction = std::make_shared<TxnLog>();
-        log_compaction->set_tablet_id(tablet_id);
-        log_compaction->set_txn_id(next_id());
-
-        auto rowset = log_compaction->mutable_op_compaction()->mutable_output_rowset();
-        rowset->add_segments(segments[valid_segment_cnt++]);
-        rowset->add_segments(segments[valid_segment_cnt++]);
-        ASSERT_OK(s_tablet_manager->put_txn_log(log_compaction));
-    }
-    {
-        auto log_schema_change = std::make_shared<TxnLog>();
-        log_schema_change->set_tablet_id(tablet_id);
-        log_schema_change->set_txn_id(next_id());
-
-        auto rowset = log_schema_change->mutable_op_schema_change()->add_rowsets();
-        rowset->add_segments(segments[valid_segment_cnt++]);
-        rowset->add_segments(segments[valid_segment_cnt++]);
-        ASSERT_OK(s_tablet_manager->put_txn_log(log_schema_change));
-    }
-    ASSERT_LT(valid_segment_cnt, segments.size());
-
-    config::lake_gc_segment_expire_seconds = 600;
-    ASSERT_OK(segment_gc(kTestDir, s_tablet_manager.get()));
-
-    for (const auto& seg : segments) {
-        auto location = s_tablet_manager->segment_location(tablet_id, seg);
-        ASSERT_OK(fs->path_exists(location));
-    }
-
-    config::lake_gc_segment_expire_seconds = 0;
-    ASSERT_OK(segment_gc(kTestDir, s_tablet_manager.get()));
-
-    for (int i = 0, sz = segments.size(); i < sz; i++) {
-        auto location = s_tablet_manager->segment_location(tablet_id, segments[i]);
-        if (i < valid_segment_cnt) {
-            ASSERT_OK(fs->path_exists(location));
-        } else {
-            auto st = fs->path_exists(location);
-            ASSERT_TRUE(st.is_not_found()) << st;
-        }
-    }
-}
-
-// NOLINTNEXTLINE
-TEST_F(GCTest, test_delete_metadata_belongs_to_other_worker) {
-    auto fs = FileSystem::Default();
-    auto tablet_id = next_id();
+    auto tablet_id_1 = next_id();
+    auto tablet_id_2 = next_id();
 
     // LocationProvider and TabletManager of worker A
-    auto location_provider_1 = std::make_unique<TestLocationProvider>(s_location_provider.get());
+    auto location_provider_1 = std::make_unique<TestLocationProvider>(kTestDir);
     auto tablet_manager_1 = std::make_unique<lake::TabletManager>(location_provider_1.get(), 16384);
+    // tablet_id_1 owned by worker A
+    location_provider_1->_owned_shards.insert(tablet_id_1);
 
     // LocationProvider and TabletManager of worker B
-    auto location_provider_2 = std::make_unique<TestLocationProvider>(s_location_provider.get());
+    auto location_provider_2 = std::make_unique<TestLocationProvider>(kTestDir);
     auto tablet_manager_2 = std::make_unique<lake::TabletManager>(location_provider_2.get(), 16384);
-
-    // Add tablet to worker A
-    location_provider_1->_owned_shards.insert(tablet_id);
+    // tablet_id_2 owned by worker B
+    location_provider_2->_owned_shards.insert(tablet_id_2);
 
     // Save metadata on woker A
     auto version_count = config::lake_gc_metadata_max_versions + 4;
     for (int i = 0; i < version_count; i++) {
         auto metadata = std::make_shared<TabletMetadata>();
-        metadata->set_id(tablet_id);
+        metadata->set_id(tablet_id_1);
         metadata->set_version(i + 1);
         metadata->set_next_rowset_id(i + 1);
         ASSERT_OK(tablet_manager_1->put_tablet_metadata(metadata));
     }
     for (int i = 0; i < 5; i++) {
         auto txn_log = std::make_shared<lake::TxnLog>();
-        txn_log->set_tablet_id(tablet_id);
+        txn_log->set_tablet_id(tablet_id_1);
         txn_log->set_txn_id(i);
         ASSERT_OK(tablet_manager_1->put_txn_log(txn_log));
     }
 
+    // Save metadata on woker B
+    for (int i = 0; i < version_count; i++) {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(tablet_id_2);
+        metadata->set_version(i + 1);
+        metadata->set_next_rowset_id(i + 1);
+        ASSERT_OK(tablet_manager_2->put_tablet_metadata(metadata));
+    }
+    for (int i = 0; i < 5; i++) {
+        auto txn_log = std::make_shared<lake::TxnLog>();
+        txn_log->set_tablet_id(tablet_id_2);
+        txn_log->set_txn_id(i);
+        ASSERT_OK(tablet_manager_2->put_txn_log(txn_log));
+    }
+
+    // Doing GC on worker A
+    ASSERT_OK(metadata_gc(kTestDir, tablet_manager_1.get(), 1000));
+
+    // Woker B should only delete expired metadata of tablet_id_1
+    for (int i = 0; i < version_count - config::lake_gc_metadata_max_versions; i++) {
+        auto location = tablet_manager_1->tablet_metadata_location(tablet_id_1, i + 1);
+        auto st = fs->path_exists(location);
+        if (i < version_count - config::lake_gc_metadata_max_versions) {
+            ASSERT_TRUE(st.is_not_found()) << st;
+        } else {
+            ASSERT_TRUE(st.ok()) << st;
+        }
+
+        location = tablet_manager_2->tablet_metadata_location(tablet_id_2, i + 1);
+        st = fs->path_exists(location);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+    for (int i = 0; i < 5; i++) {
+        auto txn = tablet_manager_1->txn_log_location(tablet_id_1, i);
+        auto st = fs->path_exists(txn);
+        ASSERT_TRUE(st.is_not_found()) << st;
+
+        txn = tablet_manager_2->txn_log_location(tablet_id_2, i);
+        st = fs->path_exists(txn);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
     // Doing GC on worker B
     ASSERT_OK(metadata_gc(kTestDir, tablet_manager_2.get(), 1000));
-
-    // Woker B should have deleted expired metadata created on worker A
     for (int i = 0; i < version_count - config::lake_gc_metadata_max_versions; i++) {
-        auto location = s_tablet_manager->tablet_metadata_location(tablet_id, i + 1);
+        auto location = tablet_manager_2->tablet_metadata_location(tablet_id_2, i + 1);
         auto st = fs->path_exists(location);
         if (i < version_count - config::lake_gc_metadata_max_versions) {
             ASSERT_TRUE(st.is_not_found()) << st;
@@ -251,9 +140,121 @@ TEST_F(GCTest, test_delete_metadata_belongs_to_other_worker) {
         }
     }
     for (int i = 0; i < 5; i++) {
-        auto txn = s_tablet_manager->txn_log_location(tablet_id, i);
+        auto txn = tablet_manager_2->txn_log_location(tablet_id_2, i);
         auto st = fs->path_exists(txn);
         ASSERT_TRUE(st.is_not_found()) << st;
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(GCTest, test_segment_gc) {
+    auto fs = FileSystem::Default();
+    auto tablet_id_1 = next_id();
+    auto tablet_id_2 = next_id();
+    // LocationProvider and TabletManager of worker A
+    auto location_provider_1 = std::make_unique<TestLocationProvider>(kTestDir);
+    auto tablet_manager_1 = std::make_unique<lake::TabletManager>(location_provider_1.get(), 16384);
+    // tablet_id_1 owned by worker A
+    location_provider_1->_owned_shards.insert(tablet_id_1);
+
+    // LocationProvider and TabletManager of worker B
+    auto location_provider_2 = std::make_unique<TestLocationProvider>(kTestDir);
+    auto tablet_manager_2 = std::make_unique<lake::TabletManager>(location_provider_2.get(), 16384);
+    // tablet_id_2 owned by worker B
+    location_provider_2->_owned_shards.insert(tablet_id_2);
+
+    auto segments = std::vector<std::string>();
+    for (int i = 0; i < 10; i++) {
+        segments.emplace_back(random_segment_filename());
+        auto location = tablet_manager_1->segment_location(tablet_id_1, segments.back());
+        ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(location));
+        ASSERT_OK(wf->close());
+    }
+    auto valid_segment_cnt = 0;
+
+    // segment referenced by tablet_id_1
+    {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(tablet_id_1);
+        metadata->set_version(1);
+        metadata->set_next_rowset_id(1);
+        auto rowset = metadata->add_rowsets();
+        rowset->add_segments(segments[valid_segment_cnt++]);
+        ASSERT_OK(tablet_manager_1->put_tablet_metadata(metadata));
+    }
+    // segment referenced by tablet_id_2
+    {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(tablet_id_2);
+        metadata->set_version(1);
+        metadata->set_next_rowset_id(1);
+        auto rowset = metadata->add_rowsets();
+        rowset->add_segments(segments[valid_segment_cnt++]);
+        ASSERT_OK(tablet_manager_2->put_tablet_metadata(metadata));
+    }
+    // segment referenced by txn log of tablet_id_1
+    {
+        auto log_write = std::make_shared<TxnLog>();
+        log_write->set_tablet_id(tablet_id_1);
+        log_write->set_txn_id(next_id());
+
+        auto rowset = log_write->mutable_op_write()->mutable_rowset();
+        rowset->add_segments(segments[valid_segment_cnt++]);
+        ASSERT_OK(tablet_manager_1->put_txn_log(log_write));
+    }
+    // segment referenced by txn log of tablet_id_1
+    {
+        auto log_compaction = std::make_shared<TxnLog>();
+        log_compaction->set_tablet_id(tablet_id_1);
+        log_compaction->set_txn_id(next_id());
+
+        auto rowset = log_compaction->mutable_op_compaction()->mutable_output_rowset();
+        rowset->add_segments(segments[valid_segment_cnt++]);
+        ASSERT_OK(tablet_manager_1->put_txn_log(log_compaction));
+    }
+    // segment referenced by txn log of tablet_id_1
+    {
+        auto log_schema_change = std::make_shared<TxnLog>();
+        log_schema_change->set_tablet_id(tablet_id_1);
+        log_schema_change->set_txn_id(next_id());
+
+        auto rowset = log_schema_change->mutable_op_schema_change()->add_rowsets();
+        rowset->add_segments(segments[valid_segment_cnt++]);
+        ASSERT_OK(tablet_manager_1->put_txn_log(log_schema_change));
+    }
+    ASSERT_LT(valid_segment_cnt, segments.size());
+
+    // Orphan segments have not timed out yet
+    config::lake_gc_segment_expire_seconds = 600;
+    ASSERT_OK(segment_gc(kTestDir, tablet_manager_1.get()));
+    for (const auto& seg : segments) {
+        auto location = join_path(join_path(kTestDir, kSegmentDirectoryName), seg);
+        ASSERT_OK(fs->path_exists(location));
+    }
+
+    // Segment GC on tablet_manager_2 should not delete any file
+    config::lake_gc_segment_expire_seconds = 0;
+    ASSERT_OK(segment_gc(kTestDir, tablet_manager_2.get()));
+    for (const auto& seg : segments) {
+        auto location = join_path(join_path(kTestDir, kSegmentDirectoryName), seg);
+        ASSERT_OK(fs->path_exists(location));
+    }
+
+    // Segment GC on tablet_manager_1
+    ASSERT_OK(segment_gc(kTestDir, tablet_manager_1.get()));
+    for (int i = 0, sz = segments.size(); i < sz; i++) {
+        auto location = join_path(join_path(kTestDir, kSegmentDirectoryName), segments[i]);
+        if (i < valid_segment_cnt) {
+            ASSERT_OK(fs->path_exists(location));
+        } else {
+            auto st = fs->path_exists(location);
+            ASSERT_TRUE(st.is_not_found()) << st;
+        }
+    }
+    {
+        auto orphan_list = join_path(kTestDir, kOrphanListFileName);
+        auto st = fs->path_exists(orphan_list);
+        ASSERT_OK(st);
     }
 }
 


### PR DESCRIPTION
In order to clear the disk cache in a timely manner, a list of orphan
segment is saved on the remote storage before deleting them from
the remote storage, and each BE node periodically pulls the list
and then cleans the corresponding local disk cache.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
