### PR TITLE
[Enhancement]Support get profile in json format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1900,6 +1900,13 @@ public class Config extends ConfigBase {
     public static int profile_info_reserved_num = 500;
 
     /**
+     * format of profile infos reserved by `ProfileManager` for recently executed query.
+     * Default value: "default"
+     */
+    @ConfField(mutable = true)
+    public static String profile_info_format = "default";
+
+    /**
      * Max number of roles that can be granted to user including all direct roles and all parent roles
      * Used in new RBAC framework after 3.0 released
      **/

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -131,7 +131,20 @@ public class ProfileManager {
             return "";
         }
 
-        String profileString = profile.toString();
+        String profileString;
+        switch (Config.profile_info_format) {
+            case "default":
+                profileString = profile.toString();
+                break;
+            case "json":
+                RuntimeProfile.ProfileFormater formater = new RuntimeProfile.JsonProfileFormater();
+                profileString = formater.format(profile, "");
+                break;
+            default:
+                profileString = profile.toString();
+                LOG.warn("unknown profile format '{}',  use default format instead.", Config.profile_info_format);
+        }
+
         ProfileElement element = createElement(profile.getChildList().get(0).first, profileString);
         String queryId = element.infoStrings.get(ProfileManager.QUERY_ID);
         // check when push in, which can ensure every element in the list has QUERY_ID column,


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12482

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In some scenarios like automatic profile analysis or profile visualization, we may prefer json format.

After applying this CL, we can get/show profile  in json format. Need to config 'profile_info_format' in FE
```
profile_info_format=json
```
profile in json format as follows:
```
{
  "Query": {
    "Summary": {
      "QueryCpuCost": "0",
      "User": "root",
      "Sql Statement": "select 1",
      "Start Time": "2022-12-14 20:23:39",
      "QueryMemCost": "2.773KB",
      "Variables": "parallel_fragment_exec_instance_num=1,pipeline_dop=0",
      "StarRocks Version": "2.3.3",
      "Collect Profile Time": "1ms",
      "Total": "6ms",
      "Query Type": "Query",
      "Default Db": "",
      "Query ID": "23ea2f1e-7baa-11ed-8ee1-00505698caa8",
      "Query State": "EOF",
      "End Time": "2022-12-14 20:23:39"
    },
    "Planner": {
      "Total": "1ms / 1"
    },
    "Execution Profile 23ea2f1e-7baa-11ed-8ee1-00505698caa8": {
      "ExecutionTotalTime": "187.644us",
      "Fragment 0": {
        "BackendNum": "1",
        "InstanceNum": "1",
        "MemoryLimit": "8.00 GB",
        "PeakMemoryUsage": "488.00 B",
        "Pipeline (id=0)": {
          "ActiveTime": "81.684us",
          "BlockByInputEmpty": "0",
          "BlockByOutputFull": "0",
          "BlockByPrecondition": "0",
          "DegreeOfParallelism": "1",
          "DriverTotalTime": "187.644us",
          "OverheadTime": "81.684us",
          "PendingTime": "0ns",
          "InputEmptyTime": "0ns",
          "FirstInputEmptyTime": "0ns",
          "FollowupInputEmptyTime": "0ns",
          "OutputFullTime": "0ns",
          "PendingFinishTime": "0ns",
          "PreconditionBlockTime": "0ns",
          "ScheduleCount": "1",
          "ScheduleTime": "105.960us",
          "TotalDegreeOfParallelism": "1",
          "YieldByTimeLimit": "0",
          "RESULT_SINK": {
            "CommonMetrics": {
              "CloseTime": "7.92us",
              "OperatorTotalTime": "21.471us",
              "PeakMemoryUsage": "0.00 ",
              "PrepareTime": "30.208us",
              "PullChunkNum": "0",
              "PullRowNum": "0",
              "PullTotalTime": "0ns",
              "PushChunkNum": "1",
              "PushRowNum": "1",
              "PushTotalTime": "13.636us",
              "SetFinishedTime": "188ns",
              "SetFinishingTime": "555ns"
            },
            "UniqueMetrics": {}
          },
          "PROJECT (plan_node_id=1)": {
            "CommonMetrics": {
              "CloseTime": "9.550us",
              "OperatorTotalTime": "18.392us",
              "PeakMemoryUsage": "0.00 ",
              "PrepareTime": "22.356us",
              "PullChunkNum": "1",
              "PullRowNum": "1",
              "PullTotalTime": "566ns",
              "PushChunkNum": "1",
              "PushRowNum": "1",
              "PushTotalTime": "7.812us",
              "SetFinishedTime": "204ns",
              "SetFinishingTime": "260ns"
            },
            "UniqueMetrics": {}
          },
          "UNION_CONST_SOURCE (plan_node_id=0)": {
            "CommonMetrics": {
              "CloseTime": "19.98us",
              "OperatorTotalTime": "51.297us",
              "PeakMemoryUsage": "0.00 ",
              "PrepareTime": "28.98us",
              "PullChunkNum": "1",
              "PullRowNum": "1",
              "PullTotalTime": "31.387us",
              "PushChunkNum": "0",
              "PushRowNum": "0",
              "PushTotalTime": "0ns",
              "SetFinishedTime": "226ns",
              "SetFinishingTime": "586ns"
            },
            "UniqueMetrics": {}
          }
        }
      }
    }
  }
}
```



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
