### PR TITLE
[BugFix] percentile_cont in force_streaming mode cause be's crash

### DIFF
--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -146,24 +146,22 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      ColumnPtr* dst) const override {
-        auto* dst_column = down_cast<BinaryColumn*>((*dst).get());
-        Bytes& bytes = dst_column->get_bytes();
-        size_t old_size = bytes.size();
-
         if (chunk_size <= 0) {
             return;
         }
-
+        auto* dst_column = down_cast<BinaryColumn*>((*dst).get());
+        Bytes& bytes = dst_column->get_bytes();
         double rate = ColumnHelper::get_const_value<TYPE_DOUBLE>(src[1]);
         InputColumnType src_column = *down_cast<const InputColumnType*>(src[0].get());
-        pdqsort(false, src_column.get_data().begin(), src_column.get_data().end());
-
-        bytes.resize(old_size + sizeof(double) + sizeof(size_t) + chunk_size * sizeof(InputCppType));
-
-        memcpy(bytes.data() + old_size, &rate, sizeof(double));
-        memcpy(bytes.data() + old_size + sizeof(double), &chunk_size, sizeof(size_t));
-        memcpy(bytes.data() + old_size + sizeof(double) + sizeof(size_t), src_column.get_data().data(),
-               chunk_size * sizeof(InputCppType));
+        InputCppType* src_data = src_column.get_data().data();
+        for (auto i = 0; i < chunk_size; ++i) {
+            size_t old_size = bytes.size();
+            bytes.resize(old_size + sizeof(double) + sizeof(size_t) + sizeof(InputCppType));
+            memcpy(bytes.data() + old_size, &rate, sizeof(double));
+            *reinterpret_cast<size_t*>(bytes.data() + old_size + sizeof(double)) = 1UL;
+            memcpy(bytes.data() + old_size + sizeof(double) + sizeof(size_t), &src_data[i], sizeof(InputCppType));
+            dst_column->get_offset().push_back(bytes.size());
+        }
     }
 
     std::string get_name() const override { return "percentile_cont"; }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/11262
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

PercentileContAggregateFunction's method convert_to_serialize_format is implemented incorrectly, this functions is called and causes BE's crash when streaming_preaggregation_mode = 'force_streaming'.  There are two errors as follows:
1. Forget to update offsets of BinaryColumn when append an to BinaryColumn;
2. In convert_to_serialize_format function, we must serialize row-by-row instead of sequeeze many rows into a row, since the columns in Chunk must be equal-size.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
