### PR TITLE
[Enhancement] Optimize thrift server pool 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -673,6 +673,10 @@ public class Config extends ConfigBase {
     @ConfField
     public static int thrift_server_max_worker_threads = 4096;
 
+    /**
+     * If there is no thread to handle new request, the request will be pend to a queue,
+     * the pending queue size is thrift_server_queue_size
+     */
     @ConfField
     public static int thrift_server_queue_size = 4096;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -549,7 +549,7 @@ public class Config extends ConfigBase {
      * some hang up problems in java.net.SocketInputStream.socketRead0
      */
     @ConfField
-    public static int thrift_client_timeout_ms = 0;
+    public static int thrift_client_timeout_ms = 5000;
 
     /**
      * The backlog_num for thrift server
@@ -672,6 +672,9 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static int thrift_server_max_worker_threads = 4096;
+
+    @ConfField
+    public static int thrift_server_queue_size = 4096;
 
     /**
      * Maximal wait seconds for straggler node in load

--- a/fe/fe-core/src/main/java/com/starrocks/common/SRTThreadPoolServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SRTThreadPoolServer.java
@@ -187,7 +187,19 @@ public class SRTThreadPoolServer extends TServer {
                 long remainTimeInMillis = requestTimeoutUnit.toMillis(requestTimeout);
                 while (true) {
                     try {
+                        ThreadPoolExecutor threadPoolExecutor = ((ThreadPoolExecutor) executorService);
+                        LOG.info("pool size: {}, core pool size: {}, " +
+                                        "largest pool size: {}, max pool size: {}, " +
+                                        "remaining queue size: {}, active count: {}",
+                                threadPoolExecutor.getPoolSize(),
+                                threadPoolExecutor.getCorePoolSize(),
+                                threadPoolExecutor.getLargestPoolSize(),
+                                threadPoolExecutor.getMaximumPoolSize(),
+                                threadPoolExecutor.getQueue().remainingCapacity(),
+                                threadPoolExecutor.getActiveCount());
+                        long start = System.nanoTime();
                         executorService.execute(wp);
+                        LOG.info("thrift submit time: {}", (System.nanoTime() - start) / 1000000);
                         break;
                     } catch (Throwable t) {
                         if (t instanceof RejectedExecutionException) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/SRTThreadPoolServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SRTThreadPoolServer.java
@@ -187,19 +187,7 @@ public class SRTThreadPoolServer extends TServer {
                 long remainTimeInMillis = requestTimeoutUnit.toMillis(requestTimeout);
                 while (true) {
                     try {
-                        ThreadPoolExecutor threadPoolExecutor = ((ThreadPoolExecutor) executorService);
-                        LOG.info("pool size: {}, core pool size: {}, " +
-                                        "largest pool size: {}, max pool size: {}, " +
-                                        "remaining queue size: {}, active count: {}",
-                                threadPoolExecutor.getPoolSize(),
-                                threadPoolExecutor.getCorePoolSize(),
-                                threadPoolExecutor.getLargestPoolSize(),
-                                threadPoolExecutor.getMaximumPoolSize(),
-                                threadPoolExecutor.getQueue().remainingCapacity(),
-                                threadPoolExecutor.getActiveCount());
-                        long start = System.nanoTime();
                         executorService.execute(wp);
-                        LOG.info("thrift submit time: {}", (System.nanoTime() - start) / 1000000);
                         break;
                     } catch (Throwable t) {
                         if (t instanceof RejectedExecutionException) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
@@ -117,6 +117,8 @@ public class ThriftServer {
                 .newDaemonFixedThreadPool(Config.thrift_server_max_worker_threads,
                         Config.thrift_server_queue_size,
                         "thrift-server-pool", true);
+        // allow core thread time out so that the thread can be released
+        // if not used for ThreadPoolManager.KEEP_ALIVE_TIME
         threadPoolExecutor.allowCoreThreadTimeOut(true);
         serverArgs.executorService(threadPoolExecutor);
         server = new SRTThreadPoolServer(serverArgs);

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
@@ -114,7 +114,10 @@ public class ThriftServer {
                 new SRTThreadPoolServer.Args(new TServerSocket(socketTransportArgs)).protocolFactory(
                         new TBinaryProtocol.Factory()).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager
-                .newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, "thrift-server-pool", true);
+                .newDaemonFixedThreadPool(Config.thrift_server_max_worker_threads,
+                        Config.thrift_server_queue_size,
+                        "thrift-server-pool", true);
+        threadPoolExecutor.allowCoreThreadTimeOut(true);
         serverArgs.executorService(threadPoolExecutor);
         server = new SRTThreadPoolServer(serverArgs);
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The current implementation of thrift server is blocking IO, that means a connection will occupy one thread, if the request number is more that the worker thread, some requests will be rejected. In order to release the worker thread as soon as possible, we can set the connection idle time to a small value. Since the worker thread can be released for the idle connection, the server can pend the extra request to a queue.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
