### PR TITLE
[BugFix] support structType matchesType() used in function argument type matches

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Describes a STRUCT type. STRUCT types have a list of named struct fields.
@@ -80,6 +81,32 @@ public class StructType extends Type {
             size += structField.getType().getTypeSize();
         }
         return size;
+    }
+
+    @Override
+    public boolean matchesType(Type t) {
+        if (t.isPseudoType()) {
+            return t.matchesType(this);
+        }
+        if (!t.isStructType()) {
+            return false;
+        }
+
+        if (((StructType) t).getFields().size() != fields.size()) {
+            return false;
+        }
+
+        for (Map.Entry<String, StructField> field : fieldMap.entrySet()) {
+            StructField tField = ((StructType) t).getField(field.getValue().getName());
+            if (tField == null) {
+                return false;
+            }
+            if (!tField.getType().matchesType(field.getValue().getType())) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypeTest.java
@@ -2,6 +2,14 @@
 
 package com.starrocks.sql.plan;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.AnyMapType;
+import com.starrocks.catalog.MapType;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.StructField;
+import com.starrocks.catalog.StructType;
+import com.starrocks.catalog.Type;
 import com.starrocks.utframe.StarRocksAssert;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,5 +48,70 @@ public class StructTypeTest extends PlanTestBase {
                 "  |  <slot 4> : 3: c2.a\n" +
                 "  |  <slot 5> : 3: c2.b\n" +
                 "  |  "));
+    }
+
+    @Test
+    public void testStructMatchType() throws Exception {
+        // "struct<struct_test:int,c1:struct<c1:int,cc1:string>>"
+        StructType c1 = new StructType(Lists.newArrayList(
+                new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("cc1", ScalarType.createDefaultExternalTableString())
+        ));
+        StructType root = new StructType(Lists.newArrayList(
+                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("c1", c1)
+        ));
+
+        // PseudoType MapType
+        Type t = new AnyMapType();
+        Assert.assertFalse(root.matchesType(t));
+
+        // MapType
+        Type keyType = ScalarType.createType(PrimitiveType.INT);
+        Type valueType = ScalarType.createCharType(10);
+        Type mapType = new MapType(keyType, valueType);
+
+        Assert.assertFalse(root.matchesType(mapType));
+
+        // Different fields length
+        StructType c = new StructType(Lists.newArrayList(
+                new StructField("c1", ScalarType.createType(PrimitiveType.INT))));
+        Assert.assertFalse(root.matchesType(c));
+
+        // Different field name
+        StructType diffName = new StructType(Lists.newArrayList(
+                new StructField("st", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("cc", c1)
+        ));
+        Assert.assertFalse(root.matchesType(diffName));
+
+        // Different field type
+        StructType diffType = new StructType(Lists.newArrayList(
+                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("c1", ScalarType.createType(PrimitiveType.INT))
+        ));
+        Assert.assertFalse(root.matchesType(diffType));
+
+        // matched
+        StructType mc1 = new StructType(Lists.newArrayList(
+                new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("cc1", ScalarType.createDefaultExternalTableString())
+        ));
+        StructType matched = new StructType(Lists.newArrayList(
+                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("c1", mc1)
+        ));
+        Assert.assertTrue(root.matchesType(matched));
+
+        // matched with different subfield order
+        StructType mc2 = new StructType(Lists.newArrayList(
+                new StructField("cc1", ScalarType.createDefaultExternalTableString()),
+                new StructField("c1", ScalarType.createType(PrimitiveType.INT))
+        ));
+        StructType matchedDiffOrder = new StructType(Lists.newArrayList(
+                new StructField("c1", mc2),
+                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT))
+        ));
+        Assert.assertTrue(root.matchesType(matchedDiffOrder));
     }
 }


### PR DESCRIPTION
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
