### PR TITLE
[BugFix] Update Statement fail when SET a column using DEFAULT key word(#15181)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -18,6 +18,7 @@ import com.clearspring.analytics.util.Lists;
 import com.google.common.base.Preconditions;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.KeysType;
@@ -26,6 +27,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.ColumnAssignment;
+import com.starrocks.sql.ast.DefaultValueExpr;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -79,6 +81,10 @@ public class UpdateAnalyzer {
             if (assign != null) {
                 if (col.isKey()) {
                     throw new SemanticException("primary key column cannot be updated: " + col.getName());
+                }
+
+                if (assign.getExpr() instanceof DefaultValueExpr) {
+                    assign.setExpr(TypeManager.addCastExpr(new StringLiteral(col.calculatedDefaultValue()), col.getType()));
                 }
 
                 item = new SelectListItem(assign.getExpr(), col.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnAssignment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnAssignment.java
@@ -19,7 +19,7 @@ import com.starrocks.analysis.ParseNode;
 
 public class ColumnAssignment implements ParseNode {
     private final String column;
-    private final Expr expr;
+    private Expr expr;
 
     public ColumnAssignment(String column, Expr expr) {
         this.column = column;
@@ -32,5 +32,9 @@ public class ColumnAssignment implements ParseNode {
 
     public Expr getExpr() {
         return expr;
+    }
+
+    public void setExpr(Expr expr) {
+        this.expr = expr;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -1040,7 +1040,7 @@ public class PlanTestBase {
         starRocksAssert.withTable("CREATE TABLE `tprimary` (\n" +
                 "  `pk` bigint NOT NULL COMMENT \"\",\n" +
                 "  `v1` string NOT NULL COMMENT \"\",\n" +
-                "  `v2` int NOT NULL\n" +
+                "  `v2` int NOT NULL DEFAULT \"100\"\n" +
                 ") ENGINE=OLAP\n" +
                 "PRIMARY KEY(`pk`)\n" +
                 "DISTRIBUTED BY HASH(`pk`) BUCKETS 3\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -43,6 +43,7 @@ public class UpdatePlanTest extends PlanTestBase {
         Assert.assertTrue(explainString.contains("CAST(CAST(3: v2 AS BIGINT) + 1 AS INT)"));
 
         testExplain("explain update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
+        testExplain("explain update tprimary set v2 = DEFAULT where v1 = 'aaa'");
         testExplain("explain verbose update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
         testExplain("explain costs update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15181

## Problem Summary(Required) ：
Problem:
When we Update a column which is defined the default value, if we use set = default in update statement, we will get unknow error because the DefaultValueExpr is not handled properly.

Solution:
Add the some code to cast the DefaultValueExpr to corresponding Literal type.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
