### PR TITLE
[BugFix] Fix field display order is inconsistent with the statement of table creation when select * from iceberg_table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -313,7 +313,7 @@ public class IcebergUtil {
                             LOG.error("Failed to convert iceberg type {}", field.type().toString(), e);
                             srType = Type.UNKNOWN_TYPE;
                         }
-                        Column column = new Column(field.name().toLowerCase(), srType, true);
+                        Column column = new Column(field.name(), srType, true);
                         fullSchema.add(column);
                     }
             );


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15498

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix field display order is inconsistent with the statement of table creation when select * from icebergtable
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
