### PR TITLE
[BugFix][Enhancement] handle some key requests of query and load in pthread

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -868,6 +868,8 @@ CONF_Int32(jdbc_connection_idle_timeout_ms, "600000");
 // The default value is set as the THREAD_POOL_SIZE of RoutineLoadTaskScheduler of FE.
 CONF_Int32(internal_service_async_thread_num, "10");
 
+CONF_Int32(internal_service_query_rpc_thread_num, "-1");
+
 /*
  * When compile with ENABLE_STATUS_FAILED, every use of RETURN_INJECT has probability of 1/cardinality_of_inject
  * to inject error through return random status(except ok).

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -87,7 +87,7 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::find_recvr(const TUniqueId& frag
     VLOG_ROW << "looking up fragment_instance_id=" << fragment_instance_id << ", node=" << node_id;
     uint32_t bucket = get_bucket(fragment_instance_id);
     auto& receiver_map = _receiver_map[bucket];
-    std::lock_guard<Mutex> l(_lock[bucket]);
+    std::shared_lock l(_lock[bucket]);
 
     auto iter = receiver_map.find(fragment_instance_id);
     if (iter != receiver_map.end()) {

--- a/be/src/runtime/data_stream_mgr.h
+++ b/be/src/runtime/data_stream_mgr.h
@@ -38,6 +38,7 @@
 
 #include <list>
 #include <mutex>
+#include <shared_mutex>
 #include <set>
 
 #include "column/vectorized_fwd.h"
@@ -113,7 +114,7 @@ private:
     static const uint32_t BUCKET_NUM = 127;
 
     // protects all fields below
-    typedef bthread::Mutex Mutex;
+    typedef std::shared_mutex Mutex;
     Mutex _lock[BUCKET_NUM];
 
     // map from hash value of fragment instance id/node id pair to stream receivers;

--- a/be/src/runtime/data_stream_mgr.h
+++ b/be/src/runtime/data_stream_mgr.h
@@ -38,8 +38,8 @@
 
 #include <list>
 #include <mutex>
-#include <shared_mutex>
 #include <set>
+#include <shared_mutex>
 
 #include "column/vectorized_fwd.h"
 #include "common/compiler_util.h"

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -176,7 +176,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     }
     _pipeline_sink_io_pool =
             new PriorityThreadPool("pip_sink_io", num_sink_io_threads, config::pipeline_sink_io_thread_pool_queue_size);
-    
+
     int query_rpc_threads = config::internal_service_query_rpc_thread_num;
     if (query_rpc_threads <= 0) {
         query_rpc_threads = std::thread::hardware_concurrency();

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -176,6 +176,12 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     }
     _pipeline_sink_io_pool =
             new PriorityThreadPool("pip_sink_io", num_sink_io_threads, config::pipeline_sink_io_thread_pool_queue_size);
+    
+    int query_rpc_threads = config::internal_service_query_rpc_thread_num;
+    if (query_rpc_threads <= 0) {
+        query_rpc_threads = std::thread::hardware_concurrency();
+    }
+    _query_rpc_pool = new PriorityThreadPool("query_rpc", query_rpc_threads, std::numeric_limits<uint32_t>::max());
 
     std::unique_ptr<ThreadPool> driver_executor_thread_pool;
     _max_executor_threads = std::thread::hardware_concurrency();
@@ -465,6 +471,7 @@ void ExecEnv::_destroy() {
     SAFE_DELETE(_udf_call_pool);
     SAFE_DELETE(_pipeline_prepare_pool);
     SAFE_DELETE(_pipeline_sink_io_pool);
+    SAFE_DELETE(_query_rpc_pool);
     SAFE_DELETE(_scan_executor_without_workgroup);
     SAFE_DELETE(_scan_executor_with_workgroup);
     SAFE_DELETE(_connector_scan_executor_without_workgroup);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -175,6 +175,7 @@ public:
     PriorityThreadPool* udf_call_pool() { return _udf_call_pool; }
     PriorityThreadPool* pipeline_prepare_pool() { return _pipeline_prepare_pool; }
     PriorityThreadPool* pipeline_sink_io_pool() { return _pipeline_sink_io_pool; }
+    PriorityThreadPool* query_rpc_pool() { return _query_rpc_pool; }
     FragmentMgr* fragment_mgr() { return _fragment_mgr; }
     starrocks::pipeline::DriverExecutor* driver_executor() { return _driver_executor; }
     starrocks::pipeline::DriverExecutor* wg_driver_executor() { return _wg_driver_executor; }
@@ -303,6 +304,7 @@ private:
     PriorityThreadPool* _udf_call_pool = nullptr;
     PriorityThreadPool* _pipeline_prepare_pool = nullptr;
     PriorityThreadPool* _pipeline_sink_io_pool = nullptr;
+    PriorityThreadPool* _query_rpc_pool = nullptr;
     FragmentMgr* _fragment_mgr = nullptr;
     pipeline::QueryContextManager* _query_context_mgr = nullptr;
     pipeline::DriverExecutor* _driver_executor = nullptr;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -107,7 +107,7 @@ template <typename T>
 void PInternalServiceImplBase<T>::transmit_chunk(google::protobuf::RpcController* cntl_base,
                                                  const PTransmitChunkParams* request, PTransmitChunkResult* response,
                                                  google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, response, done] () {
+    auto task = [this, cntl_base, request, response, done]() {
         this->_transmit_chunk(cntl_base, request, response, done);
     };
     if (!_exec_env->query_rpc_pool()->try_offer(task)) {
@@ -118,8 +118,8 @@ void PInternalServiceImplBase<T>::transmit_chunk(google::protobuf::RpcController
 
 template <typename T>
 void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcController* cntl_base,
-                                                 const PTransmitChunkParams* request, PTransmitChunkResult* response,
-                                                 google::protobuf::Closure* done) {
+                                                  const PTransmitChunkParams* request, PTransmitChunkResult* response,
+                                                  google::protobuf::Closure* done) {
     auto begin_ts = MonotonicNanos();
     VLOG_ROW << "transmit data: " << (uint64_t)(request) << " fragment_instance_id=" << print_id(request->finst_id())
              << " node=" << request->node_id() << " begin";
@@ -165,15 +165,15 @@ void PInternalServiceImplBase<T>::transmit_runtime_filter(google::protobuf::RpcC
     };
     if (!_exec_env->query_rpc_pool()->try_offer(task)) {
         ClosureGuard closure_guard(done);
-        Status::ServiceUnavailable("submit transmit_runtime_filter task failed").to_protobuf(response->mutable_status());
+        Status::ServiceUnavailable("submit transmit_runtime_filter task failed")
+                .to_protobuf(response->mutable_status());
     }
-
 }
 template <typename T>
 void PInternalServiceImplBase<T>::_transmit_runtime_filter(google::protobuf::RpcController* cntl_base,
-                                                          const PTransmitRuntimeFilterParams* request,
-                                                          PTransmitRuntimeFilterResult* response,
-                                                          google::protobuf::Closure* done) {
+                                                           const PTransmitRuntimeFilterParams* request,
+                                                           PTransmitRuntimeFilterResult* response,
+                                                           google::protobuf::Closure* done) {
     VLOG_FILE << "transmit runtime filter: fragment_instance_id = " << print_id(request->finst_id())
               << " query_id = " << print_id(request->query_id()) << ", is_partial = " << request->is_partial()
               << ", filter_id = " << request->filter_id() << ", is_pipeline = " << request->is_pipeline();
@@ -197,7 +197,7 @@ void PInternalServiceImplBase<T>::exec_plan_fragment(google::protobuf::RpcContro
                                                      const PExecPlanFragmentRequest* request,
                                                      PExecPlanFragmentResult* response,
                                                      google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, response, done] () {
+    auto task = [this, cntl_base, request, response, done]() {
         this->_exec_plan_fragment(cntl_base, request, response, done);
     };
     if (!_exec_env->query_rpc_pool()->try_offer(task)) {
@@ -208,9 +208,9 @@ void PInternalServiceImplBase<T>::exec_plan_fragment(google::protobuf::RpcContro
 
 template <typename T>
 void PInternalServiceImplBase<T>::_exec_plan_fragment(google::protobuf::RpcController* cntl_base,
-                                                     const PExecPlanFragmentRequest* request,
-                                                     PExecPlanFragmentResult* response,
-                                                     google::protobuf::Closure* done) {
+                                                      const PExecPlanFragmentRequest* request,
+                                                      PExecPlanFragmentResult* response,
+                                                      google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     if (k_starrocks_exit.load(std::memory_order_relaxed)) {
@@ -231,7 +231,7 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
                                                             const PExecBatchPlanFragmentsRequest* request,
                                                             PExecBatchPlanFragmentsResult* response,
                                                             google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, response, done] () {
+    auto task = [this, cntl_base, request, response, done]() {
         this->_async_exec_batch_plan_fragments(cntl_base, request, response, done);
     };
     if (!_exec_env->pipeline_prepare_pool()->try_offer(task)) {
@@ -242,9 +242,9 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
 
 template <typename T>
 void PInternalServiceImplBase<T>::_exec_batch_plan_fragments(google::protobuf::RpcController* cntl_base,
-                                                            const PExecBatchPlanFragmentsRequest* request,
-                                                            PExecBatchPlanFragmentsResult* response,
-                                                            google::protobuf::Closure* done) {
+                                                             const PExecBatchPlanFragmentsRequest* request,
+                                                             PExecBatchPlanFragmentsResult* response,
+                                                             google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     if (k_starrocks_exit.load(std::memory_order_relaxed)) {
@@ -263,15 +263,16 @@ void PInternalServiceImplBase<T>::_exec_batch_plan_fragments(google::protobuf::R
 class ExecBatchPlanFragmentsContext {
 public:
     ExecBatchPlanFragmentsContext(std::shared_ptr<TExecBatchPlanFragmentsParams> t_batch_requests,
-        PExecBatchPlanFragmentsResult* response,google::protobuf::Closure* done, int32_t remaining_task_num):
-        _t_batch_requests(t_batch_requests),
-        _response(response), _done(done), _remaining_task_num(remaining_task_num) {}
+                                  PExecBatchPlanFragmentsResult* response, google::protobuf::Closure* done,
+                                  int32_t remaining_task_num)
+            : _t_batch_requests(t_batch_requests),
+              _response(response),
+              _done(done),
+              _remaining_task_num(remaining_task_num) {}
 
     ~ExecBatchPlanFragmentsContext() = default;
 
-    TExecBatchPlanFragmentsParams* t_batch_requests() const {
-        return _t_batch_requests.get();
-    }
+    TExecBatchPlanFragmentsParams* t_batch_requests() const { return _t_batch_requests.get(); }
 
     bool has_error() const {
         std::shared_lock l(_mu);
@@ -306,9 +307,9 @@ private:
 
 template <typename T>
 void PInternalServiceImplBase<T>::_async_exec_batch_plan_fragments(google::protobuf::RpcController* cntl_base,
-                                                            const PExecBatchPlanFragmentsRequest* request,
-                                                            PExecBatchPlanFragmentsResult* response,
-                                                            google::protobuf::Closure* done) {
+                                                                   const PExecBatchPlanFragmentsRequest* request,
+                                                                   PExecBatchPlanFragmentsResult* response,
+                                                                   google::protobuf::Closure* done) {
     LOG(INFO) << "begine _async_exec_batch_plan_fragments";
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     auto ser_request = cntl->request_attachment().to_string();
@@ -316,7 +317,8 @@ void PInternalServiceImplBase<T>::_async_exec_batch_plan_fragments(google::proto
     {
         const auto* buf = (const uint8_t*)ser_request.data();
         uint32_t len = ser_request.size();
-        if (Status status = deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, t_batch_requests.get()); !status.ok()) {
+        if (Status status = deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, t_batch_requests.get());
+            !status.ok()) {
             status.to_protobuf(response->mutable_status());
             done->Run();
             return;
@@ -345,16 +347,18 @@ void PInternalServiceImplBase<T>::_async_exec_batch_plan_fragments(google::proto
         done->Run();
         return;
     }
-    std::shared_ptr<ExecBatchPlanFragmentsContext> ctx = std::make_shared<ExecBatchPlanFragmentsContext>(t_batch_requests, response, done, remaining_task_num);
-    for (int i = 1;i < unique_requests.size();i++) {
+    std::shared_ptr<ExecBatchPlanFragmentsContext> ctx =
+            std::make_shared<ExecBatchPlanFragmentsContext>(t_batch_requests, response, done, remaining_task_num);
+    for (int i = 1; i < unique_requests.size(); i++) {
         LOG(INFO) << "submit exec plan fragment " << i;
-        auto task = [this, i, ctx] () {
+        auto task = [this, i, ctx]() {
             LOG(INFO) << "run exec plan fragment " << i;
             if (ctx->has_error()) {
                 return;
             }
             auto t_batch_requests = ctx->t_batch_requests();
-            Status status = _exec_plan_fragment_by_pipeline(t_batch_requests->common_param, t_batch_requests->unique_param_per_instance[i]);
+            Status status = _exec_plan_fragment_by_pipeline(t_batch_requests->common_param,
+                                                            t_batch_requests->unique_param_per_instance[i]);
             ctx->finish_one_task(status);
         };
         if (!_exec_env->pipeline_prepare_pool()->try_offer(task)) {
@@ -362,9 +366,7 @@ void PInternalServiceImplBase<T>::_async_exec_batch_plan_fragments(google::proto
             return;
         }
     }
-
 }
-
 
 template <typename T>
 void PInternalServiceImplBase<T>::tablet_writer_add_batch(google::protobuf::RpcController* controller,
@@ -522,9 +524,9 @@ void PInternalServiceImplBase<T>::cancel_plan_fragment(google::protobuf::RpcCont
 
 template <typename T>
 void PInternalServiceImplBase<T>::_cancel_plan_fragment(google::protobuf::RpcController* cntl_base,
-                                                       const PCancelPlanFragmentRequest* request,
-                                                       PCancelPlanFragmentResult* result,
-                                                       google::protobuf::Closure* done) {
+                                                        const PCancelPlanFragmentRequest* request,
+                                                        PCancelPlanFragmentResult* result,
+                                                        google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     TUniqueId tid;
     tid.__set_hi(request->finst_id().hi());
@@ -577,9 +579,7 @@ template <typename T>
 void PInternalServiceImplBase<T>::fetch_data(google::protobuf::RpcController* cntl_base,
                                              const PFetchDataRequest* request, PFetchDataResult* result,
                                              google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, result, done] () {
-        this->_fetch_data(cntl_base, request, result, done);
-    };
+    auto task = [this, cntl_base, request, result, done]() { this->_fetch_data(cntl_base, request, result, done); };
     if (!_exec_env->query_rpc_pool()->try_offer(task)) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit fetch_data task failed").to_protobuf(result->mutable_status());
@@ -588,8 +588,8 @@ void PInternalServiceImplBase<T>::fetch_data(google::protobuf::RpcController* cn
 
 template <typename T>
 void PInternalServiceImplBase<T>::_fetch_data(google::protobuf::RpcController* cntl_base,
-                                             const PFetchDataRequest* request, PFetchDataResult* result,
-                                             google::protobuf::Closure* done) {
+                                              const PFetchDataRequest* request, PFetchDataResult* result,
+                                              google::protobuf::Closure* done) {
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     auto* ctx = new GetResultBatchCtx(cntl, result, done);
     _exec_env->result_mgr()->fetch_data(request->finst_id(), ctx);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -107,9 +107,7 @@ template <typename T>
 void PInternalServiceImplBase<T>::transmit_chunk(google::protobuf::RpcController* cntl_base,
                                                  const PTransmitChunkParams* request, PTransmitChunkResult* response,
                                                  google::protobuf::Closure* done) {
-    auto task = [=]() {
-        this->_transmit_chunk(cntl_base, request, response, done);
-    };
+    auto task = [=]() { this->_transmit_chunk(cntl_base, request, response, done); };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit transmit_chunk task failed").to_protobuf(response->mutable_status());
@@ -160,9 +158,7 @@ void PInternalServiceImplBase<T>::transmit_runtime_filter(google::protobuf::RpcC
                                                           const PTransmitRuntimeFilterParams* request,
                                                           PTransmitRuntimeFilterResult* response,
                                                           google::protobuf::Closure* done) {
-    auto task = [=]() {
-        this->_transmit_runtime_filter(cntl_base, request, response, done);
-    };
+    auto task = [=]() { this->_transmit_runtime_filter(cntl_base, request, response, done); };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit transmit_runtime_filter task failed")
@@ -197,9 +193,7 @@ void PInternalServiceImplBase<T>::exec_plan_fragment(google::protobuf::RpcContro
                                                      const PExecPlanFragmentRequest* request,
                                                      PExecPlanFragmentResult* response,
                                                      google::protobuf::Closure* done) {
-    auto task = [=]() {
-        this->_exec_plan_fragment(cntl_base, request, response, done);
-    };
+    auto task = [=]() { this->_exec_plan_fragment(cntl_base, request, response, done); };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit exec_plan_fragment task failed").to_protobuf(response->mutable_status());
@@ -231,9 +225,7 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
                                                             const PExecBatchPlanFragmentsRequest* request,
                                                             PExecBatchPlanFragmentsResult* response,
                                                             google::protobuf::Closure* done) {
-    auto task = [=]() {
-        this->_exec_batch_plan_fragments(cntl_base, request, response, done);
-    };
+    auto task = [=]() { this->_exec_batch_plan_fragments(cntl_base, request, response, done); };
     if (!_exec_env->pipeline_prepare_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit exec_batch_plan_fragments failed").to_protobuf(response->mutable_status());
@@ -242,9 +234,9 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
 
 template <typename T>
 void PInternalServiceImplBase<T>::_exec_batch_plan_fragments(google::protobuf::RpcController* cntl_base,
-                                                                   const PExecBatchPlanFragmentsRequest* request,
-                                                                   PExecBatchPlanFragmentsResult* response,
-                                                                   google::protobuf::Closure* done) {
+                                                             const PExecBatchPlanFragmentsRequest* request,
+                                                             PExecBatchPlanFragmentsResult* response,
+                                                             google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     auto ser_request = cntl->request_attachment().to_string();
@@ -370,9 +362,7 @@ void PInternalServiceImplBase<T>::cancel_plan_fragment(google::protobuf::RpcCont
                                                        const PCancelPlanFragmentRequest* request,
                                                        PCancelPlanFragmentResult* result,
                                                        google::protobuf::Closure* done) {
-    auto task = [=]() {
-        this->_cancel_plan_fragment(cntl_base, request, result, done);
-    };
+    auto task = [=]() { this->_cancel_plan_fragment(cntl_base, request, result, done); };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit cancel_plan_fragment task failed").to_protobuf(result->mutable_status());

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -107,7 +107,7 @@ template <typename T>
 void PInternalServiceImplBase<T>::transmit_chunk(google::protobuf::RpcController* cntl_base,
                                                  const PTransmitChunkParams* request, PTransmitChunkResult* response,
                                                  google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, response, done]() {
+    auto task = [=]() {
         this->_transmit_chunk(cntl_base, request, response, done);
     };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
@@ -160,7 +160,7 @@ void PInternalServiceImplBase<T>::transmit_runtime_filter(google::protobuf::RpcC
                                                           const PTransmitRuntimeFilterParams* request,
                                                           PTransmitRuntimeFilterResult* response,
                                                           google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, response, done]() {
+    auto task = [=]() {
         this->_transmit_runtime_filter(cntl_base, request, response, done);
     };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
@@ -197,7 +197,7 @@ void PInternalServiceImplBase<T>::exec_plan_fragment(google::protobuf::RpcContro
                                                      const PExecPlanFragmentRequest* request,
                                                      PExecPlanFragmentResult* response,
                                                      google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, response, done]() {
+    auto task = [=]() {
         this->_exec_plan_fragment(cntl_base, request, response, done);
     };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
@@ -231,7 +231,7 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
                                                             const PExecBatchPlanFragmentsRequest* request,
                                                             PExecBatchPlanFragmentsResult* response,
                                                             google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, response, done]() {
+    auto task = [=]() {
         this->_exec_batch_plan_fragments(cntl_base, request, response, done);
     };
     if (!_exec_env->pipeline_prepare_pool()->try_offer(std::move(task))) {
@@ -370,7 +370,7 @@ void PInternalServiceImplBase<T>::cancel_plan_fragment(google::protobuf::RpcCont
                                                        const PCancelPlanFragmentRequest* request,
                                                        PCancelPlanFragmentResult* result,
                                                        google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, result, done]() {
+    auto task = [=]() {
         this->_cancel_plan_fragment(cntl_base, request, result, done);
     };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
@@ -436,7 +436,7 @@ template <typename T>
 void PInternalServiceImplBase<T>::fetch_data(google::protobuf::RpcController* cntl_base,
                                              const PFetchDataRequest* request, PFetchDataResult* result,
                                              google::protobuf::Closure* done) {
-    auto task = [this, cntl_base, request, result, done]() { this->_fetch_data(cntl_base, request, result, done); };
+    auto task = [=]() { this->_fetch_data(cntl_base, request, result, done); };
     if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit fetch_data task failed").to_protobuf(result->mutable_status());

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -110,7 +110,7 @@ void PInternalServiceImplBase<T>::transmit_chunk(google::protobuf::RpcController
     auto task = [this, cntl_base, request, response, done]() {
         this->_transmit_chunk(cntl_base, request, response, done);
     };
-    if (!_exec_env->query_rpc_pool()->try_offer(task)) {
+    if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit transmit_chunk task failed").to_protobuf(response->mutable_status());
     }
@@ -163,7 +163,7 @@ void PInternalServiceImplBase<T>::transmit_runtime_filter(google::protobuf::RpcC
     auto task = [this, cntl_base, request, response, done]() {
         this->_transmit_runtime_filter(cntl_base, request, response, done);
     };
-    if (!_exec_env->query_rpc_pool()->try_offer(task)) {
+    if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit transmit_runtime_filter task failed")
                 .to_protobuf(response->mutable_status());
@@ -200,7 +200,7 @@ void PInternalServiceImplBase<T>::exec_plan_fragment(google::protobuf::RpcContro
     auto task = [this, cntl_base, request, response, done]() {
         this->_exec_plan_fragment(cntl_base, request, response, done);
     };
-    if (!_exec_env->query_rpc_pool()->try_offer(task)) {
+    if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit exec_plan_fragment task failed").to_protobuf(response->mutable_status());
     }
@@ -232,9 +232,9 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
                                                             PExecBatchPlanFragmentsResult* response,
                                                             google::protobuf::Closure* done) {
     auto task = [this, cntl_base, request, response, done]() {
-        this->_async_exec_batch_plan_fragments(cntl_base, request, response, done);
+        this->_exec_batch_plan_fragments(cntl_base, request, response, done);
     };
-    if (!_exec_env->pipeline_prepare_pool()->try_offer(task)) {
+    if (!_exec_env->pipeline_prepare_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit exec_batch_plan_fragments failed").to_protobuf(response->mutable_status());
     }
@@ -242,75 +242,10 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
 
 template <typename T>
 void PInternalServiceImplBase<T>::_exec_batch_plan_fragments(google::protobuf::RpcController* cntl_base,
-                                                             const PExecBatchPlanFragmentsRequest* request,
-                                                             PExecBatchPlanFragmentsResult* response,
-                                                             google::protobuf::Closure* done) {
-    ClosureGuard closure_guard(done);
-    auto* cntl = static_cast<brpc::Controller*>(cntl_base);
-    if (k_starrocks_exit.load(std::memory_order_relaxed)) {
-        cntl->SetFailed(brpc::EINTERNAL, "BE is shutting down");
-        LOG(WARNING) << "reject exec multi plan fragment because of exit";
-        return;
-    }
-
-    auto st = _exec_batch_plan_fragments(cntl);
-    if (!st.ok()) {
-        LOG(WARNING) << "exec multi plan fragments failed, errmsg=" << st.get_error_msg();
-    }
-    st.to_protobuf(response->mutable_status());
-}
-
-class ExecBatchPlanFragmentsContext {
-public:
-    ExecBatchPlanFragmentsContext(std::shared_ptr<TExecBatchPlanFragmentsParams> t_batch_requests,
-                                  PExecBatchPlanFragmentsResult* response, google::protobuf::Closure* done,
-                                  int32_t remaining_task_num)
-            : _t_batch_requests(t_batch_requests),
-              _response(response),
-              _done(done),
-              _remaining_task_num(remaining_task_num) {}
-
-    ~ExecBatchPlanFragmentsContext() = default;
-
-    TExecBatchPlanFragmentsParams* t_batch_requests() const { return _t_batch_requests.get(); }
-
-    bool has_error() const {
-        std::shared_lock l(_mu);
-        return !_final_status.ok();
-    }
-
-    void finish_one_task(Status status) {
-        std::unique_lock l(_mu);
-        if (!_final_status.ok()) {
-            return;
-        }
-        if (!status.ok()) {
-            _final_status = status;
-            status.to_protobuf(_response->mutable_status());
-            _done->Run();
-            return;
-        }
-        if (--_remaining_task_num == 0) {
-            status.to_protobuf(_response->mutable_status());
-            _done->Run();
-        }
-    }
-
-private:
-    std::shared_ptr<TExecBatchPlanFragmentsParams> _t_batch_requests;
-    PExecBatchPlanFragmentsResult* _response;
-    google::protobuf::Closure* _done;
-    int32_t _remaining_task_num;
-    mutable std::shared_mutex _mu;
-    Status _final_status;
-};
-
-template <typename T>
-void PInternalServiceImplBase<T>::_async_exec_batch_plan_fragments(google::protobuf::RpcController* cntl_base,
                                                                    const PExecBatchPlanFragmentsRequest* request,
                                                                    PExecBatchPlanFragmentsResult* response,
                                                                    google::protobuf::Closure* done) {
-    LOG(INFO) << "begine _async_exec_batch_plan_fragments";
+    ClosureGuard closure_guard(done);
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     auto ser_request = cntl->request_attachment().to_string();
     std::shared_ptr<TExecBatchPlanFragmentsParams> t_batch_requests = std::make_shared<TExecBatchPlanFragmentsParams>();
@@ -320,7 +255,6 @@ void PInternalServiceImplBase<T>::_async_exec_batch_plan_fragments(google::proto
         if (Status status = deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, t_batch_requests.get());
             !status.ok()) {
             status.to_protobuf(response->mutable_status());
-            done->Run();
             return;
         }
     }
@@ -333,39 +267,8 @@ void PInternalServiceImplBase<T>::_async_exec_batch_plan_fragments(google::proto
         return;
     }
 
-    LOG(INFO) << "prepare first plan fragment";
-    if (Status status = _exec_plan_fragment_by_pipeline(common_request, unique_requests[0]); !status.ok()) {
-        status.to_protobuf(response->mutable_status());
-        done->Run();
-        return;
-    }
-    common_request.desc_tbl.__set_is_cached(true);
-    // submit other task to prepare_pool
-    size_t remaining_task_num = unique_requests.size() - 1;
-    if (remaining_task_num == 0) {
-        Status::OK().to_protobuf(response->mutable_status());
-        done->Run();
-        return;
-    }
-    std::shared_ptr<ExecBatchPlanFragmentsContext> ctx =
-            std::make_shared<ExecBatchPlanFragmentsContext>(t_batch_requests, response, done, remaining_task_num);
-    for (int i = 1; i < unique_requests.size(); i++) {
-        LOG(INFO) << "submit exec plan fragment " << i;
-        auto task = [this, i, ctx]() {
-            LOG(INFO) << "run exec plan fragment " << i;
-            if (ctx->has_error()) {
-                return;
-            }
-            auto t_batch_requests = ctx->t_batch_requests();
-            Status status = _exec_plan_fragment_by_pipeline(t_batch_requests->common_param,
-                                                            t_batch_requests->unique_param_per_instance[i]);
-            ctx->finish_one_task(status);
-        };
-        if (!_exec_env->pipeline_prepare_pool()->try_offer(task)) {
-            ctx->finish_one_task(Status::ServiceUnavailable("cannot submit exec_plan_fragment task"));
-            return;
-        }
-    }
+    Status status = _exec_plan_fragment_by_pipeline(common_request, unique_requests[0]);
+    status.to_protobuf(response->mutable_status());
 }
 
 template <typename T>
@@ -431,52 +334,6 @@ Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl) 
 }
 
 template <typename T>
-Status PInternalServiceImplBase<T>::_exec_batch_plan_fragments(brpc::Controller* cntl) {
-    auto ser_request = cntl->request_attachment().to_string();
-    std::shared_ptr<TExecBatchPlanFragmentsParams> t_batch_requests = std::make_shared<TExecBatchPlanFragmentsParams>();
-    {
-        const auto* buf = (const uint8_t*)ser_request.data();
-        uint32_t len = ser_request.size();
-        RETURN_IF_ERROR(deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, t_batch_requests.get()));
-    }
-
-    auto& common_request = t_batch_requests->common_param;
-    auto& unique_requests = t_batch_requests->unique_param_per_instance;
-
-    if (unique_requests.empty()) {
-        return Status::OK();
-    }
-    RETURN_IF_ERROR(_exec_plan_fragment_by_pipeline(common_request, unique_requests[0]));
-    // Prepare the first fragment instance and set desc_tbl to cache,
-    // and prepare the other fragment instances concurrently using the cached desc_tbl.
-    common_request.desc_tbl.__set_is_cached(true);
-
-    std::vector<PromiseStatusSharedPtr> promise_statuses;
-    for (int i = 1; i < unique_requests.size(); ++i) {
-        auto& unique_request = unique_requests[i];
-        LOG(INFO) << "exec plan fragment, fragment_instance_id=" << print_id(unique_request.params.fragment_instance_id)
-                  << ", coord=" << common_request.coord << ", backend=" << unique_request.backend_num
-                  << ", is_pipeline=1"
-                  << ", chunk_size=" << common_request.query_options.batch_size;
-
-        PromiseStatusSharedPtr ms = std::make_shared<PromiseStatus>();
-        _exec_env->pipeline_prepare_pool()->offer([ms, t_batch_requests, i, this] {
-            ms->set_value(_exec_plan_fragment_by_pipeline(t_batch_requests->common_param,
-                                                          t_batch_requests->unique_param_per_instance[i]));
-        });
-        promise_statuses.emplace_back(std::move(ms));
-    }
-
-    for (auto& promise : promise_statuses) {
-        // When a preparation fails, return error immediately. The other unfinished preparation is safe,
-        // since they can use the shared pointer of promise and t_batch_requests.
-        RETURN_IF_ERROR(promise->get_future().get());
-    }
-
-    return Status::OK();
-}
-
-template <typename T>
 Status PInternalServiceImplBase<T>::_exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_param,
                                                                     const TExecPlanFragmentParams& t_unique_request) {
     pipeline::FragmentExecutor fragment_executor;
@@ -516,7 +373,7 @@ void PInternalServiceImplBase<T>::cancel_plan_fragment(google::protobuf::RpcCont
     auto task = [this, cntl_base, request, result, done]() {
         this->_cancel_plan_fragment(cntl_base, request, result, done);
     };
-    if (!_exec_env->query_rpc_pool()->try_offer(task)) {
+    if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit cancel_plan_fragment task failed").to_protobuf(result->mutable_status());
     }
@@ -580,7 +437,7 @@ void PInternalServiceImplBase<T>::fetch_data(google::protobuf::RpcController* cn
                                              const PFetchDataRequest* request, PFetchDataResult* result,
                                              google::protobuf::Closure* done) {
     auto task = [this, cntl_base, request, result, done]() { this->_fetch_data(cntl_base, request, result, done); };
-    if (!_exec_env->query_rpc_pool()->try_offer(task)) {
+    if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit fetch_data task failed").to_protobuf(result->mutable_status());
     }

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -124,6 +124,32 @@ public:
                                     google::protobuf::Closure* done) override;
 
 private:
+    void _transmit_chunk(::google::protobuf::RpcController* controller, const ::starrocks::PTransmitChunkParams* request,
+                        ::starrocks::PTransmitChunkResult* response, ::google::protobuf::Closure* done);
+
+    void _transmit_runtime_filter(::google::protobuf::RpcController* controller,
+                                 const ::starrocks::PTransmitRuntimeFilterParams* request,
+                                 ::starrocks::PTransmitRuntimeFilterResult* response,
+                                 ::google::protobuf::Closure* done);
+
+    void _exec_plan_fragment(google::protobuf::RpcController* controller, const PExecPlanFragmentRequest* request,
+                            PExecPlanFragmentResult* result, google::protobuf::Closure* done);
+
+    void _exec_batch_plan_fragments(google::protobuf::RpcController* controller,
+                                   const PExecBatchPlanFragmentsRequest* request, PExecBatchPlanFragmentsResult* result,
+                                   google::protobuf::Closure* done);
+
+    void _async_exec_batch_plan_fragments(google::protobuf::RpcController* controller,
+                                   const PExecBatchPlanFragmentsRequest* request, PExecBatchPlanFragmentsResult* result,
+                                   google::protobuf::Closure* done);
+
+
+    void _cancel_plan_fragment(google::protobuf::RpcController* controller, const PCancelPlanFragmentRequest* request,
+                              PCancelPlanFragmentResult* result, google::protobuf::Closure* done);
+
+    void _fetch_data(google::protobuf::RpcController* controller, const PFetchDataRequest* request,
+                    PFetchDataResult* result, google::protobuf::Closure* done);
+
     void _get_info_impl(const PProxyRequest* request, PProxyResult* response,
                         GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>* latch, int timeout_ms);
 

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -124,31 +124,31 @@ public:
                                     google::protobuf::Closure* done) override;
 
 private:
-    void _transmit_chunk(::google::protobuf::RpcController* controller, const ::starrocks::PTransmitChunkParams* request,
-                        ::starrocks::PTransmitChunkResult* response, ::google::protobuf::Closure* done);
+    void _transmit_chunk(::google::protobuf::RpcController* controller,
+                         const ::starrocks::PTransmitChunkParams* request, ::starrocks::PTransmitChunkResult* response,
+                         ::google::protobuf::Closure* done);
 
     void _transmit_runtime_filter(::google::protobuf::RpcController* controller,
-                                 const ::starrocks::PTransmitRuntimeFilterParams* request,
-                                 ::starrocks::PTransmitRuntimeFilterResult* response,
-                                 ::google::protobuf::Closure* done);
+                                  const ::starrocks::PTransmitRuntimeFilterParams* request,
+                                  ::starrocks::PTransmitRuntimeFilterResult* response,
+                                  ::google::protobuf::Closure* done);
 
     void _exec_plan_fragment(google::protobuf::RpcController* controller, const PExecPlanFragmentRequest* request,
-                            PExecPlanFragmentResult* result, google::protobuf::Closure* done);
+                             PExecPlanFragmentResult* result, google::protobuf::Closure* done);
 
     void _exec_batch_plan_fragments(google::protobuf::RpcController* controller,
-                                   const PExecBatchPlanFragmentsRequest* request, PExecBatchPlanFragmentsResult* result,
-                                   google::protobuf::Closure* done);
+                                    const PExecBatchPlanFragmentsRequest* request,
+                                    PExecBatchPlanFragmentsResult* result, google::protobuf::Closure* done);
 
     void _async_exec_batch_plan_fragments(google::protobuf::RpcController* controller,
-                                   const PExecBatchPlanFragmentsRequest* request, PExecBatchPlanFragmentsResult* result,
-                                   google::protobuf::Closure* done);
-
+                                          const PExecBatchPlanFragmentsRequest* request,
+                                          PExecBatchPlanFragmentsResult* result, google::protobuf::Closure* done);
 
     void _cancel_plan_fragment(google::protobuf::RpcController* controller, const PCancelPlanFragmentRequest* request,
-                              PCancelPlanFragmentResult* result, google::protobuf::Closure* done);
+                               PCancelPlanFragmentResult* result, google::protobuf::Closure* done);
 
     void _fetch_data(google::protobuf::RpcController* controller, const PFetchDataRequest* request,
-                    PFetchDataResult* result, google::protobuf::Closure* done);
+                     PFetchDataResult* result, google::protobuf::Closure* done);
 
     void _get_info_impl(const PProxyRequest* request, PProxyResult* response,
                         GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>* latch, int timeout_ms);

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -140,10 +140,6 @@ private:
                                     const PExecBatchPlanFragmentsRequest* request,
                                     PExecBatchPlanFragmentsResult* result, google::protobuf::Closure* done);
 
-    void _async_exec_batch_plan_fragments(google::protobuf::RpcController* controller,
-                                          const PExecBatchPlanFragmentsRequest* request,
-                                          PExecBatchPlanFragmentsResult* result, google::protobuf::Closure* done);
-
     void _cancel_plan_fragment(google::protobuf::RpcController* controller, const PCancelPlanFragmentRequest* request,
                                PCancelPlanFragmentResult* result, google::protobuf::Closure* done);
 
@@ -158,7 +154,6 @@ private:
                                int timeout_ms);
 
     Status _exec_plan_fragment(brpc::Controller* cntl);
-    Status _exec_batch_plan_fragments(brpc::Controller* cntl);
     Status _exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_request,
                                            const TExecPlanFragmentParams& t_unique_request);
     Status _exec_plan_fragment_by_non_pipeline(const TExecPlanFragmentParams& t_request);

--- a/be/src/service/service_be/internal_service.cpp
+++ b/be/src/service/service_be/internal_service.cpp
@@ -76,10 +76,16 @@ void BackendInternalServiceImpl<T>::tablet_writer_add_chunk(google::protobuf::Rp
                                                             const PTabletWriterAddChunkRequest* request,
                                                             PTabletWriterAddBatchResult* response,
                                                             google::protobuf::Closure* done) {
-    ClosureGuard closure_guard(done);
-    VLOG_RPC << "tablet writer add chunk, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
-             << ", sender_id=" << request->sender_id() << ", eos=" << request->eos();
-    PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunk(*request, response);
+    auto task = [=] () {
+        ClosureGuard closure_guard(done);
+        VLOG_RPC << "tablet writer add chunk, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
+                << ", sender_id=" << request->sender_id() << ", eos=" << request->eos();
+        PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunk(*request, response);
+    };
+    if (!PInternalServiceImplBase<T>::_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
+        ClosureGuard closure_guard(done);
+        Status::ServiceUnavailable("submit tablet_writer_add_chunk task failed").to_protobuf(response->mutable_status());
+    }
 }
 
 template <typename T>
@@ -87,8 +93,15 @@ void BackendInternalServiceImpl<T>::tablet_writer_add_chunks(google::protobuf::R
                                                              const PTabletWriterAddChunksRequest* request,
                                                              PTabletWriterAddBatchResult* response,
                                                              google::protobuf::Closure* done) {
-    ClosureGuard closure_guard(done);
-    PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunks(*request, response);
+    auto task = [=] () {
+        ClosureGuard closure_guard(done);
+        PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunks(*request, response);
+    };
+    if (!PInternalServiceImplBase<T>::_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
+        ClosureGuard closure_guard(done);
+        Status::ServiceUnavailable("submit tablet_writer_add_chunks task failed").to_protobuf(response->mutable_status());
+    }
+
 }
 
 template <typename T>

--- a/be/src/service/service_be/internal_service.cpp
+++ b/be/src/service/service_be/internal_service.cpp
@@ -76,15 +76,16 @@ void BackendInternalServiceImpl<T>::tablet_writer_add_chunk(google::protobuf::Rp
                                                             const PTabletWriterAddChunkRequest* request,
                                                             PTabletWriterAddBatchResult* response,
                                                             google::protobuf::Closure* done) {
-    auto task = [=] () {
+    auto task = [=]() {
         ClosureGuard closure_guard(done);
         VLOG_RPC << "tablet writer add chunk, id=" << print_id(request->id()) << ", index_id=" << request->index_id()
-                << ", sender_id=" << request->sender_id() << ", eos=" << request->eos();
+                 << ", sender_id=" << request->sender_id() << ", eos=" << request->eos();
         PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunk(*request, response);
     };
     if (!PInternalServiceImplBase<T>::_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
-        Status::ServiceUnavailable("submit tablet_writer_add_chunk task failed").to_protobuf(response->mutable_status());
+        Status::ServiceUnavailable("submit tablet_writer_add_chunk task failed")
+                .to_protobuf(response->mutable_status());
     }
 }
 
@@ -93,15 +94,15 @@ void BackendInternalServiceImpl<T>::tablet_writer_add_chunks(google::protobuf::R
                                                              const PTabletWriterAddChunksRequest* request,
                                                              PTabletWriterAddBatchResult* response,
                                                              google::protobuf::Closure* done) {
-    auto task = [=] () {
+    auto task = [=]() {
         ClosureGuard closure_guard(done);
         PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunks(*request, response);
     };
     if (!PInternalServiceImplBase<T>::_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
         ClosureGuard closure_guard(done);
-        Status::ServiceUnavailable("submit tablet_writer_add_chunks task failed").to_protobuf(response->mutable_status());
+        Status::ServiceUnavailable("submit tablet_writer_add_chunks task failed")
+                .to_protobuf(response->mutable_status());
     }
-
 }
 
 template <typename T>


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We rely on some thread local variables to do memory check in BE, but the scheduling mechanism of bthread doesn't allow us to rely on TLS.In this PR, I try to move the key interfaces of query and load to pthread to completely avoid all kinds of strange problems caused by the above situation.

Major changes:
1. introduce a new thread pool called query_rpc_pool. It will contain the same number of threads as logical cpu cores by default.
2. transfer the execution of some key interfaces to pthread by submitting tasks to query_rpc_pool.
3. because the calls of `DataStreamMgr` are all on the pthread after the above changes, we replace the `bthread::Mutex` in `DataStreamMgr` to `std::shared_mutex` to get better concurrent performance. This is a typical scenario of more reads and less writes.
4. since 2.4, we won't generate such a plan that contains multiple instances in one fragment. so I simplify the implementations in `exec_batch_plan_fragments` interface.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
