### PR TITLE
[BugFix] SchedEntityComparator should obey asymmetric relation

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -195,8 +195,13 @@ DriverRawPtr SubQuerySharedDriverQueue::take() {
 
 /// WorkGroupDriverQueue.
 bool WorkGroupDriverQueue::WorkGroupDriverSchedEntityComparator::operator()(
-        const WorkGroupDriverSchedEntityPtr& lhs, const WorkGroupDriverSchedEntityPtr& rhs) const {
-    return lhs->vruntime_ns() < rhs->vruntime_ns();
+        const WorkGroupDriverSchedEntityPtr& lhs_ptr, const WorkGroupDriverSchedEntityPtr& rhs_ptr) const {
+    int64_t lhs_val = lhs_ptr->vruntime_ns();
+    int64_t rhs_val = rhs_ptr->vruntime_ns();
+    if (lhs_val != rhs_val) {
+        return lhs_val < rhs_val;
+    }
+    return lhs_ptr < rhs_ptr;
 }
 
 void WorkGroupDriverQueue::close() {

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -198,7 +198,8 @@ private:
 
     struct WorkGroupDriverSchedEntityComparator {
         using WorkGroupDriverSchedEntityPtr = workgroup::WorkGroupDriverSchedEntity*;
-        bool operator()(const WorkGroupDriverSchedEntityPtr& lhs, const WorkGroupDriverSchedEntityPtr& rhs) const;
+        bool operator()(const WorkGroupDriverSchedEntityPtr& lhs_ptr,
+                        const WorkGroupDriverSchedEntityPtr& rhs_ptr) const;
     };
     using WorkgroupSet = std::set<workgroup::WorkGroupDriverSchedEntity*, WorkGroupDriverSchedEntityComparator>;
 

--- a/be/src/exec/workgroup/scan_task_queue.cpp
+++ b/be/src/exec/workgroup/scan_task_queue.cpp
@@ -38,8 +38,13 @@ bool PriorityScanTaskQueue::try_offer(ScanTask task) {
 
 /// WorkGroupScanTaskQueue.
 bool WorkGroupScanTaskQueue::WorkGroupScanSchedEntityComparator::operator()(
-        const WorkGroupScanSchedEntityPtr& lhs, const WorkGroupScanSchedEntityPtr& rhs) const {
-    return lhs->vruntime_ns() < rhs->vruntime_ns();
+        const WorkGroupScanSchedEntityPtr& lhs_ptr, const WorkGroupScanSchedEntityPtr& rhs_ptr) const {
+    int64_t lhs_val = lhs_ptr->vruntime_ns();
+    int64_t rhs_val = rhs_ptr->vruntime_ns();
+    if (lhs_val != rhs_val) {
+        return lhs_val < rhs_val;
+    }
+    return lhs_ptr < rhs_ptr;
 }
 
 void WorkGroupScanTaskQueue::close() {

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -133,7 +133,7 @@ private:
 
     struct WorkGroupScanSchedEntityComparator {
         using WorkGroupScanSchedEntityPtr = workgroup::WorkGroupScanSchedEntity*;
-        bool operator()(const WorkGroupScanSchedEntityPtr& lhs, const WorkGroupScanSchedEntityPtr& rhs) const;
+        bool operator()(const WorkGroupScanSchedEntityPtr& lhs_ptr, const WorkGroupScanSchedEntityPtr& rhs_ptr) const;
     };
     using WorkgroupSet = std::set<workgroup::WorkGroupScanSchedEntity*, WorkGroupScanSchedEntityComparator>;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -56,6 +56,7 @@ set(EXEC_FILES
         ./exec/pipeline/query_context_test.cpp
         ./exec/pipeline/table_function_operator_test.cpp
         ./exec/pipeline/pipeline_file_scan_node_test.cpp
+        ./exec/pipeline/pipeline_driver_queue_test.cpp
         ./exprs/agg/json_each_test.cpp
         ./exprs/agg/aggregate_test.cpp
         ./exprs/vectorized/arithmetic_expr_test.cpp

--- a/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
+++ b/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
@@ -245,7 +245,9 @@ TEST_F(WorkGroupDriverQueueTest, test_basic) {
     std::vector<DriverRawPtr> out_drivers = {driver1.get(), driver271.get(), driver272.get(), driver251.get(),
                                              driver261.get()};
     // a<b = (a.vruntime!=b.vruntime) ? a.vruntime<b.vruntime : a_ptr < b_ptr
-    if (driver3.get() < driver4.get()) {
+    auto* sched_entity3 = driver3->workgroup()->driver_sched_entity();
+    auto* sched_entity4 = driver4->workgroup()->driver_sched_entity();
+    if (sched_entity3 < sched_entity4) {
         out_drivers.emplace_back(driver3.get());
         out_drivers.emplace_back(driver4.get());
     } else {
@@ -260,15 +262,10 @@ TEST_F(WorkGroupDriverQueueTest, test_basic) {
     }
 
     // Take drivers from queue.
-    int i = 0;
     for (auto* out_driver : out_drivers) {
         auto maybe_driver = queue.take();
         ASSERT_TRUE(maybe_driver.ok());
-        ASSERT_EQ(out_driver, maybe_driver.value())
-                << "The " << i << "-th driver failed, "
-                << "lhs_vruntime=" << out_driver->workgroup()->driver_sched_entity()->vruntime_ns() << ", "
-                << "rhs_vruntime=" << maybe_driver.value()->workgroup()->driver_sched_entity()->vruntime_ns();
-        ++i;
+        ASSERT_EQ(out_driver, maybe_driver.value());
     }
 }
 

--- a/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
+++ b/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
@@ -82,7 +82,7 @@ PARALLEL_TEST(QuerySharedDriverQueueTest, test_basic) {
 
     // Take drivers from queue.
     for (auto* out_driver : out_drivers) {
-        auto maybe_driver = queue.take(0);
+        auto maybe_driver = queue.take();
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(out_driver, maybe_driver.value());
     }
@@ -124,7 +124,7 @@ PARALLEL_TEST(QuerySharedDriverQueueTest, test_cancel) {
 
     for (size_t i = 0; i < out_drivers.size(); i++) {
         ops_before_get[i]();
-        auto maybe_driver = queue.take(0);
+        auto maybe_driver = queue.take();
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(out_drivers[i], maybe_driver.value());
     }
@@ -139,7 +139,7 @@ PARALLEL_TEST(QuerySharedDriverQueueTest, test_take_block) {
     _set_driver_level(driver1.get(), 1);
 
     auto consumer_thread = std::make_shared<std::thread>([&queue, &driver1] {
-        auto maybe_driver = queue.take(0);
+        auto maybe_driver = queue.take();
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(driver1.get(), maybe_driver.value());
     });
@@ -155,7 +155,7 @@ PARALLEL_TEST(QuerySharedDriverQueueTest, test_take_close) {
     QuerySharedDriverQueue queue;
 
     auto consumer_thread = std::make_shared<std::thread>([&queue] {
-        auto maybe_driver = queue.take(0);
+        auto maybe_driver = queue.take();
         ASSERT_TRUE(maybe_driver.status().is_cancelled());
     });
 
@@ -172,35 +172,26 @@ public:
                                                       workgroup::WorkGroupType::WG_NORMAL);
         _wg2 = std::make_shared<workgroup::WorkGroup>("wg200", 200, workgroup::WorkGroup::DEFAULT_VERSION, 2, 0.5, 10,
                                                       workgroup::WorkGroupType::WG_NORMAL);
-        _wg3 = std::make_shared<workgroup::WorkGroup>("wg200", 300, workgroup::WorkGroup::DEFAULT_VERSION, 1, 0.5, 10,
+        _wg3 = std::make_shared<workgroup::WorkGroup>("wg300", 300, workgroup::WorkGroup::DEFAULT_VERSION, 1, 0.5, 10,
+                                                      workgroup::WorkGroupType::WG_NORMAL);
+        _wg4 = std::make_shared<workgroup::WorkGroup>("wg400", 400, workgroup::WorkGroup::DEFAULT_VERSION, 1, 0.5, 10,
                                                       workgroup::WorkGroupType::WG_NORMAL);
         _wg1 = workgroup::WorkGroupManager::instance()->add_workgroup(_wg1);
         _wg2 = workgroup::WorkGroupManager::instance()->add_workgroup(_wg2);
         _wg3 = workgroup::WorkGroupManager::instance()->add_workgroup(_wg3);
+        _wg4 = workgroup::WorkGroupManager::instance()->add_workgroup(_wg4);
     }
 
 protected:
     workgroup::WorkGroupPtr _wg1 = nullptr;
     workgroup::WorkGroupPtr _wg2 = nullptr;
     workgroup::WorkGroupPtr _wg3 = nullptr;
-
-    int _get_any_worker_from_owner(const workgroup::WorkGroupPtr& wg) {
-        for (int i = 0; i < workgroup::WorkGroupManager::instance()->num_total_driver_workers(); ++i) {
-            auto wgs = workgroup::WorkGroupManager::instance()->get_owners_of_driver_worker(i);
-            if (wgs != nullptr && wgs->find(wg) != wgs->end()) {
-                return i;
-            }
-        }
-        return -1;
-    }
+    workgroup::WorkGroupPtr _wg4 = nullptr;
 };
 
 TEST_F(WorkGroupDriverQueueTest, test_basic) {
     QueryContext query_ctx;
     WorkGroupDriverQueue queue;
-
-    int worker_id = _get_any_worker_from_owner(_wg3);
-    ASSERT_GE(worker_id, 0);
 
     // Prepare drivers for _wg2.
     int64_t sum_wg2_time_spent = 0;
@@ -239,15 +230,28 @@ TEST_F(WorkGroupDriverQueueTest, test_basic) {
     // Prepare drivers for _wg3.
     auto driver3 = std::make_shared<PipelineDriver>(_gen_operators(), &query_ctx, nullptr, -1);
     _set_driver_level(driver3.get(), 2);
-    driver3->driver_acct().update_last_time_spent(sum_wg2_time_spent * 2);
+    driver3->driver_acct().update_last_time_spent(sum_wg2_time_spent * 2 + 1);
     driver3->set_workgroup(_wg3);
 
-    std::vector<DriverRawPtr> in_drivers = {driver271.get(), driver272.get(), driver261.get(),
-                                            driver251.get(), driver1.get(),   driver3.get()};
-    // driver3 is from owner workgroup.
-    // the workgroup of driver1 has higher priority than that of driver2xx.
-    std::vector<DriverRawPtr> out_drivers = {driver3.get(),   driver1.get(),   driver271.get(),
-                                             driver272.get(), driver251.get(), driver261.get()};
+    // Prepare drivers for _wg4.
+    auto driver4 = std::make_shared<PipelineDriver>(_gen_operators(), &query_ctx, nullptr, -1);
+    _set_driver_level(driver4.get(), 2);
+    driver4->driver_acct().update_last_time_spent(sum_wg2_time_spent * 2 + 1);
+    driver4->set_workgroup(_wg4);
+
+    std::vector<DriverRawPtr> in_drivers = {driver271.get(), driver272.get(), driver261.get(), driver251.get(),
+                                            driver1.get(),   driver3.get(),   driver4.get()};
+    // wg1.vruntime < wg2.vruntime < wg4.vruntime = wg3.vruntime
+    std::vector<DriverRawPtr> out_drivers = {driver1.get(), driver271.get(), driver272.get(), driver251.get(),
+                                             driver261.get()};
+    // a<b = (a.vruntime!=b.vruntime) ? a.vruntime<b.vruntime : a_ptr < b_ptr
+    if (driver3.get() < driver4.get()) {
+        out_drivers.emplace_back(driver3.get());
+        out_drivers.emplace_back(driver4.get());
+    } else {
+        out_drivers.emplace_back(driver4.get());
+        out_drivers.emplace_back(driver3.get());
+    }
 
     // Put back drivers to queue.
     for (auto* in_driver : in_drivers) {
@@ -273,7 +277,7 @@ TEST_F(WorkGroupDriverQueueTest, test_take_block) {
     driver1->set_workgroup(_wg1);
 
     auto consumer_thread = std::make_shared<std::thread>([&queue, &driver1] {
-        auto maybe_driver = queue.take(0);
+        auto maybe_driver = queue.take();
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(driver1.get(), maybe_driver.value());
     });
@@ -289,7 +293,7 @@ TEST_F(WorkGroupDriverQueueTest, test_take_close) {
     WorkGroupDriverQueue queue;
 
     auto consumer_thread = std::make_shared<std::thread>([&queue] {
-        auto maybe_driver = queue.take(0);
+        auto maybe_driver = queue.take();
         ASSERT_TRUE(maybe_driver.status().is_cancelled());
     });
 

--- a/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
+++ b/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
@@ -260,10 +260,15 @@ TEST_F(WorkGroupDriverQueueTest, test_basic) {
     }
 
     // Take drivers from queue.
+    int i = 0;
     for (auto* out_driver : out_drivers) {
         auto maybe_driver = queue.take();
         ASSERT_TRUE(maybe_driver.ok());
-        ASSERT_EQ(out_driver, maybe_driver.value());
+        ASSERT_EQ(out_driver, maybe_driver.value())
+                << "The " << i << "-th driver failed, "
+                << "lhs_vruntime=" << out_driver->workgroup()->driver_sched_entity()->vruntime_ns() << ", "
+                << "rhs_vruntime=" << maybe_driver.value()->workgroup()->driver_sched_entity()->vruntime_ns();
+        ++i;
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`WorkGroupDriverQueue::_wg_entities` uses `std::set` to store workgroups ordered by `wg.vruntime`.
The comparator of `_wg_entities` overrides `<` operator to `lhs_ptr.vruntime<rhs_ptr.vruntime`.

However, the comparator of `std::set` should obey asymmetric relation, because it consider `a==b` is true if `a<b` is false and `a>b` is false.
Therefore, when the set receives two different workgroups with the same vruntime, it will only store the first one.



## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
