### PR TITLE
[Refactor] Remove unused sum_distinct in FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -238,7 +238,6 @@ public class FunctionSet {
     public static final String VAR_SAMP = "var_samp";
     public static final String VARIANCE_SAMP = "variance_samp";
     public static final String ANY_VALUE = "any_value";
-    public static final String SUM_DISTINCT = "sum_distinct";
     public static final String STD = "std";
     public static final String STDDEV_VAL = "stddev_val";
     public static final String HLL_UNION = "hll_union";
@@ -800,7 +799,6 @@ public class FunctionSet {
 
         // Sum
         registerBuiltinSumAggFunction(SUM);
-        registerBuiltinSumAggFunction(SUM_DISTINCT);
         // MultiDistinctSum
         registerBuiltinMultiDistinctSumAggFunction();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -55,7 +55,7 @@ public class DecimalV3FunctionAnalyzer {
 
     public static final Set<String> DECIMAL_AGG_FUNCTION_WIDER_TYPE =
             new ImmutableSortedSet.Builder<>(String::compareTo)
-                    .add(FunctionSet.COUNT).add(FunctionSet.SUM).add(FunctionSet.SUM_DISTINCT)
+                    .add(FunctionSet.COUNT).add(FunctionSet.SUM)
                     .add(FunctionSet.MULTI_DISTINCT_SUM).add(FunctionSet.AVG).add(FunctionSet.VARIANCE)
                     .add(FunctionSet.VARIANCE_POP).add(FunctionSet.VAR_POP).add(FunctionSet.VARIANCE_SAMP)
                     .add(FunctionSet.VAR_SAMP).add(FunctionSet.STD).add(FunctionSet.STDDEV).add(FunctionSet.STDDEV_POP)
@@ -69,7 +69,7 @@ public class DecimalV3FunctionAnalyzer {
 
     public static final Set<String> DECIMAL_SUM_FUNCTION_TYPE =
             new ImmutableSortedSet.Builder<>(String::compareTo).add(FunctionSet.SUM)
-                    .add(FunctionSet.SUM_DISTINCT).add(FunctionSet.MULTI_DISTINCT_SUM).build();
+                    .add(FunctionSet.MULTI_DISTINCT_SUM).build();
 
     public static final Set<String> DECIMAL_AGG_FUNCTION =
             new ImmutableSortedSet.Builder<>(String::compareTo)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -251,12 +251,6 @@ public class FunctionAnalyzer {
             throw new SemanticException(
                     fnName.getFunction() + " requires a numeric parameter: " + functionCallExpr.toSql());
         }
-        if (fnName.getFunction().equals(FunctionSet.SUM_DISTINCT)
-                && ((!arg.getType().isNumericType() && !arg.getType().isNull() && !(arg instanceof NullLiteral)) ||
-                !arg.getType().canApplyToNumeric())) {
-            throw new SemanticException(
-                    "SUM_DISTINCT requires a numeric parameter: " + functionCallExpr.toSql());
-        }
 
         if ((fnName.getFunction().equals(FunctionSet.MIN)
                 || fnName.getFunction().equals(FunctionSet.MAX)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -357,7 +357,11 @@ public class Optimizer {
                 && Utils.countInnerJoinNodeSize(tree) < sessionVariable.getCboMaxReorderNode()) {
             if (Utils.countInnerJoinNodeSize(tree) > sessionVariable.getCboMaxReorderNodeUseExhaustive()) {
                 CTEUtils.collectForceCteStatistics(memo, context);
+
+                OptimizerTraceUtil.logOptExpression(connectContext, "before ReorderJoinRule:\n%s", tree);
                 new ReorderJoinRule().transform(tree, context);
+                OptimizerTraceUtil.logOptExpression(connectContext, "after ReorderJoinRule:\n%s", tree);
+
                 context.getRuleSet().addJoinCommutativityWithOutInnerRule();
             } else {
                 if (Utils.capableSemiReorder(tree, false, 0, sessionVariable.getCboMaxReorderNodeUseExhaustive())) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -213,15 +213,15 @@ public class AnalyzeDecimalV3Test {
         String sql1 = "" +
                 "select\n" +
                 "   sum(col_decimal_p9s4) as decimal32_sum,\n" +
-                "   sum_distinct(col_decimal_p9s4) as decimal32_sum_distinct,\n" +
+                "   sum(distinct col_decimal_p9s4) as decimal32_sum_distinct,\n" +
                 "   multi_distinct_sum(col_decimal_p9s4) as decimal32_multi_distinct_sum,\n" +
 
                 "   sum(col_decimal_p15s10) as decimal64_sum,\n" +
-                "   sum_distinct(col_decimal_p15s10) as decimal64_sum_distinct,\n" +
+                "   sum(distinct col_decimal_p15s10) as decimal64_sum_distinct,\n" +
                 "   multi_distinct_sum(col_decimal_p15s10) as decimal64_multi_distinct_sum,\n" +
 
                 "   sum(col_decimal_p38s30) as decimal128_sum,\n" +
-                "   sum_distinct(col_decimal_p38s30) as decimal128_sum_distinct,\n" +
+                "   sum(distinct col_decimal_p38s30) as decimal128_sum_distinct,\n" +
                 "   multi_distinct_sum(col_decimal_p38s30) as decimal128_multi_distinct_sum\n" +
                 "from db1.decimal_table\n";
 
@@ -258,8 +258,7 @@ public class AnalyzeDecimalV3Test {
             Assert.assertEquals(type, expectReturnType);
             Assert.assertEquals(argType, expectArgType);
             System.out.printf("%s: %s\n", fn.functionName(), serdeType);
-            if (fn.functionName().equalsIgnoreCase(FunctionSet.SUM) ||
-                    fn.functionName().equalsIgnoreCase(FunctionSet.SUM_DISTINCT)) {
+            if (fn.functionName().equalsIgnoreCase(FunctionSet.SUM)) {
                 Assert.assertEquals(serdeType, null);
             } else {
                 Assert.assertEquals(serdeType, Type.VARBINARY);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
- `SUM_DISTINCT` is not implemented in BE, which can be used `sum(distinct x)` or `multi_distinct_sum`.
- Remove `SUM_DISTINCT` codes in FE.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
