### PR TITLE
[BugFix] Fix the error when getting the memory limit in cgroup v2

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -34,12 +34,12 @@
 
 #include "util/mem_info.h"
 
+#include <linux/magic.h>
+#include <sys/vfs.h>
 
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <linux/magic.h>
-#include <sys/vfs.h>
 
 #include "fs/fs_util.h"
 #include "gutil/strings/split.h"
@@ -49,6 +49,9 @@
 
 namespace starrocks {
 
+// CGROUP2_SUPER_MAGIC is the indication for cgroup v2
+// It is defined in kernel 4.5+
+// I copy the defintion from linux/magic.h in higher kernel
 #ifndef CGROUP2_SUPER_MAGIC
 #define CGROUP2_SUPER_MAGIC 0x63677270
 #endif
@@ -57,46 +60,7 @@ bool MemInfo::_s_initialized = false;
 int64_t MemInfo::_s_physical_mem = -1;
 
 void MemInfo::init() {
-    // check if application is in docker container or not via /.dockerenv file
-    while (fs::path_exist("/.dockerenv")) {
-        struct statfs fs;
-        int err = statfs("/sys/fs/cgroup", &fs);
-        if (err < 0) {
-            LOG(WARNING) << "Fail to get file system statistics. err: " << errno_to_string(err);
-            break;
-        }
-
-        std::ifstream memoryLimit;
-        std::string line;
-        StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
-        if (fs.f_type == TMPFS_MAGIC) {
-            // cgroup v1
-            // Read from /sys/fs/cgroup/memory/memory.limit_in_bytes
-            memoryLimit.open("/sys/fs/cgroup/memory/memory.limit_in_bytes");
-            getline(memoryLimit, line);
-            _s_physical_mem = StringParser::string_to_int<int64_t>(line.data(), line.size(), &result);
-        } else if (fs.f_type == CGROUP2_SUPER_MAGIC) {
-            // cgroup v2
-            // Read from /sys/fs/cgroup/memory/memory.max
-            memoryLimit.open("/sys/fs/cgroup/memory.max");
-            getline(memoryLimit, line);
-
-            if (line == "max") {
-                _s_physical_mem = std::numeric_limits<int64_t>::max();
-            } else {
-                _s_physical_mem = StringParser::string_to_int<int64_t>(line.data(), line.size(), &result);
-            }
-        }
-
-        if (result != StringParser::PARSE_SUCCESS) {
-            _s_physical_mem = std::numeric_limits<int64_t>::max();
-        }
-
-        if (memoryLimit.is_open()) {
-            memoryLimit.close();
-        }
-        break;
-    }
+    set_memlimit_if_container();
 
     // Read from /proc/meminfo
     std::ifstream meminfo("/proc/meminfo", std::ios::in);
@@ -146,6 +110,49 @@ std::string MemInfo::debug_string() {
     std::stringstream stream;
     stream << "Mem Info: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES) << std::endl;
     return stream.str();
+}
+
+void MemInfo::set_memlimit_if_container() {
+    // check if application is in docker container or not via /.dockerenv file
+    bool running_in_docker = fs::path_exist("/.dockerenv");
+    if (running_in_docker) {
+        struct statfs fs;
+        int err = statfs("/sys/fs/cgroup", &fs);
+        if (err < 0) {
+            LOG(WARNING) << "Fail to get file system statistics. err: " << errno_to_string(err);
+            return;
+        }
+
+        std::ifstream memoryLimit;
+        std::string line;
+        StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
+        if (fs.f_type == TMPFS_MAGIC) {
+            // cgroup v1
+            // Read from /sys/fs/cgroup/memory/memory.limit_in_bytes
+            memoryLimit.open("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+            getline(memoryLimit, line);
+            _s_physical_mem = StringParser::string_to_int<int64_t>(line.data(), line.size(), &result);
+        } else if (fs.f_type == CGROUP2_SUPER_MAGIC) {
+            // cgroup v2
+            // Read from /sys/fs/cgroup/memory/memory.max
+            memoryLimit.open("/sys/fs/cgroup/memory.max");
+            getline(memoryLimit, line);
+
+            if (line == "max") {
+                _s_physical_mem = std::numeric_limits<int64_t>::max();
+            } else {
+                _s_physical_mem = StringParser::string_to_int<int64_t>(line.data(), line.size(), &result);
+            }
+        }
+
+        if (result != StringParser::PARSE_SUCCESS) {
+            _s_physical_mem = std::numeric_limits<int64_t>::max();
+        }
+
+        if (memoryLimit.is_open()) {
+            memoryLimit.close();
+        }
+    }
 }
 
 } // namespace starrocks

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -58,6 +58,8 @@ public:
     static std::string debug_string();
 
 private:
+    static void set_memlimit_if_container();
+
     static bool _s_initialized;
     static int64_t _s_physical_mem;
 };

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -64,13 +64,25 @@ export_mem_limit_from_conf() {
         fi
     done < $1
 
-    if [ -f /.dockerenv ]; then
+    cgroup_version=$(stat -fc %T /sys/fs/cgroup)
+    if [ -f /.dockerenv ] && [ "$cgroup_version" == "tmpfs" ]; then
         mem_limit=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes | awk '{printf $1}')
         if [ "$mem_limit" == "" ]; then
             echo "can't get mem info from /sys/fs/cgroup/memory/memory.limit_in_bytes"
             return 1
         fi
         mem_limit=`expr $mem_limit / 1024`
+    fi
+
+    if [ -f /.dockerenv ] && [ "$cgroup_version" == "cgroup2fs" ]; then
+        mem_limit=$(cat /sys/fs/cgroup/memory/memory.max | awk '{printf $1}')
+        if [ "$mem_limit" == "" ]; then
+            echo "can't get mem info from /sys/fs/cgroup/memory/memory.max"
+            return 1
+        fi
+        if [ "$mem_limit" != "max" ]; then
+            mem_limit=`expr $mem_limit / 1024`
+        fi
     fi
 
     # read /proc/meminfo to fetch total memory of machine


### PR DESCRIPTION
cgroup V1 in Centos7 store memory limit in `/sys/fs/cgroup/memory/memory.limit_in_bytes` cgroup V2 in Ubuntu 22 store memory limit in `/sys/fs/cgroup/memory.max`

StarRocks encounters error when running in docker installed Ubuntu 22.
```
cat: /sys/fs/cgroup/memory/memory.limit_in_bytes: No such file or directory
can't get mem info from /sys/fs/cgroup/memory/memory.limit_in_bytes
There is not /sys/fs/cgroup/memory/memory.limit_in_bytes file for a centos-7 base docker container.
E.g, running this command in a centos-7 based docker container got this error.
```

This pull request figure out a solution by check the version of cgroup. According to the cgroup version, the memory limit will been automatically parsed.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13548

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
