### PR TITLE
[BugFix] When forwarding SQL to leader, forward all modified session variable as well

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -645,6 +645,11 @@ public class ConnectProcessor {
 
         StmtExecutor executor = null;
         try {
+            // set session variables first
+            if (request.isSetModified_variables_sql()) {
+                LOG.info("Set session variables first: {}", request.modified_variables_sql);
+                new StmtExecutor(ctx, new OriginStatement(request.modified_variables_sql, 0), true).execute();
+            }
             // 0 for compatibility.
             int idx = request.isSetStmtIdx() ? request.getStmtIdx() : 0;
             executor = new StmtExecutor(ctx, new OriginStatement(request.getSql(), idx), true);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
@@ -54,7 +54,7 @@ public class SetExecutor {
             // do nothing
             return;
         } else {
-            VariableMgr.setVar(ctx.getSessionVariable(), var, false);
+            ctx.modifySessionVariable(var, false);
         }
     }
 
@@ -74,6 +74,10 @@ public class SetExecutor {
         }
     }
 
+    /**
+     * This method is only called after a set statement is forward to the leader.
+     * In this case, the follower should change this session variable as well.
+     */
     public void setSessionVars() throws DdlException {
         for (SetVar var : stmt.getSetVars()) {
             if (isSessionVar(var)) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -96,13 +96,15 @@ public class VariableMgr {
     // and can modify its own variable.
     public static final int SESSION = 1;
     // Variables with this flag have only one instance in one process.
-    public static final int GLOBAL = 2;
+    public static final int GLOBAL = 1 << 1;
     // Variables with this flag only exist in each session.
-    public static final int SESSION_ONLY = 4;
+    public static final int SESSION_ONLY = 1 << 2;
     // Variables with this flag can only be read.
-    public static final int READ_ONLY = 8;
+    public static final int READ_ONLY = 1 << 3;
     // Variables with this flag can not be seen with `SHOW VARIABLES` statement.
-    public static final int INVISIBLE = 16;
+    public static final int INVISIBLE = 1 << 4;
+    // Variables with this flag will not forward to leader when modified in session
+    public static final int DISABLE_FORWARD_TO_LEADER = 1 << 5;
 
     // Map variable name to variable context which have enough information to change variable value.
     // This map contains info of all session and global variables.
@@ -516,6 +518,10 @@ public class VariableMgr {
         rows.sort(Comparator.comparing(o -> o.get(0)));
 
         return rows;
+    }
+
+    public static boolean shouldForwardToLeader(String name) {
+        return (getVarContext(name).getFlag() & DISABLE_FORWARD_TO_LEADER) == 0;
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
@@ -31,6 +31,9 @@ import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SelectList;
 import com.starrocks.analysis.SelectListItem;
+import com.starrocks.analysis.SetStmt;
+import com.starrocks.analysis.SetType;
+import com.starrocks.analysis.SetVar;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.analysis.SysVariableDesc;
@@ -66,6 +69,24 @@ public class AST2SQL {
     }
 
     public static class SQLBuilder extends AstVisitor<String, Void> {
+        @Override
+        public String visitSetStatement(SetStmt stmt, Void context) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("SET ");
+            int idx = 0;
+            for (SetVar setVar : stmt.getSetVars()) {
+                if (idx != 0) {
+                    sb.append(", ");
+                }
+                // `SET DEFAULT` is not supported
+                if (! setVar.getType().equals(SetType.DEFAULT)) {
+                    sb.append(setVar.getType().toString() + " ");
+                }
+                sb.append(setVar.getVariable() + " = " + setVar.getValue().toSql());
+                idx++;
+            }
+            return sb.toString();
+        }
         @Override
         public String visitQueryStatement(QueryStatement stmt, Void context) {
             StringBuilder sqlBuilder = new StringBuilder();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
@@ -23,11 +23,11 @@ package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.AccessTestUtil;
-import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.SetNamesVar;
 import com.starrocks.analysis.SetPassVar;
 import com.starrocks.analysis.SetStmt;
+import com.starrocks.analysis.SetType;
 import com.starrocks.analysis.SetVar;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.AnalysisException;
@@ -35,15 +35,20 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.GlobalVarPersistInfo;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 
 public class SetExecutorTest {
-    private Analyzer analyzer;
     private ConnectContext ctx;
 
     @Mocked
@@ -51,7 +56,6 @@ public class SetExecutorTest {
 
     @Before
     public void setUp() throws DdlException {
-        analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         ctx = new ConnectContext(null);
         ctx.setCatalog(AccessTestUtil.fetchAdminCatalog());
         ctx.setQualifiedUser("root");
@@ -89,9 +93,34 @@ public class SetExecutorTest {
         vars.add(new SetVar("query_timeout", new IntLiteral(10L)));
 
         SetStmt stmt = new SetStmt(vars);
-        stmt.analyze(analyzer);
+        stmt.analyze();
         SetExecutor executor = new SetExecutor(ctx, stmt);
 
         executor.execute();
+    }
+
+    @Test
+    public void testSetSessionAndGlobal(@Mocked EditLog editLog) throws Exception {
+        new Expectations(editLog) {
+            {
+                editLog.logGlobalVariableV2((GlobalVarPersistInfo)any);
+                minTimes = 1;
+            }
+        };
+        GlobalStateMgr.getCurrentState().setEditLog(editLog);
+
+        String globalSQL = "set global query_timeout = 10";
+        SetStmt stmt = (SetStmt) UtFrameUtils.parseStmtWithNewParser(globalSQL, ctx);
+        SetExecutor executor = new SetExecutor(ctx, stmt);
+        executor.execute();
+        Assert.assertEquals(null, ctx.getModifiedSessionVariables());
+        Assert.assertEquals(10, ctx.sessionVariable.getQueryTimeoutS());
+
+        String sessionSQL = "set query_timeout = 9";
+        stmt = (SetStmt) UtFrameUtils.parseStmtWithNewParser(sessionSQL, ctx);
+        executor = new SetExecutor(ctx, stmt);
+        executor.execute();
+        Assert.assertEquals(1, ctx.getModifiedSessionVariables().getSetVars().size());
+        Assert.assertEquals(9, ctx.sessionVariable.getQueryTimeoutS());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AST2SQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AST2SQLTest.java
@@ -3,6 +3,9 @@
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.analysis.CreateViewStmt;
+import com.starrocks.analysis.SetStmt;
+import com.starrocks.analysis.SetType;
+import com.starrocks.analysis.SetVar;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import org.junit.Assert;
@@ -50,4 +53,45 @@ public class AST2SQLTest {
                     "SELECT `default_cluster:test`.`t0`.`v1` AS `v1` FROM `default_cluster:test`.`t0` WHERE (NOT FALSE) IS NOT NULL");
         }
     }
+
+    @Test
+    public void testSet() {
+        // 1. one global statement
+        String sql = "SET GLOBAL time_zone = 'Asia/Shanghai'";
+
+        List<StatementBase> statementBase = SqlParser.parse(
+                sql, AnalyzeTestUtil.getConnectContext().getSessionVariable().getSqlMode());
+        Assert.assertEquals(1, statementBase.size());
+        SetStmt originStmt = (SetStmt)statementBase.get(0);
+
+        System.err.println(sql + " -> " + AST2SQL.toString(originStmt));
+
+        statementBase = SqlParser.parse(
+                AST2SQL.toString(originStmt), AnalyzeTestUtil.getConnectContext().getSessionVariable().getSqlMode());
+        Assert.assertEquals(1, statementBase.size());
+        SetStmt convertStmt = (SetStmt)statementBase.get(0);
+
+        Assert.assertEquals(1, convertStmt.getSetVars().size());
+        Assert.assertEquals(SetType.GLOBAL, convertStmt.getSetVars().get(0).getType());
+        Assert.assertEquals(AST2SQL.toString(originStmt), AST2SQL.toString(convertStmt));
+
+        // 2. two default statement
+        sql = "SET time_zone = 'Asia/Shanghai', allow_default_partition=true;";
+        statementBase = SqlParser.parse(
+                sql, AnalyzeTestUtil.getConnectContext().getSessionVariable().getSqlMode());
+        Assert.assertEquals(1, statementBase.size());
+        originStmt = (SetStmt)statementBase.get(0);
+
+        System.err.println(sql + " -> " + AST2SQL.toString(originStmt));
+
+        statementBase = SqlParser.parse(
+                AST2SQL.toString(originStmt), AnalyzeTestUtil.getConnectContext().getSessionVariable().getSqlMode());
+        Assert.assertEquals(1, statementBase.size());
+        convertStmt = (SetStmt)statementBase.get(0);
+
+        Assert.assertEquals(2, convertStmt.getSetVars().size());
+        Assert.assertEquals(SetType.DEFAULT, convertStmt.getSetVars().get(0).getType());
+        Assert.assertEquals(SetType.DEFAULT, convertStmt.getSetVars().get(1).getType());
+        Assert.assertEquals(AST2SQL.toString(originStmt), AST2SQL.toString(convertStmt));
+     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -425,6 +425,7 @@ struct TMasterOpRequest {
     // TODO(zc): Should forward all session variables and connection context
     30: optional Types.TUniqueId queryId
     31: optional bool isLastStmt
+    32: optional string modified_variables_sql
 }
 
 struct TColumnDefinition {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/753

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Store modified session variables to ConnectContext.
2. Add a SetStmt SQL to LeaderOpRequest to set all modified session variables
3. Leader will apply all session variables before executing the forwarded SQL.