### PR TITLE
[BugFix][Cherry-Pick][Branch-2.5] Avoid BE crash when ORC's type can't convert to SlotDescriptor's type

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -30,7 +30,7 @@ namespace starrocks::vectorized {
 const FillColumnFunction& find_fill_func(PrimitiveType type, bool nullable);
 
 // NOLINTNEXTLINE
-const static std::unordered_map<orc::TypeKind, PrimitiveType> g_orc_starrocks_type_mapping = {
+const static std::unordered_map<orc::TypeKind, PrimitiveType> g_orc_starrocks_primitive_type_mapping = {
         {orc::BOOLEAN, TYPE_BOOLEAN},
         {orc::BYTE, TYPE_TINYINT},
         {orc::SHORT, TYPE_SMALLINT},

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -49,11 +49,6 @@ const static std::unordered_map<orc::TypeKind, PrimitiveType> g_orc_starrocks_ty
 };
 
 // NOLINTNEXTLINE
-const static std::set<orc::TypeKind> g_orc_int_type = {
-        orc::BOOLEAN, orc::BYTE, orc::SHORT, orc::INT, orc::LONG, orc::FLOAT, orc::DOUBLE,
-};
-
-// NOLINTNEXTLINE
 const static std::set<PrimitiveType> g_starrocks_int_type = {TYPE_BOOLEAN, TYPE_TINYINT,  TYPE_SMALLINT, TYPE_INT,
                                                              TYPE_BIGINT,  TYPE_LARGEINT, TYPE_FLOAT,    TYPE_DOUBLE};
 
@@ -1459,8 +1454,8 @@ static Status _create_type_descriptor_by_orc(const TypeDescriptor& origin_type, 
         auto precision = (int)orc_type->getPrecision();
         auto scale = (int)orc_type->getScale();
         auto len = (int)orc_type->getMaximumLength();
-        auto iter = g_orc_starrocks_type_mapping.find(kind);
-        if (iter == g_orc_starrocks_type_mapping.end()) {
+        auto iter = g_orc_starrocks_primitive_type_mapping.find(kind);
+        if (iter == g_orc_starrocks_primitive_type_mapping.end()) {
             return Status::NotSupported("Unsupported ORC type: " + orc_type->toString());
         }
         result->type = iter->second;

--- a/be/src/formats/orc/orc_mapping.cpp
+++ b/be/src/formats/orc/orc_mapping.cpp
@@ -117,6 +117,26 @@ StatusOr<std::unique_ptr<OrcMapping>> OrcMappingFactory::build_mapping(
     return orc_mapping;
 }
 
+Status OrcMappingFactory::_check_orc_type_can_converte_2_logical_type(const orc::Type& orc_source_type,
+                                                                      const TypeDescriptor& slot_target_type) {
+    bool can_convert = true;
+    if (orc_source_type.getKind() == orc::TypeKind::LIST) {
+        can_convert = slot_target_type.is_array_type();
+    } else if (orc_source_type.getKind() == orc::TypeKind::MAP) {
+        can_convert = slot_target_type.is_map_type();
+    } else if (orc_source_type.getKind() == orc::TypeKind::STRUCT) {
+        can_convert = slot_target_type.is_struct_type();
+    }
+
+    //TODO Other primitive type not check now!
+
+    if (!can_convert) {
+        return Status::NotSupported("Not support to convert orc's type: " + orc_source_type.toString() +
+                                    " to: " + slot_target_type.debug_string());
+    }
+    return Status::OK();
+}
+
 Status OrcMappingFactory::_init_orc_mapping_with_orc_column_names(std::unique_ptr<OrcMapping>& mapping,
                                                                   const std::vector<SlotDescriptor*>& slot_descs,
                                                                   const orc::Type& orc_root_type,
@@ -140,6 +160,9 @@ Status OrcMappingFactory::_init_orc_mapping_with_orc_column_names(std::unique_pt
         }
 
         const orc::Type* orc_sub_type = orc_root_type.getSubtype(it->second);
+
+        RETURN_IF_ERROR(_check_orc_type_can_converte_2_logical_type(*orc_sub_type, slot_desc->type()));
+
         size_t need_add_column_id = orc_sub_type->getColumnId();
 
         OrcMappingPtr need_add_child_mapping = nullptr;
@@ -193,6 +216,9 @@ Status OrcMappingFactory::_init_orc_mapping_with_hive_column_names(std::unique_p
 
         size_t pos_in_slot_descriptor = it->second;
 
+        RETURN_IF_ERROR(
+                _check_orc_type_can_converte_2_logical_type(*orc_sub_type, slot_descs[pos_in_slot_descriptor]->type()));
+
         OrcMappingPtr need_add_child_mapping = nullptr;
         // handle nested mapping for complex type mapping
         if (slot_descs[pos_in_slot_descriptor]->type().is_complex_type()) {
@@ -231,11 +257,12 @@ Status OrcMappingFactory::_set_child_mapping(const OrcMappingPtr& mapping, const
                 return Status::NotFound(s);
             }
             const orc::Type& orc_child_type = *orc_type.getSubtype(it->second);
+            const TypeDescriptor& origin_child_type = origin_type.children[index];
+            RETURN_IF_ERROR(_check_orc_type_can_converte_2_logical_type(orc_child_type, origin_child_type));
 
             size_t need_add_column_id = orc_child_type.getColumnId();
             OrcMappingPtr need_add_child_mapping = nullptr;
 
-            const TypeDescriptor& origin_child_type = origin_type.children[index];
             if (origin_child_type.is_complex_type()) {
                 need_add_child_mapping = std::make_shared<OrcMapping>();
                 RETURN_IF_ERROR(
@@ -245,8 +272,10 @@ Status OrcMappingFactory::_set_child_mapping(const OrcMappingPtr& mapping, const
         }
     } else if (origin_type.type == PrimitiveType::TYPE_ARRAY) {
         DCHECK(orc_type.getKind() == orc::TypeKind::LIST);
-        const TypeDescriptor& origin_child_type = origin_type.children[0];
         const orc::Type& orc_child_type = *orc_type.getSubtype(0);
+        const TypeDescriptor& origin_child_type = origin_type.children[0];
+        // Check Array's element can be converted
+        RETURN_IF_ERROR(_check_orc_type_can_converte_2_logical_type(orc_child_type, origin_child_type));
 
         size_t need_add_column_id = orc_child_type.getColumnId();
         OrcMappingPtr need_add_child_mapping = nullptr;
@@ -260,6 +289,11 @@ Status OrcMappingFactory::_set_child_mapping(const OrcMappingPtr& mapping, const
         mapping->add_mapping(0, need_add_column_id, need_add_child_mapping);
     } else if (origin_type.type == PrimitiveType::TYPE_MAP) {
         DCHECK(orc_type.getKind() == orc::TypeKind::MAP);
+
+        // Check Map's key can be converted
+        RETURN_IF_ERROR(_check_orc_type_can_converte_2_logical_type(*orc_type.getSubtype(0), origin_type.children[0]));
+        // Check Map's value can be converted
+        RETURN_IF_ERROR(_check_orc_type_can_converte_2_logical_type(*orc_type.getSubtype(1), origin_type.children[1]));
 
         // Map's key must be primitivte type
         mapping->add_mapping(0, orc_type.getSubtype(0)->getColumnId(), nullptr);
@@ -278,6 +312,8 @@ Status OrcMappingFactory::_set_child_mapping(const OrcMappingPtr& mapping, const
                                                case_sensitive));
         }
         mapping->add_mapping(1, need_add_value_column_id, need_add_vaule_child_mapping);
+    } else {
+        DCHECK(false) << "Unreachable";
     }
     return Status::OK();
 }

--- a/be/src/formats/orc/orc_mapping.h
+++ b/be/src/formats/orc/orc_mapping.h
@@ -105,6 +105,9 @@ public:
                                                                const std::vector<std::string>* hive_column_names);
 
 private:
+    static Status _check_orc_type_can_converte_2_logical_type(const orc::Type& orc_source_type,
+                                                              const TypeDescriptor& slot_target_type);
+
     static Status _init_orc_mapping_with_orc_column_names(std::unique_ptr<OrcMapping>& mapping,
                                                           const std::vector<SlotDescriptor*>& slot_descs,
                                                           const orc::Type& orc_root_type, const bool case_sensitve);

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1565,6 +1565,44 @@ TEST_F(OrcChunkReaderTest, TestReadStructCaseSensitiveField) {
 }
 
 /**
+ * ORC format: struct<c0:int,c1:struct<cc0:int,Cc1:string>>
+ * Data:
+ * {c0: 1, c1: {cc0: 11, Cc1: "Smith"}}
+ * {c0: 2, c1: {cc0: 22, Cc1: "Cruise"}}
+ * {c0: 3, c1: {cc0: 33, Cc1: "hello"}}
+ * {c0: 4, c1: {cc0: 44, Cc1: "world"}}
+ */
+TEST_F(OrcChunkReaderTest, TestUnConvertableType) {
+    static const std::string input_orc_file = "./be/test/exec/test_data/orc_scanner/orc_test_struct_basic.orc";
+
+    {
+        /**
+        *  Load one subfield
+        */
+        SlotDesc c0{"c1", TypeDescriptor::from_primtive_type(LogicalType::TYPE_INT)};
+        SlotDesc c1{"c0", TypeDescriptor::from_primtive_type(LogicalType::TYPE_STRUCT)};
+        c1.type.children.push_back(TypeDescriptor::from_primtive_type(LogicalType::TYPE_VARCHAR));
+        c1.type.field_names.emplace_back("Cc1");
+        c1.type.selected_fields.reserve(1);
+        c1.type.selected_fields.clear();
+        c1.type.selected_fields.push_back(true);
+
+        SlotDesc slot_descs[] = {c0, c1, {""}};
+
+        std::vector<SlotDescriptor*> src_slot_descriptors;
+        ObjectPool pool;
+        create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+        OrcChunkReader reader(_runtime_state.get(), src_slot_descriptors);
+        reader.set_use_orc_column_names(true);
+        reader.set_case_sensitive(true);
+        auto input_stream = orc::readLocalFile(input_orc_file);
+        Status st = reader.init(std::move(input_stream));
+        EXPECT_FALSE(st.ok());
+    }
+}
+
+/**
  * ORC format: struct<c0:int,c1:array<struct<c11:int,c12:array<string>>>,c2:array<map<int,struct<c21:int,c22:string>>>>
  */
 TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1579,9 +1579,9 @@ TEST_F(OrcChunkReaderTest, TestUnConvertableType) {
         /**
         *  Load one subfield
         */
-        SlotDesc c0{"c1", TypeDescriptor::from_primtive_type(LogicalType::TYPE_INT)};
-        SlotDesc c1{"c0", TypeDescriptor::from_primtive_type(LogicalType::TYPE_STRUCT)};
-        c1.type.children.push_back(TypeDescriptor::from_primtive_type(LogicalType::TYPE_VARCHAR));
+        SlotDesc c0{"c1", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)};
+        SlotDesc c1{"c0", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_STRUCT)};
+        c1.type.children.push_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
         c1.type.field_names.emplace_back("Cc1");
         c1.type.selected_fields.reserve(1);
         c1.type.selected_fields.clear();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Cherry-Pick from #14224

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
