### PR TITLE
[Refactor] Use AggregateFunction in storage layer 

### DIFF
--- a/be/src/exprs/agg/maxmin.h
+++ b/be/src/exprs/agg/maxmin.h
@@ -41,9 +41,6 @@ struct MaxAggregateData<PT, StringPTGuard<PT>> {
     int32_t size = -1;
     raw::RawVector<uint8_t> buffer;
 
-    ~MaxAggregateData() {
-        std::cerr << "calling max deconstructor" << std::endl;
-    }
     bool has_value() const { return buffer.size() > 0; }
 
     Slice slice() const { return {buffer.data(), buffer.size()}; }

--- a/be/src/exprs/agg/maxmin.h
+++ b/be/src/exprs/agg/maxmin.h
@@ -41,6 +41,9 @@ struct MaxAggregateData<PT, StringPTGuard<PT>> {
     int32_t size = -1;
     raw::RawVector<uint8_t> buffer;
 
+    ~MaxAggregateData() {
+        std::cerr << "calling max deconstructor" << std::endl;
+    }
     bool has_value() const { return buffer.size() > 0; }
 
     Slice slice() const { return {buffer.data(), buffer.size()}; }
@@ -65,7 +68,7 @@ struct MinAggregateData<PT, AggregatePTGuard<PT>> {
 template <LogicalType PT>
 struct MinAggregateData<PT, StringPTGuard<PT>> {
     int32_t size = -1;
-    Buffer<uint8_t> buffer;
+    raw::RawVector<uint8_t> buffer;
 
     bool has_value() const { return size > -1; }
 

--- a/be/src/storage/column_aggregate_func.cpp
+++ b/be/src/storage/column_aggregate_func.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/column_aggregate_func.h"
 
+#include "exprs/agg/aggregate.h"
+#include "exprs/agg/factory/aggregate_resolver.hpp"
 #include "column/array_column.h"
 #include "column/vectorized_fwd.h"
 #include "storage/column_aggregator.h"
@@ -21,27 +23,8 @@
 
 namespace starrocks::vectorized {
 
-// SUM
-template <typename ColumnType, typename StateType>
-class SumAggregator final : public ValueColumnAggregator<ColumnType, StateType> {
-public:
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* data = down_cast<ColumnType*>(src.get())->get_data().data();
-        this->data() += data[row];
-    }
-
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* data = down_cast<ColumnType*>(src.get())->get_data().data();
-        for (int i = start; i < end; ++i) {
-            this->data() += data[i];
-        }
-    }
-
-    void append_data(Column* agg) override { down_cast<ColumnType*>(agg)->append(this->data()); }
-};
-
 struct SliceState {
-    std::vector<uint8_t> data;
+    raw::RawVector<uint8_t> data;
     bool has_value = false;
 
     Slice slice() { return {data.data(), data.size()}; }
@@ -55,159 +38,6 @@ struct SliceState {
     void reset() {
         has_value = false;
         data.clear();
-    }
-};
-
-template <typename T>
-struct MinMaxAggregateData {
-    static T min() { return std::numeric_limits<T>::lowest(); }
-    static T max() { return std::numeric_limits<T>::max(); }
-};
-
-template <>
-struct MinMaxAggregateData<DecimalV2Value> {
-    static DecimalV2Value min() { return DecimalV2Value::get_min_decimal(); }
-    static DecimalV2Value max() { return DecimalV2Value::get_max_decimal(); }
-};
-
-template <>
-struct MinMaxAggregateData<DateValue> {
-    static DateValue min() { return DateValue::MIN_DATE_VALUE; }
-    static DateValue max() { return DateValue::MAX_DATE_VALUE; }
-};
-
-template <>
-struct MinMaxAggregateData<TimestampValue> {
-    static TimestampValue min() { return TimestampValue::MIN_TIMESTAMP_VALUE; }
-    static TimestampValue max() { return TimestampValue::MAX_TIMESTAMP_VALUE; }
-};
-
-// MAX
-template <typename ColumnType, typename StateType>
-class MaxAggregator final : public ValueColumnAggregator<ColumnType, StateType> {
-public:
-    void reset() override { this->data() = MinMaxAggregateData<StateType>::min(); }
-
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* data = down_cast<ColumnType*>(src.get())->get_data().data();
-        this->data() = std::max<StateType>(this->data(), data[row]);
-    }
-
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* data = down_cast<ColumnType*>(src.get())->get_data().data();
-        for (int i = start; i < end; ++i) {
-            this->data() = std::max<StateType>(this->data(), data[i]);
-        }
-    }
-
-    void append_data(Column* agg) override { down_cast<ColumnType*>(agg)->append(this->data()); }
-};
-
-template <>
-class MaxAggregator<BinaryColumn, SliceState> final : public ValueColumnAggregator<BinaryColumn, SliceState> {
-public:
-    void reset() override { this->data().reset(); }
-
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* col = down_cast<BinaryColumn*>(src.get());
-
-        Slice data = col->get_slice(row);
-        if (!this->data().has_value || this->data().slice() < data) {
-            this->data().update(data);
-        }
-    }
-
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* col = down_cast<BinaryColumn*>(src.get());
-        Slice data = col->get_slice(start);
-
-        for (int i = start + 1; i < end; ++i) {
-            data = std::max<Slice>(data, col->get_slice(i));
-        }
-
-        if (!this->data().has_value || this->data().slice() < data) {
-            this->data().update(data);
-        }
-    }
-
-    void append_data(Column* agg) override {
-        auto* col = down_cast<BinaryColumn*>(agg);
-        col->append(this->data().slice());
-    }
-};
-
-// MIN
-template <typename ColumnType, typename StateType>
-class MinAggregator final : public ValueColumnAggregator<ColumnType, StateType> {
-public:
-    void reset() override { this->data() = MinMaxAggregateData<StateType>::max(); }
-
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* data = down_cast<ColumnType*>(src.get())->get_data().data();
-        this->data() = std::min<StateType>(this->data(), data[row]);
-    }
-
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* data = down_cast<ColumnType*>(src.get())->get_data().data();
-        for (int i = start; i < end; ++i) {
-            this->data() = std::min<StateType>(this->data(), data[i]);
-        }
-    }
-
-    void append_data(Column* agg) override { down_cast<ColumnType*>(agg)->append(this->data()); }
-};
-
-template <>
-class MinAggregator<BooleanColumn, uint8_t> final : public ValueColumnAggregator<BooleanColumn, uint8_t> {
-public:
-    // The max value of boolean type is 1 (not uint8_t max).
-    void reset() override { this->data() = 1; }
-
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* data = down_cast<BooleanColumn*>(src.get())->get_data().data();
-        this->data() = std::min<uint8_t>(this->data(), data[row]);
-    }
-
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* data = down_cast<BooleanColumn*>(src.get())->get_data().data();
-        for (int i = start; i < end; ++i) {
-            this->data() = std::min<uint8_t>(this->data(), data[i]);
-        }
-    }
-
-    void append_data(Column* agg) override { down_cast<BooleanColumn*>(agg)->append(this->data()); }
-};
-
-template <>
-class MinAggregator<BinaryColumn, SliceState> final : public ValueColumnAggregator<BinaryColumn, SliceState> {
-public:
-    void reset() override { this->data().reset(); }
-
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* col = down_cast<BinaryColumn*>(src.get());
-
-        Slice data = col->get_slice(row);
-        if (!this->data().has_value || this->data().slice() > data) {
-            this->data().update(data);
-        }
-    }
-
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* col = down_cast<BinaryColumn*>(src.get());
-        Slice data = col->get_slice(start);
-
-        for (int i = start + 1; i < end; ++i) {
-            data = std::min<Slice>(data, col->get_slice(i));
-        }
-
-        if (!this->data().has_value || this->data().slice() > data) {
-            this->data().update(data);
-        }
-    }
-
-    void append_data(Column* agg) override {
-        auto* col = down_cast<BinaryColumn*>(agg);
-        col->append(this->data().slice());
     }
 };
 
@@ -425,107 +255,76 @@ private:
     ValueColumnAggregatorPtr _child;
 };
 
-// HLL_UNION
-class HllUnionAggregator final : public ValueColumnAggregator<HyperLogLogColumn, HyperLogLog> {
+class AggFuncBasedValueAggregator : public ValueColumnAggregatorBase {
 public:
+    AggFuncBasedValueAggregator(const vectorized::AggregateFunction* agg_func) : _agg_func(agg_func) {
+        _state = static_cast<vectorized::AggDataPtr>(std::aligned_alloc(_agg_func->alignof_size(), _agg_func->size()));
+        _agg_func->create(nullptr, _state);
+    }
+
+    ~AggFuncBasedValueAggregator() override {
+        if (_state != nullptr) {
+            _agg_func->destroy(nullptr, _state);
+            std::free(_state);
+        }
+    }
+
     void reset() override {
-        this->data().clear();
-        _inited = false;
+        _agg_func->destroy(nullptr, _state);
+        _agg_func->create(nullptr, _state);
     }
 
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* col = down_cast<HyperLogLogColumn*>(src.get());
-        if (!_inited) {
-            // First value, directly move it
-            _inited = true;
-            this->data() = std::move(*col->get_object(row));
-        } else {
-            this->data().merge(*(col->get_object(row)));
+    void update_aggregate(Column* agg) override {
+        _aggregate_column = agg;
+        reset();
+    }
+
+    void append_data(Column* agg) override {
+        _agg_func->finalize_to_column(nullptr, _state, agg);
+    }
+
+    // |data| is readonly.
+    void aggregate_impl(int row, const ColumnPtr& data) override {
+        _agg_func->merge(nullptr, data.get(), _state, row);
+    }
+
+    // |data| is readonly.
+    void aggregate_batch_impl(int start, int end, const ColumnPtr& input) override {
+        _agg_func->merge_batch_single_state(nullptr, _state, input.get(), start, end - start);
+    }
+
+    bool need_deep_copy() const override { return false; };
+
+    void aggregate_values(int start, int nums, const uint32* aggregate_loops, bool previous_neq) override {
+        if (nums <= 0) {
+            return;
+        }
+
+        // if different with last row in previous chunk
+        if (previous_neq) {
+            append_data(_aggregate_column);
+            reset();
+        }
+
+        for (int i = 0; i < nums; ++i) {
+            aggregate_batch_impl(start, start + aggregate_loops[i], _source_column);
+            start += aggregate_loops[i];
+            // If there is another loop, append current state to result column
+            if (i < nums - 1) {
+                append_data(_aggregate_column);
+                reset();
+            }
         }
     }
 
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* col = down_cast<HyperLogLogColumn*>(src.get());
-        if (!_inited) {
-            // First value, directly move it
-            _inited = true;
-            this->data() = std::move(*col->get_object(start));
-            for (int i = start + 1; i < end; ++i) {
-                this->data().merge(*(col->get_object(i)));
-            }
-        } else {
-            for (int i = start; i < end; ++i) {
-                this->data().merge(*(col->get_object(i)));
-            }
-        }
+    void finalize() override {
+        append_data(_aggregate_column);
+        _aggregate_column = nullptr;
     }
-
-    void append_data(Column* agg) override { down_cast<HyperLogLogColumn*>(agg)->append(std::move(this->data())); }
 
 private:
-    // The aggregate state whether initialized
-    bool _inited = false;
-};
-
-// BITMAP_UNION
-class BitmapUnionAggregator final : public ValueColumnAggregator<BitmapColumn, BitmapValue> {
-public:
-    void reset() override {
-        this->data().clear();
-        _inited = false;
-    }
-
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        auto* col = down_cast<BitmapColumn*>(src.get());
-        if (!_inited) {
-            // First value, directly move it
-            _inited = true;
-            this->data() = std::move(*col->get_object(row));
-        } else {
-            this->data() |= *(col->get_object(row));
-        }
-    }
-
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* col = down_cast<BitmapColumn*>(src.get());
-        if (!_inited) {
-            // First value, directly move it
-            _inited = true;
-            this->data() = std::move(*col->get_object(start));
-            for (int i = start + 1; i < end; ++i) {
-                this->data() |= *(col->get_object(i));
-            }
-        } else {
-            for (int i = start; i < end; ++i) {
-                this->data() |= *(col->get_object(i));
-            }
-        }
-    }
-
-    void append_data(Column* agg) override { down_cast<BitmapColumn*>(agg)->append(std::move(this->data())); }
-
-private:
-    // The aggregate state whether initialized
-    bool _inited = false;
-};
-
-// PERCENTILE_UNION
-class PercentileUnionAggregator final : public ValueColumnAggregator<PercentileColumn, PercentileValue> {
-public:
-    void reset() override { this->data() = PercentileValue(); }
-
-    void aggregate_impl(int row, const ColumnPtr& src) override {
-        this->data().merge(down_cast<PercentileColumn*>(src.get())->get_object(row));
-    }
-
-    void aggregate_batch_impl(int start, int end, const ColumnPtr& src) override {
-        auto* col = down_cast<PercentileColumn*>(src.get());
-        for (int i = start; i < end; ++i) {
-            this->data().merge(col->get_object(i));
-        }
-    }
-
-    void append_data(Column* agg) override { down_cast<PercentileColumn*>(agg)->append(&this->data()); }
+    const vectorized::AggregateFunction* _agg_func;
+    vectorized::AggDataPtr _state{nullptr};
 };
 
 #define CASE_DEFAULT_WARNING(TYPE)                                             \
@@ -543,87 +342,11 @@ public:
     case CASE_TYPE: {                                                        \
         return std::make_unique<CLASS<COLUMN_TYPE, STATE_TYPE>>();           \
     }
-
-#define CASE_SUM(CASE_TYPE, COLUMN_TYPE, STATE_TYPE) \
-    CASE_NEW_VALUE_AGGREGATOR(CASE_TYPE, COLUMN_TYPE, STATE_TYPE, SumAggregator)
-
-#define CASE_MAX(CASE_TYPE, COLUMN_TYPE, STATE_TYPE) \
-    CASE_NEW_VALUE_AGGREGATOR(CASE_TYPE, COLUMN_TYPE, STATE_TYPE, MaxAggregator)
-
-#define CASE_MIN(CASE_TYPE, COLUMN_TYPE, STATE_TYPE) \
-    CASE_NEW_VALUE_AGGREGATOR(CASE_TYPE, COLUMN_TYPE, STATE_TYPE, MinAggregator)
-
 #define CASE_REPLACE(CASE_TYPE, COLUMN_TYPE, STATE_TYPE) \
     CASE_NEW_VALUE_AGGREGATOR(CASE_TYPE, COLUMN_TYPE, STATE_TYPE, ReplaceAggregator)
 
 ValueColumnAggregatorPtr create_value_aggregator(LogicalType type, StorageAggregateType method) {
     switch (method) {
-    case STORAGE_AGGREGATE_SUM: {
-        switch (type) {
-            CASE_SUM(TYPE_TINYINT, Int8Column, int8_t)
-            CASE_SUM(TYPE_SMALLINT, Int16Column, int16_t)
-            CASE_SUM(TYPE_INT, Int32Column, int32_t)
-            CASE_SUM(TYPE_BIGINT, Int64Column, int64_t)
-            CASE_SUM(TYPE_LARGEINT, Int128Column, int128_t)
-            CASE_SUM(TYPE_FLOAT, FloatColumn, float)
-            CASE_SUM(TYPE_DOUBLE, DoubleColumn, double)
-            CASE_SUM(TYPE_DECIMAL, DecimalColumn, DecimalV2Value)
-            CASE_SUM(TYPE_DECIMALV2, DecimalColumn, DecimalV2Value)
-            CASE_SUM(TYPE_DECIMAL32, Decimal32Column, int32_t)
-            CASE_SUM(TYPE_DECIMAL64, Decimal64Column, int64_t)
-            CASE_SUM(TYPE_DECIMAL128, Decimal128Column, int128_t)
-            CASE_SUM(TYPE_BOOLEAN, BooleanColumn, uint8_t)
-            CASE_DEFAULT_WARNING(type)
-        }
-    }
-    case STORAGE_AGGREGATE_MAX: {
-        switch (type) {
-            CASE_MAX(TYPE_TINYINT, Int8Column, int8_t)
-            CASE_MAX(TYPE_SMALLINT, Int16Column, int16_t)
-            CASE_MAX(TYPE_INT, Int32Column, int32_t)
-            CASE_MAX(TYPE_BIGINT, Int64Column, int64_t)
-            CASE_MAX(TYPE_LARGEINT, Int128Column, int128_t)
-            CASE_MAX(TYPE_FLOAT, FloatColumn, float)
-            CASE_MAX(TYPE_DOUBLE, DoubleColumn, double)
-            CASE_MAX(TYPE_DECIMAL, DecimalColumn, DecimalV2Value)
-            CASE_MAX(TYPE_DECIMALV2, DecimalColumn, DecimalV2Value)
-            CASE_MAX(TYPE_DECIMAL32, Decimal32Column, int32_t)
-            CASE_MAX(TYPE_DECIMAL64, Decimal64Column, int64_t)
-            CASE_MAX(TYPE_DECIMAL128, Decimal128Column, int128_t)
-            CASE_MAX(TYPE_DATE_V1, DateColumn, DateValue)
-            CASE_MAX(TYPE_DATE, DateColumn, DateValue)
-            CASE_MAX(TYPE_DATETIME_V1, TimestampColumn, TimestampValue)
-            CASE_MAX(TYPE_DATETIME, TimestampColumn, TimestampValue)
-            CASE_MAX(TYPE_CHAR, BinaryColumn, SliceState)
-            CASE_MAX(TYPE_VARCHAR, BinaryColumn, SliceState)
-            CASE_MAX(TYPE_BOOLEAN, BooleanColumn, uint8_t)
-            CASE_DEFAULT_WARNING(type)
-        }
-    }
-    case STORAGE_AGGREGATE_MIN: {
-        switch (type) {
-            CASE_MIN(TYPE_TINYINT, Int8Column, int8_t)
-            CASE_MIN(TYPE_SMALLINT, Int16Column, int16_t)
-            CASE_MIN(TYPE_INT, Int32Column, int32_t)
-            CASE_MIN(TYPE_BIGINT, Int64Column, int64_t)
-            CASE_MIN(TYPE_LARGEINT, Int128Column, int128_t)
-            CASE_MIN(TYPE_FLOAT, FloatColumn, float)
-            CASE_MIN(TYPE_DOUBLE, DoubleColumn, double)
-            CASE_MIN(TYPE_DECIMAL, DecimalColumn, DecimalV2Value)
-            CASE_MIN(TYPE_DECIMAL32, Decimal32Column, int32_t)
-            CASE_MIN(TYPE_DECIMAL64, Decimal64Column, int64_t)
-            CASE_MIN(TYPE_DECIMAL128, Decimal128Column, int128_t)
-            CASE_MIN(TYPE_DECIMALV2, DecimalColumn, DecimalV2Value)
-            CASE_MIN(TYPE_DATE_V1, DateColumn, DateValue)
-            CASE_MIN(TYPE_DATE, DateColumn, DateValue)
-            CASE_MIN(TYPE_DATETIME_V1, TimestampColumn, TimestampValue)
-            CASE_MIN(TYPE_DATETIME, TimestampColumn, TimestampValue)
-            CASE_MIN(TYPE_CHAR, BinaryColumn, SliceState)
-            CASE_MIN(TYPE_VARCHAR, BinaryColumn, SliceState)
-            CASE_MIN(TYPE_BOOLEAN, BooleanColumn, uint8_t)
-            CASE_DEFAULT_WARNING(type)
-        }
-    }
     case STORAGE_AGGREGATE_REPLACE:
     case STORAGE_AGGREGATE_REPLACE_IF_NOT_NULL: {
         switch (type) {
@@ -655,30 +378,7 @@ ValueColumnAggregatorPtr create_value_aggregator(LogicalType type, StorageAggreg
             CASE_DEFAULT_WARNING(type)
         }
     }
-    case STORAGE_AGGREGATE_HLL_UNION: {
-        switch (type) {
-        case TYPE_HLL: {
-            return std::make_unique<HllUnionAggregator>();
-        }
-            CASE_DEFAULT_WARNING(type)
-        }
-    }
-    case STORAGE_AGGREGATE_BITMAP_UNION: {
-        switch (type) {
-        case TYPE_OBJECT: {
-            return std::make_unique<BitmapUnionAggregator>();
-        }
-            CASE_DEFAULT_WARNING(type)
-        }
-    }
-    case STORAGE_AGGREGATE_PERCENTILE_UNION: {
-        switch (type) {
-        case TYPE_PERCENTILE: {
-            return std::make_unique<PercentileUnionAggregator>();
-        }
-            CASE_DEFAULT_WARNING(type)
-        }
-    }
+    default:
     case STORAGE_AGGREGATE_NONE:
         CHECK(false) << "invalid aggregate method: STORAGE_AGGREGATE_NONE";
     case STORAGE_AGGREGATE_UNKNOWN:
@@ -727,13 +427,20 @@ ColumnAggregatorPtr ColumnAggregatorFactory::create_value_column_aggregator(
         } else {
             return p;
         }
-    } else {
+    } else if (method == STORAGE_AGGREGATE_REPLACE_IF_NOT_NULL) {
         auto p = create_value_aggregator(type, method);
         if (field->is_nullable()) {
             return std::make_unique<ValueNullableColumnAggregator>(std::move(p));
         } else {
             return p;
         }
+    } else {
+        auto func_name = get_string_by_aggregation_type(method);
+        auto agg_func = vectorized::AggregateFuncResolver::instance()->get_aggregate_info(
+                func_name, type, type, false, field->is_nullable());
+        CHECK(agg_func != nullptr) << "Unknown aggregate function, name=" << func_name << ", type=" << type
+                                   << ", is_nullable=" << field->is_nullable();
+        return std::make_unique<AggFuncBasedValueAggregator>(agg_func);
     }
 }
 } // namespace starrocks::vectorized

--- a/be/src/storage/column_aggregate_func.cpp
+++ b/be/src/storage/column_aggregate_func.cpp
@@ -14,10 +14,10 @@
 
 #include "storage/column_aggregate_func.h"
 
-#include "exprs/agg/aggregate.h"
-#include "exprs/agg/factory/aggregate_resolver.hpp"
 #include "column/array_column.h"
 #include "column/vectorized_fwd.h"
+#include "exprs/agg/aggregate.h"
+#include "exprs/agg/factory/aggregate_resolver.hpp"
 #include "storage/column_aggregator.h"
 #include "util/percentile_value.h"
 
@@ -279,14 +279,10 @@ public:
         reset();
     }
 
-    void append_data(Column* agg) override {
-        _agg_func->finalize_to_column(nullptr, _state, agg);
-    }
+    void append_data(Column* agg) override { _agg_func->finalize_to_column(nullptr, _state, agg); }
 
     // |data| is readonly.
-    void aggregate_impl(int row, const ColumnPtr& data) override {
-        _agg_func->merge(nullptr, data.get(), _state, row);
-    }
+    void aggregate_impl(int row, const ColumnPtr& data) override { _agg_func->merge(nullptr, data.get(), _state, row); }
 
     // |data| is readonly.
     void aggregate_batch_impl(int start, int end, const ColumnPtr& input) override {
@@ -436,8 +432,8 @@ ColumnAggregatorPtr ColumnAggregatorFactory::create_value_column_aggregator(
         }
     } else {
         auto func_name = get_string_by_aggregation_type(method);
-        auto agg_func = vectorized::AggregateFuncResolver::instance()->get_aggregate_info(
-                func_name, type, type, false, field->is_nullable());
+        auto agg_func = vectorized::AggregateFuncResolver::instance()->get_aggregate_info(func_name, type, type, false,
+                                                                                          field->is_nullable());
         CHECK(agg_func != nullptr) << "Unknown aggregate function, name=" << func_name << ", type=" << type
                                    << ", is_nullable=" << field->is_nullable();
         return std::make_unique<AggFuncBasedValueAggregator>(agg_func);

--- a/be/src/storage/column_aggregator.h
+++ b/be/src/storage/column_aggregator.h
@@ -57,6 +57,8 @@ class KeyColumnAggregator final : public ColumnAggregatorBase {
 
 class ValueColumnAggregatorBase : public ColumnAggregatorBase {
 public:
+    ~ValueColumnAggregatorBase() override = default;
+
     virtual void reset() = 0;
 
     virtual void append_data(Column* agg) = 0;

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -382,8 +382,9 @@ TEST(ColumnAggregator, testNullBooleanMin) {
     ASSERT_EQ("0", agg->debug_item(2));
 
     // check agg data and null column
-    ASSERT_EQ("[1, 1, 0]", agg->data_column()->debug_string());
     ASSERT_EQ("[1, 0, 0]", agg->null_column()->debug_string());
+    ASSERT_TRUE(agg->data_column()->get(1).get_uint8());
+    ASSERT_FALSE(agg->data_column()->get(2).get_uint8());
 }
 
 TEST(ColumnAggregator, testNullIntReplaceIfNotNull) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, there are two implementation in both storage layer and
computation layer of aggregate function, such as sum, min, max,
bitmap_union, hll_union and percentile_union. There are some bad
influences of this kind of implementation
1. similiar code are implemented in two different places
2. difficult to add new aggregate function. When new aggregate function
   is added, these two places must be changed too.
3. some already exists computation aggregate functions can't be used by
   storage layer, and can't be used in aggregate model. For example:
   groupby_concat

After this change, most of aggregate functions can be used in Aggregate
Key model as long as it has the same input and output type. Even UDAF
can be supported in the future.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
