### PR TITLE
[Doc] Change s3-ap-northeast-1 to s3.ap-northeast-1

### DIFF
--- a/docs/loading/BrokerLoad.md
+++ b/docs/loading/BrokerLoad.md
@@ -159,7 +159,7 @@ WITH BROKER
 (
     "fs.s3a.access.key" = "xxxxxxxxxxxxxxxxxxxx",
     "fs.s3a.secret.key" = "yyyyyyyyyyyyyyyyyyyy",
-    "fs.s3a.endpoint" = "s3-ap-northeast-1.amazonaws.com"
+    "fs.s3a.endpoint" = "s3.ap-northeast-1.amazonaws.com"
 )
 ```
 


### PR DESCRIPTION
The `s3.` is the standard edition to access S3. `s3-` sometimes works, sometimes do not works.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
