### PR TITLE
[BugFix] [Cherry-pick branch-2.4] Fix statistic_collect_parallel does not take effect because reuses the thread ConnectContext

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -889,8 +889,14 @@ public class StmtExecutor {
 
     private void executeAnalyze(AnalyzeStmt analyzeStmt, AnalyzeStatus analyzeStatus, Database db, OlapTable table) {
         StatisticExecutor statisticExecutor = new StatisticExecutor();
+
+        ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+        // from current session, may execute analyze stmt
+        statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
+                context.getSessionVariable().getStatisticCollectParallelism());
+
         if (analyzeStmt.getAnalyzeTypeDesc() instanceof AnalyzeHistogramDesc) {
-            statisticExecutor.collectStatistics(
+            statisticExecutor.collectStatistics(statsConnectCtx,
                     new HistogramStatisticsCollectJob(db, table, analyzeStmt.getColumnNames(),
                             StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE,
                             analyzeStmt.getProperties()),
@@ -898,7 +904,7 @@ public class StmtExecutor {
                     //Sync load cache, auto-populate column statistic cache after Analyze table manually
                     false);
         } else {
-            statisticExecutor.collectStatistics(
+            statisticExecutor.collectStatistics(statsConnectCtx,
                     StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table, null,
                             analyzeStmt.getColumnNames(),
                             analyzeStmt.isSample() ? StatsConstants.AnalyzeType.SAMPLE :
@@ -917,7 +923,8 @@ public class StmtExecutor {
                 .collect(Collectors.toList());
 
         GlobalStateMgr.getCurrentAnalyzeMgr().dropAnalyzeStatus(table.getId());
-        GlobalStateMgr.getCurrentAnalyzeMgr().dropBasicStatsMetaAndData(Sets.newHashSet(table.getId()));
+        GlobalStateMgr.getCurrentAnalyzeMgr()
+                .dropBasicStatsMetaAndData(StatisticUtils.buildConnectContext(), Sets.newHashSet(table.getId()));
         GlobalStateMgr.getCurrentStatisticStorage().expireColumnStatistics(table, columns);
     }
 
@@ -928,9 +935,11 @@ public class StmtExecutor {
                 .collect(Collectors.toList());
 
         GlobalStateMgr.getCurrentAnalyzeMgr().dropAnalyzeStatus(table.getId());
-        GlobalStateMgr.getCurrentAnalyzeMgr().dropHistogramStatsMetaAndData(Sets.newHashSet(table.getId()));
+        GlobalStateMgr.getCurrentAnalyzeMgr()
+                .dropHistogramStatsMetaAndData(StatisticUtils.buildConnectContext(), Sets.newHashSet(table.getId()));
         GlobalStateMgr.getCurrentStatisticStorage().expireHistogramStatistics(table.getId(), columns);
     }
+
 
     private void handleKillAnalyzeStmt() {
         KillAnalyzeStmt killAnalyzeStmt = (KillAnalyzeStmt) parsedStmt;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
@@ -16,8 +16,10 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatisticExecutor;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TStatisticData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,8 +47,10 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
                                                      @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
             try {
+                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+                connectContext.setThreadLocalInfo();
                 List<TStatisticData> statisticData =
-                        queryHistogramStatistics(cacheKey.tableId, Lists.newArrayList(cacheKey.column));
+                        queryHistogramStatistics(connectContext, cacheKey.tableId, Lists.newArrayList(cacheKey.column));
                 // check TStatisticData is not empty, There may be no such column Statistics in BE
                 if (!statisticData.isEmpty()) {
                     return Optional.of(convert2Histogram(statisticData.get(0)));
@@ -74,7 +78,10 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
                     columns.add(key.column);
                     result.put(key, Optional.empty());
                 }
-                List<TStatisticData> histogramStatsDataList = queryHistogramStatistics(tableId, columns);
+                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+                connectContext.setThreadLocalInfo();
+
+                List<TStatisticData> histogramStatsDataList = queryHistogramStatistics(connectContext, tableId, columns);
                 for (TStatisticData histogramStatsData : histogramStatsDataList) {
                     Histogram histogram = convert2Histogram(histogramStatsData);
                     result.put(new ColumnStatsCacheKey(histogramStatsData.tableId, histogramStatsData.columnName),
@@ -97,8 +104,8 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
         return asyncLoad(key, executor);
     }
 
-    public List<TStatisticData> queryHistogramStatistics(long tableId, List<String> column) {
-        return statisticExecutor.queryHistogram(tableId, column);
+    public List<TStatisticData> queryHistogramStatistics(ConnectContext context, long tableId, List<String> column) {
+        return statisticExecutor.queryHistogram(context, tableId, column);
     }
 
     private Histogram convert2Histogram(TStatisticData statisticData) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeJob.java
@@ -6,6 +6,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatsConstants.AnalyzeType;
 import com.starrocks.statistic.StatsConstants.ScheduleStatus;
@@ -120,7 +121,7 @@ public class AnalyzeJob implements Writable {
         return properties;
     }
 
-    public void run(StatisticExecutor statisticExecutor) {
+    public void run(ConnectContext statsConnectContext, StatisticExecutor statisticExecutor) {
         setStatus(StatsConstants.ScheduleStatus.RUNNING);
         GlobalStateMgr.getCurrentAnalyzeMgr().updateAnalyzeJobWithoutLog(this);
         List<StatisticsCollectJob> statisticsCollectJobList =
@@ -134,7 +135,7 @@ public class AnalyzeJob implements Writable {
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
             GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
 
-            statisticExecutor.collectStatistics(statsJob, analyzeStatus, true);
+            statisticExecutor.collectStatistics(statsConnectContext, statsJob, analyzeStatus, true);
             if (analyzeStatus.getStatus().equals(StatsConstants.ScheduleStatus.FAILED)) {
                 setStatus(StatsConstants.ScheduleStatus.FAILED);
                 setWorkTime(LocalDateTime.now());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -60,7 +60,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         for (String column : columns) {
             String sql = buildCollectMCV(db, table, mcvSize, column);
             StatisticExecutor statisticExecutor = new StatisticExecutor();
-            List<TStatisticData> mcv = statisticExecutor.queryMCV(sql);
+            List<TStatisticData> mcv = statisticExecutor.queryMCV(context, sql);
 
             Map<String, String> mostCommonValues = new HashMap<>();
             for (TStatisticData tStatisticData : mcv) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.LeaderDaemon;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatsConstants.AnalyzeType;
 import com.starrocks.statistic.StatsConstants.ScheduleStatus;
@@ -58,13 +59,17 @@ public class StatisticAutoCollector extends LeaderDaemon {
                 analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
                 GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
 
-                statisticExecutor.collectStatistics(statsJob, analyzeStatus, true);
+                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                statsConnectCtx.setThreadLocalInfo();
+                statisticExecutor.collectStatistics(statsConnectCtx, statsJob, analyzeStatus, true);
             }
         } else {
             List<AnalyzeJob> allAnalyzeJobs = GlobalStateMgr.getCurrentAnalyzeMgr().getAllAnalyzeJobList();
             allAnalyzeJobs.sort((o1, o2) -> Long.compare(o2.getId(), o1.getId()));
             for (AnalyzeJob analyzeJob : allAnalyzeJobs) {
-                analyzeJob.run(statisticExecutor);
+                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                statsConnectCtx.setThreadLocalInfo();
+                analyzeJob.run(statsConnectCtx, statisticExecutor);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -45,18 +45,13 @@ public class StatisticUtils {
             .add("starrocks_monitor")
             .add("information_schema").build();
 
+
     public static ConnectContext buildConnectContext() {
         ConnectContext context = new ConnectContext();
         // Note: statistics query does not register query id to QeProcessorImpl::coordinatorMap,
         // but QeProcessorImpl::reportExecStatus will check query id,
         // So we must disable report query status from BE to FE
         context.getSessionVariable().setReportSuccess(false);
-        if (null != ConnectContext.get()) {
-            // from current session, may execute analyze stmt
-            context.getSessionVariable().setStatisticCollectParallelism(
-                    ConnectContext.get().getSessionVariable().getStatisticCollectParallelism());
-        }
-
         context.getSessionVariable().setParallelExecInstanceNum(1);
         context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
         context.getSessionVariable().setEnablePipelineEngine(true);
@@ -66,8 +61,8 @@ public class StatisticUtils {
         context.setQualifiedUser(UserIdentity.ROOT.getQualifiedUser());
         context.setQueryId(UUIDUtil.genUUID());
         context.setExecutionId(UUIDUtil.toTUniqueId(context.getQueryId()));
-        context.setThreadLocalInfo();
         context.setStartTime();
+
         return context;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -22,6 +22,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.common.ErrorType;
@@ -111,7 +112,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
             "table_id", "column_name"
     );
 
-    private boolean createSampleStatisticsTable() {
+    private boolean createSampleStatisticsTable(ConnectContext context) {
         LOG.info("create statistics table start");
         TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
                 StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
@@ -128,7 +129,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 properties,
                 null,
                 "");
-        Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
+
+        Analyzer.analyze(stmt, context);
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
         } catch (DdlException e) {
@@ -140,7 +142,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         return checkTableExist(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
     }
 
-    private boolean createFullStatisticsTable() {
+    private boolean createFullStatisticsTable(ConnectContext context) {
         LOG.info("create statistics table v2 start");
         TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
                 StatsConstants.FULL_STATISTICS_TABLE_NAME);
@@ -157,7 +159,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 properties,
                 null,
                 "");
-        Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
+   
+        Analyzer.analyze(stmt, context);
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
         } catch (DdlException e) {
@@ -169,7 +172,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         return checkTableExist(StatsConstants.FULL_STATISTICS_TABLE_NAME);
     }
 
-    private boolean createHistogramStatisticsTable() {
+    private boolean createHistogramStatisticsTable(ConnectContext context) {
         LOG.info("create statistics table v2 start");
         TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
                 StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME);
@@ -186,7 +189,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 properties,
                 null,
                 "");
-        Analyzer.analyze(stmt, StatisticUtils.buildConnectContext());
+        
+        Analyzer.analyze(stmt, context);
         try {
             GlobalStateMgr.getCurrentState().createTable(stmt);
         } catch (DdlException e) {
@@ -243,12 +247,15 @@ public class StatisticsMetaManager extends LeaderDaemon {
     }
 
     private boolean createTable(String tableName) {
+        ConnectContext context = StatisticUtils.buildConnectContext();
+        context.setThreadLocalInfo();
+
         if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
-            return createSampleStatisticsTable();
+            return createSampleStatisticsTable(context);
         } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
-            return createFullStatisticsTable();
+            return createFullStatisticsTable(context);
         } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
-            return createHistogramStatisticsTable();
+            return createHistogramStatisticsTable(context);
         } else {
             throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -25,6 +25,7 @@ public class StatisticExecutorTest extends PlanTestBase {
                 Maps.newHashMap()));
 
         Assert.assertThrows(IllegalStateException.class,
-                () -> statisticExecutor.queryStatisticSync(db.getId(), olapTable.getId(), Lists.newArrayList("foo", "bar")));
+                () -> statisticExecutor.queryStatisticSync(
+                        StatisticUtils.buildConnectContext(), db.getId(), olapTable.getId(), Lists.newArrayList("foo", "bar")));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -104,4 +104,14 @@ public class StatisticsExecutorTest extends PlanTestBase {
 
         collectJob.collectStatisticSync(sql, context);
     }
+
+    @Test
+    public void testSessionVariableInStats() {
+        ConnectContext context = new ConnectContext();
+        context.getSessionVariable().setStatisticCollectParallelism(5);
+        context.setThreadLocalInfo();
+
+        ConnectContext statsContext = StatisticUtils.buildConnectContext();
+        Assert.assertEquals(1, statsContext.getSessionVariable().getParallelExecInstanceNum());
+    }
 }


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
