### PR TITLE
[BugFix] Fix pagecache memtraker statistics error

### DIFF
--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -87,11 +87,13 @@ StoragePageCache::StoragePageCache(MemTracker* mem_tracker, size_t capacity)
 
 StoragePageCache::~StoragePageCache() = default;
 
+#define CHECKOUT_MEMTRACKER()                                                   \
+    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker); \
+    DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
+
 void StoragePageCache::set_capacity(size_t capacity) {
 #ifndef BE_TEST
-    // set_capacity may free memory, so we switch to Pagecache's own memtracker.
-    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker);
-    DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
+    CHECKOUT_MEMTRACKER()
 #endif
     _cache->set_capacity(capacity);
 }
@@ -109,6 +111,7 @@ uint64_t StoragePageCache::get_hit_count() {
 }
 
 bool StoragePageCache::adjust_capacity(int64_t delta, size_t min_capacity) {
+    CHECKOUT_MEMTRACKER()
     return _cache->adjust_capacity(delta, min_capacity);
 }
 
@@ -125,9 +128,8 @@ void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheH
 #ifndef BE_TEST
     int64_t mem_size = malloc_usable_size(data.data);
     tls_thread_status.mem_release(mem_size);
-    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_mem_tracker);
+    CHECKOUT_MEMTRACKER()
     tls_thread_status.mem_consume(mem_size);
-    DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 #endif
 
     auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[](uint8_t*) value; };

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -89,7 +89,7 @@ StoragePageCache::~StoragePageCache() = default;
 
 void StoragePageCache::set_capacity(size_t capacity) {
 #ifndef BE_TEST
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker)
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
 #endif
     _cache->set_capacity(capacity);
 }
@@ -107,7 +107,9 @@ uint64_t StoragePageCache::get_hit_count() {
 }
 
 bool StoragePageCache::adjust_capacity(int64_t delta, size_t min_capacity) {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker)
+#ifndef BE_TEST
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+#endif
     return _cache->adjust_capacity(delta, min_capacity);
 }
 
@@ -124,7 +126,7 @@ void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheH
 #ifndef BE_TEST
     int64_t mem_size = malloc_usable_size(data.data);
     tls_thread_status.mem_release(mem_size);
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker)
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
     tls_thread_status.mem_consume(mem_size);
 #endif
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the capacity of pagecache is adjusted, the memtracker is not switched to the memtracker of pagecache. As a result, statistics are incorrect. This PR fixes this issue.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
