### PR TITLE
[cherry-pick][branch-2.5][BugFix] Fix Potential out of bounds or heap overflow in encode procedure when primary key model compaction with sort key. (#15124)

### DIFF
--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -40,6 +40,9 @@ public:
     static void encode(const vectorized::Schema& schema, const vectorized::Chunk& chunk, size_t offset, size_t len,
                        vectorized::Column* dest);
 
+    static void encode_sort_key(const vectorized::Schema& schema, const vectorized::Chunk& chunk, size_t offset,
+                                size_t len, vectorized::Column* dest);
+
     static void encode_selective(const vectorized::Schema& schema, const vectorized::Chunk& chunk,
                                  const uint32_t* indexes, size_t len, vectorized::Column* dest);
 

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -92,7 +92,8 @@ struct MergeEntry {
                 if (encode_schema != nullptr) {
                     // need to encode
                     chunk_pk_column->reset_column();
-                    PrimaryKeyEncoder::encode(*encode_schema, *chunk, 0, chunk->num_rows(), chunk_pk_column.get());
+                    PrimaryKeyEncoder::encode_sort_key(*encode_schema, *chunk, 0, chunk->num_rows(),
+                                                       chunk_pk_column.get());
                 } else {
                     // just use chunk's first column
                     chunk_pk_column = chunk->get_column_by_index(chunk->schema()->sort_key_idxes()[0]);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15122

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the old code use the number of primary keys as encode columns' number, should not still use this way. for example, when sort keys exist, primary keys indexes are {0}, the sort keys indexes are {1, 2}, use the size of primary keys indexes will be 1, in the function prepare_ops_datas, will encode the 1 prefix of sort keys indexes, it will be {1}, it is not right, should be {1, 2}. this PR change the function to use an indexes instead of the prefix N indexes. and, added some new corresponding case to expose this bug.

```
./run-ut.sh --run --gtest_filter=TabletUpdatesTest.horizontal_compaction_with_sort_key
```

### Expected behavior (Required)
pass

### Real behavior (Required)

```
*** Aborted at 1670899524 (unix time) try "date -d @1670899524" if you are using GNU date ***
PC: @     0x7f28e8dbf387 __GI_raise
*** SIGABRT (@0x3ee0001b246) received by PID 111174 (TID 0x7f28eac7e2c0) from PID 111174; stack trace: ***
    @         0x14b1a902 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f28e9874630 (unknown)
    @     0x7f28e8dbf387 __GI_raise
    @     0x7f28e8dc0a78 __GI_abort
    @     0x7f28e8db81a6 __assert_fail_base
    @     0x7f28e8db8252 __GI___assert_fail
    @          0x9e68f4f down_cast<>()
    @          0xcaf4524 starrocks::vectorized::BinaryColumnBase<>::append()
    @         0x121f507b starrocks::PrimaryKeyEncoder::encode()
    @         0x12bd4e14 starrocks::vectorized::MergeEntry<>::next()
    @         0x12bc6ab6 starrocks::vectorized::MergeEntry<>::init()
    @         0x12b9d0bf starrocks::vectorized::RowsetMergerImpl<>::_do_merge_horizontally()
    @         0x12b90cdb starrocks::vectorized::RowsetMergerImpl<>::do_merge()
    @         0x12b8629c starrocks::vectorized::compaction_merge_rowsets()
    @         0x123b7f6d starrocks::TabletUpdates::_do_compaction()
    @         0x123ca03c starrocks::TabletUpdates::compaction()
    @          0xbd8b6b5 starrocks::TabletUpdatesTest_horizontal_compaction_with_sort_key_Test::TestBody()
    @         0x16766936 testing::Test::Run()
    @         0x16766aa5 testing::TestInfo::Run()
    @         0x16766b95 testing::TestSuite::Run()
    @         0x167670e6 testing::internal::UnitTestImpl::RunAllTests()
    @         0x16767328 testing::UnitTest::Run()
    @          0x90f1cce RUN_ALL_TESTS()
    @          0x90e919f main
    @     0x7f28e8dab555 __libc_start_main
    @          0x90225bc (unknown)
    @                0x0 (unknown)
./run-ut.sh: line 258: 111174 Aborted                 ${GTEST_PARALLEL} ${STARROCKS_TEST_BINARY_DIR}/starrocks_test --gtest_catch_exceptions=0 --gtest_filter=${TEST_FILTER} --serialize_test_cases ${GTEST_PARALLEL_OPTIONS}
```

```
./run-ut.sh --run --gtest_filter=TabletUpdatesTest.horizontal_compaction_with_sort_key
```

### Expected behavior (Required)
pass

### Real behavior (Required)
```
[ RUN      ] TabletUpdatesTest.horizontal_compaction_with_sort_key_error_encode_case
=================================================================
==144061==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020002c5a98 at pc 0x0000121f4690 bp 0x7ffd7c205610 sp 0x7ffd7c205608
WRITE of size 8 at 0x6020002c5a98 thread T0
    #0 0x121f468f in prepare_ops_datas /home/disk3/starrocks/be/src/storage/primary_key_encoder.cpp:366
    #1 0x121f5c06 in starrocks::PrimaryKeyEncoder::encode_sort_key(starrocks::vectorized::VectorizedSchema const&, starrocks::vectorized::Chunk const&, unsigned long, unsigned long, starrocks::vectorized::Column*) /home/disk3/starrocks/be/src/storage/primary_key_encoder.cpp:460
    #2 0x12bd4d19 in starrocks::vectorized::MergeEntry<starrocks::Slice>::next() /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:107
    #3 0x12bc69bb in starrocks::vectorized::MergeEntry<starrocks::Slice>::init() /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:94
    #4 0x12b9cfc4 in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::_do_merge_horizontally(starrocks::Tablet&, long, starrocks::vectorized::VectorizedSchema const&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&, unsigned long*, unsigned long*, unsigned long*, starrocks::OlapReaderStatistics*, starrocks::vectorized::RowSourceMaskBuffer*, std::vector<std::unique_ptr<starrocks::vectorized::RowSourceMaskBuffer, std::default_delete<starrocks::vectorized::RowSourceMaskBuffer> >, std::allocator<std::unique_ptr<starrocks::vectorized::RowSourceMaskBuffer, std::default_delete<starrocks::vectorized::RowSourceMaskBuffer> > > >*) /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:311
    #5 0x12b90be0 in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::do_merge(starrocks::Tablet&, long, starrocks::vectorized::VectorizedSchema const&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&) /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:245
    #6 0x12b861a1 in starrocks::vectorized::compaction_merge_rowsets(starrocks::Tablet&, long, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&) /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:574
    #7 0x123b7e72 in starrocks::TabletUpdates::_do_compaction(std::unique_ptr<starrocks::CompactionInfo, std::default_delete<starrocks::CompactionInfo> >*) /home/disk3/starrocks/be/src/storage/tablet_updates.cpp:1263
    #8 0x123c9f41 in starrocks::TabletUpdates::compaction(starrocks::MemTracker*) /home/disk3/starrocks/be/src/storage/tablet_updates.cpp:1892
    #9 0xbd8f072 in starrocks::TabletUpdatesTest_horizontal_compaction_with_sort_key_error_encode_case_Test::TestBody() /home/disk3/starrocks/be/test/storage/tablet_updates_test.cpp:1497
    #10 0x16765935 in testing::Test::Run() ../googletest/src/gtest.cc:2508
    #11 0x16765935 in testing::Test::Run() ../googletest/src/gtest.cc:2498
    #12 0x16765aa4 in testing::TestInfo::Run() ../googletest/src/gtest.cc:2684
    #13 0x16765aa4 in testing::TestInfo::Run() ../googletest/src/gtest.cc:2657
    #14 0x16765b94 in testing::TestSuite::Run() ../googletest/src/gtest.cc:2816
    #15 0x16765b94 in testing::TestSuite::Run() ../googletest/src/gtest.cc:2795
    #16 0x167660e5 in testing::internal::UnitTestImpl::RunAllTests() ../googletest/src/gtest.cc:5338
    #17 0x16766327 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../googletest/src/gtest.cc:2491
    #18 0x16766327 in testing::UnitTest::Run() ../googletest/src/gtest.cc:4925
    #19 0x90f1ccd in RUN_ALL_TESTS() (/home/disk3/starrocks/be/ut_build_ASAN/test/starrocks_test+0x90f1ccd)
    #20 0x90e919e in main /home/disk3/starrocks/be/test/test_main.cpp:93
    #21 0x7f2aaf301554 in __libc_start_main (/lib64/libc.so.6+0x22554)
    #22 0x90225bb  (/home/disk3/starrocks/be/ut_build_ASAN/test/starrocks_test+0x90225bb)

0x6020002c5a98 is located 0 bytes to the right of 8-byte region [0x6020002c5a90,0x6020002c5a98)
allocated by thread T0 here:
    #0 0x90a9db7 in operator new(unsigned long) ../../../../libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x121fe28e in __gnu_cxx::new_allocator<void const*>::allocate(unsigned long, void const*) /home/disk1/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/ext/new_allocator.h:115
    #2 0x121fdf8d in std::allocator_traits<std::allocator<void const*> >::allocate(std::allocator<void const*>&, unsigned long) /home/disk1/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/alloc_traits.h:460
    #3 0x121fdd41 in std::_Vector_base<void const*, std::allocator<void const*> >::_M_allocate(unsigned long) /home/disk1/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/stl_vector.h:346
    #4 0x121fd8e0 in std::_Vector_base<void const*, std::allocator<void const*> >::_M_create_storage(unsigned long) /home/disk1/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/stl_vector.h:361
    #5 0x121fd0ca in std::_Vector_base<void const*, std::allocator<void const*> >::_Vector_base(unsigned long, std::allocator<void const*> const&) /home/disk1/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/stl_vector.h:305
    #6 0x121fbb38 in std::vector<void const*, std::allocator<void const*> >::vector(unsigned long, std::allocator<void const*> const&) /home/disk1/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/stl_vector.h:511
    #7 0x121f5b27 in starrocks::PrimaryKeyEncoder::encode_sort_key(starrocks::vectorized::VectorizedSchema const&, starrocks::vectorized::Chunk const&, unsigned long, unsigned long, starrocks::vectorized::Column*) /home/disk3/starrocks/be/src/storage/primary_key_encoder.cpp:459
    #8 0x12bd4d19 in starrocks::vectorized::MergeEntry<starrocks::Slice>::next() /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:107
    #9 0x12bc69bb in starrocks::vectorized::MergeEntry<starrocks::Slice>::init() /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:94
    #10 0x12b9cfc4 in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::_do_merge_horizontally(starrocks::Tablet&, long, starrocks::vectorized::VectorizedSchema const&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&, unsigned long*, unsigned long*, unsigned long*, starrocks::OlapReaderStatistics*, starrocks::vectorized::RowSourceMaskBuffer*, std::vector<std::unique_ptr<starrocks::vectorized::RowSourceMaskBuffer, std::default_delete<starrocks::vectorized::RowSourceMaskBuffer> >, std::allocator<std::unique_ptr<starrocks::vectorized::RowSourceMaskBuffer, std::default_delete<starrocks::vectorized::RowSourceMaskBuffer> > > >*) /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:311
    #11 0x12b90be0 in starrocks::vectorized::RowsetMergerImpl<starrocks::Slice>::do_merge(starrocks::Tablet&, long, starrocks::vectorized::VectorizedSchema const&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&) /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:245
    #12 0x12b861a1 in starrocks::vectorized::compaction_merge_rowsets(starrocks::Tablet&, long, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&, starrocks::RowsetWriter*, starrocks::vectorized::MergeConfig const&) /home/disk3/starrocks/be/src/storage/rowset_merger.cpp:574
    #13 0x123b7e72 in starrocks::TabletUpdates::_do_compaction(std::unique_ptr<starrocks::CompactionInfo, std::default_delete<starrocks::CompactionInfo> >*) /home/disk3/starrocks/be/src/storage/tablet_updates.cpp:1263
    #14 0x123c9f41 in starrocks::TabletUpdates::compaction(starrocks::MemTracker*) /home/disk3/starrocks/be/src/storage/tablet_updates.cpp:1892
    #15 0xbd8f072 in starrocks::TabletUpdatesTest_horizontal_compaction_with_sort_key_error_encode_case_Test::TestBody() /home/disk3/starrocks/be/test/storage/tablet_updates_test.cpp:1497
    #16 0x16765935 in testing::Test::Run() ../googletest/src/gtest.cc:2508
    #17 0x16765935 in testing::Test::Run() ../googletest/src/gtest.cc:2498
    #18 0x16765aa4 in testing::TestInfo::Run() ../googletest/src/gtest.cc:2684
    #19 0x16765aa4 in testing::TestInfo::Run() ../googletest/src/gtest.cc:2657
    #20 0x16765b94 in testing::TestSuite::Run() ../googletest/src/gtest.cc:2816
    #21 0x16765b94 in testing::TestSuite::Run() ../googletest/src/gtest.cc:2795
    #22 0x167660e5 in testing::internal::UnitTestImpl::RunAllTests() ../googletest/src/gtest.cc:5338
    #23 0x16766327 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../googletest/src/gtest.cc:2491
    #24 0x16766327 in testing::UnitTest::Run() ../googletest/src/gtest.cc:4925
    #25 0x90f1ccd in RUN_ALL_TESTS() (/home/disk3/starrocks/be/ut_build_ASAN/test/starrocks_test+0x90f1ccd)
    #26 0x90e919e in main /home/disk3/starrocks/be/test/test_main.cpp:93
    #27 0x7f2aaf301554 in __libc_start_main (/lib64/libc.so.6+0x22554)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/disk3/starrocks/be/src/storage/primary_key_encoder.cpp:366 in prepare_ops_datas
Shadow bytes around the buggy address:
  0x0c0480050b00: fa fa 07 fa fa fa 00 06 fa fa 03 fa fa fa fd fd
  0x0c0480050b10: fa fa fd fa fa fa fd fa fa fa 00 fa fa fa fd fa
  0x0c0480050b20: fa fa 00 fa fa fa 00 06 fa fa 00 02 fa fa fd fa
  0x0c0480050b30: fa fa 00 fa fa fa fd fd fa fa fd fd fa fa fd fa
  0x0c0480050b40: fa fa fd fa fa fa fd fa fa fa fd fa fa fa 00 fa
=>0x0c0480050b50: fa fa 00[fa]fa fa 00 fa fa fa fa fa fa fa fa fa
  0x0c0480050b60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480050b70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480050b80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480050b90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480050ba0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==144061==ABORTING
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
