### PR TITLE
[BugFix] Be crash when doing compaction apply

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1418,7 +1418,15 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         _set_error(msg);
         return;
     }
-    if (!(st = _compaction_state->load(_get_rowset(rowset_id).get())).ok()) {
+    Rowset* output_rowset = _get_rowset(rowset_id).get();
+    if (output_rowset == nullptr) {
+        string msg = strings::Substitute("_apply_compaction_commit rowset not found tablet=$0 rowset=$1",
+                                         _tablet.tablet_id(), rowset_id);
+        LOG(ERROR) << msg;
+        _set_error(msg);
+        return;
+    }
+    if (!(st = _compaction_state->load(output_rowset)).ok()) {
         manager->index_cache().release(index_entry);
         _compaction_state.reset();
         std::string msg = strings::Substitute("_apply_compaction_commit error: load compaction state failed: $0 $1",
@@ -1449,7 +1457,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     uint32_t max_src_rssid = max_rowset_id + rowset->num_segments() - 1;
 
     for (size_t i = 0; i < _compaction_state->pk_cols.size(); i++) {
-        if (st = _compaction_state->load_segments(rowset, i); !st.ok()) {
+        if (st = _compaction_state->load_segments(output_rowset, i); !st.ok()) {
             manager->index_cache().release(index_entry);
             _compaction_state.reset();
             std::string msg = strings::Substitute("_apply_compaction_commit error: load compaction state failed: $0 $1",


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/14508

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This bug is introduced by https://github.com/StarRocks/starrocks/pull/12068. In order to reduce the memory usage during apply, we don't preload all segments' primary keys and process segment by segment(https://github.com/StarRocks/starrocks/pull/12068).

```
 ....
 uint32_t max_rowset_id = *std::max_element(info->inputs.begin(), info->inputs.end());
 Rowset* rowset = _get_rowset(max_rowset_id).get();
 .....
 for (size_t i = 0; i < _compaction_state->pk_cols.size(); i++) {
       // the rowset is not what we should load 
       if (st = _compaction_state->load_segments(rowset, i); !st.ok()) {
            manager->index_cache().release(index_entry);
            _compaction_state.reset();
            std::string msg = strings::Substitute("_apply_compaction_commit error: load compaction state failed: $0 $1",
                                                  st.to_string(), debug_string());
            LOG(ERROR) << msg;
            _set_error(msg);
            return;
        }
        .....
    }
```
As the above code shown, we will load one segment in the for loop. However, the `rowset` is not the output rowset after compaction but one of the input rowsets, so we may get an unexpected error.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
