### PR TITLE
[BugFix] Fix plan connectedness for NlJoin

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2067,7 +2067,7 @@ public class PlanFragmentBuilder {
             context.getFragments().add(stayFragment);
 
             stayFragment.setPlanRoot(hashJoinNode);
-            stayFragment.addChild(removeFragment.getChild(0));
+            stayFragment.addChildren(removeFragment.getChildren());
             stayFragment.mergeQueryGlobalDicts(removeFragment.getQueryGlobalDicts());
             return stayFragment;
         }
@@ -2089,7 +2089,7 @@ public class PlanFragmentBuilder {
             context.getFragments().add(stayFragment);
 
             stayFragment.setPlanRoot(hashJoinNode);
-            stayFragment.addChild(removeFragment.getChild(0));
+            stayFragment.addChildren(removeFragment.getChildren());
             stayFragment.mergeQueryGlobalDicts(removeFragment.getQueryGlobalDicts());
             return stayFragment;
         }
@@ -2625,7 +2625,7 @@ public class PlanFragmentBuilder {
                 context.getFragments().remove(leftFragment);
                 context.getFragments().add(leftFragment);
                 leftFragment.setPlanRoot(joinNode);
-                leftFragment.addChild(rightFragment.getChild(0));
+                leftFragment.addChildren(rightFragment.getChildren());
                 leftFragment.mergeQueryGlobalDicts(rightFragment.getQueryGlobalDicts());
                 return leftFragment;
             } else if (distributionMode.equals(JoinNode.DistributionMode.PARTITIONED)) {
@@ -2644,8 +2644,8 @@ public class PlanFragmentBuilder {
 
                 PlanFragment joinFragment = new PlanFragment(context.getNextFragmentId(),
                         joinNode, lhsJoinPartition);
-                joinFragment.addChild(leftFragment.getChild(0));
-                joinFragment.addChild(rightFragment.getChild(0));
+                joinFragment.addChildren(leftFragment.getChildren());
+                joinFragment.addChildren(rightFragment.getChildren());
 
                 joinFragment.mergeQueryGlobalDicts(leftFragment.getQueryGlobalDicts());
                 joinFragment.mergeQueryGlobalDicts(rightFragment.getQueryGlobalDicts());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1852,10 +1852,7 @@ public class PlanFragmentBuilder {
             context.getFragments().add(leftFragment);
 
             leftFragment.setPlanRoot(joinNode);
-            if (!rightFragment.getChildren().isEmpty()) {
-                // right table isn't value operator
-                leftFragment.addChild(rightFragment.getChild(0));
-            }
+            leftFragment.addChildren(rightFragment.getChildren());
 
             if (!(joinNode.getChild(1) instanceof ExchangeNode)) {
                 joinNode.setReplicated(true);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -24,7 +24,9 @@ package com.starrocks.utframe;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Database;
@@ -82,6 +84,7 @@ import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TResultSinkType;
 import org.apache.commons.codec.binary.Hex;
+import org.junit.Assert;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -99,6 +102,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -299,6 +303,31 @@ public class UtFrameUtils {
         throw new RuntimeException("can not find valid port");
     }
 
+    /**
+     * Validate whether all the fragments belong to the fragment tree.
+     * @param plan The plan need to validate.
+     */
+    public static void validatePlanConnectedness(ExecPlan plan) {
+        PlanFragment root = plan.getTopFragment();
+
+        Queue<PlanFragment> queue = Lists.newLinkedList();
+        Set<PlanFragment> visitedFragments = Sets.newHashSet();
+        visitedFragments.add(root);
+        queue.add(root);
+        while (!queue.isEmpty()) {
+            PlanFragment fragment = queue.poll();
+            for (PlanFragment child : fragment.getChildren()) {
+                if (!visitedFragments.contains(child)) {
+                    visitedFragments.add(child);
+                    queue.add(child);
+                }
+            }
+        }
+
+        Assert.assertEquals("Some fragments do not belong to the fragment tree",
+                plan.getFragments().size(), visitedFragments.size());
+    }
+
     public static Pair<String, ExecPlan> getPlanAndFragment(ConnectContext connectContext, String originStmt)
             throws Exception {
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext.getSessionVariable()));
@@ -350,6 +379,7 @@ public class UtFrameUtils {
                 }
             }
 
+            validatePlanConnectedness(execPlan);
             return new Pair<>(LogicalPlanPrinter.print(execPlan.getPhysicalPlan()), execPlan);
         } finally {
             // before returning we have to restore session variable.


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14416.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When merge right fragment and left fragment, we use `leftFragment.addChild(rightFragment.getChild(0))`. However, right fragment may have multiple children, when multiple nested Nl Join in one fragment.

Validate the plan connectedness in the entrance of getting plan of UT, that is in `UtFrameUtils::getPlanAndFragment`.

```text
  11:NESTLOOP JOIN
  |  join op: RIGHT OUTER JOIN
  |  colocate: false, reason: 
  |  other join predicates: 1: v1 < 10: v1
  |  
  |----10:Project
  |    |  <slot 10> : 10: v1
  |    |  
  |    9:NESTLOOP JOIN
  |    |  join op: CROSS JOIN
  |    |  colocate: false, reason: 
  |    |  
  |    |----8:EXCHANGE
  |    |    
  |    6:Project
  |    |  <slot 4> : 4: v1
  |    |  
  |    5:NESTLOOP JOIN
  |    |  join op: CROSS JOIN
  |    |  colocate: false, reason: 
  |    |  
  |    |----4:EXCHANGE
  |    |    
  |    2:EMPTYSET
  |    
  1:EXCHANGE
````


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
