### PR TITLE
[Enhancement] Support cancel for TabletReader and SegmentIterator

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -31,6 +31,7 @@
 #include "gutil/strings/substitute.h"
 #include "rowset_options.h"
 #include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
 #include "segment_options.h"
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
@@ -359,6 +360,9 @@ Status Rowset::get_segment_iterators(const vectorized::VectorizedSchema& schema,
     }
     seg_options.rowid_range_option = options.rowid_range_option;
     seg_options.short_key_ranges = options.short_key_ranges;
+    if (options.runtime_state != nullptr) {
+        seg_options.is_cancelled = &options.runtime_state->cancelled_ref();
+    }
 
     auto segment_schema = schema;
     // Append the columns with delete condition to segment schema.

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -325,6 +325,9 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, vectorized::V
 
 Status SegmentIterator::_init() {
     SCOPED_RAW_TIMER(&_opts.stats->segment_init_ns);
+    if (_opts.is_cancelled != nullptr && _opts.is_cancelled->load(std::memory_order_acquire)) {
+        return Status::Cancelled("Cancelled");
+    }
     if (!_get_del_vec_st.ok()) {
         return _get_del_vec_st;
     }

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -68,6 +68,8 @@ public:
 
     OlapRuntimeScanRangePruner runtime_range_pruner;
 
+    const std::atomic<bool>* is_cancelled = nullptr;
+
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -13,6 +13,7 @@
 #include "column/vectorized_fwd.h"
 #include "fs/fs.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/runtime_state.h"
 #include "storage/chunk_helper.h"
 #include "storage/empty_iterator.h"
 #include "storage/kv_store.h"
@@ -569,6 +570,35 @@ static ssize_t read_until_eof(const vectorized::ChunkIteratorPtr& iter) {
     return count;
 }
 
+static Status read_with_cancel(const TabletSharedPtr& tablet, int64_t version) {
+    vectorized::VectorizedSchema schema = ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
+    vectorized::TabletReader reader(tablet, Version(0, version), schema);
+    vectorized::TabletReaderParams params;
+    RuntimeState state;
+    params.runtime_state = &state;
+    RETURN_IF_ERROR(reader.prepare());
+    std::vector<ChunkIteratorPtr> seg_iters;
+    RETURN_IF_ERROR(reader.get_segment_iterators(params, &seg_iters));
+    if (seg_iters.empty()) {
+        return Status::OK();
+    }
+    state.set_is_cancelled(true);
+    auto iter = vectorized::new_union_iterator(seg_iters);
+    auto chunk = ChunkHelper::new_chunk(iter->schema(), 100);
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (st.ok()) {
+            chunk->reset();
+        } else {
+            LOG(WARNING) << "read error: " << st.to_string();
+            return st;
+        }
+    }
+    return Status::OK();
+}
+
 static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
     vectorized::VectorizedSchema schema = ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
     vectorized::TabletReader reader(tablet, Version(0, version), schema);
@@ -648,6 +678,7 @@ void TabletUpdatesTest::test_writeread(bool enable_persistent_index) {
     ASSERT_EQ(N, read_tablet(_tablet, 4));
     ASSERT_EQ(N, read_tablet(_tablet, 3));
     ASSERT_EQ(N, read_tablet(_tablet, 2));
+    ASSERT_TRUE(read_with_cancel(_tablet, 4).is_cancelled());
 }
 
 TEST_F(TabletUpdatesTest, writeread) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14290

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds cancelling support for TabletReader and SegmentIterator, so setting RuntimeState's canceled flag could cancel TabletReader and SegmentIterator's iteration.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
