### PR TITLE
[BugFix]make a new operator instead of modifying the old one in pruning cols

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.LogicalProperty;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -36,11 +37,14 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -213,14 +217,7 @@ public class ReorderJoinRule extends Rule {
                     for (ColumnRefOperator ref : outputColumns) {
                         newOutputProjections.put(ref, projection.getColumnRefMap().get(ref));
                     }
-
-                    Operator.Builder builder = OperatorBuilderFactory.build(operator);
-
-                    Operator newOp = builder.withOperator(operator)
-                            .setProjection(new Projection(newOutputProjections))
-                            .build();
-                    optExpression = OptExpression.create(newOp, optExpression.getInputs());
-                    optExpression.deriveLogicalPropertyItself();
+                    optExpression = deriveNewOptExpression(optExpression, newOutputProjections);
                 }
 
                 for (ScalarOperator value : optExpression.getOp().getProjection().getColumnRefMap().values()) {
@@ -273,6 +270,34 @@ public class ReorderJoinRule extends Rule {
             statisticsCalculator.estimatorStats();
             joinOpt.setStatistics(expressionContext.getStatistics());
             return joinOpt;
+        }
+
+        private OptExpression deriveNewOptExpression(OptExpression optExpression,
+                                                     Map<ColumnRefOperator, ScalarOperator> newOutputProjections) {
+            Operator operator = optExpression.getOp();
+            ColumnRefSet newCols = new ColumnRefSet(newOutputProjections.keySet());
+            LogicalProperty newProperty = new LogicalProperty(optExpression.getLogicalProperty());
+            newProperty.setOutputColumns(newCols);
+
+            Statistics newStats = Statistics.buildFrom(optExpression.getStatistics()).build();
+            Iterator<Map.Entry<ColumnRefOperator, ColumnStatistic>>
+                    iterator = newStats.getColumnStatistics().entrySet().iterator();
+            while(iterator.hasNext()) {
+                Map.Entry<ColumnRefOperator, ColumnStatistic> columnStatistic = iterator.next();
+                if (!newCols.contains(columnStatistic.getKey())) {
+                    iterator.remove();
+                }
+            }
+
+            Operator.Builder builder = OperatorBuilderFactory.build(operator);
+            Operator newOp = builder.withOperator(operator)
+                    .setProjection(new Projection(newOutputProjections))
+                    .build();
+
+            OptExpression newOpt = OptExpression.create(newOp, optExpression.getInputs());
+            newOpt.setLogicalProperty(newProperty);
+            newOpt.setStatistics(newStats);
+            return newOpt;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -220,6 +220,7 @@ public class ReorderJoinRule extends Rule {
                             .setProjection(new Projection(newOutputProjections))
                             .build();
                     optExpression = OptExpression.create(newOp, optExpression.getInputs());
+                    optExpression.deriveLogicalPropertyItself();
                 }
 
                 for (ScalarOperator value : optExpression.getOp().getProjection().getColumnRefMap().values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
@@ -213,7 +214,12 @@ public class ReorderJoinRule extends Rule {
                         newOutputProjections.put(ref, projection.getColumnRefMap().get(ref));
                     }
 
-                    optExpression.getOp().setProjection(new Projection(newOutputProjections));
+                    Operator.Builder builder = OperatorBuilderFactory.build(operator);
+
+                    Operator newOp = builder.withOperator(operator)
+                            .setProjection(new Projection(newOutputProjections))
+                            .build();
+                    optExpression = OptExpression.create(newOp, optExpression.getInputs());
                 }
 
                 for (ScalarOperator value : optExpression.getOp().getProjection().getColumnRefMap().values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.join;
 
 import com.google.common.collect.Lists;
@@ -282,7 +281,7 @@ public class ReorderJoinRule extends Rule {
             Statistics newStats = Statistics.buildFrom(optExpression.getStatistics()).build();
             Iterator<Map.Entry<ColumnRefOperator, ColumnStatistic>>
                     iterator = newStats.getColumnStatistics().entrySet().iterator();
-            while(iterator.hasNext()) {
+            while (iterator.hasNext()) {
                 Map.Entry<ColumnRefOperator, ColumnStatistic> columnStatistic = iterator.next();
                 if (!newCols.contains(columnStatistic.getKey())) {
                     iterator.remove();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -467,4 +467,21 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("<slot 27> : NULL"));
     }
+
+    @Test
+    public void testPruneColsWithMultiJoin() throws Exception {
+        String sql = "select true from t1, (select v10, v11, v12, 3 from t3) subt3 inner join (select v3, v1, 4 from t0) " +
+                "subt0 on subt3.v10 =subt0.v1 and subt0.v1 = 1 and subt3.v10 != subt0.v3, " +
+                "(select v7, v8, 'aa' from t2) subv0 inner join t2 on subv0.v7 = t2.v7 group by 'abc';";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  4 <-> [4: v10, BIGINT, true]\n" +
+                "  |  cardinality: 500000000\n" +
+                "  |  column statistics: \n" +
+                "  |  * v10-->[1.0, 1.0, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     table: t3, rollup: t3");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15255

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When obtain a joinExpr genreted by reorder algorithm, we need prune the redundant cols in it. At this time, the prune process should make a new operator instead of modifying the old one. If not, the pruned output cols of the old operator  is different from the logcial property info in the group, which leads to wrong plan.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
