### PR TITLE
[Feature] support ignore nulls for first_value and last_value

### DIFF
--- a/be/src/exec/vectorized/analytor.cpp
+++ b/be/src/exec/vectorized/analytor.cpp
@@ -172,9 +172,20 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
             // we should always use nullable aggregate function.
             is_input_nullable = true;
             VLOG_ROW << "try get function " << fn.name.function_name << " arg_type.type " << arg_type.type
-                     << " return_type.type " << return_type.type;
-            auto* func = vectorized::get_window_function(fn.name.function_name, arg_type.type, return_type.type,
-                                                         is_input_nullable, fn.binary_type, state->func_version());
+                     << " return_type.type " << return_type.type << " ignore nulls: " << fn.ignore_nulls;
+            const vectorized::AggregateFunction* func = nullptr;
+            if (fn.ignore_nulls) {
+                DCHECK(fn.name.function_name == "first_value" || fn.name.function_name == "last_value");
+                std::stringstream function_name;
+                // "in" means "ignore nulls", we use first_value_in/last_value_in instead of first_value/last_value
+                // to find right AggregateFunction to support ignore nulls.
+                function_name << fn.name.function_name << "_in";
+                func = vectorized::get_window_function(function_name.str(), arg_type.type, return_type.type,
+                                                       is_input_nullable, fn.binary_type, state->func_version());
+            } else {
+                func = vectorized::get_window_function(fn.name.function_name, arg_type.type, return_type.type,
+                                                       is_input_nullable, fn.binary_type, state->func_version());
+            }
             if (func == nullptr) {
                 return Status::InternalError(
                         strings::Substitute("Invalid window function plan: $0", fn.name.function_name));

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -171,14 +171,14 @@ public:
 
     static AggregateFunctionPtr MakeNtileWindowFunction();
 
-    template <LogicalType PT>
+    template <LogicalType PT, bool ignoreNulls>
     static AggregateFunctionPtr MakeFirstValueWindowFunction() {
-        return std::make_shared<FirstValueWindowFunction<PT>>();
+        return std::make_shared<FirstValueWindowFunction<PT, ignoreNulls>>();
     }
 
-    template <LogicalType PT>
+    template <LogicalType PT, bool ignoreNulls>
     static AggregateFunctionPtr MakeLastValueWindowFunction() {
-        return std::make_shared<LastValueWindowFunction<PT>>();
+        return std::make_shared<LastValueWindowFunction<PT, ignoreNulls>>();
     }
 
     template <LogicalType PT>

--- a/be/src/exprs/agg/factory/aggregate_resolver_window.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_window.cpp
@@ -25,10 +25,16 @@ struct WindowDispatcher {
     template <LogicalType pt>
     void operator()(AggregateFuncResolver* resolver) {
         if constexpr (pt_is_aggregate<pt> || pt_is_string<pt> || pt_is_hll<pt> || pt_is_object<pt>) {
-            resolver->add_aggregate_mapping_notnull<pt, pt>("first_value", true,
-                                                            AggregateFactory::MakeFirstValueWindowFunction<pt>());
+            resolver->add_aggregate_mapping_notnull<pt, pt>(
+                    "first_value", true, AggregateFactory::MakeFirstValueWindowFunction<pt, false>());
+            // use first_value_in for first_value with ingnore nulls.
+            resolver->add_aggregate_mapping_notnull<pt, pt>("first_value_in", true,
+                                                            AggregateFactory::MakeFirstValueWindowFunction<pt, true>());
             resolver->add_aggregate_mapping_notnull<pt, pt>("last_value", true,
-                                                            AggregateFactory::MakeLastValueWindowFunction<pt>());
+                                                            AggregateFactory::MakeLastValueWindowFunction<pt, false>());
+            // use last_value_in for last_value with ingnore nulls.
+            resolver->add_aggregate_mapping_notnull<pt, pt>("last_value_in", true,
+                                                            AggregateFactory::MakeLastValueWindowFunction<pt, true>());
             resolver->add_aggregate_mapping_notnull<pt, pt>("lead", true,
                                                             AggregateFactory::MakeLeadLagWindowFunction<pt>());
             resolver->add_aggregate_mapping_notnull<pt, pt>("lag", true,

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -305,7 +305,7 @@ struct FirstValueState {
     bool is_null = false;
 };
 
-template <LogicalType PT, typename T = RunTimeCppType<PT>, typename = guard::Guard>
+template <LogicalType PT, bool ignoreNulls, typename T = RunTimeCppType<PT>, typename = guard::Guard>
 class FirstValueWindowFunction final : public ValueWindowFunction<PT, FirstValueState<PT>, T> {
     using InputColumnType = typename ValueWindowFunction<PT, FirstValueState<PT>, T>::InputColumnType;
 
@@ -318,8 +318,14 @@ class FirstValueWindowFunction final : public ValueWindowFunction<PT, FirstValue
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
-        if (this->data(state).has_value) {
-            return;
+        if constexpr (ignoreNulls) {
+            if (!this->data(state).is_null && this->data(state).has_value) {
+                return;
+            }
+        } else {
+            if (this->data(state).has_value) {
+                return;
+            }
         }
 
         // For cases like: rows between 2 preceding and 1 preceding
@@ -339,6 +345,7 @@ class FirstValueWindowFunction final : public ValueWindowFunction<PT, FirstValue
         const Column* data_column = ColumnHelper::get_data_column(columns[0]);
         const InputColumnType* column = down_cast<const InputColumnType*>(data_column);
         this->data(state).value = column->get_data()[frame_start];
+        this->data(state).is_null = false;
         this->data(state).has_value = true;
     }
 
@@ -350,35 +357,45 @@ class FirstValueWindowFunction final : public ValueWindowFunction<PT, FirstValue
     std::string get_name() const override { return "nullable_first_value"; }
 };
 
-template <LogicalType PT, typename = guard::Guard>
+template <LogicalType PT, bool ignoreNulls, typename = guard::Guard>
 struct LastValueState {
     using T = RunTimeCppType<PT>;
     T value;
-    bool is_null = false;
+    bool is_null = ignoreNulls;
 };
 
-template <LogicalType PT, typename T = RunTimeCppType<PT>, typename = guard::Guard>
-class LastValueWindowFunction final : public ValueWindowFunction<PT, LastValueState<PT>, T> {
+template <LogicalType PT, bool ignoreNulls, typename T = RunTimeCppType<PT>, typename = guard::Guard>
+class LastValueWindowFunction final : public ValueWindowFunction<PT, LastValueState<PT, ignoreNulls>, T> {
     using InputColumnType = typename ValueWindowFunction<PT, FirstValueState<PT>, T>::InputColumnType;
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).value = {};
-        this->data(state).is_null = false;
+        this->data(state).is_null = ignoreNulls;
     }
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
-        // For cases like: rows between 2 preceding and 1 preceding
-        // If frame_start ge frame_end, means the frame is empty
-        if (frame_start >= frame_end) {
-            this->data(state).is_null = true;
-            return;
-        }
+        if constexpr (!ignoreNulls) {
+            // For cases like: rows between 2 preceding and 1 preceding
+            // If frame_start ge frame_end, means the frame is empty
+            if (frame_start >= frame_end) {
+                this->data(state).is_null = true;
+                return;
+            }
 
-        if (columns[0]->is_null(frame_end - 1)) {
-            this->data(state).is_null = true;
-            return;
+            if (columns[0]->is_null(frame_end - 1)) {
+                this->data(state).is_null = true;
+                return;
+            }
+        } else {
+            if (frame_start >= frame_end) {
+                return;
+            }
+
+            if (columns[0]->is_null(frame_end - 1)) {
+                return;
+            }
         }
 
         this->data(state).is_null = false;
@@ -464,8 +481,9 @@ struct FirstValueState<PT, StringPTGuard<PT>> {
     Slice slice() const { return {buffer.data(), buffer.size()}; }
 };
 
-template <LogicalType PT>
-class FirstValueWindowFunction<PT, Slice, StringPTGuard<PT>> final : public WindowFunction<FirstValueState<PT>> {
+template <LogicalType PT, bool ignoreNulls>
+class FirstValueWindowFunction<PT, ignoreNulls, Slice, StringPTGuard<PT>> final
+        : public WindowFunction<FirstValueState<PT>> {
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).buffer.clear();
         this->data(state).has_value = false;
@@ -475,8 +493,14 @@ class FirstValueWindowFunction<PT, Slice, StringPTGuard<PT>> final : public Wind
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
-        if (this->data(state).has_value) {
-            return;
+        if constexpr (ignoreNulls) {
+            if (!this->data(state).is_null && this->data(state).has_value) {
+                return;
+            }
+        } else {
+            if (this->data(state).has_value) {
+                return;
+            }
         }
 
         if (columns[0]->is_null(frame_start)) {
@@ -490,6 +514,7 @@ class FirstValueWindowFunction<PT, Slice, StringPTGuard<PT>> final : public Wind
         Slice slice = column->get_slice(frame_start);
         const auto* p = reinterpret_cast<const uint8_t*>(slice.data);
         this->data(state).buffer.insert(this->data(state).buffer.end(), p, p + slice.size);
+        this->data(state).is_null = false;
         this->data(state).has_value = true;
     }
 
@@ -501,36 +526,40 @@ class FirstValueWindowFunction<PT, Slice, StringPTGuard<PT>> final : public Wind
     std::string get_name() const override { return "nullable_first_value"; }
 };
 
-template <LogicalType PT>
-struct LastValueState<PT, StringPTGuard<PT>> {
+template <LogicalType PT, bool ignoreNulls>
+struct LastValueState<PT, ignoreNulls, StringPTGuard<PT>> {
     Buffer<uint8_t> buffer;
-    bool is_null = false;
+    bool is_null = ignoreNulls;
 
     Slice slice() const { return {buffer.data(), buffer.size()}; }
 };
 
-template <LogicalType PT>
-class LastValueWindowFunction<PT, Slice, StringPTGuard<PT>> final : public WindowFunction<LastValueState<PT>> {
+template <LogicalType PT, bool ignoreNulls>
+class LastValueWindowFunction<PT, ignoreNulls, Slice, StringPTGuard<PT>> final
+        : public WindowFunction<LastValueState<PT, ignoreNulls>> {
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).buffer.clear();
-        this->data(state).is_null = false;
+        this->data(state).is_null = ignoreNulls;
     }
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
-        if (columns[0]->is_null(frame_end - 1)) {
-            this->data(state).is_null = true;
-            return;
-        }
-        this->data(state).is_null = false;
+        if (!columns[0]->is_null(frame_end - 1)) {
+            this->data(state).is_null = false;
 
-        const Column* data_column = ColumnHelper::get_data_column(columns[0]);
-        const auto* column = down_cast<const BinaryColumn*>(data_column);
-        Slice slice = column->get_slice(frame_end - 1);
-        const auto* p = reinterpret_cast<const uint8_t*>(slice.data);
-        this->data(state).buffer.clear();
-        this->data(state).buffer.insert(this->data(state).buffer.end(), p, p + slice.size);
+            const Column* data_column = ColumnHelper::get_data_column(columns[0]);
+            const auto* column = down_cast<const BinaryColumn*>(data_column);
+            Slice slice = column->get_slice(frame_end - 1);
+            const auto* p = reinterpret_cast<const uint8_t*>(slice.data);
+            this->data(state).buffer.clear();
+            this->data(state).buffer.insert(this->data(state).buffer.end(), p, p + slice.size);
+        } else {
+            if constexpr (!ignoreNulls) {
+                this->data(state).is_null = true;
+                return;
+            }
+        }
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -65,6 +65,7 @@ import com.starrocks.sql.plan.ScalarOperatorToExpr;
 import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprOpcode;
+import com.starrocks.thrift.TFunction;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -189,6 +190,9 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     // The function to call. This can either be a scalar or aggregate function.
     // Set in analyze().
     protected Function fn;
+
+    // Ignore nulls.
+    private boolean ignoreNulls = false;
 
     // Cached value of IsConstant(), set during analyze() and valid if isAnalyzed_ is true.
     private boolean isConstant_;
@@ -760,7 +764,9 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         msg.setHas_nullable_child(hasNullableChild());
         msg.setIs_nullable(isNullable());
         if (fn != null) {
-            msg.setFn(fn.toThrift());
+            TFunction tfn = fn.toThrift();
+            tfn.setIgnore_nulls(getIgnoreNulls());
+            msg.setFn(tfn);
             if (fn.hasVarArgs()) {
                 msg.setVararg_start_idx(fn.getNumArgs() - 1);
             }
@@ -1341,6 +1347,14 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     public void setFn(Function fn) {
         this.fn = fn;
+    }
+
+    public void setIgnoreNulls(boolean ignoreNulls) {
+        this.ignoreNulls = ignoreNulls;
+    }
+
+    public boolean getIgnoreNulls() {
+        return ignoreNulls;
     }
 
     // only the first/last one can be lambda functions.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -48,6 +48,9 @@ public class CallOperator extends ScalarOperator {
     // The flag for distinct function
     private final boolean isDistinct;
 
+    // Ignore nulls.
+    private boolean ignoreNulls = false;
+
     public CallOperator(String fnName, Type returnType, List<ScalarOperator> arguments) {
         this(fnName, returnType, arguments, null);
     }
@@ -63,6 +66,14 @@ public class CallOperator extends ScalarOperator {
         this.arguments = new ArrayList<>(requireNonNull(arguments, "arguments is null"));
         this.fn = fn;
         this.isDistinct = isDistinct;
+    }
+
+    public void setIgnoreNulls(boolean ignoreNulls) {
+        this.ignoreNulls = ignoreNulls;
+    }
+
+    public boolean getIgnoreNulls() {
+        return ignoreNulls;
     }
 
     public String getFnName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -649,12 +649,14 @@ public final class SqlToScalarOperatorTranslator {
                     .stream()
                     .map(child -> visit(child, context.clone(node)))
                     .collect(Collectors.toList());
-            return new CallOperator(
+            CallOperator callOperator = new CallOperator(
                     functionCallExpr.getFnName().getFunction(),
                     functionCallExpr.getType(),
                     arguments,
                     functionCallExpr.getFn(),
                     functionCallExpr.getParams().isDistinct());
+            callOperator.setIgnoreNulls(functionCallExpr.getIgnoreNulls());
+            return callOperator;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4545,8 +4545,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitWindowFunction(StarRocksParser.WindowFunctionContext context) {
         if (WINDOW_FUNCTION_SET.contains(context.name.getText().toLowerCase())) {
-            return new FunctionCallExpr(context.name.getText().toLowerCase(),
+            FunctionCallExpr functionCallExpr = new FunctionCallExpr(context.name.getText().toLowerCase(),
                     new FunctionParams(false, visit(context.expression(), Expr.class)));
+            functionCallExpr.setIgnoreNulls(context.ignoreNulls() != null);
+            return functionCallExpr;
         }
         throw new ParsingException("Unknown window function " + context.name.getText());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1809,8 +1809,8 @@ windowFunction
     | name = NTILE  '(' expression? ')'
     | name = LEAD  '(' (expression (',' expression)*)? ')'
     | name = LAG '(' (expression (',' expression)*)? ')'
-    | name = FIRST_VALUE '(' (expression (',' expression)*)? ')'
-    | name = LAST_VALUE '(' (expression (',' expression)*)? ')'
+    | name = FIRST_VALUE '(' (expression ignoreNulls? (',' expression)*)? ')'
+    | name = LAST_VALUE '(' (expression ignoreNulls? (',' expression)*)? ')'
     ;
 
 whenClause
@@ -1823,6 +1823,10 @@ over
         (ORDER BY sortItem (',' sortItem)*)?
         windowFrame?
       ')'
+    ;
+
+ignoreNulls
+    : IGNORE NULLS
     ;
 
 windowFrame

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -481,6 +481,7 @@ public class ScalarOperatorToExpr {
                     }
                     Preconditions.checkNotNull(call.getFunction());
                     callExpr.setFn(call.getFunction());
+                    callExpr.setIgnoreNulls(call.getIgnoreNulls());
                     break;
             }
             callExpr.setType(call.getType());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -456,7 +456,8 @@ public class ExpressionTest extends PlanTestBase {
         String plan = getThriftPlan(sql);
         Assert.assertTrue(
                 plan.contains("signature:unix_timestamp(VARCHAR, VARCHAR), scalar_fn:TScalarFunction(symbol:), " +
-                        "id:0, fid:50303, could_apply_dict_optimize:false), has_nullable_child:false, is_nullable:true"));
+                        "id:0, fid:50303, could_apply_dict_optimize:false, ignore_nulls:false), has_nullable_child:false, " + 
+                        "is_nullable:true"));
     }
 
     @Test
@@ -527,11 +528,25 @@ public class ExpressionTest extends PlanTestBase {
     }
     @Test
     public void testLambdaPredicateOnScan() throws Exception {
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> f71009fa5 (Fix fe ut)
         starRocksAssert.withTable("create table test_lambda_on_scan" +
                 "(c0 INT, c2 array<int>) " +
                 " duplicate key(c0) distributed by hash(c0) buckets 1 " +
                 "properties('replication_num'='1');");
+<<<<<<< HEAD
         String sql = "select * from test_lambda_on_scan where array_map(x -> x + 1, c2) is not null";
+=======
+        starRocksAssert.withTable("create table test_lambda_on_scan"
+                + "(c0 INT, c2 array<int>) "
+                + " duplicate key(c0) distributed by hash(c0) buckets 1 "
+                + "properties('replication_num'='1');");
+=======
+>>>>>>> f71009fa5 (Fix fe ut)
+        String sql = "select * from test_lambda_on_scan where array_map(x -> x, c2) is not null";
+>>>>>>> aa6b04e8a (Fix fe ut)
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("array_map"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -528,25 +528,11 @@ public class ExpressionTest extends PlanTestBase {
     }
     @Test
     public void testLambdaPredicateOnScan() throws Exception {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> f71009fa5 (Fix fe ut)
         starRocksAssert.withTable("create table test_lambda_on_scan" +
                 "(c0 INT, c2 array<int>) " +
                 " duplicate key(c0) distributed by hash(c0) buckets 1 " +
                 "properties('replication_num'='1');");
-<<<<<<< HEAD
         String sql = "select * from test_lambda_on_scan where array_map(x -> x + 1, c2) is not null";
-=======
-        starRocksAssert.withTable("create table test_lambda_on_scan"
-                + "(c0 INT, c2 array<int>) "
-                + " duplicate key(c0) distributed by hash(c0) buckets 1 "
-                + "properties('replication_num'='1');");
-=======
->>>>>>> f71009fa5 (Fix fe ut)
-        String sql = "select * from test_lambda_on_scan where array_map(x -> x, c2) is not null";
->>>>>>> aa6b04e8a (Fix fe ut)
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("array_map"));
     }

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -348,6 +348,9 @@ struct TFunction {
   30: optional i64 fid
   31: optional TTableFunction table_fn
   32: optional bool could_apply_dict_optimize
+
+  // Ignore nulls
+  33: optional bool ignore_nulls
 }
 
 enum TLoadJobState {


### PR DESCRIPTION
add thrift

## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support https://github.com/StarRocks/starrocks/issues/13632
examples:
```
mysql> select * from window_funnel_ignore_nulls order by uid, time;
+------+------------+---------------------+---------------------+
| uid  | event_type | time                | other_time          |
+------+------------+---------------------+---------------------+
| 1    | NULL       | 2020-01-02 10:30:00 | 2015-03-12 12:12:13 |
| 1    | 浏览       | 2020-01-02 11:00:00 | 2015-03-12 12:12:12 |
| 1    | 点击       | 2020-01-02 11:10:00 | 2015-03-12 12:12:12 |
| 1    | 放弃       | 2020-01-02 11:10:01 | 2015-03-12 12:12:14 |
| 1    | NULL       | 2020-01-02 11:10:02 | 2015-03-12 12:12:14 |
| 1    | 下单       | 2020-01-02 11:29:00 | 2015-03-12 12:12:12 |
| 1    | 点击       | 2020-01-02 11:29:01 | 2015-03-12 12:12:12 |
| 1    | 支付       | 2020-01-02 11:30:00 | 2015-03-12 12:12:12 |
| 2    | 离开       | 2020-01-02 11:10:55 | 2015-03-12 12:12:12 |
| 2    | NULL       | 2020-01-02 11:10:56 | 2015-03-12 12:12:15 |
| 2    | 去世       | 2020-01-02 11:10:57 | 2015-03-12 12:12:19 |
+------+------------+---------------------+---------------------+
11 rows in set

mysql> select uid, first_value(event_type ignore nulls)  over (partition by uid order by time) as first_event_type, other_time from window_funnel_ignore_nulls;
+------+------------------+---------------------+
| uid  | first_event_type | other_time          |
+------+------------------+---------------------+
| 1    | NULL             | 2015-03-12 12:12:13 |
| 1    | 浏览             | 2015-03-12 12:12:12 |
| 1    | 浏览             | 2015-03-12 12:12:12 |
| 1    | 浏览             | 2015-03-12 12:12:14 |
| 1    | 浏览             | 2015-03-12 12:12:14 |
| 1    | 浏览             | 2015-03-12 12:12:12 |
| 1    | 浏览             | 2015-03-12 12:12:12 |
| 1    | 浏览             | 2015-03-12 12:12:12 |
| 2    | 离开             | 2015-03-12 12:12:12 |
| 2    | 离开             | 2015-03-12 12:12:15 |
| 2    | 离开             | 2015-03-12 12:12:19 |
+------+------------------+---------------------+
11 rows in set

mysql> select uid, last_value(event_type ignore nulls)  over (partition by uid order by time) as last_event_type, other_time from window_funnel_ignore_nulls;
+------+-----------------+---------------------+
| uid  | last_event_type | other_time          |
+------+-----------------+---------------------+
| 1    | NULL            | 2015-03-12 12:12:13 |
| 1    | 浏览            | 2015-03-12 12:12:12 |
| 1    | 点击            | 2015-03-12 12:12:12 |
| 1    | 放弃            | 2015-03-12 12:12:14 |
| 1    | 放弃            | 2015-03-12 12:12:14 |
| 1    | 下单            | 2015-03-12 12:12:12 |
| 1    | 点击            | 2015-03-12 12:12:12 |
| 1    | 支付            | 2015-03-12 12:12:12 |
| 2    | 离开            | 2015-03-12 12:12:12 |
| 2    | 离开            | 2015-03-12 12:12:15 |
| 2    | 去世            | 2015-03-12 12:12:19 |
+------+-----------------+---------------------+
11 rows in set
```
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
