### PR TITLE
[BugFix] Merge overlap segments of one rowset in lake tablet compaction

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -95,7 +95,7 @@ StatusOr<ChunkIteratorPtr> Rowset::read(const vectorized::VectorizedSchema& sche
         return vectorized::new_empty_iterator(schema, options.chunk_size);
     } else if (segment_iterators.size() == 1) {
         return segment_iterators[0];
-    } else if (options.sorted) {
+    } else if (options.sorted && is_overlapped()) {
         return vectorized::new_heap_merge_iterator(segment_iterators);
     } else {
         return vectorized::new_union_iterator(segment_iterators);

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -109,7 +109,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.predicates = _pushdown_predicates;
     RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_map(&_obj_pool, rs_opts.predicates,
                                                                      &rs_opts.predicates_for_zone_map));
-    rs_opts.sorted = (keys_type != DUP_KEYS && keys_type != PRIMARY_KEYS) && !params.skip_aggregation;
+    rs_opts.sorted = ((keys_type != DUP_KEYS && keys_type != PRIMARY_KEYS) && !params.skip_aggregation) ||
+                     is_compaction(params.reader_type);
     rs_opts.reader_type = params.reader_type;
     rs_opts.chunk_size = params.chunk_size;
     rs_opts.delete_predicates = &_delete_predicates;

--- a/be/test/storage/lake/horizontal_compaction_task_test.cpp
+++ b/be/test/storage/lake/horizontal_compaction_task_test.cpp
@@ -191,6 +191,180 @@ TEST_F(DuplicateKeyHorizontalCompactionTest, test1) {
     ASSERT_EQ(1, new_tablet_metadata->rowsets_size());
 }
 
+class DuplicateKeyOverlapSegmentsHorizontalCompactionTest : public testing::Test {
+public:
+    DuplicateKeyOverlapSegmentsHorizontalCompactionTest() {
+        _tablet_manager = ExecEnv::GetInstance()->lake_tablet_manager();
+
+        _parent_mem_tracker = std::make_unique<MemTracker>(-1);
+        _mem_tracker = std::make_unique<MemTracker>(-1, "", _parent_mem_tracker.get());
+        _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
+        _backup_location_provider = _tablet_manager->TEST_set_location_provider(_location_provider.get());
+
+        _tablet_metadata = std::make_shared<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_cumulative_point(0);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+        }
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(*_tablet_schema));
+    }
+
+protected:
+    constexpr static const char* const kTestGroupPath = "test_lake_hcompaction_task_duplicate_overlap_segments";
+    constexpr static const int kChunkSize = 12;
+
+    void SetUp() override {
+        (void)ExecEnv::GetInstance()->lake_tablet_manager()->TEST_set_location_provider(_location_provider.get());
+        (void)fs::remove_all(kTestGroupPath);
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kTxnLogDirectoryName)));
+        CHECK_OK(_tablet_manager->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+        tablet.delete_txn_log(_txn_id);
+        _txn_id++;
+        (void)ExecEnv::GetInstance()->lake_tablet_manager()->TEST_set_location_provider(_backup_location_provider);
+        (void)fs::remove_all(kTestGroupPath);
+    }
+
+    VChunk generate_data(int64_t chunk_size) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i;
+        }
+        auto rng = std::default_random_engine{};
+        std::shuffle(v0.begin(), v0.end(), rng);
+        for (int i = 0; i < chunk_size; i++) {
+            v1[i] = v0[i] * 3;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        return VChunk({c0, c1}, _schema);
+    }
+
+    int64_t read(int64_t version) {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        auto chunk = ChunkHelper::new_chunk(*_schema, 128);
+        int64_t ret = 0;
+        while (true) {
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            ret += chunk->num_rows();
+            chunk->reset();
+        }
+        return ret;
+    }
+
+    TabletManager* _tablet_manager;
+    std::unique_ptr<MemTracker> _parent_mem_tracker;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<FixedLocationProvider> _location_provider;
+    LocationProvider* _backup_location_provider;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<VSchema> _schema;
+    int64_t _partition_id = 4563;
+    int64_t _txn_id = 1233;
+};
+
+TEST_F(DuplicateKeyOverlapSegmentsHorizontalCompactionTest, test) {
+    // Prepare data for writing
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(tablet_id, _txn_id, _partition_id, nullptr, _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        for (int j = 0; j < i + 1; ++j) {
+            ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+            ASSERT_OK(delta_writer->flush());
+        }
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * 6, read(version));
+
+    _txn_id++;
+    ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
+    ASSERT_OK(task->execute(nullptr));
+    ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
+    version++;
+    ASSERT_EQ(kChunkSize * 6, read(version));
+
+    // check metadata
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    ASSERT_EQ(1, new_tablet_metadata->cumulative_point());
+    ASSERT_EQ(1, new_tablet_metadata->rowsets_size());
+    ASSERT_EQ(1, new_tablet_metadata->rowsets(0).segments_size());
+
+    // check data
+    ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+    CHECK_OK(reader->prepare());
+    CHECK_OK(reader->open(TabletReaderParams()));
+    auto chunk = ChunkHelper::new_chunk(*_schema, 128);
+    auto st = reader->get_next(chunk.get());
+    ASSERT_FALSE(st.is_end_of_file());
+    ASSERT_EQ(kChunkSize * 6, chunk->num_rows());
+    for (int i = 0; i < chunk->num_rows(); ++i) {
+        auto row = chunk->get(i);
+        ASSERT_EQ(i / 6, row.get(0).get_int32());
+        ASSERT_EQ(i / 6 * 3, row.get(1).get_int32());
+    }
+    chunk->reset();
+    st = reader->get_next(chunk.get());
+    ASSERT_TRUE(st.is_end_of_file());
+}
+
 class UniqueKeyHorizontalCompactionTest : public testing::Test {
 public:
     UniqueKeyHorizontalCompactionTest() {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In compaction, all the overlap segments should be merged to ensure that the output rowset data is in order


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
