### PR TITLE
[BugFix] Fix export hll bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -309,6 +309,9 @@ public class Coordinator {
 
     public void setQueryId(TUniqueId queryId) {
         this.queryId = queryId;
+        if (this.coordinatorPreprocessor != null) {
+            this.coordinatorPreprocessor.setQueryId(queryId);
+        }
     }
 
     public void setQueryType(TQueryType type) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -108,7 +108,7 @@ public class CoordinatorPreprocessor {
     private final Random random = new Random();
 
     private TNetworkAddress coordAddress;
-    private final TUniqueId queryId;
+    private TUniqueId queryId;
     private final ConnectContext connectContext;
     private final TQueryGlobals queryGlobals;
     private final TQueryOptions queryOptions;
@@ -220,6 +220,10 @@ public class CoordinatorPreprocessor {
 
     public TUniqueId getQueryId() {
         return queryId;
+    }
+
+    public void setQueryId(TUniqueId queryId) {
+        this.queryId = queryId;
     }
 
     public ConnectContext getConnectContext() {


### PR DESCRIPTION
When exporting hll/bitmap column to csv, BE will fail, error msg is 'No CSV converter for type HLL'.
Then FE will try to rerun the fail export job without changing the query_id (RETRY_NUM is 2).
Since second running job's query_id is same, BE can not cancel it.

This problem is caused by setQueryId function in Coordinator didn't reset the queryId of CoordinatorPreprocessor.
In exec function of ExportExportingTask, it didn't reset query id success
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/1689

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
- [ ] 2.5
- [ ] 2.4
- [ ] 2.3
- [ ] 2.2
