### PR TITLE
[Enhancement] avoid copy user‘s data to butil::IOBuff

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -73,7 +73,7 @@ public:
     // This function is only used when broadcast, because request can be reused
     // by all the channels.
     Status send_chunk_request(RuntimeState* state, PTransmitChunkParamsPtr chunk_request,
-                              const butil::IOBuf& attachment, int64_t attachment_physical_bytes);
+                              const butil::IOBuf& attachment, std::shared_ptr<ChunksDataRef> chunks_data_ref);
 
     // Used when doing shuffle.
     // This function will copy selective rows in chunks to batch.
@@ -249,9 +249,9 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(RuntimeState* state, const 
             delta_statistic->to_pb(_chunk_request->mutable_query_statistics());
         }
         butil::IOBuf attachment;
-        int64_t attachment_physical_bytes = _parent->construct_brpc_attachment(_chunk_request, attachment);
+        auto chunks_data_ref = _parent->construct_brpc_attachment(_chunk_request, attachment);
         TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment,
-                                  attachment_physical_bytes};
+                                  std::move(chunks_data_ref)};
         RETURN_IF_ERROR(_parent->_buffer->add_request(info));
         _current_request_bytes = 0;
         _chunk_request.reset();
@@ -263,7 +263,7 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(RuntimeState* state, const 
 
 Status ExchangeSinkOperator::Channel::send_chunk_request(RuntimeState* state, PTransmitChunkParamsPtr chunk_request,
                                                          const butil::IOBuf& attachment,
-                                                         int64_t attachment_physical_bytes) {
+                                                         std::shared_ptr<ChunksDataRef> chunks_data_ref) {
     if (_ignore_local_data) {
         return Status::OK();
     }
@@ -278,7 +278,7 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(RuntimeState* state, PT
     }
 
     TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment,
-                              attachment_physical_bytes};
+                              chunks_data_ref};
     RETURN_IF_ERROR(_parent->_buffer->add_request(info));
 
     return Status::OK();
@@ -509,12 +509,11 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chu
             // 3. if request bytes exceede the threshold, send current request
             if (_current_request_bytes > config::max_transmit_batched_bytes) {
                 butil::IOBuf attachment;
-                int64_t attachment_physical_bytes = construct_brpc_attachment(_chunk_request, attachment);
+                auto chunks_data_ref = construct_brpc_attachment(_chunk_request, attachment);
                 for (auto idx : _channel_indices) {
                     if (!_channels[idx]->use_pass_through()) {
                         PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
-                        RETURN_IF_ERROR(
-                                _channels[idx]->send_chunk_request(state, copy, attachment, attachment_physical_bytes));
+                        RETURN_IF_ERROR(_channels[idx]->send_chunk_request(state, copy, attachment, chunks_data_ref));
                     }
                 }
                 _current_request_bytes = 0;
@@ -616,10 +615,10 @@ Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 
     if (_chunk_request != nullptr) {
         butil::IOBuf attachment;
-        int64_t attachment_physical_bytes = construct_brpc_attachment(_chunk_request, attachment);
+        auto chunks_data_ref = construct_brpc_attachment(_chunk_request, attachment);
         for (const auto& [_, channel] : _instance_id2channel) {
             PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
-            channel->send_chunk_request(state, copy, attachment, attachment_physical_bytes);
+            channel->send_chunk_request(state, copy, attachment, chunks_data_ref);
         }
         _current_request_bytes = 0;
         _chunk_request.reset();
@@ -710,40 +709,34 @@ Status ExchangeSinkOperator::serialize_chunk(const Chunk* src, ChunkPB* dst, boo
     return Status::OK();
 }
 
-int64_t ExchangeSinkOperator::construct_brpc_attachment(const PTransmitChunkParamsPtr& chunk_request,
-                                                        butil::IOBuf& attachment) {
-    int64_t attachment_physical_bytes = 0;
+std::shared_ptr<ChunksDataRef> ExchangeSinkOperator::construct_brpc_attachment(
+        const PTransmitChunkParamsPtr& chunk_request, butil::IOBuf& attachment) {
+    auto chunks_data_ref = std::make_shared<ChunksDataRef>(0);
     for (int i = 0; i < chunk_request->chunks().size(); ++i) {
         auto chunk = chunk_request->mutable_chunks(i);
         chunk->set_data_size(chunk->data().size());
 
-#ifndef NDEBUG
-        // avoid AddressSanitizer: alloc-dealloc-mismatch
-        int64_t before_bytes = CurrentThread::current().get_consumed_bytes();
-        // if avoid this copy of `append()`, the chunk shouldn't be deleted until sent many times. To simple such
-        // issue, here just directly append().
-        attachment.append(chunk->data());
-        attachment_physical_bytes += CurrentThread::current().get_consumed_bytes() - before_bytes;
-#else
-        attachment_physical_bytes += chunk->data().size();
-        // release chunk->data() to iobuf
-        auto res = attachment.append_user_data((void*)((static_cast<std::string*>(chunk->release_data()))->c_str()),
-                                               chunk->data().size(), [](void* buf) { delete[] (char*)buf; });
+        chunks_data_ref->data_bytes += chunk->data().size();
+
+        auto shared_data = std::make_shared<std::string>();
+        chunk->mutable_data()->swap(*shared_data);
+        if (UNLIKELY(chunk->data_size() != shared_data->size())) {
+            throw std::runtime_error(
+                    fmt::format("chunk size {} != shared data {}.", chunk->data_size(), shared_data->size()));
+        }
+        auto res = attachment.append_user_data((void*)shared_data->c_str(), shared_data->size(), [](void* buf) {});
         if (UNLIKELY(res != 0)) {
             throw std::runtime_error("append user data to brpc iobuf error.");
         }
-        if (UNLIKELY(!chunk->data().empty())) {
-            throw std::runtime_error("chunk is not empty after released.");
-        }
-#endif
         chunk->clear_data();
+        chunks_data_ref->chunks_data_ref.push_back(std::move(shared_data));
 
         // If the request is too big, free the memory in order to avoid OOM
         if (_is_large_chunk(chunk->data_size())) {
             chunk->mutable_data()->shrink_to_fit();
         }
     }
-    return attachment_physical_bytes;
+    return chunks_data_ref;
 }
 
 ExchangeSinkOperatorFactory::ExchangeSinkOperatorFactory(

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -722,12 +722,12 @@ int64_t ExchangeSinkOperator::construct_brpc_attachment(const PTransmitChunkPara
         int64_t before_bytes = CurrentThread::current().get_consumed_bytes();
 
         if (_encode_context != nullptr && _encode_context->get_session_encode_level() >= 32) {
-            size_t size = attachment.append_user_data((void*)(chunk->data().c_str()), chunk->data().size(), none_free);
-            attachment_physical_bytes += size;
-        } else {
             attachment.append(chunk->data());
             attachment_physical_bytes += CurrentThread::current().get_consumed_bytes() - before_bytes;
             chunk->clear_data();
+        } else {
+            size_t size = attachment.append_user_data((void*)(chunk->data().c_str()), chunk->data().size(), none_free);
+            attachment_physical_bytes += size;
         }
 
         // If the request is too big, free the memory in order to avoid OOM

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -38,8 +38,6 @@
 
 namespace starrocks::pipeline {
 
-
-
 class ExchangeSinkOperator::Channel {
 public:
     // Create channel to send data to particular ipaddress/port/query/node

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -711,7 +711,7 @@ Status ExchangeSinkOperator::serialize_chunk(const Chunk* src, ChunkPB* dst, boo
     return Status::OK();
 }
 
-static void NoOpDeleter(void *) {}
+static void none_free(void *) {}
 
 int64_t ExchangeSinkOperator::construct_brpc_attachment(const PTransmitChunkParamsPtr& chunk_request,
                                                         butil::IOBuf& attachment) {
@@ -723,7 +723,7 @@ int64_t ExchangeSinkOperator::construct_brpc_attachment(const PTransmitChunkPara
 
         if (_encode_context != nullptr && _encode_context->get_session_encode_level() >= 32) {
             size_t size =
-                    attachment.append_user_data((void*)(chunk->data().c_str()), chunk->data().size(), NoOpDeleter);
+                    attachment.append_user_data((void*)(chunk->data().c_str()), chunk->data().size(), none_free);
             attachment_physical_bytes += size;
         } else {
             attachment.append(chunk->data());

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -729,7 +729,7 @@ std::shared_ptr<ChunksDataRef> ExchangeSinkOperator::construct_brpc_attachment(
             throw std::runtime_error("append user data to brpc iobuf error.");
         }
         chunk->clear_data();
-        chunks_data_ref->chunks_data_ref.push_back(std::move(shared_data));
+        chunks_data_ref->data_buffer.push_back(std::move(shared_data));
 
         // If the request is too big, free the memory in order to avoid OOM
         if (_is_large_chunk(chunk->data_size())) {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -711,7 +711,7 @@ Status ExchangeSinkOperator::serialize_chunk(const Chunk* src, ChunkPB* dst, boo
     return Status::OK();
 }
 
-static void none_free(void *) {}
+static void none_free(void*) {}
 
 int64_t ExchangeSinkOperator::construct_brpc_attachment(const PTransmitChunkParamsPtr& chunk_request,
                                                         butil::IOBuf& attachment) {
@@ -722,8 +722,7 @@ int64_t ExchangeSinkOperator::construct_brpc_attachment(const PTransmitChunkPara
         int64_t before_bytes = CurrentThread::current().get_consumed_bytes();
 
         if (_encode_context != nullptr && _encode_context->get_session_encode_level() >= 32) {
-            size_t size =
-                    attachment.append_user_data((void*)(chunk->data().c_str()), chunk->data().size(), none_free);
+            size_t size = attachment.append_user_data((void*)(chunk->data().c_str()), chunk->data().size(), none_free);
             attachment_physical_bytes += size;
         } else {
             attachment.append(chunk->data());

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -79,8 +79,9 @@ public:
     // For other chunk, only serialize the chunk data to ChunkPB.
     Status serialize_chunk(const Chunk* chunk, ChunkPB* dst, bool* is_first_chunk, int num_receivers = 1);
 
-    // Return the physical bytes of attachment.
-    int64_t construct_brpc_attachment(const PTransmitChunkParamsPtr& _chunk_request, butil::IOBuf& attachment);
+    // Return the physical bytes of attachment and chunks data ref.
+    std::shared_ptr<ChunksDataRef> construct_brpc_attachment(const PTransmitChunkParamsPtr& _chunk_request,
+                                                             butil::IOBuf& attachment);
 
 private:
     bool _is_large_chunk(size_t sz) const {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -80,7 +80,8 @@ public:
     Status serialize_chunk(const Chunk* chunk, ChunkPB* dst, bool* is_first_chunk, int num_receivers = 1);
 
     // Return the physical bytes of attachment.
-    int64_t construct_brpc_attachment(const PTransmitChunkParamsPtr& _chunk_request, butil::IOBuf& attachment);
+    int64_t construct_brpc_attachment(const PTransmitChunkParamsPtr& _chunk_request, butil::IOBuf& attachment,
+                                      bool copy);
 
 private:
     bool _is_large_chunk(size_t sz) const {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -81,7 +81,7 @@ public:
 
     // Return the physical bytes of attachment.
     int64_t construct_brpc_attachment(const PTransmitChunkParamsPtr& _chunk_request, butil::IOBuf& attachment,
-                                      bool copy);
+                                      bool copy = true);
 
 private:
     bool _is_large_chunk(size_t sz) const {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -80,8 +80,7 @@ public:
     Status serialize_chunk(const Chunk* chunk, ChunkPB* dst, bool* is_first_chunk, int num_receivers = 1);
 
     // Return the physical bytes of attachment.
-    int64_t construct_brpc_attachment(const PTransmitChunkParamsPtr& _chunk_request, butil::IOBuf& attachment,
-                                      bool copy = true);
+    int64_t construct_brpc_attachment(const PTransmitChunkParamsPtr& _chunk_request, butil::IOBuf& attachment);
 
 private:
     bool _is_large_chunk(size_t sz) const {

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -322,7 +322,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         }
 
         auto* closure = new DisposableClosure<PTransmitChunkResult, ClosureContext>(
-                {instance_id, request.params->sequence(), GetCurrentTimeNanos()});
+                {instance_id, request.params->sequence(), GetCurrentTimeNanos(), request.chunk_data_ref});
         if (_first_send_time == -1) {
             _first_send_time = MonotonicNanos();
         }
@@ -365,8 +365,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
         // Attachment will be released by process_mem_tracker in closure->Run() in bthread, when receiving the response,
         // so decrease the memory usage of attachment from instance_mem_tracker immediately before sending the request.
-        _mem_tracker->release(request.attachment_physical_bytes);
-        ExecEnv::GetInstance()->process_mem_tracker()->consume(request.attachment_physical_bytes);
+        _mem_tracker->release(request.chunk_data_ref->data_bytes);
+        ExecEnv::GetInstance()->process_mem_tracker()->consume(request.chunk_data_ref->data_bytes);
 
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -80,8 +80,8 @@ Status SinkBuffer::add_request(TransmitChunkInfo& request) {
     if (_is_finishing) {
         return Status::OK();
     }
-    if (request.attachment_physical_bytes > 0) {
-        _bytes_enqueued += request.attachment_physical_bytes;
+    if (!request.attachment.empty()) {
+        _bytes_enqueued += request.attachment.size();
         _request_enqueued++;
     }
     {
@@ -316,8 +316,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         *request.params->mutable_finst_id() = _instance_id2finst_id[instance_id.lo];
         request.params->set_sequence(++_request_seqs[instance_id.lo]);
 
-        if (request.attachment_physical_bytes > 0) {
-            _bytes_sent += request.attachment_physical_bytes;
+        if (!request.attachment.empty()) {
+            _bytes_sent += request.attachment.size();
             _request_sent++;
         }
 

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -380,7 +380,6 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
             request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
         }
-
         return Status::OK();
     }
 

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -322,7 +322,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         }
 
         auto* closure = new DisposableClosure<PTransmitChunkResult, ClosureContext>(
-                {instance_id, request.params->sequence(), GetCurrentTimeNanos(), request.chunk_data_ref});
+                {instance_id, request.params->sequence(), GetCurrentTimeNanos(), request.chunks_data_ref});
         if (_first_send_time == -1) {
             _first_send_time = MonotonicNanos();
         }
@@ -365,8 +365,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
         // Attachment will be released by process_mem_tracker in closure->Run() in bthread, when receiving the response,
         // so decrease the memory usage of attachment from instance_mem_tracker immediately before sending the request.
-        _mem_tracker->release(request.chunk_data_ref->data_bytes);
-        ExecEnv::GetInstance()->process_mem_tracker()->consume(request.chunk_data_ref->data_bytes);
+        _mem_tracker->release(request.chunks_data_ref->data_bytes);
+        ExecEnv::GetInstance()->process_mem_tracker()->consume(request.chunks_data_ref->data_bytes);
 
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -80,8 +80,8 @@ Status SinkBuffer::add_request(TransmitChunkInfo& request) {
     if (_is_finishing) {
         return Status::OK();
     }
-    if (!request.attachment.empty()) {
-        _bytes_enqueued += request.attachment.size();
+    if (request.attachment_physical_bytes > 0) {
+        _bytes_enqueued += request.attachment_physical_bytes;
         _request_enqueued++;
     }
     {
@@ -316,8 +316,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         *request.params->mutable_finst_id() = _instance_id2finst_id[instance_id.lo];
         request.params->set_sequence(++_request_seqs[instance_id.lo]);
 
-        if (!request.attachment.empty()) {
-            _bytes_sent += request.attachment.size();
+        if (request.attachment_physical_bytes > 0) {
+            _bytes_sent += request.attachment_physical_bytes;
             _request_sent++;
         }
 

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -38,6 +38,12 @@ namespace starrocks::pipeline {
 
 using PTransmitChunkParamsPtr = std::shared_ptr<PTransmitChunkParams>;
 
+struct ChunksDataRef {
+    ChunksDataRef(int64_t bytes) : data_bytes(bytes) {}
+    std::vector<std::shared_ptr<string>> chunks_data_ref;
+    int64_t data_bytes;
+};
+
 struct TransmitChunkInfo {
     // For BUCKET_SHUFFLE_HASH_PARTITIONED, multiple channels may be related to
     // a same exchange source fragment instance, so we should use fragment_instance_id
@@ -46,13 +52,14 @@ struct TransmitChunkInfo {
     doris::PBackendService_Stub* brpc_stub;
     PTransmitChunkParamsPtr params;
     butil::IOBuf attachment;
-    int64_t attachment_physical_bytes;
+    std::shared_ptr<ChunksDataRef> chunk_data_ref;
 };
 
 struct ClosureContext {
     TUniqueId instance_id;
     int64_t sequence;
     int64_t send_timestamp;
+    std::shared_ptr<ChunksDataRef> chunk_data_ref;
 };
 
 // TimeTrace is introduced to estimate time more accurately.

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -38,9 +38,11 @@ namespace starrocks::pipeline {
 
 using PTransmitChunkParamsPtr = std::shared_ptr<PTransmitChunkParams>;
 
+// ChunksDataRef holds reference to chunks' data and is released after sent by brpc,
+// so that it is valid that brpc IO::buf refers to the c_str of data chunks' data.
 struct ChunksDataRef {
     ChunksDataRef(int64_t bytes) : data_bytes(bytes) {}
-    std::vector<std::shared_ptr<string>> chunks_data_ref;
+    std::vector<std::shared_ptr<string>> data_buffer;
     int64_t data_bytes;
 };
 
@@ -52,14 +54,14 @@ struct TransmitChunkInfo {
     doris::PBackendService_Stub* brpc_stub;
     PTransmitChunkParamsPtr params;
     butil::IOBuf attachment;
-    std::shared_ptr<ChunksDataRef> chunk_data_ref;
+    std::shared_ptr<ChunksDataRef> chunks_data_ref;
 };
 
 struct ClosureContext {
     TUniqueId instance_id;
     int64_t sequence;
     int64_t send_timestamp;
-    std::shared_ptr<ChunksDataRef> chunk_data_ref;
+    std::shared_ptr<ChunksDataRef> chunks_data_ref;
 };
 
 // TimeTrace is introduced to estimate time more accurately.

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -167,6 +167,7 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
                 auto msg = fmt::format("iobuf's size {} < {}", io_buf.size(), chunk->data_size());
                 LOG(WARNING) << msg;
                 st = Status::InternalError(msg);
+                return;
             }
             // Note the ref memory is freed after closure is called.
             auto size = io_buf.cutn(chunk->mutable_data(), chunk->data_size());
@@ -174,6 +175,7 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
                 auto msg = fmt::format("iobuf read {} != expected {}.", size, chunk->data_size());
                 LOG(WARNING) << msg;
                 st = Status::InternalError(msg);
+                return;
             }
             offset += chunk->data_size();
         }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -150,7 +150,6 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
         size_t offset = 0;
         for (size_t i = 0; i < req->chunks().size(); ++i) {
             auto chunk = req->mutable_chunks(i);
-#if 1
             if (UNLIKELY(io_buf.size() < chunk->data_size())) {
                 auto msg = fmt::format("iobuf's size {} < {}", io_buf.size(), chunk->data_size());
                 LOG(WARNING) << msg;
@@ -159,13 +158,10 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
             // Note the ref memory is freed after closure is called.
             auto size = io_buf.cutn(chunk->mutable_data(), chunk->data_size());
             if (UNLIKELY(size != chunk->data_size())) {
-                auto msg = fmt::format("read {} != expected {}.", size, chunk->data_size());
+                auto msg = fmt::format("iobuf read {} != expected {}.", size, chunk->data_size());
                 LOG(WARNING) << msg;
                 throw std::runtime_error(msg);
             }
-#else
-            io_buf.copy_to(chunk->mutable_data(), chunk->data_size(), offset);
-#endif
             offset += chunk->data_size();
         }
     }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -169,7 +169,7 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
     st.to_protobuf(response->mutable_status());
     TRY_CATCH_ALL(st, _exec_env->stream_mgr()->transmit_chunk(*request, &done));
     if (!st.ok()) {
-        LOG(WARNING) << msg << " failed.";
+        LOG(WARNING) << "failed to " << msg;
     }
     if (done != nullptr) {
         // NOTE: only when done is not null, we can set response status

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -134,8 +134,10 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
                                                   const PTransmitChunkParams* request, PTransmitChunkResult* response,
                                                   google::protobuf::Closure* done) {
     auto begin_ts = MonotonicNanos();
-    VLOG_ROW << "transmit data: " << (uint64_t)(request) << " fragment_instance_id=" << print_id(request->finst_id())
-             << " node=" << request->node_id() << " begin";
+    auto msg = "transmit data: " + std::to_string((uint64_t)(request)) +
+               " fragment_instance_id=" + print_id(request->finst_id()) +
+               " node = " + std::to_string(request->node_id());
+    VLOG_ROW << msg << " begin";
     // NOTE: we should give a default value to response to avoid concurrent risk
     // If we don't give response here, stream manager will call done->Run before
     // transmit_data(), which will cause a dirty memory access.
@@ -154,6 +156,7 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
                 LOG(WARNING) << msg;
                 throw std::runtime_error(msg);
             }
+            // Note the ref memory is freed after closure is called.
             auto size = io_buf.cutn(chunk->mutable_data(), chunk->data_size());
             if (UNLIKELY(size != chunk->data_size())) {
                 auto msg = fmt::format("read {} != expected {}.", size, chunk->data_size());
@@ -170,16 +173,14 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
     st.to_protobuf(response->mutable_status());
     TRY_CATCH_ALL(st, _exec_env->stream_mgr()->transmit_chunk(*request, &done));
     if (!st.ok()) {
-        LOG(WARNING) << "transmit_data failed, message=" << st.get_error_msg()
-                     << ", fragment_instance_id=" << print_id(request->finst_id()) << ", node=" << request->node_id();
+        LOG(WARNING) << msg << " failed.";
     }
     if (done != nullptr) {
         // NOTE: only when done is not null, we can set response status
         st.to_protobuf(response->mutable_status());
         done->Run();
     }
-    VLOG_ROW << "transmit data: " << (uint64_t)(request) << " fragment_instance_id=" << print_id(request->finst_id())
-             << " node=" << request->node_id() << " cost time = " << MonotonicNanos() - begin_ts;
+    VLOG_ROW << msg << " cost time = " << MonotonicNanos() - begin_ts;
 }
 
 template <typename T>

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -160,7 +160,6 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
     });
     if (cntl->request_attachment().size() > 0) {
         butil::IOBuf& io_buf = cntl->request_attachment();
-        size_t offset = 0;
         for (size_t i = 0; i < req->chunks().size(); ++i) {
             auto chunk = req->mutable_chunks(i);
             if (UNLIKELY(io_buf.size() < chunk->data_size())) {
@@ -169,7 +168,7 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
                 st = Status::InternalError(msg);
                 return;
             }
-            // Note the ref memory is freed after closure is called.
+            // also with copying due to the discontinuous memory in chunk
             auto size = io_buf.cutn(chunk->mutable_data(), chunk->data_size());
             if (UNLIKELY(size != chunk->data_size())) {
                 auto msg = fmt::format("iobuf read {} != expected {}.", size, chunk->data_size());
@@ -177,7 +176,6 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
                 st = Status::InternalError(msg);
                 return;
             }
-            offset += chunk->data_size();
         }
     }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -155,7 +155,6 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
                 throw std::runtime_error(msg);
             }
             auto size = io_buf.cutn(chunk->mutable_data(), chunk->data_size());
-            LOG(WARNING) << i << " th read chunk size = " << size;
             if (UNLIKELY(size != chunk->data_size())) {
                 auto msg = fmt::format("read {} != expected {}.", size, chunk->data_size());
                 LOG(WARNING) << msg;


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

chunkPB list is copied to/from butil::IOBuff when sending and receiving, this introduces extra two times of copy cost. 
when sending data, butil::IOBuff's `append_user_data()` avoids serializing data and is directly sent; but the received data slice should be in continuous memory when deserializing chunks, so a chunk's data should be copied to a block of continuous memory.

in detail, `append_user_data()` just refers to the chunk's data of string type, we introduce `ChunksDataRef` to guarantee chunk's data is released after sent.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature (manually test in ASAN mode)
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
