### PR TITLE
[Feature] Support configure rocksdb meta column family options.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -895,4 +895,6 @@ CONF_Int32(exception_stack_level, "1");
 CONF_String(exception_stack_white_list, "std::");
 CONF_String(exception_stack_black_list, "apache::thrift::,ue2::,arangodb::");
 
+CONF_Int32(rocksdb_block_cache, "512"); // 512MB
+
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -895,8 +895,6 @@ CONF_Int32(exception_stack_level, "1");
 CONF_String(exception_stack_white_list, "std::");
 CONF_String(exception_stack_black_list, "apache::thrift::,ue2::,arangodb::");
 
-CONF_String(rocksdb_meta_cf_opts_string,
-            "prefix_extractor=rocksdb.FixedPrefix.4;compression=kSnappyCompression;block_based_table_factory={block_"
-            "cache=128M}");
+CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache=128M}");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -895,6 +895,8 @@ CONF_Int32(exception_stack_level, "1");
 CONF_String(exception_stack_white_list, "std::");
 CONF_String(exception_stack_black_list, "apache::thrift::,ue2::,arangodb::");
 
-CONF_Int32(rocksdb_block_cache, "512"); // 512MB
+CONF_String(rocksdb_meta_cf_opts_string,
+            "prefix_extractor=rocksdb.FixedPrefix.4;compression=kSnappyCompression;block_based_table_factory={block_"
+            "cache=128M}");
 
 } // namespace starrocks::config

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -74,7 +74,8 @@ Status KVStore::init(bool read_only) {
     std::string db_path = _root_path + META_POSTFIX;
 
     ColumnFamilyOptions meta_cf_options;
-    rocksdb::GetColumnFamilyOptionsFromString(meta_cf_options, config::rocksdb_meta_cf_opts_string, &meta_cf_options);
+    RETURN_IF_ERROR(rocksdb::GetColumnFamilyOptionsFromString(meta_cf_options, config::rocksdb_cf_options_string,
+                                                              &meta_cf_options));
     // The index of each column family must be consistent with the enum `ColumnFamilyIndex`
     // defined in olap_define.h
     std::vector<ColumnFamilyDescriptor> cf_descs(NUM_COLUMN_FAMILY_INDEX);
@@ -84,6 +85,8 @@ Status KVStore::init(bool read_only) {
     cf_descs[1].options.compression = rocksdb::kSnappyCompression;
     cf_descs[2].name = META_COLUMN_FAMILY;
     cf_descs[2].options = meta_cf_options;
+    cf_descs[2].options.prefix_extractor.reset(NewFixedPrefixTransform(PREFIX_LENGTH));
+    cf_descs[2].options.compression = rocksdb::kSnappyCompression;
     static_assert(NUM_COLUMN_FAMILY_INDEX == 3);
 
     rocksdb::Status s;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14395

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The default rocksdb block cache size is 8M, which may be too small. It should be configured.
just like block cache size, other column family options should also be configured.
This PR adds a configuration in be.conf to deliver a string to rocksdb `GetColumnFamilyOptionsFromString` API to parse.
Besides, prefix_extractor and compression are fixed options in case of incorrect.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
