### PR TITLE
[BugFix] fix the problem that privileges do not take effect in JDBC external table

### DIFF
--- a/be/src/exec/vectorized/jdbc_scanner.cpp
+++ b/be/src/exec/vectorized/jdbc_scanner.cpp
@@ -395,8 +395,10 @@ Status JDBCScanner::_fill_chunk(jobject jchunk, size_t num_rows, ChunkPtr* chunk
             auto st =
                     helper.get_result_from_boxed_array(_result_column_types[i], result_column.get(), jcolumn, num_rows);
             RETURN_IF_ERROR(st);
-            // check data's length for varchar type
-            if (_slot_descs[i]->type().type == TYPE_VARCHAR) {
+            // check data's length for string type
+            auto origin_type = _slot_descs[i]->type().type;
+            if (origin_type == TYPE_VARCHAR || origin_type == TYPE_CHAR) {
+                DCHECK_EQ(_result_column_types[i], TYPE_VARCHAR);
                 int max_len = _slot_descs[i]->type().len;
                 ColumnViewer<TYPE_VARCHAR> viewer(result_column);
                 for (int row = 0; row < viewer.size(); row++) {

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
@@ -43,8 +43,8 @@ public class JDBCScanner {
     }
 
     public void open() throws Exception {
-
-        dataSource = DataSourceCache.getInstance().getSource(scanContext.getJdbcURL(), () -> {
+        String key = scanContext.getUser() + "/" + scanContext.getJdbcURL();
+        dataSource = DataSourceCache.getInstance().getSource(key, () -> {
             HikariConfig config = new HikariConfig();
             config.setDriverClassName(scanContext.getDriverClassName());
             config.setJdbcUrl(scanContext.getJdbcURL());

--- a/java-extensions/jdbc-bridge/src/main/resources/log4j.properties
+++ b/java-extensions/jdbc-bridge/src/main/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.rootLogger=ERROR, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n

--- a/java-extensions/jdbc-bridge/src/main/resources/log4j.properties
+++ b/java-extensions/jdbc-bridge/src/main/resources/log4j.properties
@@ -1,4 +1,0 @@
-log4j.rootLogger=ERROR, stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14235 #15082

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. fix the privilege problem when querying jdbc external table which was introduced by [#12295](https://github.com/StarRocks/starrocks/pull/12295).
We use jdbc_uri as the key in DataSourceCache to identify the connection pool, the queries with the same jdbc_uri will share the same connection pool. user will be used to authenticate when creating a connection. if we create jdbc_resources with the same jdbc_uri but different user, they will use the same connection pool, which will cause privilege confusion.
in this PR, I also add user to the key of DataSourceCache and use user+jdbc_uri as key to fix this problem.

2. I miss a problem when I fixed #14235 in #14903, I forgot to check data length for TYPE_CHAR, so fix it here.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
