### PR TITLE
[BugFix] fix visitor cannot process case when operator correctly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -204,10 +204,10 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
             ScalarOperator clonedCaseClause = null;
             ScalarOperator clonedElseClause = null;
             List<ScalarOperator> clonedWhenThenClauses;
-            if (operator.getCaseClause() != null) {
+            if (operator.hasCase()) {
                 clonedCaseClause = clonedOperators.get(0);
             }
-            if (operator.getElseClause() != null) {
+            if (operator.hasElse()) {
                 clonedElseClause = clonedOperators.get(clonedOperators.size() - 1);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
@@ -16,9 +16,11 @@
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ArraySliceOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import static com.starrocks.catalog.Type.ARRAY_TINYINT;
 import static com.starrocks.catalog.Type.INT;
 import static com.starrocks.catalog.Type.STRING;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class BaseScalarOperatorShuttleTest {
@@ -116,5 +119,32 @@ class BaseScalarOperatorShuttleTest {
         CaseWhenOperator operator = new CaseWhenOperator(INT, null, null, ImmutableList.of());
         ScalarOperator newOperator = shuttle.visitCaseWhenOperator(operator, null);
         assertEquals(operator, newOperator);
+    }
+
+    @Test
+    void visitCaseWhenOperator_1() {
+        ColumnRefOperator columnRefOperator = new ColumnRefOperator(1, Type.INT, "", true);
+        BinaryPredicateOperator whenOperator1 =
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ, columnRefOperator,
+                        ConstantOperator.createInt(1));
+        ConstantOperator constantOperator1 = ConstantOperator.createChar("1");
+        BinaryPredicateOperator whenOperator2 =
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ, columnRefOperator,
+                        ConstantOperator.createInt(2));
+        ConstantOperator constantOperator2 = ConstantOperator.createChar("2");
+
+        CaseWhenOperator operator =
+                new CaseWhenOperator(Type.VARCHAR, null, ConstantOperator.createChar("others", Type.VARCHAR),
+                        ImmutableList.of(whenOperator1, constantOperator1, whenOperator2, constantOperator2));
+
+        BaseScalarOperatorShuttle testShuttle = new BaseScalarOperatorShuttle() {
+            @Override
+            public ScalarOperator visitConstant(ConstantOperator literal, Void context) {
+                return ConstantOperator.createChar("3");
+            }
+        };
+        ScalarOperator newOperator = testShuttle.visitCaseWhenOperator(operator, null);
+        assertNotEquals(operator, newOperator);
+
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The old code directly calls `getCaseClause() ` before calling `hasCase` which violations the state check.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
