### PR TITLE
[Enhancement] Disable GroupByCountDistinctRewriteRule if has limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.base.Preconditions;
@@ -129,6 +128,11 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
                 .collect(Collectors.toList());
 
         if (groupBy.isEmpty() || groupBy.containsAll(scan.getDistributionSpec().getShuffleColumns())) {
+            return false;
+        }
+
+        // check limit
+        if (aggregate.hasLimit()) {
             return false;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.google.common.collect.Lists;
@@ -329,7 +328,8 @@ public class ReplayFromDumpTest {
         sessionVariable.setNewPlanerAggStage(1);
         Pair<QueryDumpInfo, String> replayPair =
                 getCostPlanFragment(getDumpInfoFromFile("query_dump/groupby_limit"), sessionVariable);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("1:AGGREGATE (update finalize)"));
+        Assert.assertTrue(replayPair.second, replayPair.second.contains(
+                "aggregate: multi_distinct_count[([1: LO_ORDERKEY, INT, false])"));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

We found that the following queries are of great regression comparing to version 2.4.1

```sql
SELECT COUNT (DISTINCT lo_orderkey), lo_extendedprice, lo_revenue FROM lineorder group by lo_extendedprice, lo_revenue limit 1;
SELECT COUNT (DISTINCT lo_orderkey), lo_extendedprice, lo_revenue FROM lineorder group by lo_extendedprice, lo_revenue limit 10000;
SELECT COUNT (DISTINCT lo_orderkey), lo_extendedprice, lo_revenue FROM lineorder group by lo_extendedprice, lo_revenue limit 100;
```

#9833 introduce a rule to transform count distinct to multi-stage aggregation. And here is the problem, if the count distinct has limitation, multi-stage aggregation will prevent limitation from pushing down.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
