### PR TITLE
[Enhancement] Adapt list partition names when manually refreshing external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -57,6 +57,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
     public static final long NEVER_CACHE = 0;
     public static final long NEVER_EVICT = -1;
     public static final long NEVER_REFRESH = -1;
+    private final boolean enableListNameCache;
     protected final IHiveMetastore metastore;
 
     protected LoadingCache<String, List<String>> databaseNamesCache;
@@ -92,20 +93,18 @@ public class CachingHiveMetastore implements IHiveMetastore {
     protected CachingHiveMetastore(IHiveMetastore metastore, Executor executor, long expireAfterWriteSec,
                                    long refreshIntervalSec, long maxSize, boolean enableListNamesCache) {
         this.metastore = metastore;
+        this.enableListNameCache = enableListNamesCache;
+
+        databaseNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
+                .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
+        tableNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
+                .build(asyncReloading(CacheLoader.from(this::loadAllTableNames), executor));
 
         // The list names interface of hive metastore latency is very low, so we default to pull the latest every time.
         if (enableListNamesCache) {
-            databaseNamesCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
-                    .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
-            tableNamesCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
-                    .build(asyncReloading(CacheLoader.from(this::loadAllTableNames), executor));
             partitionKeysCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
                     .build(asyncReloading(CacheLoader.from(this::loadPartitionKeys), executor));
         } else {
-            databaseNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
-                    .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
-            tableNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
-                    .build(asyncReloading(CacheLoader.from(this::loadAllTableNames), executor));
             partitionKeysCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
                     .build(asyncReloading(CacheLoader.from(this::loadPartitionKeys), executor));
         }
@@ -302,6 +301,9 @@ public class CachingHiveMetastore implements IHiveMetastore {
         HiveTableName hiveTableName = HiveTableName.of(hiveDbName, hiveTblName);
         Table updatedTable = loadTable(hiveTableName);
         tableCache.put(hiveTableName, updatedTable);
+        if (enableListNameCache) {
+            partitionKeysCache.put(hiveTableName, loadPartitionKeys(hiveTableName));
+        }
 
         HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) updatedTable;
         if (hmsTable.isUnPartitioned()) {
@@ -353,6 +355,12 @@ public class CachingHiveMetastore implements IHiveMetastore {
 
         Map<HivePartitionName, HivePartitionStats> updatePartitionStats = loadPartitionsStatistics(partitionNames);
         partitionStatsCache.putAll(updatePartitionStats);
+
+        if (enableListNameCache && !partitionNames.isEmpty()) {
+            HivePartitionName firstName = partitionNames.get(0);
+            HiveTableName hiveTableName = HiveTableName.of(firstName.getDatabaseName(), firstName.getTableName());
+            partitionKeysCache.put(hiveTableName, loadPartitionKeys(hiveTableName));
+        }
     }
 
     private static <K, V> V get(LoadingCache<K, V> cache, K key) {
@@ -398,6 +406,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
         HiveTableName hiveTableName = HiveTableName.of(dbName, tableName);
         tableCache.invalidate(hiveTableName);
         tableStatsCache.invalidate(hiveTableName);
+        partitionKeysCache.invalidate(hiveTableName);
         List<HivePartitionName> presentPartitions = getPresentPartitionNames(partitionCache, dbName, tableName);
         presentPartitions.forEach(p -> partitionCache.invalidate(p));
         List<HivePartitionName> presentPartitionStats = getPresentPartitionNames(partitionStatsCache, dbName, tableName);
@@ -405,6 +414,8 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     public synchronized void invalidatePartition(HivePartitionName partitionName) {
+        HiveTableName hiveTableName = HiveTableName.of(partitionName.getDatabaseName(), partitionName.getTableName());
+        partitionKeysCache.invalidate(hiveTableName);
         partitionCache.invalidate(partitionName);
         partitionStatsCache.invalidate(partitionName);
     }
@@ -428,6 +439,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
             tableStatsCache.put(hiveTableName, updatedPartitionStats);
             partitionCache.put(HivePartitionName.of(dbName, tableName, Lists.newArrayList()), partition);
         } else {
+            partitionKeysCache.invalidate(hiveTableName);
             List<HivePartitionName> presentPartitions = getPresentPartitionNames(partitionCache, dbName, tableName);
             presentPartitions.forEach(p -> partitionCache.invalidate(p));
             List<HivePartitionName> presentPartitionStats = getPresentPartitionNames(partitionStatsCache, dbName, tableName);
@@ -440,6 +452,8 @@ public class CachingHiveMetastore implements IHiveMetastore {
                                                      Partition partition) {
         Map<String, HiveColumnStats> columnStats = get(partitionStatsCache, hivePartitionName).getColumnStats();
         HivePartitionStats updatedPartitionStats = createPartitionStats(commonStats, columnStats);
+        HiveTableName hiveTableName = HiveTableName.of(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName());
+        partitionKeysCache.invalidate(hiveTableName);
         partitionCache.put(hivePartitionName, partition);
         partitionStatsCache.put(hivePartitionName, updatedPartitionStats);
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
we found that list_partition_names interface of glue on aws is very slow and isn't as expected. it should be 50ms around. but  it's 800ms in glue. so some user may set "enable_cache_list_names"="true" when creating an external hive/hudi catalog. 


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
