### PR TITLE
[Enhancement] Support specifying AnonymousAWSCredentialsProvider after removing the broker in ingestion

### DIFF
--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -213,10 +213,12 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
     bool path_style_access = config::object_storage_endpoint_path_style_access;
     const THdfsProperties* hdfs_properties = opts.hdfs_properties();
     if (hdfs_properties != nullptr) {
-        DCHECK(hdfs_properties->__isset.access_key);
-        DCHECK(hdfs_properties->__isset.secret_key);
-        access_key_id = hdfs_properties->access_key;
-        secret_access_key = hdfs_properties->secret_key;
+        if (hdfs_properties->__isset.access_key) {
+            access_key_id = hdfs_properties->access_key;
+        }
+        if (hdfs_properties->__isset.secret_key) {
+            secret_access_key = hdfs_properties->secret_key;
+        }
     } else {
         access_key_id = config::object_storage_access_key_id;
         secret_access_key = config::object_storage_secret_access_key;

--- a/fe/fe-core/src/test/java/com/starrocks/fs/TestHdfsFsManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/TestHdfsFsManager.java
@@ -69,11 +69,28 @@ public class TestHdfsFsManager extends TestCase {
     }
 
     @Test
-    public void testGetRegionFromEndPoint() throws IOException {
+    public void testS3GetRegionFromEndPoint1() throws IOException {
         Map<String, String> properties = new HashMap<String, String>();
         properties.put("fs.s3a.access.key", "accessKey");
         properties.put("fs.s3a.secret.key", "secretKey");
         properties.put("fs.s3a.endpoint", "s3.ap-southeast-1.amazonaws.com");
+        THdfsProperties property = new THdfsProperties();
+        try {
+            HdfsFs fs = fileSystemManager.getFileSystem("s3a://testbucket/data/abc/logs", properties, property);
+            assertNotNull(fs);
+            Assert.assertEquals(property.region, "ap-southeast-1");
+            fs.getDFSFileSystem().close();
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testS3GetRegionFromEndPoint2() throws IOException {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("fs.s3a.access.key", "accessKey");
+        properties.put("fs.s3a.secret.key", "secretKey");
+        properties.put("fs.s3a.endpoint", "s3-ap-southeast-1.amazonaws.com");
         THdfsProperties property = new THdfsProperties();
         try {
             HdfsFs fs = fileSystemManager.getFileSystem("s3a://testbucket/data/abc/logs", properties, property);


### PR DESCRIPTION
Support specifying AnonymousAWSCredentialsProvider after removing the broker in ingestion.
According to doc link https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html, several default providers are chained, it should suffice for most cases.
```
    <property>
        <name>fs.s3a.aws.credentials.provider</name>
        <value>
            org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider,
            org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider,
            org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider,
            com.amazonaws.auth.EnvironmentVariableCredentialsProvider,
            org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider
            com.amazonaws.auth.InstanceProfileCredentialsProvider
        </value>
    </property>
```
For org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider, it doesn't need ak/sk, here we remove the check for ak/sk for broker load, following is the example for org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider
```
LOAD LABEL test.label
(
    DATA INFILE("xxxxx")
    INTO TABLE tab
    FORMAT AS "csv"
)
WITH BROKER
(
    "fs.s3a.endpoint" = "s3-us-west-2.amazonaws.com",
    "fs.s3a.aws.credentials.provider" = "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider"
);
```
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15548

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
