### PR TITLE
[BugFix] fix the inconsistent behavior of JDBC external table with version 2.4

### DIFF
--- a/be/src/exec/vectorized/jdbc_scanner.cpp
+++ b/be/src/exec/vectorized/jdbc_scanner.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include "column/column_helper.h"
+#include "column/column_viewer.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
@@ -390,10 +391,26 @@ Status JDBCScanner::_fill_chunk(jobject jchunk, size_t num_rows, ChunkPtr* chunk
         for (size_t i = 0; i < _slot_descs.size(); i++) {
             jobject jcolumn = helper.list_get(jchunk, i);
             LOCAL_REF_GUARD_ENV(env, jcolumn);
-            auto result_column = _result_chunk->columns()[i].get();
-            auto st = helper.get_result_from_boxed_array(_result_column_types[i], result_column, jcolumn, num_rows);
+            auto& result_column = _result_chunk->columns()[i];
+            auto st = helper.get_result_from_boxed_array(_result_column_types[i], result_column.get(), jcolumn, num_rows);
             RETURN_IF_ERROR(st);
-            down_cast<NullableColumn*>(result_column)->update_has_null();
+            // check data's length for varchar type
+            if (_slot_descs[i]->type().type == TYPE_VARCHAR) {
+                int max_len = _slot_descs[i]->type().len; 
+                ColumnViewer<TYPE_VARCHAR> viewer(result_column);
+                for (int row = 0;row < viewer.size();row++) {
+                    if (viewer.is_null(row)) {
+                        continue;
+                    }
+                    auto value = viewer.value(row);
+                    if ((int)value.size > max_len) {
+                        return Status::DataQualityError(
+                                fmt::format("Value length exceeds limit on column[{}], max length is [{}], value is [{}]",
+                            _slot_descs[i]->col_name(), max_len, value));
+                    }
+                }
+            }
+            down_cast<NullableColumn*>(result_column.get())->update_has_null();
         }
     }
 

--- a/be/src/exec/vectorized/jdbc_scanner.cpp
+++ b/be/src/exec/vectorized/jdbc_scanner.cpp
@@ -392,21 +392,22 @@ Status JDBCScanner::_fill_chunk(jobject jchunk, size_t num_rows, ChunkPtr* chunk
             jobject jcolumn = helper.list_get(jchunk, i);
             LOCAL_REF_GUARD_ENV(env, jcolumn);
             auto& result_column = _result_chunk->columns()[i];
-            auto st = helper.get_result_from_boxed_array(_result_column_types[i], result_column.get(), jcolumn, num_rows);
+            auto st =
+                    helper.get_result_from_boxed_array(_result_column_types[i], result_column.get(), jcolumn, num_rows);
             RETURN_IF_ERROR(st);
             // check data's length for varchar type
             if (_slot_descs[i]->type().type == TYPE_VARCHAR) {
-                int max_len = _slot_descs[i]->type().len; 
+                int max_len = _slot_descs[i]->type().len;
                 ColumnViewer<TYPE_VARCHAR> viewer(result_column);
-                for (int row = 0;row < viewer.size();row++) {
+                for (int row = 0; row < viewer.size(); row++) {
                     if (viewer.is_null(row)) {
                         continue;
                     }
                     auto value = viewer.value(row);
                     if ((int)value.size > max_len) {
-                        return Status::DataQualityError(
-                                fmt::format("Value length exceeds limit on column[{}], max length is [{}], value is [{}]",
-                            _slot_descs[i]->col_name(), max_len, value));
+                        return Status::DataQualityError(fmt::format(
+                                "Value length exceeds limit on column[{}], max length is [{}], value is [{}]",
+                                _slot_descs[i]->col_name(), max_len, value));
                     }
                 }
             }

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
@@ -88,7 +88,28 @@ public class JDBCScanner {
         resultNumRows = 0;
         do {
             for (int i = 0; i < columnCount; i++) {
-                resultChunk.get(i)[resultNumRows] = resultSet.getObject(i + 1);
+                Object[] dataColumn = resultChunk.get(i);
+                Object resultObject = resultSet.getObject(i + 1);
+                // in some cases, the real java class type of result is not consistent with the type from
+                // resultSetMetadata,
+                // for example,FLOAT type in oracle gives java.lang.Double type in resultSetMetaData,
+                // but the result type is BigDecimal when we getObject from resultSet.
+                // So we choose to convert the value to the target type here.
+                if (resultObject == null) {
+                    dataColumn[resultNumRows] = null;
+                } else if (dataColumn instanceof Short[]) {
+                    dataColumn[resultNumRows] = ((Number) resultObject).shortValue();
+                } else if (dataColumn instanceof Integer[]) {
+                    dataColumn[resultNumRows] = ((Number) resultObject).intValue();
+                } else if (dataColumn instanceof Long[]) {
+                    dataColumn[resultNumRows] = ((Number) resultObject).longValue();
+                } else if (dataColumn instanceof Float[]) {
+                    dataColumn[resultNumRows] = ((Number) resultObject).floatValue();
+                } else if (dataColumn instanceof Double[]) {
+                    dataColumn[resultNumRows] = ((Number) resultObject).doubleValue();
+                } else {
+                    dataColumn[resultNumRows] = resultObject;
+                }
             }
             resultNumRows++;
         } while (resultNumRows < chunkSize && resultSet.next());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14235

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

fix some inconsistent behavior of JDBC external table with version 2.4, which is introduced by https://github.com/StarRocks/starrocks/pull/9944

1. when the length of string type exceeds the limit, the query will return an error in version 2.4, but the previous optimization doesn't handle this case, so I add checking logic to do this after we get_result_from_boxed_array.

2. in some cases, the java class type of result in ResultSetMetadata is not consistent with it in real return data.
for example,FLOAT type in oracle gives java.lang.Double in resultSetMetaData, but the result type is BigDecimal when we getObject from resultSet.
in version 2.4, we get the value by calling `doubleValue()` method through JNI, avoiding this problem.
But after the previous optimization, JDBCScanner will create an object array according to the type in ResultSetMetadata, and an error will occur when assigning BigDecimal to Double.
I made some changes to getNextChunk to fix it by casting the result object to the target type as before.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
