### PR TITLE
[Enhancement] Infer default storage medium when creating table (#14394)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ModifyPartitionClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ModifyPartitionClause.java
@@ -100,7 +100,7 @@ public class ModifyPartitionClause extends AlterTableClause {
     private void checkProperties(Map<String, String> properties) throws AnalysisException {
         // 1. data property
         DataProperty newDataProperty = null;
-        newDataProperty = PropertyAnalyzer.analyzeDataProperty(properties, DataProperty.DEFAULT_DATA_PROPERTY);
+        newDataProperty = PropertyAnalyzer.analyzeDataProperty(properties, DataProperty.getInferredDefaultDataProperty());
         Preconditions.checkNotNull(newDataProperty);
 
         // 2. replication num

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/MultiItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/MultiItemListPartitionDesc.java
@@ -114,7 +114,7 @@ public class MultiItemListPartitionDesc extends PartitionDesc {
 
         // analyze data property
         this.partitionDataProperty = PropertyAnalyzer.analyzeDataProperty(allProperties,
-                DataProperty.DEFAULT_DATA_PROPERTY);
+                DataProperty.getInferredDefaultDataProperty());
 
         // analyze replication num
         this.replicationNum =

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleItemListPartitionDesc.java
@@ -103,7 +103,7 @@ public class SingleItemListPartitionDesc extends PartitionDesc {
 
         // analyze data property
         this.partitionDataProperty = PropertyAnalyzer.analyzeDataProperty(allProperties,
-                DataProperty.DEFAULT_DATA_PROPERTY);
+                DataProperty.getInferredDefaultDataProperty());
 
         // analyze replication num
         this.replicationNum =

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SingleRangePartitionDesc.java
@@ -61,7 +61,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
         this.partitionKeyDesc = partitionKeyDesc;
         this.properties = properties;
 
-        this.partitionDataProperty = DataProperty.DEFAULT_DATA_PROPERTY;
+        this.partitionDataProperty = DataProperty.getInferredDefaultDataProperty();
         this.replicationNum = FeConstants.default_replication_num;
     }
 
@@ -128,7 +128,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
 
         // analyze data property
         partitionDataProperty = PropertyAnalyzer.analyzeDataProperty(properties,
-                DataProperty.DEFAULT_DATA_PROPERTY);
+                DataProperty.getInferredDefaultDataProperty());
         Preconditions.checkNotNull(partitionDataProperty);
 
         // analyze replication num

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DataProperty.java
@@ -21,20 +21,33 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageMedium;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DataProperty implements Writable {
-    public static final DataProperty DEFAULT_DATA_PROPERTY = new DataProperty(
-            "SSD".equalsIgnoreCase(Config.default_storage_medium) ? TStorageMedium.SSD : TStorageMedium.HDD);
+    private static final Logger LOG = LogManager.getLogger(DataProperty.class);
+    /**
+     * Default data property will be inferred from be path configuration,
+     * this static member is reserved only for compatibility with current unit tests.
+     */
+    public static final DataProperty DEFAULT_DATA_PROPERTY = new DataProperty(TStorageMedium.HDD);
     public static final long MAX_COOLDOWN_TIME_MS = 253402271999000L; // 9999-12-31 23:59:59
 
     @SerializedName(value = "storageMedium")
@@ -53,6 +66,32 @@ public class DataProperty implements Writable {
     public DataProperty(TStorageMedium medium, long cooldown) {
         this.storageMedium = medium;
         this.cooldownTimeMs = cooldown;
+    }
+
+    public static DataProperty getInferredDefaultDataProperty() {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        SystemInfoService infoService = globalStateMgr.getClusterInfo();
+        List<Backend> backends = infoService.getClusterBackends(SystemInfoService.DEFAULT_CLUSTER);
+        Set<TStorageMedium> mediumSet = Sets.newHashSet();
+        for (Backend backend : backends) {
+            if (backend.hasPathHash()) {
+                mediumSet.addAll(backend.getDisks().values().stream()
+                        .filter(v -> v.getState() == DiskInfo.DiskState.ONLINE)
+                        .map(DiskInfo::getStorageMedium).collect(Collectors.toSet()));
+            }
+        }
+
+        Preconditions.checkState(mediumSet.size() <= 2, "current medium set: " + mediumSet);
+        TStorageMedium m = TStorageMedium.SSD;
+        // If the storage paths reported by all the backends all have storage medium type HDD,
+        // we infer that user wants to create a table or partition with storage_medium=HDD when not explicitly
+        // specify the storage_medium property, otherwise it's SSD
+        if (mediumSet.size() == 0 ||
+                (mediumSet.size() == 1 && mediumSet.iterator().next() == TStorageMedium.HDD)) {
+            m = TStorageMedium.HDD;
+        }
+
+        return new DataProperty(m);
     }
 
     public TStorageMedium getStorageMedium() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -757,18 +757,24 @@ public class Config extends ConfigBase {
 
     /**
      * When create a table(or partition), you can specify its storage medium(HDD or SSD).
-     * If not set, this specifies the default medium when creat.
-     */
-    @ConfField
-    public static String default_storage_medium = "HDD";
-    /**
-     * When create a table(or partition), you can specify its storage medium(HDD or SSD).
      * If set to SSD, this specifies the default duration that tablets will stay on SSD.
      * After that, tablets will be moved to HDD automatically.
      * You can set storage cooldown time in CREATE TABLE stmt.
      */
     @ConfField
     public static long storage_cooldown_second = 30 * 24 * 3600L; // 30 days
+
+    /**
+     * If set to true, FE will check backend available capacity by storage medium when create table
+     * <p>
+     * The default value should better set to true because if user
+     * has a deployment with only SSD or HDD medium storage paths,
+     * create an incompatible table will cause balance problem(SSD tablet cannot move to HDD path, vice versa).
+     * But currently for compatibility reason, we keep it to false.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_strict_storage_medium_check = false;
+
     /**
      * After dropping database(table/partition), you can recover it by using RECOVER stmt.
      * And this specifies the maximal data retention time. After time, the data will be deleted permanently.
@@ -1184,12 +1190,6 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int max_running_rollup_job_num_per_table = 1;
-
-    /**
-     * If set to true, FE will check backend available capacity by storage medium when create table
-     */
-    @ConfField(mutable = true)
-    public static boolean enable_strict_storage_medium_check = false;
 
     /**
      * if set to false, auth check will be disable, in case some goes wrong with the new privilege system.

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1839,7 +1839,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 if (properties != null) {
                     hasMedium = properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM);
                 }
-                dataProperty = PropertyAnalyzer.analyzeDataProperty(properties, DataProperty.DEFAULT_DATA_PROPERTY);
+                dataProperty = PropertyAnalyzer.analyzeDataProperty(properties,
+                        DataProperty.getInferredDefaultDataProperty());
                 if (hasMedium) {
                     olapTable.setStorageMedium(dataProperty.getStorageMedium());
                 }
@@ -1959,7 +1960,7 @@ public class LocalMetastore implements ConnectorMetadata {
                             hasMedium = properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM);
                         }
                         DataProperty dataProperty = PropertyAnalyzer.analyzeDataProperty(properties,
-                                DataProperty.DEFAULT_DATA_PROPERTY);
+                                DataProperty.getInferredDefaultDataProperty());
                         DynamicPartitionUtil
                                 .checkAndSetDynamicPartitionBuckets(properties, distributionDesc.getBuckets());
                         DynamicPartitionUtil.checkAndSetDynamicPartitionProperty(olapTable, properties);

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -484,6 +484,12 @@ public class Backend implements Writable {
         }
     }
 
+    public void setStorageMediumForAllDisks(TStorageMedium m) {
+        for (DiskInfo diskInfo : disksRef.values()) {
+            diskInfo.setStorageMedium(m);
+        }
+    }
+
     public static Backend read(DataInput in) throws IOException {
         Backend backend = new Backend();
         backend.readFields(in);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StorageMediumInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StorageMediumInfoTest.java
@@ -1,0 +1,133 @@
+// This file is made available under Elastic License 2.0.
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.catalog;
+
+import com.clearspring.analytics.util.Lists;
+import com.starrocks.analysis.AlterTableStmt;
+import com.starrocks.analysis.CreateDbStmt;
+import com.starrocks.analysis.CreateTableStmt;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class StorageMediumInfoTest {
+    private static ConnectContext connectContext;
+    private static Backend be1;
+    private static Backend be2;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        be1 = GlobalStateMgr.getCurrentSystemInfo().getBackend(10001);
+        be1.getDisks().get("10001/path1").setPathHash(10001);
+        be2 = UtFrameUtils.addMockBackend(10002);
+        be2.getDisks().get("10002/path1").setPathHash(10002);
+        Config.enable_strict_storage_medium_check = false;
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database test;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().createDb(createDbStmt);
+    }
+
+    private static void createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+    }
+
+    private static void alterTable(String sql) throws Exception {
+        AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseAndAnalyzeStmt(sql, connectContext);
+        GlobalStateMgr.getCurrentState().alterTable(alterTableStmt);
+    }
+
+    @Test
+    public void testCreateTable() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+
+        be1.setStorageMediumForAllDisks(TStorageMedium.HDD);
+        be2.setStorageMediumForAllDisks(TStorageMedium.HDD);
+        createTable("create table test.tbl1(key1 int, key2 varchar(10)) \n" +
+                "distributed by hash(key1) buckets 10 properties('replication_num' = '1');");
+        OlapTable tbl1 = (OlapTable) db.getTable("tbl1");
+        List<Partition> partitionList1 = Lists.newArrayList(tbl1.getPartitions());
+        DataProperty dataProperty1 =
+                globalStateMgr.getDataPropertyIncludeRecycleBin(tbl1.getPartitionInfo(),
+                        partitionList1.get(0).getId());
+        Assert.assertEquals(TStorageMedium.HDD, dataProperty1.getStorageMedium());
+
+        be1.setStorageMediumForAllDisks(TStorageMedium.SSD);
+        be2.setStorageMediumForAllDisks(TStorageMedium.SSD);
+        String sql = "create table test.tbl2\n" + "(k1 int, k2 int)\n"
+                + "duplicate key(k1)\n" + "partition by range(k2)\n" + "(partition p1 values less than(\"10\"))\n"
+                + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
+        createTable(sql);
+        OlapTable tbl2 = (OlapTable) db.getTable("tbl2");
+        List<Partition> partitionList2 = Lists.newArrayList(tbl2.getPartitions());
+        DataProperty dataProperty2 =
+                globalStateMgr.getDataPropertyIncludeRecycleBin(tbl2.getPartitionInfo(),
+                        partitionList2.get(0).getId());
+        Assert.assertEquals(TStorageMedium.SSD, dataProperty2.getStorageMedium());
+
+        be1.setStorageMediumForAllDisks(TStorageMedium.SSD);
+        be2.setStorageMediumForAllDisks(TStorageMedium.HDD);
+        createTable("create table test.tbl3(key1 int, key2 varchar(10)) \n" +
+                "distributed by hash(key1) buckets 10 properties('replication_num' = '1');");
+        OlapTable tbl3 = (OlapTable) db.getTable("tbl3");
+        List<Partition> partitionList3 = Lists.newArrayList(tbl3.getPartitions());
+        DataProperty dataProperty3 =
+                globalStateMgr.getDataPropertyIncludeRecycleBin(tbl3.getPartitionInfo(),
+                        partitionList3.get(0).getId());
+        Assert.assertEquals(TStorageMedium.SSD, dataProperty3.getStorageMedium());
+    }
+
+    @Test
+    public void testAlterTableAddPartition() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getDb("default_cluster:test");
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        be1.setStorageMediumForAllDisks(TStorageMedium.SSD);
+        be2.setStorageMediumForAllDisks(TStorageMedium.SSD);
+        String sql = "create table test.tblp2\n" + "(k1 int, k2 int)\n"
+                + "duplicate key(k1)\n" + "partition by range(k2)\n" + "(partition p1 values less than(\"10\"))\n"
+                + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ";
+        createTable(sql);
+        alterTable("ALTER TABLE test.tblp2 ADD PARTITION IF NOT EXISTS p2 VALUES LESS THAN (\"20\")");
+        OlapTable tbl2 = (OlapTable) db.getTable("tblp2");
+        List<Partition> partitionList2 = Lists.newArrayList(tbl2.getPartitions());
+        Assert.assertEquals(2, partitionList2.size());
+        for (Partition partition : partitionList2) {
+            DataProperty dataProperty2 =
+                    globalStateMgr.getDataPropertyIncludeRecycleBin(tbl2.getPartitionInfo(),
+                            partition.getId());
+            Assert.assertEquals(TStorageMedium.SSD, dataProperty2.getStorageMedium());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -248,7 +248,7 @@ public class UtFrameUtils {
         createMinStarRocksCluster(false);
     }
 
-    public static void addMockBackend(int backendId) throws Exception {
+    public static Backend addMockBackend(int backendId) throws Exception {
         // start be
         MockedBackend backend = new MockedBackend("127.0.0.1");
 
@@ -268,6 +268,8 @@ public class UtFrameUtils {
         be.setBrpcPort(backend.getBrpcPort());
         be.setHttpPort(backend.getHttpPort());
         GlobalStateMgr.getCurrentSystemInfo().addBackend(be);
+
+        return be;
     }
 
     public static void dropMockBackend(int backendId) throws DdlException {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If the storage paths reported by all the backends all have storage medium type HDD,
we infer that user wants to create a table or partition with storage_medium=HDD
when not explicitly specify the storage_medium property, otherwise it's SSD

(cherry picked from commit 336b33cbe150ec526cdae99f3b759cd1ea981f3f)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
