### PR TITLE
[BugFix] reserve smallest column only for join operator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectColumnsRule.java
@@ -62,11 +62,12 @@ public class PruneProjectColumnsRule extends TransformationRule {
             }
         }));
 
-        if (newMap.isEmpty()) {
+        // Join Operator could not accept an output column, so try to choose a column for it
+        LogicalOperator inputOp = (LogicalOperator) input.inputAt(0).getOp();
+        if (newMap.isEmpty() && inputOp.getOpType().equals(OperatorType.LOGICAL_JOIN)) {
             ColumnRefSet candidates = new ColumnRefSet(projectOperator.getColumnRefMap().keySet());
             ColumnRefOperator smallestColumn =
-                    ((LogicalOperator) input.inputAt(0).getOp())
-                            .getSmallestColumn(candidates, context.getColumnRefFactory(), input.inputAt(0));
+                    inputOp.getSmallestColumn(candidates, context.getColumnRefFactory(), input.inputAt(0));
             if (smallestColumn != null) {
                 ScalarOperator expr = projectOperator.getColumnRefMap().get(smallestColumn);
                 newMap.put(smallestColumn, expr);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -720,7 +720,7 @@ public class AggregateTest extends PlanTestBase {
     @Test
     public void testVarianceStddevAnalyze() throws Exception {
         String sql = "select stddev_pop(1222) from (select 1) t;";
-        assertPlanContains(sql, "1:AGGREGATE (update finalize)\n" +
+        assertPlanContains(sql, "  1:AGGREGATE (update finalize)\n" +
                 "  |  output: stddev_pop(1222)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -275,15 +275,8 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         String sql =
                 "select count(*) from lineorder_new_l where LO_ORDERDATE not in ('1998-04-10', '1994-04-11', '1994-04-12');";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "4:AGGREGATE (merge finalize)\n" +
-                "  |  output: count(39: count)\n" +
-                "  |  group by: ");
-        assertContains(plan, "2:AGGREGATE (update serialize)\n" +
-                "  |  output: count(*)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 3> : 3: LO_LINENUMBER");
+        assertContains(plan, "3:AGGREGATE (merge finalize)");
+        assertContains(plan, "1:AGGREGATE (update serialize)");
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 
@@ -294,15 +287,8 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "select count(*) from lineorder_new_l where LO_ORDERDATE > '1994-01-01' " +
                         "and LO_ORDERDATE < '1995-01-01' and LO_ORDERDATE != '1994-04-11'";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "4:AGGREGATE (merge finalize)\n" +
-                "  |  output: count(39: count)\n" +
-                "  |  group by: ");
-        assertContains(plan, "2:AGGREGATE (update serialize)\n" +
-                "  |  output: count(*)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 3> : 3: LO_LINENUMBE");
+        assertContains(plan, "3:AGGREGATE (merge finalize)");
+        assertContains(plan, "1:AGGREGATE (update serialize)");
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -160,7 +160,8 @@ public class LimitTest extends PlanTestBase {
     public void testCountStarWithLimitForOneAggStage() throws Exception {
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         String sql = "select count(*) from (select v1 from t0 order by v2 limit 10,20) t;";
-        assertPlanContains(sql, "4:AGGREGATE (update finalize)");
+        String plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("3:AGGREGATE (update finalize)"));
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -124,14 +124,12 @@ public class NestLoopJoinTest extends PlanTestBase {
         getFragmentPlan(sql);
 
         sql = " select a.v2 from t0 a join t0 b on a.v3 < b.v3;";
-        String planFragment = getFragmentPlan(sql);
-        System.err.println(planFragment);
-        Assert.assertTrue(planFragment, planFragment.contains(" 3:NESTLOOP JOIN\n" +
+        assertPlanContains(sql, " 3:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other join predicates: 3: v3 < 6: v3\n" +
                 "  |  \n" +
-                "  |----2:EXCHANGE\n"));
+                "  |----2:EXCHANGE\n");
 
         PlanTestBase.connectContext.getSessionVariable().setJoinImplementationMode("auto");
         // Prune should make the HASH JOIN(LEFT ANTI) could output the left table, but not join slot

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -971,11 +971,11 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = t1.v4 " +
                     "and t0.v1 = (exists (select v7 from t2 where t2.v8 = 1))";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  12:HASH JOIN\n" +
+            assertContains(plan, "  11:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 4: v4");
-            assertContains(plan, "  8:HASH JOIN\n" +
+            assertContains(plan, "  7:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (PARTITIONED)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 12: cast");
@@ -986,10 +986,10 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on " +
                     "t0.v1 = (exists (select v7 from t2 where t2.v8 = 1))";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  11:NESTLOOP JOIN\n" +
+            assertContains(plan, "  10:NESTLOOP JOIN\n" +
                     "  |  join op: CROSS JOIN\n" +
                     "  |  colocate: false, reason: ");
-            assertContains(plan, "  7:HASH JOIN\n" +
+            assertContains(plan, "  6:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 12: cast");
@@ -1001,14 +1001,14 @@ public class SubqueryTest extends PlanTestBase {
                     "t0.v1 = (not exists (select v7 from t2 where t2.v8 = 1)) " +
                     "and t1.v4 = (exists(select v10 from t3 where t3.v11 < 5))";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, ":NESTLOOP JOIN\n" +
+            assertContains(plan, "  17:NESTLOOP JOIN\n" +
                     "  |  join op: CROSS JOIN\n" +
                     "  |  colocate: false, reason: ");
-            assertContains(plan, ":HASH JOIN\n" +
+            assertContains(plan, "  6:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 1: v1 = 18: cast");
-            assertContains(plan, ":HASH JOIN\n" +
+            assertContains(plan, "  14:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 17: cast");
@@ -1019,12 +1019,12 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on t0.v1 = t1.v4 " +
                     "and t0.v1 = (exists (select v7 from t2 where t2.v8 = t1.v5))";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, ":HASH JOIN\n" +
+            assertContains(plan, "  8:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 4: v4 = 1: v1\n" +
                     "  |  equal join conjunct: 12: cast = 1: v1");
-            assertContains(plan, ":HASH JOIN\n" +
+            assertContains(plan, "  4:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +
@@ -1036,11 +1036,11 @@ public class SubqueryTest extends PlanTestBase {
                     "join t1 on " +
                     "t0.v1 = (exists (select v7 from t2 where t2.v8 = t1.v5))";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, ":HASH JOIN\n" +
+            assertContains(plan, "  8:HASH JOIN\n" +
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 12: cast = 1: v1");
-            assertContains(plan, ":HASH JOIN\n" +
+            assertContains(plan, "  4:HASH JOIN\n" +
                     "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 5: v5 = 8: v8\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -56,6 +56,14 @@ public class WindowTest extends PlanTestBase {
     }
 
     @Test
+    public void testPruneEmptyWindow() throws Exception {
+        String sql = "select count(*) from( select avg(t1g) over(partition by t1a) from test_all_type ) r";
+        assertLogicalPlanContains(sql,
+                "AGGREGATE ([GLOBAL] aggregate [{12: count=count()}] group by [[]] having [null]\n" +
+                        "    SCAN (columns[2: t1b] predicate[null])");
+    }
+
+    @Test
     public void testWindowFunctionTest() throws Exception {
         String sql = "select sum(id_decimal - ifnull(id_decimal, 0)) over (partition by t1c) from test_all_type";
         String plan = getThriftPlan(sql);

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/select.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/select.sql
@@ -96,7 +96,7 @@ select count(*) from (select v1 from t0 order by v2 limit 10,20) t
 AGGREGATE ([GLOBAL] aggregate [{4: count=count()}] group by [[]] having [null]
     TOP-N (order by [[2: v2 ASC NULLS FIRST]])
         TOP-N (order by [[2: v2 ASC NULLS FIRST]])
-            SCAN (columns[1: v1, 2: v2] predicate[null])
+            SCAN (columns[2: v2] predicate[null])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/window.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/window.sql
@@ -436,7 +436,7 @@ select count(*) from (select v1, row_number() over (order by v2, v3) from t0 whe
 AGGREGATE ([GLOBAL] aggregate [{5: count=count(5: count)}] group by [[]] having [null]
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{5: count=count()}] group by [[]] having [null]
-            SCAN (columns[1: v1, 2: v2] predicate[2: v2 = 2])
+            SCAN (columns[2: v2] predicate[2: v2 = 2])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/exists-subquery.sql
@@ -5,7 +5,7 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
     SCAN (columns[1: v1] predicate[null])
     EXCHANGE BROADCAST
         EXCHANGE GATHER
-            SCAN (columns[5: v11] predicate[null]) Limit 1
+            SCAN (columns[4: v10] predicate[null]) Limit 1
 [end]
 
 [sql]
@@ -26,7 +26,7 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
         AGGREGATE ([GLOBAL] aggregate [{8: count=count(8: count)}] group by [[]] having [8: count = 0]
             EXCHANGE GATHER
                 AGGREGATE ([LOCAL] aggregate [{8: count=count(1)}] group by [[]] having [null]
-                    SCAN (columns[5: v11] predicate[null])
+                    SCAN (columns[4: v10] predicate[null])
 [end]
 
 [sql]
@@ -81,7 +81,7 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
     SCAN (columns[1: v1] predicate[null])
     EXCHANGE BROADCAST
         EXCHANGE GATHER
-            SCAN (columns[4: v10, 5: v11] predicate[4: v10 = 123]) Limit 1
+            SCAN (columns[4: v10] predicate[4: v10 = 123]) Limit 1
 [end]
 
 [sql]
@@ -93,7 +93,7 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
         AGGREGATE ([GLOBAL] aggregate [{8: count=count(8: count)}] group by [[]] having [8: count = 0]
             EXCHANGE GATHER
                 AGGREGATE ([LOCAL] aggregate [{8: count=count(1)}] group by [[]] having [null]
-                    SCAN (columns[4: v10, 5: v11] predicate[4: v10 = 123])
+                    SCAN (columns[4: v10] predicate[4: v10 = 123])
 [end]
 
 [sql]
@@ -130,7 +130,7 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
                 SCAN (columns[1: v1, 3: v3] predicate[null])
     EXCHANGE BROADCAST
         EXCHANGE GATHER
-            SCAN (columns[5: v4, 6: v5, 7: v6] predicate[6: v5 = 7: v6]) Limit 1
+            SCAN (columns[6: v5, 7: v6] predicate[6: v5 = 7: v6]) Limit 1
 [end]
 
 [sql]
@@ -143,10 +143,10 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
                 SCAN (columns[1: v1, 3: v3] predicate[null])
     EXCHANGE BROADCAST
         EXCHANGE GATHER
-            AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[7: v6]] having [null]
+            AGGREGATE ([GLOBAL] aggregate [{}] group by [[7: v6]] having [null]
                 EXCHANGE SHUFFLE[7]
-                    AGGREGATE ([LOCAL] aggregate [{8: max=max(5: v4)}] group by [[7: v6]] having [null]
-                        SCAN (columns[5: v4, 6: v5, 7: v6] predicate[6: v5 = 5])
+                    AGGREGATE ([LOCAL] aggregate [{}] group by [[7: v6]] having [null]
+                        SCAN (columns[6: v5, 7: v6] predicate[6: v5 = 5])
 [end]
 
 [sql]
@@ -168,7 +168,7 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
     AGGREGATE ([GLOBAL] aggregate [{9: count=count(9: count)}] group by [[]] having [9: count = 0]
         EXCHANGE GATHER
             AGGREGATE ([LOCAL] aggregate [{9: count=count(1)}] group by [[]] having [null]
-                SCAN (columns[5: v4, 6: v5, 7: v6] predicate[6: v5 = 7: v6])
+                SCAN (columns[6: v5, 7: v6] predicate[6: v5 = 7: v6])
     EXCHANGE BROADCAST
         AGGREGATE ([GLOBAL] aggregate [{4: min=min(4: min)}] group by [[3: v3]] having [null]
             EXCHANGE SHUFFLE[3]
@@ -188,10 +188,10 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
         AGGREGATE ([GLOBAL] aggregate [{10: count=count(10: count)}] group by [[]] having [10: count = 0]
             EXCHANGE GATHER
                 AGGREGATE ([LOCAL] aggregate [{10: count=count(1)}] group by [[]] having [null]
-                    AGGREGATE ([GLOBAL] aggregate [{8: max=max(8: max)}] group by [[7: v6]] having [null]
+                    AGGREGATE ([GLOBAL] aggregate [{}] group by [[7: v6]] having [null]
                         EXCHANGE SHUFFLE[7]
-                            AGGREGATE ([LOCAL] aggregate [{8: max=max(5: v4)}] group by [[7: v6]] having [null]
-                                SCAN (columns[5: v4, 6: v5, 7: v6] predicate[6: v5 = 5])
+                            AGGREGATE ([LOCAL] aggregate [{}] group by [[7: v6]] having [null]
+                                SCAN (columns[6: v5, 7: v6] predicate[6: v5 = 5])
 [end]
 
 [sql]
@@ -213,7 +213,7 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
     SCAN (columns[1: v1, 3: v3] predicate[null])
     EXCHANGE BROADCAST
         EXCHANGE GATHER
-            SCAN (columns[6: v6] predicate[null]) Limit 1
+            SCAN (columns[4: v4] predicate[null]) Limit 1
 [end]
 
 [sql]


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15216

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Not all operator need to reserve a *smallest* column but only join operator.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
