### PR TITLE
[cherry-pick][branch-2.2][Feature] Support configure rocksdb meta column family options. (#14398)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -715,4 +715,7 @@ CONF_Int32(internal_service_async_thread_num, "10");
 
 // Used to limit buffer size of tablet send channel.
 CONF_mInt64(send_channel_buffer_limit, "67108864");
+
+CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache=128M}");
+
 } // namespace starrocks::config


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14395

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The default rocksdb block cache size is 8M, which may be too small. It should be configured. just like block cache size, other column family options should also be configured. This PR adds a configuration in be.conf to deliver a string to rocksdb GetColumnFamilyOptionsFromString API to parse. Besides, prefix_extractor and compression are fixed options in case of incorrect.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
