### PR TITLE
[Refactor] Remove unused logicalPlan.canUsePipeline

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -103,9 +103,9 @@ public class OlapTableSink extends DataSink {
     // set after init called
     private TDataSink tDataSink;
 
-    private boolean enablePipelineLoad;
-    private TWriteQuorumType writeQuorum;
-    private boolean enableReplicatedStorage;
+    private final boolean enablePipelineLoad;
+    private final TWriteQuorumType writeQuorum;
+    private final boolean enableReplicatedStorage;
 
     public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
             TWriteQuorumType writeQuorum, boolean enableReplicatedStorage) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
@@ -110,10 +110,6 @@ public class ResultSink extends DataSink {
 
     @Override
     public boolean canUsePipeLine() {
-        return canUsePipeLine(sinkType);
-    }
-
-    public static boolean canUsePipeLine(TResultSinkType sinkType) {
-        return sinkType == TResultSinkType.MYSQL_PROTOCAL || sinkType == TResultSinkType.STATISTIC || sinkType == TResultSinkType.FILE || sinkType == TResultSinkType.VARIABLE;
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -43,9 +43,7 @@ public class DeletePlanner {
 
         // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
         boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
-        boolean canUsePipeline =
-                isEnablePipeline && DataSink.canTableSinkUsePipeline(deleteStatement.getTable()) &&
-                        logicalPlan.canUsePipeline();
+        boolean canUsePipeline = isEnablePipeline && DataSink.canTableSinkUsePipeline(deleteStatement.getTable());
         boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
         try {
             if (forceDisablePipeline) {
@@ -91,7 +89,7 @@ public class DeletePlanner {
             DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, table.writeQuorum(),
                     table.enableReplicatedStorage());
             execPlan.getFragments().get(0).setSink(dataSink);
-            if (isEnablePipeline && canUsePipeline) {
+            if (canUsePipeline) {
                 PlanFragment sinkFragment = execPlan.getFragments().get(0);
                 if (ConnectContext.get().getSessionVariable().getPipelineSinkDop() <= 0) {
                     sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -112,9 +112,7 @@ public class InsertPlanner {
 
         // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
         boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
-        boolean canUsePipeline =
-                isEnablePipeline && DataSink.canTableSinkUsePipeline(insertStmt.getTargetTable()) &&
-                        logicalPlan.canUsePipeline();
+        boolean canUsePipeline = isEnablePipeline && DataSink.canTableSinkUsePipeline(insertStmt.getTargetTable());
         boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
         try {
             if (forceDisablePipeline) {
@@ -176,7 +174,7 @@ public class InsertPlanner {
                 throw new SemanticException("Unknown table type " + insertStmt.getTargetTable().getType());
             }
 
-            if (isEnablePipeline && canUsePipeline && insertStmt.getTargetTable() instanceof OlapTable) {
+            if (canUsePipeline && insertStmt.getTargetTable() instanceof OlapTable) {
                 PlanFragment sinkFragment = execPlan.getFragments().get(0);
                 if (shuffleServiceEnable) {
                     // For shuffle insert into, we only support tablet sink dop = 1

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -40,8 +40,7 @@ public class UpdatePlanner {
 
         // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
         boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
-        boolean canUsePipeline = isEnablePipeline && DataSink.canTableSinkUsePipeline(updateStmt.getTable()) &&
-                logicalPlan.canUsePipeline();
+        boolean canUsePipeline = isEnablePipeline && DataSink.canTableSinkUsePipeline(updateStmt.getTable());
         boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
         try {
             if (forceDisablePipeline) {
@@ -86,7 +85,7 @@ public class UpdatePlanner {
                     table.enableReplicatedStorage());
             execPlan.getFragments().get(0).setSink(dataSink);
             execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
-            if (isEnablePipeline && canUsePipeline) {
+            if (canUsePipeline) {
                 PlanFragment sinkFragment = execPlan.getFragments().get(0);
                 if (ConnectContext.get().getSessionVariable().getPipelineSinkDop() <= 0) {
                     sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -182,8 +182,4 @@ public class OptExpression {
         }
         return sb.toString();
     }
-
-    public boolean canUsePipeLine() {
-        return op.canUsePipeLine() && inputs.stream().allMatch(OptExpression::canUsePipeLine);
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -112,10 +112,6 @@ public abstract class Operator {
         return Objects.hash(opType.ordinal(), limit, predicate, projection);
     }
 
-    public boolean canUsePipeLine() {
-        return true;
-    }
-
     public abstract static class Builder<O extends Operator, B extends Builder> {
         protected OperatorType opType;
         protected long limit = DEFAULT_LIMIT;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
@@ -73,11 +73,6 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
         return Objects.hash(super.hashCode(), aggColumnIdToNames);
     }
 
-    @Override
-    public boolean canUsePipeLine() {
-        return true;
-    }
-
     public static class Builder
             extends LogicalScanOperator.Builder<LogicalMetaScanOperator, LogicalMetaScanOperator.Builder> {
         private Map<Integer, String> aggColumnIdToNames;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalSchemaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalSchemaScanOperator.java
@@ -46,11 +46,6 @@ public class LogicalSchemaScanOperator extends LogicalScanOperator {
         return visitor.visitLogicalSchemaScan(this, context);
     }
 
-    @Override
-    public boolean canUsePipeLine() {
-        return true;
-    }
-
     public static class Builder
             extends LogicalScanOperator.Builder<LogicalSchemaScanOperator, LogicalSchemaScanOperator.Builder> {
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
@@ -62,9 +62,4 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
     public int hashCode() {
         return Objects.hash(super.hashCode(), aggColumnIdToNames);
     }
-
-    @Override
-    public boolean canUsePipeLine() {
-        return false;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSchemaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSchemaScanOperator.java
@@ -32,9 +32,4 @@ public class PhysicalSchemaScanOperator extends PhysicalScanOperator {
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalSchemaScan(optExpression, context);
     }
-
-    @Override
-    public boolean canUsePipeLine() {
-        return false;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/LogicalPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/LogicalPlan.java
@@ -33,8 +33,4 @@ public class LogicalPlan {
     public List<ColumnRefOperator> getCorrelation() {
         return correlation;
     }
-
-    public boolean canUsePipeline() {
-        return root.getRoot().canUsePipeLine();
-    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now, the pipeline engine supports all the operators, so remove the logic about `LogicalPlan::canUsePipeline` and simplify some judgment logic before optimizing about `forceDisablePipeline`.
- `StatementPlanner` can completely remove the logic about `forceDisablePipeline`.
- `InsertPlanner`, `DeletePlanner`, and `UpdatePlanner` need still retain `forceDisablePipeline`, because `OlapTableSink::canUsePipeLine` returns false when `Config.enable_pipeline_load` is false.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
