### PR TITLE
[BugFix] Fix missing hack NULL_TYPE for field child_type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
@@ -754,6 +755,10 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         msg.output_scale = getOutputScale();
         msg.setIs_monotonic(isMonotonic());
         visitor.visit(this, msg);
+        // Echoes the above hack
+        if (PrimitiveType.NULL_TYPE.toThrift().equals(msg.child_type)) {
+            msg.child_type = PrimitiveType.BOOLEAN.toThrift();
+        }
         container.addToNodes(msg);
         for (Expr child : children) {
             child.treeToThriftHelper(container, visitor);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -755,7 +755,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         msg.output_scale = getOutputScale();
         msg.setIs_monotonic(isMonotonic());
         visitor.visit(this, msg);
-        // Echoes the above hack
+        // Echoes the above hack process
         if (PrimitiveType.NULL_TYPE.toThrift().equals(msg.child_type)) {
             msg.child_type = PrimitiveType.BOOLEAN.toThrift();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -729,4 +729,20 @@ public class CTEPlanTest extends PlanTestBase {
                 "  |  order by: <slot 14> 14: v3 ASC, <slot 13> 13: v2 ASC\n" +
                 "  |  offset: 0");
     }
+
+    @Test
+    public void testNullTypeHack() throws Exception {
+        String sql = "WITH cte_1 AS (\n" +
+                "  SELECT null v1\n" +
+                ")\n" +
+                "SELECT  \n" +
+                "  CASE \n" +
+                "    WHEN a.v1 = b.v1 THEN 1 \n" +
+                "    ELSE -1 \n" +
+                "  END IS_OK\n" +
+                "FROM cte_1 a, cte_1 b";
+
+        String plan = getThriftPlan(sql);
+        assertNotContains(plan, "NULL_TYPE");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14288

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

By design, be cannot see this specific type `NULL_TYPE`, so it need to be hacked in fe, by replacing it with a null literal of boolean type. And here is the problem, it forgot to hack another field `child_type` which will be checked in be that causing be to crash. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
