### PR TITLE
[Enhancement] Show enable pipeline cmds when query only supported by pipeline

### DIFF
--- a/be/src/runtime/multi_cast_data_stream_sink.cpp
+++ b/be/src/runtime/multi_cast_data_stream_sink.cpp
@@ -4,7 +4,10 @@
 
 namespace starrocks {
 
-static Status kOnlyPipelinedEngine = Status::NotSupported("Don't support non-pipelined query engine");
+static Status kOnlyPipelinedEngine = Status::NotSupported(
+        "Don't support non-pipelined query engine. "
+        "enable by: set enable_pipeline=true; "
+        "and ADMIN SET FRONTEND CONFIG (\"enable_pipeline_load_for_insert\" = \"true\"); (for INSERT INTO)");
 
 MultiCastDataStreamSink::MultiCastDataStreamSink(RuntimeState* state) : _state(state), _sinks() {}
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2OuterJoinRule.java
@@ -208,7 +208,8 @@ public class QuantifiedApply2OuterJoinRule extends TransformationRule {
         private void check() {
             if (!context.getSessionVariable().isEnablePipelineEngine()) {
                 throw new SemanticException("In sub-query depend on pipeline which one not in where-clause, " +
-                        "enable by: set enable_pipeline=true;");
+                        "enable by: set enable_pipeline=true; " +
+                        "and ADMIN SET FRONTEND CONFIG (\"enable_pipeline_load_for_insert\" = \"true\"); (for INSERT INTO)");
             }
         }
 


### PR DESCRIPTION


## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Show enable pipeline cmds when query only supported by pipeline
```
Don't support non-pipelined query engine. enable by: set enable_pipeline=true; and ADMIN SET FRONTEND CONFIG ("enable_pipeline_load_for_insert" = "true"); (for INSERT INTO)

or

In sub-query depend on pipeline which one not in where-clause, enable by: set enable_pipeline=true; and ADMIN SET FRONTEND CONFIG ("enable_pipeline_load_for_insert" = "true"); (for INSERT INTO)
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [x] 2.3
  - [ ] 2.2
