### PR TITLE
[Enhancement] enable storage cache by default for lake table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2061,7 +2061,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 // storage cache property
                 boolean enableStorageCache =
                         PropertyAnalyzer.analyzeBooleanProp(properties,
-                                PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, false);
+                                PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, true);
                 long storageCacheTtlS = 0;
                 try {
                     storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(properties,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -148,7 +148,7 @@ public class SingleRangePartitionDesc extends PartitionDesc {
 
         // analyze enable storage cache and cache ttl, and whether allow async write back
         boolean enableStorageCache = PropertyAnalyzer.analyzeBooleanProp(
-                properties, PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, false);
+                properties, PropertyAnalyzer.PROPERTIES_ENABLE_STORAGE_CACHE, true);
         long storageCacheTtlS = PropertyAnalyzer.analyzeLongProp(
                 properties, PropertyAnalyzer.PROPERTIES_STORAGE_CACHE_TTL, Config.lake_default_storage_cache_ttl_seconds);
         boolean allowAsyncWriteBack = PropertyAnalyzer.analyzeBooleanProp(

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -234,23 +234,24 @@ public class CreateLakeTableTest {
                         "engine = starrocks unique key (key1, key2)\n" +
                         "partition by range(key1)\n" +
                         "(partition p1 values less than (\"10\"),\n" +
-                        " partition p2 values less than (\"20\") ('enable_storage_cache' = 'true'))\n" +
+                        " partition p2 values less than (\"20\") ('enable_storage_cache' = 'false'))\n" +
                         "distributed by hash(key2) buckets 1\n" +
                         "properties('replication_num' = '1');"));
         {
             LakeTable lakeTable = getLakeTable("lake_test", "multi_partition_unique_key_cache");
             // check table property
             StorageInfo storageInfo = lakeTable.getTableProperty().getStorageInfo();
-            Assert.assertFalse(storageInfo.isEnableStorageCache());
+            // enabled by default if property key `enable_storage_cache` is absent
+            Assert.assertTrue(storageInfo.isEnableStorageCache());
             Assert.assertEquals(Config.lake_default_storage_cache_ttl_seconds, storageInfo.getStorageCacheTtlS());
             // check partition property
             long partition1Id = lakeTable.getPartition("p1").getId();
             StorageCacheInfo partition1StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition1Id);
-            Assert.assertFalse(partition1StorageCacheInfo.isEnableStorageCache());
+            Assert.assertTrue(partition1StorageCacheInfo.isEnableStorageCache());
             Assert.assertEquals(Config.lake_default_storage_cache_ttl_seconds, partition1StorageCacheInfo.getStorageCacheTtlS());
             long partition2Id = lakeTable.getPartition("p2").getId();
             StorageCacheInfo partition2StorageCacheInfo = lakeTable.getPartitionInfo().getStorageCacheInfo(partition2Id);
-            Assert.assertTrue(partition2StorageCacheInfo.isEnableStorageCache());
+            Assert.assertFalse(partition2StorageCacheInfo.isEnableStorageCache());
             Assert.assertEquals(Config.lake_default_storage_cache_ttl_seconds,
                     partition2StorageCacheInfo.getStorageCacheTtlS());
         }


### PR DESCRIPTION
* enable cache when creating lake table if property key 'enable_storage_cache` is not present in table/parititon properties

Signed-off-by: Kevin Xiaohua Cai <caixiaohua@starrocks.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
