### PR TITLE
[BugFix][Enhancement]Lambda functions reuse sub expressions without lambda arguments

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -118,6 +118,7 @@ public class AnalyzeExprTest {
         analyzeSuccess("select array_map([1], x -> x)");
         analyzeSuccess("select array_map([1], x -> x + v1) from t0");
         analyzeSuccess("select transform([1], x -> x)");
+        analyzeSuccess("select arr,array_length(arr) from (select array_map(x->x+1, [1,2]) as arr)T");
 
         analyzeFail("select array_map(x,y -> x + y, [], [])"); // should be (x,y)
         analyzeFail("select array_map((x,y,z) -> x + y, [], [])");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -547,6 +547,11 @@ public class ExpressionTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("common expressions"));
         Assert.assertTrue(plan.contains("array_length(6: array_map)"));
+
+        sql = "select  array_map(x->x+ 3 *c1 + 3*c1, c2) from test_array";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) + 7: multiply + 7: multiply, 2: c2)"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -543,7 +543,7 @@ public class ExpressionTest extends PlanTestBase {
         sql = "select 3*c1, array_map(x->x+ 3 *c1, c2) from test_array";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("common expressions"));
-        Assert.assertTrue(plan.contains("array_map(<slot 5> -> CAST(<slot 5> AS BIGINT) + 8: multiply, 2: c2)"));
+        Assert.assertTrue(plan.contains("array_map(<slot 5> -> CAST(<slot 5> AS BIGINT) + 8: multiply"));
 
         sql = "select arr,array_length(arr) from (select array_map(x->x+1, [1,2]) as arr)T";
         plan = getFragmentPlan(sql);
@@ -554,7 +554,7 @@ public class ExpressionTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("common expressions"));
         Assert.assertTrue(plan.contains(
-                "array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) + 7: multiply + 7: multiply, 2: c2)"));
+                "array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) + 7: multiply + 7: multiply"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -523,6 +523,33 @@ public class ExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testLambdaReuseSubExpression() throws Exception {
+        starRocksAssert.withTable("create table test_array" +
+                "(c0 INT,c1 int, c2 array<int>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+        String sql = "select b, array_map(x->x+b, arr) from (select array_map(x->x+1, [1,2]) as arr, 3*c1 as b from test_array)T";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_map(<slot 7> -> CAST(<slot 7> AS BIGINT) + 10: multiply"));
+
+        sql = "select b, array_map(x->x+ 3 *c1, arr) from (select array_map(x->x+1, [1,2]) as arr, 3*c1 as b,c1 from test_array)T";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_map(<slot 7> -> CAST(<slot 7> AS BIGINT) + 10: multiply"));
+
+        sql = "select 3*c1, array_map(x->x+ 3 *c1, c2) from test_array";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_map(<slot 5> -> CAST(<slot 5> AS BIGINT) + 8: multiply, 2: c2)"));
+
+        sql = "select arr,array_length(arr) from (select array_map(x->x+1, [1,2]) as arr)T";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_length(6: array_map)"));
+    }
+
+    @Test
     public void testInPredicateNormalize() throws Exception {
         starRocksAssert.withTable("create table test_in_pred_norm" +
                 "(c0 INT, c1 INT, c2 INT, c3 INT, c4 DATE, c5 DATE) " +


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/14747

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

reusing sub expressions in lambda functions cause errors because the lambda arguments are not identified in the columnRef.

to fix the problem, we support reusing sub expressions in lambda functions, but the sub expressions cannot contain lambda arguments. this limit will removed later.
```
mysql> explain select 3*c1, array_map(x->x+ 3 *c1, c2) from test_array;
+--------------------------------------------------------------------------------------+
| Explain String                                                                       |
+--------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                      |
|  OUTPUT EXPRS:4: expr | 6: array_map                                                 |
|   PARTITION: UNPARTITIONED                                                           |
|                                                                                      |
|   RESULT SINK                                                                        |
|                                                                                      |
|   2:EXCHANGE                                                                         |
|                                                                                      |
| PLAN FRAGMENT 1                                                                      |
|  OUTPUT EXPRS:                                                                       |
|   PARTITION: RANDOM                                                                  |
|                                                                                      |
|   STREAM DATA SINK                                                                   |
|     EXCHANGE ID: 02                                                                  |
|     UNPARTITIONED                                                                    |
|                                                                                      |
|   1:Project                                                                          |
|   |  <slot 4> : 8: multiply                                                          |
|   |  <slot 6> : array_map(<slot 5> -> CAST(<slot 5> AS BIGINT) + 8: multiply, 2: c2) |
|   |  common expressions:                                                             |
|   |  <slot 7> : CAST(1: c1 AS BIGINT)                                                |
|   |  <slot 8> : 3 * 7: cast                                                          |
|   |                                                                                  |
|   0:OlapScanNode                                                                     |
|      TABLE: test_array                                                               |
|      PREAGGREGATION: ON                                                              |
|      partitions=1/1                                                                  |
|      rollup: test_array                                                              |
|      tabletRatio=2/2                                                                 |
|      tabletList=13004,13006                                                          |
|      cardinality=9                                                                   |
|      avgRowSize=29.0                                                                 |
|      numNodes=0                                                                      |
+--------------------------------------------------------------------------------------+
33 rows in set (0.01 sec)

mysql> explain select  arr,array_length(arr) from (select  array_map(x->x+1, [1,2]) as arr)T;
+-----------------------------------------------------------------------------------------------+
| Explain String                                                                                |
+-----------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                               |
|  OUTPUT EXPRS:3: array_map | 4: array_length                                                  |
|   PARTITION: UNPARTITIONED                                                                    |
|                                                                                               |
|   RESULT SINK                                                                                 |
|                                                                                               |
|   1:Project                                                                                   |
|   |  <slot 3> : 6: array_map                                                                  |
|   |  <slot 4> : array_length(6: array_map)                                                    |
|   |  common expressions:                                                                      |
|   |  <slot 5> : ARRAY<tinyint(4)>[1,2]                                                        |
|   |  <slot 6> : array_map(<slot 2> -> CAST(<slot 2> AS SMALLINT) + 1, ARRAY<tinyint(4)>[1,2]) |
|   |                                                                                           |
|   0:UNION                                                                                     |
|      constant exprs:                                                                          |
|          NULL                                                                                 |
+-----------------------------------------------------------------------------------------------+
16 rows in set (0.01 sec)

mysql> select  arr,array_length(arr) from (select  array_map(x->x+1, [1,2]) as arr)T;
+-------+-------------------+
| arr   | array_length(arr) |
+-------+-------------------+
| [2,3] |                 2 |
+-------+-------------------+
1 row in set (0.01 sec)

mysql> explain select 3*c1, array_map(x->x+ 3 *c1, c2) from test_array;
+--------------------------------------------------------------------------------------+
| Explain String                                                                       |
+--------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                      |
|  OUTPUT EXPRS:4: expr | 6: array_map                                                 |
|   PARTITION: UNPARTITIONED                                                           |
|                                                                                      |
|   RESULT SINK                                                                        |
|                                                                                      |
|   2:EXCHANGE                                                                         |
|                                                                                      |
| PLAN FRAGMENT 1                                                                      |
|  OUTPUT EXPRS:                                                                       |
|   PARTITION: RANDOM                                                                  |
|                                                                                      |
|   STREAM DATA SINK                                                                   |
|     EXCHANGE ID: 02                                                                  |
|     UNPARTITIONED                                                                    |
|                                                                                      |
|   1:Project                                                                          |
|   |  <slot 4> : 8: multiply                                                          |
|   |  <slot 6> : array_map(<slot 5> -> CAST(<slot 5> AS BIGINT) + 8: multiply, 2: c2) |
|   |  common expressions:                                                             |
|   |  <slot 7> : CAST(1: c1 AS BIGINT)                                                |
|   |  <slot 8> : 3 * 7: cast                                                          |
|   |                                                                                  |
|   0:OlapScanNode                                                                     |
|      TABLE: test_array                                                               |
|      PREAGGREGATION: ON                                                              |
|      partitions=1/1                                                                  |
|      rollup: test_array                                                              |
|      tabletRatio=2/2                                                                 |
|      tabletList=13004,13006                                                          |
|      cardinality=9                                                                   |
|      avgRowSize=29.0                                                                 |
|      numNodes=0                                                                      |
+--------------------------------------------------------------------------------------+
33 rows in set (0.01 sec)


mysql> explain select  array_map(x->x+ 3 *c1 + 3*c1, c2) from test_array;
+----------------------------------------------------------------------------------------------------+
| Explain String                                                                                     |
+----------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                    |
|  OUTPUT EXPRS:5: array_map                                                                         |
|   PARTITION: UNPARTITIONED                                                                         |
|                                                                                                    |
|   RESULT SINK                                                                                      |
|                                                                                                    |
|   2:EXCHANGE                                                                                       |
|                                                                                                    |
| PLAN FRAGMENT 1                                                                                    |
|  OUTPUT EXPRS:                                                                                     |
|   PARTITION: RANDOM                                                                                |
|                                                                                                    |
|   STREAM DATA SINK                                                                                 |
|     EXCHANGE ID: 02                                                                                |
|     UNPARTITIONED                                                                                  |
|                                                                                                    |
|   1:Project                                                                                        |
|   |  <slot 5> : array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) + 7: multiply + 7: multiply, 2: c2) |
|   |  common expressions:                                                                           |
|   |  <slot 6> : CAST(1: c1 AS BIGINT)                                                              |
|   |  <slot 7> : 3 * 6: cast                                                                        |
|   |                                                                                                |
|   0:OlapScanNode                                                                                   |
|      TABLE: test_array                                                                             |
|      PREAGGREGATION: ON                                                                            |
|      partitions=1/1                                                                                |
|      rollup: test_array                                                                            |
|      tabletRatio=2/2                                                                               |
|      tabletList=13004,13006                                                                        |
|      cardinality=9                                                                                 |
|      avgRowSize=21.0                                                                               |
|      numNodes=0                                                                                    |
+----------------------------------------------------------------------------------------------------+
32 rows in set (0.01 sec)
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
