### PR TITLE
[Doc]iceberg catalog does not support v2 tables in 2.5

### DIFF
--- a/docs/data_source/catalog/iceberg_catalog.md
+++ b/docs/data_source/catalog/iceberg_catalog.md
@@ -9,7 +9,7 @@ An Iceberg catalog is an external catalog supported in StarRocks 2.4 and later v
 - StarRocks supports querying data files of Iceberg in the following formats: Parquet and ORC
 - StarRocks supports querying compressed data files of Iceberg in the following formats: gzip, Zstd, LZ4, and Snappy.
 - StarRocks supports querying Iceberg data in the following types: BOOLEAN, INTEGER, LONG, FLOAT, DOUBLE, DECIMAL(P, S), DATE, TIME, TIMESTAMP, STRING, UUID, LIST, FIXED(L), BINARY, STRUCT, and MAP. The TIMESTAMPTZ type is not supported. An error occurs when you query Iceberg data of the TIMESTAMPTZ type.
-- StarRocks supports querying Versions 1 tables (Analytic Data Tables) and Versions 2 tables (Row-level Deletes). For the differences between these two types of tables, see [Iceberg Table Spec](https://iceberg.apache.org/spec/).
+- StarRocks supports querying Versions 1 tables (Analytic Data Tables). Versions 2 tables (Row-level Deletes) are not supported. For the differences between these two types of tables, see [Iceberg Table Spec](https://iceberg.apache.org/spec/).
 - You can use the [DESC](../../sql-reference/sql-statements/Utility/DESCRIBE.md) statement to view the schema of an Iceberg table in StarRocks 2.4 and later versions.
 
 ## Before you begin


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
