### PR TITLE
[Enhancement] lambda functions can work with aggregation and window functions without lambda arguments

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -224,6 +224,10 @@ public class SlotRef extends Expr {
         }
     }
 
+    public boolean isFromLambda() {
+        return tblName.getTbl().equals(TableName.LAMBDA_FUNC_TABLE);
+    }
+
     public void setTblName(TableName name) {
         this.tblName = name;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -225,7 +225,7 @@ public class SlotRef extends Expr {
     }
 
     public boolean isFromLambda() {
-        return tblName.getTbl().equals(TableName.LAMBDA_FUNC_TABLE);
+        return tblName != null && tblName.getTbl().equals(TableName.LAMBDA_FUNC_TABLE);
     }
 
     public void setTblName(TableName name) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -47,6 +47,7 @@ import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.ast.LambdaFunctionExpr;
 import com.starrocks.sql.ast.QueryStatement;
 
 import java.util.List;
@@ -166,6 +167,12 @@ public class AggregationAnalyzer {
             return node.getChildren().stream().allMatch(this::visit);
         }
 
+        // only check lambda body here.
+        @Override
+        public Boolean visitLambdaFunctionExpr(LambdaFunctionExpr node, Void context) {
+            return visit(node.getChild(0));
+        }
+
         @Override
         public Boolean visitCollectionElementExpr(CollectionElementExpr node, Void context) {
             return visit(node.getChild(0));
@@ -278,6 +285,9 @@ public class AggregationAnalyzer {
 
         @Override
         public Boolean visitSlot(SlotRef node, Void context) {
+            if (node.isFromLambda()) {
+                return true;
+            }
             return isGroupingKey(node);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
@@ -31,11 +31,11 @@ import java.util.List;
 import java.util.Map;
 
 public class ExpressionMapping {
+
     /**
      * This structure is responsible for the translation map from Expr to operator
      */
-    public Map<Expr, ColumnRefOperator> expressionToColumns = new HashMap<>();
-
+    private Map<Expr, ColumnRefOperator> expressionToColumns = new HashMap<>();
     /**
      * The purpose of below property is to hold the current plan built so far,
      * and the mapping to indicate how the fields (by position) in the relation map to

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/ExpressionMapping.java
@@ -34,7 +34,7 @@ public class ExpressionMapping {
     /**
      * This structure is responsible for the translation map from Expr to operator
      */
-    private final Map<Expr, ColumnRefOperator> expressionToColumns = new HashMap<>();
+    public Map<Expr, ColumnRefOperator> expressionToColumns = new HashMap<>();
 
     /**
      * The purpose of below property is to hold the current plan built so far,
@@ -63,6 +63,9 @@ public class ExpressionMapping {
             this.scope.setParent(outer.getScope());
             fieldsList.addAll(outer.getFieldMappings());
             this.outerScopeRelationId = outer.getScope().getRelationId();
+            if (scope.isLambdaScope()) { // lambda can use outer scope's expression, like agg.
+                this.expressionToColumns = outer.expressionToColumns;
+            }
         }
         this.fieldMappings = new ColumnRefOperator[fieldsList.size()];
         fieldsList.toArray(this.fieldMappings);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -119,6 +119,14 @@ public class AnalyzeExprTest {
         analyzeSuccess("select array_map([1], x -> x + v1) from t0");
         analyzeSuccess("select transform([1], x -> x)");
         analyzeSuccess("select arr,array_length(arr) from (select array_map(x->x+1, [1,2]) as arr)T");
+        analyzeSuccess("select array_agg(array_length(array_map(x->x*2, v3))) from tarray");
+        analyzeSuccess("select array_map(x->x+ array_length(array_agg(v1)),[2,6]) from tarray");
+        analyzeSuccess("select array_agg(v1), array_map(x->(array_map((y,z)->y+z, x, array_agg(v1))), [[2,4]]) from tarray");
+        analyzeSuccess("select array_map(x->x+12, array_agg(v1)) from tarray");
+        analyzeSuccess("select array_map(x->x >  count(v1), v3) from tarray group by v3");
+        analyzeSuccess("select array_map(x-> x +  count(v1) over (partition by v1 order by v2),[111]) from tarray");
+        analyzeSuccess("select v1, v2, count(v1) over (partition by v1 order by v2) from tarray");
+        analyzeSuccess("select v1, v2, count(v1) over (partition by array_sum(array_map(x->x+1, [1])) order by v2) from tarray");
 
         analyzeFail("select array_map(x,y -> x + y, [], [])"); // should be (x,y)
         analyzeFail("select array_map((x,y,z) -> x + y, [], [])");
@@ -141,6 +149,8 @@ public class AnalyzeExprTest {
         analyzeFail("select transform(null, null)");
         analyzeFail("select transform([1],null);");
         analyzeFail("select transform(1)");
+        analyzeFail("select array_map(x->x+ array_length(array_agg(x)),[2,6]) from tarray");
+        analyzeFail("select array_map(x->x >  count(v1), v3) from tarray");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -164,7 +164,6 @@ public class ExpressionTest extends PlanTestBase {
     public void testExpression6() throws Exception {
         String sql = "select cast(v1 as decimal64(7,2)) + cast(v2 as decimal64(9,3)) from t0";
         String planFragment = getFragmentPlan(sql);
-        System.out.println("planFragment = " + planFragment);
         Assert.assertTrue(planFragment.contains("  1:Project\n" +
                 "  |  <slot 4> : CAST(CAST(1: v1 AS DECIMAL64(7,2)) AS DECIMAL64(10,2)) + " +
                 "CAST(CAST(2: v2 AS DECIMAL64(9,3)) AS DECIMAL64(10,3))\n"));
@@ -428,7 +427,7 @@ public class ExpressionTest extends PlanTestBase {
     public void testDateTypeReduceCast() throws Exception {
         String sql = "select * from test_all_type_distributed_by_datetime " +
                 "where cast(cast(id_datetime as date) as datetime) >= '1970-01-01 12:00:00' " +
-                        "and cast(cast(id_datetime as date) as datetime) <= '1970-01-02 18:00:00'";
+                "and cast(cast(id_datetime as date) as datetime) <= '1970-01-02 18:00:00'";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(
                 plan.contains("8: id_datetime >= '1970-01-02 00:00:00', 8: id_datetime < '1970-01-03 00:00:00'"));
@@ -525,6 +524,7 @@ public class ExpressionTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertFalse(plan.contains("array_map"));
     }
+
     @Test
     public void testLambdaPredicateOnScan() throws Exception {
         starRocksAssert.withTable("create table test_lambda_on_scan" +
@@ -538,7 +538,7 @@ public class ExpressionTest extends PlanTestBase {
 
     @Test
     public void testLambdaReuseSubExpressionWithoutLambdaArguments() throws Exception {
-        starRocksAssert.withTable("create table test_array" +
+        starRocksAssert.withTable("create table if not exists test_array" +
                 "(c0 INT,c1 int, c2 array<int>) " +
                 " duplicate key(c0) distributed by hash(c0) buckets 1 " +
                 "properties('replication_num'='1');");
@@ -569,6 +569,44 @@ public class ExpressionTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("common expressions"));
         Assert.assertTrue(plan.contains(
                 "array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) + 7: multiply + 7: multiply"));
+    }
+
+    @Test
+    public void testLambdaWithAggAndWindowFunctions() throws Exception {
+        starRocksAssert.withTable("create table if not exists test_array " +
+                "(c0 INT,c1 int, c2 array<int>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+        // aggregations
+        String sql = "select array_agg(array_length(array_map(x->x*2, c2))) from test_array";
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  2:AGGREGATE (update finalize)\n" +
+                "  |  output: array_agg(5: array_length)"));
+        Assert.assertTrue(plan.contains("  1:Project\n" +
+                "  |  <slot 5> : array_length(array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) * 2, 3: c2))"));
+
+        sql = "select array_map(x->x > count(c1), c2) from test_array group by c2";
+        plan = getFragmentPlan(sql);
+
+        Assert.assertTrue(plan.contains("  2:Project\n" +
+                "  |  <slot 6> : array_map(<slot 5> -> CAST(<slot 5> AS BIGINT) > 4: count, 3: c2)\n"));
+        Assert.assertTrue(plan.contains("  1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(2: c1)\n" +
+                "  |  group by: 3: c2"));
+
+        // window functions
+        sql = "select count(c1) over (partition by array_sum(array_map(x->x+1, [1]))) from test_array";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  4:ANALYTIC\n" +
+                "  |  functions: [, count(6: c1), ]\n" +
+                "  |  partition by: 8: array_sum"));
+        Assert.assertTrue(plan.contains("  3:SORT\n" +
+                "  |  order by: <slot 8> 8: array_sum ASC\n" +
+                "  |  offset:"));
+        Assert.assertTrue(plan.contains("  1:Project\n" +
+                "  |  <slot 6> : 2: c1\n" +
+                "  |  <slot 8> : array_sum(array_map(<slot 4> -> " +
+                "CAST(<slot 4> AS SMALLINT) + 1, ARRAY<tinyint(4)>[1]))"));
     }
 
     @Test


### PR DESCRIPTION
…unctions.

Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

let lambda functions work with aggregations and window functions
```
select array_agg(array_length(array_map(x->x*2, c3))) from test_array;


mysql> select array_map(x->x+ array_length(array_agg(x)),[2,6]) from t;
ERROR 1064 (HY000): Column '`__LAMBDA_TABLE`.`__LAMBDA_TABLE`.`x`' cannot be resolved
mysql> select array_map(x->x+ array_length(array_agg(a)),[2,6]) from t;
+----------------------------------------------------------+
| array_map(x -> x + (array_length(array_agg(a))), [2, 6]) |
+----------------------------------------------------------+
| [4,8]                                                    |
+----------------------------------------------------------+

mysql> select array_agg(a), array_map(x->(array_map((y,z)->y+z, x, array_agg(a))), [[2,4]]) from t;
+--------------+-----------------------------------------------------------------------+
| array_agg(a) | array_map(x -> array_map((y, z) -> y + z, x, array_agg(a)), [[2, 4]]) |
+--------------+-----------------------------------------------------------------------+
| [1,11]       | [[3,15]]                                                              |
+--------------+-----------------------------------------------------------------------+
1 row in set (0.02 sec)

mysql> select array_map(x->x+12, array_agg(a)) from t;
+--------------------------------------+
| array_map(x -> x + 12, array_agg(a)) |
+--------------------------------------+
| [13,23]                              |
+--------------------------------------+
1 row in set (0.03 sec)

mysql> select array_group(array_map(x->x+3,[2,6])) from test_array;
ERROR 1064 (HY000): No matching function with signature: array_group(ARRAY<smallint(6)>).

mysql> select array_map(x->x >  count(c1), c2) from test_array;
ERROR 1064 (HY000): 'array_map(x -> `__LAMBDA_TABLE`.`__LAMBDA_TABLE`.`x` > count(`test`.`test_array`.`c1`), `test`.`test_array`.`c2`)' must be an aggregate expression or appear in GROUP BY clause

mysql> select c2, count(c1), array_map(x->x >  count(c1), c2) from test_array group by c2;
+-------------+-----------+-------------------------------------+
| c2          | count(c1) | array_map(x -> x > (count(c1)), c2) |
+-------------+-----------+-------------------------------------+
| []          |         2 | []                                  |
| [3,4,5]     |         1 | [1,1,1]                             |
| [432,23]    |         1 | [1,1]                               |
| [2,4]       |         1 | [1,1]                               |
| NULL        |         3 | NULL                                |
| [null,null] |         1 | [null,null]                         |
+-------------+-----------+-------------------------------------+
6 rows in set (0.03 sec)

/// window functions 
mysql> select array_map(x-> x +  count(a) over (partition by a order by x),[111] ) from t;
ERROR 1064 (HY000): Column '`__LAMBDA_TABLE`.`__LAMBDA_TABLE`.`x`' cannot be resolved
mysql> select array_map(x-> x +  count(a) over (partition by a order by pv),[111] ) from t;
+------------------------------------------------------------------------------+
| array_map(x -> x + (count(a) OVER (PARTITION BY a ORDER BY pv ASC )), [111]) |
+------------------------------------------------------------------------------+
| [112]                                                                        |
| [113]                                                                        |
| [114]                                                                        |
| [112]                                                                        |
+------------------------------------------------------------------------------+
4 rows in set (0.03 sec)

mysql> select a, pv, count(a) over (partition by a order by pv) from t;
+------+------+-------------------------------------------------+
| a    | pv   | count(a) OVER (PARTITION BY a ORDER BY pv ASC ) |
+------+------+-------------------------------------------------+
|   11 |   33 |                                               1 |
|    1 |    3 |                                               1 |
|    1 |    4 |                                               2 |
|    1 |    5 |                                               3 |
+------+------+-------------------------------------------------+
4 rows in set (0.03 sec)

mysql> select a, pv, count(a) over (partition by array_map(x->x+1, [1]) order by pv) from t;
ERROR 1064 (HY000): order by type ARRAY<SMALLINT> is not supported
mysql> select a, pv, count(a) over (partition by array_sum(array_map(x->x+1, [1])) order by pv) from t;
+------+------+-------------------------------------------------------------------------------------+
| a    | pv   | count(a) OVER (PARTITION BY array_sum(array_map(x -> x + 1, [1])) ORDER BY pv ASC ) |
+------+------+-------------------------------------------------------------------------------------+
|    1 |    3 |                                                                                   1 |
|    1 |    4 |                                                                                   2 |
|    1 |    5 |                                                                                   3 |
|   11 |   33 |                                                                                   4 |
+------+------+-------------------------------------------------------------------------------------+
4 rows in set (0.04 sec)

```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
