### PR TITLE
[Enhancement] Routine load timeout config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -173,9 +173,11 @@ public class KafkaUtil {
                 address = new TNetworkAddress(be.getHost(), be.getBrpcPort());
 
                 // get info
-                request.timeout = Config.routine_load_kafka_timeout_second;
+                long timeout =  Config.routine_load_kafka_timeout_second > Config.routine_load_task_timeout_second * 2 ?
+                        Config.routine_load_kafka_timeout_second : Config.routine_load_kafka_timeout_second * 2;
+                request.timeout = timeout;
                 Future<PProxyResult> future = BackendServiceClient.getInstance().getInfo(address, request);
-                PProxyResult result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
+                PProxyResult result = future.get(timeout, TimeUnit.SECONDS);
                 TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
                 if (code != TStatusCode.OK) {
                     LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/8786

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now, if the `routine_load_task_timeout_second` is set smaller than `routine_load_task_consume_second`, most of the routine load tasks would fail.
This PR set the timeout as 2x of `routine_load_task_consume_second` at least.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
