### PR TITLE
[Enhancement] Rename session variable and add metric for query queue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -81,6 +81,11 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_QUERY_TIMEOUT;
     public static LongCounterMetric COUNTER_QUERY_SUCCESS;
     public static LongCounterMetric COUNTER_SLOW_QUERY;
+
+    public static LongCounterMetric COUNTER_QUERY_QUEUE_PENDING;
+    public static LongCounterMetric COUNTER_QUERY_QUEUE_TOTAL;
+    public static LongCounterMetric COUNTER_QUERY_QUEUE_TIMEOUT;
+
     public static LongCounterMetric COUNTER_LOAD_ADD;
     public static LongCounterMetric COUNTER_LOAD_FINISHED;
     public static LongCounterMetric COUNTER_EDIT_LOG_WRITE;
@@ -329,6 +334,15 @@ public final class MetricRepo {
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_SUCCESS);
         COUNTER_SLOW_QUERY = new LongCounterMetric("slow_query", MetricUnit.REQUESTS, "total slow query");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SLOW_QUERY);
+        COUNTER_QUERY_QUEUE_PENDING = new LongCounterMetric("query_queue_pending", MetricUnit.REQUESTS,
+                "total pending query");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_QUEUE_PENDING);
+        COUNTER_QUERY_QUEUE_TOTAL = new LongCounterMetric("query_queue_total", MetricUnit.REQUESTS,
+                "total history queued query");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_QUEUE_TOTAL);
+        COUNTER_QUERY_QUEUE_TIMEOUT = new LongCounterMetric("query_queue_timeout", MetricUnit.REQUESTS,
+                "total history query for timeout in queue");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_QUEUE_TIMEOUT);
         COUNTER_LOAD_ADD = new LongCounterMetric("load_add", MetricUnit.REQUESTS, "total load submit");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_LOAD_ADD);
         COUNTER_ROUTINE_LOAD_PAUSED =

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -46,9 +46,9 @@ public final class GlobalVariable {
     public static final String DEFAULT_ROWSET_TYPE = "default_rowset_type";
     public static final String CHARACTER_SET_DATABASE = "character_set_database";
 
-    public static final String QUERY_QUEUE_SELECT_ENABLE = "query_queue_select_enable";
-    public static final String QUERY_QUEUE_STATISTIC_ENABLE = "query_queue_statistic_enable";
-    public static final String QUERY_QUEUE_INSERT_ENABLE = "query_queue_insert_enable";
+    public static final String ENABLE_QUERY_QUEUE_SELECT = "enable_query_queue_select";
+    public static final String ENABLE_QUERY_QUEUE_STATISTIC = "enable_query_queue_statistic";
+    public static final String ENABLE_QUERY_QUEUE_LOAD = "enable_query_queue_load";
     public static final String QUERY_QUEUE_FRESH_RESOURCE_USAGE_INTERVAL_MS =
             "query_queue_fresh_resource_usage_interval_ms";
     public static final String QUERY_QUEUE_CONCURRENCY_LIMIT = "query_queue_concurrency_limit";
@@ -99,7 +99,7 @@ public final class GlobalVariable {
     private static boolean performanceSchema = false;
 
     /**
-     * Query will be pending when BE is overloaded, if `queryQueueEnable` is true.
+     * Query will be pending when BE is overloaded, if `enableQueryQueueXxx` is true.
      * <p>
      * If the number of running queries of any BE `exceeds queryQueueConcurrencyLimit`,
      * or memory usage rate of any BE exceeds `queryQueueMemUsedPctLimit`,
@@ -115,12 +115,12 @@ public final class GlobalVariable {
      * The queries only using schema meta will never been queued, because a MySQL client will
      * query schema meta after the connection is established.
      */
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_SELECT_ENABLE, flag = VariableMgr.GLOBAL)
-    private static boolean queryQueueSelectEnable = false;
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_STATISTIC_ENABLE, flag = VariableMgr.GLOBAL)
-    private static boolean queryQueueStatisticEnable = false;
-    @VariableMgr.VarAttr(name = QUERY_QUEUE_INSERT_ENABLE, flag = VariableMgr.GLOBAL)
-    private static boolean queryQueueInsertEnable = false;
+    @VariableMgr.VarAttr(name = ENABLE_QUERY_QUEUE_SELECT, flag = VariableMgr.GLOBAL)
+    private static boolean enableQueryQueueSelect = false;
+    @VariableMgr.VarAttr(name = ENABLE_QUERY_QUEUE_STATISTIC, flag = VariableMgr.GLOBAL)
+    private static boolean enableQueryQueueStatistic = false;
+    @VariableMgr.VarAttr(name = ENABLE_QUERY_QUEUE_LOAD, flag = VariableMgr.GLOBAL)
+    private static boolean enableQueryQueueLoad = false;
     // Use the resource usage, only when the duration from the last report is within this interval.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_FRESH_RESOURCE_USAGE_INTERVAL_MS, flag = VariableMgr.GLOBAL)
     private static long queryQueueResourceUsageIntervalMs = 5000;
@@ -139,28 +139,28 @@ public final class GlobalVariable {
     @VariableMgr.VarAttr(name = QUERY_QUEUE_MAX_QUEUED_QUERIES, flag = VariableMgr.GLOBAL)
     private static int queryQueueMaxQueuedQueries = 1024;
 
-    public static boolean isQueryQueueSelectEnable() {
-        return queryQueueSelectEnable;
+    public static boolean isEnableQueryQueueSelect() {
+        return enableQueryQueueSelect;
     }
 
-    public static void setQueryQueueSelectEnable(boolean queryQueueSelectEnable) {
-        GlobalVariable.queryQueueSelectEnable = queryQueueSelectEnable;
+    public static void setEnableQueryQueueSelect(boolean enableQueryQueueSelect) {
+        GlobalVariable.enableQueryQueueSelect = enableQueryQueueSelect;
     }
 
-    public static boolean isQueryQueueStatisticEnable() {
-        return queryQueueStatisticEnable;
+    public static boolean isEnableQueryQueueStatistic() {
+        return enableQueryQueueStatistic;
     }
 
-    public static void setQueryQueueStatisticEnable(boolean queryQueueStatisticEnable) {
-        GlobalVariable.queryQueueStatisticEnable = queryQueueStatisticEnable;
+    public static void setEnableQueryQueueStatistic(boolean enableQueryQueueStatistic) {
+        GlobalVariable.enableQueryQueueStatistic = enableQueryQueueStatistic;
     }
 
-    public static boolean isQueryQueueInsertEnable() {
-        return queryQueueInsertEnable;
+    public static boolean isEnableQueryQueueLoad() {
+        return enableQueryQueueLoad;
     }
 
-    public static void setQueryQueueInsertEnable(boolean queryQueueInsertEnable) {
-        GlobalVariable.queryQueueInsertEnable = queryQueueInsertEnable;
+    public static void setEnableQueryQueueLoad(boolean enableQueryQueueLoad) {
+        GlobalVariable.enableQueryQueueLoad = enableQueryQueueLoad;
     }
 
     public static long getQueryQueueResourceUsageIntervalMs() {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
@@ -4,10 +4,9 @@ package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.UserException;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.planner.ExportSink;
-import com.starrocks.planner.MysqlTableSink;
 import com.starrocks.planner.OlapScanNode;
-import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ResultSink;
@@ -23,6 +22,7 @@ import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -39,9 +39,14 @@ public class QueryQueueManagerTest {
     private int taskQueuePendingTimeoutSecond;
     private int taskQueueMaxQueuedQueries;
 
+    @BeforeClass
+    public static void beforeClass() {
+        MetricRepo.init();
+    }
+
     @Before
     public void before() {
-        taskQueueEnable = GlobalVariable.isQueryQueueSelectEnable();
+        taskQueueEnable = GlobalVariable.isEnableQueryQueueSelect();
         taskQueueConcurrencyHardLimit = GlobalVariable.getQueryQueueConcurrencyLimit();
         taskQueueMemUsedPctHardLimit = GlobalVariable.getQueryQueueMemUsedPctLimit();
         taskQueuePendingTimeoutSecond = GlobalVariable.getQueryQueuePendingTimeoutSecond();
@@ -51,7 +56,7 @@ public class QueryQueueManagerTest {
     @After
     public void after() {
         // Reset query queue configs.
-        GlobalVariable.setQueryQueueSelectEnable(taskQueueEnable);
+        GlobalVariable.setEnableQueryQueueSelect(taskQueueEnable);
         GlobalVariable.setQueryQueueConcurrencyLimit(taskQueueConcurrencyHardLimit);
         GlobalVariable.setQueryQueueMemUsedPctLimit(taskQueueMemUsedPctHardLimit);
         GlobalVariable.setQueryQueuePendingTimeoutSecond(taskQueuePendingTimeoutSecond);
@@ -126,7 +131,7 @@ public class QueryQueueManagerTest {
         // Case 1: Coordinator needn't check queue.
         mockCoordinatorNotNeedCheckQueue();
         mockCoordinatorEnableCheckQueue();
-        GlobalVariable.setQueryQueueSelectEnable(true);
+        GlobalVariable.setEnableQueryQueueSelect(true);
         manager.maybeWait(connectCtx, coordinator);
         Assert.assertEquals(-1, connectCtx.getAuditEventBuilder().build().pendingTimeMs);
         Assert.assertEquals(0, manager.numPendingQueries());
@@ -134,7 +139,7 @@ public class QueryQueueManagerTest {
         // Case 2: Coordinator doesn't enable to check queue.
         mockCoordinatorNeedCheckQueue();
         mockCoordinatorNotEnableCheckQueue();
-        GlobalVariable.setQueryQueueSelectEnable(true);
+        GlobalVariable.setEnableQueryQueueSelect(true);
         manager.maybeWait(connectCtx, coordinator);
         Assert.assertEquals(-1, connectCtx.getAuditEventBuilder().build().pendingTimeMs);
         Assert.assertEquals(0, manager.numPendingQueries());
@@ -160,7 +165,7 @@ public class QueryQueueManagerTest {
         mockNotCanRunMore();
 
         // Case 1: Pending timeout.
-        GlobalVariable.setQueryQueueSelectEnable(true);
+        GlobalVariable.setEnableQueryQueueSelect(true);
         GlobalVariable.setQueryQueuePendingTimeoutSecond(1);
         Thread thread = new Thread(() -> {
             Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> {
@@ -288,8 +293,6 @@ public class QueryQueueManagerTest {
 
     @Test
     public void testEnableCheckQueue(@Mocked PlanFragment fragment,
-                                     @Mocked OlapTableSink olapTableSink,
-                                     @Mocked MysqlTableSink mysqlTableSink,
                                      @Mocked ExportSink exportSink) {
         QueryQueueManager manager = QueryQueueManager.getInstance();
 
@@ -300,7 +303,10 @@ public class QueryQueueManagerTest {
                 result = true;
             }
         };
+        GlobalVariable.setEnableQueryQueueLoad(false);
         Assert.assertFalse(manager.enableCheckQueue(coordinator));
+        GlobalVariable.setEnableQueryQueueLoad(true);
+        Assert.assertTrue(manager.enableCheckQueue(coordinator));
         new Expectations(coordinator) {
             {
                 coordinator.isLoadType();
@@ -308,36 +314,13 @@ public class QueryQueueManagerTest {
             }
         };
 
-        // 2. Insert to MySQL table.
+        // 2. Query for select.
         new Expectations(coordinator, fragment) {
             {
                 coordinator.getFragments();
                 result = ImmutableList.of(fragment);
             }
-
-            {
-                fragment.getSink();
-                result = mysqlTableSink;
-            }
         };
-        GlobalVariable.setQueryQueueInsertEnable(false);
-        Assert.assertFalse(manager.enableCheckQueue(coordinator));
-        GlobalVariable.setQueryQueueInsertEnable(true);
-        Assert.assertTrue(manager.enableCheckQueue(coordinator));
-
-        // 3. Insert to OLAP table.
-        new Expectations(coordinator, fragment) {
-            {
-                fragment.getSink();
-                result = olapTableSink;
-            }
-        };
-        GlobalVariable.setQueryQueueInsertEnable(false);
-        Assert.assertFalse(manager.enableCheckQueue(coordinator));
-        GlobalVariable.setQueryQueueInsertEnable(true);
-        Assert.assertTrue(manager.enableCheckQueue(coordinator));
-
-        // 4. Query for select.
         PlanNodeId nodeId = new PlanNodeId(0);
         ResultSink queryResultSink = new ResultSink(nodeId, TResultSinkType.MYSQL_PROTOCAL);
         new Expectations(coordinator, fragment) {
@@ -346,12 +329,12 @@ public class QueryQueueManagerTest {
                 result = queryResultSink;
             }
         };
-        GlobalVariable.setQueryQueueSelectEnable(false);
+        GlobalVariable.setEnableQueryQueueSelect(false);
         Assert.assertFalse(manager.enableCheckQueue(coordinator));
-        GlobalVariable.setQueryQueueSelectEnable(true);
+        GlobalVariable.setEnableQueryQueueSelect(true);
         Assert.assertTrue(manager.enableCheckQueue(coordinator));
 
-        // 5. Query for statistic.
+        // 3. Query for statistic.
         ResultSink statisticResultSink = new ResultSink(nodeId, TResultSinkType.STATISTIC);
         new Expectations(coordinator, fragment) {
             {
@@ -359,12 +342,12 @@ public class QueryQueueManagerTest {
                 result = statisticResultSink;
             }
         };
-        GlobalVariable.setQueryQueueStatisticEnable(false);
+        GlobalVariable.setEnableQueryQueueStatistic(false);
         Assert.assertFalse(manager.enableCheckQueue(coordinator));
-        GlobalVariable.setQueryQueueStatisticEnable(true);
+        GlobalVariable.setEnableQueryQueueStatistic(true);
         Assert.assertTrue(manager.enableCheckQueue(coordinator));
 
-        // 6. Query for outfile.
+        // 4. Query for outfile.
         ResultSink fileResultSink = new ResultSink(nodeId, TResultSinkType.FILE);
         new Expectations(coordinator, fragment) {
             {
@@ -374,7 +357,7 @@ public class QueryQueueManagerTest {
         };
         Assert.assertFalse(manager.enableCheckQueue(coordinator));
 
-        // 7. Export.
+        // 5. Export.
         new Expectations(coordinator, fragment) {
             {
                 fragment.getSink();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
1. Rename `query_queue_select_enable` to `enable_query_queue_select`.
2. Add FE metrics for query queue:
    - starrocks_fe_query_queue_pending
    - starrocks_fe_query_queue_total
    - starrocks_fe_query_queue_timeout

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
