### PR TITLE
[Enhancement] vectorized runtime filter min/max

### DIFF
--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -316,11 +316,6 @@ public:
     CppType max_value() const { return _max; }
 
     bool test_data(CppType value) const {
-        if constexpr (!IsSlice<CppType>) {
-            if (value < _min || value > _max) {
-                return false;
-            }
-        }
         size_t hash = compute_hash(value);
         return _bf.test_hash(hash);
     }
@@ -329,11 +324,6 @@ public:
         static constexpr uint32_t BUCKET_ABSENT = 2147483647;
         if (shuffle_hash == BUCKET_ABSENT) {
             return false;
-        }
-        if constexpr (!IsSlice<CppType>) {
-            if (value < _min || value > _max) {
-                return false;
-            }
         }
         // module has been done outside, so actually here is bucket idx.
         const uint32_t bucket_idx = shuffle_hash;
@@ -423,6 +413,16 @@ public:
         }
     }
 
+    void evaluate_min_max(const CppType* values, uint8_t* selection, size_t size) const {
+        if constexpr (!IsSlice<CppType>) {
+            for (size_t i = 0; i < size; i++) {
+                selection[i] = (values[i] >= _min && values[i] <= _max);
+            }
+        } else {
+            memset(selection, 0x1, size);
+        }
+    }
+
     // `hash_parittion` parameters means if this runtime filter has multiple `simd-block-filter` underneath.
     // for local runtime filter, it only has once `simd-block-filter`, and `hash_partition` is false.
     // and for global runtime filter, since it concates multiple runtime filters from partitions
@@ -431,64 +431,57 @@ public:
     template <bool hash_partition = false>
     void t_evaluate(Column* input_column, RunningContext* ctx) const {
         size_t size = input_column->size();
-        Column::Filter& _selection = ctx->use_merged_selection ? ctx->merged_selection : ctx->selection;
-        _selection.resize(size);
+        Column::Filter& _selection_filter = ctx->use_merged_selection ? ctx->merged_selection : ctx->selection;
+        _selection_filter.resize(size);
+        uint8_t* _selection = _selection_filter.data();
 
+#define RF_TEST_DATA(i)                                                          \
+    if (_selection[i]) {                                                         \
+        if constexpr (hash_partition) {                                          \
+            _selection[i] = test_data_with_hash(input_data[i], _hash_values[i]); \
+        } else {                                                                 \
+            _selection[i] = test_data(input_data[i]);                            \
+        }                                                                        \
+    }
         // reuse ctx's hash_values object.
         std::vector<uint32_t>& _hash_values = ctx->hash_values;
         if constexpr (hash_partition) {
             DCHECK_LE(size, _hash_values.size());
         }
-
         if (input_column->is_constant()) {
             const auto* const_column = down_cast<const ConstColumn*>(input_column);
-            bool sel = true;
             if (const_column->only_null()) {
-                sel = _has_null;
+                _selection[0] = _has_null;
             } else {
                 auto* input_data = down_cast<const ColumnType*>(const_column->data_column().get())->get_data().data();
-                if constexpr (hash_partition) {
-                    sel = test_data_with_hash(input_data[0], _hash_values[0]);
-                } else {
-                    sel = test_data(input_data[0]);
-                }
+                evaluate_min_max(input_data, _selection, 1);
+                RF_TEST_DATA(0);
             }
-            for (int i = 0; i < size; i++) {
-                _selection[i] = sel;
-            }
+            uint8_t sel = _selection[0];
+            memset(_selection, sel, size);
         } else if (input_column->is_nullable()) {
             const auto* nullable_column = down_cast<const NullableColumn*>(input_column);
             auto* input_data = down_cast<const ColumnType*>(nullable_column->data_column().get())->get_data().data();
+            evaluate_min_max(input_data, _selection, size);
             if (nullable_column->has_null()) {
                 const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
-                for (int i = 0; i < size; ++i) {
+                for (int i = 0; i < size; i++) {
                     if (null_data[i]) {
                         _selection[i] = _has_null;
                     } else {
-                        if constexpr (hash_partition) {
-                            _selection[i] = test_data_with_hash(input_data[i], _hash_values[i]);
-                        } else {
-                            _selection[i] = test_data(input_data[i]);
-                        }
+                        RF_TEST_DATA(i);
                     }
                 }
             } else {
                 for (int i = 0; i < size; ++i) {
-                    if constexpr (hash_partition) {
-                        _selection[i] = test_data_with_hash(input_data[i], _hash_values[i]);
-                    } else {
-                        _selection[i] = test_data(input_data[i]);
-                    }
+                    RF_TEST_DATA(i);
                 }
             }
         } else {
             auto* input_data = down_cast<const ColumnType*>(input_column)->get_data().data();
+            evaluate_min_max(input_data, _selection, size);
             for (int i = 0; i < size; ++i) {
-                if constexpr (hash_partition) {
-                    _selection[i] = test_data_with_hash(input_data[i], _hash_values[i]);
-                } else {
-                    _selection[i] = test_data(input_data[i]);
-                }
+                RF_TEST_DATA(i);
             }
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to vectorized min/max in runtime filter.

I have not done thorough test. But from ssb/q07, latency can be reduced from 985ms to 967ms

And from perf, we can see 
- comparison has been removed: <Before> `jl` and `jg`, in <After> it's only `je`
- and there are more free registers can be used. <Before> `setb %dl; mov (%r15),%rax; mov %dl, %(rax,%rbx,1)` in <After> its `setb (%r15,%r12,1)`

----

Before

<img width="845" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/1081215/205234005-2d274dae-9482-4e16-ad47-6d3b19f52ba9.png">

-----

After

<img width="1238" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/1081215/205234023-45caf008-f290-4e10-a0b2-e91a7eea0a53.png">


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
