### PR TITLE
[BugFix]get empty table names in drop db

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -568,7 +568,7 @@ public class Database extends MetaObject implements Writable {
         return materializedViews;
     }
 
-    public Set<String> getTableNamesWithLock() {
+    public Set<String> getTableNamesViewWithLock() {
         readLock();
         try {
             return Collections.unmodifiableSet(this.nameToTable.keySet());

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -423,7 +423,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 }
 
                 // save table names for recycling
-                Set<String> tableNames = db.getTableNamesWithLock();
+                Set<String> tableNames = new HashSet(db.getTableNamesViewWithLock());
                 runnableList = unprotectDropDb(db, isForceDrop, false);
                 if (!isForceDrop) {
                     recycleBin.recycleDatabase(db, tableNames);
@@ -479,7 +479,7 @@ public class LocalMetastore implements ConnectorMetadata {
             Database db = fullNameToDb.get(dbName);
             db.writeLock();
             try {
-                Set<String> tableNames = db.getTableNamesWithLock();
+                Set<String> tableNames = new HashSet(db.getTableNamesViewWithLock());
                 runnableList = unprotectDropDb(db, isForceDrop, true);
                 if (!isForceDrop) {
                     recycleBin.recycleDatabase(db, tableNames);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -257,7 +257,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
         }
         if (db != null) {
-            for (String tableName : db.getTableNamesWithLock()) {
+            for (String tableName : db.getTableNamesViewWithLock()) {
                 LOG.debug("get table: {}, wait to check", tableName);
                 if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(currentUser, params.db,
                         tableName, PrivPredicate.SHOW)) {
@@ -713,7 +713,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             Database db = GlobalStateMgr.getCurrentState().getDb(fullName);
             if (db != null) {
-                for (String tableName : db.getTableNamesWithLock()) {
+                for (String tableName : db.getTableNamesViewWithLock()) {
                     LOG.debug("get table: {}, wait to check", tableName);
                     if (!GlobalStateMgr.getCurrentState().getAuth().checkTblPriv(currentUser, fullName,
                             tableName, PrivPredicate.SHOW)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -185,7 +185,7 @@ public class AccessTestUtil {
                 minTimes = 0;
                 result = null;
 
-                db.getTableNamesWithLock();
+                db.getTableNamesViewWithLock();
                 minTimes = 0;
                 result = Sets.newHashSet("testTable");
 
@@ -368,7 +368,7 @@ public class AccessTestUtil {
                 minTimes = 0;
                 result = null;
 
-                db.getTableNamesWithLock();
+                db.getTableNamesViewWithLock();
                 minTimes = 0;
                 result = Sets.newHashSet("t");
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -126,8 +126,8 @@ public class DatabaseTest {
         Assert.assertEquals(1, db.getTables().size());
         Assert.assertEquals(table, db.getTables().get(0));
 
-        Assert.assertEquals(1, db.getTableNamesWithLock().size());
-        for (String tableFamilyGroupName : db.getTableNamesWithLock()) {
+        Assert.assertEquals(1, db.getTableNamesViewWithLock().size());
+        for (String tableFamilyGroupName : db.getTableNamesViewWithLock()) {
             Assert.assertEquals(table.getName(), tableFamilyGroupName);
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13921

## Problem Summary(Required) ：
Problem:
    This Problem was introduced by commit bdb4da1. This commit use Collections.unmodifiableSet instead of the new HashSet to reduce the memory usage of FE. But the problem here is that Collections.unmodifiableSet returns the view of nameToTable.keySet(). Before using the TableNames in recycleDatabase, nameToTable had been dropped, and also the view of it would become empty, which caused this problem.
    
Solution:
    We copy the nameToTable.keySet() only when dropping the database.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
