### PR TITLE
[Enhancement] [cherry-pick] Reduce the memory usage of small segment file iterator (#13861)

### DIFF
--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -153,7 +153,9 @@ inline Status MergeIterator::init() {
     DCHECK(_chunk_size > 0);
     DCHECK_EQ(_children.size(), _chunk_pool.size());
     for (size_t i = 0; i < _children.size(); i++) {
-        _chunk_pool[i] = ChunkHelper::new_chunk(output_schema(), _chunk_size);
+        // No need to reserve, because it's already reserved in segment interators.
+        // If we reserve here, for small segment files, it will consume large memory then need.
+        _chunk_pool[i] = ChunkHelper::new_chunk(output_schema(), 0);
         RETURN_IF_ERROR(fill(i));
     }
     _inited = true;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -120,17 +120,6 @@ private:
             return Status::OK();
         }
 
-        Status read_columns(Chunk* chunk, size_t n) {
-            bool may_has_del_row = chunk->delete_state() != DEL_NOT_SATISFIED;
-            for (size_t i = 0; i < _column_iterators.size(); i++) {
-                const ColumnPtr& col = chunk->get_column_by_index(i);
-                RETURN_IF_ERROR(_column_iterators[i]->next_batch(&n, col.get()));
-                may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
-            }
-            chunk->set_delete_state(may_has_del_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
-            return Status::OK();
-        }
-
         Status read_columns(Chunk* chunk, const vectorized::SparseRange& range) {
             bool may_has_del_row = chunk->delete_state() != DEL_NOT_SATISFIED;
             for (size_t i = 0; i < _column_iterators.size(); i++) {
@@ -248,8 +237,6 @@ private:
 
     Status _read(Chunk* chunk, vector<rowid_t>* rowid, size_t n);
 
-    Status _read_by_column(size_t n, Chunk* result, vector<rowid_t>* rowids);
-
 private:
     using RawColumnIterators = std::vector<ColumnIterator*>;
     using ColumnDecoders = std::vector<ColumnDecoder>;
@@ -296,6 +283,8 @@ private:
 
     int _late_materialization_ratio = 0;
 
+    int _reserve_chunk_size = 0;
+
     bool _inited = false;
     bool _has_bitmap_index = false;
 
@@ -309,6 +298,14 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, vectorized::S
           _opts(std::move(options)),
           _predicate_columns(_opts.predicates.size()),
           _context_switch_next_time(false) {
+    // For small segment file (the number of rows is less than chunk_size),
+    // the segment iterator will reserve a large amount of memory,
+    // especially when there are many columns, many small files, many versions,
+    // a compaction task or query will consume a lot of memory,
+    // increasing the burden on the memory allocator, while increasing memory consumption.
+    // Therefore, when the segment file is relatively small, we should only reserve necessary memory.
+    _reserve_chunk_size = static_cast<int32_t>(std::min(static_cast<uint32_t>(_opts.chunk_size), _segment->num_rows()));
+
     // for very long queries(>30min), delvec may got GCed, to prevent this, load delvec at query start, call stack:
     //   olap_chunk_source::prepare -> tablet_reader::open -> get_segment_iterators -> create SegmentIterator
     SCOPED_RAW_TIMER(&_opts.stats->get_delvec_ns);
@@ -344,11 +341,11 @@ Status SegmentIterator::_init() {
     }
 
     if (config::enable_segment_overflow_read_chunk) {
-        _selection.resize(_opts.chunk_size + _opts.chunk_size / 4 + 1);
-        _selected_idx.resize(_opts.chunk_size + _opts.chunk_size / 4 + 1);
+        _selection.resize(_reserve_chunk_size + _reserve_chunk_size / 4 + 1);
+        _selected_idx.resize(_reserve_chunk_size + _reserve_chunk_size / 4 + 1);
     } else {
-        _selection.resize(_opts.chunk_size);
-        _selected_idx.resize(_opts.chunk_size);
+        _selection.resize(_reserve_chunk_size);
+        _selected_idx.resize(_reserve_chunk_size);
     }
 
     StarRocksMetrics::instance()->segment_read_total.increment(1);
@@ -814,7 +811,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     MonotonicStopWatch sw;
     sw.start();
 
-    const uint32_t chunk_capacity = _opts.chunk_size;
+    const uint32_t chunk_capacity = _reserve_chunk_size;
     const bool has_predicate = !_opts.predicates.empty();
     const int64_t prev_raw_rows_read = _opts.stats->raw_rows_read;
 
@@ -864,9 +861,9 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     // If _read_chunk contains more rows than its capacity, we save the overflow rows in _overflow_read_chunk.
     if (chunk_start > chunk_capacity) {
         if (_context->_overflow_read_chunk == nullptr) {
-            _context->_overflow_read_chunk = chunk->clone_empty(_opts.chunk_size / 4 + 1);
+            _context->_overflow_read_chunk = chunk->clone_empty(_reserve_chunk_size / 4 + 1);
             if (rowid != nullptr) {
-                _context->_overflow_read_chunk_rowids.reserve(_opts.chunk_size / 4 + 1);
+                _context->_overflow_read_chunk_rowids.reserve(_reserve_chunk_size / 4 + 1);
             }
         }
         DCHECK(_context->_overflow_read_chunk->is_empty());
@@ -985,15 +982,16 @@ void SegmentIterator::_switch_context(ScanContext* to) {
 
     if (to->_read_chunk == nullptr) {
         if (config::enable_segment_overflow_read_chunk) {
-            to->_read_chunk = ChunkHelper::new_chunk(to->_read_schema, _opts.chunk_size + _opts.chunk_size / 4 + 1);
+            to->_read_chunk =
+                    ChunkHelper::new_chunk(to->_read_schema, _reserve_chunk_size + _reserve_chunk_size / 4 + 1);
         } else {
-            to->_read_chunk = ChunkHelper::new_chunk(to->_read_schema, _opts.chunk_size);
+            to->_read_chunk = ChunkHelper::new_chunk(to->_read_schema, _reserve_chunk_size);
         }
     }
 
     if (to->_has_dict_column) {
         if (to->_dict_chunk == nullptr) {
-            to->_dict_chunk = ChunkHelper::new_chunk(to->_dict_decode_schema, _opts.chunk_size);
+            to->_dict_chunk = ChunkHelper::new_chunk(to->_dict_decode_schema, _reserve_chunk_size);
         }
     } else {
         to->_dict_chunk = to->_read_chunk;
@@ -1011,13 +1009,13 @@ void SegmentIterator::_switch_context(ScanContext* to) {
                 _encoded_schema.append(field);
             }
         }
-        to->_final_chunk = ChunkHelper::new_chunk(this->_encoded_schema, _opts.chunk_size);
+        to->_final_chunk = ChunkHelper::new_chunk(this->_encoded_schema, _reserve_chunk_size);
     } else {
-        to->_final_chunk = ChunkHelper::new_chunk(this->output_schema(), _opts.chunk_size);
+        to->_final_chunk = ChunkHelper::new_chunk(this->output_schema(), _reserve_chunk_size);
     }
 
     to->_adapt_global_dict_chunk = to->_has_force_dict_encode
-                                           ? ChunkHelper::new_chunk(this->output_schema(), _opts.chunk_size)
+                                           ? ChunkHelper::new_chunk(this->output_schema(), _reserve_chunk_size)
                                            : to->_final_chunk;
 
     _context = to;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If a BE hangs up for some time, it will copy incremental versions from other BEs and execute compaction. The current primary key model does not limit the number of compaction versions, and SegmentIterator will reserve unnecessary memory. If there are many versions, each segment is small, and there are many columns, a large amount of memory will be consumed. In the user's scenario, 10,000 versions and one wide table consume 100G+ memory.

In my test, the pr can reduce the memory usage from 3.2G to 200M in the test case described in issue #13873

The current repair method is not elegant, and the allocation/release logic of `Column` on the storage layer is quite chaotic, so it will be optimized after careful consideration.

In my performance test, there is no impact on the compaction performance of large files or small files

Q: Why not modify the `_chunk_size `on `ChunkIterator` ? A: Because the `_chunk_size`, will be used by upper-level `ChunkIterator` such as `AggregateIterar`.

Q: if `enable_segment_overflow_read_chunk` why reserve more memory for a small segment file?
A: In fact, it is not necessary, mainly because of code unification.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
