### PR TITLE
[BugFix] Remove precondition check in TransactionGraph.remove

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
@@ -77,6 +77,11 @@ public class TransactionGraph {
         public int hashCode() {
             return Objects.hash(txnId);
         }
+
+        @Override
+        public String toString() {
+            return Long.toString(txnId);
+        }
     }
 
     private Map<Long, Node> nodes = new HashMap<>();
@@ -117,7 +122,12 @@ public class TransactionGraph {
         if (node == null) {
             return;
         }
-        Preconditions.checkState(node.ins == null || node.ins.isEmpty(), "only can remove node with no dependency");
+        if (node.ins != null && !node.ins.isEmpty()) {
+            LOG.warn("remove txn " + txnId + " with dependency: " + node.ins + " this may happen during FE upgrading");
+            for (Node dep : node.ins) {
+                dep.outs.remove(node);
+            }
+        }
         nodes.remove(txnId);
         nodesWithoutIns.remove(node);
         for (long tableId : node.writeTableIds) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
@@ -54,6 +54,24 @@ public class TransactionGraphTest {
     }
 
     @Test
+    public void testRemoveNodeWithDependency() {
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(1, Lists.newArrayList(1L));
+        graph.add(2, Lists.newArrayList(2L));
+        graph.add(3, Lists.newArrayList(1L));
+        graph.add(4, Lists.newArrayList(2L));
+        graph.add(5, Lists.newArrayList(1L));
+        graph.add(6, Lists.newArrayList(2L));
+        assertEquals(graph.size(), 6);
+        graph.remove(3);
+        graph.remove(4);
+        assertEquals(graph.size(), 4);
+        expectNextBatch(graph, Lists.newArrayList(1L, 2L, 5L, 6L));
+        assertEquals(graph.size(), 0);
+        assertEquals(graph.getTxnsWithoutDependency().size(), 0);
+    }
+
+    @Test
     public void testMultiTableTxn() {
         TransactionGraph graph = new TransactionGraph();
         graph.add(1, Lists.newArrayList(1L));


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14803

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
2.5 enables new publish by default, which may cause FE error during upgrade. During upgrade, some txns may remove txn's earlier than it's dependent txn in log replay, so removing the precondition check and allow remove all txns from txngraph. 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
