### PR TITLE
[Feature] Support adaptive DOP for agg and sort

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -133,6 +133,7 @@ set(EXEC_FILES
     pipeline/exchange/sink_buffer.cpp
     pipeline/fragment_executor.cpp
     pipeline/operator.cpp
+    pipeline/source_operator.cpp
     pipeline/limit_operator.cpp
     pipeline/pipeline_builder.cpp
     pipeline/project_operator.cpp
@@ -211,6 +212,11 @@ set(EXEC_FILES
     pipeline/set/intersect_build_sink_operator.cpp
     pipeline/set/intersect_probe_sink_operator.cpp
     pipeline/set/intersect_output_source_operator.cpp
+    pipeline/adaptive/collect_stats_sink_operator.cpp
+    pipeline/adaptive/collect_stats_source_operator.cpp
+    pipeline/adaptive/collect_stats_context.cpp
+    pipeline/adaptive/lazy_instantiate_drivers_operator.cpp
+    pipeline/adaptive/utils.cpp
     pipeline/chunk_accumulate_operator.cpp
     pipeline/pipeline.cpp
     workgroup/work_group.cpp

--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -246,7 +246,7 @@ pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilde
     this->init_runtime_filter_for_operator(ops_with_except_build_sink.back().get(), context, rc_rf_probe_collector);
     context->add_pipeline(ops_with_except_build_sink);
 
-    // Use the rest children to erase keys from the hast table by ExceptProbeSinkOperator.
+    // Use the rest children to erase keys from the hash table by ExceptProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
         OpFactories ops_with_except_probe_sink = child(i)->decompose_to_pipeline(context);
         ops_with_except_probe_sink = context->maybe_interpolate_local_shuffle_exchange(

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -270,6 +270,9 @@ pipeline::OpFactories ExchangeNode::decompose_to_pipeline(pipeline::PipelineBuil
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
+
+    operators = context->maybe_interpolate_collect_stats(runtime_state(), operators);
+
     return operators;
 }
 

--- a/be/src/exec/pipeline/adaptive/adaptive_dop_param.h
+++ b/be/src/exec/pipeline/adaptive/adaptive_dop_param.h
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace starrocks::pipeline {
+
+struct AdaptiveDopParam {
+    size_t max_block_rows_per_driver_seq = 0;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/adaptive_fwd.h
+++ b/be/src/exec/pipeline/adaptive/adaptive_fwd.h
@@ -1,0 +1,33 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+namespace starrocks::pipeline {
+
+class CollectStatsContext;
+using CollectStatsContextPtr = std::shared_ptr<CollectStatsContext>;
+using CollectStatsContextRawPtr = CollectStatsContext*;
+
+class CollectStatsState;
+using CollectStatsStatePtr = std::shared_ptr<CollectStatsState>;
+using CollectStatsStateRawPtr = CollectStatsState*;
+class BlockState;
+class RoundRobinState;
+class PassthroughState;
+struct AdaptiveDopParam;
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/collect_stats_context.cpp
+++ b/be/src/exec/pipeline/adaptive/collect_stats_context.cpp
@@ -1,0 +1,296 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/adaptive/collect_stats_context.h"
+
+#include <utility>
+
+#include "column/chunk.h"
+#include "common/statusor.h"
+#include "exec/pipeline/adaptive/adaptive_dop_param.h"
+#include "exec/pipeline/adaptive/utils.h"
+
+namespace starrocks::pipeline {
+
+/// BlockState.
+std::string BlockState::name() const {
+    return "Block";
+}
+
+bool BlockState::need_input(int32_t driver_seq) const {
+    return true;
+}
+
+Status BlockState::push_chunk(int32_t driver_seq, ChunkPtr chunk) {
+    size_t num_chunk_rows = chunk->num_rows();
+    _ctx->_buffer_chunk_queue(driver_seq).emplace(std::move(chunk));
+    size_t prev_num_rows = _num_rows.fetch_add(num_chunk_rows);
+
+    // It receives _max_buffer_rows rows after this push_chunk, so transform to PASSTHROUGH state.
+    if (prev_num_rows < _max_buffer_rows && prev_num_rows + num_chunk_rows >= _max_buffer_rows) {
+        _ctx->_transform_state(CollectStatsStateEnum::PASSTHROUGH, _ctx->_upstream_dop);
+    }
+    return Status::OK();
+}
+
+bool BlockState::has_output(int32_t driver_seq) const {
+    return false;
+}
+
+StatusOr<ChunkPtr> BlockState::pull_chunk(int32_t driver_seq) {
+    return Status::InternalError("Shouldn't call BlockState::pull_chunk");
+}
+
+Status BlockState::set_finishing(int32_t driver_seq) {
+    int num_finished_seqs = ++_num_finished_seqs;
+    if (num_finished_seqs != _ctx->_upstream_dop) {
+        return Status::OK();
+    }
+
+    size_t num_partial_rows = _ctx->_max_block_rows_per_driver_seq;
+    size_t adjusted_dop = _num_rows / num_partial_rows;
+
+    adjusted_dop = compute_max_le_power2(adjusted_dop);
+    adjusted_dop = std::max<size_t>(1, adjusted_dop);
+    adjusted_dop = std::min<size_t>(adjusted_dop, _ctx->_upstream_dop);
+
+    _ctx->_transform_state(CollectStatsStateEnum::ROUND_ROBIN, adjusted_dop);
+
+    return Status::OK();
+}
+
+bool BlockState::is_downstream_finished(int32_t driver_seq) const {
+    return false;
+}
+bool BlockState::is_upstream_finished(int32_t driver_seq) const {
+    return false;
+}
+
+/// PassthroughState.
+std::string PassthroughState::name() const {
+    return "Passthrough";
+}
+
+PassthroughState::PassthroughState(CollectStatsContext* const ctx)
+        : CollectStatsState(ctx),
+          _in_chunk_queue_per_driver_seq(ctx->_upstream_dop),
+          _unpluging_per_driver_seq(ctx->_upstream_dop) {}
+
+bool PassthroughState::need_input(int32_t driver_seq) const {
+    return _in_chunk_queue_per_driver_seq[driver_seq].size_approx() < MAX_PASSTHROUGH_CHUNKS_PER_DRIVER_SEQ;
+}
+
+Status PassthroughState::push_chunk(int32_t driver_seq, ChunkPtr chunk) {
+    _in_chunk_queue_per_driver_seq[driver_seq].enqueue(std::move(chunk));
+    return Status::OK();
+}
+
+bool PassthroughState::has_output(int32_t driver_seq) const {
+    const auto& buffer_chunk_queue = _ctx->_buffer_chunk_queue(driver_seq);
+    if (!buffer_chunk_queue.empty()) {
+        return true;
+    }
+
+    size_t num_chunks = _in_chunk_queue_per_driver_seq[driver_seq].size_approx();
+    auto& unpluging = _unpluging_per_driver_seq[driver_seq];
+    if (unpluging) {
+        if (num_chunks > 0) {
+            return true;
+        }
+        unpluging = false;
+        return false;
+    } else if (num_chunks >= UNPLUG_THRESHOLD_PER_DRIVER_SEQ) {
+        unpluging = true;
+        return true;
+    }
+
+    if (_ctx->_is_finishing_per_driver_seq[driver_seq]) {
+        return num_chunks > 0;
+    }
+    return false;
+}
+
+StatusOr<ChunkPtr> PassthroughState::pull_chunk(int32_t driver_seq) {
+    auto& buffer_chunk_queue = _ctx->_buffer_chunk_queue(driver_seq);
+    if (!buffer_chunk_queue.empty()) {
+        auto chunk = std::move(buffer_chunk_queue.front());
+        buffer_chunk_queue.pop();
+        return chunk;
+    }
+
+    auto& passthrough_chunk_queue = _in_chunk_queue_per_driver_seq[driver_seq];
+    ChunkPtr chunk = nullptr;
+    passthrough_chunk_queue.try_dequeue(chunk);
+    return chunk;
+}
+
+Status PassthroughState::set_finishing(int32_t driver_seq) {
+    return Status::OK();
+}
+
+bool PassthroughState::is_downstream_finished(int32_t driver_seq) const {
+    if (!_ctx->_is_finishing_per_driver_seq[driver_seq]) {
+        return false;
+    }
+
+    const auto& buffer_chunk_queue = _ctx->_buffer_chunk_queue(driver_seq);
+    const auto& passthrough_chunk_queue = _in_chunk_queue_per_driver_seq[driver_seq];
+    return buffer_chunk_queue.empty() && passthrough_chunk_queue.size_approx() <= 0;
+}
+bool PassthroughState::is_upstream_finished(int32_t driver_seq) const {
+    return _ctx->_is_finished_per_driver_seq[driver_seq];
+}
+
+/// RoundRobinState.
+RoundRobinState::RoundRobinState(CollectStatsContext* const ctx) : CollectStatsState(ctx) {
+    _info_per_driver_seq.reserve(ctx->_upstream_dop);
+    for (int i = 0; i < ctx->_upstream_dop; i++) {
+        _info_per_driver_seq.emplace_back(i, _ctx->_runtime_state->chunk_size());
+    }
+}
+
+std::string RoundRobinState::name() const {
+    return "RoundRobin";
+}
+
+bool RoundRobinState::need_input(int32_t driver_seq) const {
+    return false;
+}
+
+Status RoundRobinState::push_chunk(int32_t driver_seq, ChunkPtr chunk) {
+    return Status::InternalError("Shouldn't call RoundRobinState::push_chunk");
+}
+
+bool RoundRobinState::has_output(int32_t driver_seq) const {
+    if (driver_seq >= _ctx->_downstream_dop) {
+        return false;
+    }
+
+    const auto& [buffer_idx, accumulator] = _info_per_driver_seq[driver_seq];
+    return buffer_idx < _ctx->_upstream_dop || !accumulator.empty();
+}
+
+StatusOr<ChunkPtr> RoundRobinState::pull_chunk(int32_t driver_seq) {
+    auto& [buffer_idx, accumulator] = _info_per_driver_seq[driver_seq];
+    if (!accumulator.empty()) {
+        return accumulator.pull();
+    }
+
+    while (buffer_idx < _ctx->_upstream_dop) {
+        auto& buffer_chunk_queue = _ctx->_buffer_chunk_queue(buffer_idx);
+        while (!buffer_chunk_queue.empty()) {
+            accumulator.push(std::move(buffer_chunk_queue.front()));
+            buffer_chunk_queue.pop();
+            if (!accumulator.empty()) {
+                return accumulator.pull();
+            }
+        }
+
+        buffer_idx += _ctx->_downstream_dop;
+    }
+
+    accumulator.finalize();
+    return accumulator.pull();
+}
+
+Status RoundRobinState::set_finishing(int32_t driver_seq) {
+    return Status::InternalError("Shouldn't call RoundRobinState::set_finishing");
+}
+
+bool RoundRobinState::is_downstream_finished(int32_t driver_seq) const {
+    return !has_output(driver_seq);
+}
+bool RoundRobinState::is_upstream_finished(int32_t driver_seq) const {
+    return true;
+}
+
+/// CollectStatsContext.
+CollectStatsContext::CollectStatsContext(RuntimeState* const runtime_state, size_t dop, const AdaptiveDopParam& param)
+        : _upstream_dop(dop),
+          _downstream_dop(dop),
+          _max_block_rows_per_driver_seq(param.max_block_rows_per_driver_seq),
+          _buffer_chunk_queue_per_driver_seq(dop),
+          _is_finishing_per_driver_seq(dop),
+          _is_finished_per_driver_seq(dop),
+          _runtime_state(runtime_state) {
+    _state_payloads[CollectStatsStateEnum::BLOCK] = std::make_unique<BlockState>(this);
+    _state_payloads[CollectStatsStateEnum::PASSTHROUGH] = std::make_unique<PassthroughState>(this);
+    _state_payloads[CollectStatsStateEnum::ROUND_ROBIN] = std::make_unique<RoundRobinState>(this);
+    _set_state(CollectStatsStateEnum::BLOCK);
+}
+
+std::string CollectStatsContext::readable_state() const {
+    return _state_ref()->name();
+}
+
+void CollectStatsContext::close(RuntimeState* state) {}
+
+bool CollectStatsContext::need_input(int32_t driver_seq) const {
+    return _state_ref()->need_input(driver_seq);
+}
+
+Status CollectStatsContext::push_chunk(int32_t driver_seq, ChunkPtr chunk) {
+    return _state_ref()->push_chunk(driver_seq, std::move(chunk));
+}
+
+bool CollectStatsContext::has_output(int32_t driver_seq) const {
+    return _state_ref()->has_output(driver_seq);
+}
+
+StatusOr<ChunkPtr> CollectStatsContext::pull_chunk(int32_t driver_seq) {
+    return _state_ref()->pull_chunk(driver_seq);
+}
+
+Status CollectStatsContext::set_finishing(int32_t driver_seq) {
+    _is_finishing_per_driver_seq[driver_seq] = true;
+    return _state_ref()->set_finishing(driver_seq);
+}
+
+Status CollectStatsContext::set_finished(int32_t driver_seq) {
+    _is_finished_per_driver_seq[driver_seq] = true;
+    return Status::OK();
+}
+
+bool CollectStatsContext::is_downstream_finished(int32_t driver_seq) const {
+    return _state_ref()->is_downstream_finished(driver_seq);
+}
+
+bool CollectStatsContext::is_upstream_finished(int32_t driver_seq) const {
+    return _state_ref()->is_upstream_finished(driver_seq);
+}
+
+bool CollectStatsContext::is_downstream_ready() const {
+    return _state_ref() != _get_state(CollectStatsStateEnum::BLOCK);
+}
+
+CollectStatsStateRawPtr CollectStatsContext::_get_state(CollectStatsStateEnum state) const {
+    return _state_payloads.at(state).get();
+}
+CollectStatsStateRawPtr CollectStatsContext::_state_ref() const {
+    return _state.load();
+}
+void CollectStatsContext::_set_state(CollectStatsStateEnum state_enum) {
+    _state = _get_state(state_enum);
+}
+void CollectStatsContext::_transform_state(CollectStatsStateEnum state_enum, size_t downstream_dop) {
+    auto* next_state = _get_state(state_enum);
+    _downstream_dop = downstream_dop;
+    _state = next_state;
+}
+
+CollectStatsContext::BufferChunkQueue& CollectStatsContext::_buffer_chunk_queue(int32_t driver_seq) {
+    return _buffer_chunk_queue_per_driver_seq[driver_seq];
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/collect_stats_context.h
+++ b/be/src/exec/pipeline/adaptive/collect_stats_context.h
@@ -1,0 +1,204 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/vectorized_fwd.h"
+#include "exec/pipeline/adaptive/adaptive_fwd.h"
+#include "exec/pipeline/context_with_dependency.h"
+#include "storage/chunk_helper.h"
+#include "util/moodycamel/concurrentqueue.h"
+
+namespace starrocks {
+
+class Status;
+template <typename T>
+class StatusOr;
+
+namespace pipeline {
+
+enum class CollectStatsStateEnum { BLOCK = 0, PASSTHROUGH, ROUND_ROBIN };
+
+/// CollectStatsContext is shared by CollectStatsSinkOperator (CsSink) and CollectStatsSourceOperator (CsSource).
+///
+/// It is used to adjust DOP after some streaming source operators, such as ScanNode and ExchangeNode.
+/// [SourceOp->NextOp] will be modified to [SourceOp->CsSink] --(CsContext)--> [CsSource->NextOp].
+///                                             Pipeline#1                          Pipeline#2
+///
+///                PassthroughState
+///             /
+/// BlockState
+///             \
+///                RoundRobinState
+/// CsSink starts from BlockState and transforms to PassthroughState or RoundRobinState conditionally.
+/// - BlockState blocks the input data and doesn't push it to NextOp.
+/// - PassthroughState is transformed to,
+///   when BlockState receives max_block_rows_per_driver_seq*DOP rows and SourceOp hasn't been not EOS.
+///   - It doesn't adjust DOP of pipeline#2,
+///   - and passes chunks from the i-th pipeline#1 driver to the i-th pipeline#2 driver.
+/// - RoundRobinState is transformed to,
+///   when SourceOp has been EOS before BlockState receives max_block_rows_per_driver_seq*DOP rows.
+///   - It adjust DOP of pipeline#2 to compute_max_le_power2(num_rows/max_block_rows_per_driver_seq),
+///   - and passes chunks from the i-th pipeline#1 driver to the j-th pipeline#2 driver, where j=i%new_dop.
+class CollectStatsContext final : public ContextWithDependency {
+public:
+    CollectStatsContext(RuntimeState* const runtime_state, size_t dop, const AdaptiveDopParam& param);
+    ~CollectStatsContext() override = default;
+
+    std::string readable_state() const;
+
+    void close(RuntimeState* state) override;
+
+    bool need_input(int32_t driver_seq) const;
+    bool has_output(int32_t driver_seq) const;
+    bool is_downstream_finished(int32_t driver_seq) const;
+    bool is_upstream_finished(int32_t driver_seq) const;
+
+    Status push_chunk(int32_t driver_seq, ChunkPtr chunk);
+    StatusOr<ChunkPtr> pull_chunk(int32_t driver_seq);
+    Status set_finishing(int32_t driver_seq);
+    Status set_finished(int32_t driver_seq);
+
+    bool is_downstream_ready() const;
+    size_t downstream_dop() const { return _downstream_dop; }
+
+private:
+    using BufferChunkQueue = std::queue<ChunkPtr>;
+
+    CollectStatsStateRawPtr _get_state(CollectStatsStateEnum state) const;
+    CollectStatsStateRawPtr _state_ref() const;
+    void _set_state(CollectStatsStateEnum state_enum);
+    void _transform_state(CollectStatsStateEnum state_enum, size_t downstream_dop);
+    BufferChunkQueue& _buffer_chunk_queue(int32_t driver_seq);
+
+private:
+    friend class BlockState;
+    friend class RoundRobinState;
+    friend class PassthroughState;
+
+    std::atomic<CollectStatsStateRawPtr> _state = nullptr;
+    std::unordered_map<CollectStatsStateEnum, CollectStatsStatePtr> _state_payloads;
+
+    // _upstream_dop and _downstream_dop are DOP of CollectStatsSinkOperator and CollectStatsSourceOperator.
+    // They are both power of two, and upstream_dop is times of downstream_dop.
+    const size_t _upstream_dop;
+    size_t _downstream_dop;
+
+    const size_t _max_block_rows_per_driver_seq;
+
+    std::vector<BufferChunkQueue> _buffer_chunk_queue_per_driver_seq;
+    std::vector<uint8_t> _is_finishing_per_driver_seq;
+    std::vector<uint8_t> _is_finished_per_driver_seq;
+
+    RuntimeState* const _runtime_state;
+};
+
+class CollectStatsState {
+public:
+    CollectStatsState(CollectStatsContext* const ctx) : _ctx(ctx) {}
+    virtual ~CollectStatsState() = default;
+
+    virtual std::string name() const = 0;
+
+    virtual bool need_input(int32_t driver_seq) const = 0;
+    virtual bool has_output(int32_t driver_seq) const = 0;
+    virtual bool is_downstream_finished(int32_t driver_seq) const = 0;
+    virtual bool is_upstream_finished(int32_t driver_seq) const = 0;
+
+    virtual Status push_chunk(int32_t driver_seq, ChunkPtr chunk) = 0;
+    virtual StatusOr<ChunkPtr> pull_chunk(int32_t driver_seq) = 0;
+    virtual Status set_finishing(int32_t driver_seq) = 0;
+
+protected:
+    CollectStatsContext* const _ctx;
+};
+
+class BlockState final : public CollectStatsState {
+public:
+    BlockState(CollectStatsContext* const ctx)
+            : CollectStatsState(ctx), _max_buffer_rows(ctx->_max_block_rows_per_driver_seq * ctx->_upstream_dop) {}
+    ~BlockState() override = default;
+
+    std::string name() const override;
+
+    bool need_input(int32_t driver_seq) const override;
+    bool has_output(int32_t driver_seq) const override;
+    bool is_downstream_finished(int32_t driver_seq) const override;
+    bool is_upstream_finished(int32_t driver_seq) const override;
+
+    Status push_chunk(int32_t driver_seq, ChunkPtr chunk) override;
+    StatusOr<ChunkPtr> pull_chunk(int32_t driver_seq) override;
+    Status set_finishing(int32_t driver_seq) override;
+
+private:
+    std::atomic<int> _num_finished_seqs = 0;
+    std::atomic<size_t> _num_rows = 0;
+    const size_t _max_buffer_rows;
+};
+
+class PassthroughState final : public CollectStatsState {
+public:
+    PassthroughState(CollectStatsContext* const ctx);
+    ~PassthroughState() override = default;
+
+    std::string name() const override;
+
+    bool need_input(int32_t driver_seq) const override;
+    bool has_output(int32_t driver_seq) const override;
+    bool is_downstream_finished(int32_t driver_seq) const override;
+    bool is_upstream_finished(int32_t driver_seq) const override;
+
+    Status push_chunk(int32_t driver_seq, ChunkPtr chunk) override;
+    StatusOr<ChunkPtr> pull_chunk(int32_t driver_seq) override;
+    Status set_finishing(int32_t driver_seq) override;
+
+private:
+    static constexpr size_t MAX_PASSTHROUGH_CHUNKS_PER_DRIVER_SEQ = 32;
+    static constexpr size_t UNPLUG_THRESHOLD_PER_DRIVER_SEQ = MAX_PASSTHROUGH_CHUNKS_PER_DRIVER_SEQ / 2;
+
+    using ChunkQueue = moodycamel::ConcurrentQueue<ChunkPtr>;
+    std::vector<ChunkQueue> _in_chunk_queue_per_driver_seq;
+    mutable std::vector<uint8_t> _unpluging_per_driver_seq;
+};
+
+class RoundRobinState final : public CollectStatsState {
+public:
+    RoundRobinState(CollectStatsContext* const ctx);
+    ~RoundRobinState() override = default;
+
+    std::string name() const override;
+
+    bool need_input(int32_t driver_seq) const override;
+    bool has_output(int32_t driver_seq) const override;
+    bool is_downstream_finished(int32_t driver_seq) const override;
+    bool is_upstream_finished(int32_t driver_seq) const override;
+
+    Status push_chunk(int32_t driver_seq, ChunkPtr chunk) override;
+    StatusOr<ChunkPtr> pull_chunk(int32_t driver_seq) override;
+    Status set_finishing(int32_t driver_seq) override;
+
+private:
+    struct DriverInfo {
+    public:
+        DriverInfo(int32_t driver_seq, size_t chunk_size) : buffer_idx(driver_seq), accumulator(chunk_size) {}
+
+        int buffer_idx;
+        ChunkAccumulator accumulator;
+    };
+
+    std::vector<DriverInfo> _info_per_driver_seq;
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/adaptive/collect_stats_sink_operator.cpp
+++ b/be/src/exec/pipeline/adaptive/collect_stats_sink_operator.cpp
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/adaptive/collect_stats_sink_operator.h"
+
+#include "exec/pipeline/adaptive/collect_stats_context.h"
+
+namespace starrocks::pipeline {
+
+/// CollectStatsSinkOperator.
+CollectStatsSinkOperator::CollectStatsSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                                                   const int32_t driver_sequence, CollectStatsContextRawPtr ctx)
+        : Operator(factory, id, "collect_stats_sink", plan_node_id, driver_sequence), _ctx(ctx) {}
+
+Status CollectStatsSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    _ctx->ref();
+
+    return Status::OK();
+}
+
+void CollectStatsSinkOperator::close(RuntimeState* state) {
+    _ctx->unref(state);
+    Operator::close(state);
+}
+
+bool CollectStatsSinkOperator::need_input() const {
+    return _ctx->need_input(_driver_sequence);
+}
+bool CollectStatsSinkOperator::has_output() const {
+    return false;
+}
+bool CollectStatsSinkOperator::is_finished() const {
+    return _is_finishing || _ctx->is_upstream_finished(_driver_sequence);
+}
+
+Status CollectStatsSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    return _ctx->push_chunk(_driver_sequence, chunk);
+}
+StatusOr<ChunkPtr> CollectStatsSinkOperator::pull_chunk(RuntimeState* state) {
+    return Status::InternalError("Not support");
+}
+Status CollectStatsSinkOperator::set_finishing(RuntimeState* state) {
+    _is_finishing = true;
+    return _ctx->set_finishing(_driver_sequence);
+}
+
+/// CollectStatsSinkOperatorFactory.
+CollectStatsSinkOperatorFactory::CollectStatsSinkOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                                 CollectStatsContextPtr ctx)
+        : OperatorFactory(id, "collect_stats_sink", plan_node_id), _ctx(std::move(ctx)) {}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/collect_stats_sink_operator.h
+++ b/be/src/exec/pipeline/adaptive/collect_stats_sink_operator.h
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/pipeline/adaptive/adaptive_fwd.h"
+#include "exec/pipeline/operator.h"
+
+namespace starrocks::pipeline {
+
+class CollectStatsSinkOperator final : public Operator {
+public:
+    CollectStatsSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, const int32_t driver_sequence,
+                             CollectStatsContextRawPtr ctx);
+    ~CollectStatsSinkOperator() override = default;
+
+    Status prepare(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
+
+    bool has_output() const override;
+    bool need_input() const override;
+    bool is_finished() const override;
+
+    Status set_finishing(RuntimeState* state) override;
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+private:
+    CollectStatsContextRawPtr _ctx;
+    bool _is_finishing = false;
+};
+
+class CollectStatsSinkOperatorFactory final : public OperatorFactory {
+public:
+    CollectStatsSinkOperatorFactory(int32_t id, int32_t plan_node_id, CollectStatsContextPtr ctx);
+    ~CollectStatsSinkOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<CollectStatsSinkOperator>(this, _id, _plan_node_id, driver_sequence, _ctx.get());
+    }
+
+private:
+    CollectStatsContextPtr _ctx;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/collect_stats_source_operator.cpp
+++ b/be/src/exec/pipeline/adaptive/collect_stats_source_operator.cpp
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/adaptive/collect_stats_source_operator.h"
+
+#include "exec/pipeline/adaptive/collect_stats_context.h"
+#include "exec/pipeline/adaptive/utils.h"
+#include "exec/pipeline/pipeline.h"
+
+namespace starrocks::pipeline {
+
+/// CollectStatsSourceOperator.
+CollectStatsSourceOperator::CollectStatsSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                                                       const int32_t driver_sequence, CollectStatsContextRawPtr ctx)
+        : SourceOperator(factory, id, "collect_stats_source", plan_node_id, driver_sequence), _ctx(ctx) {}
+
+void CollectStatsSourceOperator::close(RuntimeState* state) {
+    Operator::close(state);
+
+    _unique_metrics->add_info_string("State", _ctx->readable_state());
+}
+
+bool CollectStatsSourceOperator::need_input() const {
+    return false;
+}
+bool CollectStatsSourceOperator::has_output() const {
+    return _ctx->has_output(_driver_sequence);
+}
+bool CollectStatsSourceOperator::is_finished() const {
+    return _is_finished || _ctx->is_downstream_finished(_driver_sequence);
+}
+
+Status CollectStatsSourceOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    return Status::InternalError("Not support");
+}
+StatusOr<ChunkPtr> CollectStatsSourceOperator::pull_chunk(RuntimeState* state) {
+    return _ctx->pull_chunk(_driver_sequence);
+}
+Status CollectStatsSourceOperator::set_finishing(RuntimeState* state) {
+    return Status::OK();
+}
+Status CollectStatsSourceOperator::set_finished(RuntimeState* state) {
+    _is_finished = true;
+    return _ctx->set_finished(_driver_sequence);
+}
+
+/// CollectStatsSourceOperatorFactory.
+CollectStatsSourceOperatorFactory::CollectStatsSourceOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                                     CollectStatsContextPtr ctx)
+        : SourceOperatorFactory(id, "collect_stats_source", plan_node_id), _ctx(std::move(ctx)) {}
+
+Status CollectStatsSourceOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
+    _ctx->ref();
+
+    return Status::OK();
+}
+
+void CollectStatsSourceOperatorFactory::close(RuntimeState* state) {
+    _ctx->unref(state);
+    OperatorFactory::close(state);
+}
+
+OperatorPtr CollectStatsSourceOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    return std::make_shared<CollectStatsSourceOperator>(this, _id, _plan_node_id, driver_sequence, _ctx.get());
+}
+
+SourceOperatorFactory::AdaptiveState CollectStatsSourceOperatorFactory::adaptive_state() const {
+    if (_ctx->is_downstream_ready()) {
+        return SourceOperatorFactory::AdaptiveState::ACTIVE;
+    }
+    return SourceOperatorFactory::AdaptiveState::INACTIVE;
+}
+
+size_t CollectStatsSourceOperatorFactory::degree_of_parallelism() const {
+    return _ctx->downstream_dop();
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/collect_stats_source_operator.h
+++ b/be/src/exec/pipeline/adaptive/collect_stats_source_operator.h
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/pipeline/adaptive/adaptive_fwd.h"
+#include "exec/pipeline/source_operator.h"
+
+namespace starrocks::pipeline {
+
+class CollectStatsSourceOperator final : public SourceOperator {
+public:
+    CollectStatsSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                               const int32_t driver_sequence, CollectStatsContextRawPtr ctx);
+    ~CollectStatsSourceOperator() override = default;
+
+    void close(RuntimeState* state) override;
+
+    bool has_output() const override;
+    bool need_input() const override;
+    bool is_finished() const override;
+
+    Status set_finishing(RuntimeState* state) override;
+    Status set_finished(RuntimeState* state) override;
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+private:
+    CollectStatsContextRawPtr _ctx;
+    bool _is_finished = false;
+};
+
+class CollectStatsSourceOperatorFactory final : public SourceOperatorFactory {
+public:
+    CollectStatsSourceOperatorFactory(int32_t id, int32_t plan_node_id, CollectStatsContextPtr ctx);
+    ~CollectStatsSourceOperatorFactory() override = default;
+
+    Status prepare(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override;
+    size_t degree_of_parallelism() const override;
+
+private:
+    static constexpr size_t ABSENT_ADJUSTED_DOP = 0;
+
+    CollectStatsContextPtr _ctx;
+
+    mutable size_t _adjusted_dop = ABSENT_ADJUSTED_DOP;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/lazy_instantiate_drivers_operator.cpp
+++ b/be/src/exec/pipeline/adaptive/lazy_instantiate_drivers_operator.cpp
@@ -1,0 +1,138 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/adaptive/lazy_instantiate_drivers_operator.h"
+
+#include "exec/pipeline/pipeline.h"
+#include "exec/pipeline/pipeline_driver.h"
+#include "exec/pipeline/pipeline_driver_executor.h"
+#include "exec/pipeline/result_sink_operator.h"
+
+namespace starrocks::pipeline {
+
+/// LazyInstantiateDriversOperator.
+LazyInstantiateDriversOperator::LazyInstantiateDriversOperator(OperatorFactory* factory, int32_t id,
+                                                               int32_t plan_node_id, const int32_t driver_sequence,
+                                                               const PipelineGroupMap& unready_pipeline_group_mapping)
+        : SourceOperator(factory, id, "lazy_instantiate_drivers", plan_node_id, driver_sequence) {
+    std::vector<PipelineGroup> unready_pipeline_groups;
+    unready_pipeline_groups.reserve(unready_pipeline_groups.size());
+    for (const auto& [leader_source_op, pipes] : unready_pipeline_group_mapping) {
+        unready_pipeline_groups.emplace_back(leader_source_op, leader_source_op->degree_of_parallelism(), pipes);
+    }
+    std::sort(unready_pipeline_groups.begin(), unready_pipeline_groups.end(),
+              [](const PipelineGroup& lhs, const PipelineGroup& rhs) {
+                  auto lhs_id = lhs.pipelines[0]->get_id();
+                  auto rhs_id = rhs.pipelines[0]->get_id();
+                  return lhs_id < rhs_id;
+              });
+
+    _unready_pipeline_groups.insert(_unready_pipeline_groups.end(), std::move_iterator{unready_pipeline_groups.begin()},
+                                    std::move_iterator{unready_pipeline_groups.end()});
+}
+
+bool LazyInstantiateDriversOperator::has_output() const {
+    return std::any_of(
+            _unready_pipeline_groups.begin(), _unready_pipeline_groups.end(),
+            [](const auto& pipeline_group) { return pipeline_group.leader_source_op->is_adaptive_group_active(); });
+}
+bool LazyInstantiateDriversOperator::need_input() const {
+    return false;
+}
+bool LazyInstantiateDriversOperator::is_finished() const {
+    return _unready_pipeline_groups.empty();
+}
+
+Status LazyInstantiateDriversOperator::set_finishing(RuntimeState* state) {
+    return Status::OK();
+}
+Status LazyInstantiateDriversOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    return Status::InternalError("Not support");
+}
+
+StatusOr<ChunkPtr> LazyInstantiateDriversOperator::pull_chunk(RuntimeState* state) {
+    auto* fragment_ctx = state->fragment_ctx();
+
+    std::vector<PipelinePtr> ready_pipelines;
+    auto pipe_group_it = _unready_pipeline_groups.begin();
+    while (pipe_group_it != _unready_pipeline_groups.end()) {
+        auto& [leader_source_op, original_leader_dop, pipelines] = *pipe_group_it;
+        if (!leader_source_op->is_adaptive_group_active()) {
+            pipe_group_it++;
+            continue;
+        }
+
+        size_t leader_dop = leader_source_op->degree_of_parallelism();
+        bool adjust_dop = leader_dop != original_leader_dop;
+
+        for (auto& pipeline : pipelines) {
+            if (adjust_dop) {
+                pipeline->source_operator_factory()->set_max_dop(leader_dop);
+            }
+            pipeline->instantiate_drivers(state);
+            ready_pipelines.emplace_back(std::move(pipeline));
+        }
+
+        _unready_pipeline_groups.erase(pipe_group_it++);
+    }
+
+    for (const auto& pipe : ready_pipelines) {
+        for (const auto& driver : pipe->drivers()) {
+            RETURN_IF_ERROR(driver->prepare(state));
+        }
+    }
+
+    auto* executor = fragment_ctx->enable_resource_group() ? state->exec_env()->wg_driver_executor()
+                                                           : state->exec_env()->driver_executor();
+    for (const auto& pipe : ready_pipelines) {
+        for (const auto& driver : pipe->drivers()) {
+            DCHECK(!fragment_ctx->enable_resource_group() || driver->workgroup() != nullptr);
+            executor->submit(driver.get());
+        }
+    }
+
+    return nullptr;
+}
+
+void LazyInstantiateDriversOperator::close(RuntimeState* state) {
+    auto* fragment_ctx = state->fragment_ctx();
+    for (auto& pipeline_group : _unready_pipeline_groups) {
+        for (auto& pipeline : pipeline_group.pipelines) {
+            if (typeid(*pipeline->sink_operator_factory()) != typeid(ResultSinkOperatorFactory)) {
+                fragment_ctx->count_down_pipeline(state);
+            } else {
+                // Closing ResultSinkOperator notifies FE not to wait fetch_data anymore.
+                pipeline->source_operator_factory()->set_degree_of_parallelism(1);
+                pipeline->instantiate_drivers(state);
+                for (auto& driver : pipeline->drivers()) {
+                    driver->prepare(state);
+                }
+                for (auto& driver : pipeline->drivers()) {
+                    driver->finalize(state, DriverState::FINISH);
+                }
+            }
+        }
+    }
+    _unready_pipeline_groups.clear();
+
+    Operator::close(state);
+}
+
+/// LazyInstantiateDriversOperatorFactory.
+LazyInstantiateDriversOperatorFactory::LazyInstantiateDriversOperatorFactory(int32_t id, int32_t plan_node_id,
+                                                                             PipelineGroupMap&& unready_pipeline_groups)
+        : SourceOperatorFactory(id, "lazy_instantiate_drivers", plan_node_id),
+          _unready_pipeline_groups(std::move(unready_pipeline_groups)) {}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/lazy_instantiate_drivers_operator.h
+++ b/be/src/exec/pipeline/adaptive/lazy_instantiate_drivers_operator.h
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <unordered_map>
+
+#include "exec/pipeline/pipeline_fwd.h"
+#include "exec/pipeline/source_operator.h"
+
+namespace starrocks::pipeline {
+
+using PipelineGroupMap = std::unordered_map<SourceOperatorFactory*, Pipelines>;
+
+/// Lazily instantiate drivers of pipelines.
+///
+/// The pipelines of a fragment instance are organized by groups.
+/// See the comment of SourceOperatorFactory::AdaptiveState for detail.
+///
+/// Instantiate the drivers and maybe adjust DOP, when a pipeline group is ready.
+class LazyInstantiateDriversOperator final : public SourceOperator {
+public:
+    LazyInstantiateDriversOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
+                                   const int32_t driver_sequence, const PipelineGroupMap& unready_pipeline_groups);
+    ~LazyInstantiateDriversOperator() override = default;
+
+    bool has_output() const override;
+    bool need_input() const override;
+    bool is_finished() const override;
+
+    Status set_finishing(RuntimeState* state) override;
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+    void close(RuntimeState* state) override;
+
+private:
+    struct PipelineGroup {
+        SourceOperatorFactory* leader_source_op;
+        size_t original_leader_dop;
+        Pipelines pipelines;
+
+        PipelineGroup(SourceOperatorFactory* leader_source_op, size_t original_leader_dop, const Pipelines& pipelines)
+                : leader_source_op(leader_source_op), original_leader_dop(original_leader_dop), pipelines(pipelines) {}
+    };
+    std::list<PipelineGroup> _unready_pipeline_groups;
+};
+
+class LazyInstantiateDriversOperatorFactory final : public SourceOperatorFactory {
+public:
+    LazyInstantiateDriversOperatorFactory(int32_t id, int32_t plan_node_id, PipelineGroupMap&& unready_pipeline_groups);
+    ~LazyInstantiateDriversOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<LazyInstantiateDriversOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                                _unready_pipeline_groups);
+    }
+
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
+
+private:
+    const PipelineGroupMap _unready_pipeline_groups;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/utils.cpp
+++ b/be/src/exec/pipeline/adaptive/utils.cpp
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/adaptive/utils.h"
+
+namespace starrocks::pipeline {
+
+size_t compute_max_le_power2(size_t num) {
+    num |= (num >> 1);
+    num |= (num >> 2);
+    num |= (num >> 4);
+    num |= (num >> 8);
+    num |= (num >> 16);
+    return num - (num >> 1);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/utils.h
+++ b/be/src/exec/pipeline/adaptive/utils.h
@@ -1,0 +1,24 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdlib>
+
+namespace starrocks::pipeline {
+
+/// Compute the maximal power-of-two number which is less than or equal to the given number.
+size_t compute_max_le_power2(size_t num);
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/empty_set_operator.h
+++ b/be/src/exec/pipeline/empty_set_operator.h
@@ -44,6 +44,8 @@ public:
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         return std::make_shared<EmptySetOperator>(this, _id, _plan_node_id, driver_sequence);
     }
+
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
@@ -97,6 +97,8 @@ public:
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
+
 private:
     int32_t _num_sender;
     const RowDescriptor& _row_desc;

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -69,6 +69,8 @@ public:
                                                          const std::shared_ptr<RuntimeProfile>& profile);
     void close_stream_recvr();
 
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
+
 private:
     const TExchangeNode& _texchange_node;
     const int32_t _num_sender;

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 
 #include "exec/exec_node.h"
+#include "exec/pipeline/adaptive/adaptive_dop_param.h"
 #include "exec/pipeline/driver_limiter.h"
 #include "exec/pipeline/pipeline.h"
 #include "exec/pipeline/pipeline_driver.h"
@@ -118,6 +119,10 @@ public:
 
     void set_stream_load_contexts(const std::vector<StreamLoadContext*>& contexts);
 
+    void set_enable_adaptive_dop(bool val) { _enable_adaptive_dop = val; }
+    bool enable_adaptive_dop() const { return _enable_adaptive_dop; }
+    AdaptiveDopParam& adaptive_dop_param() { return _adaptive_dop_param; }
+
     size_t next_driver_id() { return _next_driver_id++; }
 
     void set_workgroup(workgroup::WorkGroupPtr wg) { _workgroup = std::move(wg); }
@@ -171,6 +176,9 @@ private:
     // STREAM MV
     std::atomic<size_t> _num_finished_epoch_pipelines = 0;
     bool _is_stream_pipeline = false;
+
+    bool _enable_adaptive_dop = false;
+    AdaptiveDopParam _adaptive_dop_param;
 };
 
 class FragmentContextManager {

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -20,6 +20,7 @@
 #include "exec/cross_join_node.h"
 #include "exec/exchange_node.h"
 #include "exec/olap_scan_node.h"
+#include "exec/pipeline/adaptive/lazy_instantiate_drivers_operator.h"
 #include "exec/pipeline/exchange/exchange_sink_operator.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange.h"
 #include "exec/pipeline/exchange/sink_buffer.h"
@@ -65,6 +66,7 @@ namespace starrocks::pipeline {
 using WorkGroupManager = workgroup::WorkGroupManager;
 using WorkGroup = workgroup::WorkGroup;
 using WorkGroupPtr = workgroup::WorkGroupPtr;
+using PipelineGroupMap = std::unordered_map<SourceOperatorFactory*, Pipelines>;
 
 /// UnifiedExecPlanFragmentParams.
 const std::vector<TScanRangeParams> UnifiedExecPlanFragmentParams::_no_scan_ranges;
@@ -152,6 +154,11 @@ Status FragmentExecutor::_prepare_fragment_ctx(const UnifiedExecPlanFragmentPara
     _fragment_ctx->set_fragment_instance_id(fragment_instance_id);
     _fragment_ctx->set_fe_addr(coord);
     _fragment_ctx->set_is_stream_pipeline(is_stream_pipeline);
+    if (request.common().__isset.adaptive_dop_param) {
+        _fragment_ctx->set_enable_adaptive_dop(true);
+        const auto& tparam = request.common().adaptive_dop_param;
+        _fragment_ctx->adaptive_dop_param().max_block_rows_per_driver_seq = tparam.max_block_rows_per_driver_seq;
+    }
 
     LOG(INFO) << "Prepare(): query_id=" << print_id(query_id)
               << " fragment_instance_id=" << print_id(fragment_instance_id)
@@ -473,6 +480,35 @@ Status FragmentExecutor::_prepare_stream_load_pipe(ExecEnv* exec_env, const Unif
     return Status::OK();
 }
 
+Status create_lazy_instantiate_drivers_pipeline(RuntimeState* state, PipelineBuilderContext* ctx,
+                                                QueryContext* query_ctx, FragmentContext* fragment_ctx,
+                                                PipelineGroupMap&& unready_pipeline_groups, Drivers& drivers) {
+    if (unready_pipeline_groups.empty()) {
+        return Status::OK();
+    }
+
+    int32_t min_leader_plan_node_id = unready_pipeline_groups.begin()->first->plan_node_id();
+    for (const auto& [leader_source_op, _] : unready_pipeline_groups) {
+        min_leader_plan_node_id = std::min(min_leader_plan_node_id, leader_source_op->plan_node_id());
+    }
+
+    auto source_op = std::make_shared<LazyInstantiateDriversOperatorFactory>(
+            ctx->next_operator_id(), min_leader_plan_node_id, std::move(unready_pipeline_groups));
+    source_op->set_degree_of_parallelism(1);
+
+    OpFactories ops;
+    ops.emplace_back(std::move(source_op));
+    ops.emplace_back(std::make_shared<NoopSinkOperatorFactory>(ctx->next_operator_id(), min_leader_plan_node_id));
+
+    auto pipe = std::make_shared<Pipeline>(ctx->next_pipe_id(), ops);
+    fragment_ctx->pipelines().emplace_back(pipe);
+
+    RETURN_IF_ERROR(pipe->prepare(state));
+    pipe->instantiate_drivers(state);
+
+    return Status::OK();
+}
+
 Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) {
     const auto degree_of_parallelism = _calc_dop(exec_env, request);
     const auto& fragment = request.common().fragment;
@@ -521,8 +557,21 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
         }
     }
 
+    PipelineGroupMap unready_pipeline_groups;
     for (const auto& pipeline : pipelines) {
+        auto* source_op = pipeline->source_operator_factory();
+        if (!source_op->is_adaptive_group_active()) {
+            auto* group_leader_source_op = source_op->group_leader();
+            unready_pipeline_groups[group_leader_source_op].emplace_back(pipeline);
+            continue;
+        }
+
         pipeline->instantiate_drivers(runtime_state);
+    }
+
+    if (!unready_pipeline_groups.empty()) {
+        RETURN_IF_ERROR(create_lazy_instantiate_drivers_pipeline(
+                runtime_state, &context, _query_ctx, _fragment_ctx.get(), std::move(unready_pipeline_groups), drivers));
     }
 
     // Acquire driver token to avoid overload
@@ -736,10 +785,11 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
 
         // === create sink op ====
         auto pseudo_plan_node_id = context->next_pseudo_plan_node_id();
+        auto* upstream_pipeline = fragment_ctx->pipelines().back().get();
         {
             OpFactoryPtr sink_op = std::make_shared<MultiCastLocalExchangeSinkOperatorFactory>(
                     context->next_operator_id(), pseudo_plan_node_id, mcast_local_exchanger);
-            fragment_ctx->pipelines().back()->add_op_factory(sink_op);
+            upstream_pipeline->add_op_factory(sink_op);
         }
 
         // ==== create source/sink pipelines ====
@@ -754,6 +804,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
             auto source_op = std::make_shared<MultiCastLocalExchangeSourceOperatorFactory>(
                     context->next_operator_id(), pseudo_plan_node_id, i, mcast_local_exchanger);
             source_op->set_degree_of_parallelism(dop);
+            source_op->set_group_leader(upstream_pipeline->source_operator_factory());
 
             // sink op
             auto sink_op = _create_exchange_sink_operator(context, t_stream_sink, sender.get(), dop);
@@ -811,6 +862,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
             auto local_exchange_source = std::make_shared<LocalExchangeSourceOperatorFactory>(
                     context->next_operator_id(), pseudo_plan_node_id, mem_mgr);
             local_exchange_source->set_runtime_state(runtime_state);
+            local_exchange_source->set_group_leader(source_operator);
             auto exchanger = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());
 
             auto local_exchange_sink = std::make_shared<LocalExchangeSinkOperatorFactory>(

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -61,6 +61,10 @@ public:
         DCHECK(!_op_factories.empty());
         return down_cast<SourceOperatorFactory*>(_op_factories[0].get());
     }
+    OperatorFactory* sink_operator_factory() {
+        DCHECK(!_op_factories.empty());
+        return down_cast<SourceOperatorFactory*>(_op_factories[_op_factories.size() - 1].get());
+    }
     size_t degree_of_parallelism() const;
 
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
@@ -92,6 +96,7 @@ public:
         ss << "]";
         return ss.str();
     }
+
     // STREAM MV
     Status reset_epoch(RuntimeState* state);
     void count_down_epoch_finished_driver(RuntimeState* state);

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -417,8 +417,10 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
     copied_driver.set_in_queue(_in_queue);
     copied_driver.set_driver_queue_level(_driver_queue_level);
     DeferOp defer([&copied_driver, &time_spent]() {
-        copied_driver._update_driver_acct(0, 0, time_spent);
-        copied_driver._in_queue->update_statistics(&copied_driver);
+        if (copied_driver._in_queue != nullptr) {
+            copied_driver._update_driver_acct(0, 0, time_spent);
+            copied_driver._in_queue->update_statistics(&copied_driver);
+        }
     });
     SCOPED_RAW_TIMER(&time_spent);
 

--- a/be/src/exec/pipeline/pipeline_fwd.h
+++ b/be/src/exec/pipeline/pipeline_fwd.h
@@ -39,6 +39,7 @@ using Drivers = std::vector<DriverPtr>;
 class OperatorFactory;
 using OpFactoryPtr = std::shared_ptr<OperatorFactory>;
 using OpFactories = std::vector<OpFactoryPtr>;
+class SourceOperatorFactory;
 class Operator;
 using OperatorRawPtr = Operator*;
 using OperatorPtr = std::shared_ptr<Operator>;

--- a/be/src/exec/pipeline/scan/meta_scan_prepare_operator.h
+++ b/be/src/exec/pipeline/scan/meta_scan_prepare_operator.h
@@ -50,6 +50,8 @@ public:
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
+
 protected:
     std::shared_ptr<MetaScanContextFactory> _scan_ctx_factory;
 };

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.h
@@ -57,6 +57,8 @@ public:
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
+
 private:
     OlapScanNode* const _scan_node;
     OlapScanContextFactoryPtr _ctx_factory;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -539,6 +539,8 @@ pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperat
                 std::make_shared<pipeline::LimitOperatorFactory>(context->next_operator_id(), scan_node->id(), limit));
     }
 
+    ops = context->maybe_interpolate_collect_stats(context->runtime_state(), ops);
+
     return ops;
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -191,6 +191,8 @@ public:
     virtual void do_close(RuntimeState* state) = 0;
     virtual OperatorPtr do_create(int32_t dop, int32_t driver_sequence) = 0;
 
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
+
 protected:
     ScanNode* const _scan_node;
 };

--- a/be/src/exec/pipeline/set/union_const_source_operator.h
+++ b/be/src/exec/pipeline/set/union_const_source_operator.h
@@ -83,6 +83,8 @@ public:
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
+
 private:
     const std::vector<SlotDescriptor*>& _dst_slots;
 

--- a/be/src/exec/pipeline/source_operator.cpp
+++ b/be/src/exec/pipeline/source_operator.cpp
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/source_operator.h"
+
+#include "exec/pipeline/pipeline.h"
+#include "exec/pipeline/pipeline_driver.h"
+
+namespace starrocks::pipeline {
+
+void SourceOperatorFactory::add_group_dependent_pipeline(const Pipeline* dependent_op) {
+    _group_leader->_group_dependent_pipelines.emplace_back(dependent_op);
+}
+const std::vector<const Pipeline*>& SourceOperatorFactory::group_dependent_pipelines() const {
+    return _group_leader->_group_dependent_pipelines;
+}
+
+void SourceOperatorFactory::set_group_leader(SourceOperatorFactory* parent) {
+    if (this == parent) {
+        return;
+    }
+    _group_leader = parent->group_leader();
+}
+SourceOperatorFactory* SourceOperatorFactory::group_leader() {
+    return _group_leader;
+}
+
+bool SourceOperatorFactory::is_adaptive_group_active() const {
+    if (_group_leader != this) {
+        return _group_leader->is_adaptive_group_active();
+    }
+
+    if (adaptive_state() != AdaptiveState::ACTIVE) {
+        return false;
+    }
+
+    const auto& pipelines = _group_dependent_pipelines;
+    if (!_group_dependent_pipelines_ready) {
+        _group_dependent_pipelines_ready = std::all_of(pipelines.begin(), pipelines.end(), [](const auto& pipeline) {
+            return pipeline->source_operator_factory()->is_adaptive_group_active();
+        });
+        if (!_group_dependent_pipelines_ready) {
+            return false;
+        }
+    }
+
+    _group_dependent_pipelines_finished = std::all_of(pipelines.begin(), pipelines.end(), [](const auto& pipeline) {
+        const auto& drivers = pipeline->drivers();
+        if (drivers.empty()) {
+            return false;
+        }
+        return std::all_of(drivers.begin(), drivers.end(),
+                           [](const auto& driver) { return driver->sink_operator()->is_finished(); });
+    });
+    return _group_dependent_pipelines_finished;
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -40,6 +40,7 @@ public:
     virtual bool with_morsels() const { return false; }
     // Set the DOP(degree of parallelism) of the SourceOperator, SourceOperator's DOP determine the Pipeline's DOP.
     void set_degree_of_parallelism(size_t degree_of_parallelism) { _degree_of_parallelism = degree_of_parallelism; }
+    void set_max_dop(size_t max_dop) { _degree_of_parallelism = std::min(max_dop, _degree_of_parallelism); }
     virtual size_t degree_of_parallelism() const { return _degree_of_parallelism; }
 
     MorselQueueFactory* morsel_queue_factory() { return _morsel_queue_factory; }
@@ -60,12 +61,60 @@ public:
     virtual const std::vector<ExprContext*>& partition_exprs() const { return _partition_exprs; }
     void set_partition_exprs(const std::vector<ExprContext*>& partition_exprs) { _partition_exprs = partition_exprs; }
 
+    /// The pipelines of a fragment instance are organized by groups.
+    /// - The operator tree is broken into several groups by CollectStatsSourceOperator (CsSource)
+    ///   and the operators with multiple children, such as HashJoin, NLJoin, Except, and Intersect.
+    /// - The group leader is the source operator of the most downstream pipeline in the group,
+    ///   including CsSource, Scan, and Exchange.
+    /// - The adaptive_state of group leader is ACTIVE or INACTIVE,
+    ///   and that of the other pipelines is NONE.
+    ///
+    /// Dependent relations between groups.
+    /// - As for the operator who depends on other operators, e.g. HashJoinProbe depends on HashJoinBuild,
+    ///   the group of this operator also depends on the group of the dependent operators.
+    ///
+    /// A group cannot instantiate drivers until three conditions satisfy:
+    /// 1. The adaptive_state of leader source operator is READY.
+    /// 2. The adaptive_state of dependent pipelines is READY.
+    /// 3. All the drivers of dependent pipelines are finished.
+    ///
+    /// For example, the following fragment contains three pipeline groups: [pipe#1], [pipe#2, pipe#3], [pipe#4],
+    /// and [pipe#2, pipe#3] depends on [pipe#4].
+    ///          ExchangeSink
+    ///               |
+    ///          HashJoinProbe                       HashJoinBuild
+    ///  pipe#3       |                                    |                  pipe#4
+    ///          BlockingAggSource(NONE)          ExchangeSource(ACTIVE)
+    ///
+    ///          BlockingAggSink
+    ///  pipe#2       |
+    ///          CsSource(INACTIVE)
+    ///
+    ///          CsSink
+    ///  pipe#1     |
+    ///          ScanNode(ACTIVE)
+    enum class AdaptiveState { ACTIVE, INACTIVE, NONE };
+    virtual AdaptiveState adaptive_state() const { return AdaptiveState::NONE; }
+    bool is_adaptive_group_active() const;
+
+    void add_group_dependent_pipeline(const Pipeline* dependent_op);
+    const std::vector<const Pipeline*>& group_dependent_pipelines() const;
+
+    void set_group_leader(SourceOperatorFactory* parent);
+    SourceOperatorFactory* group_leader();
+
 protected:
     size_t _degree_of_parallelism = 1;
     bool _could_local_shuffle = true;
     TPartitionType::type _partition_type = TPartitionType::type::HASH_PARTITIONED;
     MorselQueueFactory* _morsel_queue_factory = nullptr;
+
     std::vector<ExprContext*> _partition_exprs;
+
+    SourceOperatorFactory* _group_leader = this;
+    std::vector<const Pipeline*> _group_dependent_pipelines;
+    mutable bool _group_dependent_pipelines_ready = false;
+    mutable bool _group_dependent_pipelines_finished = false;
 };
 
 class SourceOperator : public Operator {
@@ -85,6 +134,9 @@ public:
     const MorselQueue* morsel_queue() const { return _morsel_queue; }
 
     size_t degree_of_parallelism() const { return _source_factory()->degree_of_parallelism(); }
+    const std::vector<const Pipeline*>& group_dependent_pipelines() const {
+        return _source_factory()->group_dependent_pipelines();
+    }
 
 protected:
     const SourceOperatorFactory* _source_factory() const { return down_cast<const SourceOperatorFactory*>(_factory); }

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -273,7 +273,6 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
         source_operator = std::make_shared<LocalMergeSortSourceOperatorFactory>(context->next_operator_id(), id(),
                                                                                 sort_context_factory);
     }
-    // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(source_operator.get(), context, rc_rf_probe_collector);
 
     ops_sink_with_sort.emplace_back(std::move(sink_operator));

--- a/be/test/exec/pipeline/pipeline_control_flow_test.cpp
+++ b/be/test/exec/pipeline/pipeline_control_flow_test.cpp
@@ -250,6 +250,7 @@ public:
         return std::make_shared<TestSourceOperator>(this, _id, _plan_node_id, driver_sequence, _chunk_num, _chunk_size,
                                                     _counter, _pending_finish_cnt);
     }
+    SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
 
 private:
     size_t _chunk_num;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -345,6 +345,11 @@ public class AggregationNode extends PlanNode {
         return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
     }
 
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
     private void disableCacheIfHighCardinalityGroupBy(FragmentNormalizer normalizer) {
         if (ConnectContext.get() == null || getCardinality() == -1) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
@@ -308,6 +308,11 @@ public class AnalyticEvalNode extends PlanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
+    @Override
     public boolean extractConjunctsToNormalize(FragmentNormalizer normalizer) {
         List<Expr> conjuncts = normalizer.getConjunctsByPlanNodeId(this);
         normalizer.filterOutPartColRangePredicates(getId(), conjuncts, FragmentNormalizer.getSlotIdSet(partitionExprs));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AssertNumRowsNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AssertNumRowsNode.java
@@ -87,6 +87,11 @@ public class AssertNumRowsNode extends PlanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
+    @Override
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
         TNormalAssertNumRowsNode assertNumRowsNode = new TNormalAssertNumRowsNode();
         assertNumRowsNode.setDesired_num_rows(desiredNumOfRows);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
@@ -99,4 +99,8 @@ public abstract class DataSink {
     public boolean canUsePipeLine() {
         return false;
     }
+
+    public boolean canUseRuntimeAdaptiveDop() {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataStreamSink.java
@@ -125,4 +125,9 @@ public class DataStreamSink extends DataSink {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
@@ -54,6 +54,11 @@ public class DecodeNode extends PlanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
+    @Override
     protected void toThrift(TPlanNode msg) {
         msg.node_type = TPlanNodeType.DECODE_NODE;
         msg.decode_node = new TDecodeNode();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -301,4 +301,9 @@ public class DeltaLakeScanNode extends ScanNode {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/EmptySetNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/EmptySetNode.java
@@ -77,6 +77,11 @@ public class EmptySetNode extends PlanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
+    @Override
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
         planNode.setNode_type(TPlanNodeType.EXCHANGE_NODE);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
@@ -291,4 +291,9 @@ public class EsScanNode extends ScanNode {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -241,6 +241,11 @@ public class ExchangeNode extends PlanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
+
+    @Override
     public boolean pushDownRuntimeFilters(DescriptorTable descTbl, RuntimeFilterDescription description, Expr probeExpr,
                                           List<Expr> partitionByExprs) {
         if (!canPushDownRuntimeFilter()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -205,4 +205,9 @@ public class FileTableScanNode extends ScanNode {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -214,4 +214,9 @@ public class HdfsScanNode extends ScanNode {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -192,4 +192,9 @@ public class HudiScanNode extends ScanNode {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -413,4 +413,9 @@ public class IcebergScanNode extends ScanNode {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -136,6 +136,11 @@ public class JDBCScanNode extends ScanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
+
+    @Override
     protected void toThrift(TPlanNode msg) {
         msg.node_type = TPlanNodeType.JDBC_SCAN_NODE;
         msg.jdbc_scan_node = new TJDBCScanNode();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
@@ -166,4 +166,8 @@ public class MetaScanNode extends ScanNode {
         return true;
     }
 
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastDataSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastDataSink.java
@@ -90,4 +90,9 @@ public class MultiCastDataSink extends DataSink {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MysqlScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MysqlScanNode.java
@@ -195,4 +195,9 @@ public class MysqlScanNode extends ScanNode {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -818,6 +818,11 @@ public class OlapScanNode extends ScanNode {
         return true;
     }
 
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
+
     /**
      * Below function is added by new analyzer
      */

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -43,8 +43,8 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.TreeNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
-import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TCacheParam;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TGlobalDict;
@@ -154,6 +154,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     private boolean forceSetTableSinkDop = false;
     private boolean forceAssignScanRangesPerDriverSeq = false;
 
+    private boolean useRuntimeAdaptiveDop = false;
+
     /**
      * C'tor for fragment with specific partition; the output is by default broadcast.
      */
@@ -189,6 +191,26 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public boolean canUsePipeline() {
         return getPlanRoot().canUsePipeLine() && getSink().canUsePipeLine();
+    }
+
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getPlanRoot().canUseRuntimeAdaptiveDop() && getSink().canUseRuntimeAdaptiveDop();
+    }
+
+    public void enableAdaptiveDop() {
+        useRuntimeAdaptiveDop = true;
+        // Constrict DOP as the power of two to make the strategy of decrement DOP easy.
+        // After decreasing DOP from old_dop to new_dop, chunks from the i-th input driver is passed
+        // to the j-th output driver, where j=i%new_dop.
+        pipelineDop = Utils.computeMaxLEPower2(pipelineDop);
+    }
+
+    public void disableRuntimeAdaptiveDop() {
+        useRuntimeAdaptiveDop = false;
+    }
+
+    public boolean isUseRuntimeAdaptiveDop() {
+        return useRuntimeAdaptiveDop;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -722,6 +722,10 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         return false;
     }
 
+    public boolean canUseRuntimeAdaptiveDop() {
+        return false;
+    }
+
     public boolean canPushDownRuntimeFilter() {
         // RuntimeFilter can only be pushed into multicast fragment iff.
         // this runtime filter is applied to all consumers. It's quite hard to do

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -128,6 +128,11 @@ public class ProjectNode extends PlanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
+    @Override
     public Optional<List<Expr>> candidatesOfSlotExpr(Expr expr) {
         if (!(expr instanceof SlotRef)) {
             return Optional.empty();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RepeatNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RepeatNode.java
@@ -167,6 +167,11 @@ public class RepeatNode extends PlanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
+    @Override
     public void checkRuntimeFilterOnNullValue(RuntimeFilterDescription description, Expr probeExpr) {
         // note(yan): repeat node may generate null values, and if runtime filter does not accept null value
         // we have opportunity to filter those values out.

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ResultSink.java
@@ -129,4 +129,10 @@ public class ResultSink extends DataSink {
     public boolean canUsePipeLine() {
         return true;
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return sinkType == TResultSinkType.MYSQL_PROTOCAL || sinkType == TResultSinkType.STATISTIC ||
+                sinkType == TResultSinkType.VARIABLE;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -157,4 +157,9 @@ public class SchemaScanNode extends ScanNode {
         return true;
     }
 
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SelectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SelectNode.java
@@ -89,4 +89,9 @@ public class SelectNode extends PlanNode {
     public boolean canUsePipeLine() {
         return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
     }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -337,6 +337,11 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
+    @Override
     public boolean canPushDownRuntimeFilter() {
         return !useTopN;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionNode.java
@@ -86,6 +86,11 @@ public class TableFunctionNode extends PlanNode {
     }
 
     @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+    }
+
+    @Override
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
         TNormalTableFunctionNode tableFunctionNode = new TNormalTableFunctionNode();
         tableFunctionNode.setTable_function(tableFunction.toThrift());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -57,11 +57,13 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.InternalServiceVersion;
+import com.starrocks.thrift.TAdaptiveDopParam;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TEsScanRange;
 import com.starrocks.thrift.TExecBatchPlanFragmentsParams;
@@ -494,7 +496,7 @@ public class CoordinatorPreprocessor {
             FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
 
             boolean dopAdaptionEnabled = usePipeline &&
-                    connectContext.getSessionVariable().isPipelineDopAdaptionEnabled();
+                    connectContext.getSessionVariable().isEnablePipelineAdaptiveDop();
 
             // If left child is MultiCastDataFragment(only support left now), will keep same instance with child.
             if (fragment.getChildren().size() > 0 && fragment.getChild(0) instanceof MultiCastPlanFragment) {
@@ -681,10 +683,17 @@ public class CoordinatorPreprocessor {
                                 List<List<TScanRangeParams>> scanRangeParamsPerDriverSeq =
                                         ListUtil.splitBySize(scanRangeParams, expectedDop);
                                 instanceParam.pipelineDop = scanRangeParamsPerDriverSeq.size();
+                                if (fragment.isUseRuntimeAdaptiveDop()) {
+                                    instanceParam.pipelineDop = Utils.computeMinGEPower2(instanceParam.pipelineDop);
+                                }
                                 Map<Integer, List<TScanRangeParams>> scanRangesPerDriverSeq = new HashMap<>();
                                 instanceParam.nodeToPerDriverSeqScanRanges.put(planNodeId, scanRangesPerDriverSeq);
                                 for (int driverSeq = 0; driverSeq < scanRangeParamsPerDriverSeq.size(); ++driverSeq) {
                                     scanRangesPerDriverSeq.put(driverSeq, scanRangeParamsPerDriverSeq.get(driverSeq));
+                                }
+                                for (int driverSeq = scanRangeParamsPerDriverSeq.size();
+                                        driverSeq < instanceParam.pipelineDop; ++driverSeq) {
+                                    scanRangesPerDriverSeq.put(driverSeq, Lists.newArrayList());
                                 }
                             }
                             if (this.queryOptions.getLoad_job_type() == TLoadJobType.STREAM_LOAD) {
@@ -932,6 +941,9 @@ public class CoordinatorPreprocessor {
 
                 if (assignPerDriverSeq) {
                     instanceParam.pipelineDop = scanRangesPerDriverSeq.size();
+                    if (params.fragment.isUseRuntimeAdaptiveDop()) {
+                        instanceParam.pipelineDop = Utils.computeMinGEPower2(instanceParam.pipelineDop);
+                    }
                 }
 
                 for (int driverSeq = 0; driverSeq < scanRangesPerDriverSeq.size(); ++driverSeq) {
@@ -1529,6 +1541,11 @@ public class CoordinatorPreprocessor {
                     commonParams.setEnable_resource_group(enableResourceGroup);
                     if (enableResourceGroup && resourceGroup != null) {
                         commonParams.setWorkgroup(resourceGroup);
+                    }
+                    if (fragment.isUseRuntimeAdaptiveDop()) {
+                        commonParams.setAdaptive_dop_param(new TAdaptiveDopParam());
+                        commonParams.adaptive_dop_param.setMax_block_rows_per_driver_seq(
+                                sessionVariable.getAdaptiveDopMaxBlockRowsPerDriverSeq());
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -161,6 +161,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // them do the real work on core.
     public static final String ENABLE_PIPELINE = "enable_pipeline";
 
+    public static final String ENABLE_RUNTIME_ADAPTIVE_DOP = "enable_runtime_adaptive_dop";
+    public static final String ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ = "runtime_adaptive_dop_max_block_rows_per_driver_seq";
+
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
     public static final String ENABLE_PIPELINE_QUERY_STATISTIC = "enable_pipeline_query_statistic";
 
@@ -364,6 +367,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE, alias = ENABLE_PIPELINE_ENGINE, show = ENABLE_PIPELINE_ENGINE)
     private boolean enablePipelineEngine = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_RUNTIME_ADAPTIVE_DOP)
+    private boolean enableRuntimeAdaptiveDop = false;
+
+    @VariableMgr.VarAttr(name = ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ, flag = VariableMgr.INVISIBLE)
+    private long adaptiveDopMaxBlockRowsPerDriverSeq = 4096L * 4;
 
     @VarAttr(name = ENABLE_MV_PLANNER)
     private boolean enableMVPlanner = false;
@@ -1224,8 +1233,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enablePipelineEngine;
     }
 
-    public boolean isPipelineDopAdaptionEnabled() {
+    public boolean isEnablePipelineAdaptiveDop() {
         return enablePipelineEngine && pipelineDop <= 0;
+    }
+
+    public boolean isEnableRuntimeAdaptiveDop() {
+        return enablePipelineEngine && enableRuntimeAdaptiveDop;
+    }
+
+    public long getAdaptiveDopMaxBlockRowsPerDriverSeq() {
+        return adaptiveDopMaxBlockRowsPerDriverSeq;
     }
 
     public void setEnablePipelineEngine(boolean enablePipelineEngine) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -259,6 +259,9 @@ public class StmtExecutor {
             sb.append(SessionVariable.ENABLE_ADAPTIVE_SINK_DOP).append("=")
                     .append(variables.getEnableAdaptiveSinkDop())
                     .append(",");
+            sb.append(SessionVariable.ENABLE_RUNTIME_ADAPTIVE_DOP).append("=")
+                    .append(variables.isEnableRuntimeAdaptiveDop())
+                    .append(",");
             if (context.getResourceGroup() != null) {
                 sb.append(SessionVariable.RESOURCE_GROUP).append("=").append(context.getResourceGroup().getName())
                         .append(",");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -112,6 +112,7 @@ public class DeletePlanner {
                 sinkFragment.setHasOlapTableSink();
                 sinkFragment.setForceSetTableSinkDop();
                 sinkFragment.setForceAssignScanRangesPerDriverSeq();
+                sinkFragment.disableRuntimeAdaptiveDop();
             } else {
                 execPlan.getFragments().get(0).setPipelineDop(1);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -210,6 +210,7 @@ public class InsertPlanner {
                 sinkFragment.setHasOlapTableSink();
                 sinkFragment.setForceSetTableSinkDop();
                 sinkFragment.setForceAssignScanRangesPerDriverSeq();
+                sinkFragment.disableRuntimeAdaptiveDop();
             }
             execPlan.getFragments().get(0).setSink(dataSink);
             execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -109,6 +109,7 @@ public class UpdatePlanner {
                 sinkFragment.setHasOlapTableSink();
                 sinkFragment.setForceSetTableSinkDop();
                 sinkFragment.setForceAssignScanRangesPerDriverSeq();
+                sinkFragment.disableRuntimeAdaptiveDop();
             } else {
                 execPlan.getFragments().get(0).setPipelineDop(1);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -526,4 +526,29 @@ public class Utils {
 
         root.getChildren().forEach(child -> collect(child, clazz, output));
     }
+
+    /**
+     * Compute the maximal power-of-two number which is less than or equal to the given number.
+     */
+    public static int computeMaxLEPower2(int num) {
+        num |= (num >>> 1);
+        num |= (num >>> 2);
+        num |= (num >>> 4);
+        num |= (num >>> 8);
+        num |= (num >>> 16);
+        return num - (num >>> 1);
+    }
+
+    /**
+     * Compute the maximal power-of-two number which is less than or equal to the given number.
+     */
+    public static int computeMinGEPower2(int num) {
+        num -= 1;
+        num |= (num >>> 1);
+        num |= (num >>> 2);
+        num |= (num >>> 4);
+        num |= (num >>> 8);
+        num |= (num >>> 16);
+        return num < 0 ? 1 : num + 1;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -311,6 +311,7 @@ public class PlanFragmentBuilder {
             fragment.createDataSink(resultSinkType);
         }
         Collections.reverse(fragments);
+
         // compute local_rf_waiting_set for each PlanNode.
         // when enable_pipeline_engine=true and enable_global_runtime_filter=false, we should clear
         // runtime filters from PlanNode.
@@ -326,7 +327,14 @@ public class PlanFragmentBuilder {
                 FragmentNormalizer normalizer = new FragmentNormalizer(execPlan, fragment);
                 normalizer.normalize();
             }
+        } else if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().isEnableRuntimeAdaptiveDop()) {
+            for (PlanFragment fragment : fragments) {
+                if (fragment.canUseRuntimeAdaptiveDop()) {
+                    fragment.enableAdaptiveDop();
+                }
+            }
         }
+
         return execPlan;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -75,13 +75,17 @@ public class CoordinatorTest extends PlanTestBase {
         coordinatorPreprocessor = coordinator.getPrepareInfo();
     }
 
-    private void testComputeBucketSeq2InstanceOrdinal(JoinNode.DistributionMode mode) throws IOException {
-
+    private PlanFragment genFragment() {
         ArrayList<TupleId> tupleIdArrayList = new ArrayList<>();
         tupleIdArrayList.add(new TupleId(1));
         PlanFragment fragment =
                 new PlanFragment(new PlanFragmentId(1), new EmptySetNode(new PlanNodeId(1), tupleIdArrayList),
                         new DataPartition(TPartitionType.RANDOM));
+        return fragment;
+    }
+
+    private void testComputeBucketSeq2InstanceOrdinal(JoinNode.DistributionMode mode) throws IOException {
+        PlanFragment fragment = genFragment();
         CoordinatorPreprocessor.FragmentExecParams params = coordinatorPreprocessor.new FragmentExecParams(fragment);
         CoordinatorPreprocessor.FInstanceExecParam instance0 =
                 new CoordinatorPreprocessor.FInstanceExecParam(null, null, 0, params);
@@ -133,7 +137,7 @@ public class CoordinatorTest extends PlanTestBase {
                                                              List<Map<Integer, Integer>> expectedBucketSeqToDriverSeqs,
                                                              List<Integer> expectedNumScanRangesList,
                                                              List<Map<Integer, Integer>> expectedDriverSeq2NumScanRangesList) {
-        CoordinatorPreprocessor.FragmentExecParams params = coordinatorPreprocessor.new FragmentExecParams(null);
+        CoordinatorPreprocessor.FragmentExecParams params = coordinatorPreprocessor.new FragmentExecParams(genFragment());
         CoordinatorPreprocessor.BucketSeqToScanRange bucketSeqToScanRange =
                 new CoordinatorPreprocessor.BucketSeqToScanRange();
         for (Integer bucketSeq : bucketSeqToAddress.keySet()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/UtilsTest.java
@@ -353,4 +353,28 @@ public class UtilsTest {
 
         assertEquals(4, Utils.countJoinNodeSize(root, JoinOperator.semiAntiJoinSet()));
     }
+
+    @Test
+    public void testComputeMaxLEPower2() {
+        Assert.assertEquals(0, Utils.computeMaxLEPower2(0));
+
+        for (int i = 1; i < 10000; i++) {
+            int out = Utils.computeMaxLEPower2(i);
+            // The number i belongs to the range [out, out*2).
+            Assert.assertTrue(out <= i);
+            Assert.assertTrue(out * 2 > i);
+        }
+    }
+
+    @Test
+    public void testComputeMinGEPower2() {
+        Assert.assertEquals(1, Utils.computeMinGEPower2(0));
+
+        for (int i = 1; i < 10000; i++) {
+            int out = Utils.computeMinGEPower2(i);
+            // The number i belongs to the range (out/2, out].
+            Assert.assertTrue(out >= i);
+            Assert.assertTrue(out / 2 < i);
+        }
+    }
 }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -296,6 +296,10 @@ enum InternalServiceVersion {
   V1
 }
 
+struct TAdaptiveDopParam {
+  1: optional i64 max_block_rows_per_driver_seq
+}
+
 // ExecPlanFragment
 
 struct TExecPlanFragmentParams {
@@ -352,6 +356,8 @@ struct TExecPlanFragmentParams {
   56: optional bool enable_shared_scan
 
   57: optional bool is_stream_pipeline
+
+  58: optional TAdaptiveDopParam adaptive_dop_param
 }
 
 struct TExecPlanFragmentResult {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #15717.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Support adaptive DOP for OlapScanNode, ExchangeSource, Agg and Sort.

1. Constrict DOP as a power of 2.
2. Append `CollectStatsSinkOperator` and `CollectStatsSourceOperator` to `OlapScanNode` and `ExchangeNode`.
3. The drivers of pipelines starting with `CollectStatsSourceOperator` will be created and executed after `CollectStatsSourceOperator` is ready.


4. CollectStatsContext

CollectStatsContext is shared by CollectStatsSinkOperator (`CsSink`) and CollectStatsSourceOperator (`CsSource`). It is used to adjust DOP after some streaming source operators, such as ScanNode and ExchangeNode.
```
[SourceOp->NextOp] will be modified to [SourceOp->CsSink] --(CsContext)--> [CsSource->NextOp].
                                           Pipeline#1                          Pipeline#2
```

```
              PassthroughState
             /
BlockState
            \
              MappingPower2State
```
CsSink starts from `BlockState` and transforms to `PassthroughState` or `MappingPower2State` conditionally.
 - `BlockState` blocks the input data and doesn't push it to NextOp.
 - `PassthroughState` is transformed to when BlockState receives *MAX_BUFFER_CHUNKS_PER_DRIVER* rows and SourceOp is not EOS.
    - It doesn't adjust DOP of pipeline#2,
    - and passes chunks from the i-th pipeline#1 driver to the i-th pipeline#2 driver.
- `MappingPower2State` is transformed to when SourceOp is EOS before BlockState receives *MAX_BUFFER_CHUNKS_PER_DRIVER* rows.
    - It adjust DOP of pipeline#2 to num_rows/MAX_BUFFER_CHUNKS_PER_DRIVER*chunk_size,
    - and passes chunks from the i-th pipeline#1 driver to the j-th pipeline#2 driver, where j=i%new_dop.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
