### PR TITLE
[BugFix] keep at least one version whose create_time is before expire time in remove_expire_versions

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1606,12 +1606,16 @@ void TabletUpdates::_erase_expired_versions(int64_t expire_time,
         LOG(WARNING) << "tablet deleted when erase_expired_versions tablet:" << _tablet.tablet_id();
         return;
     }
-    for (int i = 0; i < _apply_version_idx; i++) {
-        if (_edit_version_infos[i]->creation_time <= expire_time) {
-            expire_list->emplace_back(std::move(_edit_version_infos[i]));
-        } else {
+    // only keep at most one version which is before expire_time
+    int keep_index_min = _apply_version_idx;
+    while (keep_index_min > 0) {
+        if (_edit_version_infos[keep_index_min]->creation_time <= expire_time) {
             break;
         }
+        keep_index_min--;
+    }
+    for (int i = 0; i < keep_index_min; i++) {
+        expire_list->emplace_back(std::move(_edit_version_infos[i]));
     }
     auto n = expire_list->size();
     _edit_version_infos.erase(_edit_version_infos.begin(), _edit_version_infos.begin() + n);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
remove_expire_versions should keep at least one version whose create_time is before or equal to expire time, because the 
 ongoing query may still need to read that version. 
```
I1222 04:35:59.996146 11389 txn_manager.cpp:212] Commit txn successfully.  tablet: 548104, txn_id: 10912392, rowsetid: 02000000322dc9b45844f11e15a6aeb2f8b2d558b99d3997
I1222 04:36:03.671463 11710 tablet_updates.cpp:467] commit rowset tablet:548104 version:7417 txn_id: 10912392 02000000322dc9b45844f11e15a6aeb2f8b2d558b99d3997 rowset:11977 #seg:0 #row:0 size:0 #pending:0
I1222 04:36:03.671473 11710 txn_manager.cpp:318] publish txn successfully. partition_id: 532953, txn_id: 10912392, tablet: 548104, rowsetid: 02000000322dc9b45844f11e15a6aeb2f8b2d558b99d3997, version: 7417 (primary key)
I1222 04:36:03.671504 21404 tablet_updates.cpp:900] apply_rowset_commit finish. tablet:548104 version:7417 txn_id: 10912392 total del/row:1780/935557 0% rowset:11977 #seg:0 #op(upsert:0 del:0) #del:0+0=0 #dv:0 duration:0ms(0/0/0/0/0)
I1222 04:36:04.795640 11669 tablet_updates.cpp:1384] remove_expired_versions tablet:548104 #version:1 [7417 7417@0 7417] #pending:0 time:1671653164 max_expire_version:7416 deletes: #version:1 #rowset:0 #delvecrange:2
W1222 04:36:04.969908 11780 tablet_updates.cpp:1879] get_applied_rowsets(version 7416) failed tablet:548104 #version:1 [7417 7417@0 7417] #pending:0

```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
