### PR TITLE
[BugFix] shouldn't use TreeNode.contains to check the type support join on or not

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -283,8 +283,8 @@ public class BinaryPredicate extends Predicate implements Writable {
         if (type1.isJsonType() || type2.isJsonType()) {
             return Type.JSON;
         }
-        if (type1.isArrayType() || type2.isArrayType()) {
-            // We don't support array type for binary predicate.
+        if (type1.isComplexType() || type2.isComplexType()) {
+            // We don't support complex type for binary predicate.
             return Type.INVALID;
         }
         if (t1 == PrimitiveType.VARCHAR && t2 == PrimitiveType.VARCHAR) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -681,8 +681,8 @@ public class ExpressionAnalyzer {
 
             for (Expr expr : node.getChildren()) {
                 if (expr.getType().isOnlyMetricType() ||
-                        (expr.getType() instanceof ArrayType && !(node instanceof IsNullPredicate))) {
-                    throw new SemanticException("HLL, BITMAP, PERCENTILE and ARRAY type couldn't as Predicate");
+                        (expr.getType().isComplexType() && !(node instanceof IsNullPredicate))) {
+                    throw new SemanticException("HLL, BITMAP, PERCENTILE and ARRAY, MAP, STRUCT type couldn't as Predicate");
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -403,6 +403,11 @@ public class QueryAnalyzer {
                     throw new SemanticException("WHERE clause must evaluate to a boolean: actual type %s",
                             joinEqual.getType());
                 }
+                // check the join on predicate, example:
+                // we have col_json, we can't join on table_a.col_json = table_b.col_json,
+                // but we can join on cast(table_a.col_json->"a" as int) = cast(table_b.col_json->"a" as int)
+                // similarly, we can join on table_a.col_map['a'] = table_b.col_map['a'],
+                // and table_a.col_struct.a = table_b.col_struct.a
                 checkJoinEqual(joinEqual);
             } else {
                 if (join.getJoinOp().isOuterJoin() || join.getJoinOp().isSemiAntiJoin()) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleQueryAnalyzer.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleQueryAnalyzer.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.connector.analyzer;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.CompoundPredicate;
@@ -33,6 +32,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.QueryAnalyzer;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
@@ -161,9 +161,7 @@ public class SimpleQueryAnalyzer {
                     throw new SemanticException("WHERE clause must evaluate to a boolean: actual type %s",
                             joinEqual.getType());
                 }
-                if (joinEqual.contains((Predicate<Expr>) node -> !node.getType().canJoinOn())) {
-                    throw new SemanticException(Type.ONLY_METRIC_TYPE_ERROR_MSG);
-                }
+                QueryAnalyzer.checkJoinEqual(joinEqual);
             } else {
                 if (join.getJoinOp().isOuterJoin() || join.getJoinOp().isSemiAntiJoin()) {
                     throw new SemanticException(join.getJoinOp() + " requires an ON or USING clause.");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzePredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzePredicateTest.java
@@ -33,9 +33,9 @@ public class AnalyzePredicateTest {
     public void testArrayPredicate() {
         analyzeSuccess("select * from tarray where v3 is null");
         analyzeFail("select * from tarray where v3 between [1,2,3] and [4,5,6]",
-                "HLL, BITMAP, PERCENTILE and ARRAY type couldn't as Predicate");
+                "HLL, BITMAP, PERCENTILE and ARRAY, MAP, STRUCT type couldn't as Predicate");
         analyzeFail("select * from tarray where v3 in ([1,2,3], [4,5,6])",
-                "HLL, BITMAP, PERCENTILE and ARRAY type couldn't as Predicate");
+                "HLL, BITMAP, PERCENTILE and ARRAY, MAP, STRUCT type couldn't as Predicate");
     }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -65,6 +65,19 @@ public class JsonTypeTest extends PlanTestBase {
 
         ExceptionChecker.expectThrowsNoException(
                 () -> getFragmentPlan("select * from tjson_test t1 join tjson_test t2 on t1.v_id = t2.v_id"));
+
+        ExceptionChecker.expectThrowsNoException(
+                () -> getFragmentPlan("select * from tjson_test t1 join tjson_test t2 on" +
+                        " cast(t1.v_json->'a' as int) = cast(t2.v_json->'a' as int)"));
+
+        ExceptionChecker.expectThrowsNoException(
+                () -> getFragmentPlan("select * from tjson_test t1 join tjson_test t2 on" +
+                        " cast(t1.v_json->'a' as int) = cast(t2.v_json->'a' as int) and t1.v_id = t2.v_id"));
+
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "Type percentile/hll/bitmap/json/struct/map not support aggregation/group-by/order-by/union/join",
+                () -> getFragmentPlan("select * from tjson_test t1 join tjson_test t2 on" +
+                        " t1.v_id = t2.v_id and t1.v_json = t2.v_json"));
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MetricTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MetricTypeTest.java
@@ -94,7 +94,7 @@ public class MetricTypeTest extends PlanTestBase {
         starRocksAssert.query(sql).analysisError("bitmap", "not support binary predicate");
 
         sql = "select * from test.bitmap_table a join test.hll_table b where a.id2 in (1, 2, 3)";
-        starRocksAssert.query(sql).analysisError("HLL, BITMAP, PERCENTILE and ARRAY type couldn't as Predicate");
+        starRocksAssert.query(sql).analysisError("HLL, BITMAP, PERCENTILE and ARRAY, MAP, STRUCT type couldn't as Predicate");
     }
 
 }


### PR DESCRIPTION
fix bug when join on complex type's element expr, such as a.array[1]=b.array[1], a.map['a']=b.map['a'], a.struct.a=b.struct.a, cast(a.json->'a' as int)=cast(b.json->'a' as int)
shouldn't use TreeNode.contains to check the type support join on or not, because it will check every node in the tree, though we don't support join on map<string, int>, but we support join on table_a.map['a'] = table_b.map['a']

Signed-off-by: zombee0 <flylucas_10@163.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14727 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
