### PR TITLE
[BugFix] backup empty database: error message is not clear (#13382)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
@@ -1217,10 +1217,18 @@ public class PrivilegeChecker {
 
         @Override
         public Void visitBackupStatement(BackupStmt statement, ConnectContext context) {
-            TableRef tableRef = statement.getTableRefs().get(0);
-            if (!GlobalStateMgr.getCurrentState().getAuth().checkDbPriv(ConnectContext.get(),
-                    tableRef.getName().getDb(), PrivPredicate.LOAD)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "LOAD");
+            try {
+                TableRef tableRef = statement.getTableRefs().get(0);
+                if (!GlobalStateMgr.getCurrentState().getAuth().checkDbPriv(ConnectContext.get(),
+                        tableRef.getName().getDb(), PrivPredicate.LOAD)) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "LOAD");
+                }
+            } catch (Exception e) {
+                if (statement.getTableRefs().size() == 0) {
+                    throw new SemanticException("Table not found.");
+                } else {
+                    throw new SemanticException("BackupStatement failed");
+                }
             }
             return null;
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13382

## Problem Summary(Required) ：
Problem:
When backup a entire database, the statement will fail if db is empty. But the error msg is unclear.

Solution:
Add more error msg.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
