### PR TITLE
[Enhancement] Remove db lock when planning olap table query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvId.java
@@ -14,10 +14,14 @@
 
 package com.starrocks.catalog;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.Objects;
 
 public class MvId {
+    @SerializedName(value = "dbId")
     private final long dbId;
+    @SerializedName(value = "id")
     private final long id;
 
     public MvId(long dbId, long id) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -335,10 +335,6 @@ public class OlapTable extends Table {
         return indexes.getIndexes();
     }
 
-    public TableIndexes getTableIndexes() {
-        return indexes;
-    }
-
     public void checkAndSetName(String newName, boolean onlyCheck) throws DdlException {
         // check if rollup has same name
         for (String idxName : getIndexNameToId().keySet()) {
@@ -1443,7 +1439,6 @@ public class OlapTable extends Table {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        super.gsonPostProcess();
         // In the present, the fullSchema could be rebuilt by schema change while the properties is changed by MV.
         // After that, some properties of fullSchema and nameToColumn may be not same as properties of base columns.
         // So, here we need to rebuild the fullSchema to ensure the correctness of the properties.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -140,6 +140,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
 
     // not serialized field
     // record all materialized views based on this Table
+    @SerializedName(value = "mvs")
     private Set<MvId> relatedMaterializedViews;
 
     public Table(TableType type) {
@@ -168,10 +169,6 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         }
         this.createTime = Instant.now().getEpochSecond();
         this.relatedMaterializedViews = Sets.newConcurrentHashSet();
-    }
-
-    public boolean isTypeRead() {
-        return isTypeRead;
     }
 
     public void setTypeRead(boolean isTypeRead) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -58,21 +58,35 @@ public class StatementPlanner {
 
         Map<String, Database> dbs = AnalyzerUtils.collectAllDatabase(session, stmt);
         Map<String, Database> dbLocks = null;
+
+        // 1. For all queries, we need db lock when analyze phase
         if (lockDb) {
             dbLocks = dbs;
+            try {
+                lock(dbLocks);
+                try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Analyzer")) {
+                    Analyzer.analyze(stmt, session);
+                }
+
+                PrivilegeChecker.check(stmt, session);
+                if (stmt instanceof QueryStatement) {
+                    OptimizerTraceUtil.logQueryStatement(session, "after analyze:\n%s", (QueryStatement) stmt);
+                }
+
+                session.setCurrentSqlDbIds(dbs.values().stream().map(Database::getId).collect(Collectors.toSet()));
+            } finally {
+                unLock(dbLocks);
+            }
         }
+
+        // 2. For only olap table queries, we have snapshot the olap table metadata, so we needn't db lock again
+        boolean isOnlyOlapTableQueries = AnalyzerUtils.isOnlyHasOlapTables(stmt);
+        if (isOnlyOlapTableQueries && stmt instanceof QueryStatement) {
+            dbLocks = null;
+        }
+
         try {
             lock(dbLocks);
-            try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Analyzer")) {
-                Analyzer.analyze(stmt, session);
-            }
-
-            PrivilegeChecker.check(stmt, session);
-            if (stmt instanceof QueryStatement) {
-                OptimizerTraceUtil.logQueryStatement(session, "after analyze:\n%s", (QueryStatement) stmt);
-            }
-
-            session.setCurrentSqlDbIds(dbs.values().stream().map(Database::getId).collect(Collectors.toSet()));
             if (stmt instanceof QueryStatement) {
                 QueryStatement queryStmt = (QueryStatement) stmt;
                 resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -167,7 +167,7 @@ public class MvRewritePreprocessor {
             }
         }
         PartitionNames partitionNames = new PartitionNames(false, selectedPartitionNames);
-        LogicalOlapScanOperator scanOperator = new LogicalOlapScanOperator(mv,
+        return new LogicalOlapScanOperator(mv,
                 colRefToColumnMetaMapBuilder.build(),
                 columnMetaToColRefMap,
                 DistributionSpec.createHashDistributionSpec(hashDistributionDesc),
@@ -178,6 +178,5 @@ public class MvRewritePreprocessor {
                 partitionNames,
                 selectTabletIds,
                 Lists.newArrayList());
-        return scanOperator;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -170,6 +170,7 @@ public abstract class StarRocksHttpTestCase {
         PartitionInfo partitionInfo = new SinglePartitionInfo();
         partitionInfo.setDataProperty(testPartitionId, DataProperty.DEFAULT_DATA_PROPERTY);
         partitionInfo.setReplicationNum(testPartitionId, (short) 3);
+        partitionInfo.setIsInMemory(testPartitionId, false);
         OlapTable table = new OlapTable(testTableId, name, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
@@ -306,7 +306,13 @@ public class OptimizerTest {
                 "as select k1, k2, v1  from tbl_with_mv;");
         refreshMaterializedView("test", "mv_5");
         cluster.runSql("test", "insert into tbl_with_mv partition(p3) values(\"2020-03-05\", 20, 30)");
+
+        stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        query = (QueryStatement) stmt;
+
         Optimizer optimizer3 = new Optimizer();
+        logicalPlan = new RelationTransformer(columnRefFactory, connectContext)
+                .transformWithSelectLimit(query.getQueryRelation());
         OptExpression expr3 = optimizer3.optimize(connectContext, logicalPlan.getRoot(), new PhysicalPropertySet(),
                 new ColumnRefSet(logicalPlan.getOutputColumn()), columnRefFactory);
         Assert.assertNotNull(expr3);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/15627

## Problem Summary(Required) ：

1. Remove the db lock when planning olap table query
2. deep copy the olap table meta when query analyze
3. when query optimizer, use the copied olap table meta all the time.
