### PR TITLE
[Enhancement] load support fast cancel step 1: make `cancel` no longer blocks

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -62,6 +62,8 @@ public:
 
     void cancel() override;
 
+    void abort() override;
+
     MemTracker* mem_tracker() { return _mem_tracker; }
 
 private:
@@ -376,10 +378,14 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
     return Status::OK();
 }
 
-void LakeTabletsChannel::cancel() {
+void LakeTabletsChannel::abort() {
     for (auto& it : _delta_writers) {
         it.second->close();
     }
+}
+
+void LakeTabletsChannel::cancel() {
+    //TODO: Current LakeDeltaWriter don't support fast cancel
 }
 
 StatusOr<std::unique_ptr<LakeTabletsChannel::WriteContext>> LakeTabletsChannel::_create_write_context(

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -196,21 +196,28 @@ void LoadChannel::add_segment(brpc::Controller* cntl, const PTabletWriterAddSegm
 }
 
 void LoadChannel::cancel() {
-    _span->AddEvent("cancel");
-    auto scoped = trace::Scope(_span);
     std::lock_guard l(_lock);
     for (auto& it : _tablets_channels) {
         it.second->cancel();
     }
 }
 
-void LoadChannel::cancel(int64_t index_id, int64_t tablet_id) {
+void LoadChannel::abort() {
+    _span->AddEvent("cancel");
+    auto scoped = trace::Scope(_span);
+    std::lock_guard l(_lock);
+    for (auto& it : _tablets_channels) {
+        it.second->abort();
+    }
+}
+
+void LoadChannel::abort(int64_t index_id, int64_t tablet_id) {
     std::lock_guard l(_lock);
     auto it = _tablets_channels.find(index_id);
     if (it != _tablets_channels.end()) {
         auto local_tablets_channel = down_cast<LocalTabletsChannel*>(it->second.get());
         if (local_tablets_channel != nullptr) {
-            local_tablets_channel->cancel(tablet_id);
+            local_tablets_channel->abort(tablet_id);
         }
     }
 }

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -90,7 +90,9 @@ public:
 
     void cancel();
 
-    void cancel(int64_t index_id, int64_t tablet_id);
+    void abort();
+
+    void abort(int64_t index_id, int64_t tablet_id);
 
     time_t last_updated_time() const { return _last_updated_time.load(std::memory_order_relaxed); }
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -163,11 +163,13 @@ void LoadChannelMgr::cancel(brpc::Controller* cntl, const PTabletWriterCancelReq
     if (request.has_tablet_id()) {
         auto channel = _find_load_channel(load_id);
         if (channel != nullptr) {
-            channel->cancel(request.index_id(), request.tablet_id());
+            channel->cancel();
+            channel->abort(request.index_id(), request.tablet_id());
         }
     } else {
         if (auto channel = remove_load_channel(load_id); channel != nullptr) {
             channel->cancel();
+            channel->abort();
         }
     }
 }
@@ -217,6 +219,9 @@ void LoadChannelMgr::_start_load_channels_clean() {
     // eg: MemTracker in load channel
     for (auto& channel : timeout_channels) {
         channel->cancel();
+    }
+    for (auto& channel : timeout_channels) {
+        channel->abort();
         LOG(INFO) << "Deleted timeout channel. load id=" << channel->load_id() << " timeout=" << channel->timeout();
     }
 

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -446,6 +446,12 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
 }
 
 void LocalTabletsChannel::cancel() {
+    for (auto& it : _delta_writers) {
+        it.second->cancel(Status::Cancelled("cancel"));
+    }
+}
+
+void LocalTabletsChannel::abort() {
     vector<int64_t> tablet_ids;
     tablet_ids.reserve(_delta_writers.size());
     for (auto& it : _delta_writers) {
@@ -459,7 +465,7 @@ void LocalTabletsChannel::cancel() {
               << " tablet_ids:" << tablet_id_list_str;
 }
 
-void LocalTabletsChannel::cancel(int64_t tablet_id) {
+void LocalTabletsChannel::abort(int64_t tablet_id) {
     auto it = _delta_writers.find(tablet_id);
     if (it != _delta_writers.end()) {
         it->second->abort(true);

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -61,7 +61,9 @@ public:
 
     void cancel() override;
 
-    void cancel(int64_t tablet_id);
+    void abort() override;
+
+    void abort(int64_t tablet_id);
 
     MemTracker* mem_tracker() { return _mem_tracker; }
 

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -55,6 +55,8 @@ public:
                            PTabletWriterAddBatchResult* response) = 0;
 
     virtual void cancel() = 0;
+
+    virtual void abort() = 0;
 };
 
 struct TabletsChannelKey {

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -136,13 +136,16 @@ void AsyncDeltaWriter::commit(AsyncDeltaWriterCallback* cb) {
     }
 }
 
+void AsyncDeltaWriter::cancel(const Status& st) {
+    _writer->cancel(st);
+}
+
 void AsyncDeltaWriter::abort(bool with_log) {
     Task task;
     task.abort = true;
     task.abort_with_log = with_log;
 
     bthread::TaskOptions options;
-    options.high_priority = true;
     int r = bthread::execution_queue_execute(_queue_id, task, &options);
     LOG_IF(WARNING, r != 0) << "Fail to execution_queue_execute: " << r;
 

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -83,6 +83,8 @@ public:
     // [thread-safe and wait-free]
     void abort(bool with_log = true);
 
+    void cancel(const Status& st);
+
     int64_t partition_id() const { return _writer->partition_id(); }
 
     ReplicaState replica_state() const { return _writer->replica_state(); }

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -58,7 +58,7 @@ DeltaWriter::DeltaWriter(DeltaWriterOptions opt, MemTracker* mem_tracker, Storag
 DeltaWriter::~DeltaWriter() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     if (_flush_token != nullptr) {
-        _flush_token->cancel();
+        _flush_token->shutdown();
     }
     if (_replicate_token != nullptr) {
         _replicate_token->cancel();
@@ -487,13 +487,20 @@ Status DeltaWriter::commit() {
     return Status::OK();
 }
 
+void DeltaWriter::cancel(const Status& st) {
+    _set_state(kAborted, st);
+    if (_flush_token != nullptr) {
+        _flush_token->cancel(st);
+    }
+}
+
 void DeltaWriter::abort(bool with_log) {
     _set_state(kAborted, Status::Cancelled("aborted by others"));
     _with_rollback_log = with_log;
     if (_flush_token != nullptr) {
         // Wait until all background tasks finished/cancelled.
         // https://github.com/StarRocks/starrocks/issues/8906
-        _flush_token->cancel();
+        _flush_token->shutdown();
     }
     if (_replicate_token != nullptr) {
         _replicate_token->cancel();

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -94,6 +94,8 @@ public:
     // [NOT thread-safe]
     [[nodiscard]] Status close();
 
+    void cancel(const Status& st);
+
     // Wait until all data have been flushed to disk, then create a new Rowset.
     // Prerequite: the DeltaWriter has been successfully `close()`d.
     // [NOT thread-safe]

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -102,8 +102,16 @@ Status FlushToken::submit(std::unique_ptr<vectorized::MemTable> memtable, bool e
     return _flush_token->submit(std::move(task));
 }
 
-void FlushToken::cancel() {
+void FlushToken::shutdown() {
     _flush_token->shutdown();
+}
+
+void FlushToken::cancel(const Status& st) {
+    if (st.ok()) return;
+    std::lock_guard l(_status_lock);
+    if (_status.ok()) {
+        _status = st;
+    }
 }
 
 Status FlushToken::wait() {

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -81,7 +81,9 @@ public:
 
     // error has happpens, so we cancel this token
     // And remove all tasks in the queue.
-    void cancel();
+    void shutdown();
+
+    void cancel(const Status& st);
 
     // wait all tasks in token to be completed.
     Status wait();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15513 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If the load task times out or the user terminates early, the resources used by load cannot be released immediately.
So we need to support FastCancel and release resources as soon as possible.
This is the first pr: Modify the implement of  `cancel`, only set status, will not be blocked by I/O, queue or other behavior.
Other: Replicated load and lake storage is not support fast cancel now, it will be fixed in other pr.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
