### PR TITLE
[BugFix] Use nullable aggregator instead of aggregator for max_by

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
@@ -67,7 +67,7 @@ struct MaxByDispatcherInner {
     void operator()(AggregateFuncResolver* resolver) {
         if constexpr ((pt_is_aggregate<arg_type> || pt_is_string<arg_type>)&&(pt_is_aggregate<ret_type> ||
                                                                               pt_is_string<ret_type>)) {
-            resolver->add_aggregate_mapping_notnull<arg_type, ret_type>(
+            resolver->add_aggregate_mapping_variadic<arg_type, ret_type, MaxByAggregateData<arg_type>>(
                     "max_by", true, AggregateFactory::MakeMaxByAggregateFunction<arg_type>());
         }
     }

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -652,7 +652,7 @@ TEST_F(AggregateTest, test_stddev_samp) {
 }
 
 TEST_F(AggregateTest, test_maxby) {
-    const AggregateFunction* func = get_aggregate_function("max_by", TYPE_VARCHAR, TYPE_INT, true);
+    const AggregateFunction* func = get_aggregate_function("max_by", TYPE_VARCHAR, TYPE_INT, false);
     auto result_column = Int32Column::create();
     auto aggr_state = ManagedAggrState::create(ctx, func);
     auto int_column = Int32Column::create();
@@ -675,7 +675,7 @@ TEST_F(AggregateTest, test_maxby) {
     ASSERT_EQ(2, result_column->get_data()[0]);
 
     //test nullable column
-    func = get_aggregate_function("max_by", TYPE_DECIMALV2, TYPE_DOUBLE, true);
+    func = get_aggregate_function("max_by", TYPE_DECIMALV2, TYPE_DOUBLE, false);
     aggr_state = ManagedAggrState::create(ctx, func);
     auto data_column1 = DoubleColumn::create();
     auto null_column1 = NullColumn::create();
@@ -704,6 +704,73 @@ TEST_F(AggregateTest, test_maxby) {
     }
     func->update_batch_single_state(ctx, doubleColumn->size(), raw_nullColumns.data(), aggr_state->state());
     func->finalize_to_column(ctx, aggr_state->state(), nullable_result_column.get());
+    ASSERT_EQ(98.11, nullable_result_column->data_column()->get(0).get<double>());
+}
+
+TEST_F(AggregateTest, test_maxby_with_nullable_aggregator) {
+    const AggregateFunction* func = get_aggregate_function("max_by", TYPE_VARCHAR, TYPE_INT, true);
+    auto* ctx_with_args0 = FunctionContext::create_test_context(
+            {FunctionContext::TypeDesc{.type = TYPE_INT}, FunctionContext::TypeDesc{.type = TYPE_VARCHAR}},
+            FunctionContext::TypeDesc{.type = TYPE_INT});
+    std::unique_ptr<FunctionContext> gc_ctx0(ctx_with_args0);
+
+    auto result_column = Int32Column::create();
+    auto aggr_state = ManagedAggrState::create(ctx_with_args0, func);
+    auto int_column = Int32Column::create();
+    for (int i = 0; i < 10; i++) {
+        int_column->append(i);
+    }
+    auto varchar_column = BinaryColumn::create();
+    std::vector<Slice> strings{{"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}, {""}};
+    varchar_column->append_strings(strings);
+    Columns columns;
+    columns.emplace_back(int_column);
+    columns.emplace_back(varchar_column);
+    std::vector<const Column*> raw_columns;
+    raw_columns.resize(columns.size());
+    for (int i = 0; i < columns.size(); ++i) {
+        raw_columns[i] = columns[i].get();
+    }
+    func->update_batch_single_state(ctx_with_args0, int_column->size(), raw_columns.data(), aggr_state->state());
+    func->finalize_to_column(ctx_with_args0, aggr_state->state(), result_column.get());
+    ASSERT_EQ(2, result_column->get_data()[0]);
+
+    //test nullable column
+    func = get_aggregate_function("max_by", TYPE_DECIMALV2, TYPE_DOUBLE, true);
+    auto* ctx_with_args1 = FunctionContext::create_test_context(
+            {FunctionContext::TypeDesc{.type = TYPE_DOUBLE},
+             FunctionContext::TypeDesc{.type = TYPE_DECIMALV2, .precision = 38, .scale = 9}},
+            FunctionContext::TypeDesc{.type = TYPE_DOUBLE});
+    std::unique_ptr<FunctionContext> gc_ctx1(ctx_with_args1);
+
+    aggr_state = ManagedAggrState::create(ctx_with_args1, func);
+    auto data_column1 = DoubleColumn::create();
+    auto null_column1 = NullColumn::create();
+    for (int i = 0; i < 100; i++) {
+        data_column1->append(i + 0.11);
+        null_column1->append(i % 13 ? false : true);
+    }
+    auto doubleColumn = NullableColumn::create(std::move(data_column1), std::move(null_column1));
+    auto data_column2 = DecimalColumn::create();
+    auto null_column2 = NullColumn::create();
+    for (int i = 0; i < 100; i++) {
+        data_column2->append(DecimalV2Value(i));
+        null_column2->append(i % 11 ? false : true);
+    }
+    auto decimalColumn = NullableColumn::create(std::move(data_column2), std::move(null_column2));
+    auto data_column3 = DoubleColumn::create();
+    auto null_column3 = NullColumn::create();
+    auto nullable_result_column = NullableColumn::create(std::move(data_column3), std::move(null_column3));
+    Columns nullColumns;
+    nullColumns.emplace_back(doubleColumn);
+    nullColumns.emplace_back(decimalColumn);
+    std::vector<const Column*> raw_nullColumns;
+    raw_nullColumns.resize(nullColumns.size());
+    for (int i = 0; i < nullColumns.size(); ++i) {
+        raw_nullColumns[i] = nullColumns[i].get();
+    }
+    func->update_batch_single_state(ctx_with_args1, doubleColumn->size(), raw_nullColumns.data(), aggr_state->state());
+    func->finalize_to_column(ctx_with_args1, aggr_state->state(), nullable_result_column.get());
     ASSERT_EQ(98.11, nullable_result_column->data_column()->get(0).get<double>());
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1535
We should use nullable aggregator to process nullable columns.
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
