### PR TITLE
[Enhancement] Increase the default identifier name length to 1023 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -44,7 +44,7 @@ public class FeNameFormat {
     private FeNameFormat() {}
 
     private static final String LABEL_REGEX = "^[-\\w]{1,128}$";
-    public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
+    public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,1023}$|^_[a-zA-Z0-9]\\w{0,1023}$";
 
     public static final String TABLE_NAME_REGEX = "^[^\0]{1,1024}$";
     // Now we can not accept all characters because current design of delete save delete cond contains column name,

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableTest.java
@@ -19,7 +19,9 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
 import org.jetbrains.annotations.TestOnly;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -111,5 +113,18 @@ public class CreateTableTest {
             db.readUnlock();
         }
         Assert.assertEquals(bucketNum, 12);
+    }
+
+
+    @Test
+    public void createBadDbName() {
+        String longDbName = new String(new char[1026]).replace('\0', 'a');
+        String sql = "create database " + longDbName;
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, UtFrameUtils.createDefaultCtx());
+            Assert.fail(); // should raise Exception
+        } catch (Exception e) {
+            Assert.assertEquals("Incorrect database name '" + longDbName + "'", e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # N/A

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Previously, the common identifier length limit is 63 characters (for DB names and aliases). We raised the limit to 1023 (the default limit in Hive) in this PR.

Note that for table name and column name, their limit is already increased to 1024: https://github.com/StarRocks/starrocks/pull/14896.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
