### PR TITLE
[cherry-pick][branch-2.5][BugFix] Fix key index out of bound in schema of _do_merge_horizontally. (#13963)

### DIFF
--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -31,7 +31,20 @@ Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids)
         DCHECK_LT(cids[i], schema->_fields.size());
         _fields[i] = schema->_fields[cids[i]];
     }
-    _sort_key_idxes = schema->sort_key_idxes();
+    auto is_key = [](const FieldPtr& f) { return f->is_key(); };
+    _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
+    _build_index_map(_fields);
+}
+
+Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids, const std::vector<ColumnId>& scids)
+        : _name_to_index_append_buffer(nullptr), _keys_type(schema->_keys_type) {
+    DCHECK(!scids.empty());
+    _fields.resize(cids.size());
+    for (int i = 0; i < cids.size(); i++) {
+        DCHECK_LT(cids[i], schema->_fields.size());
+        _fields[i] = schema->_fields[cids[i]];
+    }
+    _sort_key_idxes = scids;
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -30,6 +30,8 @@ public:
 
     explicit Schema(Schema* schema, const std::vector<ColumnId>& cids);
 
+    explicit Schema(Schema* schema, const std::vector<ColumnId>& cids, const std::vector<ColumnId>& scids);
+
     // if we use this constructor and share the name_to_index with another schema,
     // we must make sure another shema is read only!!!
     Schema(const Schema& schema);

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -156,6 +156,21 @@ starrocks::vectorized::Schema ChunkHelper::get_short_key_schema_with_format_v2(c
     return starrocks::vectorized::Schema(schema.schema(), short_key_cids);
 }
 
+starrocks::vectorized::Schema ChunkHelper::get_sort_key_schema_with_format_v2(const starrocks::TabletSchema& schema) {
+    std::vector<ColumnId> sort_key_iota_idxes(schema.sort_key_idxes().size());
+    std::iota(sort_key_iota_idxes.begin(), sort_key_iota_idxes.end(), 0);
+    return starrocks::vectorized::Schema(schema.schema(), schema.sort_key_idxes(), sort_key_iota_idxes);
+}
+
+starrocks::vectorized::Schema ChunkHelper::get_sort_key_schema_by_primary_key_format_v2(
+        const starrocks::TabletSchema& tablet_schema) {
+    std::vector<ColumnId> primary_key_iota_idxes(tablet_schema.num_key_columns());
+    std::iota(primary_key_iota_idxes.begin(), primary_key_iota_idxes.end(), 0);
+    std::vector<ColumnId> all_keys_iota_idxes(tablet_schema.num_columns());
+    std::iota(all_keys_iota_idxes.begin(), all_keys_iota_idxes.end(), 0);
+    return starrocks::vectorized::Schema(tablet_schema.schema(), all_keys_iota_idxes, primary_key_iota_idxes);
+}
+
 ColumnId ChunkHelper::max_column_id(const starrocks::vectorized::Schema& schema) {
     ColumnId id = 0;
     for (const auto& field : schema.fields()) {

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -37,6 +37,13 @@ public:
     // Get schema with format v2 type containing short key columns from TabletSchema.
     static vectorized::Schema get_short_key_schema_with_format_v2(const TabletSchema& tablet_schema);
 
+    // Get schema with format v2 type containing sort key columns from TabletSchema.
+    static vectorized::Schema get_sort_key_schema_with_format_v2(const TabletSchema& tablet_schema);
+
+    // Get schema with format v2 type containing sort key columns filled by primary key columns from TabletSchema.
+    static vectorized::Schema get_sort_key_schema_by_primary_key_format_v2(
+            const starrocks::TabletSchema& tablet_schema);
+
     static ColumnId max_column_id(const vectorized::Schema& schema);
 
     // Create an empty chunk according to the |schema| and reserve it of size |n|.

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -95,7 +95,7 @@ struct MergeEntry {
                     PrimaryKeyEncoder::encode(*encode_schema, *chunk, 0, chunk->num_rows(), chunk_pk_column.get());
                 } else {
                     // just use chunk's first column
-                    chunk_pk_column = chunk->get_column_by_index(0);
+                    chunk_pk_column = chunk->get_column_by_index(chunk->schema()->sort_key_idxes()[0]);
                 }
                 DCHECK(chunk_pk_column->size() > 0);
                 DCHECK(chunk_pk_column->size() == chunk->num_rows());
@@ -223,7 +223,7 @@ public:
         MonotonicStopWatch timer;
         timer.start();
         if (cfg.algorithm == VERTICAL_COMPACTION) {
-            CompactionUtils::split_column_into_groups(tablet.num_columns(), tablet.tablet_schema().sort_key_idxes(),
+            CompactionUtils::split_column_into_groups(tablet.num_columns(), schema.sort_key_idxes(),
                                                       config::vertical_compaction_max_columns_per_group,
                                                       &column_groups);
             RETURN_IF_ERROR(_do_merge_vertically(tablet, version, rowsets, writer, cfg, column_groups,
@@ -238,7 +238,8 @@ public:
         StarRocksMetrics::instance()->update_compaction_bytes_total.increment(total_input_size);
         StarRocksMetrics::instance()->update_compaction_outputs_total.increment(1);
         StarRocksMetrics::instance()->update_compaction_outputs_bytes_total.increment(writer->total_data_size());
-        LOG(INFO) << "compaction merge finished. tablet=" << tablet.tablet_id() << " #key=" << schema.num_key_fields()
+        LOG(INFO) << "compaction merge finished. tablet=" << tablet.tablet_id()
+                  << " #key=" << schema.sort_key_idxes().size()
                   << " algorithm=" << CompactionUtils::compaction_algorithm_to_string(cfg.algorithm)
                   << " column_group_size=" << column_groups.size() << " input("
                   << "entry=" << _entries.size() << " rows=" << stats.raw_rows_read
@@ -257,14 +258,8 @@ private:
                                   OlapReaderStatistics* stats, RowSourceMaskBuffer* mask_buffer = nullptr,
                                   std::vector<std::unique_ptr<RowSourceMaskBuffer>>* rowsets_mask_buffer = nullptr) {
         std::unique_ptr<vectorized::Column> sort_column;
-        std::vector<ColumnId> sort_key_idxes;
         if (schema.sort_key_idxes().size() > 1) {
-            sort_key_idxes = schema.sort_key_idxes();
-            if (!PrimaryKeyEncoder::create_column(schema, &sort_column, sort_key_idxes).ok()) {
-                LOG(FATAL) << "create column for primary key encoder failed";
-            }
-        } else if (schema.num_key_fields() > 1) {
-            if (!PrimaryKeyEncoder::create_column(schema, &sort_column).ok()) {
+            if (!PrimaryKeyEncoder::create_column(schema, &sort_column, schema.sort_key_idxes()).ok()) {
                 LOG(FATAL) << "create column for primary key encoder failed";
             }
         }
@@ -413,7 +408,9 @@ private:
             rowsets_mask_buffer.emplace_back(std::move(rowset_mask_buffer));
         }
         {
-            Schema schema = ChunkHelper::convert_schema_to_format_v2(tablet.tablet_schema(), column_groups[0]);
+            Schema schema = tablet.tablet_schema().sort_key_idxes().empty()
+                                    ? ChunkHelper::convert_schema_to_format_v2(tablet.tablet_schema(), column_groups[0])
+                                    : ChunkHelper::get_sort_key_schema_with_format_v2(tablet.tablet_schema());
             RETURN_IF_ERROR(_do_merge_horizontally(tablet, version, schema, rowsets, writer, cfg, total_input_size,
                                                    total_rows, total_chunk, stats, mask_buffer.get(),
                                                    &rowsets_mask_buffer));
@@ -518,7 +515,13 @@ private:
 
 Status compaction_merge_rowsets(Tablet& tablet, int64_t version, const vector<RowsetSharedPtr>& rowsets,
                                 RowsetWriter* writer, const MergeConfig& cfg) {
-    Schema schema = ChunkHelper::convert_schema_to_format_v2(tablet.tablet_schema());
+    Schema schema = [&tablet]() {
+        if (tablet.tablet_schema().sort_key_idxes().empty()) {
+            return ChunkHelper::get_sort_key_schema_by_primary_key_format_v2(tablet.tablet_schema());
+        } else {
+            return ChunkHelper::convert_schema_to_format_v2(tablet.tablet_schema());
+        }
+    }();
     std::unique_ptr<RowsetMerger> merger;
     auto key_type = PrimaryKeyEncoder::encoded_primary_key_type(schema, schema.sort_key_idxes());
     switch (key_type) {

--- a/be/test/storage/compaction_utils_test.cpp
+++ b/be/test/storage/compaction_utils_test.cpp
@@ -78,6 +78,15 @@ TEST(CompactionUtilsTest, test_split_column_into_groups) {
     ASSERT_EQ(5, column_groups[1].size());
     ASSERT_EQ(5, column_groups[2].size());
     ASSERT_EQ(4, column_groups[3].size());
+
+    std::vector<std::vector<uint32_t>> column_groups1;
+    CompactionUtils::split_column_into_groups(num_columns, {0}, max_columns_per_group, &column_groups1);
+    ASSERT_EQ(5, column_groups1.size());
+    ASSERT_EQ(1, column_groups1[0].size());
+    ASSERT_EQ(5, column_groups1[1].size());
+    ASSERT_EQ(5, column_groups1[2].size());
+    ASSERT_EQ(5, column_groups1[3].size());
+    ASSERT_EQ(1, column_groups1[4].size());
 }
 
 TEST(CompactionUtilsTest, test_choose_compaction_algorithm) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13935

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
potential array index out of bound. should be an iota array of sort key indexes, not sort key indexes directly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
