### PR TITLE
[BugFix] When forwarding SQL to leader, forward all modified session variable as well

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -623,6 +623,11 @@ public class ConnectProcessor {
 
         StmtExecutor executor = null;
         try {
+            // set session variables first
+            if (request.isSetModified_variables_sql()) {
+                LOG.info("Set session variables first: {}", request.modified_variables_sql);
+                new StmtExecutor(ctx, new OriginStatement(request.modified_variables_sql, 0), true).execute();
+            }
             // 0 for compatibility.
             int idx = request.isSetStmtIdx() ? request.getStmtIdx() : 0;
             executor = new StmtExecutor(ctx, new OriginStatement(request.getSql(), idx), true);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/MasterOpExecutor.java
@@ -30,6 +30,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.qe.QueryState.MysqlStateType;
 import com.starrocks.rpc.FrontendServiceProxy;
+import com.starrocks.sql.analyzer.AST2SQL;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -135,7 +136,12 @@ public class MasterOpExecutor {
         params.setQuery_options(queryOptions);
 
         params.setQueryId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-        LOG.info("Forward statement {} to Master {}", ctx.getStmtId(), thriftAddress);
+        // forward all session variables
+        SetStmt setStmt = ctx.getModifiedSessionVariables();
+        if (setStmt != null) {
+            params.setModified_variables_sql(AST2SQL.toString(setStmt));
+        }
+        LOG.info("Forward statement {} to Leader {}", ctx.getStmtId(), thriftAddress);
 
         result = FrontendServiceProxy.call(thriftAddress,
                 thriftTimeoutMs,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
@@ -54,7 +54,7 @@ public class SetExecutor {
             // do nothing
             return;
         } else {
-            VariableMgr.setVar(ctx.getSessionVariable(), var, false);
+            ctx.modifySessionVariable(var, false);
         }
     }
 
@@ -75,6 +75,10 @@ public class SetExecutor {
         }
     }
 
+    /**
+     * This method is only called after a set statement is forward to the leader.
+     * In this case, the follower should change this session variable as well.
+     */
     public void setSessionVars() throws DdlException {
         for (SetVar var : stmt.getSetVars()) {
             if (isSessionVar(var)) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -96,13 +96,15 @@ public class VariableMgr {
     // and can modify its own variable.
     public static final int SESSION = 1;
     // Variables with this flag have only one instance in one process.
-    public static final int GLOBAL = 2;
+    public static final int GLOBAL = 1 << 1;
     // Variables with this flag only exist in each session.
-    public static final int SESSION_ONLY = 4;
+    public static final int SESSION_ONLY = 1 << 2;
     // Variables with this flag can only be read.
-    public static final int READ_ONLY = 8;
+    public static final int READ_ONLY = 1 << 3;
     // Variables with this flag can not be seen with `SHOW VARIABLES` statement.
-    public static final int INVISIBLE = 16;
+    public static final int INVISIBLE = 1 << 4;
+    // Variables with this flag will not forward to leader when modified in session
+    public static final int DISABLE_FORWARD_TO_LEADER = 1 << 5;
 
     // Map variable name to variable context which have enough information to change variable value.
     // This map contains info of all session and global variables.
@@ -539,6 +541,10 @@ public class VariableMgr {
     public static long saveGlobalVariable(DataOutputStream out, long checksum) throws IOException {
         VariableMgr.write(out);
         return checksum;
+    }
+
+    public static boolean shouldForwardToLeader(String name) {
+        return (getVarContext(name).getFlag() & DISABLE_FORWARD_TO_LEADER) == 0;
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -87,14 +87,12 @@ public class TaskRun {
         newCtx.setCurrentUserIdentity(ctx.getCurrentUserIdentity());
         newCtx.getState().reset();
         newCtx.setQueryId(UUID.fromString(status.getQueryId()));
-        SessionVariable sessionVariable = (SessionVariable) ctx.getSessionVariable().clone();
+        newCtx.resetSessionVariable();
         if (properties != null) {
             for (String key : properties.keySet()) {
-                VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(properties.get(key))),
-                        true);
+                newCtx.modifySessionVariable(new SetVar(key, new StringLiteral(properties.get(key))), true);
             }
         }
-        newCtx.setSessionVariable(sessionVariable);
         taskRunContext.setCtx(newCtx);
         taskRunContext.setRemoteIp(ctx.getMysqlChannel().getRemoteHostPortString());
         processor.processTaskRun(taskRunContext);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AST2SQL.java
@@ -31,6 +31,9 @@ import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SelectList;
 import com.starrocks.analysis.SelectListItem;
+import com.starrocks.analysis.SetStmt;
+import com.starrocks.analysis.SetType;
+import com.starrocks.analysis.SetVar;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.analysis.SysVariableDesc;
@@ -66,6 +69,24 @@ public class AST2SQL {
     }
 
     public static class SQLBuilder extends AstVisitor<String, Void> {
+        @Override
+        public String visitSetStatement(SetStmt stmt, Void context) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("SET ");
+            int idx = 0;
+            for (SetVar setVar : stmt.getSetVars()) {
+                if (idx != 0) {
+                    sb.append(", ");
+                }
+                // `SET DEFAULT` is not supported
+                if (! setVar.getType().equals(SetType.DEFAULT)) {
+                    sb.append(setVar.getType().toString() + " ");
+                }
+                sb.append(setVar.getVariable() + " = " + setVar.getValue().toSql());
+                idx++;
+            }
+            return sb.toString();
+        }
         @Override
         public String visitQueryStatement(QueryStatement stmt, Void context) {
             StringBuilder sqlBuilder = new StringBuilder();

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -469,6 +469,7 @@ struct TMasterOpRequest {
     // TODO(zc): Should forward all session variables and connection context
     30: optional Types.TUniqueId queryId
     31: optional bool isLastStmt
+    32: optional string modified_variables_sql
 }
 
 struct TColumnDefinition {


### PR DESCRIPTION
## What type of PR is this：
- [x] bug
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/753

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Store modified session variables to ConnectContext.
2. Add a SetStmt SQL to LeaderOpRequest to set all modified session variables
3. Leader will apply all session variables before executing the forwarded SQL.