### PR TITLE
[BugFix] Fix statistic_collect_parallel does not take effect because  reuses the thread ConnectContext

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
@@ -12,9 +12,11 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.statistic.StatisticExecutor;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TStatisticData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,7 +42,9 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
                                                                            @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                List<TStatisticData> statisticData = queryStatisticsData(cacheKey.tableId, cacheKey.column);
+                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+                connectContext.setThreadLocalInfo();
+                List<TStatisticData> statisticData = queryStatisticsData(connectContext, cacheKey.tableId, cacheKey.column);
                 // check TStatisticData is not empty, There may be no such column Statistics in BE
                 if (!statisticData.isEmpty()) {
                     return Optional.of(convert2ColumnStatistics(statisticData.get(0)));
@@ -67,7 +71,10 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
                     tableId = key.tableId;
                     columns.add(key.column);
                 }
-                List<TStatisticData> statisticData = queryStatisticsData(tableId, columns);
+
+                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                statsConnectCtx.setThreadLocalInfo();
+                List<TStatisticData> statisticData = queryStatisticsData(statsConnectCtx, tableId, columns);
                 Map<ColumnStatsCacheKey, Optional<ColumnStatistic>> result = new HashMap<>();
                 // There may be no statistics for the column in BE
                 // Complete the list of statistics information, otherwise the columns without statistics may be called repeatedly
@@ -96,12 +103,12 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
         return asyncLoad(key, executor);
     }
 
-    private List<TStatisticData> queryStatisticsData(long tableId, String column) throws Exception {
-        return queryStatisticsData(tableId, ImmutableList.of(column));
+    private List<TStatisticData> queryStatisticsData(ConnectContext context, long tableId, String column) {
+        return queryStatisticsData(context, tableId, ImmutableList.of(column));
     }
 
-    private List<TStatisticData> queryStatisticsData(long tableId, List<String> columns) throws Exception {
-        return statisticExecutor.queryStatisticSync(null, tableId, columns);
+    private List<TStatisticData> queryStatisticsData(ConnectContext context, long tableId, List<String> columns) {
+        return statisticExecutor.queryStatisticSync(context, null, tableId, columns);
     }
 
     private ColumnStatistic convert2ColumnStatistics(TStatisticData statisticData) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
@@ -16,9 +16,11 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.statistic.StatisticExecutor;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TStatisticData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,8 +48,10 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
                                                      @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
             try {
+                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+                connectContext.setThreadLocalInfo();
                 List<TStatisticData> statisticData =
-                        queryHistogramStatistics(cacheKey.tableId, Lists.newArrayList(cacheKey.column));
+                        queryHistogramStatistics(connectContext, cacheKey.tableId, Lists.newArrayList(cacheKey.column));
                 // check TStatisticData is not empty, There may be no such column Statistics in BE
                 if (!statisticData.isEmpty()) {
                     return Optional.of(convert2Histogram(statisticData.get(0)));
@@ -75,7 +79,10 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
                     columns.add(key.column);
                     result.put(key, Optional.empty());
                 }
-                List<TStatisticData> histogramStatsDataList = queryHistogramStatistics(tableId, columns);
+                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+                connectContext.setThreadLocalInfo();
+
+                List<TStatisticData> histogramStatsDataList = queryHistogramStatistics(connectContext, tableId, columns);
                 for (TStatisticData histogramStatsData : histogramStatsDataList) {
                     Histogram histogram = convert2Histogram(histogramStatsData);
                     result.put(new ColumnStatsCacheKey(histogramStatsData.tableId, histogramStatsData.columnName),
@@ -98,8 +105,8 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
         return asyncLoad(key, executor);
     }
 
-    public List<TStatisticData> queryHistogramStatistics(long tableId, List<String> column) {
-        return statisticExecutor.queryHistogram(tableId, column);
+    public List<TStatisticData> queryHistogramStatistics(ConnectContext context, long tableId, List<String> column) {
+        return statisticExecutor.queryHistogram(context, tableId, column);
     }
 
     private Histogram convert2Histogram(TStatisticData statisticData) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeJob.java
@@ -6,6 +6,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatsConstants.AnalyzeType;
 import com.starrocks.statistic.StatsConstants.ScheduleStatus;
@@ -120,7 +121,7 @@ public class AnalyzeJob implements Writable {
         return properties;
     }
 
-    public void run(StatisticExecutor statisticExecutor) {
+    public void run(ConnectContext statsConnectContext, StatisticExecutor statisticExecutor) {
         setStatus(StatsConstants.ScheduleStatus.RUNNING);
         GlobalStateMgr.getCurrentAnalyzeMgr().updateAnalyzeJobWithoutLog(this);
         List<StatisticsCollectJob> statisticsCollectJobList =
@@ -134,7 +135,7 @@ public class AnalyzeJob implements Writable {
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
             GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
 
-            statisticExecutor.collectStatistics(statsJob, analyzeStatus, true);
+            statisticExecutor.collectStatistics(statsConnectContext, statsJob, analyzeStatus, true);
             if (analyzeStatus.getStatus().equals(StatsConstants.ScheduleStatus.FAILED)) {
                 setStatus(StatsConstants.ScheduleStatus.FAILED);
                 setWorkTime(LocalDateTime.now());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
@@ -242,11 +242,14 @@ public class AnalyzeManager implements Writable {
         Set<Long> tableIdHasDeleted = new HashSet<>(basicStatsMetaMap.keySet());
         tableIdHasDeleted.removeAll(tables);
 
-        dropBasicStatsMetaAndData(tableIdHasDeleted);
-        dropHistogramStatsMetaAndData(tableIdHasDeleted);
+        ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+        statsConnectCtx.setThreadLocalInfo();
+
+        dropBasicStatsMetaAndData(statsConnectCtx, tableIdHasDeleted);
+        dropHistogramStatsMetaAndData(statsConnectCtx, tableIdHasDeleted);
     }
 
-    public void dropBasicStatsMetaAndData(Set<Long> tableIdHasDeleted) {
+    public void dropBasicStatsMetaAndData(ConnectContext statsConnectCtx, Set<Long> tableIdHasDeleted) {
         StatisticExecutor statisticExecutor = new StatisticExecutor();
         for (Long tableId : tableIdHasDeleted) {
             BasicStatsMeta basicStatsMeta = basicStatsMetaMap.get(tableId);
@@ -255,14 +258,14 @@ public class AnalyzeManager implements Writable {
             }
             // Both types of tables need to be deleted, because there may have been a switch of
             // collecting statistics types, leaving some discarded statistics data.
-            statisticExecutor.dropTableStatistics(tableId, StatsConstants.AnalyzeType.SAMPLE);
-            statisticExecutor.dropTableStatistics(tableId, StatsConstants.AnalyzeType.FULL);
+            statisticExecutor.dropTableStatistics(statsConnectCtx, tableId, StatsConstants.AnalyzeType.SAMPLE);
+            statisticExecutor.dropTableStatistics(statsConnectCtx, tableId, StatsConstants.AnalyzeType.FULL);
             GlobalStateMgr.getCurrentState().getEditLog().logRemoveBasicStatsMeta(basicStatsMetaMap.get(tableId));
             basicStatsMetaMap.remove(tableId);
         }
     }
 
-    public void dropHistogramStatsMetaAndData(Set<Long> tableIdHasDeleted) {
+    public void dropHistogramStatsMetaAndData(ConnectContext statsConnectCtx, Set<Long> tableIdHasDeleted) {
         Map<Long, List<String>> expireHistogram = new HashMap<>();
         for (Pair<Long, String> entry : histogramStatsMetaMap.keySet()) {
             if (tableIdHasDeleted.contains(entry.first)) {
@@ -276,7 +279,7 @@ public class AnalyzeManager implements Writable {
 
         for (Map.Entry<Long, List<String>> histogramItem : expireHistogram.entrySet()) {
             StatisticExecutor statisticExecutor = new StatisticExecutor();
-            statisticExecutor.dropHistogram(histogramItem.getKey(), histogramItem.getValue());
+            statisticExecutor.dropHistogram(statsConnectCtx, histogramItem.getKey(), histogramItem.getValue());
 
             for (String histogramColumn : histogramItem.getValue()) {
                 Pair<Long, String> histogramKey = new Pair<>(histogramItem.getKey(), histogramColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -60,7 +60,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         for (String column : columns) {
             String sql = buildCollectMCV(db, table, mcvSize, column);
             StatisticExecutor statisticExecutor = new StatisticExecutor();
-            List<TStatisticData> mcv = statisticExecutor.queryMCV(sql);
+            List<TStatisticData> mcv = statisticExecutor.queryMCV(context, sql);
 
             Map<String, String> mostCommonValues = new HashMap<>();
             for (TStatisticData tStatisticData : mcv) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.LeaderDaemon;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatsConstants.AnalyzeType;
 import com.starrocks.statistic.StatsConstants.ScheduleStatus;
@@ -58,13 +59,17 @@ public class StatisticAutoCollector extends LeaderDaemon {
                 analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
                 GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
 
-                STATISTIC_EXECUTOR.collectStatistics(statsJob, analyzeStatus, true);
+                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                statsConnectCtx.setThreadLocalInfo();
+                STATISTIC_EXECUTOR.collectStatistics(statsConnectCtx, statsJob, analyzeStatus, true);
             }
         } else {
             List<AnalyzeJob> allAnalyzeJobs = GlobalStateMgr.getCurrentAnalyzeMgr().getAllAnalyzeJobList();
             allAnalyzeJobs.sort((o1, o2) -> Long.compare(o2.getId(), o1.getId()));
             for (AnalyzeJob analyzeJob : allAnalyzeJobs) {
-                analyzeJob.run(STATISTIC_EXECUTOR);
+                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                statsConnectCtx.setThreadLocalInfo();
+                analyzeJob.run(statsConnectCtx, STATISTIC_EXECUTOR);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -37,7 +37,8 @@ import java.util.List;
 public class StatisticExecutor {
     private static final Logger LOG = LogManager.getLogger(StatisticExecutor.class);
 
-    public List<TStatisticData> queryStatisticSync(Long dbId, Long tableId, List<String> columnNames) throws Exception {
+    public List<TStatisticData> queryStatisticSync(ConnectContext context,
+                                                   Long dbId, Long tableId, List<String> columnNames) {
         String sql;
         BasicStatsMeta meta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().get(tableId);
         if (meta != null && meta.getType().equals(StatsConstants.AnalyzeType.FULL)) {
@@ -69,40 +70,38 @@ public class StatisticExecutor {
             sql = StatisticSQLBuilder.buildQuerySampleStatisticsSQL(dbId, tableId, columnNames);
         }
 
-        return executeDQL(sql);
+        return executeDQL(context, sql);
     }
 
-    public void dropTableStatistics(Long tableIds, StatsConstants.AnalyzeType analyzeType) {
+    public void dropTableStatistics(ConnectContext statsConnectCtx, Long tableIds, StatsConstants.AnalyzeType analyzeType) {
         String sql = StatisticSQLBuilder.buildDropStatisticsSQL(tableIds, analyzeType);
         LOG.debug("Expire statistic SQL: {}", sql);
 
-        ConnectContext context = StatisticUtils.buildConnectContext();
         StatementBase parsedStmt;
         try {
-            parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
-            StmtExecutor executor = new StmtExecutor(context, parsedStmt);
+            parsedStmt = SqlParser.parseFirstStatement(sql, statsConnectCtx.getSessionVariable().getSqlMode());
+            StmtExecutor executor = new StmtExecutor(statsConnectCtx, parsedStmt);
             executor.execute();
         } catch (Exception e) {
             LOG.warn("Execute statistic table expire fail.", e);
         }
     }
 
-    public List<TStatisticData> queryHistogram(Long tableId, List<String> columnNames) {
+    public List<TStatisticData> queryHistogram(ConnectContext statsConnectCtx, Long tableId, List<String> columnNames) {
         String sql = StatisticSQLBuilder.buildQueryHistogramStatisticsSQL(tableId, columnNames);
-        return executeDQL(sql);
+        return executeDQL(statsConnectCtx, sql);
     }
 
-    public List<TStatisticData> queryMCV(String sql) {
-        return executeDQL(sql);
+    public List<TStatisticData> queryMCV(ConnectContext statsConnectCtx, String sql) {
+        return executeDQL(statsConnectCtx, sql);
     }
 
-    public void dropHistogram(Long tableId, List<String> columnNames) {
+    public void dropHistogram(ConnectContext statsConnectCtx, Long tableId, List<String> columnNames) {
         String sql = StatisticSQLBuilder.buildDropHistogramSQL(tableId, columnNames);
-        ConnectContext context = StatisticUtils.buildConnectContext();
         StatementBase parsedStmt;
         try {
-            parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
-            StmtExecutor executor = new StmtExecutor(context, parsedStmt);
+            parsedStmt = SqlParser.parseFirstStatement(sql, statsConnectCtx.getSessionVariable().getSqlMode());
+            StmtExecutor executor = new StmtExecutor(statsConnectCtx, parsedStmt);
             executor.execute();
         } catch (Exception e) {
             LOG.warn("Execute statistic table expire fail.", e);
@@ -138,6 +137,7 @@ public class StatisticExecutor {
 
 
         ConnectContext context = StatisticUtils.buildConnectContext();
+        context.setThreadLocalInfo();
         StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
 
         ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, false, TResultSinkType.STATISTIC);
@@ -180,7 +180,10 @@ public class StatisticExecutor {
         return statistics;
     }
 
-    public AnalyzeStatus collectStatistics(StatisticsCollectJob statsJob, AnalyzeStatus analyzeStatus, boolean refreshAsync) {
+    public AnalyzeStatus collectStatistics(ConnectContext statsConnectCtx,
+                                           StatisticsCollectJob statsJob,
+                                           AnalyzeStatus analyzeStatus,
+                                           boolean refreshAsync) {
         Database db = statsJob.getDb();
         Table table = statsJob.getTable();
 
@@ -189,9 +192,8 @@ public class StatisticExecutor {
         GlobalStateMgr.getCurrentAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
 
         try {
-            ConnectContext context = StatisticUtils.buildConnectContext();
-            GlobalStateMgr.getCurrentAnalyzeMgr().registerConnection(analyzeStatus.getId(), context);
-            statsJob.collect(context, analyzeStatus);
+            GlobalStateMgr.getCurrentAnalyzeMgr().registerConnection(analyzeStatus.getId(), statsConnectCtx);
+            statsJob.collect(statsConnectCtx, analyzeStatus);
         } catch (Exception e) {
             LOG.warn("Collect statistics error ", e);
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
@@ -226,8 +228,7 @@ public class StatisticExecutor {
         return analyzeStatus;
     }
 
-    private List<TStatisticData> executeDQL(String sql) {
-        ConnectContext context = StatisticUtils.buildConnectContext();
+    private List<TStatisticData> executeDQL(ConnectContext context, String sql) {
         StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
         ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, true, TResultSinkType.STATISTIC);
         StmtExecutor executor = new StmtExecutor(context, parsedStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -44,18 +44,13 @@ public class StatisticUtils {
             .add("starrocks_monitor")
             .add("information_schema").build();
 
+
     public static ConnectContext buildConnectContext() {
         ConnectContext context = new ConnectContext();
         // Note: statistics query does not register query id to QeProcessorImpl::coordinatorMap,
         // but QeProcessorImpl::reportExecStatus will check query id,
         // So we must disable report query status from BE to FE
         context.getSessionVariable().setEnableProfile(false);
-        if (null != ConnectContext.get()) {
-            // from current session, may execute analyze stmt
-            context.getSessionVariable().setStatisticCollectParallelism(
-                    ConnectContext.get().getSessionVariable().getStatisticCollectParallelism());
-        }
-
         context.getSessionVariable().setParallelExecInstanceNum(1);
         context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
         context.getSessionVariable().setEnablePipelineEngine(true);
@@ -65,8 +60,8 @@ public class StatisticUtils {
         context.setQualifiedUser(UserIdentity.ROOT.getQualifiedUser());
         context.setQueryId(UUIDUtil.genUUID());
         context.setExecutionId(UUIDUtil.toTUniqueId(context.getQueryId()));
-        context.setThreadLocalInfo();
         context.setStartTime();
+
         return context;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -18,6 +18,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.CreateDbStmt;
@@ -114,7 +115,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
             "table_id", "column_name"
     );
 
-    private boolean createSampleStatisticsTable() {
+    private boolean createSampleStatisticsTable(ConnectContext context) {
         LOG.info("create statistics table start");
         TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
                 StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
@@ -134,7 +135,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 properties,
                 null,
                 "");
-        Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
+
+        Analyzer.analyze(stmt, context);
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
         } catch (DdlException e) {
@@ -146,7 +148,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         return checkTableExist(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
     }
 
-    private boolean createFullStatisticsTable() {
+    private boolean createFullStatisticsTable(ConnectContext context) {
         LOG.info("create statistics table v2 start");
         TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
                 StatsConstants.FULL_STATISTICS_TABLE_NAME);
@@ -167,7 +169,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 null,
                 "");
    
-        Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
+        Analyzer.analyze(stmt, context);
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
         } catch (DdlException e) {
@@ -179,7 +181,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         return checkTableExist(StatsConstants.FULL_STATISTICS_TABLE_NAME);
     }
 
-    private boolean createHistogramStatisticsTable() {
+    private boolean createHistogramStatisticsTable(ConnectContext context) {
         LOG.info("create statistics table v2 start");
         TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
                 StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME);
@@ -200,7 +202,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 null,
                 "");
         
-        Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
+        Analyzer.analyze(stmt, context);
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
         } catch (DdlException e) {
@@ -257,12 +259,15 @@ public class StatisticsMetaManager extends LeaderDaemon {
     }
 
     private boolean createTable(String tableName) {
+        ConnectContext context = StatisticUtils.buildConnectContext();
+        context.setThreadLocalInfo();
+
         if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
-            return createSampleStatisticsTable();
+            return createSampleStatisticsTable(context);
         } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
-            return createFullStatisticsTable();
+            return createFullStatisticsTable(context);
         } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
-            return createHistogramStatisticsTable();
+            return createHistogramStatisticsTable(context);
         } else {
             throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -25,6 +25,7 @@ public class StatisticExecutorTest extends PlanTestBase {
                 Maps.newHashMap()));
 
         Assert.assertThrows(IllegalStateException.class,
-                () -> statisticExecutor.queryStatisticSync(db.getId(), olapTable.getId(), Lists.newArrayList("foo", "bar")));
+                () -> statisticExecutor.queryStatisticSync(
+                        StatisticUtils.buildConnectContext(), db.getId(), olapTable.getId(), Lists.newArrayList("foo", "bar")));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -104,4 +104,14 @@ public class StatisticsExecutorTest extends PlanTestBase {
 
         collectJob.collectStatisticSync(sql, context);
     }
+
+    @Test
+    public void testSessionVariableInStats() {
+        ConnectContext context = new ConnectContext();
+        context.getSessionVariable().setStatisticCollectParallelism(5);
+        context.setThreadLocalInfo();
+
+        ConnectContext statsContext = StatisticUtils.buildConnectContext();
+        Assert.assertEquals(1, statsContext.getSessionVariable().getParallelExecInstanceNum());
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14353

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Because in buildConnectContext, the statistical information collection thread will set the context of this build as Thread Connect Context after the first call. For each subsequent call, if null != ConnectContext.get(), then take the value of the parameters in ConnectContext.get(). This causes the parameters set in the session to fail to take effect unless the FE is restarted
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
