### PR TITLE
[BugFix] fix aggregate checker bug during mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateRewriteChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateRewriteChecker.java
@@ -51,19 +51,19 @@ public class AggregateRewriteChecker {
 
         boolean isMatched(ScalarOperator scalarOperator) {
             // judge child first
-            boolean childMatched = true;
+            boolean allChildMatched = !scalarOperator.getChildren().isEmpty() && scalarOperator.isVariable();
             for (int i = 0; i < scalarOperator.getChildren().size(); i++) {
                 if (scalarOperator.getChild(i).isVariable()) {
                     Boolean matched = scalarOperator.getChild(i).accept(this, null);
                     if (!Boolean.TRUE.equals(matched)) {
-                        childMatched = false;
+                        allChildMatched = false;
                     }
                 }
             }
             if (targetAggregates.contains(scalarOperator)) {
                 return true;
             }
-            return childMatched;
+            return allChildMatched;
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -987,6 +987,10 @@ public class MvRewriteOptimizationTest {
         PlanTestBase.assertContains(plan8, "partial_mv_5");
         PlanTestBase.assertContains(plan8, "UNION");
         PlanTestBase.assertNotContains(plan8, "c3 < -9223372036854775808");
+
+        String query9 = "select sum(c3) from test_base_part";
+        String plan9 = getFragmentPlan(query9);
+        PlanTestBase.assertNotContains(plan9, "partial_mv_5");
         dropMv("test", "partial_mv_5");
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14557 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
fix aggregate checker bug during mv rewrite. Aggregate checker judges the condition incorrectly, which leads to query failure.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
