### PR TITLE
[BugFix] fix NLJ left outer join: store the probe_start when it really starts

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -350,7 +350,14 @@ Status NLJoinProbeOperator::_probe(RuntimeState* state, ChunkPtr chunk) {
 ChunkPtr NLJoinProbeOperator::_permute_chunk(RuntimeState* state) {
     // TODO: optimize the loop order for small build chunk
     ChunkPtr chunk = _init_output_chunk(state);
-    _probe_row_start = _probe_row_current;
+    bool probe_started = false;
+    _probe_row_start = 0;
+    auto probe_row_start = [&]() {
+        if (!probe_started) {
+            probe_started = true;
+            _probe_row_start = _probe_row_current;
+        }
+    };
     for (; _probe_row_current < _probe_chunk->num_rows(); ++_probe_row_current) {
         // Last build chunk must permute a chunk
         bool is_last_build_chunk = _curr_build_chunk_index == _num_build_chunks() - 1 && _num_build_chunks() > 1;
@@ -358,6 +365,7 @@ ChunkPtr NLJoinProbeOperator::_permute_chunk(RuntimeState* state) {
             _permute_probe_row(state, chunk);
             _move_build_chunk_index(0);
             _probe_row_finished = true;
+            probe_row_start();
             return chunk;
         }
 
@@ -366,6 +374,7 @@ ChunkPtr NLJoinProbeOperator::_permute_chunk(RuntimeState* state) {
         while (!_probe_row_finished && _curr_build_chunk_index < _num_build_chunks()) {
             _permute_probe_row(state, chunk);
             _move_build_chunk_index(_curr_build_chunk_index + 1);
+            probe_row_start();
             if (chunk->num_rows() >= state->chunk_size()) {
                 return chunk;
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15169
https://github.com/StarRocks/starrocks/issues/14911

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In NLJ operator two states implement the for-loop:
- `_probe_row_start`: start position of probe chunk for the enumerated chunk
- `_probe_row_current`: end position of probe chunk for the enumerated chunk
- The `_probe_row_start` should be set to `_probe_row_current` when emit the first row, instead of at the entrance


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
