### PR TITLE
[BugFix] Fix the problem of null aware anti join

### DIFF
--- a/be/src/exec/vectorized/join_hash_map.h
+++ b/be/src/exec/vectorized/join_hash_map.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#define JOIN_HASH_MAP_H
+
 #include <gen_cpp/PlanNodes_types.h>
 #include <runtime/descriptors.h>
 #include <runtime/runtime_state.h>
@@ -747,4 +749,8 @@ private:
 };
 } // namespace starrocks::vectorized
 
+#ifndef JOIN_HASH_MAP_TPP
 #include "exec/vectorized/join_hash_map.tpp"
+#endif
+
+#undef JOIN_HASH_MAP_H

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -14,6 +14,12 @@
 
 #include "simd/simd.h"
 
+#define JOIN_HASH_MAP_TPP
+
+#ifndef JOIN_HASH_MAP_H
+#include "join_hash_map.h"
+#endif
+
 namespace starrocks::vectorized {
 template <LogicalType PT>
 void JoinBuildFunc<PT>::prepare(RuntimeState* runtime, JoinHashTableItems* table_items) {
@@ -1702,3 +1708,5 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_full_outer_join_w
 }
 
 } // namespace starrocks::vectorized
+
+#undef JOIN_HASH_MAP_TPP

--- a/be/src/exec/vectorized/join_hash_map.tpp
+++ b/be/src/exec/vectorized/join_hash_map.tpp
@@ -1478,6 +1478,7 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
 
     size_t probe_row_count = _probe_state->probe_row_count;
     for (; i < probe_row_count; i++) {
+        _probe_state->cur_row_match_count = 0;
         size_t build_index = _probe_state->next[i];
         if (build_index == 0) {
             bool change_flag = false;
@@ -1542,7 +1543,6 @@ void JoinHashMap<PT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
 
             RETURN_IF_CHUNK_FULL()
         }
-        _probe_state->cur_row_match_count = 0;
     }
     _probe_state->has_null_build_tuple = true;
     PROBE_OVER()


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15260

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```cpp
    if (build_index == 0) {
            ...
            // Here miss reseting cur_row_match_count
            continue;
        }
```

So I move the `_probe_state->cur_row_match_count = 0;` from end of the loop to the beginning

## Other changes

Since all the implementations of template JoinHashMap are written in `join_hash_map.tpp`, but this kind of code formation cannot work well with lsp plugin, so,  I add some macro conditions to make `.h` and `.tpp` files include each other


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
