### PR TITLE
[BugFix] compute memory layout of TupleDescriptor after setting nullable for SlotDescriptor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1978,18 +1978,20 @@ public class PlanFragmentBuilder {
             List<Expr> conjuncts = joinExpr.conjuncts;
 
             List<PlanFragment> nullablePlanFragments = new ArrayList<>();
+            Set<TupleId> nullableTupleIds = new HashSet<>();
+            nullableTupleIds.addAll(leftFragment.getPlanRoot().getNullableTupleIds());
+            nullableTupleIds.addAll(rightFragment.getPlanRoot().getNullableTupleIds());
             if (joinOperator.isLeftOuterJoin()) {
-                nullablePlanFragments.add(rightFragment);
+                nullableTupleIds.addAll(rightFragment.getPlanRoot().getTupleIds());
             } else if (joinOperator.isRightOuterJoin()) {
-                nullablePlanFragments.add(leftFragment);
+                nullableTupleIds.addAll(leftFragment.getPlanRoot().getTupleIds());
             } else if (joinOperator.isFullOuterJoin()) {
-                nullablePlanFragments.add(leftFragment);
-                nullablePlanFragments.add(rightFragment);
+                nullableTupleIds.addAll(leftFragment.getPlanRoot().getTupleIds());
+                nullableTupleIds.addAll(rightFragment.getPlanRoot().getTupleIds());
             }
-            for (PlanFragment planFragment : nullablePlanFragments) {
-                for (TupleId tupleId : planFragment.getPlanRoot().getTupleIds()) {
-                    context.getDescTbl().getTupleDesc(tupleId).getSlots().forEach(slot -> slot.setIsNullable(true));
-                }
+            for (TupleId tupleId : nullableTupleIds) {
+                context.getDescTbl().getTupleDesc(tupleId).getSlots().forEach(slot -> slot.setIsNullable(true));
+                context.getDescTbl().getTupleDesc(tupleId).computeMemLayout();
             }
 
             JoinNode joinNode;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14239 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In BE, SlotDescriptor judges nullable based on the information of nullIndicator passed from FE. This information is computed in `TupleDescriptor::computeMemLayout` method, If you only setNullable to SlotDescriptor but not re-compute memory layout of TupleDescriptor, it will pass a wrong result to BE.

The following is the physical plan of the query in the issue
![image](https://user-images.githubusercontent.com/3675229/206060173-60f0d331-c724-4b70-a639-ab139ba8fe34.png)

`c_2_4` is a NOT NULL column, but it will be rewritten as nullable during `visitPhysicalJoin` because it appears in the left side of right outer join. At this time, the computeMemLayout logic is missed and the correct information is not passed to BE.

In this PR, I fixed the above problem and also handle nullable property of SlotDescriptor in visitPhysicalNestLoopJoin, just like it in visitPhysicalJoin


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
