### PR TITLE
[Enhancement] reduce trivial lambda functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LambdaFunctionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LambdaFunctionOperator.java
@@ -30,6 +30,15 @@ public class LambdaFunctionOperator extends ScalarOperator {
         return lambdaExpr;
     }
 
+    // array_map((x,y) -> x, arr1, arr2) can be reduced to arr1
+    public int canReduce() {
+        int res = 0;
+        if (lambdaExpr.getOpType().equals(OperatorType.LAMBDA_ARGUMENT) && refColumns.contains(lambdaExpr)) {
+            return refColumns.indexOf(lambdaExpr) + 1;
+        }
+        return res;
+    }
+
     // only need to concern the lambda expression.
     @Override
     public List<ScalarOperator> getChildren() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -15,6 +15,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
 import com.starrocks.sql.optimizer.rewrite.EliminateNegationsRewriter;
@@ -298,8 +299,19 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return ifCall(call);
         } else if (FunctionSet.IFNULL.equalsIgnoreCase(call.getFnName())) {
             return ifNull(call);
+        } else if (FunctionSet.ARRAY_MAP.equals(call.getFnName())) {
+            return arrayMap(call);
         }
+        return call;
+    }
 
+    // Reduce array_map whose lambda functions is trivial
+    // e.g. array_map((x,y)->x, arr1,arr2) is reduced to arr1
+    private static ScalarOperator arrayMap(CallOperator call) {
+        int index = ((LambdaFunctionOperator) call.getChild(0)).canReduce();
+        if (index > 0) {
+            return call.getChild(index);
+        }
         return call;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -518,7 +518,7 @@ public class ExpressionTest extends PlanTestBase {
                 "(c0 INT, c2 array<int>) " +
                 " duplicate key(c0) distributed by hash(c0) buckets 1 " +
                 "properties('replication_num'='1');");
-        String sql = "select * from test_lambda_on_scan where array_map(x -> x, c2) is not null";
+        String sql = "select * from test_lambda_on_scan where array_map(x -> x + 1, c2) is not null";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("array_map"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -499,6 +499,20 @@ public class ExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testLambdaReduce() throws Exception {
+        starRocksAssert.withTable("create table test_lambda" +
+                "(c0 INT, c2 array<int>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+        String sql = "select * from test_lambda where array_map(x -> x, c2) is not null";
+        String plan = getFragmentPlan(sql);
+        Assert.assertFalse(plan.contains("array_map"));
+
+        sql = "select array_map(x -> x, c2) from test_lambda";
+        plan = getFragmentPlan(sql);
+        Assert.assertFalse(plan.contains("array_map"));
+    }
+    @Test
     public void testLambdaPredicateOnScan() throws Exception {
         starRocksAssert.withTable("create table test_lambda_on_scan" +
                 "(c0 INT, c2 array<int>) " +


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
reduce trivial lambda functions, which just return original elements of an input array.

```
mysql> explain  select  array_map(x-> x, c2) from test_array;
+-----------------------------+
| Explain String              |
+-----------------------------+
| PLAN FRAGMENT 0             |
|  OUTPUT EXPRS:2: c2         |
|   PARTITION: UNPARTITIONED  |
|                             |
|   RESULT SINK               |
|                             |
|   1:EXCHANGE                |
|                             |
| PLAN FRAGMENT 1             |
|  OUTPUT EXPRS:              |
|   PARTITION: RANDOM         |
|                             |
|   STREAM DATA SINK          |
|     EXCHANGE ID: 01         |
|     UNPARTITIONED           |
|                             |
|   0:OlapScanNode            |
|      TABLE: test_array      |
|      PREAGGREGATION: ON     |
|      partitions=1/1         |
|      rollup: test_array     |
|      tabletRatio=2/2        |
|      tabletList=13004,13006 |
|      cardinality=9          |
|      avgRowSize=16.0        |
|      numNodes=0             |
+-----------------------------+
26 rows in set (0.01 sec)

mysql> explain  select  array_map(x-> x+1, c2) from test_array;
+----------------------------------------------------------------------------+
| Explain String                                                             |
+----------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                            |
|  OUTPUT EXPRS:5: array_map                                                 |
|   PARTITION: UNPARTITIONED                                                 |
|                                                                            |
|   RESULT SINK                                                              |
|                                                                            |
|   2:EXCHANGE                                                               |
|                                                                            |
| PLAN FRAGMENT 1                                                            |
|  OUTPUT EXPRS:                                                             |
|   PARTITION: RANDOM                                                        |
|                                                                            |
|   STREAM DATA SINK                                                         |
|     EXCHANGE ID: 02                                                        |
|     UNPARTITIONED                                                          |
|                                                                            |
|   1:Project                                                                |
|   |  <slot 5> : array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) + 1, 2: c2) |
|   |                                                                        |
|   0:OlapScanNode                                                           |
|      TABLE: test_array                                                     |
|      PREAGGREGATION: ON                                                    |
|      partitions=1/1                                                        |
|      rollup: test_array                                                    |
|      tabletRatio=2/2                                                       |
|      tabletList=13004,13006                                                |
|      cardinality=9                                                         |
|      avgRowSize=17.0                                                       |
|      numNodes=0                                                            |
+----------------------------------------------------------------------------+
29 rows in set (0.01 sec)

mysql> explain  select  array_map((x,y)->y, c2,c3) from test_array;
+-----------------------------+
| Explain String              |
+-----------------------------+
| PLAN FRAGMENT 0             |
|  OUTPUT EXPRS:3: c3         |
|   PARTITION: UNPARTITIONED  |
|                             |
|   RESULT SINK               |
|                             |
|   1:EXCHANGE                |
|                             |
| PLAN FRAGMENT 1             |
|  OUTPUT EXPRS:              |
|   PARTITION: RANDOM         |
|                             |
|   STREAM DATA SINK          |
|     EXCHANGE ID: 01         |
|     UNPARTITIONED           |
|                             |
|   0:OlapScanNode            |
|      TABLE: test_array      |
|      PREAGGREGATION: ON     |
|      partitions=1/1         |
|      rollup: test_array     |
|      tabletRatio=2/2        |
|      tabletList=13004,13006 |
|      cardinality=9          |
|      avgRowSize=1.0         |
|      numNodes=0             |
+-----------------------------+
mysql> explain  select  array_map((x,y)->y, c2,c3) from test_array where array_length(array_map(x->x,c2)) >0;
+------------------------------------------+
| Explain String                           |
+------------------------------------------+
| PLAN FRAGMENT 0                          |
|  OUTPUT EXPRS:3: c3                      |
|   PARTITION: UNPARTITIONED               |
|                                          |
|   RESULT SINK                            |
|                                          |
|   2:EXCHANGE                             |
|                                          |
| PLAN FRAGMENT 1                          |
|  OUTPUT EXPRS:                           |
|   PARTITION: RANDOM                      |
|                                          |
|   STREAM DATA SINK                       |
|     EXCHANGE ID: 02                      |
|     UNPARTITIONED                        |
|                                          |
|   1:Project                              |
|   |  <slot 3> : 3: c3                    |
|   |                                      |
|   0:OlapScanNode                         |
|      TABLE: test_array                   |
|      PREAGGREGATION: ON                  |
|      PREDICATES: array_length(2: c2) > 0 |
|      partitions=1/1                      |
|      rollup: test_array                  |
|      tabletRatio=2/2                     |
|      tabletList=13004,13006              |
|      cardinality=5                       |
|      avgRowSize=32.0                     |
|      numNodes=0                          |
+------------------------------------------+
30 rows in set (0.01 sec)

mysql> explain  select  array_map((x,y)->y, c2,c3) from test_array where array_length(array_map(x->x,c2)) is null;
+----------------------------------------------+
| Explain String                               |
+----------------------------------------------+
| PLAN FRAGMENT 0                              |
|  OUTPUT EXPRS:3: c3                          |
|   PARTITION: UNPARTITIONED                   |
|                                              |
|   RESULT SINK                                |
|                                              |
|   2:EXCHANGE                                 |
|                                              |
| PLAN FRAGMENT 1                              |
|  OUTPUT EXPRS:                               |
|   PARTITION: RANDOM                          |
|                                              |
|   STREAM DATA SINK                           |
|     EXCHANGE ID: 02                          |
|     UNPARTITIONED                            |
|                                              |
|   1:Project                                  |
|   |  <slot 3> : 3: c3                        |
|   |                                          |
|   0:OlapScanNode                             |
|      TABLE: test_array                       |
|      PREAGGREGATION: ON                      |
|      PREDICATES: array_length(2: c2) IS NULL |
|      partitions=1/1                          |
|      rollup: test_array                      |
|      tabletRatio=2/2                         |
|      tabletList=13004,13006                  |
|      cardinality=1                           |
|      avgRowSize=32.0                         |
|      numNodes=0                              |
+----------------------------------------------+
30 rows in set (0.01 sec)
```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
