### PR TITLE
[BugFix] avoid accumulate too many chunks in NLJ

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -488,6 +488,11 @@ StatusOr<vectorized::ChunkPtr> NLJoinProbeOperator::pull_chunk(RuntimeState* sta
         if (ChunkPtr res = _output_accumulator.pull()) {
             return res;
         }
+
+        if (_output_accumulator.reach_limit()) {
+            _output_accumulator.finalize();
+            return _output_accumulator.pull();
+        }
     }
     _output_accumulator.finalize();
 

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -427,6 +427,7 @@ void ChunkAccumulator::set_desired_size(size_t desired_size) {
 void ChunkAccumulator::reset() {
     _output.clear();
     _tmp_chunk.reset();
+    _accumulate_count = 0;
 }
 
 Status ChunkAccumulator::push(vectorized::ChunkPtr&& chunk) {
@@ -450,6 +451,7 @@ Status ChunkAccumulator::push(vectorized::ChunkPtr&& chunk) {
         }
         start += need_rows;
     }
+    _accumulate_count++;
     return Status::OK();
 }
 
@@ -457,12 +459,18 @@ bool ChunkAccumulator::empty() const {
     return _output.empty();
 }
 
+bool ChunkAccumulator::reach_limit() const {
+    return _accumulate_count >= kAccumulateLimit;
+}
+
 vectorized::ChunkPtr ChunkAccumulator::pull() {
     if (!_output.empty()) {
         auto res = std::move(_output.front());
         _output.pop_front();
+        _accumulate_count = 0;
         return res;
     }
+    _accumulate_count = 0;
     return nullptr;
 }
 
@@ -470,6 +478,7 @@ void ChunkAccumulator::finalize() {
     if (_tmp_chunk) {
         _output.emplace_back(std::move(_tmp_chunk));
     }
+    _accumulate_count = 0;
 }
 
 void ChunkPipelineAccumulator::push(const vectorized::ChunkPtr& chunk) {

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -77,19 +77,24 @@ public:
 // Accumulate small chunk into desired size
 class ChunkAccumulator {
 public:
+    // Avoid accumulate too many chunks in case that chunks' selectivity is very low
+    static inline size_t kAccumulateLimit = 64;
+
     ChunkAccumulator() = default;
     ChunkAccumulator(size_t desired_size);
     void set_desired_size(size_t desired_size);
     void reset();
-    Status push(vectorized::ChunkPtr&& chunk);
     void finalize();
     bool empty() const;
+    bool reach_limit() const;
+    Status push(vectorized::ChunkPtr&& chunk);
     vectorized::ChunkPtr pull();
 
 private:
     size_t _desired_size;
     vectorized::ChunkPtr _tmp_chunk;
     std::deque<vectorized::ChunkPtr> _output;
+    size_t _accumulate_count = 0;
 };
 
 class ChunkPipelineAccumulator {

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -294,6 +294,16 @@ TEST_F(ChunkHelperTest, Accumulator) {
         output_rows += output->num_rows();
     }
     EXPECT_EQ(input_rows, output_rows);
+
+    // push empty chunks
+    for (int i = 0; i < ChunkAccumulator::kAccumulateLimit; i++) {
+        auto chunk = ChunkHelper::new_chunk(*tuple_desc, 1);
+        accumulator.push(std::move(chunk));
+    }
+    EXPECT_TRUE(accumulator.reach_limit());
+    auto output = accumulator.pull();
+    EXPECT_EQ(nullptr, output);
+    EXPECT_FALSE(accumulator.reach_limit());
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14366

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

- A false predicate would case NestLoopJoin accumulate a lot of empty chunk but not return, affects pipeline scheduling and workgroup isolation
- Optimization: make NLJ accumulate at most `64` chunks in `ChunkAccumulator`


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
