### PR TITLE
[BugFix] align the null flag of evaluating a part of elements

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -189,10 +189,11 @@ ColumnPtr ColumnHelper::create_const_null_column(size_t chunk_size) {
     return ConstColumn::create(nullable_column, chunk_size);
 }
 
-// expression trees' return column should align return type when some return columns may be different from
-// the required return type. e.g., concat_ws returns col from create_const_null_column(), it's type is Nullable(int8),
-// but required return type is nullable(string), so col need align return type to nullable(string).
-ColumnPtr ColumnHelper::align_return_type(const ColumnPtr& old_col, const TypeDescriptor& type_desc, size_t num_rows) {
+// expression trees' return column should align return type when some return columns maybe diff from the required
+// return type, as well the null flag. e.g., concat_ws returns col from create_const_null_column(), it's type is
+// Nullable(int8), but required return type is nullable(string), so col need align return type to nullable(string).
+ColumnPtr ColumnHelper::align_return_type(const ColumnPtr& old_col, const TypeDescriptor& type_desc, size_t num_rows,
+                                          const bool is_nullable) {
     ColumnPtr new_column = old_col;
     if (old_col->only_null()) {
         new_column = ColumnHelper::create_column(type_desc, true);
@@ -204,6 +205,9 @@ ColumnPtr ColumnHelper::align_return_type(const ColumnPtr& old_col, const TypeDe
         auto* const_column = down_cast<ConstColumn*>(old_col.get());
         new_column->append(*const_column->data_column(), 0, 1);
         new_column->assign(num_rows, 0);
+    }
+    if (is_nullable && !new_column->is_nullable()) {
+        new_column = NullableColumn::create(std::move(new_column), NullColumn::create(new_column->size(), 0));
     }
     return new_column;
 }

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -186,10 +186,11 @@ public:
     // Create an empty column
     static ColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable);
 
-    // expression trees' return column should align return type when some return columns may be different from
-    // the required return type. e.g., concat_ws returns col from create_const_null_column(), it's type is Nullable(int8),
-    // but required return type is nullable(string), so col need align return type to nullable(string).
-    static ColumnPtr align_return_type(const ColumnPtr& old_col, const TypeDescriptor& type_desc, size_t num_rows);
+    // expression trees' return column should align return type when some return columns maybe diff from the required
+    // return type, as well the null flag. e.g., concat_ws returns col from create_const_null_column(), it's type is
+    // Nullable(int8), but required return type is nullable(string), so col need align return type to nullable(string).
+    static ColumnPtr align_return_type(const ColumnPtr& old_col, const TypeDescriptor& type_desc, size_t num_rows,
+                                       const bool is_nullable);
 
     // Create a column with specified size, the column will be resized to size
     static ColumnPtr create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size);

--- a/be/src/exec/vectorized/project_node.cpp
+++ b/be/src/exec/vectorized/project_node.cpp
@@ -144,12 +144,7 @@ Status ProjectNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
         for (size_t i = 0; i < _slot_ids.size(); ++i) {
             ASSIGN_OR_RETURN(result_columns[i], _expr_ctxs[i]->evaluate((*chunk).get()));
             result_columns[i] = ColumnHelper::align_return_type(result_columns[i], _expr_ctxs[i]->root()->type(),
-                                                                (*chunk)->num_rows());
-            // follow SlotDescriptor is_null flag
-            if (_type_is_nullable[i] && !result_columns[i]->is_nullable()) {
-                result_columns[i] =
-                        NullableColumn::create(result_columns[i], NullColumn::create(result_columns[i]->size(), 0));
-            }
+                                                                (*chunk)->num_rows(), _type_is_nullable[i]);
         }
         RETURN_IF_HAS_ERROR(_expr_ctxs);
     }

--- a/be/src/exprs/vectorized/array_map_expr.cpp
+++ b/be/src/exprs/vectorized/array_map_expr.cpp
@@ -48,7 +48,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
         ColumnPtr child_col = EVALUATE_NULL_IF_ERROR(context, _children[i], chunk);
         // the column is a null literal.
         if (child_col->only_null()) {
-            return ColumnHelper::align_return_type(child_col, type(), chunk->num_rows());
+            return ColumnHelper::align_return_type(child_col, type(), chunk->num_rows(), true);
         }
         // no optimization for const columns.
         child_col = ColumnHelper::unpack_and_duplicate_const_column(child_col->size(), child_col);
@@ -109,14 +109,14 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
         }
         if (cur_chunk->num_rows() <= chunk->num_rows() * 8) {
             column = EVALUATE_NULL_IF_ERROR(context, _children[0], cur_chunk.get());
-            column = ColumnHelper::align_return_type(column, type().children[0], cur_chunk->num_rows());
+            column = ColumnHelper::align_return_type(column, type().children[0], cur_chunk->num_rows(), true);
         } else { // split large chunks into small ones to avoid too large or various batch_size
             ChunkAccumulator accumulator(DEFAULT_CHUNK_SIZE);
             accumulator.push(std::move(cur_chunk));
             accumulator.finalize();
             while (auto tmp_chunk = accumulator.pull()) {
                 auto tmp_col = EVALUATE_NULL_IF_ERROR(context, _children[0], tmp_chunk.get());
-                tmp_col = ColumnHelper::align_return_type(tmp_col, type().children[0], tmp_chunk->num_rows());
+                tmp_col = ColumnHelper::align_return_type(tmp_col, type().children[0], tmp_chunk->num_rows(), true);
                 if (column == nullptr) {
                     column = tmp_col;
                 } else {

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -36,4 +36,13 @@ TEST_F(ColumnHelperTest, cast_to_nullable_column) {
     ASSERT_FALSE(col->is_constant());
 }
 
+TEST_F(ColumnHelperTest, align_return_type) {
+    auto nullable_column = create_nullable_column();
+    auto not_null_column = create_column();
+    nullable_column->append(ColumnHelper::align_return_type(
+            not_null_column, TypeDescriptor::from_primtive_type(TYPE_VARCHAR), not_null_column->size(), true));
+    ASSERT_TRUE(nullable_column->is_nullable());
+    ASSERT_FALSE(nullable_column->is_constant());
+}
+
 } // namespace starrocks::vectorized

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -39,7 +39,7 @@ TEST_F(ColumnHelperTest, cast_to_nullable_column) {
 TEST_F(ColumnHelperTest, align_return_type) {
     auto nullable_column = create_nullable_column();
     auto not_null_column = create_column();
-    nullable_column->append(ColumnHelper::align_return_type(
+    nullable_column->append(*ColumnHelper::align_return_type(
             not_null_column, TypeDescriptor::from_primtive_type(TYPE_VARCHAR), not_null_column->size(), true));
     ASSERT_TRUE(nullable_column->is_nullable());
     ASSERT_FALSE(nullable_column->is_constant());


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/14553

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the nullable property of results from evaluting lambda functions may be different if splitting large columns into small pieces to run. so a none-nullable column appends a nullable column causes crash.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
