### PR TITLE
[BugFix]when decimal as map's key type in parquet, the real type is FIXED_LEN_BYTE_ARRAY which is OPTIONAL

### DIFF
--- a/be/src/formats/parquet/schema.cpp
+++ b/be/src/formats/parquet/schema.cpp
@@ -206,7 +206,9 @@ Status SchemaDescriptor::map_to_field(const std::vector<tparquet::SchemaElement>
     auto& key_schema = t_schemas[pos + 2];
     // when key type is char or varchar in hive, not string
     // the real type is BYTE_ARRAY which is OPTIONAL
-    if ((!is_required(key_schema)) && (key_schema.type != tparquet::Type::type::BYTE_ARRAY)) {
+    // when key type is decimal, the real type is FIXED_LEN_BYTE_ARRAY which is OPTIONAL
+    if ((!is_required(key_schema)) && (key_schema.type != tparquet::Type::type::BYTE_ARRAY) &&
+        (key_schema.type != tparquet::Type::type::FIXED_LEN_BYTE_ARRAY)) {
         return Status::InvalidArgument("key in map group must be required");
     }
 


### PR DESCRIPTION

<img width="1499" alt="截屏2022-12-07 08 24 47" src="https://user-images.githubusercontent.com/28446271/206061840-a5da8ffe-7774-46f4-a2e9-dcb712855de3.png">

it is similar to pr https://github.com/StarRocks/starrocks/pull/12921
Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14734 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
