### PR TITLE
[Enhancement] treat invalid date as null value in partition prune

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -498,6 +498,7 @@ public class Utils {
                 }
             }
         } catch (Exception ignored) {
+            LOG.debug("invalid value: {} to type {}", op, descType);
         }
         return Optional.empty();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -101,11 +101,14 @@ public class ColumnFilterConverter {
             return;
         }
 
-        if (predicate.getChildren().stream().skip(1).anyMatch(d -> !OperatorType.CONSTANT.equals(d.getOpType()))) {
+        // rewrite invalid date cast expr to NullLiteral
+        ScalarOperator rewritePredicate = rewriteInvalidDateCast(predicate);
+
+        if (rewritePredicate.getChildren().stream().skip(1).anyMatch(d -> !OperatorType.CONSTANT.equals(d.getOpType()))) {
             return;
         }
 
-        predicate.accept(COLUMN_FILTER_VISITOR, result);
+        rewritePredicate.accept(COLUMN_FILTER_VISITOR, result);
     }
 
     private static boolean checkColumnRefCanPartition(ScalarOperator right, Table table) {
@@ -190,6 +193,31 @@ public class ColumnFilterConverter {
                 (Objects.equals(exprTimeArg, callTimeArg) ||
                         (TIME_MAP.containsKey(exprTimeArg) && TIME_MAP.containsKey(callTimeArg) &&
                                 TIME_MAP.get(exprTimeArg) > TIME_MAP.get(callTimeArg)));
+    }
+
+    // only rewrite cast invalid date value to null like cast('abc' as date)
+    private static ScalarOperator rewriteInvalidDateCast(ScalarOperator scalarOperator) {
+        ScalarOperator copy = scalarOperator.clone();
+        List<ScalarOperator> children = copy.getChildren();
+
+        for (int i = 1; i < children.size(); i++) {
+            ScalarOperator child = children.get(i);
+            if (child instanceof CastOperator) {
+                CastOperator cast = (CastOperator) child;
+                Type toType = cast.getType();
+                if (cast.getChildren().size() == 1
+                        && cast.getChildren().get(0).isConstantRef()
+                        && toType.isDateType()) {
+                    ConstantOperator value = (ConstantOperator) cast.getChildren().get(0);
+                    try {
+                        value.castTo(toType);
+                    } catch (Exception e) {
+                        children.set(i, ConstantOperator.createNull(toType));
+                    }
+                }
+            }
+        }
+        return copy;
     }
 
     private static class ColumnFilterVisitor

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -15,9 +15,12 @@
 
 package com.starrocks.sql.plan;
 
+import com.clearspring.analytics.util.Lists;
 import com.starrocks.common.FeConstants;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -129,5 +132,40 @@ public class PartitionPruneTest extends PlanTestBase {
                 "     PREDICATES: (2: d2 > '1000-01-01') OR (2: d2 IN (NULL, NULL)), 2: d2 > '1000-01-01'\n" +
                 "     partitions=4/4\n" +
                 "     rollup: ptest"));
+    }
+
+    @Test
+    public void testInvalidDatePrune() throws Exception {
+        List<String> sqls = Lists.newArrayList();
+
+        sqls.add("select * from ptest where d2 in ('1998-01-32', 'abc', 'abc')");
+        String plan = getFragmentPlan(sqls.get(0));
+        assertContains(plan, "partitions=0/4");
+
+        sqls.clear();
+        sqls.add("select * from ptest where d2 in ('abc')");
+        sqls.add("select * from ptest where d2 in ('1998-01-32')");
+        sqls.add("select * from ptest where d2 = '1998-01-32'");
+        sqls.add("select * from ptest where d2 in ('1998-01-01', 'abc', '1998-13-01')");
+        for (String sql : sqls) {
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "partitions=1/4");
+        }
+
+        sqls.clear();
+        sqls.add("select * from ptest where d2 in ('2020-06-01', 'abc', '1998-11-01')");
+        sqls.add("select * from ptest where d2 in ('2020-06-01', 'abc', '1998-11-01', '2001-01-33')");
+        for (String sql : sqls) {
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "partitions=2/4");
+        }
+
+        sqls.clear();
+        sqls.add("select * from ptest where d2 in ('1998-01-32', cast(cast('2021-01-12' as SIGNED) as DATE))");
+        sqls.add("select * from ptest where d2 in ('1998-01-01', cast(cast('2021-01-12' as SIGNED) as DATE))");
+        for (String sql : sqls) {
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "partitions=4/4");
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -136,11 +136,16 @@ public class PartitionPruneTest extends PlanTestBase {
 
     @Test
     public void testInvalidDatePrune() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
         List<String> sqls = Lists.newArrayList();
 
+        String plan = "";
         sqls.add("select * from ptest where d2 in ('1998-01-32', 'abc', 'abc')");
-        String plan = getFragmentPlan(sqls.get(0));
-        assertContains(plan, "partitions=0/4");
+        sqls.add("select * from ptest where d2 <= '1998-01-32'");
+        for (String sql : sqls) {
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "partitions=0/4");
+        }
 
         sqls.clear();
         sqls.add("select * from ptest where d2 in ('abc')");


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When use predicate like `date_col = '2020-01-32`, we add a cast to `2020-01-32` and it prevent the partition prune process. This pr only rewrite it in column filter to `date_col = null` used to partition process while the pushdown predicate to be still is  `date_col = '2020-01-32'`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
