### PR TITLE
[BugFix][Enhancement]Lambda functions reuse sub expressions without lambda arguments (backport #14817)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -5,6 +5,7 @@ package com.starrocks.sql.optimizer.rule.tree;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
@@ -16,6 +17,7 @@ import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
@@ -71,7 +73,7 @@ public class ScalarOperatorsReuse {
             ColumnRefFactory columnRefFactory) {
         // 1. Recursively collect common sub operators for the input operators
         CommonSubScalarOperatorCollector operatorCollector = new CommonSubScalarOperatorCollector();
-        scalarOperators.forEach(operator -> operator.accept(operatorCollector, null));
+        scalarOperators.forEach(operator -> operator.accept(operatorCollector, new CollectorContext(false)));
         if (operatorCollector.commonOperatorsByDepth.isEmpty()) {
             return ImmutableMap.of();
         }
@@ -129,6 +131,14 @@ public class ScalarOperatorsReuse {
                     call.getFunction(),
                     call.isDistinct());
             return tryRewrite(operator);
+        }
+
+        @Override
+        public ScalarOperator visitLambdaFunctionOperator(LambdaFunctionOperator operator, Void context) {
+            ScalarOperator newOperator = new LambdaFunctionOperator(operator.getRefColumns(),
+                    operator.getLambdaExpr().accept(this, null), operator.getType()
+            );
+            return tryRewrite(newOperator);
         }
 
         @Override
@@ -207,7 +217,19 @@ public class ScalarOperatorsReuse {
         }
     }
 
-    private static class CommonSubScalarOperatorCollector extends ScalarOperatorVisitor<Integer, Void> {
+    private static class CollectorContext {
+        public boolean isWithinLambda() {
+            return withinLambda;
+        }
+
+        private final boolean withinLambda;
+        CollectorContext(boolean withinLambda) {
+            this.withinLambda = withinLambda;
+        }
+
+    }
+
+    private static class CommonSubScalarOperatorCollector extends ScalarOperatorVisitor<Integer, CollectorContext> {
         // The key is operator tree depth, the value is operator set with same tree depth.
         // For operator list [a + b, a + b + c, a + d]
         // The operatorsByDepth is
@@ -217,9 +239,9 @@ public class ScalarOperatorsReuse {
         private final Map<Integer, Set<ScalarOperator>> operatorsByDepth = new HashMap<>();
         private final Map<Integer, Set<ScalarOperator>> commonOperatorsByDepth = new HashMap<>();
 
-        private int collectCommonOperatorsByDepth(int depth, ScalarOperator operator) {
+        private int collectCommonOperatorsByDepth(int depth, ScalarOperator operator, boolean lambda) {
             Set<ScalarOperator> operators = getOperatorsByDepth(depth, operatorsByDepth);
-            if (!isNonDeterministicFuncExist(operator) && operators.contains(operator)) {
+            if (!isNonDeterministicFuncOrLambdaArgumentExist(operator, lambda) && operators.contains(operator)) {
                 Set<ScalarOperator> commonOperators = getOperatorsByDepth(depth, commonOperatorsByDepth);
                 commonOperators.add(operator);
             }
@@ -234,23 +256,36 @@ public class ScalarOperatorsReuse {
         }
 
         @Override
-        public Integer visit(ScalarOperator scalarOperator, Void context) {
+        public Integer visit(ScalarOperator scalarOperator, CollectorContext context) {
             if (scalarOperator.getChildren().isEmpty()) {
                 return 0;
             }
 
-            return collectCommonOperatorsByDepth(scalarOperator.getChildren().stream().map(
-                    argument -> argument.accept(this, context)).reduce(Math::max).get() + 1, scalarOperator);
+            return collectCommonOperatorsByDepth(scalarOperator.getChildren().stream().map(argument ->
+                    argument.accept(this, context)).reduce(Math::max).get() + 1, scalarOperator, context.isWithinLambda());
+        }
+
+        // get rid of the expressions with lambda arguments, for example, select a+b, array_map(x-> 2*x+2*x > a+b, [1])
+        // the a+b is reused, but 2*x is not reused as it contains the lambda argument x.
+        // TODO(fzh) support reusing lambda argument related expressions.
+        @Override
+        public Integer visitLambdaFunctionOperator(LambdaFunctionOperator scalarOperator, CollectorContext context) {
+            return collectCommonOperatorsByDepth(scalarOperator.getLambdaExpr().accept(this, new CollectorContext(true)),
+                    scalarOperator, true);
         }
 
         @Override
-        public Integer visitDictMappingOperator(DictMappingOperator scalarOperator, Void context) {
-            return collectCommonOperatorsByDepth(1, scalarOperator);
+        public Integer visitDictMappingOperator(DictMappingOperator scalarOperator, CollectorContext context) {
+            return collectCommonOperatorsByDepth(1, scalarOperator, context.isWithinLambda());
         }
 
         // If a scalarOperator contains any non-deterministic function, it cannot be reused
         // because the non-deterministic function results returned each time are inconsistent.
-        private boolean isNonDeterministicFuncExist(ScalarOperator scalarOperator) {
+        private boolean isNonDeterministicFuncOrLambdaArgumentExist(ScalarOperator scalarOperator, boolean lambda) {
+            if (lambda && scalarOperator.getOpType().equals(OperatorType.LAMBDA_ARGUMENT)) {
+                return true;
+            }
+
             if (scalarOperator instanceof CallOperator) {
                 String fnName = ((CallOperator) scalarOperator).getFnName();
                 if (FunctionSet.nonDeterministicFunctions.contains(fnName)) {
@@ -259,7 +294,7 @@ public class ScalarOperatorsReuse {
             }
 
             for (ScalarOperator child : scalarOperator.getChildren()) {
-                if (isNonDeterministicFuncExist(child)) {
+                if (isNonDeterministicFuncOrLambdaArgumentExist(child, lambda)) {
                     return true;
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -105,6 +105,7 @@ public class AnalyzeExprTest {
         analyzeSuccess("select array_map([1], x -> x)");
         analyzeSuccess("select array_map([1], x -> x + v1) from t0");
         analyzeSuccess("select transform([1], x -> x)");
+        analyzeSuccess("select arr,array_length(arr) from (select array_map(x->x+1, [1,2]) as arr)T");
 
         analyzeFail("select array_map(x,y -> x + y, [], [])"); // should be (x,y)
         analyzeFail("select array_map((x,y,z) -> x + y, [], [])");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -524,6 +524,41 @@ public class ExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testLambdaReuseSubExpressionWithoutLambdaArguments() throws Exception {
+        starRocksAssert.withTable("create table test_array" +
+                "(c0 INT,c1 int, c2 array<int>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+        String sql = "select b, array_map(x->x+b, arr) from (select array_map(x->x+1, [1,2]) as arr, 3*c1 as b " +
+                "from test_array)T";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_map(<slot 7> -> CAST(<slot 7> AS BIGINT) + 10: multiply"));
+
+        sql = "select b, array_map(x->x+ 3 *c1, arr) from (select array_map(x->x+1, [1,2]) as arr, 3*c1 as b,c1 " +
+                "from test_array)T";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_map(<slot 7> -> CAST(<slot 7> AS BIGINT) + 10: multiply"));
+
+        sql = "select 3*c1, array_map(x->x+ 3 *c1, c2) from test_array";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_map(<slot 5> -> CAST(<slot 5> AS BIGINT) + 8: multiply"));
+
+        sql = "select arr,array_length(arr) from (select array_map(x->x+1, [1,2]) as arr)T";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains("array_length(6: array_map)"));
+
+        sql = "select  array_map(x->x+ 3 *c1 + 3*c1, c2) from test_array";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("common expressions"));
+        Assert.assertTrue(plan.contains(
+                "array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) + 7: multiply + 7: multiply"));
+    }
+
+    @Test
     public void testInPredicateNormalize() throws Exception {
         starRocksAssert.withTable("create table test_in_pred_norm" +
                 "(c0 INT, c1 INT, c2 INT, c3 INT, c4 DATE, c5 DATE) " +


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/pull/14904

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
