### PR TITLE
[BugFix] Fix heap-buffer-overflow when memtable call finalize in PK

### DIFF
--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -243,8 +243,9 @@ Status MemTable::finalize() {
                     primary_key_idxes[i] = i;
                 }
                 const auto& sort_key_idxes = _vectorized_schema->sort_key_idxes();
-                if (std::mismatch(sort_key_idxes.begin(), sort_key_idxes.end(), primary_key_idxes.begin()).first !=
-                    sort_key_idxes.end()) {
+                if (sort_key_idxes.size() != primary_key_idxes.size() ||
+                    std::mismatch(sort_key_idxes.begin(), sort_key_idxes.end(), primary_key_idxes.begin()).first !=
+                            sort_key_idxes.end()) {
                     _chunk = _result_chunk;
                     _sort(true, true);
                 }

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -243,9 +243,9 @@ Status MemTable::finalize() {
                     primary_key_idxes[i] = i;
                 }
                 const auto& sort_key_idxes = _vectorized_schema->sort_key_idxes();
-                if (sort_key_idxes.size() != primary_key_idxes.size() ||
-                    std::mismatch(sort_key_idxes.begin(), sort_key_idxes.end(), primary_key_idxes.begin()).first !=
-                            sort_key_idxes.end()) {
+                if (std::mismatch(sort_key_idxes.begin(), sort_key_idxes.end(), primary_key_idxes.begin(),
+                                  primary_key_idxes.end())
+                            .first != sort_key_idxes.end()) {
                     _chunk = _result_chunk;
                     _sort(true, true);
                 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15058

## Problem Summary(Required) ：
the size for sort_key_idxes may not equals to _vectorized_schema->num_key_fields(). which may cause a heap-buffer-overflow

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
