### PR TITLE
[Enhancement] Remove sensitive info of broker load from audit log (branch-2.4)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LabelName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LabelName.java
@@ -31,7 +31,6 @@ import com.starrocks.common.FeNameFormat;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.SystemInfoService;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.io.DataInput;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -38,6 +38,12 @@ public class PrintableMap<K, V> {
         SENSITIVE_KEY.add("password");
         SENSITIVE_KEY.add("kerberos_keytab_content");
         SENSITIVE_KEY.add("bos_secret_accesskey");
+        SENSITIVE_KEY.add("fs.s3a.access.key");
+        SENSITIVE_KEY.add("fs.s3a.secret.key");
+        SENSITIVE_KEY.add("fs.oss.accessKeyId");
+        SENSITIVE_KEY.add("fs.oss.accessKeySecret");
+        SENSITIVE_KEY.add("fs.cosn.userinfo.secretId");
+        SENSITIVE_KEY.add("fs.cosn.userinfo.secretKey");
     }
 
     public PrintableMap(Map<K, V> map, String keyValueSaperator,
@@ -79,7 +85,7 @@ public class PrintableMap<K, V> {
                 sb.append("\"");
             }
             if (hidePassword && SENSITIVE_KEY.contains(entry.getKey())) {
-                sb.append("*XXX");
+                sb.append("***");
             } else {
                 sb.append(entry.getValue());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
@@ -116,4 +116,19 @@ public class LoadStmtTest {
                 "LOAD LABEL testLabel (DATA FROM TABLE t0 INTO TABLE t1)",
                 "Load from table should use Spark Load");
     }
+
+    @Test
+    public void testBrokerLoad() {
+        analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0`) WITH BROKER hdfs_broker PROPERTIES (\"strict_mode\"=\"true\")");
+        analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0`) WITH BROKER PROPERTIES (\"strict_mode\"=\"true\")");
+        analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0`) WITH BROKER hdfs_broker (\"username\"=\"sr\") PROPERTIES (\"strict_mode\"=\"true\")");
+        analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0`) WITH BROKER (\"username\"=\"sr\") PROPERTIES (\"strict_mode\"=\"true\")");
+        analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0`) WITH BROKER (\"username\"=\"sr\")");
+    }
+
+    @Test
+    public void testToSql() {
+        LoadStmt stmt = (LoadStmt) analyzeSuccess("LOAD        LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0`) WITH BROKER hdfs_broker (\"username\"=\"sr\", \"password\"=\"PASSWORDDDD\") PROPERTIES (\"strict_mode\"=\"true\")");
+        Assert.assertEquals("LOAD LABEL `test`.`testLabel`(DATA INFILE ('hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file') INTO TABLE t0)WITH BROKER hdfs_broker (\"password\"  =  \"***\", \"username\"  =  \"sr\")PROPERTIES (\"strict_mode\" = \"true\")", stmt.toSql());
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13324

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR removes access key/secret from audit log of broker load. The new output would be like
```
2022-11-15 11:53:26,539 [query] |Client=127.0.0.1:56418|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=db0|State=ERR|ErrorCode=|Time=1|ScanBytes=0|ScanRows=0|ReturnRows=0|CpuCostNs=0|MemCostBytes=0|StmtId=4|QueryId=0f279750-6499-11ed-90d8-52243889412b|IsQuery=false|feIp=172.17.0.1|Stmt=LOAD LABEL `db0`.`11label_test3`(DATA INFILE ('gs://test_simo/4097.csv') INTO TABLE tbl_test COLUMNS TERMINATED BY ',' (key1, key2))WITH BROKER hdfs_broker ("fs.s3a.access.key"  =  "***", "fs.s3a.secret.key"  =  "*XXX", "fs.s3a.endpoint"  =  "storage.googleapis.com")|Digest=|PlanCpuCost=0.0|PlanMemCost=0.0
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
