### PR TITLE
[Enhancement] Take container into consideration when initiating concurrency

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -108,7 +108,7 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
         // nothing to do
     }
 
-    static auto num_hardware_cores = (int32_t)std::thread::hardware_concurrency();
+    static auto num_hardware_cores = static_cast<int32_t>(CpuInfo::num_cores());
     if (res.ok()) {
         heartbeat_result.backend_info.__set_be_port(config::be_port);
         heartbeat_result.backend_info.__set_http_port(config::webserver_port);

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -20,6 +20,7 @@
 #include "exec/workgroup/work_group_fwd.h"
 #include "glog/logging.h"
 #include "runtime/exec_env.h"
+#include "util/cpu_info.h"
 #include "util/metrics.h"
 #include "util/starrocks_metrics.h"
 #include "util/time.h"
@@ -532,7 +533,7 @@ std::vector<TWorkGroup> WorkGroupManager::list_all_workgroups() {
 }
 
 size_t WorkGroupManager::normal_workgroup_cpu_hard_limit() const {
-    static int num_hardware_cores = std::thread::hardware_concurrency();
+    static int num_hardware_cores = CpuInfo::num_cores();
     return std::max<int>(1, num_hardware_cores - _rt_cpu_limit);
 }
 

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -63,6 +63,7 @@ set(UTIL_FILES
   mysql_row_buffer.cpp
   error_util.cc
   spinlock.cc
+  file_util.cpp
   filesystem_util.cc
   time.cpp
 # coding_util.cpp

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -42,6 +42,7 @@ set(UTIL_FILES
   json.cpp
   json_converter.cpp
   starrocks_metrics.cpp
+  cpu_info.cpp
   mem_info.cpp
   metrics.cpp
   murmur_hash3.cpp

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -42,7 +42,6 @@ set(UTIL_FILES
   json.cpp
   json_converter.cpp
   starrocks_metrics.cpp
-  cpu_info.cpp
   mem_info.cpp
   metrics.cpp
   murmur_hash3.cpp

--- a/be/src/util/core_local.h
+++ b/be/src/util/core_local.h
@@ -26,6 +26,7 @@
 
 #include "common/compiler_util.h"
 #include "gutil/macros.h"
+#include "util/cpu_info.h"
 
 namespace starrocks {
 

--- a/be/src/util/cpu_info.cpp
+++ b/be/src/util/cpu_info.cpp
@@ -247,9 +247,8 @@ void CpuInfo::_init_num_cores_with_cgroup() {
         return;
     }
     struct statfs fs;
-    int err = statfs("/sys/fs/cgroup", &fs);
-    if (err < 0) {
-        LOG(WARNING) << "Fail to get file system statistics. err: " << errno_to_string(err);
+    if (statfs("/sys/fs/cgroup", &fs) < 0) {
+        LOG(WARNING) << "Fail to get file system statistics. err: " << errno_to_string(errno);
         return;
     }
     std::ifstream ifs;

--- a/be/src/util/cpu_info.h
+++ b/be/src/util/cpu_info.h
@@ -185,6 +185,9 @@ private:
     /// Initialize NUMA-related state - called from Init();
     static void _init_numa();
 
+    /// Initialize num cores taking cgroup config into consideration
+    static void _init_num_cores_with_cgroup();
+
     /// Initialize 'numa_node_to_cores_' based on 'max_num_numa_nodes_' and
     /// 'core_to_numa_node_'. Called from InitNuma();
     static void _init_numa_node_to_cores();

--- a/be/src/util/cpu_usage_info.cpp
+++ b/be/src/util/cpu_usage_info.cpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <thread>
 
+#include "util/cpu_info.h"
 #include "util/defer_op.h"
 #include "util/time.h"
 

--- a/be/src/util/file_util.cpp
+++ b/be/src/util/file_util.cpp
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "file_util.h"
+
+#include <fstream>
+#include <sstream>
+namespace starrocks {
+
+bool FileUtil::read_whole_content(const std::string& path, std::string& dest) {
+    std::ifstream ifs;
+    ifs.open(path);
+    if (!ifs.good()) {
+        return false;
+    }
+    std::stringstream ss;
+    ss << ifs.rdbuf();
+    ifs.close();
+
+    dest = ss.str();
+    return true;
+}
+}; // namespace starrocks

--- a/be/src/util/file_util.h
+++ b/be/src/util/file_util.h
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <fstream>
+#include <string>
+
+namespace starrocks {
+class FileUtil {
+public:
+    static bool read_whole_content(const std::string& path, std::string& dest);
+
+    template <typename... Args>
+    static bool read_contents(const std::string& path, Args&... values) {
+        std::ifstream ifs;
+        ifs.open(path);
+        if (!ifs.good()) {
+            return false;
+        }
+
+        (ifs >> ... >> values);
+
+        bool ok = ifs.good();
+        ifs.close();
+        return ok;
+    }
+};
+}; // namespace starrocks

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -119,9 +119,8 @@ void MemInfo::set_memlimit_if_container() {
         return;
     }
     struct statfs fs;
-    int err = statfs("/sys/fs/cgroup", &fs);
-    if (err < 0) {
-        LOG(WARNING) << "Fail to get file system statistics. err: " << errno_to_string(err);
+    if (statfs("/sys/fs/cgroup", &fs) < 0) {
+        LOG(WARNING) << "Fail to get file system statistics. err: " << errno_to_string(errno);
         return;
     }
 

--- a/be/test/storage/tablet_meta_manager_test.cpp
+++ b/be/test/storage/tablet_meta_manager_test.cpp
@@ -364,8 +364,8 @@ protected:
         };
 
         auto t0 = std::chrono::steady_clock::now();
-        std::vector<std::thread> threads(std::thread::hardware_concurrency());
-        for (int i = 0; i < std::thread::hardware_concurrency(); i++) {
+        std::vector<std::thread> threads(CpuInfo::num_cores());
+        for (int i = 0; i < CpuInfo::num_cores(); i++) {
             threads[i] = std::thread(rowset_commit_thread);
         }
         for (auto& t : threads) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There are many ways to set cpu limitation of a container, taking docker for example

* `--cpu-period`: affect cpu.cfs_period_us
* `--cpu-quota`: affect cpu.cfs_quota_us
* `--cpu-rt-period`: affect cpu.rt_period_us
* `--cpu-rt-runtime`: affect cpu.rt_runtime_us
* `--cpus`: affect both `cpu.cfs_period_us` and `cpu.cfs_quota_us`
* `--cpuset-cpus`: set cpu affinity

Now, for cpu limitation, we only respect `cpu.cfs_period_us` and `cpu.cfs_quota_us` and `cpuset.cpus`. And real time scheduler configs(`cpu.rt_period_us`, `cpu.rt_runtime_us`) will be ignored when calculating relative core number

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
