### PR TITLE
[WIP] [Enhancement] Add more metrics for scan

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -496,7 +496,7 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _zm_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", "SegmentInit");
 
     _sk_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
-    _sk_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyIndexFilter", "SegmentInit");
+    _sk_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyFilter", "SegmentInit");
 
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -119,7 +119,6 @@ private:
     RuntimeProfile::Counter* _chunk_copy_timer = nullptr;
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _block_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_seek_counter = nullptr;
     RuntimeProfile::Counter* _block_load_timer = nullptr;
@@ -136,6 +135,9 @@ private:
 
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _zm_filter_timer = nullptr;
+
+    RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _sk_filter_timer = nullptr;
 
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;
@@ -556,7 +558,6 @@ void LakeDataSource::update_counter() {
     COUNTER_UPDATE(_del_vec_filter_counter, _reader->stats().rows_del_vec_filtered);
 
     COUNTER_UPDATE(_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
-    COUNTER_UPDATE(_sk_filtered_counter, _reader->stats().rows_key_range_filtered);
 
     COUNTER_UPDATE(_read_pages_num_counter, _reader->stats().total_pages_num);
     COUNTER_UPDATE(_cached_pages_num_counter, _reader->stats().cached_pages_num);
@@ -569,6 +570,9 @@ void LakeDataSource::update_counter() {
 
     COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_zm_filtered);
     COUNTER_UPDATE(_zm_filter_timer, _reader->stats().zm_filter_timer);
+
+    COUNTER_UPDATE(_sk_filtered_counter, _reader->stats().rows_sk_filtered);
+    COUNTER_UPDATE(_sk_filter_timer, _reader->stats().sk_filter_timer);
 
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
 

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -495,9 +495,11 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _zm_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _zm_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", "SegmentInit");
 
+    _sk_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
+    _sk_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyIndexFilter", "SegmentInit");
+
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
-    _sk_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
 
     // SegmentRead
     _block_load_timer = ADD_TIMER(_runtime_profile, "SegmentRead");

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -101,14 +101,20 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
 
     // SegmentInit
     _seg_init_timer = ADD_TIMER(_runtime_profile, "SegmentInit");
-    _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", "SegmentInit");
+
     _bi_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BitmapIndexFilterRows", TUnit::UNIT, "SegmentInit");
+    _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", "SegmentInit");
+
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, "SegmentInit");
+    _bf_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BloomFilterFilter", "SegmentInit");
+
+    _zm_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
+    _zm_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", "SegmentInit");
+
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
     _seg_rt_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
-    _zm_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _sk_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
 
     // SegmentRead

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -111,11 +111,13 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _zm_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _zm_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", "SegmentInit");
 
+    _sk_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
+    _sk_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyFilter", "SegmentInit");
+
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
     _seg_rt_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
-    _sk_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
 
     // SegmentRead
     _block_load_timer = ADD_TIMER(_runtime_profile, "SegmentRead");

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -429,7 +429,6 @@ void OlapChunkSource::_update_counter() {
 
     COUNTER_UPDATE(_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
     COUNTER_UPDATE(_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);
-    COUNTER_UPDATE(_sk_filtered_counter, _reader->stats().rows_key_range_filtered);
 
     COUNTER_UPDATE(_read_pages_num_counter, _reader->stats().total_pages_num);
     COUNTER_UPDATE(_cached_pages_num_counter, _reader->stats().cached_pages_num);
@@ -442,6 +441,9 @@ void OlapChunkSource::_update_counter() {
 
     COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_zm_filtered);
     COUNTER_UPDATE(_zm_filter_timer, _reader->stats().zm_filter_timer);
+
+    COUNTER_UPDATE(_sk_filtered_counter, _reader->stats().rows_sk_filtered);
+    COUNTER_UPDATE(_sk_filter_timer, _reader->stats().sk_filter_timer);
 
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -423,15 +423,20 @@ void OlapChunkSource::_update_counter() {
 
     COUNTER_UPDATE(_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
     COUNTER_UPDATE(_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);
-    COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_stats_filtered);
-    COUNTER_UPDATE(_bf_filtered_counter, _reader->stats().rows_bf_filtered);
     COUNTER_UPDATE(_sk_filtered_counter, _reader->stats().rows_key_range_filtered);
 
     COUNTER_UPDATE(_read_pages_num_counter, _reader->stats().total_pages_num);
     COUNTER_UPDATE(_cached_pages_num_counter, _reader->stats().cached_pages_num);
 
-    COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
-    COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bi_filtered);
+    COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bi_filter_timer);
+
+    COUNTER_UPDATE(_bf_filtered_counter, _reader->stats().rows_bf_filtered);
+    COUNTER_UPDATE(_bf_filter_timer, _reader->stats().bf_filter_timer);
+
+    COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_zm_filtered);
+    COUNTER_UPDATE(_zm_filter_timer, _reader->stats().zm_filter_timer);
+
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -118,8 +118,16 @@ private:
     RuntimeProfile::Counter* _get_rowsets_timer = nullptr;
     RuntimeProfile::Counter* _get_delvec_timer = nullptr;
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
-    RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
+
+    RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _bi_filter_timer = nullptr;
+
     RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _bf_filter_timer = nullptr;
+
+    RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _zm_filter_timer = nullptr;
+
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
     RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
@@ -130,8 +138,6 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _read_pages_num_counter = nullptr;
     RuntimeProfile::Counter* _cached_pages_num_counter = nullptr;
-    RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _bi_filter_timer = nullptr;
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;
     RuntimeProfile::Counter* _segments_read_count = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -128,9 +128,11 @@ private:
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _zm_filter_timer = nullptr;
 
+    RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _sk_filter_timer = nullptr;
+
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _block_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_seek_counter = nullptr;
     RuntimeProfile::Counter* _block_load_timer = nullptr;

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -512,6 +512,10 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _sk_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
     _sk_filter_timer = ADD_CHILD_TIMER(_scan_profile, "ShortKeyFilter", "SegmentInit");
 
+    _ordinal_index_load_timer = ADD_CHILD_TIMER(_scan_profile, "OrdinalIndexLoad", "SegmentInit");
+    _ordinal_index_load_count = ADD_CHILD_COUNTER(_scan_profile, "OrdinalIndexLoadCount", TUnit::UNIT, "SegmentInit");
+    _dict_load_timer = ADD_CHILD_TIMER(_scan_profile, "DictLoadTimer", "SegmentInit");
+
     _seg_zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
     _seg_rt_filtered_counter =
             ADD_CHILD_COUNTER(_scan_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, "SegmentInit");

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -499,13 +499,19 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
 
     /// SegmentInit
     _seg_init_timer = ADD_TIMER(_scan_profile, "SegmentInit");
-    _bi_filter_timer = ADD_CHILD_TIMER(_scan_profile, "BitmapIndexFilter", "SegmentInit");
+
     _bi_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BitmapIndexFilterRows", TUnit::UNIT, "SegmentInit");
+    _bi_filter_timer = ADD_CHILD_TIMER(_scan_profile, "BitmapIndexFilter", "SegmentInit");
+
     _bf_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BloomFilterFilterRows", TUnit::UNIT, "SegmentInit");
+    _bf_filter_timer = ADD_CHILD_TIMER(_scan_profile, "BloomFilterFilter", "SegmentInit");
+
+    _zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
+    _zm_filter_timer = ADD_CHILD_TIMER(_scan_profile, "ZoneMapIndexFilter", "SegmentInit");
+
     _seg_zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
     _seg_rt_filtered_counter =
             ADD_CHILD_COUNTER(_scan_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
-    _zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _sk_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
 
     /// SegmentRead

--- a/be/src/exec/vectorized/olap_scan_node.cpp
+++ b/be/src/exec/vectorized/olap_scan_node.cpp
@@ -509,10 +509,12 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _zm_filter_timer = ADD_CHILD_TIMER(_scan_profile, "ZoneMapIndexFilter", "SegmentInit");
 
+    _sk_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
+    _sk_filter_timer = ADD_CHILD_TIMER(_scan_profile, "ShortKeyFilter", "SegmentInit");
+
     _seg_zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
     _seg_rt_filtered_counter =
             ADD_CHILD_COUNTER(_scan_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
-    _sk_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "ShortKeyFilterRows", TUnit::UNIT, "SegmentInit");
 
     /// SegmentRead
     _block_load_timer = ADD_TIMER(_scan_profile, "SegmentRead");

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -220,8 +220,6 @@ private:
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
     RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _block_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_seek_counter = nullptr;
@@ -230,8 +228,16 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _read_pages_num_counter = nullptr;
     RuntimeProfile::Counter* _cached_pages_num_counter = nullptr;
+
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
+
+    RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _bf_filter_timer = nullptr;
+
+    RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _zm_filter_timer = nullptr;
+
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;
     RuntimeProfile::Counter* _segments_read_count = nullptr;

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -220,7 +220,6 @@ private:
     RuntimeProfile::Counter* _seg_init_timer = nullptr;
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
-    RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _block_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_seek_counter = nullptr;
     RuntimeProfile::Counter* _block_load_timer = nullptr;
@@ -237,6 +236,9 @@ private:
 
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _zm_filter_timer = nullptr;
+
+    RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _sk_filter_timer = nullptr;
 
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;

--- a/be/src/exec/vectorized/olap_scan_node.h
+++ b/be/src/exec/vectorized/olap_scan_node.h
@@ -240,6 +240,10 @@ private:
     RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _sk_filter_timer = nullptr;
 
+    RuntimeProfile::Counter* _ordinal_index_load_timer = nullptr;
+    RuntimeProfile::Counter* _ordinal_index_load_count = nullptr;
+    RuntimeProfile::Counter* _dict_load_timer = nullptr;
+
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;
     RuntimeProfile::Counter* _segments_read_count = nullptr;

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -351,8 +351,6 @@ void TabletScanner::update_counter() {
     COUNTER_UPDATE(_parent->_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
     COUNTER_UPDATE(_parent->_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);
 
-    COUNTER_UPDATE(_parent->_sk_filtered_counter, _reader->stats().rows_key_range_filtered);
-
     COUNTER_UPDATE(_parent->_read_pages_num_counter, _reader->stats().total_pages_num);
     COUNTER_UPDATE(_parent->_cached_pages_num_counter, _reader->stats().cached_pages_num);
 
@@ -364,6 +362,9 @@ void TabletScanner::update_counter() {
 
     COUNTER_UPDATE(_parent->_zm_filtered_counter, _reader->stats().rows_zm_filtered);
     COUNTER_UPDATE(_parent->_zm_filter_timer, _reader->stats().zm_filter_timer);
+
+    COUNTER_UPDATE(_parent->_sk_filtered_counter, _reader->stats().rows_sk_filtered);
+    COUNTER_UPDATE(_parent->_sk_filter_timer, _reader->stats().sk_filter_timer);
 
     COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
 

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -366,6 +366,10 @@ void TabletScanner::update_counter() {
     COUNTER_UPDATE(_parent->_sk_filtered_counter, _reader->stats().rows_sk_filtered);
     COUNTER_UPDATE(_parent->_sk_filter_timer, _reader->stats().sk_filter_timer);
 
+    COUNTER_UPDATE(_parent->_ordinal_index_load_timer, _reader->stats().ordinal_index_load_timer);
+    COUNTER_UPDATE(_parent->_ordinal_index_load_count, _reader->stats().ordinal_index_load_count);
+    COUNTER_UPDATE(_parent->_dict_load_timer, _reader->stats().dict_load_timer);
+
     COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_parent->_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -351,15 +351,20 @@ void TabletScanner::update_counter() {
     COUNTER_UPDATE(_parent->_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
     COUNTER_UPDATE(_parent->_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);
 
-    COUNTER_UPDATE(_parent->_zm_filtered_counter, _reader->stats().rows_stats_filtered);
-    COUNTER_UPDATE(_parent->_bf_filtered_counter, _reader->stats().rows_bf_filtered);
     COUNTER_UPDATE(_parent->_sk_filtered_counter, _reader->stats().rows_key_range_filtered);
 
     COUNTER_UPDATE(_parent->_read_pages_num_counter, _reader->stats().total_pages_num);
     COUNTER_UPDATE(_parent->_cached_pages_num_counter, _reader->stats().cached_pages_num);
 
-    COUNTER_UPDATE(_parent->_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
-    COUNTER_UPDATE(_parent->_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_parent->_bi_filtered_counter, _reader->stats().rows_bi_filtered);
+    COUNTER_UPDATE(_parent->_bi_filter_timer, _reader->stats().bi_filter_timer);
+
+    COUNTER_UPDATE(_parent->_bf_filtered_counter, _reader->stats().rows_bf_filtered);
+    COUNTER_UPDATE(_parent->_bf_filter_timer, _reader->stats().bf_filter_timer);
+
+    COUNTER_UPDATE(_parent->_zm_filtered_counter, _reader->stats().rows_zm_filtered);
+    COUNTER_UPDATE(_parent->_zm_filter_timer, _reader->stats().zm_filter_timer);
+
     COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_parent->_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -243,16 +243,20 @@ struct OlapReaderStatistics {
 
     int64_t segment_stats_filtered = 0;
     int64_t rows_key_range_filtered = 0;
-    int64_t rows_stats_filtered = 0;
-    int64_t rows_bf_filtered = 0;
     int64_t rows_del_filtered = 0;
     int64_t del_filter_ns = 0;
 
     int64_t total_pages_num = 0;
     int64_t cached_pages_num = 0;
 
-    int64_t rows_bitmap_index_filtered = 0;
-    int64_t bitmap_index_filter_timer = 0;
+    int64_t rows_bi_filtered = 0;
+    int64_t bi_filter_timer = 0;
+
+    int64_t rows_bf_filtered = 0;
+    int64_t bf_filter_timer = 0;
+
+    int64_t rows_zm_filtered = 0;
+    int64_t zm_filter_timer = 0;
 
     int64_t rows_del_vec_filtered = 0;
 

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -242,7 +242,6 @@ struct OlapReaderStatistics {
     int64_t segment_init_ns = 0;
 
     int64_t segment_stats_filtered = 0;
-    int64_t rows_key_range_filtered = 0;
     int64_t rows_del_filtered = 0;
     int64_t del_filter_ns = 0;
 
@@ -257,6 +256,9 @@ struct OlapReaderStatistics {
 
     int64_t rows_zm_filtered = 0;
     int64_t zm_filter_timer = 0;
+
+    int64_t rows_sk_filtered = 0;
+    int64_t sk_filter_timer = 0;
 
     int64_t rows_del_vec_filtered = 0;
 

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -260,6 +260,10 @@ struct OlapReaderStatistics {
     int64_t rows_sk_filtered = 0;
     int64_t sk_filter_timer = 0;
 
+    int64_t ordinal_index_load_timer = 0;
+    int64_t ordinal_index_load_count = 0;
+    int64_t dict_load_timer = 0;
+
     int64_t rows_del_vec_filtered = 0;
 
     int64_t rowsets_read_count = 0;

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -83,8 +83,8 @@ Status BitmapIndexReader::_do_load(FileSystem* fs, const std::string& filename, 
     _has_null = meta.has_null();
     _dict_column_reader = std::make_unique<IndexedColumnReader>(fs, filename, dict_meta);
     _bitmap_column_reader = std::make_unique<IndexedColumnReader>(fs, filename, bitmap_meta);
-    RETURN_IF_ERROR(_dict_column_reader->load(use_page_cache, kept_in_memory));
-    RETURN_IF_ERROR(_bitmap_column_reader->load(use_page_cache, kept_in_memory));
+    RETURN_IF_ERROR(_dict_column_reader->load(use_page_cache, kept_in_memory, 3));
+    RETURN_IF_ERROR(_bitmap_column_reader->load(use_page_cache, kept_in_memory, 4));
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -107,7 +107,7 @@ Status BitmapIndexIterator::read_bitmap(rowid_t ordinal, Roaring* result) {
     DCHECK(0 <= ordinal && ordinal < _reader->bitmap_nums());
 
     auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
-    RETURN_IF_ERROR(_bitmap_column_iter->seek_to_ordinal(ordinal));
+    RETURN_IF_ERROR(_bitmap_column_iter->seek_to_ordinal(ordinal, 6));
     size_t num_to_read = 1;
     size_t num_read = num_to_read;
     RETURN_IF_ERROR(_bitmap_column_iter->next_batch(&num_read, column.get()));

--- a/be/src/storage/rowset/bloom_filter_index_reader.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_reader.cpp
@@ -75,7 +75,7 @@ Status BloomFilterIndexReader::_do_load(FileSystem* fs, const std::string& filen
     _hash_strategy = meta.hash_strategy();
     const IndexedColumnMetaPB& bf_index_meta = meta.bloom_filter();
     _bloom_filter_reader = std::make_unique<IndexedColumnReader>(fs, filename, bf_index_meta);
-    RETURN_IF_ERROR(_bloom_filter_reader->load(use_page_cache, kept_in_memory));
+    RETURN_IF_ERROR(_bloom_filter_reader->load(use_page_cache, kept_in_memory, 2));
     return Status::OK();
 }
 
@@ -95,7 +95,7 @@ Status BloomFilterIndexReader::new_iterator(std::unique_ptr<BloomFilterIndexIter
 
 Status BloomFilterIndexIterator::read_bloom_filter(rowid_t ordinal, std::unique_ptr<BloomFilter>* bf) {
     auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
-    RETURN_IF_ERROR(_bloom_filter_iter->seek_to_ordinal(ordinal));
+    RETURN_IF_ERROR(_bloom_filter_iter->seek_to_ordinal(ordinal, 2));
     size_t num_to_read = 1;
     size_t num_read = num_to_read;
     RETURN_IF_ERROR(_bloom_filter_iter->next_batch(&num_read, column.get()));

--- a/be/src/storage/rowset/indexed_column_reader.cpp
+++ b/be/src/storage/rowset/indexed_column_reader.cpp
@@ -44,7 +44,7 @@ namespace starrocks {
 
 using strings::Substitute;
 
-Status IndexedColumnReader::load(bool use_page_cache, bool kept_in_memory) {
+Status IndexedColumnReader::load(bool use_page_cache, bool kept_in_memory, int flag) {
     _use_page_cache = use_page_cache;
     _kept_in_memory = kept_in_memory;
 
@@ -62,6 +62,7 @@ Status IndexedColumnReader::load(bool use_page_cache, bool kept_in_memory) {
         if (_meta.ordinal_index_meta().is_root_data_page()) {
             _sole_data_page = PagePointer(_meta.ordinal_index_meta().root_page());
         } else {
+            std::cout<<"FLAG:"<<flag<<":"<<_meta.ordinal_index_meta().root_page().size()<<std::endl;
             RETURN_IF_ERROR(load_index_page(read_file.get(), _meta.ordinal_index_meta().root_page(),
                                             &_ordinal_index_page_handle, &_ordinal_index_reader));
             _has_index_page = true;
@@ -73,6 +74,7 @@ Status IndexedColumnReader::load(bool use_page_cache, bool kept_in_memory) {
         if (_meta.value_index_meta().is_root_data_page()) {
             _sole_data_page = PagePointer(_meta.value_index_meta().root_page());
         } else {
+            std::cout<<"FLAG:"<<flag<<":"<<_meta.value_index_meta().root_page().size()<<std::endl;
             RETURN_IF_ERROR(load_index_page(read_file.get(), _meta.value_index_meta().root_page(),
                                             &_value_index_page_handle, &_value_index_reader));
             _has_index_page = true;
@@ -130,7 +132,7 @@ Status IndexedColumnIterator::_read_data_page(const PagePointer& pp) {
     return parse_page(&_data_page, std::move(handle), body, footer.data_page_footer(), _reader->encoding_info(), pp, 0);
 }
 
-Status IndexedColumnIterator::seek_to_ordinal(ordinal_t idx) {
+Status IndexedColumnIterator::seek_to_ordinal(ordinal_t idx, int flag) {
     DCHECK(idx >= 0 && idx <= _reader->num_values());
 
     if (!_reader->support_ordinal_seek()) {
@@ -153,6 +155,7 @@ Status IndexedColumnIterator::seek_to_ordinal(ordinal_t idx) {
             RETURN_IF_ERROR(_read_data_page(_ordinal_iter.current_page_pointer()));
             _current_iter = &_ordinal_iter;
         } else {
+            std::cout<<"FLAG:"<<flag<<":"<<_reader->_sole_data_page.size<<std::endl;
             RETURN_IF_ERROR(_read_data_page(_reader->_sole_data_page));
         }
     }

--- a/be/src/storage/rowset/indexed_column_reader.cpp
+++ b/be/src/storage/rowset/indexed_column_reader.cpp
@@ -62,7 +62,6 @@ Status IndexedColumnReader::load(bool use_page_cache, bool kept_in_memory, int f
         if (_meta.ordinal_index_meta().is_root_data_page()) {
             _sole_data_page = PagePointer(_meta.ordinal_index_meta().root_page());
         } else {
-            std::cout<<"FLAG:"<<flag<<":"<<_meta.ordinal_index_meta().root_page().size()<<std::endl;
             RETURN_IF_ERROR(load_index_page(read_file.get(), _meta.ordinal_index_meta().root_page(),
                                             &_ordinal_index_page_handle, &_ordinal_index_reader));
             _has_index_page = true;
@@ -74,7 +73,6 @@ Status IndexedColumnReader::load(bool use_page_cache, bool kept_in_memory, int f
         if (_meta.value_index_meta().is_root_data_page()) {
             _sole_data_page = PagePointer(_meta.value_index_meta().root_page());
         } else {
-            std::cout<<"FLAG:"<<flag<<":"<<_meta.value_index_meta().root_page().size()<<std::endl;
             RETURN_IF_ERROR(load_index_page(read_file.get(), _meta.value_index_meta().root_page(),
                                             &_value_index_page_handle, &_value_index_reader));
             _has_index_page = true;
@@ -155,7 +153,6 @@ Status IndexedColumnIterator::seek_to_ordinal(ordinal_t idx, int flag) {
             RETURN_IF_ERROR(_read_data_page(_ordinal_iter.current_page_pointer()));
             _current_iter = &_ordinal_iter;
         } else {
-            std::cout<<"FLAG:"<<flag<<":"<<_reader->_sole_data_page.size<<std::endl;
             RETURN_IF_ERROR(_read_data_page(_reader->_sole_data_page));
         }
     }

--- a/be/src/storage/rowset/indexed_column_reader.h
+++ b/be/src/storage/rowset/indexed_column_reader.h
@@ -63,7 +63,7 @@ public:
     // Seek to the given ordinal entry. Entry 0 is the first entry.
     // Return NotFound if provided seek point is past the end.
     // Return NotSupported for column without ordinal index.
-    Status seek_to_ordinal(ordinal_t idx);
+    Status seek_to_ordinal(ordinal_t idx, int flag=0);
 
     // Seek the index to the given key, or to the index entry immediately
     // before it. Then seek the data block to the value matching value or to
@@ -115,7 +115,7 @@ public:
     IndexedColumnReader(FileSystem* fs, std::string file_name, IndexedColumnMetaPB meta)
             : _fs(fs), _file_name(std::move(file_name)), _meta(std::move(meta)){};
 
-    Status load(bool use_page_cache, bool kept_in_memory);
+    Status load(bool use_page_cache, bool kept_in_memory, int flag=0);
 
     Status new_iterator(std::unique_ptr<IndexedColumnIterator>* iter);
 

--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -123,6 +123,7 @@ Status OrdinalIndexReader::_do_load(FileSystem* fs, const std::string& filename,
     PageHandle page_handle;
     Slice body;
     PageFooterPB footer;
+    std::cout<<"ORDINAL:"<<opts.page_pointer.size<<std::endl;
     RETURN_IF_ERROR(PageIO::read_and_decompress_page(opts, &page_handle, &body, &footer));
 
     // parse and save all (ordinal, pp) from index page

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -487,6 +487,7 @@ void SegmentIterator::_init_column_predicates() {
 }
 
 Status SegmentIterator::_get_row_ranges_by_keys() {
+    SCOPED_RAW_TIMER(&_opts.stats->sk_filter_timer);
     StarRocksMetrics::instance()->segment_row_total.increment(num_rows());
 
     if (!_opts.short_key_ranges.empty()) {
@@ -495,7 +496,7 @@ Status SegmentIterator::_get_row_ranges_by_keys() {
         RETURN_IF_ERROR(_get_row_ranges_by_key_ranges());
     }
 
-    _opts.stats->rows_key_range_filtered += num_rows() - _scan_range.span_size();
+    _opts.stats->rows_sk_filtered += num_rows() - _scan_range.span_size();
     StarRocksMetrics::instance()->segment_rows_by_short_key.increment(_scan_range.span_size());
     return Status::OK();
 }

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -288,7 +288,7 @@ Status ZoneMapIndexReader::_do_load(FileSystem* fs, const std::string& filename,
     auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
     // read and cache all page zone maps
     for (int i = 0; i < reader.num_values(); ++i) {
-        RETURN_IF_ERROR(iter->seek_to_ordinal(i));
+        RETURN_IF_ERROR(iter->seek_to_ordinal(i, 5));
         size_t num_to_read = 1;
         size_t num_read = num_to_read;
         RETURN_IF_ERROR(iter->next_batch(&num_read, column.get()));

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -279,7 +279,7 @@ StatusOr<bool> ZoneMapIndexReader::load(FileSystem* fs, const std::string& filen
 Status ZoneMapIndexReader::_do_load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta,
                                     bool use_page_cache, bool kept_in_memory) {
     IndexedColumnReader reader(fs, filename, meta.page_zone_maps());
-    RETURN_IF_ERROR(reader.load(use_page_cache, kept_in_memory));
+    RETURN_IF_ERROR(reader.load(use_page_cache, kept_in_memory, 1));
     std::unique_ptr<IndexedColumnIterator> iter;
     RETURN_IF_ERROR(reader.new_iterator(&iter));
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When loading the segment file for the first time, it will takes many time to load the Index from the disk, but the current profile indicators are not counted.

`FilterTimer` includes two parts of time, `load time` and `filter time`, but for `BloomFilter` and `ZoneMap` filtering, these two logics are integrated together. If the time is forcibly counted separately, the code intrusion is relatively large. So i merge the two logic together.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
