### PR TITLE
[Enhancement] Make exchange, local exchange, sort not use static dop

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -385,7 +385,7 @@ ExchangeSinkOperator::ExchangeSinkOperator(
 Status ExchangeSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
 
-    RETURN_IF_ERROR(_buffer->prepare(state));
+    _buffer->incr_sinker(state);
 
     _be_number = state->be_number();
     if (state->query_options().__isset.transmission_encode_level) {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -385,6 +385,8 @@ ExchangeSinkOperator::ExchangeSinkOperator(
 Status ExchangeSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
 
+    RETURN_IF_ERROR(_buffer->prepare(state));
+
     _be_number = state->be_number();
     if (state->query_options().__isset.transmission_encode_level) {
         _encode_level = state->query_options().transmission_encode_level;

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -73,13 +73,14 @@ Status PartitionExchanger::Partitioner::partition_chunk(const ChunkPtr& chunk,
 
 PartitionExchanger::PartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
                                        LocalExchangeSourceOperatorFactory* source, const TPartitionType::type part_type,
-                                       const std::vector<ExprContext*>& partition_expr_ctxs, const size_t num_sinks)
+                                       const std::vector<ExprContext*>& partition_expr_ctxs)
         : LocalExchanger(strings::Substitute("Partition($0)", to_string(part_type)), memory_manager, source),
-          _partition_exprs(partition_expr_ctxs) {
-    _partitioners.reserve(num_sinks);
-    for (size_t i = 0; i < num_sinks; i++) {
-        _partitioners.emplace_back(source, part_type, partition_expr_ctxs);
-    }
+          _part_type(part_type),
+          _partition_exprs(partition_expr_ctxs) {}
+
+void PartitionExchanger::incr_sinker() {
+    LocalExchanger::incr_sinker();
+    _partitioners.emplace_back(_source, _part_type, _partition_exprs);
 }
 
 Status PartitionExchanger::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -22,7 +22,7 @@ namespace starrocks::pipeline {
 /// LocalExchangeSinkOperator.
 Status LocalExchangeSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    _exchanger->increment_sink_number();
+    _exchanger->incr_sinker();
     _unique_metrics->add_info_string("ShuffleNum", std::to_string(_exchanger->source_dop()));
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -25,12 +25,11 @@
 namespace starrocks::pipeline {
 
 SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFragmentDestination>& destinations,
-                       bool is_dest_merge, size_t num_sinkers)
+                       bool is_dest_merge)
         : _fragment_ctx(fragment_ctx),
           _mem_tracker(fragment_ctx->runtime_state()->instance_mem_tracker()),
           _brpc_timeout_ms(std::min(3600, fragment_ctx->runtime_state()->query_options().query_timeout) * 1000),
-          _is_dest_merge(is_dest_merge),
-          _num_uncancelled_sinkers(num_sinkers) {
+          _is_dest_merge(is_dest_merge) {
     for (const auto& dest : destinations) {
         const auto& instance_id = dest.fragment_instance_id;
         // instance_id.lo == -1 indicates that the destination is pseudo for bucket shuffle join.
@@ -40,8 +39,7 @@ SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFra
 
         auto it = _num_sinkers.find(instance_id.lo);
         if (it == _num_sinkers.end()) {
-            _num_sinkers[instance_id.lo] = num_sinkers;
-
+            _num_sinkers[instance_id.lo] = 0;
             _request_seqs[instance_id.lo] = -1;
             _max_continuous_acked_seqs[instance_id.lo] = -1;
             _discontinuous_acked_seqs[instance_id.lo] = std::unordered_set<int64_t>();
@@ -57,8 +55,6 @@ SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFra
             _instance_id2finst_id[instance_id.lo] = std::move(finst_id);
         }
     }
-
-    _num_remaining_eos = _num_sinkers.size() * num_sinkers;
 }
 
 SinkBuffer::~SinkBuffer() {
@@ -69,6 +65,16 @@ SinkBuffer::~SinkBuffer() {
     DCHECK(is_finished());
 
     _buffers.clear();
+}
+
+Status SinkBuffer::prepare(RuntimeState* state) {
+    _num_uncancelled_sinkers++;
+    for (auto& [_, num_sinkers_per_instance] : _num_sinkers) {
+        num_sinkers_per_instance++;
+    }
+    _num_remaining_eos += _num_sinkers.size();
+
+    return Status::OK();
 }
 
 Status SinkBuffer::add_request(TransmitChunkInfo& request) {

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -67,14 +67,12 @@ SinkBuffer::~SinkBuffer() {
     _buffers.clear();
 }
 
-Status SinkBuffer::prepare(RuntimeState* state) {
+void SinkBuffer::incr_sinker(RuntimeState* state) {
     _num_uncancelled_sinkers++;
     for (auto& [_, num_sinkers_per_instance] : _num_sinkers) {
         num_sinkers_per_instance++;
     }
     _num_remaining_eos += _num_sinkers.size();
-
-    return Status::OK();
 }
 
 Status SinkBuffer::add_request(TransmitChunkInfo& request) {

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -79,7 +79,7 @@ struct TimeTrace {
 class SinkBuffer {
 public:
     SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFragmentDestination>& destinations,
-               bool is_dest_merge, size_t num_sinkers);
+               bool is_dest_merge);
     ~SinkBuffer();
 
     Status add_request(TransmitChunkInfo& request);
@@ -94,6 +94,8 @@ public:
     // When all the ExchangeSinkOperator shared this SinkBuffer are cancelled,
     // the rest chunk request and EOS request needn't be sent anymore.
     void cancel_one_sinker(RuntimeState* const state);
+
+    Status prepare(RuntimeState* state);
 
 private:
     using Mutex = bthread::Mutex;
@@ -139,7 +141,7 @@ private:
     phmap::flat_hash_map<int64_t, int64_t> _max_continuous_acked_seqs;
     phmap::flat_hash_map<int64_t, std::unordered_set<int64_t>> _discontinuous_acked_seqs;
     std::atomic<int32_t> _total_in_flight_rpc = 0;
-    std::atomic<int32_t> _num_uncancelled_sinkers;
+    std::atomic<int32_t> _num_uncancelled_sinkers = 0;
     std::atomic<int32_t> _num_remaining_eos = 0;
 
     // The request needs the reference to the allocated finst id,

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -95,7 +95,7 @@ public:
     // the rest chunk request and EOS request needn't be sent anymore.
     void cancel_one_sinker(RuntimeState* const state);
 
-    Status prepare(RuntimeState* state);
+    void incr_sinker(RuntimeState* state);
 
 private:
     using Mutex = bthread::Mutex;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -700,7 +700,7 @@ std::shared_ptr<ExchangeSinkOperatorFactory> _create_exchange_sink_operator(Pipe
     }
 
     std::shared_ptr<SinkBuffer> sink_buffer =
-            std::make_shared<SinkBuffer>(fragment_ctx, sender->destinations(), is_dest_merge, dop);
+            std::make_shared<SinkBuffer>(fragment_ctx, sender->destinations(), is_dest_merge);
 
     auto exchange_sink = std::make_shared<ExchangeSinkOperatorFactory>(
             context->next_operator_id(), stream_sink.dest_node_id, sink_buffer, sender->get_partition_type(),

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -143,8 +143,7 @@ OpFactories PipelineBuilderContext::_do_maybe_interpolate_local_shuffle_exchange
     local_shuffle_source->set_partition_type(pred_source_op->partition_type());
 
     auto local_shuffle =
-            std::make_shared<PartitionExchanger>(mem_mgr, local_shuffle_source.get(), part_type, partition_expr_ctxs,
-                                                 pred_source_op->degree_of_parallelism());
+            std::make_shared<PartitionExchanger>(mem_mgr, local_shuffle_source.get(), part_type, partition_expr_ctxs);
 
     // Append local shuffle sink to the tail of the current pipeline, which comes to end.
     auto local_shuffle_sink =

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.cpp
@@ -20,6 +20,11 @@
 
 namespace starrocks::pipeline {
 
+Status LocalMergeSortSourceOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    _sort_context->ref();
+    return Status::OK();
+}
 void LocalMergeSortSourceOperator::close(RuntimeState* state) {
     _sort_context->unref(state);
     Operator::close(state);

--- a/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_merge_sort_source_operator.h
@@ -34,12 +34,11 @@ public:
     LocalMergeSortSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                                  SortContext* sort_context)
             : SourceOperator(factory, id, "local_merge_source", plan_node_id, driver_sequence),
-              _sort_context(sort_context) {
-        _sort_context->ref();
-    }
+              _sort_context(sort_context) {}
 
     ~LocalMergeSortSourceOperator() override = default;
 
+    Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
     bool has_output() const override;

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -158,7 +158,7 @@ LocalPartitionTopnContext* LocalPartitionTopnContextFactory::create(int32_t driv
             std::make_shared<LocalPartitionTopnContext>(_t_partition_exprs, _sort_exprs, _is_asc_order, _is_null_first,
                                                         _sort_keys, _offset, _partition_limit, _topn_type);
     auto* ctx_raw_ptr = ctx.get();
-    _ctxs[driver_sequence] = std::move(ctx);
+    _ctxs.emplace(driver_sequence, std::move(ctx));
     return ctx_raw_ptr;
 }
 

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -135,13 +135,12 @@ StatusOr<ChunkPtr> LocalPartitionTopnContext::pull_one_chunk_from_sorters() {
 }
 
 LocalPartitionTopnContextFactory::LocalPartitionTopnContextFactory(
-        const int32_t degree_of_parallelism, const std::vector<TExpr>& t_partition_exprs,
-        const std::vector<ExprContext*>& sort_exprs, std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
-        std::string sort_keys, int64_t offset, int64_t partition_limit, const TTopNType::type topn_type,
-        const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
-        const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc)
-        : _ctxs(degree_of_parallelism),
-          _t_partition_exprs(t_partition_exprs),
+        const std::vector<TExpr>& t_partition_exprs, const std::vector<ExprContext*>& sort_exprs,
+        std::vector<bool> is_asc_order, std::vector<bool> is_null_first, std::string sort_keys, int64_t offset,
+        int64_t partition_limit, const TTopNType::type topn_type, const std::vector<OrderByType>& order_by_types,
+        TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
+        const RowDescriptor& parent_node_child_row_desc)
+        : _t_partition_exprs(t_partition_exprs),
           _sort_exprs(sort_exprs),
           _is_asc_order(std::move(is_asc_order)),
           _is_null_first(std::move(is_null_first)),
@@ -151,15 +150,16 @@ LocalPartitionTopnContextFactory::LocalPartitionTopnContextFactory(
           _topn_type(topn_type) {}
 
 LocalPartitionTopnContext* LocalPartitionTopnContextFactory::create(int32_t driver_sequence) {
-    DCHECK_LT(driver_sequence, _ctxs.size());
-
-    if (_ctxs[driver_sequence] == nullptr) {
-        _ctxs[driver_sequence] = std::make_shared<LocalPartitionTopnContext>(_t_partition_exprs, _sort_exprs,
-                                                                             _is_asc_order, _is_null_first, _sort_keys,
-                                                                             _offset, _partition_limit, _topn_type);
+    if (auto it = _ctxs.find(driver_sequence); it != _ctxs.end()) {
+        return it->second.get();
     }
 
-    return _ctxs[driver_sequence].get();
+    auto ctx =
+            std::make_shared<LocalPartitionTopnContext>(_t_partition_exprs, _sort_exprs, _is_asc_order, _is_null_first,
+                                                        _sort_keys, _offset, _partition_limit, _topn_type);
+    auto* ctx_raw_ptr = ctx.get();
+    _ctxs[driver_sequence] = std::move(ctx);
+    return ctx_raw_ptr;
 }
 
 Status LocalPartitionTopnContextFactory::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -97,7 +97,7 @@ using LocalPartitionTopnContextPtr = std::shared_ptr<LocalPartitionTopnContext>;
 
 class LocalPartitionTopnContextFactory {
 public:
-    LocalPartitionTopnContextFactory(const int32_t degree_of_parallelism, const std::vector<TExpr>& t_partition_exprs,
+    LocalPartitionTopnContextFactory(const std::vector<TExpr>& t_partition_exprs,
                                      const std::vector<ExprContext*>& sort_exprs, std::vector<bool> is_asc_order,
                                      std::vector<bool> is_null_first, std::string sort_keys, int64_t offset,
                                      int64_t partition_limit, const TTopNType::type topn_type,
@@ -110,7 +110,7 @@ public:
     LocalPartitionTopnContext* create(int32_t driver_sequence);
 
 private:
-    std::vector<LocalPartitionTopnContextPtr> _ctxs;
+    std::unordered_map<int32_t, LocalPartitionTopnContextPtr> _ctxs;
 
     const std::vector<TExpr>& _t_partition_exprs;
 

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -93,7 +93,7 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
                                                        &_is_asc_order, &_is_null_first, _sort_keys);
     }
     auto sort_context = _sort_context_factory->create(driver_sequence);
-
+    sort_context->incr_partition_sinker();
     sort_context->add_partition_chunks_sorter(chunks_sorter);
     auto ope = std::make_shared<PartitionSortSinkOperator>(this, _id, _plan_node_id, driver_sequence, chunks_sorter,
                                                            _sort_exec_exprs, _order_by_types, _materialized_tuple_desc,

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -28,13 +28,18 @@ using namespace starrocks;
 namespace starrocks::pipeline {
 Status PartitionSortSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
+
+    _sort_context->ref();
+    _sort_context->incr_sinker();
     _chunks_sorter->setup_runtime(_unique_metrics.get());
+
     return Status::OK();
 }
 
 void PartitionSortSinkOperator::close(RuntimeState* state) {
     _sort_context->unref(state);
     _chunks_sorter.reset();
+
     Operator::close(state);
 }
 
@@ -93,7 +98,6 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
                                                        &_is_asc_order, &_is_null_first, _sort_keys);
     }
     auto sort_context = _sort_context_factory->create(driver_sequence);
-    sort_context->incr_partition_sinker();
     sort_context->add_partition_chunks_sorter(chunks_sorter);
     auto ope = std::make_shared<PartitionSortSinkOperator>(this, _id, _plan_node_id, driver_sequence, chunks_sorter,
                                                            _sort_exec_exprs, _order_by_types, _materialized_tuple_desc,

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -47,9 +47,7 @@ public:
               _sort_exec_exprs(sort_exec_exprs),
               _order_by_types(order_by_types),
               _materialized_tuple_desc(materialized_tuple_desc),
-              _sort_context(sort_context) {
-        _sort_context->ref();
-    }
+              _sort_context(sort_context) {}
 
     ~PartitionSortSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/sort/sort_context.cpp
+++ b/be/src/exec/pipeline/sort/sort_context.cpp
@@ -130,7 +130,7 @@ SortContextPtr SortContextFactory::create(int32_t idx) {
     }
 
     auto ctx = std::make_shared<SortContext>(_state, _topn_type, _offset, _limit, _sort_exprs, _sort_descs);
-    _sort_contexts[actual_idx] = ctx;
+    _sort_contexts.emplace(actual_idx, ctx);
     return ctx;
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -34,22 +34,20 @@ using SortContextPtr = std::shared_ptr<SortContext>;
 class SortContext final : public ContextWithDependency {
 public:
     explicit SortContext(RuntimeState* state, const TTopNType::type topn_type, int64_t offset, int64_t limit,
-                         const int32_t num_right_sinkers, const std::vector<ExprContext*>& sort_exprs,
-                         const SortDescs& sort_descs)
+                         const std::vector<ExprContext*>& sort_exprs, const SortDescs& sort_descs)
             : _state(state),
               _topn_type(topn_type),
               _offset(offset),
               _limit(limit),
-              _num_partition_sinkers(num_right_sinkers),
               _sort_exprs(sort_exprs),
-              _sort_desc(sort_descs) {
-        _chunks_sorter_partitions.reserve(num_right_sinkers);
-    }
+              _sort_desc(sort_descs) {}
     ~SortContext() override = default;
 
     void close(RuntimeState* state) override;
 
+    void incr_partition_sinker() { ++_num_partition_sinkers; }
     void add_partition_chunks_sorter(const std::shared_ptr<ChunksSorter>& chunks_sorter);
+
     void finish_partition(uint64_t partition_rows);
     bool is_partition_sort_finished() const;
     bool is_output_finished() const;
@@ -63,7 +61,7 @@ private:
     const TTopNType::type _topn_type;
     int64_t _offset;
     const int64_t _limit;
-    const int32_t _num_partition_sinkers;
+    int32_t _num_partition_sinkers = 0;
     const std::vector<ExprContext*> _sort_exprs;
     const SortDescs _sort_desc;
 
@@ -81,8 +79,8 @@ private:
 class SortContextFactory {
 public:
     SortContextFactory(RuntimeState* state, const TTopNType::type topn_type, bool is_merging, int64_t offset,
-                       int64_t limit, int32_t num_right_sinkers, std::vector<ExprContext*> sort_exprs,
-                       const std::vector<bool>& _is_asc_order, const std::vector<bool>& is_null_first);
+                       int64_t limit, std::vector<ExprContext*> sort_exprs, const std::vector<bool>& _is_asc_order,
+                       const std::vector<bool>& is_null_first);
 
     SortContextPtr create(int32_t idx);
 
@@ -94,10 +92,9 @@ private:
     // _is_merging is false means to pipe each output stream of PartitionSortSinkOperators to an independent
     // LocalMergeSortSourceOperator respectively for scenarios of AnalyticNode with partition by.
     const bool _is_merging;
-    std::vector<SortContextPtr> _sort_contexts;
+    std::unordered_map<int32_t, SortContextPtr> _sort_contexts;
     const int64_t _offset;
     const int64_t _limit;
-    const int32_t _num_right_sinkers;
     const std::vector<ExprContext*> _sort_exprs;
     const SortDescs _sort_descs;
 };

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -45,7 +45,7 @@ public:
 
     void close(RuntimeState* state) override;
 
-    void incr_partition_sinker() { ++_num_partition_sinkers; }
+    void incr_sinker() { ++_num_partition_sinkers; }
     void add_partition_chunks_sorter(const std::shared_ptr<ChunksSorter>& chunks_sorter);
 
     void finish_partition(uint64_t partition_rows);

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -227,12 +227,12 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
     std::any context_factory;
     if (is_partition) {
         context_factory = std::make_shared<LocalPartitionTopnContextFactory>(
-                degree_of_parallelism, _tnode.sort_node.partition_exprs, _sort_exec_exprs.lhs_ordering_expr_ctxs(),
-                _is_asc_order, _is_null_first, _sort_keys, _offset, partition_limit, _tnode.sort_node.topn_type,
-                _order_by_types, _materialized_tuple_desc, child(0)->row_desc(), _row_descriptor);
+                _tnode.sort_node.partition_exprs, _sort_exec_exprs.lhs_ordering_expr_ctxs(), _is_asc_order,
+                _is_null_first, _sort_keys, _offset, partition_limit, _tnode.sort_node.topn_type, _order_by_types,
+                _materialized_tuple_desc, child(0)->row_desc(), _row_descriptor);
     } else {
         context_factory = std::make_shared<SortContextFactory>(
-                runtime_state(), _tnode.sort_node.topn_type, is_merging, _offset, _limit, degree_of_parallelism,
+                runtime_state(), _tnode.sort_node.topn_type, is_merging, _offset, _limit,
                 _sort_exec_exprs.lhs_ordering_expr_ctxs(), _is_asc_order, _is_null_first);
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #15717.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Make complex operators not depend on static DOP when creating, in order to make it able adjust DOP after creating.

This PR is only for ExchangeSink, LocalExchangeSink, Sort.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
