### PR TITLE
[Enhancement] Support adaptive dop for broker load & insert into

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -822,7 +822,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
         // For insert into select, in the simplest case like insert into table select * from table2;
         // the desired_tablet_sink_dop set by FE is same as the source_operator_dop.
         // However, if the select statement is complex, like insert into table select * from table2 limit 1,
-        // the desired_tablet_sink_dop set by FE is same as the source_operator_dop, and it needs to
+        // the desired_tablet_sink_dop set by FE is not same as the source_operator_dop, and it needs to
         // add a local passthrough exchange here
         if (desired_tablet_sink_dop != source_operator_dop) {
             std::vector<OpFactories> pred_operators_list;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -214,7 +214,8 @@ public class LoadLoadingTask extends LoadTask {
                     sb.append(SessionVariable.PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM).append("=")
                             .append(variables.getParallelExecInstanceNum()).append(",");
                     sb.append(SessionVariable.PIPELINE_DOP).append("=").append(variables.getPipelineDop()).append(",");
-                    sb.append(SessionVariable.PIPELINE_SINK_DOP).append("=").append(variables.getPipelineSinkDop())
+                    sb.append(SessionVariable.ENABLE_ADAPTIVE_SINK_DOP).append("=")
+                            .append(variables.getEnableAdaptiveSinkDop())
                             .append(",");
                     if (context.getResourceGroup() != null) {
                         sb.append(SessionVariable.RESOURCE_GROUP).append("=")

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -281,6 +281,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String HIVE_PARTITION_STATS_SAMPLE_SIZE = "hive_partition_stats_sample_size";
 
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
+    public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
     public static final String RUNTIME_FILTER_ON_EXCHANGE_NODE = "runtime_filter_on_exchange_node";
     public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =
@@ -336,6 +337,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             .add(DISABLE_BUCKET_JOIN)
             .add(CBO_ENABLE_REPLICATED_JOIN)
             .add(FOREIGN_KEY_CHECKS)
+            .add(PIPELINE_SINK_DOP)
             .add("enable_cbo")
             .add("enable_vectorized_engine")
             .add("vectorized_engine_enable")
@@ -704,8 +706,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = HIVE_PARTITION_STATS_SAMPLE_SIZE)
     private int hivePartitionStatsSampleSize = 3000;
 
-    @VariableMgr.VarAttr(name = PIPELINE_SINK_DOP)
-    private int pipelineSinkDop = 0;
+    @VariableMgr.VarAttr(name = ENABLE_ADAPTIVE_SINK_DOP)
+    private boolean enableAdaptiveSinkDop = false;
 
     @VariableMgr.VarAttr(name = JOIN_IMPLEMENTATION_MODE_V2, alias = JOIN_IMPLEMENTATION_MODE)
     private String joinImplementationMode = "auto"; // auto, merge, hash, nestloop
@@ -871,12 +873,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return hivePartitionStatsSampleSize;
     }
 
-    public int getPipelineSinkDop() {
-        return pipelineSinkDop;
+    public boolean getEnableAdaptiveSinkDop() {
+        return enableAdaptiveSinkDop;
     }
 
-    public void setPipelineSinkDop(int dop) {
-        this.pipelineSinkDop = dop;
+    public void setEnableAdaptiveSinkDop(boolean e) {
+        this.enableAdaptiveSinkDop = e;
     }
 
     public long getMaxExecMemByte() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -252,7 +252,9 @@ public class StmtExecutor {
             sb.append(SessionVariable.PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM).append("=")
                     .append(variables.getParallelExecInstanceNum()).append(",");
             sb.append(SessionVariable.PIPELINE_DOP).append("=").append(variables.getPipelineDop()).append(",");
-            sb.append(SessionVariable.PIPELINE_SINK_DOP).append("=").append(variables.getPipelineSinkDop()).append(",");
+            sb.append(SessionVariable.ENABLE_ADAPTIVE_SINK_DOP).append("=")
+                    .append(variables.getEnableAdaptiveSinkDop())
+                    .append(",");
             if (context.getResourceGroup() != null) {
                 sb.append(SessionVariable.RESOURCE_GROUP).append("=").append(context.getResourceGroup().getName())
                         .append(",");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -104,10 +104,10 @@ public class DeletePlanner {
             execPlan.getFragments().get(0).setSink(dataSink);
             if (canUsePipeline) {
                 PlanFragment sinkFragment = execPlan.getFragments().get(0);
-                if (ConnectContext.get().getSessionVariable().getPipelineSinkDop() <= 0) {
-                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
+                if (ConnectContext.get().getSessionVariable().getEnableAdaptiveSinkDop()) {
+                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getDegreeOfParallelism());
                 } else {
-                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getPipelineSinkDop());
+                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
                 }
                 sinkFragment.setHasOlapTableSink();
                 sinkFragment.setForceSetTableSinkDop();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -176,11 +176,6 @@ public class InsertPlanner {
                 dataSink = new OlapTableSink((OlapTable) insertStmt.getTargetTable(), olapTuple,
                         insertStmt.getTargetPartitionIds(), canUsePipeline, olapTable.writeQuorum(),
                         olapTable.enableReplicatedStorage());
-                // At present, we only support dop=1 for olap table sink.
-                // because tablet writing needs to know the number of senders in advance
-                // and guaranteed order of data writing
-                // It can be parallel only in some scenes, for easy use 1 dop now.
-                execPlan.getFragments().get(0).setPipelineDop(1);
             } else if (insertStmt.getTargetTable() instanceof MysqlTable) {
                 dataSink = new MysqlTableSink((MysqlTable) insertStmt.getTargetTable());
             } else {
@@ -196,10 +191,11 @@ public class InsertPlanner {
                     // If you want to set tablet sink dop > 1, please enable single tablet loading and disable shuffle service
                     sinkFragment.setPipelineDop(1);
                 } else {
-                    if (ConnectContext.get().getSessionVariable().getPipelineSinkDop() <= 0) {
-                        sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
+                    if (ConnectContext.get().getSessionVariable().getEnableAdaptiveSinkDop()) {
+                        sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getDegreeOfParallelism());
                     } else {
-                        sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getPipelineSinkDop());
+                        sinkFragment
+                                .setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
                     }
                 }
                 sinkFragment.setHasOlapTableSink();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -142,12 +142,16 @@ public class LoadPlanner {
         this.strictMode = strictMode;
         this.timeoutS = timeoutS;
         this.partialUpdate = partialUpdate;
-        this.parallelInstanceNum = Config.load_parallel_instance_num;
         this.startTime = startTime;
         if (context != null) {
             this.context = context;
         } else {
             this.context = new ConnectContext();
+        }
+        if (this.context.getSessionVariable().getEnableAdaptiveSinkDop()) {
+            this.parallelInstanceNum = this.context.getSessionVariable().getDegreeOfParallelism();
+        } else {
+            this.parallelInstanceNum = Config.load_parallel_instance_num;
         }
         this.analyzer = new Analyzer(GlobalStateMgr.getCurrentState(), this.context);
         this.analyzer.setTimezone(timezone);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -100,10 +100,11 @@ public class UpdatePlanner {
             execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
             if (canUsePipeline) {
                 PlanFragment sinkFragment = execPlan.getFragments().get(0);
-                if (ConnectContext.get().getSessionVariable().getPipelineSinkDop() <= 0) {
-                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
+                if (ConnectContext.get().getSessionVariable().getEnableAdaptiveSinkDop()) {
+                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getDegreeOfParallelism());
                 } else {
-                    sinkFragment.setPipelineDop(ConnectContext.get().getSessionVariable().getPipelineSinkDop());
+                    sinkFragment
+                            .setPipelineDop(ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
                 }
                 sinkFragment.setHasOlapTableSink();
                 sinkFragment.setForceSetTableSinkDop();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
@@ -35,7 +35,6 @@ public class PipelineParallelismTest extends PlanTestBase {
     private int prevParallelExecInstanceNum = 0;
     private boolean prevEnablePipelineEngine = true;
     private int prevPipelineDop = 0;
-    private int pipelineSinkDop = 8;
 
     @Before
     public void setUp() {
@@ -53,8 +52,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         connectContext.getSessionVariable().setParallelExecInstanceNum(parallelExecInstanceNum);
         connectContext.getSessionVariable().setEnablePipelineEngine(true);
         connectContext.getSessionVariable().setPipelineDop(0);
-        connectContext.getSessionVariable().setPipelineSinkDop(pipelineSinkDop);
-
+        connectContext.getSessionVariable().setEnableAdaptiveSinkDop(false);
     }
 
     @After
@@ -111,13 +109,25 @@ public class PipelineParallelismTest extends PlanTestBase {
             Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
             Assert.assertEquals(1, fragment0.getPipelineDop());
 
+            connectContext.getSessionVariable().setEnableAdaptiveSinkDop(false);
+
             Config.enable_pipeline_load = true;
             plan = getExecPlan("insert into t0 select * from t0");
             fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // ParallelExecNum of fragment not 1. still can not use pipeline
             Assert.assertEquals(1, fragment0.getParallelExecNum());
-            Assert.assertEquals(pipelineSinkDop, fragment0.getPipelineDop());
+            Assert.assertEquals(parallelExecInstanceNum, fragment0.getPipelineDop());
+
+            connectContext.getSessionVariable().setEnableAdaptiveSinkDop(true);
+
+            Config.enable_pipeline_load = true;
+            plan = getExecPlan("insert into t0 select * from t0");
+            fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // ParallelExecNum of fragment not 1. still can not use pipeline
+            Assert.assertEquals(1, fragment0.getParallelExecNum());
+            Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }
@@ -137,13 +147,25 @@ public class PipelineParallelismTest extends PlanTestBase {
             Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
             Assert.assertEquals(1, fragment0.getPipelineDop());
 
+            connectContext.getSessionVariable().setEnableAdaptiveSinkDop(false);
+
             Config.enable_pipeline_load = true;
             plan = getExecPlan("delete from tprimary where pk = 1");
             fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
             Assert.assertEquals(1, fragment0.getParallelExecNum());
-            Assert.assertEquals(pipelineSinkDop, fragment0.getPipelineDop());
+            Assert.assertEquals(parallelExecInstanceNum, fragment0.getPipelineDop());
+
+            connectContext.getSessionVariable().setEnableAdaptiveSinkDop(true);
+
+            Config.enable_pipeline_load = true;
+            plan = getExecPlan("delete from tprimary where pk = 1");
+            fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
+            Assert.assertEquals(1, fragment0.getParallelExecNum());
+            Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }
@@ -163,13 +185,25 @@ public class PipelineParallelismTest extends PlanTestBase {
             Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
             Assert.assertEquals(1, fragment0.getPipelineDop());
 
+            connectContext.getSessionVariable().setEnableAdaptiveSinkDop(false);
+
             Config.enable_pipeline_load = true;
             plan = getExecPlan("update tprimary set v1 = 'aaa' where pk = 1");
             fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
             Assert.assertEquals(1, fragment0.getParallelExecNum());
-            Assert.assertEquals(pipelineSinkDop, fragment0.getPipelineDop());
+            Assert.assertEquals(parallelExecInstanceNum, fragment0.getPipelineDop());
+
+            connectContext.getSessionVariable().setEnableAdaptiveSinkDop(true);
+
+            Config.enable_pipeline_load = true;
+            plan = getExecPlan("update tprimary set v1 = 'aaa' where pk = 1");
+            fragment0 = plan.getFragments().get(0);
+            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
+            // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
+            Assert.assertEquals(1, fragment0.getParallelExecNum());
+            Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the StarRocks is initially deployed, we set `ENABLE_ADAPTIVE_SINK_DOP=true` so that the `broker load` and `insert into` is automatically configured as the best performance configuration. 
If StarRocks is upgraded from an old version, the `ENABLE_ADAPTIVE_SINK_DOP=false`, the original configuration is retained to avoid system stability problems caused by change load concurrency.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
