### PR TITLE
[Enhancement] optimize `filter_range` when avx512f available

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -427,7 +427,8 @@ if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" 
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -msse4.2")
     endif()
     if (USE_AVX2)
-        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -mavx2")
+        # avx512f is checked by runtime.
+        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -mavx2 -mavx512f")
     endif()
 elseif ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -march=armv8-a+crc")

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -427,8 +427,7 @@ if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" 
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -msse4.2")
     endif()
     if (USE_AVX2)
-        # avx512f is checked by runtime.
-        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -mavx2 -mavx512f")
+        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -mavx2")
     endif()
 elseif ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -march=armv8-a+crc")

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -364,9 +364,9 @@ public:
                              "vpcompress" #WIDTHX                 \
                              " %%zmm1, %%zmm0%{%%k1%}%{z%}\n"     \
                              "vmovdqu" #WIDTH " %%zmm0, (%[d])\n" \
-                             : [ s ] "+r"(src), [ d ] "+r"(dst)   \
-                             : [ mask ] "r"(m)                    \
-                             : "zmm0", "zmm1", "k1", "memory");   \
+                             : [s] "+r"(src), [d] "+r"(dst)       \
+                             : [mask] "r"(m)                      \
+                             : "zmm0", "zmm1", "memory");         \
             result_offset += __builtin_popcount(m);               \
         }                                                         \
     }

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -349,9 +349,29 @@ public:
             result_offset += __builtin_popcount(m);                             \
         }                                                                       \
     }
+
+// In theory we should put k1 in clobbers.
+// But since we compile code with AVX2, k1 register is not used.
+#define AVX512F_ASM_COPY(SHIFT, MASK, WIDTH)                    \
+    {                                                           \
+        auto m = (mask >> SHIFT) & MASK;                        \
+        if (m) {                                                \
+            T* src = data + start_offset + SHIFT;               \
+            T* dst = data + result_offset;                      \
+            __asm__ volatile(                                   \
+                    "vmovdqu32 (%[s]), %%zmm1\n"                \
+                    "kmovw %[mask], %%k1\n"                     \
+                    "vpcompressd %%zmm1, %%zmm0%{%%k1%}%{z%}\n" \
+                    "vmovdqu32 %%zmm0, (%[d])\n"                \
+                    : [s] "+r"(src), [d] "+r"(dst)              \
+                    : [mask] "r"(m)                             \
+                    : "zmm0", "zmm1", "memory");                \
+            result_offset += __builtin_popcount(m);             \
+        }                                                       \
+    }
                 if constexpr (avx512f && sizeof(T) == 4) {
-                    AVX512F_COPY(0, 0xffff, 32);
-                    AVX512F_COPY(16, 0xffff, 32);
+                    AVX512F_ASM_COPY(0, 0xffff, 32);
+                    AVX512F_ASM_COPY(16, 0xffff, 32);
                 } else {
                     phmap::priv::BitMask<uint32_t, 32> bitmask(mask);
                     for (auto idx : bitmask) {

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -364,8 +364,8 @@ public:
                              "vpcompress" #WIDTHX                 \
                              " %%zmm1, %%zmm0%{%%k1%}%{z%}\n"     \
                              "vmovdqu" #WIDTH " %%zmm0, (%[d])\n" \
-                             : [s] "+r"(src), [d] "+r"(dst)       \
-                             : [mask] "r"(m)                      \
+                             : [ s ] "+r"(src), [ d ] "+r"(dst)   \
+                             : [ mask ] "r"(m)                    \
                              : "zmm0", "zmm1", "memory");         \
             result_offset += __builtin_popcount(m);               \
         }                                                         \

--- a/be/src/gutil/cpu.cc
+++ b/be/src/gutil/cpu.cc
@@ -214,6 +214,11 @@ void CPU::Initialize() {
             has_non_stop_time_stamp_counter_ = true;
         }
     }
+    // https://gcc.gnu.org/onlinedocs/gcc/x86-Built-in-Functions.html
+    __builtin_cpu_init();
+    if (__builtin_cpu_supports("avx512f")) {
+        has_avx512f_ = true;
+    }
 #elif defined(ARCH_CPU_ARM_FAMILY)
 #if (defined(OS_ANDROID) || defined(OS_LINUX))
     cpu_brand_ = *CpuInfoBrand();
@@ -235,4 +240,10 @@ CPU::IntelMicroArchitecture CPU::GetIntelMicroArchitecture() const {
     if (has_sse()) return SSE;
     return PENTIUM;
 }
+
+CPU _cpu_global_instance;
+const CPU* CPU::instance() {
+    return &_cpu_global_instance;
+}
+
 } // namespace base

--- a/be/src/gutil/cpu.h
+++ b/be/src/gutil/cpu.h
@@ -83,10 +83,12 @@ public:
     bool has_avx() const { return has_avx_; }
     bool has_avx2() const { return has_avx2_; }
     bool has_aesni() const { return has_aesni_; }
+    bool has_avx512f() const { return has_avx512f_; }
     bool has_non_stop_time_stamp_counter() const { return has_non_stop_time_stamp_counter_; }
     bool is_running_in_vm() const { return is_running_in_vm_; }
     IntelMicroArchitecture GetIntelMicroArchitecture() const;
     const std::string& cpu_brand() const { return cpu_brand_; }
+    static const CPU* instance();
 
 private:
     // Query the processor for CPUID information.
@@ -109,9 +111,11 @@ private:
     bool has_avx_{false};
     bool has_avx2_{false};
     bool has_aesni_{false};
+    bool has_avx512f_{false};
     bool has_non_stop_time_stamp_counter_{false};
     bool is_running_in_vm_{false};
     std::string cpu_vendor_;
     std::string cpu_brand_;
 };
+
 } // namespace base

--- a/be/test/exec/vectorized/json_parser_test.cpp
+++ b/be/test/exec/vectorized/json_parser_test.cpp
@@ -448,7 +448,8 @@ PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
 PARALLEL_TEST(JsonParserTest, test_big_value) {
     simdjson::ondemand::parser simdjson_parser;
     // The padded_string would allocate memory with simdjson::SIMDJSON_PADDING bytes padding.
-    simdjson::padded_string input = simdjson::padded_string::load("./be/test/exec/test_data/json_scanner/big_value.json");
+    simdjson::padded_string input =
+            simdjson::padded_string::load("./be/test/exec/test_data/json_scanner/big_value.json");
 
     std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
 

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1095,7 +1095,7 @@ TEST_F(OrcChunkReaderTest, TestReadArrayDecimal) {
     type_array.children.emplace_back(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 9, 9));
 
     SlotDesc slot_descs[] = {
-            {"id",  TypeDescriptor::from_primtive_type(LogicalType::TYPE_INT)},
+            {"id", TypeDescriptor::from_primtive_type(LogicalType::TYPE_INT)},
             {"arr", type_array},
             {""},
     };


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

A small benchmark shows avx512f implementation has better performance than bitmask:
- bitmask means current version
- hybrid means proposal version
- bitmask/X means the case that X elements in 32 should be selected.

We can see in almost all cases, hybrid version is better than bitmask.

Some observations:
- 64bit does not accelerate a lot
- 8/16bit needs AVX512_VBMI feature, which we don't have on our dev machine.
- TODO: but I think 8/16 bits has another way using 128bit register.

<img width="2042" alt="image" src="https://user-images.githubusercontent.com/1081215/204691031-32784333-5b8a-4b69-af42-534630d4f294.png">


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
