### PR TITLE
[BugFix] unstable case for backup(#15097)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -98,6 +98,8 @@ public class BackupHandler extends LeaderDaemon implements Writable {
     public static final Path BACKUP_ROOT_DIR = Paths.get(Config.tmp_dir, "backup").normalize();
     public static final Path RESTORE_ROOT_DIR = Paths.get(Config.tmp_dir, "restore").normalize();
 
+    public static final Path TEST_BACKUP_ROOT_DIR = Paths.get(Config.tmp_dir, "test_backup").normalize();
+
     private RepositoryMgr repoMgr = new RepositoryMgr();
 
     // db id -> last running or finished backup/restore jobs

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -142,6 +142,8 @@ public class BackupJob extends AbstractJob {
 
     private AgentBatchTask batchTask;
 
+    private boolean testPrimaryKey = false;
+
     public BackupJob() {
         super(JobType.BACKUP);
     }
@@ -151,6 +153,10 @@ public class BackupJob extends AbstractJob {
         super(JobType.BACKUP, label, dbId, dbName, timeoutMs, globalStateMgr, repoId);
         this.tableRefs = tableRefs;
         this.state = BackupJobState.PENDING;
+    }
+
+    public void setTestPrimaryKey() {
+        testPrimaryKey = true;
     }
 
     public BackupJobState getState() {
@@ -621,9 +627,14 @@ public class BackupJob extends AbstractJob {
     private void saveMetaInfo() {
         String createTimeStr = TimeUtils.longToTimeString(createTime,
                 new SimpleDateFormat(TIMESTAMP_FORMAT));
-        // local job dir: backup/label__createtime/
-        localJobDirPath = Paths.get(BackupHandler.BACKUP_ROOT_DIR.toString(),
-                label + "__" + UUIDUtil.genUUID().toString()).normalize();
+        if (testPrimaryKey) {
+            localJobDirPath = Paths.get(BackupHandler.TEST_BACKUP_ROOT_DIR.toString(),
+                    label + "__" + UUIDUtil.genUUID().toString()).normalize();
+        } else {
+            // local job dir: backup/label__createtime/
+            localJobDirPath = Paths.get(BackupHandler.BACKUP_ROOT_DIR.toString(),
+                    label + "__" + UUIDUtil.genUUID().toString()).normalize();
+        }
 
         try {
             // 1. create local job dir of this backup job

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
@@ -137,16 +137,16 @@ public class BackupJobPrimaryKeyTest {
     @BeforeClass
     public static void start() {
         Config.tmp_dir = "./";
-        File backupDir = new File(BackupHandler.BACKUP_ROOT_DIR.toString());
+        File backupDir = new File(BackupHandler.TEST_BACKUP_ROOT_DIR.toString());
         backupDir.mkdirs();
     }
 
     @AfterClass
     public static void end() throws IOException {
         Config.tmp_dir = "./";
-        File backupDir = new File(BackupHandler.BACKUP_ROOT_DIR.toString());
+        File backupDir = new File(BackupHandler.TEST_BACKUP_ROOT_DIR.toString());
         if (backupDir.exists()) {
-            Files.walk(BackupHandler.BACKUP_ROOT_DIR,
+            Files.walk(BackupHandler.TEST_BACKUP_ROOT_DIR,
                             FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
                     .forEach(File::delete);
         }
@@ -218,6 +218,7 @@ public class BackupJobPrimaryKeyTest {
         List<TableRef> tableRefs = Lists.newArrayList();
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME), null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job.setTestPrimaryKey();
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15097

## Problem Summary(Required) ：
Problem:
exec the BackupPrimaryKeyTest and BackupTest concurrently, sometimes the metafile is not found. because this two cases use the same file path to save the meta data. If one of them finished first the directory may be deleted and the other one may lost its meta data.

Solution:
Change the directory of BackupPrimaryKeyTest for saving meta file.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
