### PR TITLE
[BugFix] Clear destination of CTE after retrying a query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -289,6 +289,7 @@ public class CoordinatorPreprocessor {
 
     public void prepareExec() throws Exception {
         // prepare information
+        resetFragmentState();
         prepareFragments();
 
         // prepare workgroup
@@ -302,17 +303,22 @@ public class CoordinatorPreprocessor {
         computeBeInstanceNumbers();
     }
 
-    private void prepareFragments() {
+    /**
+     * Reset state of all the fragments set in Coordinator, when retrying the same query with the fragments.
+     */
+    private void resetFragmentState() {
         for (PlanFragment fragment : fragments) {
-            // Clear each destination for multi sink to avoid add destinations multiple times
-            // when retrying the query with these fragments.
             if (fragment instanceof MultiCastPlanFragment) {
                 MultiCastDataSink multiSink = (MultiCastDataSink) fragment.getSink();
                 for (List<TPlanFragmentDestination> destination : multiSink.getDestinations()) {
                     destination.clear();
                 }
             }
-            
+        }
+    }
+
+    private void prepareFragments() {
+        for (PlanFragment fragment : fragments) {
             fragmentExecParamsMap.put(fragment.getFragmentId(), new FragmentExecParams(fragment));
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -304,6 +304,15 @@ public class CoordinatorPreprocessor {
 
     private void prepareFragments() {
         for (PlanFragment fragment : fragments) {
+            // Clear each destination for multi sink to avoid add destinations multiple times
+            // when retrying the query with these fragments.
+            if (fragment instanceof MultiCastPlanFragment) {
+                MultiCastDataSink multiSink = (MultiCastDataSink) fragment.getSink();
+                for (List<TPlanFragmentDestination> destination : multiSink.getDestinations()) {
+                    destination.clear();
+                }
+            }
+            
             fragmentExecParamsMap.put(fragment.getFragmentId(), new FragmentExecParams(fragment));
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15183.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`MultiCastPlanFragment` appends destinations to `MultiCastPlanFragment.dataSink.destinations` in `Coordinator::prepareFragments`.

However, when execution of this query fails and retries, destinations will be appended multiple times.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
