### PR TITLE
[Feature] temporary account locking on multiple failed login for xct (#5694)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1906,4 +1906,15 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean enable_check_db_state = true;
+    /**
+     * Max attemps to login if failed. -1 means unlimited.
+     */
+    @ConfField(mutable = true)
+    public static int max_failed_login_attempts = 3;
+
+    /**
+     * How long in seconds to lock the account after too many consecutive login attempts provide an incorrect password.
+     */
+    @ConfField(mutable = true)
+    public static int password_lock_interval_seconds = 600;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -115,6 +115,10 @@ public enum ErrorCode {
             "data cannot be inserted into table with empty partition. " +
                     "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
     ERR_NO_SUCH_PARTITION(1749, new byte[] {'H', 'Y', '0', '0', '0'}, "partition '%s' doesn't exist"),
+    // ERROR 3955 (HY000): Access denied for user 'asdf'@'localhost'. Account is blocked for 3 day(s) (3 day(s) remaining) due to 3 consecutive failed logins.
+    ERR_FAILED_ATTEMPT(3955, new byte[] {'H', 'Y', '0', '0', '0'}, "Access denied for user '%s'@'%s'. "
+            + "Account is blocked for %d second(s) (%d second(s) remaining) due to %d consecutive failed logins."),
+
     // Following is StarRocks's error code, which start from 5000
     ERR_NOT_OLAP_TABLE(5000, new byte[] {'H', 'Y', '0', '0', '0'}, "Table '%s' is not a OLAP table"),
     ERR_WRONG_PROC_PATH(5001, new byte[] {'H', 'Y', '0', '0', '0'}, "Proc path '%s' doesn't exist"),

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -73,7 +73,6 @@ public class MysqlProto {
         List<UserIdentity> currentUserIdentity = Lists.newArrayList();
         if (!GlobalStateMgr.getCurrentState().getAuth().checkPassword(user, remoteIp,
                 scramble, randomString, currentUserIdentity)) {
-            ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED_ERROR, user, usePasswd);
             return false;
         }
         context.setAuthDataSalt(randomString);

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthTest.java
@@ -112,6 +112,8 @@ public class AuthTest {
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException {
         auth = new Auth();
+        // unlimited failed login attempts
+        Config.max_failed_login_attempts = -1;
 
         new Expectations() {
             {
@@ -2155,5 +2157,53 @@ public class AuthTest {
         CreateUserStmt createUserStmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         auth.createUser(createUserStmt);
         Assert.assertNotNull(auth.getUserProperties("'12345'@'%'"));
+    }
+
+    @Test
+    public void testLoginFailed() throws Exception {
+        // 1. create user with no role
+        String userName = "test_user";
+        String password = "123456AAbb";
+        UserIdentity user = new UserIdentity(userName, "%");
+        user.analyze();
+        UserDesc userDesc = new UserDesc(user, password, true);
+        CreateUserStmt createUserStmt = new CreateUserStmt(false, userDesc, null);
+        createUserStmt.analyze(analyzer);
+        auth.createUser(createUserStmt);
+        String userFullName = user.getQualifiedUser();
+        String host = "data01.com";
+        String badpassword = "12345";
+        List<UserIdentity> currentUser = Lists.newArrayList();
+        byte[] seed = "dJSH\\]mcwKJlLH[bYunm".getBytes("utf-8");
+        Assert.assertTrue(auth.checkPassword(userFullName, host, MysqlPassword.scramble(seed, password), seed, currentUser));
+
+        Config.max_failed_login_attempts = 2;
+        Config.password_lock_interval_seconds = 60;
+
+        // 1. normal login
+        Assert.assertTrue(auth.checkPassword(userFullName, host, MysqlPassword.scramble(seed, password), seed, currentUser));
+
+        // 2. failed login, first time
+        Assert.assertFalse(auth.checkPassword(userFullName, host, MysqlPassword.scramble(seed, badpassword), seed, currentUser));
+        Assert.assertTrue(ConnectContext.get().getState().getErrorMessage().contains("password"));
+
+        // 3. normal login
+        Assert.assertTrue(auth.checkPassword(userFullName, host, MysqlPassword.scramble(seed, password), seed, currentUser));
+
+        // 4. failed login, first time
+        Assert.assertFalse(auth.checkPassword(userFullName, host, MysqlPassword.scramble(seed, badpassword), seed, currentUser));
+        Assert.assertTrue(ConnectContext.get().getState().getErrorMessage().contains("password"));
+        // 5. failed login, second time
+        Assert.assertFalse(auth.checkPassword(userFullName, host, MysqlPassword.scramble(seed, badpassword), seed, currentUser));
+        Assert.assertTrue(ConnectContext.get().getState().getErrorMessage().contains("password"));
+        // 6. failed login, third time, locked
+        Assert.assertFalse(auth.checkPassword(userFullName, host, MysqlPassword.scramble(seed, password), seed, currentUser));
+        Assert.assertTrue(ConnectContext.get().getState().getErrorMessage().contains("Account is blocked"));
+
+        // 7. timeout & relogin
+        Config.password_lock_interval_seconds = 1;
+        Thread.sleep(1000);
+        Assert.assertTrue(auth.checkPassword(userFullName, host, MysqlPassword.scramble(seed, password), seed, currentUser));
+
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5633

## Problem Summary(Required) ：
Account will be locked for password_lock_interval_seconds after max_failed_login_attempts

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
