### PR TITLE
[Refactor] refactor type-specific code in aggregate function

### DIFF
--- a/be/src/column/type_traits.h
+++ b/be/src/column/type_traits.h
@@ -240,6 +240,9 @@ using RunTimeColumnType = typename RunTimeTypeTraits<Type>::ColumnType;
 template <LogicalType Type>
 using RunTimeCppMovableType = std::add_rvalue_reference_t<std::remove_pointer_t<RunTimeCppType<Type>>>;
 
+template <LogicalType Type>
+using RunTimeCppValueType = std::remove_pointer_t<RunTimeCppType<Type>>;
+
 // Value type instead of pointer type
 
 template <typename T>

--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+#include "column/type_traits.h"
+#include "runtime/primitive_type.h"
+#include "types/logical_type.h"
+
+namespace starrocks::vectorized {
+
+// Type traits from aggregate functions
+template <LogicalType lt, typename = void>
+struct AggDataTypeTraits {};
+
+template <LogicalType lt>
+struct AggDataTypeTraits<lt, typename std::enable_if<pt_is_numeric<lt>>> {
+    using ColumnType = RunTimeColumnType<lt>;
+    using ValueType = RunTimeCppValueType<lt>;
+    using RefType = RunTimeCppType<lt>;
+
+    static void assign_value(ValueType& value, const RefType& ref) { value = ref; }
+
+    static void append_value(ColumnType* column, const ValueType& value) { column->append(value); }
+
+    static RefType get_row_ref(const ColumnType& column, size_t row) { return column.get_data()[row]; }
+};
+
+// For pointer ref types
+template <LogicalType lt>
+struct AggDataTypeTraits<lt, typename std::enable_if<is_object_type(lt)>> {
+    using ColumnType = RunTimeColumnType<lt>;
+    using ValueType = RunTimeCppValueType<lt>;
+    using RefType = RunTimeCppType<lt>;
+
+    static void assign_value(ValueType& value, const RefType ref) { value = *ref; }
+
+    static void append_value(ColumnType* column, const ValueType& value) { column->append(&value); }
+
+    static const RefType get_row_ref(const ColumnType& column, size_t row) { return column.get_object(row); }
+};
+
+template <LogicalType lt>
+struct AggDataTypeTraits<lt, typename std::enable_if<pt_is_string<lt>>> {
+    using ColumnType = RunTimeColumnType<lt>;
+    using ValueType = Buffer<uint8_t>;
+    using RefType = Slice;
+
+    static void assign_value(ValueType& value, const RefType& ref) {
+        value.resize(ref.size);
+        memcpy(value.data(), ref.data, ref.size);
+    }
+
+    static void append_value(ColumnType* column, const ValueType& value) {
+        column->append(Slice(value.data(), value.size()));
+    }
+
+    static RefType get_row_ref(const ColumnType& column, size_t row) { return column.get_slice(row); }
+};
+
+template <LogicalType lt>
+using AggDataValueType = typename AggDataTypeTraits<lt>::ValueType;
+template <LogicalType lt>
+using AggDataRefType = typename AggDataTypeTraits<lt>::RefType;
+
+} // namespace starrocks::vectorized

--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -23,11 +23,11 @@
 namespace starrocks::vectorized {
 
 // Type traits from aggregate functions
-template <LogicalType lt, typename = void>
+template <LogicalType lt, typename = guard::Guard>
 struct AggDataTypeTraits {};
 
 template <LogicalType lt>
-struct AggDataTypeTraits<lt, typename std::enable_if<pt_is_numeric<lt>>> {
+struct AggDataTypeTraits<lt, FixedLengthPTGuard<lt>> {
     using ColumnType = RunTimeColumnType<lt>;
     using ValueType = RunTimeCppValueType<lt>;
     using RefType = RunTimeCppType<lt>;
@@ -41,12 +41,12 @@ struct AggDataTypeTraits<lt, typename std::enable_if<pt_is_numeric<lt>>> {
 
 // For pointer ref types
 template <LogicalType lt>
-struct AggDataTypeTraits<lt, typename std::enable_if<is_object_type(lt)>> {
+struct AggDataTypeTraits<lt, ObjectFamilyPTGuard<lt>> {
     using ColumnType = RunTimeColumnType<lt>;
     using ValueType = RunTimeCppValueType<lt>;
     using RefType = RunTimeCppType<lt>;
 
-    static void assign_value(ValueType& value, const RefType ref) { value = *ref; }
+    static void assign_value(ValueType& value, RefType ref) { value = *ref; }
 
     static void append_value(ColumnType* column, const ValueType& value) { column->append(&value); }
 
@@ -54,7 +54,7 @@ struct AggDataTypeTraits<lt, typename std::enable_if<is_object_type(lt)>> {
 };
 
 template <LogicalType lt>
-struct AggDataTypeTraits<lt, typename std::enable_if<pt_is_string<lt>>> {
+struct AggDataTypeTraits<lt, StringPTGuard<lt>> {
     using ColumnType = RunTimeColumnType<lt>;
     using ValueType = Buffer<uint8_t>;
     using RefType = Slice;

--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -17,6 +17,7 @@
 #include <type_traits>
 
 #include "column/type_traits.h"
+#include "gutil/strings/fastmem.h"
 #include "runtime/primitive_type.h"
 #include "types/logical_type.h"
 
@@ -61,7 +62,7 @@ struct AggDataTypeTraits<lt, StringPTGuard<lt>> {
 
     static void assign_value(ValueType& value, const RefType& ref) {
         value.resize(ref.size);
-        memcpy(value.data(), ref.data, ref.size);
+        strings::memcpy_inlined(value.data(), ref.data, ref.size);
     }
 
     static void append_value(ColumnType* column, const ValueType& value) {

--- a/be/src/exprs/agg/any_value.h
+++ b/be/src/exprs/agg/any_value.h
@@ -63,7 +63,7 @@ public:
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
-        DCHECK(!columns[0]->is_nullable() && !columns[0]->is_binary());
+        DCHECK(!columns[0]->is_nullable());
         const auto& column = down_cast<const InputColumnType&>(*columns[0]);
         OP()(this->data(state), AggDataTypeTraits<PT>::get_row_ref(column, row_num));
     }
@@ -74,13 +74,13 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        DCHECK(!column->is_nullable() && !column->is_binary());
+        DCHECK(!column->is_nullable());
         const auto& input_column = down_cast<const InputColumnType&>(*column);
         OP()(this->data(state), AggDataTypeTraits<PT>::get_row_ref(input_column, row_num));
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        DCHECK(!to->is_nullable() && !to->is_binary());
+        DCHECK(!to->is_nullable());
         AggDataTypeTraits<PT>::append_value(down_cast<InputColumnType*>(to), this->data(state).result);
     }
 
@@ -90,7 +90,7 @@ public:
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        DCHECK(!to->is_nullable() && !to->is_binary());
+        DCHECK(!to->is_nullable());
         AggDataTypeTraits<PT>::append_value(down_cast<InputColumnType*>(to), this->data(state).result);
     }
 

--- a/be/src/exprs/agg/any_value.h
+++ b/be/src/exprs/agg/any_value.h
@@ -20,82 +20,33 @@
 #include "column/fixed_length_column.h"
 #include "column/type_traits.h"
 #include "exprs/agg/aggregate.h"
+#include "exprs/agg/aggregate_traits.h"
 #include "gutil/casts.h"
 #include "util/raw_container.h"
 
 namespace starrocks::vectorized {
 
-template <LogicalType PT, typename = guard::Guard>
-struct AnyValueAggregateData {};
-
 template <LogicalType PT>
-struct AnyValueAggregateData<PT, AggregatePTGuard<PT>> {
-    using T = RunTimeCppType<PT>;
-    T result = RunTimeTypeLimits<PT>::max_value();
+struct AnyValueAggregateData {
+    using T = AggDataValueType<PT>;
+
+    T result;
     bool has_value = false;
 
     void reset() {
-        result = RunTimeTypeLimits<PT>::max_value();
+        result = T{};
         has_value = false;
     }
 };
 
-template <LogicalType PT>
-struct AnyValueAggregateData<PT, StringPTGuard<PT>> {
-    int32_t size = -1;
-    Buffer<uint8_t> buffer;
-
-    bool has_value() const { return size > -1; }
-
-    Slice slice() const { return {buffer.data(), buffer.size()}; }
-
-    void reset() {
-        buffer.clear();
-        size = -1;
-    }
-};
-
-template <LogicalType PT>
-struct AnyValueAggregateData<PT, JsonGuard<PT>> {
-    bool has_value = false;
-    JsonValue value;
-
-    const JsonValue* json() const { return &value; }
-
-    void reset() {
-        value = JsonValue();
-        has_value = false;
-    }
-};
-
-template <LogicalType PT, typename State, typename = guard::Guard>
+template <LogicalType PT, typename State>
 struct AnyValueElement {
-    using T = RunTimeCppType<PT>;
-    void operator()(State& state, const T& right) const {
-        if (UNLIKELY(!state.has_value)) {
-            state.result = right;
-            state.has_value = true;
-        }
-    }
-};
+    using RefType = AggDataRefType<PT>;
 
-template <LogicalType PT, typename State>
-struct AnyValueElement<PT, State, StringPTGuard<PT>> {
-    void operator()(State& state, const Slice& right) const {
-        if (UNLIKELY(!state.has_value())) {
-            state.buffer.resize(right.size);
-            memcpy(state.buffer.data(), right.data, right.size);
-            state.size = right.size;
-        }
-    }
-};
-
-template <LogicalType PT, typename State>
-struct AnyValueElement<PT, State, JsonGuard<PT>> {
-    void operator()(State& state, const JsonValue* right) const {
+    void operator()(State& state, RefType right) const {
         if (UNLIKELY(!state.has_value)) {
+            AggDataTypeTraits<PT>::assign_value(state.result, right);
             state.has_value = true;
-            state.value = *right;
         }
     }
 };
@@ -114,8 +65,7 @@ public:
                 size_t row_num) const override {
         DCHECK(!columns[0]->is_nullable() && !columns[0]->is_binary());
         const auto& column = down_cast<const InputColumnType&>(*columns[0]);
-        const T& value = column.get_data()[row_num];
-        OP()(this->data(state), value);
+        OP()(this->data(state), AggDataTypeTraits<PT>::get_row_ref(column, row_num));
     }
 
     void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
@@ -125,14 +75,13 @@ public:
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(!column->is_nullable() && !column->is_binary());
-        const auto* input_column = down_cast<const InputColumnType*>(column);
-        T value = input_column->get_data()[row_num];
-        OP()(this->data(state), value);
+        const auto& input_column = down_cast<const InputColumnType&>(*column);
+        OP()(this->data(state), AggDataTypeTraits<PT>::get_row_ref(input_column, row_num));
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(!to->is_nullable() && !to->is_binary());
-        down_cast<InputColumnType*>(to)->append(this->data(state).result);
+        AggDataTypeTraits<PT>::append_value(down_cast<InputColumnType*>(to), this->data(state).result);
     }
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
@@ -142,7 +91,7 @@ public:
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         DCHECK(!to->is_nullable() && !to->is_binary());
-        down_cast<InputColumnType*>(to)->append(this->data(state).result);
+        AggDataTypeTraits<PT>::append_value(down_cast<InputColumnType*>(to), this->data(state).result);
     }
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
@@ -150,114 +99,7 @@ public:
         DCHECK_GT(end, start);
         InputColumnType* column = down_cast<InputColumnType*>(dst);
         for (size_t i = start; i < end; ++i) {
-            column->get_data()[i] = this->data(state).result;
-        }
-    }
-
-    std::string get_name() const override { return "any_value"; }
-};
-
-template <LogicalType PT, typename State, class OP>
-class AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>, StringPTGuard<PT>> final
-        : public AggregateFunctionBatchHelper<State, AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>>> {
-public:
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
-        this->data(state).reset();
-    }
-
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
-                size_t row_num) const override {
-        DCHECK((*columns[0]).is_binary());
-        Slice value = columns[0]->get(row_num).get_slice();
-        OP()(this->data(state), value);
-    }
-
-    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
-                                   AggDataPtr __restrict state) const override {
-        update(ctx, columns, state, 0);
-    }
-
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        DCHECK(column->is_binary());
-        Slice value = column->get(row_num).get_slice();
-        OP()(this->data(state), value);
-    }
-
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        DCHECK(to->is_binary());
-        auto* column = down_cast<BinaryColumn*>(to);
-        column->append(this->data(state).slice());
-    }
-
-    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
-                                     ColumnPtr* dst) const override {
-        *dst = src[0];
-    }
-
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        DCHECK(to->is_binary());
-        auto* column = down_cast<BinaryColumn*>(to);
-        column->append(this->data(state).slice());
-    }
-
-    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
-                    size_t end) const override {
-        DCHECK_GT(end, start);
-        auto* column = down_cast<BinaryColumn*>(dst);
-        for (size_t i = start; i < end; ++i) {
-            column->append(this->data(state).slice());
-        }
-    }
-
-    std::string get_name() const override { return "any_value"; }
-};
-
-// Specialized for JSON type
-template <LogicalType PT, typename State, class OP>
-class AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>, JsonGuard<PT>> final
-        : public AggregateFunctionBatchHelper<State, AnyValueAggregateFunction<PT, State, OP, RunTimeCppType<PT>>> {
-public:
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
-        this->data(state).reset();
-    }
-
-    void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
-                size_t row_num) const override {
-        const JsonValue* value = columns[0]->get(row_num).get_json();
-        OP()(this->data(state), value);
-    }
-
-    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
-                                   AggDataPtr __restrict state) const override {
-        update(ctx, columns, state, 0);
-    }
-
-    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        const JsonValue* value = column->get(row_num).get_json();
-        OP()(this->data(state), value);
-    }
-
-    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        auto* column = down_cast<JsonColumn*>(to);
-        column->append(this->data(state).json());
-    }
-
-    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
-                                     ColumnPtr* dst) const override {
-        *dst = src[0];
-    }
-
-    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        auto* column = down_cast<JsonColumn*>(to);
-        column->append(this->data(state).json());
-    }
-
-    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
-                    size_t end) const override {
-        DCHECK_GT(end, start);
-        auto* column = down_cast<JsonColumn*>(dst);
-        for (size_t i = start; i < end; ++i) {
-            column->append(this->data(state).json());
+            AggDataTypeTraits<PT>::append_value(column, this->data(state).result);
         }
     }
 

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -117,6 +117,7 @@ VALUE_GUARD(LogicalType, StringPTGuard, pt_is_string, TYPE_CHAR, TYPE_VARCHAR)
 VALUE_GUARD(LogicalType, BinaryPTGuard, pt_is_binary, TYPE_BINARY, TYPE_VARBINARY)
 VALUE_GUARD(LogicalType, JsonGuard, pt_is_json, TYPE_JSON)
 VALUE_GUARD(LogicalType, FunctionGuard, pt_is_function, TYPE_FUNCTION)
+VALUE_GUARD(LogicalType, ObjectFamilyPTGuard, pt_is_object_family, TYPE_JSON, TYPE_HLL, TYPE_OBJECT, TYPE_PERCENTILE)
 
 VALUE_GUARD(LogicalType, DatePTGuard, pt_is_date, TYPE_DATE)
 VALUE_GUARD(LogicalType, DateTimePTGuard, pt_is_datetime, TYPE_DATETIME)

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -68,7 +68,7 @@ inline bool is_type_compatible(LogicalType lhs, LogicalType rhs) {
     return lhs == rhs;
 }
 
-inline bool is_scalar_primitive_type(LogicalType ptype) {
+constexpr bool is_scalar_primitive_type(LogicalType ptype) {
     switch (ptype) {
     case TYPE_BOOLEAN:  /* 2 */
     case TYPE_TINYINT:  /* 3 */


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There're many specialization in aggregate functions, but most of them is not necessary, and should be simplified through type traits.

So this PR introduce a general traits for aggregation, which could be specified for difference types:

```c++
struct AggDataTypeTraits {
    using ColumnType = RunTimeColumnType<lt>;
    using ValueType = RunTimeCppValueType<lt>;
    using RefType = RunTimeCppType<lt>;

    static void assign_value(ValueType& value, const RefType& ref) { value = ref; }
    static void append_value(ColumnType* column, const ValueType& value) { column->append(value); }
    static RefType get_row_ref(const ColumnType& column, size_t row) { return column.get_data()[row]; }
};
```

After this PR, many specialization in aggregate functions could be refactored into this style.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
