### PR TITLE
[BugFix] process null value in time_slice function

### DIFF
--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -776,47 +776,40 @@ Status TimeFunctions::time_slice_prepare(FunctionContext* context, FunctionConte
     return Status::OK();
 }
 
-#define DEFINE_TIME_SLICE_FN(UNIT)                                                                 \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(time_slice_datetime_start_##UNIT##Impl, v, period) {          \
-        TimestampValue result = v;                                                                 \
-        if (result.diff_microsecond(TimeFunctions::start_of_time_slice) < 0) {                     \
-            throw std::runtime_error(TimeFunctions::info_reported_by_time_slice);                  \
-        }                                                                                          \
-        result.template floor_to_##UNIT##_period<false>(period);                                   \
-        return result;                                                                             \
-    }                                                                                              \
-                                                                                                   \
-    DEFINE_TIME_CALC_FN(time_slice_datetime_start_##UNIT, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME); \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(time_slice_datetime_end_##UNIT##Impl, v, period) {            \
-        TimestampValue result = v;                                                                 \
-        if (result.diff_microsecond(TimeFunctions::start_of_time_slice) < 0) {                     \
-            throw std::runtime_error(TimeFunctions::info_reported_by_time_slice);                  \
-        }                                                                                          \
-        result.template floor_to_##UNIT##_period<true>(period);                                    \
-        return result;                                                                             \
-    }                                                                                              \
-                                                                                                   \
-    DEFINE_TIME_CALC_FN(time_slice_datetime_end_##UNIT, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);   \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(time_slice_date_start_##UNIT##Impl, v, period) {              \
-        TimestampValue result = v;                                                                 \
-        if (result.diff_microsecond(TimeFunctions::start_of_time_slice) < 0) {                     \
-            throw std::runtime_error(TimeFunctions::info_reported_by_time_slice);                  \
-        }                                                                                          \
-        result.template floor_to_##UNIT##_period<false>(period);                                   \
-        return result;                                                                             \
-    }                                                                                              \
-                                                                                                   \
-    DEFINE_TIME_CALC_FN(time_slice_date_start_##UNIT, TYPE_DATE, TYPE_INT, TYPE_DATE);             \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(time_slice_date_end_##UNIT##Impl, v, period) {                \
-        TimestampValue result = v;                                                                 \
-        if (result.diff_microsecond(TimeFunctions::start_of_time_slice) < 0) {                     \
-            throw std::runtime_error(TimeFunctions::info_reported_by_time_slice);                  \
-        }                                                                                          \
-        result.template floor_to_##UNIT##_period<true>(period);                                    \
-        return result;                                                                             \
-    }                                                                                              \
-                                                                                                   \
-    DEFINE_TIME_CALC_FN(time_slice_date_end_##UNIT, TYPE_DATE, TYPE_INT, TYPE_DATE);
+#define DEFINE_TIME_SLICE_FN_CALL(TypeName, UNIT, LType, RType, ResultType)                   \
+    StatusOr<ColumnPtr> TimeFunctions::time_slice_##TypeName##_start_##UNIT(                  \
+            FunctionContext* context, const starrocks::vectorized::Columns& columns) {        \
+        return time_slice_function_##UNIT<LType, RType, ResultType, true>(context, columns);  \
+    }                                                                                         \
+    StatusOr<ColumnPtr> TimeFunctions::time_slice_##TypeName##_end_##UNIT(                    \
+            FunctionContext* context, const starrocks::vectorized::Columns& columns) {        \
+        return time_slice_function_##UNIT<LType, RType, ResultType, false>(context, columns); \
+    }
+
+#define DEFINE_TIME_SLICE_FN(UNIT)                                                                     \
+    template <LogicalType LType, LogicalType RType, LogicalType ResultType, bool is_start>             \
+    StatusOr<ColumnPtr> time_slice_function_##UNIT(FunctionContext* context, const Columns& columns) { \
+        auto time_viewer = ColumnViewer<LType>(columns[0]);                                            \
+        auto period_viewer = ColumnViewer<RType>(columns[1]);                                          \
+        auto size = columns[0]->size();                                                                \
+        ColumnBuilder<ResultType> results(size);                                                       \
+        for (int row = 0; row < size; row++) {                                                         \
+            if (time_viewer.is_null(row) || period_viewer.is_null(row)) {                              \
+                results.append_null();                                                                 \
+                continue;                                                                              \
+            }                                                                                          \
+            TimestampValue time_value = time_viewer.value(row);                                        \
+            auto period_value = period_viewer.value(row);                                              \
+            if (time_value.diff_microsecond(TimeFunctions::start_of_time_slice) < 0) {                 \
+                return Status::InternalError(TimeFunctions::info_reported_by_time_slice);              \
+            }                                                                                          \
+            time_value.template floor_to_##UNIT##_period<!is_start>(period_value);                     \
+            results.append(time_value);                                                                \
+        }                                                                                              \
+        return results.build(ColumnHelper::is_all_const(columns));                                     \
+    }                                                                                                  \
+    DEFINE_TIME_SLICE_FN_CALL(datetime, UNIT, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);                 \
+    DEFINE_TIME_SLICE_FN_CALL(date, UNIT, TYPE_DATE, TYPE_INT, TYPE_DATE);
 
 // time_slice_to_second
 DEFINE_TIME_SLICE_FN(second);

--- a/be/src/exprs/vectorized/time_functions.cpp
+++ b/be/src/exprs/vectorized/time_functions.cpp
@@ -801,12 +801,12 @@ Status TimeFunctions::time_slice_prepare(FunctionContext* context, FunctionConte
             TimestampValue time_value = time_viewer.value(row);                                        \
             auto period_value = period_viewer.value(row);                                              \
             if (time_value.diff_microsecond(TimeFunctions::start_of_time_slice) < 0) {                 \
-                return Status::InternalError(TimeFunctions::info_reported_by_time_slice);              \
+                return Status::InvalidArgument(TimeFunctions::info_reported_by_time_slice);            \
             }                                                                                          \
             time_value.template floor_to_##UNIT##_period<!is_start>(period_value);                     \
             results.append(time_value);                                                                \
         }                                                                                              \
-        return results.build(ColumnHelper::is_all_const(columns));                                     \
+        return date_valid<ResultType>(results.build(ColumnHelper::is_all_const(columns)));             \
     }                                                                                                  \
     DEFINE_TIME_SLICE_FN_CALL(datetime, UNIT, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);                 \
     DEFINE_TIME_SLICE_FN_CALL(date, UNIT, TYPE_DATE, TYPE_INT, TYPE_DATE);

--- a/be/test/exprs/vectorized/time_functions_test.cpp
+++ b/be/test/exprs/vectorized/time_functions_test.cpp
@@ -2848,11 +2848,9 @@ TEST_F(TimeFunctionsTest, timeSliceTestWithThrowExceptions) {
                                                       FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
-        try {
-            ColumnPtr result = TimeFunctions::time_slice(time_slice_context.get(), columns).value();
-        } catch (std::runtime_error const& e) {
-            ASSERT_EQ("time used with time_slice can't before 0001-01-01 00:00:00", std::string(e.what()));
-        }
+        StatusOr<ColumnPtr> result = TimeFunctions::time_slice(time_slice_context.get(), columns);
+        ASSERT_TRUE(result.status().is_invalid_argument());
+        ASSERT_EQ(result.status().get_error_msg(), "time used with time_slice can't before 0001-01-01 00:00:00");
 
         ASSERT_TRUE(
                 TimeFunctions::time_slice_close(time_slice_context.get(),


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15022 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

time_slice function's implementation is based on VectorizedStrictBinaryFunction. for vectorization, it process data column at first and then null column. but for the null row, it's data in data column may not valid, we should check if it is null before deciding whether to apply time floor function. But the templated-based implementation can't do this, so I changed it to a custom implementation.



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
