### PR TITLE
[BugFix][Cherry-pick][Branch-2.5] Fix init_position_in_orc() case sensitive bug

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1362,11 +1362,12 @@ Status OrcChunkReader::_init_position_in_orc() {
         auto slot_desc = _src_slot_descriptors[i];
 
         if (slot_desc == nullptr) continue;
-        auto it = _name_to_column_id.find(slot_desc->col_name());
+        std::string col_name = format_column_name(slot_desc->col_name(), _case_sensitive);
+        auto it = _name_to_column_id.find(col_name);
         if (it == _name_to_column_id.end()) {
             auto s = strings::Substitute(
-                    "OrcChunkReader::init_position_in_orc. failed to find position. col_name = $0, file = $1",
-                    slot_desc->col_name(), _current_file_name);
+                    "OrcChunkReader::init_position_in_orc. failed to find position. col_name = $0, file = $1", col_name,
+                    _current_file_name);
             return Status::NotFound(s);
         }
         int col_id = it->second;

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1244,7 +1244,7 @@ Padding ratio: 0%
 TEST_F(OrcChunkReaderTest, TestColumnWithUpperCase) {
     SlotDesc slot_descs[] = {
             {"col_upper_int", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)},
-            {"col_upper_char", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_CHAR)},
+            {"col_upper_CHAR", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_CHAR)},
             {""},
     };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Cherry-Pick from: #15615

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
