### PR TITLE
[BugFix] Avoid race condition at CRUD resource group

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -485,14 +485,21 @@ void WorkGroupManager::delete_workgroup_unlocked(const WorkGroupPtr& wg) {
     if (version_it == _workgroup_versions.end()) {
         return;
     }
-    auto version_id = version_it->second;
-    DCHECK(version_id < wg->version());
-    auto unique_id = WorkGroup::create_unique_id(id, version_id);
+
+    auto curr_version = version_it->second;
+    if (wg->version() <= curr_version) {
+        LOG(WARNING) << "try to delete workgroup with fresher version: "
+                     << "[delete_version=" << wg->version() << "] "
+                     << "[curr_version=" << curr_version << "]";
+        return;
+    }
+
+    auto unique_id = WorkGroup::create_unique_id(id, curr_version);
     auto wg_it = _workgroups.find(unique_id);
     if (wg_it != _workgroups.end()) {
         wg_it->second->mark_del();
         _workgroup_expired_versions.push_back(unique_id);
-        LOG(INFO) << "workgroup expired version: " << wg->name() << "(" << wg->id() << "," << version_id << ")";
+        LOG(INFO) << "workgroup expired version: " << wg->name() << "(" << wg->id() << "," << curr_version << ")";
     }
     LOG(INFO) << "delete workgroup " << wg->name();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
@@ -452,28 +451,54 @@ public class ResourceGroupMgr implements Writable {
         }
     }
 
-    public ResourceGroup chooseResourceGroupByName(String wgName) {
+    public TWorkGroup chooseResourceGroupByName(String wgName) {
         readLock();
         try {
-            return resourceGroupMap.get(wgName);
+            ResourceGroup rg = resourceGroupMap.get(wgName);
+            if (rg == null) {
+                return null;
+            }
+            return rg.toThrift();
         } finally {
             readUnlock();
         }
     }
 
-    public ResourceGroup chooseResourceGroup(ConnectContext ctx, ResourceGroupClassifier.QueryType queryType,
-                                             Set<Long> databases) {
-        String user = getUnqualifiedUser(ctx);
-        String role = getUnqualifiedRole(ctx);
-        String remoteIp = ctx.getRemoteIP();
-        List<ResourceGroupClassifier> classifierList = classifierMap.values().stream()
-                .filter(f -> f.isSatisfied(user, role, queryType, remoteIp, databases))
-                .sorted(Comparator.comparingDouble(ResourceGroupClassifier::weight))
-                .collect(Collectors.toList());
-        if (classifierList.isEmpty()) {
-            return null;
-        } else {
-            return id2ResourceGroupMap.get(classifierList.get(classifierList.size() - 1).getResourceGroupId());
+    public TWorkGroup chooseResourceGroupByID(long wgID) {
+        readLock();
+        try {
+            ResourceGroup rg = id2ResourceGroupMap.get(wgID);
+            if (rg == null) {
+                return null;
+            }
+            return rg.toThrift();
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public TWorkGroup chooseResourceGroup(ConnectContext ctx, ResourceGroupClassifier.QueryType queryType, Set<Long> databases) {
+        readLock();
+        try {
+            String user = getUnqualifiedUser(ctx);
+            String role = getUnqualifiedRole(ctx);
+            String remoteIp = ctx.getRemoteIP();
+            List<ResourceGroupClassifier> classifierList =
+                    classifierMap.values().stream().filter(f -> f.isSatisfied(user, role, queryType, remoteIp, databases))
+                            .sorted(Comparator.comparingDouble(ResourceGroupClassifier::weight))
+                            .collect(Collectors.toList());
+            if (classifierList.isEmpty()) {
+                return null;
+            } else {
+                ResourceGroup rg =
+                        id2ResourceGroupMap.get(classifierList.get(classifierList.size() - 1).getResourceGroupId());
+                if (rg == null) {
+                    return null;
+                }
+                return rg.toThrift();
+            }
+        } finally {
+            readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
@@ -18,9 +18,9 @@ package com.starrocks.metric;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
-import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.thrift.TWorkGroup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -104,7 +104,7 @@ public class ResourceGroupMetricMgr {
         if (!sessionVariable.isEnableResourceGroup() || !sessionVariable.isEnablePipelineEngine()) {
             return null;
         }
-        ResourceGroup resourceGroup = ctx.getResourceGroup();
+        TWorkGroup resourceGroup = ctx.getResourceGroup();
         return resourceGroup == null ? "default_wg" : resourceGroup.getName();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.InternalCatalog;
-import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.TimeUtils;
@@ -59,6 +58,7 @@ import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -181,7 +181,7 @@ public class ConnectContext {
 
     protected PlannerProfile plannerProfile;
 
-    protected ResourceGroup resourceGroup;
+    protected TWorkGroup resourceGroup;
 
     protected volatile boolean isPending = false;
 
@@ -553,11 +553,11 @@ public class ConnectContext {
         return plannerProfile;
     }
 
-    public ResourceGroup getResourceGroup() {
+    public TWorkGroup getResourceGroup() {
         return resourceGroup;
     }
 
-    public void setResourceGroup(ResourceGroup resourceGroup) {
+    public void setResourceGroup(TWorkGroup resourceGroup) {
         this.resourceGroup = resourceGroup;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -39,7 +39,6 @@ import com.google.common.base.Strings;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -70,6 +69,7 @@ import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TQueryOptions;
+import com.starrocks.thrift.TWorkGroup;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -271,7 +271,7 @@ public class ConnectProcessor {
                 ctx.getDatabase(),
                 sql,
                 ctx.getQualifiedUser(),
-                Optional.ofNullable(ctx.getResourceGroup()).map(ResourceGroup::getName).orElse(""));
+                Optional.ofNullable(ctx.getResourceGroup()).map(TWorkGroup::getName).orElse(""));
         ctx.setQueryDetail(queryDetail);
         //copy queryDetail, cause some properties can be changed in future
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail.copy());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.common.Config;
 import com.starrocks.common.Reference;
@@ -76,6 +75,7 @@ import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TScanRangeParams;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -149,7 +149,7 @@ public class CoordinatorPreprocessor {
     private final Map<TNetworkAddress, Long> addressToBackendID = Maps.newHashMap();
 
     // Resource group
-    private ResourceGroup resourceGroup = null;
+    private TWorkGroup resourceGroup = null;
 
     public CoordinatorPreprocessor(TUniqueId queryId, ConnectContext context, List<PlanFragment> fragments,
                                    List<ScanNode> scanNodes,
@@ -279,7 +279,7 @@ public class CoordinatorPreprocessor {
         return addressToBackendID;
     }
 
-    public ResourceGroup getResourceGroup() {
+    public TWorkGroup getResourceGroup() {
         return resourceGroup;
     }
 
@@ -292,7 +292,7 @@ public class CoordinatorPreprocessor {
         prepareFragments();
 
         // prepare workgroup
-        this.resourceGroup = prepareResourceGroup(connectContext,
+        resourceGroup = prepareResourceGroup(connectContext,
                 queryOptions.getQuery_type() == TQueryType.LOAD ? ResourceGroupClassifier.QueryType.INSERT
                         : ResourceGroupClassifier.QueryType.SELECT);
 
@@ -1229,13 +1229,12 @@ public class CoordinatorPreprocessor {
         return null;
     }
 
-    public static ResourceGroup prepareResourceGroup(ConnectContext connect,
-                                                     ResourceGroupClassifier.QueryType queryType) {
-        ResourceGroup resourceGroup = null;
+    public static TWorkGroup prepareResourceGroup(ConnectContext connect, ResourceGroupClassifier.QueryType queryType) {
         if (connect == null || !connect.getSessionVariable().isEnableResourceGroup()) {
-            return resourceGroup;
+            return null;
         }
         SessionVariable sessionVariable = connect.getSessionVariable();
+        TWorkGroup resourceGroup = null;
 
         // 1. try to use the resource group specified by the variable
         if (StringUtils.isNotEmpty(sessionVariable.getResourceGroup())) {
@@ -1246,8 +1245,7 @@ public class CoordinatorPreprocessor {
         // 2. try to use the resource group specified by workgroup_id
         long workgroupId = connect.getSessionVariable().getResourceGroupId();
         if (resourceGroup == null && workgroupId > 0) {
-            resourceGroup = new ResourceGroup();
-            resourceGroup.setId(workgroupId);
+            resourceGroup = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByID(workgroupId);
         }
 
         // 3. if the specified resource group not exist try to use the default one
@@ -1438,7 +1436,7 @@ public class CoordinatorPreprocessor {
                     boolean enableResourceGroup = sessionVariable.isEnableResourceGroup();
                     commonParams.setEnable_resource_group(enableResourceGroup);
                     if (enableResourceGroup && resourceGroup != null) {
-                        commonParams.setWorkgroup(resourceGroup.toThrift());
+                        commonParams.setWorkgroup(resourceGroup);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -193,6 +193,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String PIPELINE_PROFILE_LEVEL = "pipeline_profile_level";
 
     public static final String RESOURCE_GROUP_ID = "workgroup_id";
+    public static final String RESOURCE_GROUP_ID_V2 = "resource_group_id";
 
     // hash join right table push down
     public static final String HASH_JOIN_PUSH_DOWN_RIGHT_TABLE = "hash_join_push_down_right_table";
@@ -568,7 +569,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_LEVEL)
     private int pipelineProfileLevel = 1;
 
-    @VariableMgr.VarAttr(name = RESOURCE_GROUP_ID, flag = VariableMgr.INVISIBLE)
+    @VariableMgr.VarAttr(name = RESOURCE_GROUP_ID, alias = RESOURCE_GROUP_ID_V2,
+            show = RESOURCE_GROUP_ID_V2, flag = VariableMgr.INVISIBLE)
     private int resourceGroupId = 0;
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -145,6 +145,7 @@ import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
@@ -1095,7 +1096,7 @@ public class StmtExecutor {
         String explainString = "";
         if (parsedStmt.getExplainLevel() == StatementBase.ExplainLevel.VERBOSE) {
             if (context.getSessionVariable().isEnableResourceGroup()) {
-                ResourceGroup resourceGroup = CoordinatorPreprocessor.prepareResourceGroup(context, queryType);
+                TWorkGroup resourceGroup = CoordinatorPreprocessor.prepareResourceGroup(context, queryType);
                 String resourceGroupStr =
                         resourceGroup != null ? resourceGroup.getName() : ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME;
                 explainString += "RESOURCE GROUP: " + resourceGroupStr + "\n\n";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetVar.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetVar.java
@@ -21,7 +21,6 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
-import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
@@ -35,6 +34,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.HeartbeatFlags;
 import com.starrocks.thrift.TTabletInternalParallelMode;
+import com.starrocks.thrift.TWorkGroup;
 import org.apache.commons.lang3.StringUtils;
 
 // change one variable.
@@ -183,12 +183,22 @@ public class SetVar implements ParseNode {
         }
 
         if (getVariable().equalsIgnoreCase(SessionVariable.RESOURCE_GROUP)) {
-            String wgName = getResolvedExpression().getStringValue();
-            if (!StringUtils.isEmpty(wgName)) {
-                ResourceGroup wg =
-                        GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByName(wgName);
+            String rgName = getResolvedExpression().getStringValue();
+            if (!StringUtils.isEmpty(rgName)) {
+                TWorkGroup wg =
+                        GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByName(rgName);
                 if (wg == null) {
-                    throw new SemanticException("resource group not exists: " + wgName);
+                    throw new SemanticException("resource group not exists: " + rgName);
+                }
+            }
+        } else if (getVariable().equalsIgnoreCase(SessionVariable.RESOURCE_GROUP_ID) ||
+                getVariable().equalsIgnoreCase(SessionVariable.RESOURCE_GROUP_ID_V2)) {
+            long rgID = getResolvedExpression().getLongValue();
+            if (rgID > 0) {
+                TWorkGroup wg =
+                        GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByID(rgID);
+                if (wg == null) {
+                    throw new SemanticException("resource group not exists: " + rgID);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -1,7 +1,6 @@
 package com.starrocks.analysis;
 
 import com.google.common.collect.ImmutableSet;
-import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
@@ -9,6 +8,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
@@ -419,7 +419,7 @@ public class ResourceGroupStmtTest {
         starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
         starRocksAssert.getCtx().setRemoteIP(remoteIp);
-        ResourceGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+        TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
                 starRocksAssert.getCtx(),
                 ResourceGroupClassifier.QueryType.SELECT,
                 null);
@@ -435,7 +435,7 @@ public class ResourceGroupStmtTest {
         starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
         starRocksAssert.getCtx().setRemoteIP(remoteIp);
-        ResourceGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+        TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
                 starRocksAssert.getCtx(),
                 ResourceGroupClassifier.QueryType.INSERT,
                 null);
@@ -454,7 +454,7 @@ public class ResourceGroupStmtTest {
         {
             long dbId = GlobalStateMgr.getCurrentState().getDb("db1").getId();
             Set<Long> dbIds = ImmutableSet.of(dbId);
-            ResourceGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+            TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
                     starRocksAssert.getCtx(),
                     ResourceGroupClassifier.QueryType.SELECT,
                     dbIds);
@@ -463,7 +463,7 @@ public class ResourceGroupStmtTest {
         {
             long dbId = GlobalStateMgr.getCurrentState().getDb("db2").getId();
             Set<Long> dbIds = ImmutableSet.of(dbId);
-            ResourceGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+            TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
                     starRocksAssert.getCtx(),
                     ResourceGroupClassifier.QueryType.SELECT,
                     dbIds);
@@ -474,7 +474,7 @@ public class ResourceGroupStmtTest {
             Set<Long> dbIds = ImmutableSet.of(
                     GlobalStateMgr.getCurrentState().getDb("db1").getId(),
                     GlobalStateMgr.getCurrentState().getDb("db2").getId());
-            ResourceGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+            TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
                     starRocksAssert.getCtx(),
                     ResourceGroupClassifier.QueryType.SELECT,
                     dbIds);

--- a/fe/fe-core/src/test/java/com/starrocks/metric/ResourceGroupMetricTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/ResourceGroupMetricTest.java
@@ -45,13 +45,13 @@ public class ResourceGroupMetricTest {
         ResourceGroup wg2 = new ResourceGroup();
         wg2.setName("wg2");
 
-        ctx.setResourceGroup(wg1);
+        ctx.setResourceGroup(wg1.toThrift());
         ctx.getAuditEventBuilder().setResourceGroup(wg1.getName());
         ResourceGroupMetricMgr.increaseQuery(ctx, 1L);
         ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
         ResourceGroupMetricMgr.updateQueryLatency(ctx, 10L);
 
-        ctx.setResourceGroup(wg2);
+        ctx.setResourceGroup(wg2.toThrift());
         ctx.getAuditEventBuilder().setResourceGroup(wg2.getName());
         ResourceGroupMetricMgr.increaseQuery(ctx, 1L);
         ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1631.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. `chooseResourceGroup` doesn't acquire read lock, which causes a race condition where a query is invoking `chooseResourceGroup` and another thread is deleting this workgroup.
2. Even if `chooseResourceGroup` acquires read lock, there is still a race condition when deleting a resource group and querying with this resource group. Therefore, make `chooseResourceGroup` returns a fixed thrift-format workgroup instead of the reference of workgroup.

| Time | Thread1                                                      | Thread2                          |
| ---- | ------------------------------------------------------------ | -------------------------------- |
| 1    | Query get resource group1(version=1) via `chooseResourceGroup` |                                  |
| 2    |                                                              | delete group1, and set version=2 |
| 3    | Deliver query with group1(version=**2**) to BE, so BE will consider group1 is altered and do some alter operations. |                                  |

3. Make `delete_workgroup_unlocked` idempotent instead of crashing when delete version <= current version.

BTW, the behaviours about the session variable `workgroup_id` is wrong. 
- It doesn't check whether this workgroup exists, when set workgroup_id.
- It only pass workgroup.id to BE, not the other necessary fields.



## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
