### PR TITLE
[Enhancement] optimize performance of percentile_cont function

### DIFF
--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -11,6 +11,7 @@
 #include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
 #include "gutil/casts.h"
+#include "util/orlp/pdqsort.h"
 
 namespace starrocks::vectorized {
 
@@ -56,16 +57,21 @@ public:
 
         const Slice slice = column->get(row_num).get_slice();
         double rate = *reinterpret_cast<double*>(slice.data);
-        size_t items_size = *reinterpret_cast<size_t*>(slice.data + sizeof(double));
+        size_t second_size = *reinterpret_cast<size_t*>(slice.data + sizeof(double));
         auto data_ptr = slice.data + sizeof(double) + sizeof(size_t);
 
-        std::vector<InputCppType> res;
-        std::vector<InputCppType>& vec = this->data(state).items;
-        res.resize(vec.size() + items_size);
+        auto second_start = reinterpret_cast<InputCppType*>(data_ptr);
+        auto second_end = reinterpret_cast<InputCppType*>(data_ptr + second_size * sizeof(InputCppType));
 
-        std::merge(vec.begin(), vec.end(), reinterpret_cast<InputCppType*>(data_ptr),
-                   reinterpret_cast<InputCppType*>(data_ptr + items_size * sizeof(InputCppType)), res.begin());
-        this->data(state).items = std::move(res);
+        // TODO(murphy) reduce the copy overhead of merge algorithm
+        auto& output = this->data(state).items;
+        size_t first_size = output.size();
+        output.resize(first_size + second_size);
+        auto first_end = output.begin() + first_size;
+        std::copy(second_start, second_end, first_end);
+        // TODO: optimize it with SIMD bitonic merge
+        std::inplace_merge(output.begin(), first_end, output.end());
+
         this->data(state).rate = rate;
     }
 
@@ -83,9 +89,9 @@ public:
         memcpy(bytes.data() + old_size + sizeof(double), &items_size, sizeof(size_t));
         memcpy(bytes.data() + old_size + sizeof(double) + sizeof(size_t), this->data(state).items.data(),
                items_size * sizeof(InputCppType));
-        std::sort(reinterpret_cast<InputCppType*>(bytes.data() + old_size + sizeof(double) + sizeof(size_t)),
-                  reinterpret_cast<InputCppType*>(bytes.data() + old_size + sizeof(double) + sizeof(size_t) +
-                                                  items_size * sizeof(InputCppType)));
+        pdqsort(false, reinterpret_cast<InputCppType*>(bytes.data() + old_size + sizeof(double) + sizeof(size_t)),
+                reinterpret_cast<InputCppType*>(bytes.data() + old_size + sizeof(double) + sizeof(size_t) +
+                                                items_size * sizeof(InputCppType)));
 
         column->get_offset().emplace_back(new_size);
     }
@@ -93,7 +99,7 @@ public:
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         using CppType = RunTimeCppType<PT>;
         std::vector<CppType> new_vector = this->data(state).items;
-        std::sort(new_vector.begin(), new_vector.end());
+        pdqsort(false, new_vector.begin(), new_vector.end());
         const double& rate = this->data(state).rate;
 
         ResultColumnType* column = down_cast<ResultColumnType*>(to);
@@ -138,7 +144,7 @@ public:
 
         double rate = ColumnHelper::get_const_value<TYPE_DOUBLE>(src[1]);
         InputColumnType src_column = *down_cast<const InputColumnType*>(src[0].get());
-        std::sort(src_column.get_data().begin(), src_column.get_data().end());
+        pdqsort(false, src_column.get_data().begin(), src_column.get_data().end());
 
         bytes.resize(old_size + sizeof(double) + sizeof(size_t) + chunk_size * sizeof(InputCppType));
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14608

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Replace the out-of-place merge with in-place merge to reduce memory allocation overhead.

Benchmark result:
- For SQL `select percentile_cont(lo_orderdate, 0.5) from lineorder` with SSB( scale=100)
- Before is `64s`, After is `37s`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
