### PR TITLE
[BugFix] provide dummy parameters to ColumnRefOperator to pass Object.requireNonNull check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -47,6 +47,7 @@ import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
@@ -340,7 +341,8 @@ public class AggregationNode extends PlanNode {
         // greater than 24 bytes(it is equivalent to three bigint-typed group-by columns), then cache populating penalty
         // is unacceptable.
         List<ColumnStatistic> stringColumnStatistics = slotRefs.stream()
-                .map(slot -> columnStatistics.get(new ColumnRefOperator(slot.getSlotId().asInt(), null, null, false)))
+                .map(slot -> columnStatistics.get(new ColumnRefOperator(slot.getSlotId().asInt(),
+                        ScalarType.UNKNOWN_TYPE, "key", false)))
                 .filter(stat -> stat != null && !stat.isUnknown() &&
                         stat.getAverageRowSize() * stat.getDistinctValuesCount() > 24 * cardinalityLimit)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In ColumnRefOperator's ctor, parameters are checked to ensure that is non-null,  here ColumnRefOperator is just used as a lookup key, only first parameter id is useful, so others are dummy.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
