### PR TITLE
[Enhancement] Ignore socket time out log for thrift server

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/SRTThreadPoolServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SRTThreadPoolServer.java
@@ -29,6 +29,7 @@ import org.apache.thrift.transport.TServerTransport;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
+import java.net.SocketTimeoutException;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -347,6 +348,9 @@ public class SRTThreadPoolServer extends TServer {
                     case TTransportException.END_OF_FILE:
                     case TTransportException.TIMED_OUT:
                         return true;
+                }
+                if (tTransportException.getCause() instanceof SocketTimeoutException) {
+                    return true;
                 }
             }
             return false;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Since we change the socket read timeout to a small value to improve the thrift server throughput, the timeout log is printed frequently. Ignore this exception.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
