### PR TITLE
[BugFix] compute large or predicate statistics timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -31,7 +31,7 @@ public class Statistics {
     // This flag set true if get table row count from GlobalStateMgr LE 1
     // Table row count in FE depends on BE reporting，but FE may not get report from BE which just started，
     // this causes the table row count stored in FE to be inaccurate.
-    private boolean tableRowCountMayInaccurate;
+    private final boolean tableRowCountMayInaccurate;
 
     private Statistics(Builder builder) {
         this.outputRowCount = builder.outputRowCount;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -52,4 +52,6 @@ public class StatisticsEstimateCoefficient {
     public static final double DEFAULT_PRUNE_SHUFFLE_COLUMN_ROWS_LIMIT = 200000;
     // default push down aggregate row count limit, 100w
     public static final long DEFAULT_PUSH_DOWN_AGGREGATE_ROWS_LIMIT = 1000000;
+    // default or predicate limit
+    public static final int DEFAULT_OR_OPERATOR_LIMIT = 20;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -53,5 +53,5 @@ public class StatisticsEstimateCoefficient {
     // default push down aggregate row count limit, 100w
     public static final long DEFAULT_PUSH_DOWN_AGGREGATE_ROWS_LIMIT = 1000000;
     // default or predicate limit
-    public static final int DEFAULT_OR_OPERATOR_LIMIT = 20;
+    public static final int DEFAULT_OR_OPERATOR_LIMIT = 15;
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1595,166 +1595,170 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "  *\n" +
                 "FROM t0\n" +
                 "WHERE\n" +
-                "  (\n" +
-                "    (v1 >= 27)\n" +
-                "    AND (v1 < 28)\n" +
-                "  )\n" +
-                "  OR (\n" +
-                "    (\n" +
-                "      (v1 >= 26)\n" +
-                "      AND (v1 < 27)\n" +
-                "    )\n" +
-                "    OR (\n" +
-                "      (\n" +
-                "        (v1 >= 25)\n" +
-                "        AND (v1 < 26)\n" +
-                "      )\n" +
-                "      OR (\n" +
-                "        (\n" +
-                "          (v1 >= 24)\n" +
-                "          AND (v1 < 25)\n" +
-                "        )\n" +
-                "        OR (\n" +
-                "          (\n" +
-                "            (v1 >= 23)\n" +
-                "            AND (v1 < 24)\n" +
-                "          )\n" +
-                "          OR (\n" +
-                "            (\n" +
-                "              (v1 >= 22)\n" +
-                "              AND (v1 < 23)\n" +
-                "            )\n" +
-                "            OR (\n" +
-                "              (\n" +
-                "                (v1 >= 21)\n" +
-                "                AND (v1 < 22)\n" +
-                "              )\n" +
-                "              OR (\n" +
-                "                (\n" +
-                "                  (v1 >= 20)\n" +
-                "                  AND (v1 < 21)\n" +
-                "                )\n" +
-                "                OR (\n" +
-                "                  (\n" +
-                "                    (v1 >= 19)\n" +
-                "                    AND (v1 < 20)\n" +
-                "                  )\n" +
-                "                  OR (\n" +
-                "                    (\n" +
-                "                      (v1 >= 18)\n" +
-                "                      AND (v1 < 19)\n" +
-                "                    )\n" +
-                "                    OR (\n" +
-                "                      (\n" +
-                "                        (v1 >= 17)\n" +
-                "                        AND (v1 < 18)\n" +
-                "                      )\n" +
-                "                      OR (\n" +
-                "                        (\n" +
-                "                          (v1 >= 16)\n" +
-                "                          AND (v1 < 17)\n" +
-                "                        )\n" +
-                "                        OR (\n" +
-                "                          (\n" +
-                "                            (v1 >= 15)\n" +
-                "                            AND (v1 < 16)\n" +
-                "                          )\n" +
-                "                          OR (\n" +
-                "                            (\n" +
-                "                              (v1 >= 14)\n" +
-                "                              AND (v1 < 15)\n" +
-                "                            )\n" +
-                "                            OR (\n" +
-                "                              (\n" +
-                "                                (v1 >= 13)\n" +
-                "                                AND (v1 < 14)\n" +
-                "                              )\n" +
-                "                              OR (\n" +
-                "                                (\n" +
-                "                                  (v1 >= 12)\n" +
-                "                                  AND (v1 < 13)\n" +
-                "                                )\n" +
-                "                                OR (\n" +
-                "                                  (\n" +
-                "                                    (v1 >= 11)\n" +
-                "                                    AND (v1 < 12)\n" +
-                "                                  )\n" +
-                "                                  OR (\n" +
-                "                                    (\n" +
-                "                                      (v1 >= 10)\n" +
-                "                                      AND (v1 < 11)\n" +
-                "                                    )\n" +
-                "                                    OR (\n" +
-                "                                      (\n" +
-                "                                        (v1 >= 09)\n" +
-                "                                        AND (v1 < 10)\n" +
-                "                                      )\n" +
-                "                                      OR (\n" +
-                "                                        (\n" +
-                "                                          (v1 >= 08)\n" +
-                "                                          AND (v1 < 09)\n" +
-                "                                        )\n" +
-                "                                        OR (\n" +
-                "                                          (\n" +
-                "                                            (v1 >= 07)\n" +
-                "                                            AND (v1 < 08)\n" +
-                "                                          )\n" +
-                "                                          OR (\n" +
-                "                                            (\n" +
-                "                                              (v1 >= 06)\n" +
-                "                                              AND (v1 < 07)\n" +
-                "                                            )\n" +
-                "                                            OR (\n" +
-                "                                              (\n" +
-                "                                                (v1 >= 05)\n" +
-                "                                                AND (v1 < 06)\n" +
-                "                                              )\n" +
-                "                                              OR (\n" +
-                "                                                (\n" +
-                "                                                  (v1 >= 04)\n" +
-                "                                                  AND (v1 < 05)\n" +
-                "                                                )\n" +
-                "                                                OR (\n" +
-                "                                                  (\n" +
-                "                                                    (v1 >= 03)\n" +
-                "                                                    AND (v1 < 04)\n" +
-                "                                                  )\n" +
-                "                                                  OR (\n" +
-                "                                                    (\n" +
-                "                                                      (v1 >= 02)\n" +
-                "                                                      AND (v1 < 03)\n" +
-                "                                                    )\n" +
-                "                                                    OR (\n" +
-                "                                                      (v1 >= 01)\n" +
-                "                                                      AND (v1 < 02)\n" +
-                "                                                    )\n" +
-                "                                                  )\n" +
-                "                                                )\n" +
-                "                                              )\n" +
-                "                                            )\n" +
-                "                                          )\n" +
-                "                                        )\n" +
-                "                                      )\n" +
-                "                                    )\n" +
-                "                                  )\n" +
-                "                                )\n" +
-                "                              )\n" +
-                "                            )\n" +
-                "                          )\n" +
-                "                        )\n" +
-                "                      )\n" +
-                "                    )\n" +
-                "                  )\n" +
-                "                )\n" +
-                "              )\n" +
-                "            )\n" +
-                "          )\n" +
-                "        )\n" +
-                "      )\n" +
-                "    )\n" +
-                "  )";
+                "  ((v1 >= 27 AND v1 < 28)) OR \n" +
+                " (((v1 >= 26 AND v1 < 27)) OR \n" +
+                " (((v1 >= 25 AND v1 < 26)) OR \n" +
+                " (((v1 >= 24 AND v1 < 25)) OR \n" +
+                " (((v1 >= 23 AND v1 < 24)) OR \n" +
+                " (((v1 >= 22 AND v1 < 23)) OR \n" +
+                " (((v1 >= 21 AND v1 < 22)) OR \n" +
+                " (((v1 >= 20 AND v1 < 21)) OR \n" +
+                " (((v1 >= 19 AND v1 < 20)) OR \n" +
+                " (((v1 >= 18 AND v1 < 19)) OR \n" +
+                " (((v1 >= 17 AND v1 < 18)) OR \n" +
+                " (((v1 >= 16 AND v1 < 17)) OR \n" +
+                " (((v1 >= 15 AND v1 < 16)) OR \n" +
+                " (((v1 >= 14 AND v1 < 15)) OR \n" +
+                " (((v1 >= 13 AND v1 < 14)) OR \n" +
+                " (((v1 >= 12 AND v1 < 13)) OR \n" +
+                " (((v1 >= 11 AND v1 < 12)) OR \n" +
+                " (((v1 >= 10 AND v1 < 11)) OR \n" +
+                " (((v1 >= 09 AND v1 < 10)) OR \n" +
+                " (((v1 >= 08 AND v1 < 09)) OR \n" +
+                " (((v1 >= 07 AND v1 < 08)) OR \n" +
+                " (((v1 >= 06 AND v1 < 07)) OR \n" +
+                " (((v1 >= 05 AND v1 < 06)) OR \n" +
+                " (((v1 >= 04 AND v1 < 05)) OR \n" +
+                " (((v1 >= 03 AND v1 < 04)) OR \n" +
+                " (((v1 >= 02 AND v1 < 03)) OR \n" +
+                "  ((v1 >= 01 AND v1 < 02)))))))))))))))))))))))))))";
 
         //Test excessive recursion and optimizer timeout due to too many OR
+        getFragmentPlan(sql);
+    }
+
+    @Test
+    public void testExcessiveAnd() throws Exception {
+        String sql = "SELECT\n" +
+                "  *\n" +
+                "FROM t0\n" +
+                "WHERE\n" +
+                "  ((v1 >= 27 OR v1 < 28)) AND \n" +
+                " (((v1 >= 26 OR v1 < 27)) AND \n" +
+                " (((v1 >= 25 OR v1 < 26)) AND \n" +
+                " (((v1 >= 24 OR v1 < 25)) AND \n" +
+                " (((v1 >= 23 OR v1 < 24)) AND \n" +
+                " (((v1 >= 22 OR v1 < 23)) AND \n" +
+                " (((v1 >= 21 OR v1 < 22)) AND \n" +
+                " (((v1 >= 20 OR v1 < 21)) AND \n" +
+                " (((v1 >= 19 OR v1 < 20)) AND \n" +
+                " (((v1 >= 18 OR v1 < 19)) AND \n" +
+                " (((v1 >= 17 OR v1 < 18)) AND \n" +
+                " (((v1 >= 16 OR v1 < 17)) AND \n" +
+                " (((v1 >= 15 OR v1 < 16)) AND \n" +
+                " (((v1 >= 14 OR v1 < 15)) AND \n" +
+                " (((v1 >= 13 OR v1 < 14)) AND \n" +
+                " (((v1 >= 12 OR v1 < 13)) AND \n" +
+                " (((v1 >= 11 OR v1 < 12)) AND \n" +
+                " (((v1 >= 10 OR v1 < 11)) AND \n" +
+                " (((v1 >= 09 OR v1 < 10)) AND \n" +
+                " (((v1 >= 08 OR v1 < 09)) AND \n" +
+                " (((v1 >= 07 OR v1 < 08)) AND \n" +
+                " (((v1 >= 06 OR v1 < 07)) AND \n" +
+                " (((v1 >= 05 OR v1 < 06)) AND \n" +
+                " (((v1 >= 04 OR v1 < 05)) AND \n" +
+                " (((v1 >= 03 OR v1 < 04)) AND \n" +
+                " (((v1 >= 02 OR v1 < 03)) AND \n" +
+                "  ((v1 >= 01 OR v1 < 02)))))))))))))))))))))))))))";
+
+        //Test excessive recursion and optimizer timeout due to too many OR
+        getFragmentPlan(sql);
+    }
+    @Test
+    public void testTimeOutOr50() throws Exception {
+        String sql = "SELECT v1\n" +
+                "FROM t0\n" +
+                "WHERE (v2 = 1\n" +
+                " OR ((v2 = 2\n" +
+                "  OR ((v2 = 3\n" +
+                "   OR ((v2 = 4\n" +
+                "    OR ((v2 = 5\n" +
+                "     OR ((v2 = 6\n" +
+                "      OR ((v2 = 7\n" +
+                "       OR ((v2 = 8\n" +
+                "        OR ((v2 = 9\n" +
+                "         OR ((v2 = 10\n" +
+                "          OR (v1 = 11 AND (v2 = 12\n" +
+                "           OR (v2 = 13\n" +
+                "            OR (v2 = 14\n" +
+                "             OR (v1 = 15 AND (v2 = 16\n" +
+                "              OR (v2 = 17\n" +
+                "               OR (v2 = 18\n" +
+                "                OR (v2 = 19\n" +
+                "                 OR (v2 = 20\n" +
+                "                  OR ((v2 = 21 AND v1 = 22)\n" +
+                "                     OR (v2 = 23 AND v1 = 24)) AND v1 = 25) AND v1 = 26\n" +
+                "                 OR (v2 = 27 AND v1 = 28)\n" +
+                "                 OR (v2 = 29 AND v1 = 30)\n" +
+                "                 OR (v2 = 31 AND v1 = 32)\n" +
+                "                 OR (v2 = 33 AND v1 = 34)\n" +
+                "                 OR (v2 = 35 AND v1 = 36)\n" +
+                "                 OR (v2 = 37 AND v1 = 38)) AND v1 = 39\n" +
+                "                OR v2 = 40 AND v1 = 41\n" +
+                "                OR v2 = 42 AND v1 = 43\n" +
+                "                OR v2 = 44 AND v1 = 45\n" +
+                "                OR v2 = 46 AND v1 = 47\n" +
+                "                OR v2 = 48 AND v1 = 49\n" +
+                "                OR v2 = 50 AND v1 = 51\n" +
+                "                OR v2 = 52 AND v1 = 53\n" +
+                "                OR v2 = 54 AND v1 = 55\n" +
+                "                OR v2 = 56 AND v1 = 57\n" +
+                "                OR v2 = 58 AND v1 = 59\n" +
+                "                OR v2 = 60 AND v1 = 61\n" +
+                "                OR v2 = 62 AND v1 = 63\n" +
+                "                OR v2 = 64 AND v1 = 65\n" +
+                "                OR v2 = 66 AND v1 = 67\n" +
+                "                OR v2 = 68 AND v1 = 69) AND v1 = 70\n" +
+                "               OR v2 = 71 AND v1 = 72) AND v1 = 73\n" +
+                "              OR v2 = 74 AND v1 = 75\n" +
+                "              OR v2 = 76 AND v1 = 77\n" +
+                "              OR v2 = 78 AND v1 = 79\n" +
+                "              OR v2 = 80))) AND v1 = 81 AND v1 = 82\n" +
+                "            OR v2 = 83 AND v1 = 84\n" +
+                "            OR v2 = 85 AND v1 = 86) AND v1 = 87\n" +
+                "           OR v2 = 88 AND v1 = 89\n" +
+                "           OR v2 = 90)))\n" +
+                "            AND v1 = 91))\n" +
+                "           AND v1 = 92))\n" +
+                "          AND v1 = 93))\n" +
+                "         AND v1 = 94))\n" +
+                "        AND v1 = 95))\n" +
+                "       AND v1 = 96))\n" +
+                "      AND v1 = 97))\n" +
+                "     AND v1 = 98))\n" +
+                "    AND v1 = 99))\n" +
+                "   AND v1 = 100";
+        String plan = getFragmentPlan(sql);
+    }
+
+    @Test
+    public void testTimeOutOr15() throws Exception {
+        String sql = "SELECT v1\n" +
+                "FROM t0\n" +
+                "WHERE (v2 = 1\n" +
+                " OR ((v2 = 2\n" +
+                "  OR ((v2 = 3\n" +
+                "   OR ((v2 = 4\n" +
+                "    OR ((v2 = 5\n" +
+                "     OR ((v2 = 6\n" +
+                "      OR ((v2 = 7\n" +
+                "       OR ((v2 = 8\n" +
+                "        OR ((v2 = 9\n" +
+                "         OR ((v2 = 10\n" +
+                "          OR (v1 = 11 AND (v2 = 12\n" +
+                "           OR (v2 = 13)\n" +
+                "                   AND v1 = 87\n" +
+                "           OR v2 = 90)))\n" +
+                "                 AND v1 = 91))\n" +
+                "                AND v1 = 92))\n" +
+                "               AND v1 = 93))\n" +
+                "              AND v1 = 94))\n" +
+                "             AND v1 = 95))\n" +
+                "            AND v1 = 96))\n" +
+                "           AND v1 = 97))\n" +
+                "          AND v1 = 98))\n" +
+                "         AND v1 = 99))\n" +
+                "        AND v1 = 100;";
         getFragmentPlan(sql);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
@@ -109,7 +109,7 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
                 Arguments.of("Q39_1", 2, 2, 2, 2, 2),
                 Arguments.of("Q39_2", 2, 2, 2, 2, 2),
                 Arguments.of("Q40", 2, 2, 2, 2, 2),
-                Arguments.of("Q41", 3, 3, 5, 3, 3),
+                Arguments.of("Q41", 2, 2, 4, 2, 2),
                 Arguments.of("Q42", 2, 4, 4, 4, 4),
                 Arguments.of("Q43", 2, 4, 4, 4, 4),
                 Arguments.of("Q44", 8, 8, 8, 8, 8),


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
The time-complexity of PredicateStatisticsCalculatingVisitor OR row-count is O(2^n), n is OR number
to compute row count, each child need compute twice:  and-statistics and or-statistics

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
