### PR TITLE
[BugFix] Make Struct create all subfield columns to prevent BE crash

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -260,13 +260,10 @@ ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool null
         Columns columns;
         BinaryColumn::Ptr field_names = BinaryColumn::create();
         for (size_t i = 0; i < field_size; i++) {
-            if (!type_desc.selected_fields.at(i)) {
-                continue;
-            }
             // Subfield column must be nullable column.
-            ColumnPtr field_column = create_column(type_desc.children.at(i), true, is_const, size);
+            ColumnPtr field_column = create_column(type_desc.children[i], true, is_const, size);
             columns.emplace_back(field_column);
-            field_names->append_string(type_desc.field_names.at(i));
+            field_names->append_string(type_desc.field_names[i]);
         }
         p = StructColumn::create(columns, field_names);
     } else {

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1025,23 +1025,19 @@ static void fill_struct_column(orc::ColumnVectorBatch* cvb, ColumnPtr& col, size
 
     Columns& field_columns = col_struct->fields_column();
 
-    size_t child_index = 0;
     for (size_t i = 0; i < type_desc.children.size(); i++) {
-        if (!type_desc.selected_fields[i]) {
-            continue;
+        if (type_desc.selected_fields[i]) {
+            const TypeDescriptor& field_type = type_desc.children[i];
+            size_t column_id = mapping->get_column_id_or_child_mapping(i).orc_column_id;
+
+            orc::ColumnVectorBatch* field_cvb = orc_struct->fieldsColumnIdMap[column_id];
+            const FillColumnFunction& fn_fill_elements = find_fill_func(field_type.type, true);
+            fn_fill_elements(field_cvb, field_columns[i], from, size, field_type,
+                             mapping->get_column_id_or_child_mapping(i).orc_mapping, ctx);
+        } else {
+            field_columns[i]->append_default(size);
         }
-
-        const TypeDescriptor& field_type = type_desc.children[i];
-        size_t column_id = mapping->get_column_id_or_child_mapping(i).orc_column_id;
-
-        orc::ColumnVectorBatch* field_cvb = orc_struct->fieldsColumnIdMap[column_id];
-        const FillColumnFunction& fn_fill_elements = find_fill_func(field_type.type, true);
-        fn_fill_elements(field_cvb, field_columns[child_index], from, size, field_type,
-                         mapping->get_column_id_or_child_mapping(i).orc_mapping, ctx);
-        child_index++;
     }
-
-    DCHECK_EQ(field_columns.size(), child_index);
 }
 
 static void fill_struct_column_with_null(orc::ColumnVectorBatch* cvb, ColumnPtr& col, size_t from, size_t size,

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -259,8 +259,10 @@ public:
         // check _value_reader
         if (_key_reader != nullptr) {
             _key_reader->get_levels(def_levels, rep_levels, num_levels);
-        } else {
+        } else if (_value_reader != nullptr) {
             _value_reader->get_levels(def_levels, rep_levels, num_levels);
+        } else {
+            DCHECK(false) << "Unreachable!";
         }
     }
 

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -325,7 +325,7 @@ public:
     Status finish_batch() override { return Status::OK(); }
 
     void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
-        for(const auto& reader : _child_readers) {
+        for (const auto& reader : _child_readers) {
             if (reader != nullptr) {
                 reader->get_levels(def_levels, rep_levels, num_levels);
                 return;

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -146,7 +146,7 @@ void TypeDescriptor::to_protobuf(PTypeDesc* proto_type) const {
     } else if (type == TYPE_STRUCT) {
         node->set_type(TTypeNodeType::STRUCT);
         DCHECK_EQ(field_names.size(), selected_fields.size());
-        for(size_t i = 0; i < field_names.size(); i++) {
+        for (size_t i = 0; i < field_names.size(); i++) {
             node->add_struct_fields()->set_name(field_names[i]);
             node->add_selected_fields(selected_fields[i]);
         }

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -137,13 +137,18 @@ void TypeDescriptor::to_protobuf(PTypeDesc* proto_type) const {
         children[0].to_protobuf(proto_type);
     } else if (type == TYPE_MAP) {
         node->set_type(TTypeNodeType::MAP);
+        DCHECK_EQ(2, selected_fields.size());
+        node->add_selected_fields(selected_fields[0]);
+        node->add_selected_fields(selected_fields[1]);
         DCHECK_EQ(2, children.size());
         children[0].to_protobuf(proto_type);
         children[1].to_protobuf(proto_type);
     } else if (type == TYPE_STRUCT) {
         node->set_type(TTypeNodeType::STRUCT);
-        for (const auto& field_name : field_names) {
-            node->add_struct_fields()->set_name(field_name);
+        DCHECK_EQ(field_names.size(), selected_fields.size());
+        for(size_t i = 0; i < field_names.size(); i++) {
+            node->add_struct_fields()->set_name(field_names[i]);
+            node->add_selected_fields(selected_fields[i]);
         }
         for (const TypeDescriptor& child : children) {
             child.to_protobuf(proto_type);
@@ -194,6 +199,7 @@ TypeDescriptor::TypeDescriptor(const google::protobuf::RepeatedPtrField<PTypeNod
         for (int i = 0; i < node.struct_fields().size(); ++i) {
             children.push_back(TypeDescriptor(types, idx));
             field_names.push_back(node.struct_fields(i).name());
+            selected_fields.push_back(node.selected_fields(i));
         }
         break;
     case TTypeNodeType::ARRAY:
@@ -208,6 +214,8 @@ TypeDescriptor::TypeDescriptor(const google::protobuf::RepeatedPtrField<PTypeNod
         DCHECK_LT(*idx, types.size() - 2);
         ++(*idx);
         type = TYPE_MAP;
+        selected_fields.push_back(node.selected_fields(0));
+        selected_fields.push_back(node.selected_fields(1));
         children.push_back(TypeDescriptor(types, idx));
         children.push_back(TypeDescriptor(types, idx));
         break;

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1326,10 +1326,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructBasic) {
         EXPECT_EQ(result->num_rows(), 4);
         EXPECT_EQ(result->num_columns(), 2);
 
-        EXPECT_EQ("[1, {cc1: 'Smith'}]", result->debug_row(0));
-        EXPECT_EQ("[2, {cc1: 'Cruise'}]", result->debug_row(1));
-        EXPECT_EQ("[3, {cc1: 'hello'}]", result->debug_row(2));
-        EXPECT_EQ("[4, {cc1: 'World'}]", result->debug_row(3));
+        EXPECT_EQ("[1, {cc0: NULL, cc1: 'Smith'}]", result->debug_row(0));
+        EXPECT_EQ("[2, {cc0: NULL, cc1: 'Cruise'}]", result->debug_row(1));
+        EXPECT_EQ("[3, {cc0: NULL, cc1: 'hello'}]", result->debug_row(2));
+        EXPECT_EQ("[4, {cc0: NULL, cc1: 'World'}]", result->debug_row(3));
     }
 }
 
@@ -1473,10 +1473,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructUnorderedField) {
         EXPECT_EQ(result->num_rows(), 4);
         EXPECT_EQ(result->num_columns(), 2);
 
-        EXPECT_EQ("[1, {cc0: 11}]", result->debug_row(0));
-        EXPECT_EQ("[2, {cc0: 22}]", result->debug_row(1));
-        EXPECT_EQ("[3, {cc0: 33}]", result->debug_row(2));
-        EXPECT_EQ("[4, {cc0: 44}]", result->debug_row(3));
+        EXPECT_EQ("[1, {cc1: NULL, cc0: 11}]", result->debug_row(0));
+        EXPECT_EQ("[2, {cc1: NULL, cc0: 22}]", result->debug_row(1));
+        EXPECT_EQ("[3, {cc1: NULL, cc0: 33}]", result->debug_row(2));
+        EXPECT_EQ("[4, {cc1: NULL, cc0: 44}]", result->debug_row(3));
     }
 }
 
@@ -1762,20 +1762,20 @@ TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {
 
         EXPECT_EQ(
                 "[1, [{c11: 2, c12: ['danny1', 'Smith2', 'Cruise']}, {c11: 4, c12: ['poal', 'alan', 'blossom']}], "
-                "[[1->{c22: 'hi1'}], [5->{c22: 'p4'}], [9->{c22: 'p5'}]]]",
+                "[[1->{c21: NULL, c22: 'hi1'}], [5->{c21: NULL, c22: 'p4'}], [9->{c21: NULL, c22: 'p5'}]]]",
                 result->debug_row(0));
         EXPECT_EQ(
-                "[2, [{c11: 3, c12: ['danny2', 'Smith3']}, {c11: 5, c12: ['poal', 'alan']}], [[2->{c22: 'hi2'}], "
-                "[6->{c22: 'p5'}]]]",
+                "[2, [{c11: 3, c12: ['danny2', 'Smith3']}, {c11: 5, c12: ['poal', 'alan']}], [[2->{c21: NULL, c22: 'hi2'}], "
+                "[6->{c21: NULL, c22: 'p5'}]]]",
                 result->debug_row(1));
-        EXPECT_EQ("[3, [{c11: 4, c12: ['danny3']}, {c11: 6, c12: ['poal']}], [[3->{c22: 'hi3'}], [7->{c22: 'p6'}]]]",
+        EXPECT_EQ("[3, [{c11: 4, c12: ['danny3']}, {c11: 6, c12: ['poal']}], [[3->{c21: NULL, c22: 'hi3'}], [7->{c21: NULL, c22: 'p6'}]]]",
                   result->debug_row(2));
         EXPECT_EQ(
-                "[4, [{c11: 5, c12: ['danny4', 'Smith5']}, {c11: 7, c12: ['poal', 'alan']}], [[4->{c22: 'hi4'}], "
-                "[8->{c22: 'p7'}]]]",
+                "[4, [{c11: 5, c12: ['danny4', 'Smith5']}, {c11: 7, c12: ['poal', 'alan']}], [[4->{c21: NULL, c22: 'hi4'}], "
+                "[8->{c21: NULL, c22: 'p7'}]]]",
                 result->debug_row(3));
         EXPECT_EQ(
-                "[5, [{c11: 6, c12: ['danny4']}, {c11: 7, c12: ['poal', 'alan']}], [[5->{c22: 'hi4'}], [9->{c22: "
+                "[5, [{c11: 6, c12: ['danny4']}, {c11: 7, c12: ['poal', 'alan']}], [[5->{c21: NULL, c22: 'hi4'}], [9->{c21: NULL, c22: "
                 "'p7'}]]]",
                 result->debug_row(4));
     }

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1403,16 +1403,16 @@ TEST_F(FileReaderTest, TestReadStructSubField) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(1024, chunk->num_rows());
 
-    EXPECT_EQ("[0, {f1: 0, f3: [0, 1, 2]}, 'a', [{e2: 'a'}, {e2: 'a'}], 'A']", chunk->debug_row(0));
-    EXPECT_EQ("[1, {f1: 1, f3: [1, 2, 3]}, 'a', [{e2: 'a'}, {e2: 'a'}], 'A']", chunk->debug_row(1));
-    EXPECT_EQ("[2, {f1: 2, f3: [2, 3, 4]}, 'a', [{e2: 'a'}, {e2: 'a'}], 'A']", chunk->debug_row(2));
-    EXPECT_EQ("[3, {f1: 3, f3: [3, 4, 5]}, 'c', [{e2: 'c'}, {e2: 'c'}], 'C']", chunk->debug_row(3));
-    EXPECT_EQ("[4, {f1: 4, f3: [4, 5, 6]}, 'c', [{e2: 'c'}, {e2: 'c'}], 'C']", chunk->debug_row(4));
-    EXPECT_EQ("[5, {f1: 5, f3: [5, 6, 7]}, 'c', [{e2: 'c'}, {e2: 'c'}], 'C']", chunk->debug_row(5));
-    EXPECT_EQ("[6, {f1: 6, f3: [6, 7, 8]}, 'a', [{e2: 'a'}, {e2: 'a'}], 'A']", chunk->debug_row(6));
-    EXPECT_EQ("[7, {f1: 7, f3: [7, 8, 9]}, 'a', [{e2: 'a'}, {e2: 'a'}], 'A']", chunk->debug_row(7));
-    EXPECT_EQ("[8, {f1: 8, f3: [8, 9, 10]}, 'a', [{e2: 'a'}, {e2: 'a'}], 'A']", chunk->debug_row(8));
-    EXPECT_EQ("[9, {f1: 9, f3: [9, 10, 11]}, 'a', [{e2: 'a'}, {e2: 'a'}], 'A']", chunk->debug_row(9));
+    EXPECT_EQ("[0, {f1: 0, f2: NULL, f3: [0, 1, 2]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']", chunk->debug_row(0));
+    EXPECT_EQ("[1, {f1: 1, f2: NULL, f3: [1, 2, 3]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']", chunk->debug_row(1));
+    EXPECT_EQ("[2, {f1: 2, f2: NULL, f3: [2, 3, 4]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']", chunk->debug_row(2));
+    EXPECT_EQ("[3, {f1: 3, f2: NULL, f3: [3, 4, 5]}, 'c', [{e1: NULL, e2: 'c'}, {e1: NULL, e2: 'c'}], 'C']", chunk->debug_row(3));
+    EXPECT_EQ("[4, {f1: 4, f2: NULL, f3: [4, 5, 6]}, 'c', [{e1: NULL, e2: 'c'}, {e1: NULL, e2: 'c'}], 'C']", chunk->debug_row(4));
+    EXPECT_EQ("[5, {f1: 5, f2: NULL, f3: [5, 6, 7]}, 'c', [{e1: NULL, e2: 'c'}, {e1: NULL, e2: 'c'}], 'C']", chunk->debug_row(5));
+    EXPECT_EQ("[6, {f1: 6, f2: NULL, f3: [6, 7, 8]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']", chunk->debug_row(6));
+    EXPECT_EQ("[7, {f1: 7, f2: NULL, f3: [7, 8, 9]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']", chunk->debug_row(7));
+    EXPECT_EQ("[8, {f1: 8, f2: NULL, f3: [8, 9, 10]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']", chunk->debug_row(8));
+    EXPECT_EQ("[9, {f1: 9, f2: NULL, f3: [9, 10, 11]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']", chunk->debug_row(9));
 
     //    for (int i = 0; i < 10; ++i) {
     //        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;

--- a/be/test/runtime/type_descriptor_test.cpp
+++ b/be/test/runtime/type_descriptor_test.cpp
@@ -459,9 +459,13 @@ TEST_F(TypeDescriptorTest, test_from_protobuf) {
         t_pb.mutable_types(0)->set_type(TTypeNodeType::STRUCT);
         t_pb.mutable_types(0)->add_struct_fields()->set_name("a");
         t_pb.mutable_types(0)->add_struct_fields()->set_name("b");
+        t_pb.mutable_types(0)->add_selected_fields(true);
+        t_pb.mutable_types(0)->add_selected_fields(true);
         t_pb.mutable_types(1)->set_type(TTypeNodeType::SCALAR);
         t_pb.mutable_types(1)->mutable_scalar_type()->set_type(TPrimitiveType::INT);
         t_pb.mutable_types(2)->set_type(TTypeNodeType::MAP);
+        t_pb.mutable_types(2)->add_selected_fields(true);
+        t_pb.mutable_types(2)->add_selected_fields(true);
         t_pb.mutable_types(3)->set_type(TTypeNodeType::SCALAR);
         t_pb.mutable_types(3)->mutable_scalar_type()->set_type(TPrimitiveType::INT);
         t_pb.mutable_types(4)->set_type(TTypeNodeType::SCALAR);
@@ -471,6 +475,8 @@ TEST_F(TypeDescriptorTest, test_from_protobuf) {
         ASSERT_TRUE(t.is_complex_type());
         ASSERT_FALSE(t.is_collection_type());
         ASSERT_EQ(LogicalType::TYPE_STRUCT, t.type);
+        ASSERT_TRUE(t.selected_fields[0]);
+        ASSERT_TRUE(t.selected_fields[1]);
         ASSERT_EQ(2, t.field_names.size());
         ASSERT_EQ("a", t.field_names[0]);
         ASSERT_EQ("b", t.field_names[1]);
@@ -478,6 +484,8 @@ TEST_F(TypeDescriptorTest, test_from_protobuf) {
         ASSERT_EQ(LogicalType::TYPE_INT, t.children[0].type);
         ASSERT_EQ(LogicalType::TYPE_MAP, t.children[1].type);
         ASSERT_EQ(2, t.children[1].children.size());
+        ASSERT_TRUE(t.children[1].selected_fields[0]);
+        ASSERT_TRUE(t.children[1].selected_fields[1]);
         ASSERT_EQ(LogicalType::TYPE_INT, t.children[1].children[0].type);
         ASSERT_EQ(LogicalType::TYPE_DOUBLE, t.children[1].children[1].type);
     }
@@ -588,6 +596,9 @@ TEST_F(TypeDescriptorTest, test_to_protobuf) {
         t.children[1].children[1].scale = 2;
         t.children[1].children[2].type = LogicalType::TYPE_VARCHAR;
         t.children[1].children[2].len = 10;
+        t.children[1].selected_fields.emplace_back(true);
+        t.children[1].selected_fields.emplace_back(true);
+        t.children[1].selected_fields.emplace_back(true);
 
         PTypeDesc t_pb = t.to_protobuf();
         ASSERT_EQ(6, t_pb.types().size());

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -48,6 +48,8 @@ message PTypeNode {
     optional PScalarType scalar_type = 2;
     // only used for structs; has struct_fields.size() corresponding child types
     repeated PStructField struct_fields = 3;
+    // only used for struct and map, mark which subfield will be loaded
+    repeated bool selected_fields = 4;
 };
 
 // A flattened representation of a tree of column types obtained by depth-first


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13595 #13589

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We will fill the default value into a column for not selected subfields.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
