### PR TITLE
[BugFix] Be maybe crash if PrimaryKey table using persistent index

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1816,7 +1816,7 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         WritableFileOptions wblock_opts;
         wblock_opts.mode = FileSystem::MUST_EXIST;
         ASSIGN_OR_RETURN(_index_file, fs->new_writable_file(wblock_opts, file_name));
-        size_t snapshot_size = dump_bound();
+        size_t snapshot_size = _index_file->size();
         meta->clear_wals();
         IndexSnapshotMetaPB* snapshot = meta->mutable_snapshot();
         version.to_pb(snapshot->mutable_version());

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -646,7 +646,103 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot) {
 
         ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
         ASSERT_EQ(keys.size(), get_values.size());
-        for (int i = 0; i < values.size(); i++) {
+        for (int i = 0; i < get_values.size(); i++) {
+            ASSERT_EQ(values[i], get_values[i]);
+        }
+    }
+    ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
+}
+
+PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal) {
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot_wal";
+    const std::string kIndexFile = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot_wal/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    using Key = std::string;
+    PersistentIndexMetaPB index_meta;
+    const int N = 100000;
+
+    // insert
+    vector<Key> keys(N);
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    key_slices.reserve(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = "test_varlen_" + std::to_string(i);
+        values.emplace_back(i);
+        key_slices.emplace_back(keys[i]);
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    {
+        EditVersion version(0, 0);
+        index_meta.set_key_size(0);
+        index_meta.set_size(0);
+        version.to_pb(index_meta.mutable_version());
+        MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+        IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+        version.to_pb(snapshot_meta->mutable_version());
+
+        PersistentIndex index(kPersistentIndexDir);
+
+        ASSERT_OK(index.load(index_meta));
+        ASSERT_OK(index.prepare(EditVersion(1, 0)));
+        ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
+        ASSERT_OK(index.commit(&index_meta));
+        ASSERT_OK(index.on_commited());
+
+        const int NUM_SNAPSHOT = 10;
+        vector<Key> snapshot_keys(NUM_SNAPSHOT);
+        vector<Slice> snapshot_key_slices;
+        vector<IndexValue> snapshot_values;
+        snapshot_key_slices.reserve(NUM_SNAPSHOT);
+        for (int i = 0; i < NUM_SNAPSHOT; i++) {
+            snapshot_keys[i] = "test_varlen_" + std::to_string(i);
+            snapshot_values.emplace_back(i * 2);
+            snapshot_key_slices.emplace_back(snapshot_keys[i]);
+        }
+
+        std::vector<IndexValue> old_values(NUM_SNAPSHOT);
+        ASSERT_OK(index.prepare(EditVersion(2, 0)));
+        ASSERT_OK(index.upsert(NUM_SNAPSHOT, snapshot_key_slices.data(), snapshot_values.data(), old_values.data()));
+        ASSERT_OK(index.commit(&index_meta));
+        ASSERT_OK(index.on_commited());
+
+        const int NUM_WAL = 20000;
+        vector<Key> wal_keys(NUM_WAL);
+        vector<Slice> wal_key_slices;
+        vector<IndexValue> wal_values;
+        wal_key_slices.reserve(NUM_WAL);
+        for (int i = NUM_SNAPSHOT; i < NUM_WAL + NUM_SNAPSHOT; i++) {
+            wal_keys[i - NUM_SNAPSHOT] = "test_varlen_" + std::to_string(i);
+            wal_values.emplace_back(i * 3);
+            wal_key_slices.emplace_back(wal_keys[i - NUM_SNAPSHOT]);
+        }
+
+        config::l0_l1_merge_ratio = 1;
+        std::vector<IndexValue> wal_old_values(NUM_WAL);
+        ASSERT_OK(index.prepare(EditVersion(3, 0)));
+        ASSERT_OK(index.upsert(NUM_WAL, wal_key_slices.data(), wal_values.data(), wal_old_values.data()));
+        ASSERT_OK(index.commit(&index_meta));
+        ASSERT_OK(index.on_commited());
+
+        std::vector<IndexValue> get_values(keys.size());
+        ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
+        ASSERT_EQ(keys.size(), get_values.size());
+
+        for (int i = 0; i < NUM_SNAPSHOT; i++) {
+            ASSERT_EQ(snapshot_values[i], get_values[i]);
+        }
+        for (int i = NUM_SNAPSHOT; i < NUM_WAL + NUM_SNAPSHOT; i++) {
+            ASSERT_EQ(wal_values[i - NUM_SNAPSHOT], get_values[i]);
+        }
+        for (int i = NUM_WAL + NUM_SNAPSHOT; i < N; i++) {
             ASSERT_EQ(values[i], get_values[i]);
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/14844

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
        ...
        std::set<uint32_t> dumped_shard_idxes;
        phmap::BinaryOutputArchive ar_out(file_name.data());
        if (!dump(ar_out, dumped_shard_idxes)) {
             std::string err_msg = strings::Substitute("failed to dump snapshot to file $0", file_name);
             LOG(WARNING) << err_msg;
             return Status::InternalError(err_msg);
        }
        // dump snapshot success, set _index_file to new snapshot file
        WritableFileOptions wblock_opts;
        wblock_opts.mode = FileSystem::MUST_EXIST;
        ASSIGN_OR_RETURN(_index_file, fs->new_writable_file(wblock_opts, file_name));
        ...
```
File is closed when archive object is destroyed and file size will be updated until file is closed. So if we open the file before archive object is closed and assigning to `_index_file`. The `_index_file` will record a error file size and the snapshot data maybe overwrite which may cause be crash.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
