### PR TITLE
[Refactor] Change struct field names to vector

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -513,7 +513,7 @@ std::string ArrayColumn::debug_item(uint32_t idx) const {
     ss << "[";
     for (size_t i = 0; i < array_size; ++i) {
         if (i > 0) {
-            ss << ", ";
+            ss << ",";
         }
         ss << _elements->debug_item(offset + i);
     }

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -23,7 +23,6 @@
 #include "column/struct_column.h"
 #include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
-#include "runtime/primitive_type.h"
 #include "runtime/primitive_type_infra.h"
 #include "simd/simd.h"
 #include "util/date_func.h"
@@ -274,7 +273,6 @@ ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool null
         size_t field_size = type_desc.children.size();
         DCHECK_EQ(field_size, type_desc.selected_fields.size());
         Columns columns;
-        BinaryColumn::Ptr field_names = BinaryColumn::create();
         for (size_t i = 0; i < field_size; i++) {
             // TODO(SmithCruise): We still create not selected column, but do append_default instead.
             // We should optimize it in future.
@@ -285,9 +283,8 @@ ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool null
             // Subfield column must be nullable column.
             ColumnPtr field_column = create_column(type_desc.children[i], true, is_const, size);
             columns.emplace_back(field_column);
-            field_names->append_string(type_desc.field_names[i]);
         }
-        p = StructColumn::create(columns, field_names);
+        p = StructColumn::create(columns, type_desc.field_names);
     } else {
         p = type_dispatch_column(type_desc.type, ColumnBuilder(), type_desc, size);
     }

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -509,7 +509,7 @@ std::string MapColumn::debug_item(uint32_t idx) const {
     ss << "{";
     for (size_t i = 0; i < map_size; ++i) {
         if (i > 0) {
-            ss << ", ";
+            ss << ",";
         }
         ss << _keys->debug_item(offset + i);
         ss << ":";

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -114,7 +114,7 @@ void StructColumn::assign(size_t n, size_t idx) {
 }
 
 void StructColumn::append_datum(const Datum& datum) {
-    const DatumStruct& datum_struct = datum.get<DatumStruct>();
+    const auto& datum_struct = datum.get<DatumStruct>();
     DCHECK_EQ(_fields.size(), datum_struct.size());
     for (size_t col = 0; col < datum_struct.size(); col++) {
         _fields[col]->append_datum(datum_struct[col]);
@@ -144,7 +144,7 @@ void StructColumn::fill_default(const Filter& filter) {
 
 Status StructColumn::update_rows(const Column& src, const uint32_t* indexes) {
     DCHECK(src.is_struct());
-    const StructColumn& src_column = down_cast<const StructColumn&>(src);
+    const auto& src_column = down_cast<const StructColumn&>(src);
     DCHECK_EQ(_fields.size(), src_column._fields.size());
     for (size_t i = 0; i < _fields.size(); i++) {
         RETURN_IF_ERROR(_fields[i]->update_rows(*src_column._fields[i], indexes));
@@ -195,7 +195,7 @@ size_t StructColumn::append_numbers(const void* buff, size_t length) {
 }
 
 void StructColumn::append_value_multiple_times(const void* value, size_t count) {
-    const Datum* datum = reinterpret_cast<const Datum*>(value);
+    const auto* datum = reinterpret_cast<const Datum*>(value);
     const auto& struct_datum = datum->get_struct();
 
     DCHECK_EQ(_fields.size(), struct_datum.size());
@@ -242,8 +242,8 @@ void StructColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, 
 }
 
 const uint8_t* StructColumn::deserialize_and_append(const uint8_t* pos) {
-    for (size_t i = 0; i < _fields.size(); i++) {
-        pos = _fields[i]->deserialize_and_append(pos);
+    for (auto& _field : _fields) {
+        pos = _field->deserialize_and_append(pos);
     }
     return pos;
 }
@@ -276,12 +276,7 @@ MutableColumnPtr StructColumn::clone_empty() const {
     for (const auto& field : _fields) {
         fields.emplace_back(field->clone_empty());
     }
-    BinaryColumn::Ptr another_field_names = BinaryColumn::create();
-    another_field_names->reserve(_field_names->size());
-    for (size_t i = 0; i < _field_names->size(); i++) {
-        another_field_names->append(_field_names->get_slice(i));
-    }
-    return create_mutable(fields, another_field_names);
+    return create_mutable(fields, _field_names);
 }
 
 size_t StructColumn::filter_range(const Filter& filter, size_t from, size_t to) {
@@ -327,7 +322,7 @@ void StructColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
     buf->begin_push_bracket();
     for (size_t i = 0; i < _fields.size(); ++i) {
         const auto& field = _fields[i];
-        buf->push_string(_field_names->get_slice(i).to_string());
+        buf->push_string(_field_names[i]);
         buf->separator(':');
         field->put_mysql_row_buffer(buf, idx);
         if (i < _fields.size() - 1) {
@@ -344,12 +339,12 @@ std::string StructColumn::debug_item(uint32_t idx) const {
     ss << '{';
     for (size_t i = 0; i < _fields.size(); i++) {
         const auto& field = _fields[i];
-        ss << _field_names->get_slice(i).to_string();
-        ss << ": ";
+        ss << _field_names[i];
+        ss << ":";
         ss << field->debug_item(idx);
         if (i < _fields.size() - 1) {
             // Add struct field separator, last field don't need ','.
-            ss << ", ";
+            ss << ",";
         }
     }
     ss << '}';
@@ -378,7 +373,7 @@ Datum StructColumn::get(size_t idx) const {
     for (size_t i = 0; i < _fields.size(); i++) {
         res[i] = _fields[i]->get(idx);
     }
-    return Datum(res);
+    return {res};
 }
 
 size_t StructColumn::memory_usage() const {
@@ -386,7 +381,6 @@ size_t StructColumn::memory_usage() const {
     for (const auto& column : _fields) {
         memory_usage += column->memory_usage();
     }
-    memory_usage += _field_names->memory_usage();
     return memory_usage;
 }
 
@@ -395,7 +389,6 @@ size_t StructColumn::container_memory_usage() const {
     for (const auto& column : _fields) {
         memory_usage += column->container_memory_usage();
     }
-    memory_usage += _field_names->container_memory_usage();
     return memory_usage;
 }
 
@@ -411,7 +404,7 @@ size_t StructColumn::element_memory_usage(size_t from, size_t size) const {
 }
 
 void StructColumn::swap_column(Column& rhs) {
-    StructColumn& struct_column = down_cast<StructColumn&>(rhs);
+    auto& struct_column = down_cast<StructColumn&>(rhs);
     for (size_t i = 0; i < _fields.size(); i++) {
         _fields[i]->swap_column(*struct_column.fields_column()[i]);
     }
@@ -429,15 +422,14 @@ bool StructColumn::capacity_limit_reached(std::string* msg) const {
 void StructColumn::check_or_die() const {
     // Struct must have at least one field.
     DCHECK(_fields.size() > 0);
-    DCHECK(_field_names->size() > 0);
+    DCHECK(_field_names.size() > 0);
 
     // fields and field_names must have the same size.
-    DCHECK(_fields.size() == _field_names->size());
+    DCHECK(_fields.size() == _field_names.size());
 
     for (const auto& column : _fields) {
         column->check_or_die();
     }
-    _field_names->check_or_die();
 }
 
 void StructColumn::reset_column() {
@@ -456,21 +448,13 @@ Columns& StructColumn::fields_column() {
 }
 
 ColumnPtr StructColumn::field_column(const std::string& field_name) {
-    for (size_t i = 0; i < _field_names->size(); i++) {
-        if (field_name == _field_names->get_slice(i)) {
+    for (size_t i = 0; i < _field_names.size(); i++) {
+        if (field_name == _field_names[i]) {
             return _fields[i];
         }
     }
     DCHECK(false) << "Struct subfield name: " << field_name << " not found!";
     return nullptr;
-}
-
-const BinaryColumn& StructColumn::field_names() const {
-    return *_field_names;
-}
-
-BinaryColumn::Ptr& StructColumn::field_names_column() {
-    return _field_names;
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -25,16 +25,14 @@ class StructColumn final : public ColumnFactory<Column, StructColumn> {
 public:
     using Container = Buffer<std::string>;
 
-    StructColumn(Columns fields, BinaryColumn::Ptr field_names) {
+    StructColumn(Columns fields, std::vector<std::string> field_names)
+            : _fields(std::move(fields)), _field_names(std::move(field_names)) {
         // Struct must have at least one field.
-        DCHECK(fields.size() > 0);
-        DCHECK(field_names->size() > 0);
+        DCHECK(_fields.size() > 0);
+        DCHECK(_field_names.size() > 0);
 
         // fields and field_names must have the same size.
-        DCHECK(fields.size() == field_names->size());
-
-        _fields = std::move(fields);
-        _field_names = std::move(field_names);
+        DCHECK(_fields.size() == _field_names.size());
     }
 
     StructColumn(const StructColumn& rhs) {
@@ -43,7 +41,7 @@ public:
             fields.emplace_back(field->clone_shared());
         }
         _fields = fields;
-        _field_names = std::static_pointer_cast<BinaryColumn>(rhs._field_names->clone_shared());
+        _field_names = rhs._field_names;
     }
 
     StructColumn(StructColumn&& rhs) noexcept
@@ -163,16 +161,15 @@ public:
 
     ColumnPtr field_column(const std::string& field_name);
 
-    const BinaryColumn& field_names() const;
-
-    BinaryColumn::Ptr& field_names_column();
+    const std::vector<std::string>& field_names() const { return _field_names; }
 
 private:
     // A collection that contains StructType's subfield column.
     Columns _fields;
+
     // A collection that contains each struct subfield name.
     // _fields and _field_names should have the same size (_fields.size() == _field_names.size()).
     // _field_names will not participate in serialization because it is created based on meta information
-    BinaryColumn::Ptr _field_names;
+    std::vector<std::string> _field_names;
 };
 } // namespace starrocks::vectorized

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -343,17 +343,17 @@ TARGET_LINK_LIBRARIES(starrocks_test ${TEST_LINK_LIBS})
 SET_TARGET_PROPERTIES(starrocks_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
 
-add_executable(query_cache_test exec/query_cache/transform_operator.cpp exec/query_cache/query_cache_test.cpp)
-
-TARGET_LINK_LIBRARIES(query_cache_test ${TEST_LINK_LIBS})
-SET_TARGET_PROPERTIES(query_cache_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
-
-add_executable(stream_mv_test
-        exec/stream/stream_mv_test.cpp
-        exec/stream/mem_state_table_test.cpp
-        )
-TARGET_LINK_LIBRARIES(stream_mv_test ${TEST_LINK_LIBS})
-SET_TARGET_PROPERTIES(stream_mv_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
+# add_executable(query_cache_test exec/query_cache/transform_operator.cpp exec/query_cache/query_cache_test.cpp)
+# 
+# TARGET_LINK_LIBRARIES(query_cache_test ${TEST_LINK_LIBS})
+# SET_TARGET_PROPERTIES(query_cache_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
+# 
+# add_executable(stream_mv_test
+#         exec/stream/stream_mv_test.cpp
+#         exec/stream/mem_state_table_test.cpp
+#         )
+# TARGET_LINK_LIBRARIES(stream_mv_test ${TEST_LINK_LIBS})
+# SET_TARGET_PROPERTIES(stream_mv_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
 # =================================================
 # bytes_test requires tcmalloc which conflicts with sanitizer.
@@ -379,16 +379,16 @@ TARGET_LINK_LIBRARIES(bytes_test
 
 # =================================================
 # test cases must be compiled as a standalone binary
-ADD_BE_TEST(http/metrics_action_test)
-ADD_BE_TEST(http/http_client_test)
-
-ADD_BE_TEST(runtime/routine_load_task_executor_test)
-ADD_BE_TEST(runtime/small_file_mgr_test)
-ADD_BE_TEST(runtime/user_function_cache_test)
-
-ADD_BE_TEST(storage/delete_handler_test)
-ADD_BE_TEST(storage/options_test)
-ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
+# ADD_BE_TEST(http/metrics_action_test)
+# ADD_BE_TEST(http/http_client_test)
+# 
+# ADD_BE_TEST(runtime/routine_load_task_executor_test)
+# ADD_BE_TEST(runtime/small_file_mgr_test)
+# ADD_BE_TEST(runtime/user_function_cache_test)
+# 
+# ADD_BE_TEST(storage/delete_handler_test)
+# ADD_BE_TEST(storage/options_test)
+# ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
 
 # you can simply add test case as single binary without adding `main`
 # ADD_BE_TEST(exec/vectorized/sorting_test)

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -343,17 +343,17 @@ TARGET_LINK_LIBRARIES(starrocks_test ${TEST_LINK_LIBS})
 SET_TARGET_PROPERTIES(starrocks_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
 
-# add_executable(query_cache_test exec/query_cache/transform_operator.cpp exec/query_cache/query_cache_test.cpp)
-# 
-# TARGET_LINK_LIBRARIES(query_cache_test ${TEST_LINK_LIBS})
-# SET_TARGET_PROPERTIES(query_cache_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
-# 
-# add_executable(stream_mv_test
-#         exec/stream/stream_mv_test.cpp
-#         exec/stream/mem_state_table_test.cpp
-#         )
-# TARGET_LINK_LIBRARIES(stream_mv_test ${TEST_LINK_LIBS})
-# SET_TARGET_PROPERTIES(stream_mv_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
+add_executable(query_cache_test exec/query_cache/transform_operator.cpp exec/query_cache/query_cache_test.cpp)
+
+TARGET_LINK_LIBRARIES(query_cache_test ${TEST_LINK_LIBS})
+SET_TARGET_PROPERTIES(query_cache_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
+
+add_executable(stream_mv_test
+        exec/stream/stream_mv_test.cpp
+        exec/stream/mem_state_table_test.cpp
+        )
+TARGET_LINK_LIBRARIES(stream_mv_test ${TEST_LINK_LIBS})
+SET_TARGET_PROPERTIES(stream_mv_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
 # =================================================
 # bytes_test requires tcmalloc which conflicts with sanitizer.
@@ -379,16 +379,16 @@ TARGET_LINK_LIBRARIES(bytes_test
 
 # =================================================
 # test cases must be compiled as a standalone binary
-# ADD_BE_TEST(http/metrics_action_test)
-# ADD_BE_TEST(http/http_client_test)
-# 
-# ADD_BE_TEST(runtime/routine_load_task_executor_test)
-# ADD_BE_TEST(runtime/small_file_mgr_test)
-# ADD_BE_TEST(runtime/user_function_cache_test)
-# 
-# ADD_BE_TEST(storage/delete_handler_test)
-# ADD_BE_TEST(storage/options_test)
-# ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
+ADD_BE_TEST(http/metrics_action_test)
+ADD_BE_TEST(http/http_client_test)
+
+ADD_BE_TEST(runtime/routine_load_task_executor_test)
+ADD_BE_TEST(runtime/small_file_mgr_test)
+ADD_BE_TEST(runtime/user_function_cache_test)
+
+ADD_BE_TEST(storage/delete_handler_test)
+ADD_BE_TEST(storage/options_test)
+ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
 
 # you can simply add test case as single binary without adding `main`
 # ADD_BE_TEST(exec/vectorized/sorting_test)

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -126,8 +126,8 @@ PARALLEL_TEST(ArrayColumnTest, test_get_elements) {
     elements->append(6);
     offsets->append(6);
 
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", column->debug_item(1));
+    ASSERT_EQ("[1,2,3]", column->debug_item(0));
+    ASSERT_EQ("[4,5,6]", column->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -433,7 +433,7 @@ PARALLEL_TEST(ArrayColumnTest, test_append_array) {
     elements->append(9);
     offsets->append(9);
 
-    ASSERT_EQ("[7, 8, 9]", column->debug_item(2));
+    ASSERT_EQ("[7,8,9]", column->debug_item(2));
 }
 
 // NOLINTNEXTLINE
@@ -461,7 +461,7 @@ PARALLEL_TEST(ArrayColumnTest, test_append_nulls) {
 
     ASSERT_EQ(3, nullable_column->size());
     ASSERT_TRUE(nullable_column->is_null(0));
-    ASSERT_EQ("[4, 5, 6]", nullable_column->debug_item(2));
+    ASSERT_EQ("[4,5,6]", nullable_column->debug_item(2));
 }
 
 // NOLINTNEXTLINE
@@ -559,8 +559,8 @@ PARALLEL_TEST(ArrayColumnTest, test_multi_dimension_array) {
     offsets->append(9);
     offsets_1->append(5);
 
-    ASSERT_EQ("[[1, 2, 3], [4, 5, 6]]", column->debug_item(0));
-    ASSERT_EQ("[[7], [8], [9]]", column->debug_item(1));
+    ASSERT_EQ("[[1,2,3],[4,5,6]]", column->debug_item(0));
+    ASSERT_EQ("[[7],[8],[9]]", column->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -587,7 +587,7 @@ PARALLEL_TEST(ArrayColumnTest, test_resize) {
 
     column->resize(1);
     ASSERT_EQ(1, column->size());
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
+    ASSERT_EQ("[1,2,3]", column->debug_item(0));
 }
 
 // NOLINTNEXTLINE
@@ -649,8 +649,8 @@ PARALLEL_TEST(ArrayColumnTest, test_swap_column) {
     offsets_2->append(6);
 
     column->swap_column(*column_2);
-    ASSERT_EQ("[4, 5, 6]", column->debug_item(0));
-    ASSERT_EQ("[7, 8, 9]", column->debug_item(1));
+    ASSERT_EQ("[4,5,6]", column->debug_item(0));
+    ASSERT_EQ("[7,8,9]", column->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -673,8 +673,8 @@ PARALLEL_TEST(ArrayColumnTest, test_copy_constructor) {
 
     ArrayColumn c1(*c0);
     c0->reset_column();
-    ASSERT_EQ("[1, 2, 3]", c1.debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", c1.debug_item(1));
+    ASSERT_EQ("[1,2,3]", c1.debug_item(0));
+    ASSERT_EQ("[4,5,6]", c1.debug_item(1));
     ASSERT_TRUE(c1.elements_column().unique());
     ASSERT_TRUE(c1.offsets_column().unique());
 }
@@ -698,8 +698,8 @@ PARALLEL_TEST(ArrayColumnTest, test_move_constructor) {
     offsets->append(6);
 
     ArrayColumn c1(std::move(*c0));
-    ASSERT_EQ("[1, 2, 3]", c1.debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", c1.debug_item(1));
+    ASSERT_EQ("[1,2,3]", c1.debug_item(0));
+    ASSERT_EQ("[4,5,6]", c1.debug_item(1));
     ASSERT_TRUE(c1.elements_column().unique());
     ASSERT_TRUE(c1.offsets_column().unique());
 }
@@ -725,8 +725,8 @@ PARALLEL_TEST(ArrayColumnTest, test_copy_assignment) {
     ArrayColumn c1(Int32Column::create(), UInt32Column::create());
     c1 = *c0;
     c0->reset_column();
-    ASSERT_EQ("[1, 2, 3]", c1.debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", c1.debug_item(1));
+    ASSERT_EQ("[1,2,3]", c1.debug_item(0));
+    ASSERT_EQ("[4,5,6]", c1.debug_item(1));
     ASSERT_TRUE(c1.elements_column().unique());
     ASSERT_TRUE(c1.offsets_column().unique());
 }
@@ -751,8 +751,8 @@ PARALLEL_TEST(ArrayColumnTest, test_move_assignment) {
 
     ArrayColumn c1(Int32Column ::create(), UInt32Column::create());
     c1 = std::move(*c0);
-    ASSERT_EQ("[1, 2, 3]", c1.debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", c1.debug_item(1));
+    ASSERT_EQ("[1,2,3]", c1.debug_item(0));
+    ASSERT_EQ("[4,5,6]", c1.debug_item(1));
     ASSERT_TRUE(c1.elements_column().unique());
     ASSERT_TRUE(c1.offsets_column().unique());
 }
@@ -777,8 +777,8 @@ PARALLEL_TEST(ArrayColumnTest, test_clone) {
 
     auto c1 = c0->clone();
     c0->reset_column();
-    ASSERT_EQ("[1, 2, 3]", c1->debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", c1->debug_item(1));
+    ASSERT_EQ("[1,2,3]", c1->debug_item(0));
+    ASSERT_EQ("[4,5,6]", c1->debug_item(1));
     ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->elements_column().unique());
     ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->offsets_column().unique());
 }
@@ -803,8 +803,8 @@ PARALLEL_TEST(ArrayColumnTest, test_clone_shared) {
 
     auto c1 = c0->clone_shared();
     c0->reset_column();
-    ASSERT_EQ("[1, 2, 3]", c1->debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", c1->debug_item(1));
+    ASSERT_EQ("[1,2,3]", c1->debug_item(0));
+    ASSERT_EQ("[4,5,6]", c1->debug_item(1));
     ASSERT_TRUE(c1.unique());
     ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->elements_column().unique());
     ASSERT_TRUE(down_cast<ArrayColumn*>(c1.get())->offsets_column().unique());
@@ -972,10 +972,10 @@ PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
     ASSERT_TRUE(column->update_rows(*replace_col1.get(), replace_idxes.data()).ok());
 
     ASSERT_EQ(4, column->size());
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
-    ASSERT_EQ("[101, 102]", column->debug_item(1));
-    ASSERT_EQ("[7, 8, 9]", column->debug_item(2));
-    ASSERT_EQ("[103, 104]", column->debug_item(3));
+    ASSERT_EQ("[1,2,3]", column->debug_item(0));
+    ASSERT_EQ("[101,102]", column->debug_item(1));
+    ASSERT_EQ("[7,8,9]", column->debug_item(2));
+    ASSERT_EQ("[103,104]", column->debug_item(3));
 
     auto offset_col2 = UInt32Column::create();
     auto element_col2 = Int32Column::create();
@@ -993,10 +993,10 @@ PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
     ASSERT_TRUE(column->update_rows(*replace_col2.get(), replace_idxes.data()).ok());
 
     ASSERT_EQ(4, column->size());
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
-    ASSERT_EQ("[201, 202]", column->debug_item(1));
-    ASSERT_EQ("[7, 8, 9]", column->debug_item(2));
-    ASSERT_EQ("[203, 204]", column->debug_item(3));
+    ASSERT_EQ("[1,2,3]", column->debug_item(0));
+    ASSERT_EQ("[201,202]", column->debug_item(1));
+    ASSERT_EQ("[7,8,9]", column->debug_item(2));
+    ASSERT_EQ("[203,204]", column->debug_item(3));
 }
 
 PARALLEL_TEST(ArrayColumnTest, test_assign) {
@@ -1019,10 +1019,10 @@ PARALLEL_TEST(ArrayColumnTest, test_assign) {
     // assign
     column->assign(4, 0);
     ASSERT_EQ(4, column->size());
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(1));
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(2));
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(3));
+    ASSERT_EQ("[1,2,3]", column->debug_item(0));
+    ASSERT_EQ("[1,2,3]", column->debug_item(1));
+    ASSERT_EQ("[1,2,3]", column->debug_item(2));
+    ASSERT_EQ("[1,2,3]", column->debug_item(3));
 
     /// test assign [null]
     elements = Int32Column::create();
@@ -1075,15 +1075,15 @@ PARALLEL_TEST(ArrayColumnTest, test_empty_null_array) {
     auto res = column->empty_null_array(null_map);
     ASSERT_FALSE(res);
     ASSERT_EQ(2, column->size());
-    ASSERT_EQ("[1, 2, 3]", column->debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", column->debug_item(1));
+    ASSERT_EQ("[1,2,3]", column->debug_item(0));
+    ASSERT_EQ("[4,5,6]", column->debug_item(1));
 
     null_map->get_data()[0] = 1;
     res = column->empty_null_array(null_map);
     ASSERT_TRUE(res);
     ASSERT_EQ(2, column->size());
     ASSERT_EQ("[]", column->debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", column->debug_item(1));
+    ASSERT_EQ("[4,5,6]", column->debug_item(1));
 
     null_map->get_data()[1] = 1;
     res = column->empty_null_array(null_map);
@@ -1118,11 +1118,11 @@ PARALLEL_TEST(ArrayColumnTest, test_replicate) {
 
     auto res = column->replicate(off);
 
-    ASSERT_EQ("[1, 2, 3]", res->debug_item(0));
-    ASSERT_EQ("[1, 2, 3]", res->debug_item(1));
-    ASSERT_EQ("[1, 2, 3]", res->debug_item(2));
-    ASSERT_EQ("[4, 5, 6]", res->debug_item(3));
-    ASSERT_EQ("[4, 5, 6]", res->debug_item(4));
+    ASSERT_EQ("[1,2,3]", res->debug_item(0));
+    ASSERT_EQ("[1,2,3]", res->debug_item(1));
+    ASSERT_EQ("[1,2,3]", res->debug_item(2));
+    ASSERT_EQ("[4,5,6]", res->debug_item(3));
+    ASSERT_EQ("[4,5,6]", res->debug_item(4));
     ASSERT_EQ("[]", res->debug_item(5));
     ASSERT_EQ("[]", res->debug_item(6));
 }

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -174,8 +174,8 @@ PARALLEL_TEST(MapColumnTest, test_get_kvs) {
     map1[(int32_t)6] = (int32_t)66;
     column->append_datum(map1);
 
-    ASSERT_EQ("{1:11, 2:22, 3:33}", column->debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", column->debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", column->debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", column->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -664,8 +664,8 @@ PARALLEL_TEST(MapColumnTest, test_array_value) {
     map1[(Slice) "g h"] = array_e;
     column->append_datum(map1);
 
-    ASSERT_EQ("{'a':[1, 2, 3],'b':[2, 3, 4],'c':[3]}", column->debug_item(0));
-    ASSERT_EQ("{'def':[4, 5, 6, 7],'g h':[5]}", column->debug_item(1));
+    ASSERT_EQ("{'a':[1,2,3],'b':[2,3,4],'c':[3]}", column->debug_item(0));
+    ASSERT_EQ("{'def':[4,5,6,7],'g h':[5]}", column->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -787,7 +787,7 @@ PARALLEL_TEST(MapColumnTest, test_swap_column) {
     ASSERT_EQ("{7:77,8:88,9:99}", column->debug_item(0));
     ASSERT_EQ(2, column2->size());
     ASSERT_EQ("{1:11,2:22,3:33}", column2->debug_item(0));
-    ASSERT_EQ("{4:44,5:55, 6:66}", column2->debug_item(1));
+    ASSERT_EQ("{4:44,5:55,6:66}", column2->debug_item(1));
 }
 
 // NOLINTNEXTLINE

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -71,8 +71,8 @@ PARALLEL_TEST(MapColumnTest, test_map_column_update_if_overflow) {
     ASSERT_TRUE(ret.ok());
     ASSERT_TRUE(ret.value() == nullptr);
     ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{'a':'hello', 'b':' ', 'c':'world'}", column->debug_item(0));
-    ASSERT_EQ("{'def':'haha', 'g h':'let's dance'}", column->debug_item(1));
+    ASSERT_EQ("{'a':'hello','b':' ','c':'world'}", column->debug_item(0));
+    ASSERT_EQ("{'def':'haha','g h':'let's dance'}", column->debug_item(1));
 
 #ifdef NDEBUG
     /*
@@ -500,7 +500,7 @@ PARALLEL_TEST(MapColumnTest, test_append_datumMap_with_null_value) {
     map2[(int32_t)8] = Datum();
     column->append_datum(map2);
 
-    ASSERT_EQ("{7:77, 8:NULL}", column->debug_item(2));
+    ASSERT_EQ("{7:77,8:NULL}", column->debug_item(2));
 }
 
 // NOLINTNEXTLINE
@@ -531,7 +531,7 @@ PARALLEL_TEST(MapColumnTest, test_append_nulls) {
 
     ASSERT_EQ(3, column->size());
     ASSERT_EQ("{}", column->debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", column->debug_item(2));
+    ASSERT_EQ("{4:44,5:55,6:66}", column->debug_item(2));
 }
 
 // NOLINTNEXTLINE
@@ -589,8 +589,8 @@ PARALLEL_TEST(MapColumnTest, test_string_key) {
     map1[(Slice) "g h"] = (int32_t)5;
     column->append_datum(map1);
 
-    ASSERT_EQ("{'a':1, 'b':2, 'c':3}", column->debug_item(0));
-    ASSERT_EQ("{'def':4, 'g h':5}", column->debug_item(1));
+    ASSERT_EQ("{'a':1,'b':2,'c':3}", column->debug_item(0));
+    ASSERT_EQ("{'def':4,'g h':5}", column->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -616,8 +616,8 @@ PARALLEL_TEST(MapColumnTest, test_string_value) {
     map1[(Slice) "g h"] = (Slice) "let's dance";
     column->append_datum(map1);
 
-    ASSERT_EQ("{'a':'hello', 'b':' ', 'c':'world'}", column->debug_item(0));
-    ASSERT_EQ("{'def':'haha', 'g h':'let's dance'}", column->debug_item(1));
+    ASSERT_EQ("{'a':'hello','b':' ','c':'world'}", column->debug_item(0));
+    ASSERT_EQ("{'def':'haha','g h':'let's dance'}", column->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -664,8 +664,8 @@ PARALLEL_TEST(MapColumnTest, test_array_value) {
     map1[(Slice) "g h"] = array_e;
     column->append_datum(map1);
 
-    ASSERT_EQ("{'a':[1, 2, 3], 'b':[2, 3, 4], 'c':[3]}", column->debug_item(0));
-    ASSERT_EQ("{'def':[4, 5, 6, 7], 'g h':[5]}", column->debug_item(1));
+    ASSERT_EQ("{'a':[1, 2, 3],'b':[2, 3, 4],'c':[3]}", column->debug_item(0));
+    ASSERT_EQ("{'def':[4, 5, 6, 7],'g h':[5]}", column->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -700,7 +700,7 @@ PARALLEL_TEST(MapColumnTest, test_resize) {
 
     column->resize(1);
     ASSERT_EQ(1, column->size());
-    ASSERT_EQ("{1:11, 2:22, 3:33}", column->debug_item(0));
+    ASSERT_EQ("{1:11,2:22,3:33}", column->debug_item(0));
     ASSERT_EQ(3, column->keys_column()->size());
     ASSERT_EQ(3, column->values_column()->size());
 }
@@ -784,10 +784,10 @@ PARALLEL_TEST(MapColumnTest, test_swap_column) {
 
     column->swap_column(*column2);
     ASSERT_EQ(1, column->size());
-    ASSERT_EQ("{7:77, 8:88, 9:99}", column->debug_item(0));
+    ASSERT_EQ("{7:77,8:88,9:99}", column->debug_item(0));
     ASSERT_EQ(2, column2->size());
-    ASSERT_EQ("{1:11, 2:22, 3:33}", column2->debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", column2->debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", column2->debug_item(0));
+    ASSERT_EQ("{4:44,5:55, 6:66}", column2->debug_item(1));
 }
 
 // NOLINTNEXTLINE
@@ -811,8 +811,8 @@ PARALLEL_TEST(MapColumnTest, test_copy_constructor) {
 
     MapColumn c1(*c0);
     c0->reset_column();
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c1.debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", c1.debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
     ASSERT_TRUE(c1.keys_column().unique());
     ASSERT_TRUE(c1.values_column().unique());
     ASSERT_TRUE(c1.offsets_column().unique());
@@ -838,8 +838,8 @@ PARALLEL_TEST(MapColumnTest, test_move_constructor) {
     c0->append_datum(map1);
 
     MapColumn c1(std::move(*c0));
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c1.debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", c1.debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
     ASSERT_TRUE(c1.keys_column().unique());
     ASSERT_TRUE(c1.values_column().unique());
     ASSERT_TRUE(c1.offsets_column().unique());
@@ -868,8 +868,8 @@ PARALLEL_TEST(MapColumnTest, test_copy_assignment) {
                  NullableColumn::create(Int32Column::create(), NullColumn::create()), UInt32Column::create());
     c1 = *c0;
     c0->reset_column();
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c1.debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", c1.debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
     ASSERT_TRUE(c1.keys_column().unique());
     ASSERT_TRUE(c1.values_column().unique());
     ASSERT_TRUE(c1.offsets_column().unique());
@@ -897,8 +897,8 @@ PARALLEL_TEST(MapColumnTest, test_move_assignment) {
     MapColumn c1(NullableColumn::create(Int32Column::create(), NullColumn::create()),
                  NullableColumn::create(Int32Column::create(), NullColumn::create()), UInt32Column::create());
     c1 = std::move(*c0);
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c1.debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", c1.debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
     ASSERT_TRUE(c1.keys_column().unique());
     ASSERT_TRUE(c1.values_column().unique());
     ASSERT_TRUE(c1.offsets_column().unique());
@@ -925,8 +925,8 @@ PARALLEL_TEST(MapColumnTest, test_clone) {
 
     auto c1 = c0->clone();
     c0->reset_column();
-    ASSERT_EQ("{1:11, 2:22, 3:33}", down_cast<MapColumn*>(c1.get())->debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", down_cast<MapColumn*>(c1.get())->debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", down_cast<MapColumn*>(c1.get())->debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", down_cast<MapColumn*>(c1.get())->debug_item(1));
     ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->keys_column().unique());
     ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->values_column().unique());
     ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->offsets_column().unique());
@@ -953,8 +953,8 @@ PARALLEL_TEST(MapColumnTest, test_clone_shared) {
 
     auto c1 = c0->clone_shared();
     c0->reset_column();
-    ASSERT_EQ("{1:11, 2:22, 3:33}", down_cast<MapColumn*>(c1.get())->debug_item(0));
-    ASSERT_EQ("{4:44, 5:55, 6:66}", down_cast<MapColumn*>(c1.get())->debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", down_cast<MapColumn*>(c1.get())->debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", down_cast<MapColumn*>(c1.get())->debug_item(1));
     ASSERT_TRUE(c1.unique());
     ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->keys_column().unique());
     ASSERT_TRUE(down_cast<MapColumn*>(c1.get())->values_column().unique());
@@ -1126,10 +1126,10 @@ PARALLEL_TEST(MapColumnTest, test_update_rows) {
     ASSERT_TRUE(c0->update_rows(*c1.get(), replace_idxes.data()).ok());
 
     ASSERT_EQ(4, c0->size());
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c0->debug_item(0));
-    ASSERT_EQ("{101:111, 102:112}", c0->debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", c0->debug_item(0));
+    ASSERT_EQ("{101:111,102:112}", c0->debug_item(1));
     ASSERT_EQ("{}", c0->debug_item(2));
-    ASSERT_EQ("{103:113, 104:114}", c0->debug_item(3));
+    ASSERT_EQ("{103:113,104:114}", c0->debug_item(3));
 
     auto c2 = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
                                 NullableColumn::create(Int32Column::create(), NullColumn::create()),
@@ -1150,10 +1150,10 @@ PARALLEL_TEST(MapColumnTest, test_update_rows) {
     ASSERT_TRUE(c0->update_rows(*c2.get(), replace_idxes_new.data()).ok());
 
     ASSERT_EQ(4, c0->size());
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c0->debug_item(0));
-    ASSERT_EQ("{201:211, 202:212}", c0->debug_item(1));
-    ASSERT_EQ("{203:213, 204:214}", c0->debug_item(2));
-    ASSERT_EQ("{103:113, 104:114}", c0->debug_item(3));
+    ASSERT_EQ("{1:11,2:22,3:33}", c0->debug_item(0));
+    ASSERT_EQ("{201:211,202:212}", c0->debug_item(1));
+    ASSERT_EQ("{203:213,204:214}", c0->debug_item(2));
+    ASSERT_EQ("{103:113,104:114}", c0->debug_item(3));
 }
 
 PARALLEL_TEST(MapColumnTest, test_assign) {
@@ -1177,10 +1177,10 @@ PARALLEL_TEST(MapColumnTest, test_assign) {
     // assign
     c0->assign(4, 0);
     ASSERT_EQ(4, c0->size());
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c0->debug_item(0));
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c0->debug_item(1));
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c0->debug_item(2));
-    ASSERT_EQ("{1:11, 2:22, 3:33}", c0->debug_item(3));
+    ASSERT_EQ("{1:11,2:22,3:33}", c0->debug_item(0));
+    ASSERT_EQ("{1:11,2:22,3:33}", c0->debug_item(1));
+    ASSERT_EQ("{1:11,2:22,3:33}", c0->debug_item(2));
+    ASSERT_EQ("{1:11,2:22,3:33}", c0->debug_item(3));
 
     /// test assign [key->null]
     c0->reset_column();

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -24,9 +24,7 @@
 namespace starrocks::vectorized {
 
 TEST(StructColumnTest, test_create) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     Columns fields{id, name};
@@ -42,17 +40,15 @@ TEST(StructColumnTest, test_create) {
     column->append_datum(struct2);
 
     ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", column->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
 
-    ASSERT_EQ("{id: 1, name: 'smith'}, {id: 2, name: 'cruise'}", column->debug_string());
+    ASSERT_EQ("{id:1,name:'smith'}, {id:2,name:'cruise'}", column->debug_string());
 }
 
 TEST(StructColumnTest, test_update_if_overflow) {
     {
-        auto field_name = BinaryColumn::create();
-        field_name->append_string("id");
-        field_name->append_string("name");
+        std::vector<std::string> field_name{"id", "name"};
         auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
         auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
@@ -95,9 +91,7 @@ TEST(StructColumnTest, test_update_if_overflow) {
 
 TEST(StructColumnTest, test_column_downgrade) {
     {
-        auto field_name = BinaryColumn::create();
-        field_name->append_string("id");
-        field_name->append_string("name");
+        std::vector<std::string> field_name{"id", "name"};
         auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
         auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
@@ -115,9 +109,7 @@ TEST(StructColumnTest, test_column_downgrade) {
     }
 
     {
-        auto field_name = BinaryColumn::create();
-        field_name->append_string("id");
-        field_name->append_string("name");
+        std::vector<std::string> field_name{"id", "name"};
         auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
         auto name = NullableColumn::create(LargeBinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
@@ -143,9 +135,7 @@ TEST(StructColumnTest, test_column_downgrade) {
 
 TEST(StructColumnTest, test_append_null) {
     {
-        auto field_name = BinaryColumn::create();
-        field_name->append_string("id");
-        field_name->append_string("name");
+        std::vector<std::string> field_name{"id", "name"};
         auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
         auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
@@ -158,15 +148,13 @@ TEST(StructColumnTest, test_append_null) {
         column->append_datum(struct3);
 
         ASSERT_EQ(column->size(), 3);
-        ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-        ASSERT_EQ("{id: NULL, name: NULL}", column->debug_item(1));
-        ASSERT_EQ("{id: 3, name: 'cruise'}", column->debug_item(2));
+        ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+        ASSERT_EQ("{id:NULL,name:NULL}", column->debug_item(1));
+        ASSERT_EQ("{id:3,name:'cruise'}", column->debug_item(2));
     }
 
     {
-        auto field_name = BinaryColumn::create();
-        field_name->append_string("id");
-        field_name->append_string("name");
+        std::vector<std::string> field_name{"id", "name"};
         auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
         // one subfield is not nullable
         auto name = BinaryColumn::create();
@@ -180,15 +168,13 @@ TEST(StructColumnTest, test_append_null) {
         column->append_datum(struct3);
 
         ASSERT_EQ(column->size(), 2);
-        ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-        ASSERT_EQ("{id: 3, name: 'cruise'}", column->debug_item(1));
+        ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+        ASSERT_EQ("{id:3,name:'cruise'}", column->debug_item(1));
     }
 }
 
 TEST(StructColumnTest, test_append_defaults) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     Columns fields{id, name};
@@ -196,18 +182,16 @@ TEST(StructColumnTest, test_append_defaults) {
 
     column->append_default();
     ASSERT_EQ(1, column->size());
-    ASSERT_EQ("{id: NULL, name: NULL}", column->debug_item(0));
+    ASSERT_EQ("{id:NULL,name:NULL}", column->debug_item(0));
 
     column->append_default(2);
     ASSERT_EQ(3, column->size());
-    ASSERT_EQ("{id: NULL, name: NULL}", column->debug_item(1));
-    ASSERT_EQ("{id: NULL, name: NULL}", column->debug_item(2));
+    ASSERT_EQ("{id:NULL,name:NULL}", column->debug_item(1));
+    ASSERT_EQ("{id:NULL,name:NULL}", column->debug_item(2));
 }
 
 TEST(StructColumnTest, test_resize) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     Columns fields{id, name};
@@ -223,13 +207,11 @@ TEST(StructColumnTest, test_resize) {
     column->resize(1);
 
     ASSERT_EQ(1, column->size());
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
 }
 
 TEST(StructColumnTest, test_reset_column) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     Columns fields{id, name};
@@ -254,9 +236,7 @@ TEST(StructColumnTest, test_swap_column) {
     ColumnPtr column1;
     ColumnPtr column2;
     {
-        auto field_name = BinaryColumn::create();
-        field_name->append_string("id");
-        field_name->append_string("name");
+        std::vector<std::string> field_name{"id", "name"};
         auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
         auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
@@ -266,9 +246,7 @@ TEST(StructColumnTest, test_swap_column) {
         column1->append_datum(struct1);
     }
     {
-        auto field_name = BinaryColumn::create();
-        field_name->append_string("id");
-        field_name->append_string("name");
+        std::vector<std::string> field_name{"id", "name"};
         auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
         auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
         Columns fields{id, name};
@@ -281,28 +259,25 @@ TEST(StructColumnTest, test_swap_column) {
     }
     ASSERT_EQ(1, column1->size());
     ASSERT_EQ(2, column2->size());
-    ASSERT_EQ("{id: 1, name: 'smith'}", column1->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'smith cruise'}", column2->debug_item(0));
-    ASSERT_EQ("{id: 3, name: 'cruise smith'}", column2->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column1->debug_item(0));
+    ASSERT_EQ("{id:2,name:'smith cruise'}", column2->debug_item(0));
+    ASSERT_EQ("{id:3,name:'cruise smith'}", column2->debug_item(1));
 
     column1->swap_column(*column2);
     ASSERT_EQ(2, column1->size());
     ASSERT_EQ(1, column2->size());
-    ASSERT_EQ("{id: 2, name: 'smith cruise'}", column1->debug_item(0));
-    ASSERT_EQ("{id: 3, name: 'cruise smith'}", column1->debug_item(1));
-    ASSERT_EQ("{id: 1, name: 'smith'}", column2->debug_item(0));
+    ASSERT_EQ("{id:2,name:'smith cruise'}", column1->debug_item(0));
+    ASSERT_EQ("{id:3,name:'cruise smith'}", column1->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column2->debug_item(0));
 }
 
 TEST(StructColumnTest, test_copy_construtor) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     auto column = StructColumn::create(Columns{id, name}, field_name);
 
     // delete reference
-    field_name = nullptr;
     id = nullptr;
     name = nullptr;
 
@@ -316,31 +291,27 @@ TEST(StructColumnTest, test_copy_construtor) {
     column->append_datum(struct2);
 
     ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", column->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
 
     StructColumn copy(*column);
     column->reset_column();
     ASSERT_EQ(0, column->size());
     ASSERT_EQ(2, copy.size());
-    ASSERT_EQ("{id: 1, name: 'smith'}", copy.debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", copy.debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", copy.debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", copy.debug_item(1));
 
-    ASSERT_TRUE(copy.field_names_column().unique());
     ASSERT_TRUE(copy.fields().at(0).unique());
     ASSERT_TRUE(copy.fields().at(1).unique());
 }
 
 TEST(StructColumnTest, test_move_construtor) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     auto column = StructColumn::create(Columns{id, name}, field_name);
 
     // delete reference
-    field_name = nullptr;
     id = nullptr;
     name = nullptr;
 
@@ -354,29 +325,25 @@ TEST(StructColumnTest, test_move_construtor) {
     column->append_datum(struct2);
 
     ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", column->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
 
     StructColumn copy(std::move(*column));
     ASSERT_EQ(2, copy.size());
-    ASSERT_EQ("{id: 1, name: 'smith'}", copy.debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", copy.debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", copy.debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", copy.debug_item(1));
 
-    ASSERT_TRUE(copy.field_names_column().unique());
     ASSERT_TRUE(copy.fields().at(0).unique());
     ASSERT_TRUE(copy.fields().at(1).unique());
 }
 
 TEST(StructColumnTest, test_clone) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     auto column = StructColumn::create(Columns{id, name}, field_name);
 
     // delete reference
-    field_name = nullptr;
     id = nullptr;
     name = nullptr;
 
@@ -390,30 +357,26 @@ TEST(StructColumnTest, test_clone) {
     column->append_datum(struct2);
 
     ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", column->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
 
     auto copy = column->clone();
     column->reset_column();
     ASSERT_EQ(2, copy->size());
-    ASSERT_EQ("{id: 1, name: 'smith'}", copy->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", copy->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", copy->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", copy->debug_item(1));
 
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->field_names_column().unique());
     ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0).unique());
     ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1).unique());
 }
 
 TEST(StructColumnTest, test_clone_shared) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     auto column = StructColumn::create(Columns{id, name}, field_name);
 
     // delete reference
-    field_name = nullptr;
     id = nullptr;
     name = nullptr;
 
@@ -427,30 +390,26 @@ TEST(StructColumnTest, test_clone_shared) {
     column->append_datum(struct2);
 
     ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", column->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
 
     auto copy = column->clone_shared();
     column->reset_column();
     ASSERT_EQ(2, copy->size());
-    ASSERT_EQ("{id: 1, name: 'smith'}", copy->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", copy->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", copy->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", copy->debug_item(1));
 
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->field_names_column().unique());
     ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0).unique());
     ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1).unique());
 }
 
 TEST(StructColumnTest, test_clone_empty) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     auto column = StructColumn::create(Columns{id, name}, field_name);
 
     // delete reference
-    field_name = nullptr;
     id = nullptr;
     name = nullptr;
 
@@ -464,22 +423,19 @@ TEST(StructColumnTest, test_clone_empty) {
     column->append_datum(struct2);
 
     ASSERT_EQ(2, column->size());
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", column->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
 
     auto copy = column->clone_empty();
     column->reset_column();
     ASSERT_EQ(0, copy->size());
 
-    ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->field_names_column().unique());
     ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0).unique());
     ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(1).unique());
 }
 
 TEST(StructColumnTest, test_update_rows) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     auto column = StructColumn::create(Columns{id, name}, field_name);
@@ -502,15 +458,13 @@ TEST(StructColumnTest, test_update_rows) {
     ASSERT_TRUE(column->update_rows(*copy.get(), replace_indexes.data()).ok());
 
     ASSERT_EQ(3, column->size());
-    ASSERT_EQ("{id: 2, name: 'cruise'}", column->debug_item(0));
-    ASSERT_EQ("{id: 2, name: 'cruise'}", column->debug_item(1));
-    ASSERT_EQ("{id: 4, name: 'world'}", column->debug_item(2));
+    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
+    ASSERT_EQ("{id:4,name:'world'}", column->debug_item(2));
 }
 
 TEST(StructColumnTest, test_assign) {
-    auto field_name = BinaryColumn::create();
-    field_name->append_string("id");
-    field_name->append_string("name");
+    std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     auto column = StructColumn::create(Columns{id, name}, field_name);
@@ -526,8 +480,8 @@ TEST(StructColumnTest, test_assign) {
     column->assign(2, 0);
 
     ASSERT_EQ(2, column->size());
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id: 1, name: 'smith'}", column->debug_item(1));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(1));
 }
 
 } // namespace starrocks::vectorized

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -1079,8 +1079,8 @@ TEST_F(HdfsScannerTest, TestOrcLazyLoad) {
 
     EXPECT_EQ(2, chunk->num_rows());
 
-    EXPECT_EQ("[3, {Cc1: 'hello'}]", chunk->debug_row(0));
-    EXPECT_EQ("[4, {Cc1: 'World'}]", chunk->debug_row(1));
+    EXPECT_EQ("[3, {Cc1:'hello'}]", chunk->debug_row(0));
+    EXPECT_EQ("[4, {Cc1:'World'}]", chunk->debug_row(1));
 
     status = scanner->get_next(_runtime_state, &chunk);
     // Should be end of file in next read.

--- a/be/test/exec/vectorized/json_scanner_test.cpp
+++ b/be/test/exec/vectorized/json_scanner_test.cpp
@@ -274,7 +274,7 @@ TEST_F(JsonScannerTest, test_one_level_array) {
     EXPECT_EQ(2, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
 
-    EXPECT_EQ("[['10.10.0.1', '10.20.1.1'], [10, 20]]", chunk->debug_row(0));
+    EXPECT_EQ("[['10.10.0.1','10.20.1.1'], [10,20]]", chunk->debug_row(0));
 }
 
 TEST_F(JsonScannerTest, test_two_level_array) {
@@ -304,7 +304,7 @@ TEST_F(JsonScannerTest, test_two_level_array) {
     EXPECT_EQ(1, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
 
-    EXPECT_EQ("[[[10, 20], [30, 40]]]", chunk->debug_row(0));
+    EXPECT_EQ("[[[10,20],[30,40]]]", chunk->debug_row(0));
 }
 
 TEST_F(JsonScannerTest, test_invalid_column_in_array) {
@@ -396,7 +396,7 @@ TEST_F(JsonScannerTest, test_invalid_nested_level2) {
     EXPECT_EQ(1, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
 
-    EXPECT_EQ("[[NULL, NULL]]", chunk->debug_row(0));
+    EXPECT_EQ("[[NULL,NULL]]", chunk->debug_row(0));
 }
 
 TEST_F(JsonScannerTest, test_json_with_long_string) {

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -229,6 +229,11 @@ TEST_F(ArrayFunctionsTest, array_length) {
         ASSERT_FALSE(result->get(5).is_null());
         ASSERT_FALSE(result->get(6).is_null());
 
+        auto datum = Datum(DatumArray{DatumArray{Datum()}});
+                           LOG(INFO) << "datum size=" << datum.get_array().size();
+
+        LOG(INFO) << c->debug_string();
+        LOG(INFO) << result->debug_string();
         EXPECT_EQ(0, result->get(0).get_int32());
         ASSERT_TRUE(result->get(1).is_null());
         EXPECT_EQ(1, result->get(2).get_int32());
@@ -4687,7 +4692,7 @@ TEST_F(ArrayFunctionsTest, array_distinct_only_null) {
         auto dest_column = ArrayDistinct<TYPE_VARCHAR>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 3);
         ASSERT_STREQ(dest_column->debug_string().c_str(),
-                     "[['5', '666', '33'], ['5', '666', '33'], ['5', '666', '33']]");
+                     "[['5','666','33'], ['5','666','33'], ['5','666','33']]");
     }
     // test normal
     {
@@ -4695,7 +4700,7 @@ TEST_F(ArrayFunctionsTest, array_distinct_only_null) {
         src_column->append_datum(DatumArray{"5", "5", "33", "666"});
         auto dest_column = ArrayDistinct<TYPE_VARCHAR>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 1);
-        ASSERT_STREQ(dest_column->debug_string().c_str(), "[['5', '666', '33']]");
+        ASSERT_STREQ(dest_column->debug_string().c_str(), "[['5','666','33']]");
     }
 }
 

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -230,7 +230,7 @@ TEST_F(ArrayFunctionsTest, array_length) {
         ASSERT_FALSE(result->get(6).is_null());
 
         auto datum = Datum(DatumArray{DatumArray{Datum()}});
-                           LOG(INFO) << "datum size=" << datum.get_array().size();
+        LOG(INFO) << "datum size=" << datum.get_array().size();
 
         LOG(INFO) << c->debug_string();
         LOG(INFO) << result->debug_string();
@@ -4691,8 +4691,7 @@ TEST_F(ArrayFunctionsTest, array_distinct_only_null) {
         src_column = std::make_shared<ConstColumn>(src_column, 3);
         auto dest_column = ArrayDistinct<TYPE_VARCHAR>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 3);
-        ASSERT_STREQ(dest_column->debug_string().c_str(),
-                     "[['5','666','33'], ['5','666','33'], ['5','666','33']]");
+        ASSERT_STREQ(dest_column->debug_string().c_str(), "[['5','666','33'], ['5','666','33'], ['5','666','33']]");
     }
     // test normal
     {

--- a/be/test/exprs/vectorized/cast_expr_test.cpp
+++ b/be/test/exprs/vectorized/cast_expr_test.cpp
@@ -1891,15 +1891,15 @@ TEST_F(VectorizedCastExprTest, string_to_array) {
     cast_expr.__isset.opcode = true;
     cast_expr.__isset.child_type = true;
 
-    EXPECT_EQ("[1, 2, 3]", cast_string_to_array(cast_expr, TYPE_INT, "[1,2,3]"));
-    EXPECT_EQ("[1, 2, 3]", cast_string_to_array(cast_expr, TYPE_INT, "1,2,3"));
-    EXPECT_EQ("[1, 2, 3]", cast_string_to_array(cast_expr, TYPE_INT, "[1,   2,  3]"));
+    EXPECT_EQ("[1,2,3]", cast_string_to_array(cast_expr, TYPE_INT, "[1,2,3]"));
+    EXPECT_EQ("[1,2,3]", cast_string_to_array(cast_expr, TYPE_INT, "1,2,3"));
+    EXPECT_EQ("[1,2,3]", cast_string_to_array(cast_expr, TYPE_INT, "[1,   2,  3]"));
     EXPECT_EQ("[]", cast_string_to_array(cast_expr, TYPE_INT, "[]"));
     EXPECT_EQ("[]", cast_string_to_array(cast_expr, TYPE_INT, ""));
-    EXPECT_EQ("[NULL, NULL, NULL]", cast_string_to_array(cast_expr, TYPE_INT, "[a,b,c]"));
-    EXPECT_EQ("[NULL, NULL]", cast_string_to_array(cast_expr, TYPE_INT, "[\"a\",\"b\"]"));
+    EXPECT_EQ("[NULL,NULL,NULL]", cast_string_to_array(cast_expr, TYPE_INT, "[a,b,c]"));
+    EXPECT_EQ("[NULL,NULL]", cast_string_to_array(cast_expr, TYPE_INT, "[\"a\",\"b\"]"));
 
-    EXPECT_EQ("[1.1, 2.2, 3.3]", cast_string_to_array(cast_expr, TYPE_DOUBLE, "[1.1,2.2,3.3]"));
+    EXPECT_EQ("[1.1,2.2,3.3]", cast_string_to_array(cast_expr, TYPE_DOUBLE, "[1.1,2.2,3.3]"));
 
     // test invalid input
     EXPECT_EQ("NULL", cast_string_to_array(cast_expr, TYPE_INT, "[[1,2,3]"));
@@ -1908,13 +1908,13 @@ TEST_F(VectorizedCastExprTest, string_to_array) {
     EXPECT_EQ("NULL", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(['"'"])"));
 
     // test cast to string array
-    EXPECT_EQ(R"(['1', '2', '3'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(1,2,3)"));
-    EXPECT_EQ(R"(['a', 'b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(["a","b"])"));
-    EXPECT_EQ(R"(['a', 'b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"([a,b])"));
+    EXPECT_EQ(R"(['1','2','3'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(1,2,3)"));
+    EXPECT_EQ(R"(['a','b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(["a","b"])"));
+    EXPECT_EQ(R"(['a','b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"([a,b])"));
     EXPECT_EQ(R"(['"a,"b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(["a,"b])"));
-    EXPECT_EQ(R"(['a', 'b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(["a", "b"])"));
-    EXPECT_EQ(R"(['a', ' b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(["a", " b"])"));
-    EXPECT_EQ(R"(['1', '2'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"([1, 2])"));
+    EXPECT_EQ(R"(['a','b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(["a", "b"])"));
+    EXPECT_EQ(R"(['a',' b'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(["a", " b"])"));
+    EXPECT_EQ(R"(['1','2'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"([1, 2])"));
     EXPECT_EQ(R"(['['])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(['['])"));
     EXPECT_EQ(R"(['"'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(['"'])"));
     EXPECT_EQ(R"(['"xxx'])", cast_string_to_array(cast_expr, TYPE_VARCHAR, R"(['"xxx'])"));
@@ -1924,13 +1924,13 @@ TEST_F(VectorizedCastExprTest, string_to_array) {
     {
         // select cast('[[["1"]],[["1,3"],["2"],["1"]]]' as array<array<array<string>>>);
         auto type = gen_multi_array_type_desc(to_thrift(TYPE_VARCHAR), 3);
-        EXPECT_EQ(R"([[['1']], [['1,3'], ['2'], ['1']]])",
+        EXPECT_EQ(R"([[['1']],[['1,3'],['2'],['1']]])",
                   cast_string_to_array(cast_expr, type, R"([[["1"]],[["1,3"],["2"],["1"]]])"));
         // select  cast('[[["1"]],[["1"],["2"],["1"]]]' as array<array<array<string>>>);
-        EXPECT_EQ(R"([[['1']], [['1'], ['2'], ['1']]])",
+        EXPECT_EQ(R"([[['1']],[['1'],['2'],['1']]])",
                   cast_string_to_array(cast_expr, type, R"([[["1"]],[["1"],["2"],["1"]]])"));
         //  select cast('[[4],[[1, 2]]]' as array<array<array<string>>>);
-        EXPECT_EQ(R"([[['4']], [['1', '2']]])", cast_string_to_array(cast_expr, type, R"([[[4]],[[1, 2]]])"));
+        EXPECT_EQ(R"([[['4']],[['1','2']]])", cast_string_to_array(cast_expr, type, R"([[[4]],[[1, 2]]])"));
     }
 }
 
@@ -2004,21 +2004,21 @@ TEST_F(VectorizedCastExprTest, json_to_array) {
     cast_expr.__isset.opcode = true;
     cast_expr.__isset.child_type = true;
 
-    EXPECT_EQ("[1, 2, 3]", cast_json_to_array(cast_expr, TYPE_INT, "[1,2,3]"));
-    EXPECT_EQ("[1, 2, 3]", cast_json_to_array(cast_expr, TYPE_INT, "[1,   2,  3]"));
+    EXPECT_EQ("[1,2,3]", cast_json_to_array(cast_expr, TYPE_INT, "[1,2,3]"));
+    EXPECT_EQ("[1,2,3]", cast_json_to_array(cast_expr, TYPE_INT, "[1,   2,  3]"));
     EXPECT_EQ("[]", cast_json_to_array(cast_expr, TYPE_INT, "[]"));
     EXPECT_EQ("[]", cast_json_to_array(cast_expr, TYPE_INT, ""));
-    EXPECT_EQ("[NULL, NULL]", cast_json_to_array(cast_expr, TYPE_INT, "[\"a\",\"b\"]"));
+    EXPECT_EQ("[NULL,NULL]", cast_json_to_array(cast_expr, TYPE_INT, "[\"a\",\"b\"]"));
 
-    EXPECT_EQ("[1.1, 2.2, 3.3]", cast_json_to_array(cast_expr, TYPE_DOUBLE, "[1.1,2.2,3.3]"));
+    EXPECT_EQ("[1.1,2.2,3.3]", cast_json_to_array(cast_expr, TYPE_DOUBLE, "[1.1,2.2,3.3]"));
 
-    EXPECT_EQ(R"(['a', 'b'])", cast_json_to_array(cast_expr, TYPE_VARCHAR, R"(["a","b"])"));
-    EXPECT_EQ(R"(['a', 'b'])", cast_json_to_array(cast_expr, TYPE_VARCHAR, R"(["a", "b"])"));
-    EXPECT_EQ(R"(['a', ' b'])", cast_json_to_array(cast_expr, TYPE_VARCHAR, R"(["a", " b"])"));
-    EXPECT_EQ(R"(['1', '2'])", cast_json_to_array(cast_expr, TYPE_VARCHAR, R"([1, 2])"));
+    EXPECT_EQ(R"(['a','b'])", cast_json_to_array(cast_expr, TYPE_VARCHAR, R"(["a","b"])"));
+    EXPECT_EQ(R"(['a','b'])", cast_json_to_array(cast_expr, TYPE_VARCHAR, R"(["a", "b"])"));
+    EXPECT_EQ(R"(['a',' b'])", cast_json_to_array(cast_expr, TYPE_VARCHAR, R"(["a", " b"])"));
+    EXPECT_EQ(R"(['1','2'])", cast_json_to_array(cast_expr, TYPE_VARCHAR, R"([1, 2])"));
 
-    EXPECT_EQ(R"([{"a": 1}, {"a": 2}])", cast_json_to_array(cast_expr, TYPE_JSON, R"([{"a": 1}, {"a": 2}])"));
-    EXPECT_EQ(R"([null, {"a": 2}])", cast_json_to_array(cast_expr, TYPE_JSON, R"( [null, {"a": 2}] )"));
+    EXPECT_EQ(R"([{"a": 1},{"a": 2}])", cast_json_to_array(cast_expr, TYPE_JSON, R"([{"a": 1}, {"a": 2}])"));
+    EXPECT_EQ(R"([null,{"a": 2}])", cast_json_to_array(cast_expr, TYPE_JSON, R"( [null, {"a": 2}] )"));
     EXPECT_EQ(R"([])", cast_json_to_array(cast_expr, TYPE_JSON, R"( {"a": 1} )"));
 }
 

--- a/be/test/exprs/vectorized/string_fn_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_test.cpp
@@ -553,7 +553,7 @@ PARALLEL_TEST(VecStringFunctionsTest, split) {
     columns.emplace_back(delim);
     ColumnPtr result = StringFunctions::split(ctx.get(), columns).value();
     auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(result.get()));
-    ASSERT_EQ("['1', '2', '3'], ['aa', 'bb', 'cc'], ['a', 'b', 'c'], ['', '']", col_array->debug_string());
+    ASSERT_EQ("['1','2','3'], ['aa','bb','cc'], ['a','b','c'], ['','']", col_array->debug_string());
 
     columns.clear();
     str->append("");
@@ -564,7 +564,7 @@ PARALLEL_TEST(VecStringFunctionsTest, split) {
     columns.emplace_back(null_column);
     columns.emplace_back(delim);
     result = StringFunctions::split(ctx.get(), columns).value();
-    ASSERT_EQ("[['1', '2', '3'], ['aa', 'bb', 'cc'], ['a', 'b', 'c'], ['', ''], NULL]", result->debug_string());
+    ASSERT_EQ("[['1','2','3'], ['aa','bb','cc'], ['a','b','c'], ['',''], NULL]", result->debug_string());
 
     //two const param
     auto str_const = ConstColumn::create(BinaryColumn::create());
@@ -577,7 +577,7 @@ PARALLEL_TEST(VecStringFunctionsTest, split) {
     ctx->set_constant_columns(columns);
     ASSERT_TRUE(StringFunctions::split_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
     result = StringFunctions::split(ctx.get(), columns).value();
-    ASSERT_EQ("['a', 'bc', 'd', 'eeee', 'f']", result->debug_string());
+    ASSERT_EQ("['a','bc','d','eeee','f']", result->debug_string());
     ASSERT_TRUE(StringFunctions::split_close(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 }
 
@@ -595,7 +595,7 @@ PARALLEL_TEST(VecStringFunctionsTest, splitConst1) {
     ctx->set_constant_columns(columns);
     ASSERT_TRUE(StringFunctions::split_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
     ColumnPtr result = StringFunctions::split(ctx.get(), columns).value();
-    ASSERT_EQ("['a,bc', 'eeee,f']", result->debug_string());
+    ASSERT_EQ("['a,bc','eeee,f']", result->debug_string());
     ASSERT_TRUE(StringFunctions::split_close(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 }
 
@@ -618,7 +618,7 @@ PARALLEL_TEST(VecStringFunctionsTest, splitConst2) {
     ctx->set_constant_columns(columns);
     ASSERT_TRUE(StringFunctions::split_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
     ColumnPtr result = StringFunctions::split(ctx.get(), columns).value();
-    ASSERT_EQ("['a', 'b', 'c'], ['aa', 'bb', 'cc'], ['eeeeeeeeee'], ['', '']", result->debug_string());
+    ASSERT_EQ("['a','b','c'], ['aa','bb','cc'], ['eeeeeeeeee'], ['','']", result->debug_string());
     ASSERT_TRUE(StringFunctions::split_close(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 }
 

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1754,19 +1754,22 @@ TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {
         //        }
 
         EXPECT_EQ(
-                "[1, [{c11:2,c12:['danny1','Smith2','Cruise']},{c11:4,c12:['poal','alan','blossom']}], [{1:{c21:11,c22:'hi1'}},{5:{c21:23,c22:'p4'}},{9:{c21:25,c22:'p5'}}]]",
+                "[1, [{c11:2,c12:['danny1','Smith2','Cruise']},{c11:4,c12:['poal','alan','blossom']}], "
+                "[{1:{c21:11,c22:'hi1'}},{5:{c21:23,c22:'p4'}},{9:{c21:25,c22:'p5'}}]]",
                 result->debug_row(0));
         EXPECT_EQ(
-                "[2, [{c11:3,c12:['danny2','Smith3']},{c11:5,c12:['poal','alan']}], [{2:{c21:12,c22:'hi2'}},{6:{c21:24,c22:'p5'}}]]",
+                "[2, [{c11:3,c12:['danny2','Smith3']},{c11:5,c12:['poal','alan']}], "
+                "[{2:{c21:12,c22:'hi2'}},{6:{c21:24,c22:'p5'}}]]",
                 result->debug_row(1));
+        EXPECT_EQ("[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], [{3:{c21:13,c22:'hi3'}},{7:{c21:25,c22:'p6'}}]]",
+                  result->debug_row(2));
         EXPECT_EQ(
-                "[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], [{3:{c21:13,c22:'hi3'}},{7:{c21:25,c22:'p6'}}]]",
-                result->debug_row(2));
-        EXPECT_EQ(
-                "[4, [{c11:5,c12:['danny4','Smith5']},{c11:7,c12:['poal','alan']}], [{4:{c21:14,c22:'hi4'}},{8:{c21:26,c22:'p7'}}]]",
+                "[4, [{c11:5,c12:['danny4','Smith5']},{c11:7,c12:['poal','alan']}], "
+                "[{4:{c21:14,c22:'hi4'}},{8:{c21:26,c22:'p7'}}]]",
                 result->debug_row(3));
         EXPECT_EQ(
-                "[5, [{c11:6,c12:['danny4']},{c11:7,c12:['poal','alan']}], [{5:{c21:14,c22:'hi4'}},{9:{c21:26,c22:'p7'}}]]",
+                "[5, [{c11:6,c12:['danny4']},{c11:7,c12:['poal','alan']}], "
+                "[{5:{c21:14,c22:'hi4'}},{9:{c21:26,c22:'p7'}}]]",
                 result->debug_row(4));
     }
 
@@ -1819,19 +1822,24 @@ TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {
         //        }
 
         EXPECT_EQ(
-                "[1, [{c11:2,c12:['danny1','Smith2','Cruise']},{c11:4,c12:['poal','alan','blossom']}], [{1:{c21:NULL,c22:'hi1'}},{5:{c21:NULL,c22:'p4'}},{9:{c21:NULL,c22:'p5'}}]]",
+                "[1, [{c11:2,c12:['danny1','Smith2','Cruise']},{c11:4,c12:['poal','alan','blossom']}], "
+                "[{1:{c21:NULL,c22:'hi1'}},{5:{c21:NULL,c22:'p4'}},{9:{c21:NULL,c22:'p5'}}]]",
                 result->debug_row(0));
         EXPECT_EQ(
-                "[2, [{c11:3,c12:['danny2','Smith3']},{c11:5,c12:['poal','alan']}], [{2:{c21:NULL,c22:'hi2'}},{6:{c21:NULL,c22:'p5'}}]]",
+                "[2, [{c11:3,c12:['danny2','Smith3']},{c11:5,c12:['poal','alan']}], "
+                "[{2:{c21:NULL,c22:'hi2'}},{6:{c21:NULL,c22:'p5'}}]]",
                 result->debug_row(1));
         EXPECT_EQ(
-                "[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], [{3:{c21:NULL,c22:'hi3'}},{7:{c21:NULL,c22:'p6'}}]]",
+                "[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], "
+                "[{3:{c21:NULL,c22:'hi3'}},{7:{c21:NULL,c22:'p6'}}]]",
                 result->debug_row(2));
         EXPECT_EQ(
-                "[4, [{c11:5,c12:['danny4','Smith5']},{c11:7,c12:['poal','alan']}], [{4:{c21:NULL,c22:'hi4'}},{8:{c21:NULL,c22:'p7'}}]]",
+                "[4, [{c11:5,c12:['danny4','Smith5']},{c11:7,c12:['poal','alan']}], "
+                "[{4:{c21:NULL,c22:'hi4'}},{8:{c21:NULL,c22:'p7'}}]]",
                 result->debug_row(3));
         EXPECT_EQ(
-                "[5, [{c11:6,c12:['danny4']},{c11:7,c12:['poal','alan']}], [{5:{c21:NULL,c22:'hi4'}},{9:{c21:NULL,c22:'p7'}}]]",
+                "[5, [{c11:6,c12:['danny4']},{c11:7,c12:['poal','alan']}], "
+                "[{5:{c21:NULL,c22:'hi4'}},{9:{c21:NULL,c22:'p7'}}]]",
                 result->debug_row(4));
     }
 

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1139,8 +1139,8 @@ TEST_F(OrcChunkReaderTest, TestReadArrayDecimal) {
             std::cout << "row" << i << ": " << result->debug_row(i) << std::endl;
         }
         EXPECT_EQ(result->debug_row(0), "[1, [0.999999999]]");
-        EXPECT_EQ(result->debug_row(1), "[2, [0.000000001, NULL]]");
-        EXPECT_EQ(result->debug_row(2), "[3, [NULL, NULL]]");
+        EXPECT_EQ(result->debug_row(1), "[2, [0.000000001,NULL]]");
+        EXPECT_EQ(result->debug_row(2), "[3, [NULL,NULL]]");
         EXPECT_EQ(result->debug_row(3), "[4, [0.123456789]]");
     }
 }
@@ -1348,10 +1348,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructBasic) {
         EXPECT_EQ(result->num_rows(), 4);
         EXPECT_EQ(result->num_columns(), 2);
 
-        EXPECT_EQ("[1, {cc0: 11, cc1: 'Smith'}]", result->debug_row(0));
-        EXPECT_EQ("[2, {cc0: 22, cc1: 'Cruise'}]", result->debug_row(1));
-        EXPECT_EQ("[3, {cc0: 33, cc1: 'hello'}]", result->debug_row(2));
-        EXPECT_EQ("[4, {cc0: 44, cc1: 'World'}]", result->debug_row(3));
+        EXPECT_EQ("[1, {cc0:11,cc1:'Smith'}]", result->debug_row(0));
+        EXPECT_EQ("[2, {cc0:22,cc1:'Cruise'}]", result->debug_row(1));
+        EXPECT_EQ("[3, {cc0:33,cc1:'hello'}]", result->debug_row(2));
+        EXPECT_EQ("[4, {cc0:44,cc1:'World'}]", result->debug_row(3));
     }
 
     {
@@ -1389,10 +1389,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructBasic) {
         EXPECT_EQ(result->num_rows(), 4);
         EXPECT_EQ(result->num_columns(), 2);
 
-        EXPECT_EQ("[1, {cc0: NULL, cc1: 'Smith'}]", result->debug_row(0));
-        EXPECT_EQ("[2, {cc0: NULL, cc1: 'Cruise'}]", result->debug_row(1));
-        EXPECT_EQ("[3, {cc0: NULL, cc1: 'hello'}]", result->debug_row(2));
-        EXPECT_EQ("[4, {cc0: NULL, cc1: 'World'}]", result->debug_row(3));
+        EXPECT_EQ("[1, {cc0:NULL,cc1:'Smith'}]", result->debug_row(0));
+        EXPECT_EQ("[2, {cc0:NULL,cc1:'Cruise'}]", result->debug_row(1));
+        EXPECT_EQ("[3, {cc0:NULL,cc1:'hello'}]", result->debug_row(2));
+        EXPECT_EQ("[4, {cc0:NULL,cc1:'World'}]", result->debug_row(3));
     }
 }
 
@@ -1451,10 +1451,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructUnorderedField) {
         EXPECT_EQ(result->num_rows(), 4);
         EXPECT_EQ(result->num_columns(), 2);
 
-        EXPECT_EQ("[1, {cc1: 'Smith', cc0: 11}]", result->debug_row(0));
-        EXPECT_EQ("[2, {cc1: 'Cruise', cc0: 22}]", result->debug_row(1));
-        EXPECT_EQ("[3, {cc1: 'hello', cc0: 33}]", result->debug_row(2));
-        EXPECT_EQ("[4, {cc1: 'World', cc0: 44}]", result->debug_row(3));
+        EXPECT_EQ("[1, {cc1:'Smith',cc0:11}]", result->debug_row(0));
+        EXPECT_EQ("[2, {cc1:'Cruise',cc0:22}]", result->debug_row(1));
+        EXPECT_EQ("[3, {cc1:'hello',cc0:33}]", result->debug_row(2));
+        EXPECT_EQ("[4, {cc1:'World',cc0:44}]", result->debug_row(3));
     }
 
     {
@@ -1495,10 +1495,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructUnorderedField) {
         EXPECT_EQ(result->num_rows(), 4);
         EXPECT_EQ(result->num_columns(), 2);
 
-        EXPECT_EQ("[{cc1: 'Smith', cc0: 11}, 1]", result->debug_row(0));
-        EXPECT_EQ("[{cc1: 'Cruise', cc0: 22}, 2]", result->debug_row(1));
-        EXPECT_EQ("[{cc1: 'hello', cc0: 33}, 3]", result->debug_row(2));
-        EXPECT_EQ("[{cc1: 'World', cc0: 44}, 4]", result->debug_row(3));
+        EXPECT_EQ("[{cc1:'Smith',cc0:11}, 1]", result->debug_row(0));
+        EXPECT_EQ("[{cc1:'Cruise',cc0:22}, 2]", result->debug_row(1));
+        EXPECT_EQ("[{cc1:'hello',cc0:33}, 3]", result->debug_row(2));
+        EXPECT_EQ("[{cc1:'World',cc0:44}, 4]", result->debug_row(3));
     }
 
     {
@@ -1536,10 +1536,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructUnorderedField) {
         EXPECT_EQ(result->num_rows(), 4);
         EXPECT_EQ(result->num_columns(), 2);
 
-        EXPECT_EQ("[1, {cc1: NULL, cc0: 11}]", result->debug_row(0));
-        EXPECT_EQ("[2, {cc1: NULL, cc0: 22}]", result->debug_row(1));
-        EXPECT_EQ("[3, {cc1: NULL, cc0: 33}]", result->debug_row(2));
-        EXPECT_EQ("[4, {cc1: NULL, cc0: 44}]", result->debug_row(3));
+        EXPECT_EQ("[1, {cc1:NULL,cc0:11}]", result->debug_row(0));
+        EXPECT_EQ("[2, {cc1:NULL,cc0:22}]", result->debug_row(1));
+        EXPECT_EQ("[3, {cc1:NULL,cc0:33}]", result->debug_row(2));
+        EXPECT_EQ("[4, {cc1:NULL,cc0:44}]", result->debug_row(3));
     }
 }
 
@@ -1594,10 +1594,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructCaseSensitiveField) {
         EXPECT_EQ(result->num_rows(), 4);
         EXPECT_EQ(result->num_columns(), 2);
 
-        EXPECT_EQ("[1, {Cc1: 'Smith'}]", result->debug_row(0));
-        EXPECT_EQ("[2, {Cc1: 'Cruise'}]", result->debug_row(1));
-        EXPECT_EQ("[3, {Cc1: 'hello'}]", result->debug_row(2));
-        EXPECT_EQ("[4, {Cc1: 'World'}]", result->debug_row(3));
+        EXPECT_EQ("[1, {Cc1:'Smith'}]", result->debug_row(0));
+        EXPECT_EQ("[2, {Cc1:'Cruise'}]", result->debug_row(1));
+        EXPECT_EQ("[3, {Cc1:'hello'}]", result->debug_row(2));
+        EXPECT_EQ("[4, {Cc1:'World'}]", result->debug_row(3));
     }
 
     {
@@ -1754,24 +1754,19 @@ TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {
         //        }
 
         EXPECT_EQ(
-                "[1, [{c11: 2, c12: ['danny1', 'Smith2', 'Cruise']}, {c11: 4, c12: ['poal', 'alan', 'blossom']}], "
-                "[{1:{c21: 11, c22: 'hi1'}}, {5:{c21: 23, c22: 'p4'}}, {9:{c21: 25, c22: 'p5'}}]]",
+                "[1, [{c11:2,c12:['danny1','Smith2','Cruise']},{c11:4,c12:['poal','alan','blossom']}], [{1:{c21:11,c22:'hi1'}},{5:{c21:23,c22:'p4'}},{9:{c21:25,c22:'p5'}}]]",
                 result->debug_row(0));
         EXPECT_EQ(
-                "[2, [{c11: 3, c12: ['danny2', 'Smith3']}, {c11: 5, c12: ['poal', 'alan']}], [{2:{c21: 12, c22: "
-                "'hi2'}}, {6:{c21: 24, c22: 'p5'}}]]",
+                "[2, [{c11:3,c12:['danny2','Smith3']},{c11:5,c12:['poal','alan']}], [{2:{c21:12,c22:'hi2'}},{6:{c21:24,c22:'p5'}}]]",
                 result->debug_row(1));
         EXPECT_EQ(
-                "[3, [{c11: 4, c12: ['danny3']}, {c11: 6, c12: ['poal']}], [{3:{c21: 13, c22: 'hi3'}}, {7:{c21: 25, "
-                "c22: 'p6'}}]]",
+                "[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], [{3:{c21:13,c22:'hi3'}},{7:{c21:25,c22:'p6'}}]]",
                 result->debug_row(2));
         EXPECT_EQ(
-                "[4, [{c11: 5, c12: ['danny4', 'Smith5']}, {c11: 7, c12: ['poal', 'alan']}], [{4:{c21: 14, c22: "
-                "'hi4'}}, {8:{c21: 26, c22: 'p7'}}]]",
+                "[4, [{c11:5,c12:['danny4','Smith5']},{c11:7,c12:['poal','alan']}], [{4:{c21:14,c22:'hi4'}},{8:{c21:26,c22:'p7'}}]]",
                 result->debug_row(3));
         EXPECT_EQ(
-                "[5, [{c11: 6, c12: ['danny4']}, {c11: 7, c12: ['poal', 'alan']}], [{5:{c21: 14, c22: 'hi4'}}, "
-                "{9:{c21: 26, c22: 'p7'}}]]",
+                "[5, [{c11:6,c12:['danny4']},{c11:7,c12:['poal','alan']}], [{5:{c21:14,c22:'hi4'}},{9:{c21:26,c22:'p7'}}]]",
                 result->debug_row(4));
     }
 
@@ -1824,24 +1819,19 @@ TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {
         //        }
 
         EXPECT_EQ(
-                "[1, [{c11: 2, c12: ['danny1', 'Smith2', 'Cruise']}, {c11: 4, c12: ['poal', 'alan', 'blossom']}], "
-                "[{1:{c21: NULL, c22: 'hi1'}}, {5:{c21: NULL, c22: 'p4'}}, {9:{c21: NULL, c22: 'p5'}}]]",
+                "[1, [{c11:2,c12:['danny1','Smith2','Cruise']},{c11:4,c12:['poal','alan','blossom']}], [{1:{c21:NULL,c22:'hi1'}},{5:{c21:NULL,c22:'p4'}},{9:{c21:NULL,c22:'p5'}}]]",
                 result->debug_row(0));
         EXPECT_EQ(
-                "[2, [{c11: 3, c12: ['danny2', 'Smith3']}, {c11: 5, c12: ['poal', 'alan']}], [{2:{c21: NULL, c22: "
-                "'hi2'}}, {6:{c21: NULL, c22: 'p5'}}]]",
+                "[2, [{c11:3,c12:['danny2','Smith3']},{c11:5,c12:['poal','alan']}], [{2:{c21:NULL,c22:'hi2'}},{6:{c21:NULL,c22:'p5'}}]]",
                 result->debug_row(1));
         EXPECT_EQ(
-                "[3, [{c11: 4, c12: ['danny3']}, {c11: 6, c12: ['poal']}], [{3:{c21: NULL, c22: 'hi3'}}, {7:{c21: "
-                "NULL, c22: 'p6'}}]]",
+                "[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], [{3:{c21:NULL,c22:'hi3'}},{7:{c21:NULL,c22:'p6'}}]]",
                 result->debug_row(2));
         EXPECT_EQ(
-                "[4, [{c11: 5, c12: ['danny4', 'Smith5']}, {c11: 7, c12: ['poal', 'alan']}], [{4:{c21: NULL, c22: "
-                "'hi4'}}, {8:{c21: NULL, c22: 'p7'}}]]",
+                "[4, [{c11:5,c12:['danny4','Smith5']},{c11:7,c12:['poal','alan']}], [{4:{c21:NULL,c22:'hi4'}},{8:{c21:NULL,c22:'p7'}}]]",
                 result->debug_row(3));
         EXPECT_EQ(
-                "[5, [{c11: 6, c12: ['danny4']}, {c11: 7, c12: ['poal', 'alan']}], [{5:{c21: NULL, c22: 'hi4'}}, "
-                "{9:{c21: NULL, c22: 'p7'}}]]",
+                "[5, [{c11:6,c12:['danny4']},{c11:7,c12:['poal','alan']}], [{5:{c21:NULL,c22:'hi4'}},{9:{c21:NULL,c22:'p7'}}]]",
                 result->debug_row(4));
     }
 
@@ -1883,15 +1873,11 @@ TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {
         EXPECT_EQ(result->num_rows(), 5);
         EXPECT_EQ(result->num_columns(), 1);
 
-        //        for (size_t i = 0; i < result->num_rows(); i++) {
-        //            std::cout << result->debug_row(i) << std::endl;
-        //        }
-
-        EXPECT_EQ("[[{1:NULL}, {5:NULL}, {9:NULL}]]", result->debug_row(0));
-        EXPECT_EQ("[[{2:NULL}, {6:NULL}]]", result->debug_row(1));
-        EXPECT_EQ("[[{3:NULL}, {7:NULL}]]", result->debug_row(2));
-        EXPECT_EQ("[[{4:NULL}, {8:NULL}]]", result->debug_row(3));
-        EXPECT_EQ("[[{5:NULL}, {9:NULL}]]", result->debug_row(4));
+        EXPECT_EQ("[[{1:NULL},{5:NULL},{9:NULL}]]", result->debug_row(0));
+        EXPECT_EQ("[[{2:NULL},{6:NULL}]]", result->debug_row(1));
+        EXPECT_EQ("[[{3:NULL},{7:NULL}]]", result->debug_row(2));
+        EXPECT_EQ("[[{4:NULL},{8:NULL}]]", result->debug_row(3));
+        EXPECT_EQ("[[{5:NULL},{9:NULL}]]", result->debug_row(4));
     }
 }
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1008,9 +1008,6 @@ TEST_F(FileReaderTest, TestOtherFilterWithMultiPage) {
         if (!status.ok()) {
             break;
         }
-        for (int i = 0; i < chunk->num_rows(); ++i) {
-            std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-        }
     }
     ASSERT_TRUE(status.is_end_of_file());
 }
@@ -1038,9 +1035,6 @@ TEST_F(FileReaderTest, TestReadStructUpperColumns) {
     status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(3, chunk->num_rows());
-    for (int i = 0; i < chunk->num_rows(); ++i) {
-        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-    }
 
     ColumnPtr int_col = chunk->get_column_by_slot_id(0);
     int i = int_col->get(0).get_int32();
@@ -1068,9 +1062,6 @@ TEST_F(FileReaderTest, TestReadWithUpperPred) {
     ASSERT_TRUE(status.ok());
     LOG(ERROR) << "status: " << status.get_error_msg();
     ASSERT_EQ(3, chunk->num_rows());
-    for (int i = 0; i < chunk->num_rows(); ++i) {
-        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-    }
 
     ColumnPtr int_col = chunk->get_column_by_slot_id(0);
     int i = int_col->get(0).get_int32();
@@ -1114,11 +1105,11 @@ TEST_F(FileReaderTest, TestReadArray2dColumn) {
     for (int i = 0; i < chunk->num_rows(); ++i) {
         std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
     }
-    EXPECT_EQ(chunk->debug_row(0), "[1, [[1, 2]]]");
-    EXPECT_EQ(chunk->debug_row(1), "[2, [[1, 2], [3, 4]]]");
-    EXPECT_EQ(chunk->debug_row(2), "[3, [[1, 2, 3], [4]]]");
-    EXPECT_EQ(chunk->debug_row(3), "[4, [[1, 2, 3], [4], [5]]]");
-    EXPECT_EQ(chunk->debug_row(4), "[5, [[1, 2, 3], [4, 5]]]");
+    EXPECT_EQ(chunk->debug_row(0), "[1, [[1,2]]]");
+    EXPECT_EQ(chunk->debug_row(1), "[2, [[1,2],[3,4]]]");
+    EXPECT_EQ(chunk->debug_row(2), "[3, [[1,2,3],[4]]]");
+    EXPECT_EQ(chunk->debug_row(3), "[4, [[1,2,3],[4],[5]]]");
+    EXPECT_EQ(chunk->debug_row(4), "[5, [[1,2,3],[4,5]]]");
 }
 
 TEST_F(FileReaderTest, TestReadRequiredArrayColumns) {
@@ -1241,18 +1232,15 @@ TEST_F(FileReaderTest, TestReadMapColumn) {
     status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ(chunk->num_rows(), 8);
-    for (int i = 0; i < chunk->num_rows(); ++i) {
-        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-    }
-    EXPECT_EQ(chunk->debug_row(0), "[1, {'k1':0, 'k2':1}, {'e1':{'f1':1, 'f2':2}}, {'g1':[1, 2]}]");
+    EXPECT_EQ(chunk->debug_row(0), "[1, {'k1':0,'k2':1}, {'e1':{'f1':1,'f2':2}}, {'g1':[1,2]}]");
     EXPECT_EQ(chunk->debug_row(1),
-              "[2, {'k1':1, 'k3':2, 'k4':3}, {'e1':{'f1':1, 'f2':2}, 'e2':{'f1':1, 'f2':2}}, {'g1':[1], 'g3':[2]}]");
-    EXPECT_EQ(chunk->debug_row(2), "[3, {'k2':2, 'k3':3, 'k5':4}, {'e1':{'f1':1, 'f2':2, 'f3':3}}, {'g1':[1, 2, 3]}]");
-    EXPECT_EQ(chunk->debug_row(3), "[4, {'k1':3, 'k2':4, 'k3':5}, {'e2':{'f2':2}}, {'g1':[1]}]");
+              "[2, {'k1':1,'k3':2,'k4':3}, {'e1':{'f1':1,'f2':2},'e2':{'f1':1,'f2':2}}, {'g1':[1],'g3':[2]}]");
+    EXPECT_EQ(chunk->debug_row(2), "[3, {'k2':2,'k3':3,'k5':4}, {'e1':{'f1':1,'f2':2,'f3':3}}, {'g1':[1,2,3]}]");
+    EXPECT_EQ(chunk->debug_row(3), "[4, {'k1':3,'k2':4,'k3':5}, {'e2':{'f2':2}}, {'g1':[1]}]");
     EXPECT_EQ(chunk->debug_row(4), "[5, {'k3':4}, {'e2':{'f2':2}}, {'g1':[NULL]}]");
     EXPECT_EQ(chunk->debug_row(5), "[6, {'k1':NULL}, {'e2':{'f2':NULL}}, {'g1':[1]}]");
-    EXPECT_EQ(chunk->debug_row(6), "[7, {'k1':1, 'k2':2}, {'e2':{'f2':2}}, {'g1':[1, 2, 3]}]");
-    EXPECT_EQ(chunk->debug_row(7), "[8, {'k3':4}, {'e1':{'f1':1, 'f2':2, 'f3':3}}, {'g2':[1], 'g3':[2]}]");
+    EXPECT_EQ(chunk->debug_row(6), "[7, {'k1':1,'k2':2}, {'e2':{'f2':2}}, {'g1':[1,2,3]}]");
+    EXPECT_EQ(chunk->debug_row(7), "[8, {'k3':4}, {'e1':{'f1':1,'f2':2,'f3':3}}, {'g2':[1],'g3':[2]}]");
 }
 
 TEST_F(FileReaderTest, TestReadStruct) {
@@ -1325,25 +1313,25 @@ TEST_F(FileReaderTest, TestReadStruct) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(1024, chunk->num_rows());
 
-    EXPECT_EQ("[0, {f2: 'a', f1: 0, f3: [0, 1, 2]}, 'a', [{e1: 0, e2: 'a'}, {e1: 1, e2: 'a'}], 'A']",
+    EXPECT_EQ("[0, {f2:'a',f1:0,f3:[0,1,2]}, 'a', [{e1:0,e2:'a'},{e1:1,e2:'a'}], 'A']",
               chunk->debug_row(0));
-    EXPECT_EQ("[1, {f2: 'a', f1: 1, f3: [1, 2, 3]}, 'a', [{e1: 1, e2: 'a'}, {e1: 2, e2: 'a'}], 'A']",
+    EXPECT_EQ("[1, {f2:'a',f1:1,f3:[1,2,3]}, 'a', [{e1:1,e2:'a'},{e1:2,e2:'a'}], 'A']",
               chunk->debug_row(1));
-    EXPECT_EQ("[2, {f2: 'a', f1: 2, f3: [2, 3, 4]}, 'a', [{e1: 2, e2: 'a'}, {e1: 3, e2: 'a'}], 'A']",
+    EXPECT_EQ("[2, {f2:'a',f1:2,f3:[2,3,4]}, 'a', [{e1:2,e2:'a'},{e1:3,e2:'a'}], 'A']",
               chunk->debug_row(2));
-    EXPECT_EQ("[3, {f2: 'c', f1: 3, f3: [3, 4, 5]}, 'c', [{e1: 3, e2: 'c'}, {e1: 4, e2: 'c'}], 'C']",
+    EXPECT_EQ("[3, {f2:'c',f1:3,f3:[3,4,5]}, 'c', [{e1:3,e2:'c'},{e1:4,e2:'c'}], 'C']",
               chunk->debug_row(3));
-    EXPECT_EQ("[4, {f2: 'c', f1: 4, f3: [4, 5, 6]}, 'c', [{e1: 4, e2: 'c'}, {e1: 5, e2: 'c'}], 'C']",
+    EXPECT_EQ("[4, {f2:'c',f1:4,f3:[4,5,6]}, 'c', [{e1:4,e2:'c'},{e1:5,e2:'c'}], 'C']",
               chunk->debug_row(4));
-    EXPECT_EQ("[5, {f2: 'c', f1: 5, f3: [5, 6, 7]}, 'c', [{e1: 5, e2: 'c'}, {e1: 6, e2: 'c'}], 'C']",
+    EXPECT_EQ("[5, {f2:'c',f1:5,f3:[5,6,7]}, 'c', [{e1:5,e2:'c'},{e1:6,e2:'c'}], 'C']",
               chunk->debug_row(5));
-    EXPECT_EQ("[6, {f2: 'a', f1: 6, f3: [6, 7, 8]}, 'a', [{e1: 6, e2: 'a'}, {e1: 7, e2: 'a'}], 'A']",
+    EXPECT_EQ("[6, {f2:'a',f1:6,f3:[6,7,8]}, 'a', [{e1:6,e2:'a'},{e1:7,e2:'a'}], 'A']",
               chunk->debug_row(6));
-    EXPECT_EQ("[7, {f2: 'a', f1: 7, f3: [7, 8, 9]}, 'a', [{e1: 7, e2: 'a'}, {e1: 8, e2: 'a'}], 'A']",
+    EXPECT_EQ("[7, {f2:'a',f1:7,f3:[7,8,9]}, 'a', [{e1:7,e2:'a'},{e1:8,e2:'a'}], 'A']",
               chunk->debug_row(7));
-    EXPECT_EQ("[8, {f2: 'a', f1: 8, f3: [8, 9, 10]}, 'a', [{e1: 8, e2: 'a'}, {e1: 9, e2: 'a'}], 'A']",
+    EXPECT_EQ("[8, {f2:'a',f1:8,f3:[8,9,10]}, 'a', [{e1:8,e2:'a'},{e1:9,e2:'a'}], 'A']",
               chunk->debug_row(8));
-    EXPECT_EQ("[9, {f2: 'a', f1: 9, f3: [9, 10, 11]}, 'a', [{e1: 9, e2: 'a'}, {e1: 10, e2: 'a'}], 'A']",
+    EXPECT_EQ("[9, {f2:'a',f1:9,f3:[9,10,11]}, 'a', [{e1:9,e2:'a'},{e1:10,e2:'a'}], 'A']",
               chunk->debug_row(9));
 
     //    for (int i = 0; i < 10; ++i) {
@@ -1422,25 +1410,25 @@ TEST_F(FileReaderTest, TestReadStructSubField) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(1024, chunk->num_rows());
 
-    EXPECT_EQ("[0, {f1: 0, f2: NULL, f3: [0, 1, 2]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']",
+    EXPECT_EQ("[0, {f1:0,f2:NULL,f3:[0,1,2]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
               chunk->debug_row(0));
-    EXPECT_EQ("[1, {f1: 1, f2: NULL, f3: [1, 2, 3]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']",
+    EXPECT_EQ("[1, {f1:1,f2:NULL,f3:[1,2,3]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
               chunk->debug_row(1));
-    EXPECT_EQ("[2, {f1: 2, f2: NULL, f3: [2, 3, 4]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']",
+    EXPECT_EQ("[2, {f1:2,f2:NULL,f3:[2,3,4]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
               chunk->debug_row(2));
-    EXPECT_EQ("[3, {f1: 3, f2: NULL, f3: [3, 4, 5]}, 'c', [{e1: NULL, e2: 'c'}, {e1: NULL, e2: 'c'}], 'C']",
+    EXPECT_EQ("[3, {f1:3,f2:NULL,f3:[3,4,5]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']",
               chunk->debug_row(3));
-    EXPECT_EQ("[4, {f1: 4, f2: NULL, f3: [4, 5, 6]}, 'c', [{e1: NULL, e2: 'c'}, {e1: NULL, e2: 'c'}], 'C']",
+    EXPECT_EQ("[4, {f1:4,f2:NULL,f3:[4,5,6]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']",
               chunk->debug_row(4));
-    EXPECT_EQ("[5, {f1: 5, f2: NULL, f3: [5, 6, 7]}, 'c', [{e1: NULL, e2: 'c'}, {e1: NULL, e2: 'c'}], 'C']",
+    EXPECT_EQ("[5, {f1:5,f2:NULL,f3:[5,6,7]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']",
               chunk->debug_row(5));
-    EXPECT_EQ("[6, {f1: 6, f2: NULL, f3: [6, 7, 8]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']",
+    EXPECT_EQ("[6, {f1:6,f2:NULL,f3:[6,7,8]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
               chunk->debug_row(6));
-    EXPECT_EQ("[7, {f1: 7, f2: NULL, f3: [7, 8, 9]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']",
+    EXPECT_EQ("[7, {f1:7,f2:NULL,f3:[7,8,9]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
               chunk->debug_row(7));
-    EXPECT_EQ("[8, {f1: 8, f2: NULL, f3: [8, 9, 10]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']",
+    EXPECT_EQ("[8, {f1:8,f2:NULL,f3:[8,9,10]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
               chunk->debug_row(8));
-    EXPECT_EQ("[9, {f1: 9, f2: NULL, f3: [9, 10, 11]}, 'a', [{e1: NULL, e2: 'a'}, {e1: NULL, e2: 'a'}], 'A']",
+    EXPECT_EQ("[9, {f1:9,f2:NULL,f3:[9,10,11]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
               chunk->debug_row(9));
 
     //    for (int i = 0; i < 10; ++i) {
@@ -1497,7 +1485,7 @@ TEST_F(FileReaderTest, TestReadStructCaseSensitive) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(1024, chunk->num_rows());
 
-    EXPECT_EQ("[0, {F1: 0, F2: 'a', F3: [0, 1, 2]}]", chunk->debug_row(0));
+    EXPECT_EQ("[0, {F1:0,F2:'a',F3:[0,1,2]}]", chunk->debug_row(0));
 
     //    for (int i = 0; i < 1; ++i) {
     //        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
@@ -1600,20 +1588,16 @@ TEST_F(FileReaderTest, TestReadStructNull) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(4, chunk->num_rows());
 
-    EXPECT_EQ("[1, {c1_0: 1, c1_1: [1, 2, 3]}, [{c2_0: 1, c2_1: 1}, {c2_0: 2, c2_1: 2}, {c2_0: 3, c2_1: 3}]]",
+    EXPECT_EQ("[1, {c1_0:1,c1_1:[1,2,3]}, [{c2_0:1,c2_1:1},{c2_0:2,c2_1:2},{c2_0:3,c2_1:3}]]",
               chunk->debug_row(0));
-    EXPECT_EQ("[2, {c1_0: NULL, c1_1: [2, 3, 4]}, [{c2_0: NULL, c2_1: 2}, {c2_0: NULL, c2_1: 3}]]",
+    EXPECT_EQ("[2, {c1_0:NULL,c1_1:[2,3,4]}, [{c2_0:NULL,c2_1:2},{c2_0:NULL,c2_1:3}]]",
               chunk->debug_row(1));
     EXPECT_EQ(
-            "[3, {c1_0: 3, c1_1: [NULL]}, [{c2_0: NULL, c2_1: NULL}, {c2_0: NULL, c2_1: NULL}, {c2_0: NULL, c2_1: "
-            "NULL}]]",
+            "[3, {c1_0:3,c1_1:[NULL]}, [{c2_0:NULL,c2_1:NULL},{c2_0:NULL,c2_1:NULL},{c2_0:NULL,c2_1:NULL}]]",
             chunk->debug_row(2));
-    EXPECT_EQ("[4, {c1_0: 4, c1_1: [4, 5, 6]}, [{c2_0: 4, c2_1: NULL}, {c2_0: 5, c2_1: NULL}, {c2_0: 6, c2_1: 4}]]",
+    EXPECT_EQ("[4, {c1_0:4,c1_1:[4,5,6]}, [{c2_0:4,c2_1:NULL},{c2_0:5,c2_1:NULL},{c2_0:6,c2_1:4}]]",
               chunk->debug_row(3));
 
-    //    for (int i = 0; i < 4; ++i) {
-    //        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-    //    }
 }
 
 TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
@@ -1663,20 +1647,16 @@ TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
     status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ(chunk->num_rows(), 8);
-    for (int i = 0; i < chunk->num_rows(); ++i) {
-        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-    }
-    EXPECT_EQ(chunk->debug_row(0), "[1, {'k1':NULL, 'k2':NULL}, {NULL:{'f1':NULL, 'f2':NULL}}, {NULL:[1, 2]}]");
+    EXPECT_EQ(chunk->debug_row(0), "[1, {'k1':NULL,'k2':NULL}, {NULL:{'f1':NULL,'f2':NULL}}, {NULL:[1,2]}]");
     EXPECT_EQ(chunk->debug_row(1),
-              "[2, {'k1':NULL, 'k3':NULL, 'k4':NULL}, {NULL:{'f1':NULL, 'f2':NULL}, NULL:{'f1':NULL, 'f2':NULL}}, "
-              "{NULL:[1], NULL:[2]}]");
+              "[2, {'k1':NULL,'k3':NULL,'k4':NULL}, {NULL:{'f1':NULL,'f2':NULL},NULL:{'f1':NULL,'f2':NULL}}, {NULL:[1],NULL:[2]}]");
     EXPECT_EQ(chunk->debug_row(2),
-              "[3, {'k2':NULL, 'k3':NULL, 'k5':NULL}, {NULL:{'f1':NULL, 'f2':NULL, 'f3':NULL}}, {NULL:[1, 2, 3]}]");
-    EXPECT_EQ(chunk->debug_row(3), "[4, {'k1':NULL, 'k2':NULL, 'k3':NULL}, {NULL:{'f2':NULL}}, {NULL:[1]}]");
+              "[3, {'k2':NULL,'k3':NULL,'k5':NULL}, {NULL:{'f1':NULL,'f2':NULL,'f3':NULL}}, {NULL:[1,2,3]}]");
+    EXPECT_EQ(chunk->debug_row(3), "[4, {'k1':NULL,'k2':NULL,'k3':NULL}, {NULL:{'f2':NULL}}, {NULL:[1]}]");
     EXPECT_EQ(chunk->debug_row(4), "[5, {'k3':NULL}, {NULL:{'f2':NULL}}, {NULL:[NULL]}]");
     EXPECT_EQ(chunk->debug_row(5), "[6, {'k1':NULL}, {NULL:{'f2':NULL}}, {NULL:[1]}]");
-    EXPECT_EQ(chunk->debug_row(6), "[7, {'k1':NULL, 'k2':NULL}, {NULL:{'f2':NULL}}, {NULL:[1, 2, 3]}]");
-    EXPECT_EQ(chunk->debug_row(7), "[8, {'k3':NULL}, {NULL:{'f1':NULL, 'f2':NULL, 'f3':NULL}}, {NULL:[1], NULL:[2]}]");
+    EXPECT_EQ(chunk->debug_row(6), "[7, {'k1':NULL,'k2':NULL}, {NULL:{'f2':NULL}}, {NULL:[1,2,3]}]");
+    EXPECT_EQ(chunk->debug_row(7), "[8, {'k3':NULL}, {NULL:{'f1':NULL,'f2':NULL,'f3':NULL}}, {NULL:[1],NULL:[2]}]");
 }
 
 TEST_F(FileReaderTest, TestReadNotNull) {
@@ -1730,13 +1710,9 @@ TEST_F(FileReaderTest, TestReadNotNull) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(3, chunk->num_rows());
 
-    EXPECT_EQ("[1, {'a':1}, {a: 'a', b: 1}]", chunk->debug_row(0));
-    EXPECT_EQ("[2, {'b':2, 'c':3}, {a: 'b', b: 2}]", chunk->debug_row(1));
-    EXPECT_EQ("[3, {'c':3}, {a: 'c', b: 3}]", chunk->debug_row(2));
-
-    for (int i = 0; i < 3; ++i) {
-        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-    }
+    EXPECT_EQ("[1, {'a':1}, {a:'a',b:1}]", chunk->debug_row(0));
+    EXPECT_EQ("[2, {'b':2,'c':3}, {a:'b',b:2}]", chunk->debug_row(1));
+    EXPECT_EQ("[3, {'c':3}, {a:'c',b:3}]", chunk->debug_row(2));
 }
 
 TEST_F(FileReaderTest, TestReadMapNull) {
@@ -1782,10 +1758,6 @@ TEST_F(FileReaderTest, TestReadMapNull) {
     EXPECT_EQ("[1, NULL]", chunk->debug_row(0));
     EXPECT_EQ("[2, NULL]", chunk->debug_row(1));
     EXPECT_EQ("[3, NULL]", chunk->debug_row(2));
-
-    for (int i = 0; i < 3; ++i) {
-        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-    }
 }
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1313,26 +1313,16 @@ TEST_F(FileReaderTest, TestReadStruct) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(1024, chunk->num_rows());
 
-    EXPECT_EQ("[0, {f2:'a',f1:0,f3:[0,1,2]}, 'a', [{e1:0,e2:'a'},{e1:1,e2:'a'}], 'A']",
-              chunk->debug_row(0));
-    EXPECT_EQ("[1, {f2:'a',f1:1,f3:[1,2,3]}, 'a', [{e1:1,e2:'a'},{e1:2,e2:'a'}], 'A']",
-              chunk->debug_row(1));
-    EXPECT_EQ("[2, {f2:'a',f1:2,f3:[2,3,4]}, 'a', [{e1:2,e2:'a'},{e1:3,e2:'a'}], 'A']",
-              chunk->debug_row(2));
-    EXPECT_EQ("[3, {f2:'c',f1:3,f3:[3,4,5]}, 'c', [{e1:3,e2:'c'},{e1:4,e2:'c'}], 'C']",
-              chunk->debug_row(3));
-    EXPECT_EQ("[4, {f2:'c',f1:4,f3:[4,5,6]}, 'c', [{e1:4,e2:'c'},{e1:5,e2:'c'}], 'C']",
-              chunk->debug_row(4));
-    EXPECT_EQ("[5, {f2:'c',f1:5,f3:[5,6,7]}, 'c', [{e1:5,e2:'c'},{e1:6,e2:'c'}], 'C']",
-              chunk->debug_row(5));
-    EXPECT_EQ("[6, {f2:'a',f1:6,f3:[6,7,8]}, 'a', [{e1:6,e2:'a'},{e1:7,e2:'a'}], 'A']",
-              chunk->debug_row(6));
-    EXPECT_EQ("[7, {f2:'a',f1:7,f3:[7,8,9]}, 'a', [{e1:7,e2:'a'},{e1:8,e2:'a'}], 'A']",
-              chunk->debug_row(7));
-    EXPECT_EQ("[8, {f2:'a',f1:8,f3:[8,9,10]}, 'a', [{e1:8,e2:'a'},{e1:9,e2:'a'}], 'A']",
-              chunk->debug_row(8));
-    EXPECT_EQ("[9, {f2:'a',f1:9,f3:[9,10,11]}, 'a', [{e1:9,e2:'a'},{e1:10,e2:'a'}], 'A']",
-              chunk->debug_row(9));
+    EXPECT_EQ("[0, {f2:'a',f1:0,f3:[0,1,2]}, 'a', [{e1:0,e2:'a'},{e1:1,e2:'a'}], 'A']", chunk->debug_row(0));
+    EXPECT_EQ("[1, {f2:'a',f1:1,f3:[1,2,3]}, 'a', [{e1:1,e2:'a'},{e1:2,e2:'a'}], 'A']", chunk->debug_row(1));
+    EXPECT_EQ("[2, {f2:'a',f1:2,f3:[2,3,4]}, 'a', [{e1:2,e2:'a'},{e1:3,e2:'a'}], 'A']", chunk->debug_row(2));
+    EXPECT_EQ("[3, {f2:'c',f1:3,f3:[3,4,5]}, 'c', [{e1:3,e2:'c'},{e1:4,e2:'c'}], 'C']", chunk->debug_row(3));
+    EXPECT_EQ("[4, {f2:'c',f1:4,f3:[4,5,6]}, 'c', [{e1:4,e2:'c'},{e1:5,e2:'c'}], 'C']", chunk->debug_row(4));
+    EXPECT_EQ("[5, {f2:'c',f1:5,f3:[5,6,7]}, 'c', [{e1:5,e2:'c'},{e1:6,e2:'c'}], 'C']", chunk->debug_row(5));
+    EXPECT_EQ("[6, {f2:'a',f1:6,f3:[6,7,8]}, 'a', [{e1:6,e2:'a'},{e1:7,e2:'a'}], 'A']", chunk->debug_row(6));
+    EXPECT_EQ("[7, {f2:'a',f1:7,f3:[7,8,9]}, 'a', [{e1:7,e2:'a'},{e1:8,e2:'a'}], 'A']", chunk->debug_row(7));
+    EXPECT_EQ("[8, {f2:'a',f1:8,f3:[8,9,10]}, 'a', [{e1:8,e2:'a'},{e1:9,e2:'a'}], 'A']", chunk->debug_row(8));
+    EXPECT_EQ("[9, {f2:'a',f1:9,f3:[9,10,11]}, 'a', [{e1:9,e2:'a'},{e1:10,e2:'a'}], 'A']", chunk->debug_row(9));
 
     //    for (int i = 0; i < 10; ++i) {
     //        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
@@ -1410,26 +1400,16 @@ TEST_F(FileReaderTest, TestReadStructSubField) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(1024, chunk->num_rows());
 
-    EXPECT_EQ("[0, {f1:0,f2:NULL,f3:[0,1,2]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
-              chunk->debug_row(0));
-    EXPECT_EQ("[1, {f1:1,f2:NULL,f3:[1,2,3]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
-              chunk->debug_row(1));
-    EXPECT_EQ("[2, {f1:2,f2:NULL,f3:[2,3,4]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
-              chunk->debug_row(2));
-    EXPECT_EQ("[3, {f1:3,f2:NULL,f3:[3,4,5]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']",
-              chunk->debug_row(3));
-    EXPECT_EQ("[4, {f1:4,f2:NULL,f3:[4,5,6]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']",
-              chunk->debug_row(4));
-    EXPECT_EQ("[5, {f1:5,f2:NULL,f3:[5,6,7]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']",
-              chunk->debug_row(5));
-    EXPECT_EQ("[6, {f1:6,f2:NULL,f3:[6,7,8]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
-              chunk->debug_row(6));
-    EXPECT_EQ("[7, {f1:7,f2:NULL,f3:[7,8,9]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
-              chunk->debug_row(7));
-    EXPECT_EQ("[8, {f1:8,f2:NULL,f3:[8,9,10]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
-              chunk->debug_row(8));
-    EXPECT_EQ("[9, {f1:9,f2:NULL,f3:[9,10,11]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']",
-              chunk->debug_row(9));
+    EXPECT_EQ("[0, {f1:0,f2:NULL,f3:[0,1,2]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']", chunk->debug_row(0));
+    EXPECT_EQ("[1, {f1:1,f2:NULL,f3:[1,2,3]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']", chunk->debug_row(1));
+    EXPECT_EQ("[2, {f1:2,f2:NULL,f3:[2,3,4]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']", chunk->debug_row(2));
+    EXPECT_EQ("[3, {f1:3,f2:NULL,f3:[3,4,5]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']", chunk->debug_row(3));
+    EXPECT_EQ("[4, {f1:4,f2:NULL,f3:[4,5,6]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']", chunk->debug_row(4));
+    EXPECT_EQ("[5, {f1:5,f2:NULL,f3:[5,6,7]}, 'c', [{e1:NULL,e2:'c'},{e1:NULL,e2:'c'}], 'C']", chunk->debug_row(5));
+    EXPECT_EQ("[6, {f1:6,f2:NULL,f3:[6,7,8]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']", chunk->debug_row(6));
+    EXPECT_EQ("[7, {f1:7,f2:NULL,f3:[7,8,9]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']", chunk->debug_row(7));
+    EXPECT_EQ("[8, {f1:8,f2:NULL,f3:[8,9,10]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']", chunk->debug_row(8));
+    EXPECT_EQ("[9, {f1:9,f2:NULL,f3:[9,10,11]}, 'a', [{e1:NULL,e2:'a'},{e1:NULL,e2:'a'}], 'A']", chunk->debug_row(9));
 
     //    for (int i = 0; i < 10; ++i) {
     //        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
@@ -1588,16 +1568,12 @@ TEST_F(FileReaderTest, TestReadStructNull) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(4, chunk->num_rows());
 
-    EXPECT_EQ("[1, {c1_0:1,c1_1:[1,2,3]}, [{c2_0:1,c2_1:1},{c2_0:2,c2_1:2},{c2_0:3,c2_1:3}]]",
-              chunk->debug_row(0));
-    EXPECT_EQ("[2, {c1_0:NULL,c1_1:[2,3,4]}, [{c2_0:NULL,c2_1:2},{c2_0:NULL,c2_1:3}]]",
-              chunk->debug_row(1));
-    EXPECT_EQ(
-            "[3, {c1_0:3,c1_1:[NULL]}, [{c2_0:NULL,c2_1:NULL},{c2_0:NULL,c2_1:NULL},{c2_0:NULL,c2_1:NULL}]]",
-            chunk->debug_row(2));
+    EXPECT_EQ("[1, {c1_0:1,c1_1:[1,2,3]}, [{c2_0:1,c2_1:1},{c2_0:2,c2_1:2},{c2_0:3,c2_1:3}]]", chunk->debug_row(0));
+    EXPECT_EQ("[2, {c1_0:NULL,c1_1:[2,3,4]}, [{c2_0:NULL,c2_1:2},{c2_0:NULL,c2_1:3}]]", chunk->debug_row(1));
+    EXPECT_EQ("[3, {c1_0:3,c1_1:[NULL]}, [{c2_0:NULL,c2_1:NULL},{c2_0:NULL,c2_1:NULL},{c2_0:NULL,c2_1:NULL}]]",
+              chunk->debug_row(2));
     EXPECT_EQ("[4, {c1_0:4,c1_1:[4,5,6]}, [{c2_0:4,c2_1:NULL},{c2_0:5,c2_1:NULL},{c2_0:6,c2_1:4}]]",
               chunk->debug_row(3));
-
 }
 
 TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
@@ -1649,7 +1625,8 @@ TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
     EXPECT_EQ(chunk->num_rows(), 8);
     EXPECT_EQ(chunk->debug_row(0), "[1, {'k1':NULL,'k2':NULL}, {NULL:{'f1':NULL,'f2':NULL}}, {NULL:[1,2]}]");
     EXPECT_EQ(chunk->debug_row(1),
-              "[2, {'k1':NULL,'k3':NULL,'k4':NULL}, {NULL:{'f1':NULL,'f2':NULL},NULL:{'f1':NULL,'f2':NULL}}, {NULL:[1],NULL:[2]}]");
+              "[2, {'k1':NULL,'k3':NULL,'k4':NULL}, {NULL:{'f1':NULL,'f2':NULL},NULL:{'f1':NULL,'f2':NULL}}, "
+              "{NULL:[1],NULL:[2]}]");
     EXPECT_EQ(chunk->debug_row(2),
               "[3, {'k2':NULL,'k3':NULL,'k5':NULL}, {NULL:{'f1':NULL,'f2':NULL,'f3':NULL}}, {NULL:[1,2,3]}]");
     EXPECT_EQ(chunk->debug_row(3), "[4, {'k1':NULL,'k2':NULL,'k3':NULL}, {NULL:{'f2':NULL}}, {NULL:[1]}]");

--- a/be/test/serde/column_array_serde_test.cpp
+++ b/be/test/serde/column_array_serde_test.cpp
@@ -334,8 +334,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, array_column) {
     auto c2 = vectorized::ArrayColumn::create(elem1, off2);
 
     ASSERT_EQ(buffer.data() + buffer.size(), ColumnArraySerde::deserialize(buffer.data(), c2.get()));
-    ASSERT_EQ("[1, 2, 3]", c2->debug_item(0));
-    ASSERT_EQ("[4, 5, 6]", c2->debug_item(1));
+    ASSERT_EQ("[1,2,3]", c2->debug_item(0));
+    ASSERT_EQ("[4,5,6]", c2->debug_item(1));
 
     for (auto level = -1; level < 8; ++level) {
         buffer.resize(ColumnArraySerde::max_serialized_size(*c1, level));
@@ -347,8 +347,8 @@ PARALLEL_TEST(ColumnArraySerdeTest, array_column) {
         c2 = vectorized::ArrayColumn::create(elem1, off2);
 
         ColumnArraySerde::deserialize(buffer.data(), c2.get(), false, level);
-        ASSERT_EQ("[1, 2, 3]", c2->debug_item(0));
-        ASSERT_EQ("[4, 5, 6]", c2->debug_item(1));
+        ASSERT_EQ("[1,2,3]", c2->debug_item(0));
+        ASSERT_EQ("[4,5,6]", c2->debug_item(1));
     }
 }
 

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -639,7 +639,7 @@ TEST(ColumnAggregator, testArrayReplace) {
     aggregator->aggregate_values(0, 2, loops.data(), false);
 
     ASSERT_EQ(1, agg->size());
-    EXPECT_EQ("['2','3','4']",agg->debug_item(0));
+    EXPECT_EQ("['2','3','4']", agg->debug_item(0));
 
     // second chunk column
     src->reset_column();
@@ -661,8 +661,8 @@ TEST(ColumnAggregator, testArrayReplace) {
     aggregator->aggregate_values(0, 3, loops.data(), false);
 
     EXPECT_EQ(3, agg->size());
-    EXPECT_EQ("['10','11']",agg->debug_item(1));
-    EXPECT_EQ("['17','18']",agg->debug_item(2));
+    EXPECT_EQ("['10','11']", agg->debug_item(1));
+    EXPECT_EQ("['17','18']", agg->debug_item(2));
 
     // third chunk column
     src->reset_column();
@@ -682,7 +682,7 @@ TEST(ColumnAggregator, testArrayReplace) {
 
     EXPECT_EQ(5, agg->size());
     EXPECT_EQ("['19']", agg->debug_item(3));
-    EXPECT_EQ("['20','21','22','23','24','25','26','27','28','29']",agg->debug_item(4));
+    EXPECT_EQ("['20','21','22','23','24','25','26','27','28','29']", agg->debug_item(4));
 }
 
 // NOLINTNEXTLINE

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -639,7 +639,7 @@ TEST(ColumnAggregator, testArrayReplace) {
     aggregator->aggregate_values(0, 2, loops.data(), false);
 
     ASSERT_EQ(1, agg->size());
-    EXPECT_EQ("['2', '3', '4']", agg->debug_item(0));
+    EXPECT_EQ("['2','3','4']",agg->debug_item(0));
 
     // second chunk column
     src->reset_column();
@@ -661,8 +661,8 @@ TEST(ColumnAggregator, testArrayReplace) {
     aggregator->aggregate_values(0, 3, loops.data(), false);
 
     EXPECT_EQ(3, agg->size());
-    EXPECT_EQ("['10', '11']", agg->debug_item(1));
-    EXPECT_EQ("['17', '18']", agg->debug_item(2));
+    EXPECT_EQ("['10','11']",agg->debug_item(1));
+    EXPECT_EQ("['17','18']",agg->debug_item(2));
 
     // third chunk column
     src->reset_column();
@@ -682,7 +682,7 @@ TEST(ColumnAggregator, testArrayReplace) {
 
     EXPECT_EQ(5, agg->size());
     EXPECT_EQ("['19']", agg->debug_item(3));
-    EXPECT_EQ("['20', '21', '22', '23', '24', '25', '26', '27', '28', '29']", agg->debug_item(4));
+    EXPECT_EQ("['20','21','22','23','24','25','26','27','28','29']",agg->debug_item(4));
 }
 
 // NOLINTNEXTLINE

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -423,8 +423,8 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("[1, 2, 3]", dst_column->debug_item(0));
-                ASSERT_EQ("[4, 5, 6]", dst_column->debug_item(1));
+                ASSERT_EQ("[1,2,3]", dst_column->debug_item(0));
+                ASSERT_EQ("[4,5,6]", dst_column->debug_item(1));
             }
 
             ASSERT_EQ(2, meta.num_rows());

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -186,7 +186,7 @@ private:
 };
 
 // test map<int, int>, and nullable
-TEST_F(MapColumnRWTest, test_array_int) {
+TEST_F(MapColumnRWTest, test_map_int) {
     test_int_map();
 }
 

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -175,8 +175,8 @@ protected:
 
                 ASSERT_EQ("{1:1}", dst_column->debug_item(0));
                 ASSERT_EQ("{}", dst_column->debug_item(1));
-                ASSERT_EQ("{2:200, 3:3000}", dst_column->debug_item(2));
-                ASSERT_EQ("{4:-1, 5:-2, 6:-3}", dst_column->debug_item(3));
+                ASSERT_EQ("{2:200,3:3000}", dst_column->debug_item(2));
+                ASSERT_EQ("{4:-1,5:-2,6:-3}", dst_column->debug_item(3));
             }
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In this CL, I changed
1. change the debug_item of ArrayColumn, MapColumn, StructColumn to be the same as MySQL result format
2. Use std::vector<std::string> as field_names in StructColumn.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
