### PR TITLE
[BugFix] Fix broker load parallel performance issue since chunk buffer limit to one

### DIFF
--- a/be/src/exec/vectorized/connector_scan_node.cpp
+++ b/be/src/exec/vectorized/connector_scan_node.cpp
@@ -141,11 +141,11 @@ pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::Pipelin
     size_t dop = context->dop_of_source_operator(id());
     std::shared_ptr<pipeline::ConnectorScanOperatorFactory> scan_op = nullptr;
 
-    if (config::connector_dynamic_chunk_buffer_limiter_enable) {
+    int64_t mem_limit = runtime_state()->query_mem_tracker_ptr()->limit() * config::scan_use_query_mem_ratio;
+    if (config::connector_dynamic_chunk_buffer_limiter_enable && mem_limit > 0) {
         // port from olap scan node.
         size_t max_buffer_capacity = pipeline::ScanOperator::max_buffer_capacity() * dop;
         size_t default_buffer_capacity = max_buffer_capacity;
-        int64_t mem_limit = runtime_state()->query_mem_tracker_ptr()->limit() * config::scan_use_query_mem_ratio;
         pipeline::ChunkBufferLimiterPtr buffer_limiter = std::make_unique<pipeline::DynamicChunkBufferLimiter>(
                 max_buffer_capacity, default_buffer_capacity, mem_limit, runtime_state()->chunk_size());
         scan_op = std::make_shared<pipeline::ConnectorScanOperatorFactory>(context->next_operator_id(), this, dop,


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14695

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`query_mem_limit` default value is `0`, so that chunk_buffer_capacity always limit to 1. This will lead to performance degradation of broker load.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
