### PR TITLE
[BugFix] Using json as TxnFinishState serde

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -51,6 +51,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.task.PublishVersionTask;
@@ -58,6 +59,7 @@ import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TUniqueId;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -712,16 +714,15 @@ public class TransactionState implements Writable {
         out.writeLong(commitTime);
         out.writeLong(finishTime);
         // if txn use new publish mechanism, store state in the space originally used by `reason`
+        // if new publish with TxnFinishState, write json {"normal":[xx],"abnormal":[xxx,xxx]}
+        // else write `reason` field
+        // they are both String, so they are compatible
         if (transactionStatus == TransactionStatus.VISIBLE) {
             if (newFinish) {
                 Preconditions.checkNotNull(finishState);
-                // write 1 as version number
-                byte[] bytes = finishState.toBytes();
-                out.writeInt(bytes.length + 1);
-                out.writeByte(1);
-                out.write(bytes);
+                Text.writeString(out, GsonUtils.GSON.toJson(finishState));
             } else {
-                out.writeInt(0);
+                Text.writeString(out, "");
             }
         } else {
             Text.writeString(out, reason);
@@ -787,14 +788,37 @@ public class TransactionState implements Writable {
             if (len == 0) {
                 newFinish = false;
             } else {
-                in.readByte(); // skip the first byte, which is the version number
-                byte[] bytes = new byte[len - 1];
+                byte[] bytes = new byte[len];
                 in.readFully(bytes);
-                if (finishState == null) {
-                    finishState = new TxnFinishState();
+                try {
+                    // originally, TxnFinishState is serialized using protobuf(baidu jprotobuf),
+                    // but looks like the ser/deser is not compatible with java native serialization
+                    // causing FE error when upgrading, so changed to json serialization, but keep
+                    // the old deserialization code here for compatibility
+                    // see: https://github.com/StarRocks/starrocks/issues/15248
+                    byte version = bytes[0];
+                    if (version == 1) {
+                        if (finishState == null) {
+                            finishState = new TxnFinishState();
+                        }
+                        byte[] pbBytes = new byte[len - 1];
+                        System.arraycopy(bytes, 1, pbBytes, 0, len - 1);
+                        finishState.fromBytes(pbBytes);
+                        newFinish = true;
+                    } else {
+                        String content = Text.decode(bytes);
+                        if (content.length() > 2 && content.charAt(0) == '{') {
+                            finishState = GsonUtils.GSON.fromJson(content, TxnFinishState.class);
+                            newFinish = true;
+                        } else {
+                            // old reason
+                            reason = content;
+                            newFinish = false;
+                        }
+                    }
+                } catch (IOException e) {
+                    LOG.warn("failed to deserialize TxnFinishState data: " + Hex.encodeHexString(bytes));
                 }
-                finishState.fromBytes(bytes);
-                newFinish = true;
             }
         } else {
             reason = Text.readString(in);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TxnFinishState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TxnFinishState.java
@@ -17,6 +17,7 @@ package com.starrocks.transaction;
 import com.baidu.bjf.remoting.protobuf.Codec;
 import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
 import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.proto.TxnFinishStatePB;
 
 import java.io.IOException;
@@ -40,8 +41,10 @@ public class TxnFinishState {
     private static Codec<TxnFinishStatePB> finishStatePBCodec = ProtobufProxy.create(TxnFinishStatePB.class);
 
     // store involved replicas with version that is same as version in commitInfo
+    @SerializedName("normal")
     public Set<Long> normalReplicas = new HashSet<>();
     // store replica,version pairs that version != commit version
+    @SerializedName("abnormal")
     public Map<Long, Long> abnormalReplicasWithVersion = new HashMap<>();
 
     public TxnFinishStatePB toPB() {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.meta.MetaContext;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.proto.TxnFinishStatePB;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
@@ -96,6 +97,18 @@ public class TransactionStateTest {
             TxnFinishStatePB txn2 = finishStatePBCodec.decode(bytes);
             Assert.assertEquals(txnFinishStatePB.normalReplicas.size(), txn2.normalReplicas.size());
             Assert.assertEquals(txnFinishStatePB.abnormalReplicasWithVersion.size(), txn2.abnormalReplicasWithVersion.size());
+        }
+    }
+
+    @Test
+    public void testSerDeTxnFinishStateJSON() throws IOException {
+        for (int i = 1; i <= 100000; i *= 10) {
+            TxnFinishState s1 = buildTxnFinishState(i);
+            String json = GsonUtils.GSON.toJson(s1);
+            System.out.printf("json: %s\n", json);
+            TxnFinishState s2 = GsonUtils.GSON.fromJson(json, TxnFinishState.class);
+            Assert.assertEquals(s1.normalReplicas.size(), s2.normalReplicas.size());
+            Assert.assertEquals(s1.abnormalReplicasWithVersion.size(), s2.abnormalReplicasWithVersion.size());
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15248

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Originally, TxnFinishState is serialized using protobuf(baidu jprotobuf) and using the existing field `reason` in TxnState, when upgrading from version before 2.4 to 2.5, TxnFinishState serialized as binary string will be treated as `reason` string in older not upgraded FE, and the serialization of `reason` string will replace illegal chars in the string, which will corrupt TxnFinishState. So serialization using binary format is dangerous, and this PR change serialization format from protobuf to json.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
