### PR TITLE
[Enhancement] [cherry-pick] Add max update compaction num singleton deltas for primary model (#13862)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -292,6 +292,7 @@ CONF_mInt32(cumulative_compaction_skip_window_seconds, "30");
 CONF_mInt32(update_compaction_check_interval_seconds, "60");
 CONF_Int32(update_compaction_num_threads_per_disk, "1");
 CONF_Int32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min
+CONF_mInt64(max_update_compaction_num_singleton_deltas, "1000");
 
 CONF_mInt32(repair_compaction_interval_seconds, "600"); // 10 min
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1728,7 +1728,8 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         total_rows_after_compaction = new_rows;
         total_bytes_after_compaction = new_bytes;
         if (total_bytes_after_compaction > compaction_result_bytes_threashold ||
-            total_rows_after_compaction > compaction_result_rows_threashold) {
+            total_rows_after_compaction > compaction_result_rows_threashold ||
+            info->inputs.size() >= config::max_update_compaction_num_singleton_deltas) {
             break;
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If a BE hangs up for some time, it will copy incremental versions from other BEs and execute compaction. The current primary key model does not limit the number of compaction versions, and SegemntItertaor will reserve unnecessary memory. If there are many versions, each segment is small, and there are many columns, a large amount of memory will be consumed. In the user's scenario, 10,000 versions and one wide table consume 100G+ memory.

So we restrict the compaction versions of the primary key table.

Q: why name to `max_update_compaction_num_singleton_deltas` not `max_update_compaction_num_singleton_versions` ?
A: Mainly to unify the naming with other models。

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
