### PR TITLE
[Enhancement][Cherry-pick 2.5] Disable GroupByCountDistinctRewriteRule if has limit (#15138)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
@@ -119,6 +119,11 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
             return false;
         }
 
+        // check limit
+        if (aggregate.hasLimit()) {
+            return false;
+        }
+
         groupBy.add(distinctColumns.get(0).getId());
         return groupBy.containsAll(scan.getDistributionSpec().getShuffleColumns());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -314,7 +314,8 @@ public class ReplayFromDumpTest {
         sessionVariable.setNewPlanerAggStage(1);
         Pair<QueryDumpInfo, String> replayPair =
                 getCostPlanFragment(getDumpInfoFromFile("query_dump/groupby_limit"), sessionVariable);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("1:AGGREGATE (update finalize)"));
+        Assert.assertTrue(replayPair.second, replayPair.second.contains(
+                "aggregate: multi_distinct_count[([1: LO_ORDERKEY, INT, false])"));
     }
 
     @Test


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
