### PR TITLE
[BugFix][Cherry-pick][Branch-2.5]map/struct type persist to support create external table with map/str…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -23,6 +23,13 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.thrift.TTypeNode;
 import com.starrocks.thrift.TTypeNodeType;
@@ -33,7 +40,9 @@ import java.util.Arrays;
  * Describes a MAP type. MAP types have a scalar key and an arbitrarily-typed value.
  */
 public class MapType extends Type {
+    @SerializedName(value = "keyType")
     private Type keyType;
+    @SerializedName(value = "valueType")
     private Type valueType;
 
     public MapType(Type keyType, Type valueType) {
@@ -148,6 +157,20 @@ public class MapType extends Type {
         clone.valueType = this.valueType.clone();
         clone.selectedFields = this.selectedFields.clone();
         return clone;
+    }
+
+    public static class MapTypeDeSerializer implements JsonDeserializer<MapType> {
+        @Override
+        public MapType deserialize(JsonElement jsonElement, java.lang.reflect.Type type,
+                                   JsonDeserializationContext jsonDeserializationContext)
+                throws JsonParseException {
+            JsonObject dumpJsonObject = jsonElement.getAsJsonObject();
+            JsonObject key = dumpJsonObject.getAsJsonObject("keyType");
+            Type keyType = GsonUtils.GSON.fromJson(key, Type.class);
+            JsonObject value = dumpJsonObject.getAsJsonObject("valueType");
+            Type valueType = GsonUtils.GSON.fromJson(value, Type.class);
+            return new MapType(keyType, valueType);
+        }
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
@@ -22,6 +22,7 @@
 package com.starrocks.catalog;
 
 import com.google.common.base.Strings;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.thrift.TStructField;
 import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.thrift.TTypeNode;
@@ -31,8 +32,11 @@ import com.starrocks.thrift.TTypeNode;
  * comments of struct fields. We set comment to null to avoid compatibility issues.
  */
 public class StructField {
+    @SerializedName(value = "name")
     private final String name;
+    @SerializedName(value = "type")
     private final Type type;
+    @SerializedName(value = "comment")
     private final String comment;
     private int position;  // in struct
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -245,6 +245,10 @@ public class GsonUtils {
 
     private static final JsonDeserializer<PrimitiveType> PRIMITIVE_TYPE_DESERIALIZER = new PrimitiveTypeDeserializer();
 
+    private static final JsonDeserializer<MapType> MAP_TYPE_JSON_DESERIALIZER = new MapType.MapTypeDeSerializer();
+
+    private static final JsonDeserializer<StructType> STRUCT_TYPE_JSON_DESERIALIZER = new StructType.StructTypeDeSerializer();
+
     // the builder of GSON instance.
     // Add any other adapters if necessary.
     private static final GsonBuilder GSON_BUILDER = new GsonBuilder()
@@ -253,6 +257,11 @@ public class GsonUtils {
             .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
             .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
             .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
+            // specified childcalss DeSerializer must be ahead of fatherclass,
+            // because when GsonBuilder::create() will reverse it,
+            // and gson::getDelegateAdapter will skip the factory ahead of father TypeAdapterFactory factory.
+            .registerTypeAdapter(MapType.class, MAP_TYPE_JSON_DESERIALIZER)
+            .registerTypeAdapter(StructType.class, STRUCT_TYPE_JSON_DESERIALIZER)
             .registerTypeAdapterFactory(COLUMN_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(DISTRIBUTION_INFO_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(RESOURCE_TYPE_ADAPTER_FACTORY)

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -21,6 +21,8 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.Lists;
+import com.starrocks.persist.gson.GsonUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -179,5 +181,42 @@ public class TypeTest {
             String name = (String) tc[1];
             Assert.assertEquals(name, type.canonicalName());
         }
+    }
+
+    @Test
+    public void testMapSerialAndDeser() {
+        // map<int,struct<c1:int,cc1:string>>
+        StructType c1 = new StructType(Lists.newArrayList(
+                new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("cc1", ScalarType.createDefaultExternalTableString())
+        ));
+        MapType mapType =
+                new MapType(ScalarType.createType(PrimitiveType.INT), c1);
+        String json = GsonUtils.GSON.toJson(mapType);
+        Type deType = GsonUtils.GSON.fromJson(json, Type.class);
+        Assert.assertTrue(deType.isMapType());
+        Assert.assertEquals("MAP<INT,STRUCT<c1:int(11), cc1:varchar(1048576)>>", deType.toString());
+        // test initialed selectedField by ctor in deserializer.
+        deType.setSelectedField(0, false);
+    }
+
+    @Test
+    public void testStructSerialAndDeser() {
+        // "struct<struct_test:int,c1:struct<c1:int,cc1:string>>"
+        StructType c1 = new StructType(Lists.newArrayList(
+                new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("cc1", ScalarType.createDefaultExternalTableString())
+        ));
+        StructType root = new StructType(Lists.newArrayList(
+                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT), "comment test"),
+                new StructField("c1", c1)
+        ));
+        String json = GsonUtils.GSON.toJson(root);
+        Type deType = GsonUtils.GSON.fromJson(json, Type.class);
+        Assert.assertTrue(deType.isStructType());
+        Assert.assertEquals("STRUCT<struct_test:int(11) COMMENT 'comment test', c1:STRUCT<c1:int(11), cc1:varchar(1048576)>>",
+                deType.toString());
+        // test initialed fieldMap by ctor in deserializer.
+        Assert.assertEquals(1, ((StructType) deType).getFieldPos("c1"));
     }
 }


### PR DESCRIPTION
…uct column  and the type can be recovered when fe restart (#15208)

map/struct type persist to support create external table with map/struct column and the type can be recovered when fe restart

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
