### PR TITLE
[BugFix][Cherry-pick 2.3] Fix missing hack NULL_TYPE for field child_type (#14308)

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -339,17 +339,9 @@
         + [get_json_double](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/get_json_double.md)
         + [get_json_int](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/get_json_int.md)
         + [get_json_string](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/get_json_string.md)
-<<<<<<< HEAD
         + [JSON_EACH](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_each.md)
         + [JSON_QUERY](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_query.md)
         + [JSON_EXISTS](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_exists.md)
-=======
-        + [json_each](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_each.md)
-        + [json_exists](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_exists.md)
-        + [json_length](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_length.md)
-        + [json_keys](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_keys.md)
-        + [json_query](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_query.md)
->>>>>>> 8926c9219 ([Doc] reorder functions and fix bugs (#14305))
     + Bitmap Functions
       + [bitmap_and](./sql-reference/sql-functions/bitmap-functions/bitmap_and.md)
       + [bitmap_or](./sql-reference/sql-functions/bitmap-functions/bitmap_or.md)

--- a/docs/sql-reference/sql-functions/cast.md
+++ b/docs/sql-reference/sql-functions/cast.md
@@ -4,13 +4,7 @@
 
 Converts an input into the specified type. For example, `cast (input as BIGINT)` converts the input into a BIGINT value.
 
-<<<<<<< HEAD
 ### Syntax
-=======
-From v2.4, StarRocks supports conversion to the ARRAY type.
-
-## Syntax
->>>>>>> 8926c9219 ([Doc] reorder functions and fix bugs (#14305))
 
 ```Haskell
 cast (input as type)

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
@@ -924,6 +925,10 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         msg.output_scale = getOutputScale();
         msg.setIs_monotonic(isMonotonic());
         toThrift(msg);
+        // Echoes the above hack process
+        if (PrimitiveType.NULL_TYPE.toThrift().equals(msg.child_type)) {
+            msg.child_type = PrimitiveType.BOOLEAN.toThrift();
+        }
         container.addToNodes(msg);
         for (Expr child : children) {
             child.treeToThriftHelper(container);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -409,4 +409,20 @@ public class CTEPlanTest extends PlanTestBase {
                 "\n" +
                 "  2:AGGREGATE (update finalize)\n");
     }
+
+    @Test
+    public void testNullTypeHack() throws Exception {
+        String sql = "WITH cte_1 AS (\n" +
+                "  SELECT null v1\n" +
+                ")\n" +
+                "SELECT  \n" +
+                "  CASE \n" +
+                "    WHEN a.v1 = b.v1 THEN 1 \n" +
+                "    ELSE -1 \n" +
+                "  END IS_OK\n" +
+                "FROM cte_1 a, cte_1 b";
+
+        String plan = getThriftPlan(sql);
+        assertNotContains(plan, "NULL_TYPE");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
