### PR TITLE
[BugFix] s3 broker load(without broker) bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -54,11 +54,28 @@ import java.util.concurrent.TimeUnit;
 
 
 class ConfigurationWrap extends Configuration {
+    private static final Logger LOG = LogManager.getLogger(ConfigurationWrap.class);
+
     ConfigurationWrap() {
     }
 
     ConfigurationWrap(boolean loadDefaults) {
         super(loadDefaults);
+    }
+
+    public String parseRegionFromEndpoint(String endPoint) {
+        if (endPoint.contains("oss")) {
+            String[] hostSplit = endPoint.split("\\.");
+            String regionId = hostSplit[0];
+            if (regionId.contains("-internal")) {
+                return regionId.substring(0, regionId.length() - "-internal".length());
+            } else {
+                return regionId;
+            }
+        } else {
+            String[] hostSplit = endPoint.split("\\.");
+            return hostSplit[1];
+        }
     }
 
     public void convertObjectStoreConfToProperties(String path, THdfsProperties tProperties, TObjectStoreType tObjectStoreType) {
@@ -69,43 +86,108 @@ class ConfigurationWrap extends Configuration {
         while (enums.hasMoreElements()) {
             String key = enums.nextElement();
             String value = props.getProperty(key);
-            switch (key) {
-                case HdfsFsManager.FS_S3A_ACCESS_KEY:
-                case HdfsFsManager.FS_KS3_ACCESS_KEY:
-                case HdfsFsManager.FS_OSS_ACCESS_KEY:
-                case HdfsFsManager.FS_COS_ACCESS_KEY:
-                case HdfsFsManager.FS_OBS_ACCESS_KEY:
-                    tProperties.setAccess_key(value);
+            switch (tObjectStoreType) {
+                case S3:
+                    switch (key) {
+                        case HdfsFsManager.FS_S3A_ACCESS_KEY:
+                            tProperties.setAccess_key(value);
+                            break;
+                        case HdfsFsManager.FS_S3A_SECRET_KEY:
+                            tProperties.setSecret_key(value);
+                            break;
+                        case HdfsFsManager.FS_S3A_ENDPOINT:
+                            tProperties.setEnd_point(value);
+                            tProperties.setRegion(parseRegionFromEndpoint(value));
+                            break;
+                        case HdfsFsManager.FS_S3A_IMPL_DISABLE_CACHE:
+                            tProperties.setDisable_cache(Boolean.parseBoolean(value));
+                            break;
+                        case HdfsFsManager.FS_S3A_CONNECTION_SSL_ENABLED:
+                            tProperties.setSsl_enable(Boolean.parseBoolean(value));
+                            break;
+                        case HdfsFsManager.FS_S3A_MAX_CONNECTION:
+                            tProperties.setMax_connection(Integer.parseInt(value));
+                    }
                     break;
-                case HdfsFsManager.FS_S3A_SECRET_KEY:
-                case HdfsFsManager.FS_KS3_SECRET_KEY:
-                case HdfsFsManager.FS_OSS_SECRET_KEY:
-                case HdfsFsManager.FS_COS_SECRET_KEY:
-                case HdfsFsManager.FS_OBS_SECRET_KEY:
-                    tProperties.setSecret_key(value);
+                case OSS:
+                    switch (key) {
+                        case HdfsFsManager.FS_OSS_ACCESS_KEY:
+                            tProperties.setAccess_key(value);
+                            break;
+                        case HdfsFsManager.FS_OSS_SECRET_KEY:
+                            tProperties.setSecret_key(value);
+                            break;
+                        case HdfsFsManager.FS_OSS_ENDPOINT:
+                            tProperties.setEnd_point(value);
+                            tProperties.setRegion(parseRegionFromEndpoint(value));
+                            break;
+                        case HdfsFsManager.FS_OSS_IMPL_DISABLE_CACHE:
+                            tProperties.setDisable_cache(Boolean.parseBoolean(value));
+                            break;
+                        case HdfsFsManager.FS_OSS_CONNECTION_SSL_ENABLED:
+                            tProperties.setSsl_enable(Boolean.parseBoolean(value));
+                            break;
+                    }
                     break;
-                case HdfsFsManager.FS_S3A_ENDPOINT:
-                case HdfsFsManager.FS_KS3_ENDPOINT:
-                case HdfsFsManager.FS_OSS_ENDPOINT:
-                case HdfsFsManager.FS_COS_ENDPOINT:
-                case HdfsFsManager.FS_OBS_ENDPOINT:
-                    tProperties.setEnd_point(value);
+                case COS:
+                    switch (key) {
+                        case HdfsFsManager.FS_COS_ACCESS_KEY:
+                            tProperties.setAccess_key(value);
+                            break;
+                        case HdfsFsManager.FS_COS_SECRET_KEY:
+                            tProperties.setSecret_key(value);
+                            break;
+                        case HdfsFsManager.FS_COS_ENDPOINT:
+                            tProperties.setEnd_point(value);
+                            tProperties.setRegion(parseRegionFromEndpoint(value));
+                            break;
+                        case HdfsFsManager.FS_COS_IMPL_DISABLE_CACHE:
+                            tProperties.setDisable_cache(Boolean.parseBoolean(value));
+                            break;
+                        case HdfsFsManager.FS_COS_CONNECTION_SSL_ENABLED:
+                            tProperties.setSsl_enable(Boolean.parseBoolean(value));
+                            break;
+                    }
                     break;
-                case HdfsFsManager.FS_S3A_IMPL_DISABLE_CACHE:
-                case HdfsFsManager.FS_KS3_IMPL_DISABLE_CACHE:
-                case HdfsFsManager.FS_OSS_IMPL_DISABLE_CACHE:
-                case HdfsFsManager.FS_COS_IMPL_DISABLE_CACHE:
-                case HdfsFsManager.FS_OBS_IMPL_DISABLE_CACHE:
-                    tProperties.setDisable_cache(Boolean.parseBoolean(value));
+                case KS3:
+                    switch (key) {
+                        case HdfsFsManager.FS_KS3_ACCESS_KEY:
+                            tProperties.setAccess_key(value);
+                            break;
+                        case HdfsFsManager.FS_KS3_SECRET_KEY:
+                            tProperties.setSecret_key(value);
+                            break;
+                        case HdfsFsManager.FS_KS3_ENDPOINT:
+                            tProperties.setEnd_point(value);
+                            tProperties.setRegion(parseRegionFromEndpoint(value));
+                            break;
+                        case HdfsFsManager.FS_KS3_IMPL_DISABLE_CACHE:
+                            tProperties.setDisable_cache(Boolean.parseBoolean(value));
+                            break;
+                        case HdfsFsManager.FS_KS3_CONNECTION_SSL_ENABLED:
+                            tProperties.setSsl_enable(Boolean.parseBoolean(value));
+                            break;
+                    }
                     break;
-                case HdfsFsManager.FS_S3A_CONNECTION_SSL_ENABLED:
-                case HdfsFsManager.FS_OSS_CONNECTION_SSL_ENABLED:
-                    tProperties.setSsl_enable(Boolean.parseBoolean(value));
-                    break;
-                case HdfsFsManager.FS_COS_BUCKET_REGION:
-                    tProperties.setRegion(value);
-                case HdfsFsManager.FS_S3A_MAX_CONNECTION:
-                    tProperties.setMax_connection(Integer.parseInt(value));
+                case OBS:
+                    switch (key) {
+                        case HdfsFsManager.FS_OBS_ACCESS_KEY:
+                            tProperties.setAccess_key(value);
+                            break;
+                        case HdfsFsManager.FS_OBS_SECRET_KEY:
+                            tProperties.setSecret_key(value);
+                            break;
+                        case HdfsFsManager.FS_OBS_ENDPOINT:
+                            tProperties.setEnd_point(value);
+                            tProperties.setRegion(parseRegionFromEndpoint(value));
+                            break;
+                        case HdfsFsManager.FS_OBS_IMPL_DISABLE_CACHE:
+                            tProperties.setDisable_cache(Boolean.parseBoolean(value));
+                            break;
+                        case HdfsFsManager.FS_OBS_CONNECTION_SSL_ENABLED:
+                            tProperties.setSsl_enable(Boolean.parseBoolean(value));
+                            break;
+                    }
             }
         }
         return;
@@ -175,6 +257,7 @@ public class HdfsFsManager {
     public static final String FS_KS3_ENDPOINT = "fs.ks3.endpoint";
     public static final String FS_KS3_IMPL = "fs.ks3.impl";
     // This property is used like 'fs.ks3.impl.disable.cache'
+    public static final String FS_KS3_CONNECTION_SSL_ENABLED = "fs.ks3.connection.ssl.enabled";
     public static final String FS_KS3_IMPL_DISABLE_CACHE = "fs.ks3.impl.disable.cache";
 
     // arguments for oss
@@ -191,8 +274,8 @@ public class HdfsFsManager {
     public static final String FS_COS_SECRET_KEY = "fs.cosn.userinfo.secretKey";
     public static final String FS_COS_ENDPOINT = "fs.cosn.bucket.endpoint_suffix";
     public static final String FS_COS_IMPL_DISABLE_CACHE = "fs.cosn.impl.disable.cache";
+    public static final String FS_COS_CONNECTION_SSL_ENABLED = "fs.cos.connection.ssl.enabled";
     public static final String FS_COS_IMPL = "fs.cosn.impl";
-    public static final String FS_COS_BUCKET_REGION = "fs.cosn.bucket.region";
 
     // arguments for obs
     public static final String FS_OBS_ACCESS_KEY = "fs.obs.access.key";
@@ -200,6 +283,7 @@ public class HdfsFsManager {
     public static final String FS_OBS_ENDPOINT = "fs.obs.endpoint";
     // This property is used like 'fs.hdfs.impl.disable.cache'
     public static final String FS_OBS_IMPL_DISABLE_CACHE = "fs.obs.impl.disable.cache";
+    public static final String FS_OBS_CONNECTION_SSL_ENABLED = "fs.obs.connection.ssl.enabled";
     public static final String FS_OBS_IMPL = "fs.obs.impl";
 
     private ScheduledExecutorService handleManagementPool = Executors.newScheduledThreadPool(1);
@@ -489,7 +573,7 @@ public class HdfsFsManager {
         String secretKey = loadProperties.getOrDefault(FS_KS3_SECRET_KEY, "");
         String endpoint = loadProperties.getOrDefault(FS_KS3_ENDPOINT, "");
         String disableCache = loadProperties.getOrDefault(FS_KS3_IMPL_DISABLE_CACHE, "true");
-        String connectionSSLEnabled = loadProperties.getOrDefault(FS_S3A_CONNECTION_SSL_ENABLED, "false");
+        String connectionSSLEnabled = loadProperties.getOrDefault(FS_KS3_CONNECTION_SSL_ENABLED, "false");
         // endpoint is the server host, pathUri.getUri().getHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will
         // cache both.
@@ -531,7 +615,7 @@ public class HdfsFsManager {
                 conf.set(FS_KS3_ENDPOINT, endpoint);
                 conf.set(FS_KS3_IMPL, "com.ksyun.kmr.hadoop.fs.ks3.Ks3FileSystem");
                 conf.set(FS_KS3_IMPL_DISABLE_CACHE, disableCache);
-                conf.set(FS_S3A_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
+                conf.set(FS_KS3_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
                 FileSystem ks3FileSystem = FileSystem.get(pathUri.getUri(), conf);
                 fileSystem.setFileSystem(ks3FileSystem);
                 fileSystem.setConfiguration(conf);
@@ -572,7 +656,7 @@ public class HdfsFsManager {
         String secretKey = loadProperties.getOrDefault(FS_OBS_SECRET_KEY, "");
         String endpoint = loadProperties.getOrDefault(FS_OBS_ENDPOINT, "");
         String disableCache = loadProperties.getOrDefault(FS_OBS_IMPL_DISABLE_CACHE, "true");
-        String connectionSSLEnabled = loadProperties.getOrDefault(FS_S3A_CONNECTION_SSL_ENABLED, "false");
+        String connectionSSLEnabled = loadProperties.getOrDefault(FS_OBS_CONNECTION_SSL_ENABLED, "false");
         if (accessKey.equals("")) {
             LOG.warn("Invalid load_properties, OBS must provide access_key");
             throw new UserException("Invalid load_properties, OBS must provide access_key");
@@ -616,7 +700,7 @@ public class HdfsFsManager {
                 conf.set(FS_OBS_ENDPOINT, endpoint);
                 conf.set(FS_OBS_IMPL, "org.apache.hadoop.fs.obs.OBSFileSystem");
                 conf.set(FS_OBS_IMPL_DISABLE_CACHE, disableCache);
-                conf.set(FS_S3A_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
+                conf.set(FS_OBS_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
                 FileSystem obsFileSystem = FileSystem.get(pathUri.getUri(), conf);
                 fileSystem.setFileSystem(obsFileSystem);
                 fileSystem.setConfiguration(conf);
@@ -700,7 +784,6 @@ public class HdfsFsManager {
                 conf.set(FS_OSS_IMPL, "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem");
                 conf.set(FS_OSS_IMPL_DISABLE_CACHE, disableCache);
                 conf.set(FS_OSS_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
-                conf.set(FS_S3A_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
                 FileSystem ossFileSystem = FileSystem.get(pathUri.getUri(), conf);
                 fileSystem.setFileSystem(ossFileSystem);
                 fileSystem.setConfiguration(conf);
@@ -735,7 +818,7 @@ public class HdfsFsManager {
         String secretKey = loadProperties.getOrDefault(FS_COS_SECRET_KEY, "");
         String endpoint = loadProperties.getOrDefault(FS_COS_ENDPOINT, "");
         String disableCache = loadProperties.getOrDefault(FS_COS_IMPL_DISABLE_CACHE, "true");
-        String connectionSSLEnabled = loadProperties.getOrDefault(FS_S3A_CONNECTION_SSL_ENABLED, "false");
+        String connectionSSLEnabled = loadProperties.getOrDefault(FS_COS_CONNECTION_SSL_ENABLED, "false");
         if (accessKey.equals("")) {
             LOG.warn("Invalid load_properties, COS must provide access_key");
             throw new UserException("Invalid load_properties, COS must provide access_key");
@@ -777,7 +860,7 @@ public class HdfsFsManager {
                 conf.set(FS_COS_ENDPOINT, endpoint);
                 conf.set(FS_COS_IMPL, "org.apache.hadoop.fs.CosFileSystem");
                 conf.set(FS_COS_IMPL_DISABLE_CACHE, disableCache);
-                conf.set(FS_S3A_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
+                conf.set(FS_COS_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
                 FileSystem cosFileSystem = FileSystem.get(pathUri.getUri(), conf);
                 fileSystem.setFileSystem(cosFileSystem);
                 fileSystem.setConfiguration(conf);

--- a/fe/fe-core/src/test/java/com/starrocks/fs/TestHdfsFsManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/TestHdfsFsManager.java
@@ -20,6 +20,7 @@ package com.starrocks.fs;
 import com.starrocks.common.UserException;
 import com.starrocks.fs.hdfs.HdfsFs;
 import com.starrocks.fs.hdfs.HdfsFsManager;
+import com.starrocks.thrift.THdfsProperties;
 import junit.framework.TestCase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -61,6 +62,23 @@ public class TestHdfsFsManager extends TestCase {
         try {
             HdfsFs fs = fileSystemManager.getFileSystem("s3a://testbucket/data/abc/logs", properties, null);
             assertNotNull(fs);
+            fs.getDFSFileSystem().close();
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetRegionFromEndPoint() throws IOException {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("fs.s3a.access.key", "accessKey");
+        properties.put("fs.s3a.secret.key", "secretKey");
+        properties.put("fs.s3a.endpoint", "s3.ap-southeast-1.amazonaws.com");
+        THdfsProperties property = new THdfsProperties();
+        try {
+            HdfsFs fs = fileSystemManager.getFileSystem("s3a://testbucket/data/abc/logs", properties, property);
+            assertNotNull(fs);
+            Assert.assertEquals(property.region, "ap-southeast-1");
             fs.getDFSFileSystem().close();
         } catch (UserException e) {
             Assert.fail(e.getMessage());


### PR DESCRIPTION
If we deploy the starrocks on ECS(aliyun), and ingest data from S3 through broker load(without broker), broker load will fail, error msg is 'empty response body'. This is because we didn't set the region field for s3-client(c++ sdk), in this pr, we parse the region field from the endpoint in FE, and send the region to BE, then BE will set the region for the s3-client.

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14474 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
