### PR TITLE
[UT] RateLimitTest failure

### DIFF
--- a/be/test/util/ratelimit_test.cpp
+++ b/be/test/util/ratelimit_test.cpp
@@ -16,21 +16,25 @@ public:
 
 TEST_F(RateLimitTest, rate_limit) {
     int count = 0;
+    int64_t start = starrocks::UnixMillis();
     for (int i = 0; i < 100; i++) {
         RATE_LIMIT(count++, 100); // inc each 0.1s
         RATE_LIMIT(std::cout << "skip log cnt: " << RATE_LIMIT_SKIP_CNT << std::endl, 100);
-        usleep(10000); // execute inc each 10ms
+        starrocks::SleepForMs(10); // execute inc each 10ms, which is probably not accurate.
     }
-    ASSERT_TRUE(count <= 10);
+    int64_t end = starrocks::UnixMillis();
+    ASSERT_TRUE(count <= (end - start) / 100);
 }
 
 TEST_F(RateLimitTest, rate_limit_by_tag) {
     int count = 0;
+    int64_t start = starrocks::UnixMillis();
     for (int i = 0; i < 100; i++) {
         RATE_LIMIT_BY_TAG(i % 2, count++, 100); // inc each 0.1s
-        usleep(10000);                          // execute inc each 10ms
+        starrocks::SleepForMs(10);              // execute inc each 10ms, which is probably not accurate.
     }
-    ASSERT_TRUE(count <= 20);
+    int64_t end = starrocks::UnixMillis();
+    ASSERT_TRUE(count <= (end - start) / 100 * 2);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The duration of `usleep` may be inaccurate, which may leads the [`RateLimitTest`'s failure](http://39.101.206.100:8090/job/starrocks_be_unittest/35753/console).
This PR improves the `RateLimitTest` and avoids the failure due to the inaccuracy of `usleep`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
