### PR TITLE
[Enhancement] avoid duplicated local shuffle (#15268)

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -58,7 +58,7 @@ void ExchangeSourceOperatorFactory::close_stream_recvr() {
     }
 }
 
-bool ExchangeSourceOperatorFactory::need_local_shuffle() const {
+bool ExchangeSourceOperatorFactory::could_local_shuffle() const {
     DCHECK(_texchange_node.__isset.partition_type);
     // There are two ways of shuffle
     // 1. If previous op is ExchangeSourceOperator and its partition type is HASH_PARTITIONED or BUCKET_SHUFFLE_HASH_PARTITIONED

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -57,4 +57,25 @@ void ExchangeSourceOperatorFactory::close_stream_recvr() {
         _stream_recvr->close();
     }
 }
+
+bool ExchangeSourceOperatorFactory::need_local_shuffle() const {
+    DCHECK(_texchange_node.__isset.partition_type);
+    // There are two ways of shuffle
+    // 1. If previous op is ExchangeSourceOperator and its partition type is HASH_PARTITIONED or BUCKET_SHUFFLE_HASH_PARTITIONED
+    // then pipeline level shuffle will be performed at sender side (ExchangeSinkOperator), so
+    // there is no need to perform local shuffle again at receiver side
+    // 2. Otherwise, add LocalExchangeOperator
+    // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes.
+    return _texchange_node.partition_type != TPartitionType::HASH_PARTITIONED &&
+           _texchange_node.partition_type != TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED;
+}
+
+TPartitionType::type ExchangeSourceOperatorFactory::partition_type() const {
+    DCHECK(_texchange_node.__isset.partition_type);
+    if (_texchange_node.partition_type != TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
+        return SourceOperatorFactory::partition_type();
+    }
+    return _texchange_node.partition_type;
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -50,6 +50,9 @@ public:
         return std::make_shared<ExchangeSourceOperator>(this, _id, _plan_node_id, driver_sequence);
     }
 
+    bool could_local_shuffle() const override;
+    TPartitionType::type partition_type() const override;
+
     std::shared_ptr<DataStreamRecvr> create_stream_recvr(RuntimeState* state,
                                                          const std::shared_ptr<RuntimeProfile>& profile);
     void close_stream_recvr();

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -62,6 +62,9 @@ public:
     size_t degree_of_parallelism_of_source_operator(int32_t source_node_id) const;
     size_t degree_of_parallelism_of_source_operator(const SourceOperatorFactory* source_op) const;
 
+    // Whether the building pipeline `ops` need local shuffle for the next operator.
+    bool could_local_shuffle(OpFactories ops) const;
+
 private:
     static constexpr int kLocalExchangeBufferChunks = 8;
 

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -31,8 +31,15 @@ public:
     }
     virtual size_t degree_of_parallelism() const { return _degree_of_parallelism; }
 
+    // When the pipeline of this source operator wants to insert a local shuffle for some complex operators,
+    // such as hash join and aggregate, use this method to decide whether really need to insert a local shuffle.
+    virtual bool could_local_shuffle() const { return _could_local_shuffle; }
+    void set_could_local_shuffle(bool could_local_shuffle) { _could_local_shuffle = could_local_shuffle; }
+    virtual TPartitionType::type partition_type() const { return TPartitionType::type::HASH_PARTITIONED; }
+
 protected:
     size_t _degree_of_parallelism = 1;
+    bool _could_local_shuffle = true;
 };
 
 class SourceOperator : public Operator {

--- a/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_blocking_node.cpp
@@ -155,21 +155,13 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory> > DistinctBlockingNode::d
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(source_operator.get(), context, rc_rf_probe_collector);
 
-    bool need_local_shuffle = true;
-    if (auto* exchange_op = dynamic_cast<ExchangeSourceOperatorFactory*>(ops_with_sink[0].get());
-        exchange_op != nullptr) {
-        auto& texchange_node = exchange_op->texchange_node();
-        DCHECK(texchange_node.__isset.partition_type);
-        need_local_shuffle = texchange_node.partition_type != TPartitionType::HASH_PARTITIONED &&
-                             texchange_node.partition_type != TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED;
-    }
-    if (need_local_shuffle) {
+    if (context->could_local_shuffle(ops_with_sink)) {
         ops_with_sink =
                 context->maybe_interpolate_local_shuffle_exchange(runtime_state(), ops_with_sink, partition_expr_ctxs);
     }
-
     ops_with_sink.push_back(std::move(sink_operator));
     context->add_pipeline(ops_with_sink);
+
     // Aggregator must be used by a pair of sink and source operators,
     // so operators_with_source's degree of parallelism must be equal with ops_with_sink's
     auto degree_of_parallelism = ((SourceOperatorFactory*)(ops_with_sink[0].get()))->degree_of_parallelism();

--- a/be/src/exec/vectorized/hash_join_node.cpp
+++ b/be/src/exec/vectorized/hash_join_node.cpp
@@ -448,32 +448,11 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
             // there is no need to perform local shuffle again at receiver side
             // 2. Otherwise, add LocalExchangeOperator
             // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into HashJoin{Build, Probe}Operator.
-            TPartitionType::type part_type = TPartitionType::type::HASH_PARTITIONED;
-            bool rhs_need_local_shuffle = true;
-            if (auto* exchange_op = dynamic_cast<ExchangeSourceOperatorFactory*>(rhs_operators[0].get());
-                exchange_op != nullptr) {
-                auto& texchange_node = exchange_op->texchange_node();
-                DCHECK(texchange_node.__isset.partition_type);
-                if (texchange_node.partition_type == TPartitionType::HASH_PARTITIONED ||
-                    texchange_node.partition_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
-                    part_type = texchange_node.partition_type;
-                    rhs_need_local_shuffle = false;
-                }
-            }
-            bool lhs_need_local_shuffle = true;
-            if (auto* exchange_op = dynamic_cast<ExchangeSourceOperatorFactory*>(lhs_operators[0].get());
-                exchange_op != nullptr) {
-                auto& texchange_node = exchange_op->texchange_node();
-                DCHECK(texchange_node.__isset.partition_type);
-                if (texchange_node.partition_type == TPartitionType::HASH_PARTITIONED ||
-                    texchange_node.partition_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
-                    part_type = texchange_node.partition_type;
-                    lhs_need_local_shuffle = false;
-                }
-            }
+            TPartitionType::type part_type =
+                    down_cast<SourceOperatorFactory*>(rhs_operators[0].get())->partition_type();
 
             // Make sure that local shuffle use the same hash function as the remote exchange sink do
-            if (rhs_need_local_shuffle) {
+            if (context->could_local_shuffle(rhs_operators)) {
                 if (part_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
                     DCHECK(!_build_equivalence_partition_expr_ctxs.empty());
                     rhs_operators = context->maybe_interpolate_local_shuffle_exchange(
@@ -483,7 +462,7 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
                                                                                       _build_expr_ctxs, part_type);
                 }
             }
-            if (lhs_need_local_shuffle) {
+            if (context->could_local_shuffle(lhs_operators)) {
                 if (part_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED) {
                     DCHECK(!_probe_equivalence_partition_expr_ctxs.empty());
                     lhs_operators = context->maybe_interpolate_local_shuffle_exchange(


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This is cherry-picked from #15268.

> As for multiple operators who need shuffle property in the same fragment, local shuffle only need insert once after the source operator of this fragment.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
