### PR TITLE
[Refactor] make ~ContextWithDependency virtual

### DIFF
--- a/be/src/exec/pipeline/context_with_dependency.h
+++ b/be/src/exec/pipeline/context_with_dependency.h
@@ -32,7 +32,7 @@ namespace starrocks::pipeline {
 class ContextWithDependency {
 public:
     ContextWithDependency() = default;
-    ~ContextWithDependency() = default;
+    virtual ~ContextWithDependency() = default;
 
     ContextWithDependency(const ContextWithDependency&) = delete;
     ContextWithDependency(ContextWithDependency&&) = delete;

--- a/be/src/exec/pipeline/nljoin/nljoin_context.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.h
@@ -50,6 +50,7 @@ public:
               _rf_conjuncts_ctx(std::move(params.filters)),
               _rf_hub(params.rf_hub),
               _rf_descs(std::move(params.rf_descs)) {}
+    ~NLJoinContext() override = default;
 
     void close(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -48,6 +48,7 @@ public:
     explicit OlapScanContext(vectorized::OlapScanNode* scan_node, int32_t dop, bool shared_scan,
                              BalancedChunkBuffer& chunk_buffer)
             : _scan_node(scan_node), _chunk_buffer(chunk_buffer), _shared_scan(shared_scan) {}
+    ~OlapScanContext() override = default;
 
     Status prepare(RuntimeState* state);
     void close(RuntimeState* state) override;

--- a/be/src/exec/pipeline/set/except_context.h
+++ b/be/src/exec/pipeline/set/except_context.h
@@ -41,6 +41,7 @@ using ExceptPartitionContextFactoryPtr = std::shared_ptr<ExceptPartitionContextF
 class ExceptContext final : public ContextWithDependency {
 public:
     explicit ExceptContext(const int dst_tuple_id) : _dst_tuple_id(dst_tuple_id) {}
+    ~ExceptContext() override = default;
 
     bool is_ht_empty() const { return _is_hash_set_empty; }
 

--- a/be/src/exec/pipeline/set/intersect_context.h
+++ b/be/src/exec/pipeline/set/intersect_context.h
@@ -42,6 +42,7 @@ class IntersectContext final : public ContextWithDependency {
 public:
     IntersectContext(const int dst_tuple_id, const size_t intersect_times)
             : _dst_tuple_id(dst_tuple_id), _intersect_times(intersect_times) {}
+    ~IntersectContext() override = default;
 
     bool is_ht_empty() const { return _is_hash_set_empty; }
 

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -48,6 +48,7 @@ public:
               _sort_desc(sort_descs) {
         _chunks_sorter_partitions.reserve(num_right_sinkers);
     }
+    ~SortContext() override = default;
 
     void close(RuntimeState* state) override;
 

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -157,7 +157,7 @@ class Aggregator : public pipeline::ContextWithDependency {
 public:
     Aggregator(const TPlanNode& tnode);
 
-    virtual ~Aggregator() noexcept {
+    virtual ~Aggregator() noexcept override {
         if (_state != nullptr) {
             close(_state);
         }

--- a/be/src/exec/vectorized/analytor.h
+++ b/be/src/exec/vectorized/analytor.h
@@ -82,7 +82,7 @@ class Analytor final : public pipeline::ContextWithDependency {
     friend class ManagedFunctionStates;
 
 public:
-    ~Analytor() {
+    ~Analytor() override {
         if (_state != nullptr) {
             close(_state);
         }

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -116,7 +116,7 @@ class HashJoiner final : public pipeline::ContextWithDependency {
 public:
     explicit HashJoiner(const HashJoinerParam& param, const std::vector<HashJoinerPtr>& read_only_join_probers);
 
-    ~HashJoiner() {
+    ~HashJoiner() override {
         if (_runtime_state != nullptr) {
             close(_runtime_state);
         }

--- a/be/test/exec/query_cache/transform_operator.h
+++ b/be/test/exec/query_cache/transform_operator.h
@@ -75,7 +75,7 @@ using Reducers = std::vector<ReducerPtr>;
 class Reducer final : public pipeline::ContextWithDependency {
 public:
     Reducer(double init_value, ReduceFunc reduce_func, size_t output_num_rows);
-    ~Reducer() = default;
+    ~Reducer() override = default;
     void close(starrocks::RuntimeState* state) override{};
     Status reset_state(RuntimeState* state, const Chunks& chunks, pipeline::Operator* op);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The destructor of `ContextWithDependency` is not virtual.
Luckily, all the usage of subclasses of `ContextWithDependency` are `shared_ptr`, so memory leak doesn't happen for now.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
