### PR TITLE
[BugFix] HANDLE_FILED catch exception when getting an external table fails.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/exception/StarRocksConnectorException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/exception/StarRocksConnectorException.java
@@ -39,4 +39,10 @@ public class StarRocksConnectorException extends RuntimeException {
         return getErrorMessage();
     }
 
+    public static void check(boolean test, String message, Object... args) {
+        if (!test) {
+            throw new StarRocksConnectorException(message, args);
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/HiveTableOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/HiveTableOperations.java
@@ -18,6 +18,7 @@ package com.starrocks.connector.iceberg.hive;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Strings;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -25,7 +26,6 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.ClientPool;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
@@ -121,7 +121,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
     static void validateTableIsIceberg(Table table, String fullName) {
         String tableType = table.getParameters().get(TABLE_TYPE_PROP);
-        NoSuchIcebergTableException.check(tableType != null && tableType.equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE),
+        StarRocksConnectorException.check(tableType != null && tableType.equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE),
                 "Not an iceberg table: %s (type=%s)", fullName, tableType);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -48,6 +48,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.StarRocksIcebergException;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.metric.ResourceGroupMetricMgr;
@@ -416,7 +417,9 @@ public class ConnectProcessor {
             }
 
         } catch (StarRocksIcebergException e) {
-            LOG.warn("errors happened when getting Iceberg table {}", tableName, e);
+            LOG.error("errors happened when getting Iceberg table {}", tableName, e);
+        } catch (StarRocksConnectorException e) {
+            LOG.error("errors happened when getting table {}", tableName, e);
         } finally {
             db.readUnlock();
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
if a hive table exists in the db under a iceberg catalog. An exception will be thrown, and subsequent queries will keep coming back with the exception.
![image](https://user-images.githubusercontent.com/91597003/208833005-26c45bc8-cb7b-40a5-9ced-6cade3437cb5.png)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
