### PR TITLE
[Bugfix][aarch64] Patch Brpc to make SR work in Aarch64

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -299,6 +299,10 @@ if [ ! -f $PATCHED_MARK ] && [ $BRPC_SOURCE == "incubator-brpc-0.9.7" ]; then
     patch -p1 < $TP_PATCH_DIR/incubator-brpc-0.9.7.patch
     touch $PATCHED_MARK
 fi
+if [ ! -f $PATCHED_MARK ] && [ $BRPC_SOURCE == "incubator-brpc-1.3.0" ]; then
+    patch -p1 < $TP_PATCH_DIR/incubator-brpc-1.3.0.patch
+    touch $PATCHED_MARK
+fi
 cd -
 echo "Finished patching $BRPC_SOURCE"
 

--- a/thirdparty/patches/incubator-brpc-1.3.0.patch
+++ b/thirdparty/patches/incubator-brpc-1.3.0.patch
@@ -1,0 +1,23 @@
+diff -rupN incubator-brpc-1.3.0.orig/src/bthread/task_group.cpp incubator-brpc-1.3.0/src/bthread/task_group.cpp
+--- incubator-brpc-1.3.0.orig/src/bthread/task_group.cpp	2022-12-21 22:05:40.833683261 +0000
++++ incubator-brpc-1.3.0/src/bthread/task_group.cpp	2022-12-21 22:06:47.413173602 +0000
+@@ -248,6 +248,9 @@ int TaskGroup::init(size_t runqueue_capa
+     return 0;
+ }
+ 
++#if defined(__aarch64__)
++__attribute__((optimize("O0")))
++#endif
+ void TaskGroup::task_runner(intptr_t skip_remained) {
+     // NOTE: tls_task_group is volatile since tasks are moved around
+     //       different groups.
+@@ -567,6 +570,9 @@ void TaskGroup::sched(TaskGroup** pg) {
+     sched_to(pg, next_tid);
+ }
+ 
++#if defined(__aarch64__)
++__attribute__((optimize("O0")))
++#endif
+ void TaskGroup::sched_to(TaskGroup** pg, TaskMeta* next_meta) {
+     TaskGroup* g = *pg;
+ #ifndef NDEBUG


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Brpc can not work on aarch64 when we building, it will report an error like
```
F1221 19:29:29.584547 11132 task_group.cpp:623] bthread=4294970624 sched_to itself!
```
And this is because brpc is not well tuned on aarch64.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
