### PR TITLE
[Enhancement] Support Struct metadata in storage layer

### DIFF
--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/be/src/olap/tablet_meta.cpp
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 #include "storage/metadata_util.h"
 
 #include <boost/algorithm/string.hpp>
@@ -44,11 +24,6 @@
 #include "storage/tablet_schema.h"
 
 namespace starrocks {
-
-enum class FieldTypeVersion {
-    kV1,
-    kV2,
-};
 
 // Old version StarRocks use `TColumnType` to save type info, convert it into `TTypeDesc`.
 static void convert_to_new_version(TColumn* tcolumn) {
@@ -92,129 +67,110 @@ static StorageAggregateType t_aggregation_type_to_field_aggregation_method(TAggr
     return STORAGE_AGGREGATE_NONE;
 }
 
-static LogicalType t_primitive_type_to_field_type(TPrimitiveType::type primitive_type, FieldTypeVersion v) {
-    switch (primitive_type) {
-    case TPrimitiveType::INVALID_TYPE:
-    case TPrimitiveType::NULL_TYPE:
-    case TPrimitiveType::BINARY:
-    case TPrimitiveType::TIME:
-        return TYPE_UNKNOWN;
-    case TPrimitiveType::BOOLEAN:
-        return TYPE_BOOLEAN;
-    case TPrimitiveType::TINYINT:
-        return TYPE_TINYINT;
-    case TPrimitiveType::SMALLINT:
-        return TYPE_SMALLINT;
-    case TPrimitiveType::INT:
-        return TYPE_INT;
-    case TPrimitiveType::BIGINT:
-        return TYPE_BIGINT;
-    case TPrimitiveType::FLOAT:
-        return TYPE_FLOAT;
-    case TPrimitiveType::DOUBLE:
-        return TYPE_DOUBLE;
-    case TPrimitiveType::DATE:
-        return v == FieldTypeVersion::kV1 ? TYPE_DATE_V1 : TYPE_DATE;
-    case TPrimitiveType::DATETIME:
-        return v == FieldTypeVersion::kV1 ? TYPE_DATETIME_V1 : TYPE_DATETIME;
-    case TPrimitiveType::CHAR:
-        return TYPE_CHAR;
-    case TPrimitiveType::LARGEINT:
-        return TYPE_LARGEINT;
-    case TPrimitiveType::VARCHAR:
-        return TYPE_VARCHAR;
-    case TPrimitiveType::HLL:
-        return TYPE_HLL;
-    case TPrimitiveType::DECIMAL:
-    case TPrimitiveType::DECIMALV2:
-        return v == FieldTypeVersion::kV1 ? TYPE_DECIMAL : TYPE_DECIMALV2;
-    case TPrimitiveType::DECIMAL32:
-        return TYPE_DECIMAL32;
-    case TPrimitiveType::DECIMAL64:
-        return TYPE_DECIMAL64;
-    case TPrimitiveType::DECIMAL128:
-        return TYPE_DECIMAL128;
-    case TPrimitiveType::OBJECT:
-        return TYPE_OBJECT;
-    case TPrimitiveType::PERCENTILE:
-        return TYPE_PERCENTILE;
-    case TPrimitiveType::JSON:
-        return TYPE_JSON;
-    case TPrimitiveType::VARBINARY:
-        return TYPE_VARBINARY;
-    case TPrimitiveType::FUNCTION:
-        return TYPE_UNKNOWN;
-    }
-    return TYPE_UNKNOWN;
-}
-
-static Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, FieldTypeVersion v, ColumnPB* column_pb,
-                                    size_t depth = 0) {
+// This function is used to initialize ColumnPB for subfield like element of Array.
+static void init_column_pb_for_sub_field(ColumnPB* field) {
     const int32_t kFakeUniqueId = -1;
 
-    const std::vector<TTypeNode>& types = t_column.type_desc.types;
-    if (depth == types.size()) {
-        return Status::InvalidArgument("type nodes must ended with scalar type");
+    field->set_unique_id(kFakeUniqueId);
+    field->set_is_key(false);
+    field->set_is_nullable(true);
+    field->set_aggregation(get_string_by_aggregation_type(STORAGE_AGGREGATE_NONE));
+}
+
+// Because thrift doesn't support nested definition. So we use list to flatten the nested.
+// In thrift, types and index will be used together to present one type.
+// After this function returned, index will point to the next position to be parsed.
+static Status type_desc_to_pb(const std::vector<TTypeNode>& types, int* index, ColumnPB* column_pb) {
+    const TTypeNode& curr_type_node = types[*index];
+    ++(*index);
+    switch (curr_type_node.type) {
+    case TTypeNodeType::SCALAR: {
+        TScalarType scalar = curr_type_node.scalar_type;
+
+        LogicalType field_type = thrift_to_type(scalar.type);
+        column_pb->set_type(logical_type_to_string(field_type));
+        column_pb->set_length(TabletColumn::get_field_length_by_type(field_type, scalar.len));
+        column_pb->set_index_length(column_pb->length());
+        column_pb->set_frac(curr_type_node.scalar_type.scale);
+        column_pb->set_precision(curr_type_node.scalar_type.precision);
+        return Status::OK();
     }
+    case TTypeNodeType::ARRAY: {
+        column_pb->set_type(logical_type_to_string(TYPE_ARRAY));
 
-    // No names provided for child columns, assign them a fake name.
-    auto c_name = depth == 0 ? t_column.column_name : strings::Substitute("_$0_$1", t_column.column_name, depth);
+        // FIXME: I'm not sure if these fields are necessary, just keep it to be safe
+        column_pb->set_length(TabletColumn::get_field_length_by_type(TYPE_ARRAY, sizeof(Collection)));
+        column_pb->set_index_length(column_pb->length());
 
-    // A child column cannot be a key column.
-    auto is_key = depth == 0 && t_column.is_key;
-    bool is_nullable = depth > 0 || t_column.is_allow_null;
+        // Currently, All array element is nullable
+        auto field_pb = column_pb->add_children_columns();
+        init_column_pb_for_sub_field(field_pb);
+        RETURN_IF_ERROR(type_desc_to_pb(types, index, field_pb));
+        field_pb->set_name("element");
+        return Status::OK();
+    }
+    case TTypeNodeType::STRUCT: {
+        column_pb->set_type(logical_type_to_string(TYPE_STRUCT));
 
+        // FIXME: I'm not sure if these fields are necessary, just keep it to be safe
+        column_pb->set_length(TabletColumn::get_field_length_by_type(TYPE_STRUCT, sizeof(Collection)));
+        column_pb->set_index_length(column_pb->length());
+
+        auto& fields = curr_type_node.struct_fields;
+        for (const auto& field : fields) {
+            auto field_pb = column_pb->add_children_columns();
+            init_column_pb_for_sub_field(field_pb);
+            // All struct fields all nullable now
+            RETURN_IF_ERROR(type_desc_to_pb(types, index, field_pb));
+            field_pb->set_name(field.name);
+        }
+        return Status::OK();
+    }
+    case TTypeNodeType::MAP: {
+        column_pb->set_type(logical_type_to_string(TYPE_MAP));
+
+        // FIXME: I'm not sure if these fields are necessary, just keep it to be safe
+        column_pb->set_length(TabletColumn::get_field_length_by_type(TYPE_MAP, sizeof(Collection)));
+        column_pb->set_index_length(column_pb->length());
+
+        {
+            auto key_pb = column_pb->add_children_columns();
+            init_column_pb_for_sub_field(key_pb);
+            RETURN_IF_ERROR(type_desc_to_pb(types, index, key_pb));
+            key_pb->set_name("key");
+        }
+        {
+            auto value_pb = column_pb->add_children_columns();
+            init_column_pb_for_sub_field(value_pb);
+            RETURN_IF_ERROR(type_desc_to_pb(types, index, value_pb));
+            value_pb->set_name("value");
+        }
+        return Status::OK();
+    }
+    }
+    return Status::InternalError("Unreachable path");
+}
+
+static Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, ColumnPB* column_pb) {
+    const std::vector<TTypeNode>& types = t_column.type_desc.types;
+    int index = 0;
+    RETURN_IF_ERROR(type_desc_to_pb(types, &index, column_pb));
+    if (index != types.size()) {
+        LOG(WARNING) << "Schema not match, size:" << types.size() << ", index=" << index;
+        return Status::InternalError("Failed to parse type, number of schema elements not match");
+    }
     column_pb->set_unique_id(unique_id);
-    column_pb->set_name(c_name);
-    column_pb->set_is_key(is_key);
-    column_pb->set_is_nullable(is_nullable);
-    if (depth > 0 || is_key) {
+    column_pb->set_name(t_column.column_name);
+    column_pb->set_is_key(t_column.is_key);
+    column_pb->set_is_nullable(t_column.is_allow_null);
+    if (t_column.is_key) {
         auto agg_method = STORAGE_AGGREGATE_NONE;
         column_pb->set_aggregation(get_string_by_aggregation_type(agg_method));
     } else {
         auto agg_method = t_aggregation_type_to_field_aggregation_method(t_column.aggregation_type);
         column_pb->set_aggregation(get_string_by_aggregation_type(agg_method));
     }
-
-    const TTypeNode& curr_type_node = types[depth];
-    switch (curr_type_node.type) {
-    case TTypeNodeType::SCALAR: {
-        TScalarType scalar = curr_type_node.scalar_type;
-
-        LogicalType field_type = t_primitive_type_to_field_type(scalar.type, v);
-        column_pb->set_type(logical_type_to_string(field_type));
-        column_pb->set_length(TabletColumn::get_field_length_by_type(field_type, scalar.len));
-        column_pb->set_index_length(column_pb->length());
-        column_pb->set_frac(curr_type_node.scalar_type.scale);
-        column_pb->set_precision(curr_type_node.scalar_type.precision);
-        if (field_type == TYPE_VARCHAR) {
-            int32_t index_len = depth == 0 && t_column.__isset.index_len ? t_column.index_len : 10;
-            column_pb->set_index_length(index_len);
-        }
-        if (depth == 0 && t_column.__isset.default_value) {
-            column_pb->set_default_value(t_column.default_value);
-        }
-        if (depth == 0 && t_column.__isset.is_bloom_filter_column) {
-            column_pb->set_is_bf_column(t_column.is_bloom_filter_column);
-        }
-        return Status::OK();
-    }
-    case TTypeNodeType::ARRAY:
-        column_pb->set_type(logical_type_to_string(TYPE_ARRAY));
-        column_pb->set_length(TabletColumn::get_field_length_by_type(TYPE_ARRAY, sizeof(Collection)));
-        column_pb->set_index_length(column_pb->length());
-        return t_column_to_pb_column(kFakeUniqueId, t_column, v, column_pb->add_children_columns(), depth + 1);
-    case TTypeNodeType::STRUCT:
-        return Status::NotSupported("struct not supported yet");
-    case TTypeNodeType::MAP:
-        column_pb->set_type(logical_type_to_string(TYPE_MAP));
-        column_pb->set_length(TabletColumn::get_field_length_by_type(TYPE_MAP, sizeof(Collection)));
-        column_pb->set_index_length(column_pb->length());
-        RETURN_IF_ERROR(
-                t_column_to_pb_column(kFakeUniqueId, t_column, v, column_pb->add_children_columns(), depth + 1));
-        return t_column_to_pb_column(kFakeUniqueId, t_column, v, column_pb->add_children_columns(), depth + 2);
-    }
-    return Status::InternalError("Unreachable path");
+    return Status::OK();
 }
 
 Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_t next_unique_id,
@@ -261,11 +217,6 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
         return Status::InternalError("Unexpected compression type");
     }
 
-    FieldTypeVersion field_version = FieldTypeVersion::kV1;
-    if (config::storage_format_version == 2) {
-        field_version = FieldTypeVersion::kV2;
-    }
-
     // set column information
     uint32_t col_ordinal = 0;
     bool has_bf_columns = false;
@@ -274,7 +225,7 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
         uint32_t col_unique_id = col_ordinal_to_unique_id.at(col_ordinal++);
         ColumnPB* column = schema->add_column();
 
-        RETURN_IF_ERROR(t_column_to_pb_column(col_unique_id, tcolumn, field_version, column));
+        RETURN_IF_ERROR(t_column_to_pb_column(col_unique_id, tcolumn, column));
 
         has_bf_columns |= column->is_bf_column();
 

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -86,7 +86,7 @@ static Status type_desc_to_pb(const std::vector<TTypeNode>& types, int* index, C
     ++(*index);
     switch (curr_type_node.type) {
     case TTypeNodeType::SCALAR: {
-        TScalarType scalar = curr_type_node.scalar_type;
+        auto& scalar = curr_type_node.scalar_type;
 
         LogicalType field_type = thrift_to_type(scalar.type);
         column_pb->set_type(logical_type_to_string(field_type));
@@ -172,6 +172,19 @@ static Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, 
         auto agg_method = t_aggregation_type_to_field_aggregation_method(t_column.aggregation_type);
         column_pb->set_aggregation(get_string_by_aggregation_type(agg_method));
     }
+
+    if (types[0].type == TTypeNodeType::SCALAR && types[0].scalar_type.type == TPrimitiveType::VARCHAR) {
+        int32_t index_len = t_column.__isset.index_len ? t_column.index_len : 10;
+        column_pb->set_index_length(index_len);
+    }
+    // Default value
+    if (t_column.__isset.default_value) {
+        column_pb->set_default_value(t_column.default_value);
+    }
+    if (t_column.__isset.is_bloom_filter_column) {
+        column_pb->set_is_bf_column(t_column.is_bloom_filter_column);
+    }
+
     return Status::OK();
 }
 

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -25,24 +25,6 @@
 
 namespace starrocks {
 
-// Old version StarRocks use `TColumnType` to save type info, convert it into `TTypeDesc`.
-static void convert_to_new_version(TColumn* tcolumn) {
-    if (!tcolumn->__isset.type_desc) {
-        tcolumn->__set_index_len(tcolumn->column_type.index_len);
-
-        TScalarType scalar_type;
-        scalar_type.__set_type(tcolumn->column_type.type);
-        scalar_type.__set_len(tcolumn->column_type.len);
-        scalar_type.__set_precision(tcolumn->column_type.precision);
-        scalar_type.__set_scale(tcolumn->column_type.scale);
-
-        tcolumn->type_desc.types.resize(1);
-        tcolumn->type_desc.types.back().__set_type(TTypeNodeType::SCALAR);
-        tcolumn->type_desc.types.back().__set_scalar_type(scalar_type);
-        tcolumn->__isset.type_desc = true;
-    }
-}
-
 static StorageAggregateType t_aggregation_type_to_field_aggregation_method(TAggregationType::type agg_type) {
     switch (agg_type) {
     case TAggregationType::NONE:
@@ -221,7 +203,6 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
     uint32_t col_ordinal = 0;
     bool has_bf_columns = false;
     for (TColumn tcolumn : tablet_schema.columns) {
-        convert_to_new_version(&tcolumn);
         uint32_t col_unique_id = col_ordinal_to_unique_id.at(col_ordinal++);
         ColumnPB* column = schema->add_column();
 

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -134,6 +134,7 @@ static Status type_desc_to_pb(const std::vector<TTypeNode>& types, int* index, C
 }
 
 static Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, ColumnPB* column_pb) {
+    DCHECK(t_column.__isset.type_desc);
     const std::vector<TTypeNode>& types = t_column.type_desc.types;
     int index = 0;
     RETURN_IF_ERROR(type_desc_to_pb(types, &index, column_pb));

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -25,6 +25,25 @@
 
 namespace starrocks {
 
+// Old version StarRocks use `TColumnType` to save type info, convert it into `TTypeDesc`.
+// NOTE: This is only used for some legacy UT
+static void convert_to_new_version(TColumn* tcolumn) {
+    if (!tcolumn->__isset.type_desc) {
+        tcolumn->__set_index_len(tcolumn->column_type.index_len);
+
+        TScalarType scalar_type;
+        scalar_type.__set_type(tcolumn->column_type.type);
+        scalar_type.__set_len(tcolumn->column_type.len);
+        scalar_type.__set_precision(tcolumn->column_type.precision);
+        scalar_type.__set_scale(tcolumn->column_type.scale);
+
+        tcolumn->type_desc.types.resize(1);
+        tcolumn->type_desc.types.back().__set_type(TTypeNodeType::SCALAR);
+        tcolumn->type_desc.types.back().__set_scalar_type(scalar_type);
+        tcolumn->__isset.type_desc = true;
+    }
+}
+
 static StorageAggregateType t_aggregation_type_to_field_aggregation_method(TAggregationType::type agg_type) {
     switch (agg_type) {
     case TAggregationType::NONE:
@@ -204,6 +223,7 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
     uint32_t col_ordinal = 0;
     bool has_bf_columns = false;
     for (TColumn tcolumn : tablet_schema.columns) {
+        convert_to_new_version(&tcolumn);
         uint32_t col_unique_id = col_ordinal_to_unique_id.at(col_ordinal++);
         ColumnPB* column = schema->add_column();
 

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -142,7 +142,7 @@ void set_default_create_tablet_request(TCreateTabletReq* request) {
     TColumn k9;
     k9.column_name = "k9";
     k9.__set_is_key(true);
-    k9.column_type.type = TPrimitiveType::DECIMAL;
+    k9.column_type.type = TPrimitiveType::DECIMALV2;
     k9.column_type.__set_precision(6);
     k9.column_type.__set_scale(3);
     request->tablet_schema.columns.push_back(k9);
@@ -222,7 +222,7 @@ void set_create_duplicate_tablet_request(TCreateTabletReq* request) {
     TColumn k9;
     k9.column_name = "k9";
     k9.__set_is_key(true);
-    k9.column_type.type = TPrimitiveType::DECIMAL;
+    k9.column_type.type = TPrimitiveType::DECIMALV2;
     k9.column_type.__set_precision(6);
     k9.column_type.__set_scale(3);
     request->tablet_schema.columns.push_back(k9);

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -100,6 +100,104 @@ static void tear_down() {
     config::storage_root_path = k_default_storage_root_path;
 }
 
+void set_scalar_type(TColumn* tcolumn, TPrimitiveType::type type) {
+    TScalarType scalar_type;
+    scalar_type.__set_type(type);
+
+    tcolumn->type_desc.types.resize(1);
+    tcolumn->type_desc.types.back().__set_type(TTypeNodeType::SCALAR);
+    tcolumn->type_desc.types.back().__set_scalar_type(scalar_type);
+    tcolumn->__isset.type_desc = true;
+}
+
+void set_decimal_type(TColumn* tcolumn, TPrimitiveType::type type, int precision, int scale) {
+    TScalarType scalar_type;
+    scalar_type.__set_type(type);
+    scalar_type.__set_precision(precision);
+    scalar_type.__set_scale(scale);
+
+    tcolumn->type_desc.types.resize(1);
+    tcolumn->type_desc.types.back().__set_type(TTypeNodeType::SCALAR);
+    tcolumn->type_desc.types.back().__set_scalar_type(scalar_type);
+    tcolumn->__isset.type_desc = true;
+}
+
+void set_varchar_type(TColumn* tcolumn, TPrimitiveType::type type, int length) {
+    TScalarType scalar_type;
+    scalar_type.__set_type(type);
+    scalar_type.__set_len(length);
+
+    tcolumn->type_desc.types.resize(1);
+    tcolumn->type_desc.types.back().__set_type(TTypeNodeType::SCALAR);
+    tcolumn->type_desc.types.back().__set_scalar_type(scalar_type);
+    tcolumn->__isset.type_desc = true;
+}
+
+void set_key_columns(TCreateTabletReq* request) {
+    TColumn k1;
+    k1.column_name = "k1";
+    k1.__set_is_key(true);
+    set_scalar_type(&k1, TPrimitiveType::TINYINT);
+    request->tablet_schema.columns.push_back(k1);
+
+    TColumn k2;
+    k2.column_name = "k2";
+    k2.__set_is_key(true);
+    set_scalar_type(&k2, TPrimitiveType::SMALLINT);
+    request->tablet_schema.columns.push_back(k2);
+
+    TColumn k3;
+    k3.column_name = "k3";
+    k3.__set_is_key(true);
+    set_scalar_type(&k3, TPrimitiveType::INT);
+    request->tablet_schema.columns.push_back(k3);
+
+    TColumn k4;
+    k4.column_name = "k4";
+    k4.__set_is_key(true);
+    set_scalar_type(&k4, TPrimitiveType::BIGINT);
+    request->tablet_schema.columns.push_back(k4);
+
+    TColumn k5;
+    k5.column_name = "k5";
+    k5.__set_is_key(true);
+    set_scalar_type(&k5, TPrimitiveType::LARGEINT);
+    request->tablet_schema.columns.push_back(k5);
+
+    TColumn k9;
+    k9.column_name = "k9";
+    k9.__set_is_key(true);
+    k9.column_type.type = TPrimitiveType::DECIMALV2;
+    k9.column_type.__set_precision(6);
+    k9.column_type.__set_scale(3);
+    set_decimal_type(&k9, TPrimitiveType::DECIMALV2, 6, 3);
+    request->tablet_schema.columns.push_back(k9);
+
+    TColumn k10;
+    k10.column_name = "k10";
+    k10.__set_is_key(true);
+    set_scalar_type(&k10, TPrimitiveType::DATE);
+    request->tablet_schema.columns.push_back(k10);
+
+    TColumn k11;
+    k11.column_name = "k11";
+    k11.__set_is_key(true);
+    set_scalar_type(&k11, TPrimitiveType::DATETIME);
+    request->tablet_schema.columns.push_back(k11);
+
+    TColumn k12;
+    k12.column_name = "k12";
+    k12.__set_is_key(true);
+    set_varchar_type(&k12, TPrimitiveType::CHAR, 64);
+    request->tablet_schema.columns.push_back(k12);
+
+    TColumn k13;
+    k13.column_name = "k13";
+    k13.__set_is_key(true);
+    set_varchar_type(&k13, TPrimitiveType::CHAR, 64);
+    request->tablet_schema.columns.push_back(k13);
+}
+
 void set_default_create_tablet_request(TCreateTabletReq* request) {
     request->tablet_id = random();
     request->__set_version(1);
@@ -109,74 +207,12 @@ void set_default_create_tablet_request(TCreateTabletReq* request) {
     request->tablet_schema.keys_type = TKeysType::AGG_KEYS;
     request->tablet_schema.storage_type = TStorageType::COLUMN;
 
-    TColumn k1;
-    k1.column_name = "k1";
-    k1.__set_is_key(true);
-    k1.column_type.type = TPrimitiveType::TINYINT;
-    request->tablet_schema.columns.push_back(k1);
-
-    TColumn k2;
-    k2.column_name = "k2";
-    k2.__set_is_key(true);
-    k2.column_type.type = TPrimitiveType::SMALLINT;
-    request->tablet_schema.columns.push_back(k2);
-
-    TColumn k3;
-    k3.column_name = "k3";
-    k3.__set_is_key(true);
-    k3.column_type.type = TPrimitiveType::INT;
-    request->tablet_schema.columns.push_back(k3);
-
-    TColumn k4;
-    k4.column_name = "k4";
-    k4.__set_is_key(true);
-    k4.column_type.type = TPrimitiveType::BIGINT;
-    request->tablet_schema.columns.push_back(k4);
-
-    TColumn k5;
-    k5.column_name = "k5";
-    k5.__set_is_key(true);
-    k5.column_type.type = TPrimitiveType::LARGEINT;
-    request->tablet_schema.columns.push_back(k5);
-
-    TColumn k9;
-    k9.column_name = "k9";
-    k9.__set_is_key(true);
-    k9.column_type.type = TPrimitiveType::DECIMALV2;
-    k9.column_type.__set_precision(6);
-    k9.column_type.__set_scale(3);
-    request->tablet_schema.columns.push_back(k9);
-
-    TColumn k10;
-    k10.column_name = "k10";
-    k10.__set_is_key(true);
-    k10.column_type.type = TPrimitiveType::DATE;
-    request->tablet_schema.columns.push_back(k10);
-
-    TColumn k11;
-    k11.column_name = "k11";
-    k11.__set_is_key(true);
-    k11.column_type.type = TPrimitiveType::DATETIME;
-    request->tablet_schema.columns.push_back(k11);
-
-    TColumn k12;
-    k12.column_name = "k12";
-    k12.__set_is_key(true);
-    k12.column_type.__set_len(64);
-    k12.column_type.type = TPrimitiveType::CHAR;
-    request->tablet_schema.columns.push_back(k12);
-
-    TColumn k13;
-    k13.column_name = "k13";
-    k13.__set_is_key(true);
-    k13.column_type.__set_len(64);
-    k13.column_type.type = TPrimitiveType::VARCHAR;
-    request->tablet_schema.columns.push_back(k13);
+    set_key_columns(request);
 
     TColumn v;
     v.column_name = "v";
     v.__set_is_key(false);
-    v.column_type.type = TPrimitiveType::BIGINT;
+    set_scalar_type(&v, TPrimitiveType::BIGINT);
     v.__set_aggregation_type(TAggregationType::SUM);
     request->tablet_schema.columns.push_back(v);
 }
@@ -189,74 +225,12 @@ void set_create_duplicate_tablet_request(TCreateTabletReq* request) {
     request->tablet_schema.keys_type = TKeysType::DUP_KEYS;
     request->tablet_schema.storage_type = TStorageType::COLUMN;
 
-    TColumn k1;
-    k1.column_name = "k1";
-    k1.__set_is_key(true);
-    k1.column_type.type = TPrimitiveType::TINYINT;
-    request->tablet_schema.columns.push_back(k1);
-
-    TColumn k2;
-    k2.column_name = "k2";
-    k2.__set_is_key(true);
-    k2.column_type.type = TPrimitiveType::SMALLINT;
-    request->tablet_schema.columns.push_back(k2);
-
-    TColumn k3;
-    k3.column_name = "k3";
-    k3.__set_is_key(true);
-    k3.column_type.type = TPrimitiveType::INT;
-    request->tablet_schema.columns.push_back(k3);
-
-    TColumn k4;
-    k4.column_name = "k4";
-    k4.__set_is_key(true);
-    k4.column_type.type = TPrimitiveType::BIGINT;
-    request->tablet_schema.columns.push_back(k4);
-
-    TColumn k5;
-    k5.column_name = "k5";
-    k5.__set_is_key(true);
-    k5.column_type.type = TPrimitiveType::LARGEINT;
-    request->tablet_schema.columns.push_back(k5);
-
-    TColumn k9;
-    k9.column_name = "k9";
-    k9.__set_is_key(true);
-    k9.column_type.type = TPrimitiveType::DECIMALV2;
-    k9.column_type.__set_precision(6);
-    k9.column_type.__set_scale(3);
-    request->tablet_schema.columns.push_back(k9);
-
-    TColumn k10;
-    k10.column_name = "k10";
-    k10.__set_is_key(true);
-    k10.column_type.type = TPrimitiveType::DATE;
-    request->tablet_schema.columns.push_back(k10);
-
-    TColumn k11;
-    k11.column_name = "k11";
-    k11.__set_is_key(true);
-    k11.column_type.type = TPrimitiveType::DATETIME;
-    request->tablet_schema.columns.push_back(k11);
-
-    TColumn k12;
-    k12.column_name = "k12";
-    k12.__set_is_key(true);
-    k12.column_type.__set_len(64);
-    k12.column_type.type = TPrimitiveType::CHAR;
-    request->tablet_schema.columns.push_back(k12);
-
-    TColumn k13;
-    k13.column_name = "k13";
-    k13.__set_is_key(true);
-    k13.column_type.__set_len(64);
-    k13.column_type.type = TPrimitiveType::VARCHAR;
-    request->tablet_schema.columns.push_back(k13);
+    set_key_columns(request);
 
     TColumn v;
     v.column_name = "v";
     v.__set_is_key(false);
-    v.column_type.type = TPrimitiveType::BIGINT;
+    set_scalar_type(&v, TPrimitiveType::BIGINT);
     request->tablet_schema.columns.push_back(v);
 }
 

--- a/be/test/storage/tablet_meta_test.cpp
+++ b/be/test/storage/tablet_meta_test.cpp
@@ -167,7 +167,7 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_EQ(STORAGE_AGGREGATE_NONE, c1.aggregation());
     ASSERT_EQ(1, c1.subcolumn_count());
 
-    ASSERT_EQ("_c1_1", c1.subcolumn(0).name());
+    ASSERT_EQ("element", c1.subcolumn(0).name());
     ASSERT_EQ(kInvalidUniqueId, c1.subcolumn(0).unique_id());
     ASSERT_EQ(TYPE_DECIMALV2, c1.subcolumn(0).type());
     ASSERT_FALSE(c1.subcolumn(0).is_key());
@@ -192,7 +192,7 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_EQ(STORAGE_AGGREGATE_NONE, c2.aggregation());
     ASSERT_EQ(1, c2.subcolumn_count());
 
-    ASSERT_EQ("_c2_1", c2.subcolumn(0).name());
+    ASSERT_EQ("element", c2.subcolumn(0).name());
     ASSERT_EQ(kInvalidUniqueId, c2.subcolumn(0).unique_id());
     ASSERT_EQ(TYPE_ARRAY, c2.subcolumn(0).type());
     ASSERT_FALSE(c2.subcolumn(0).is_key());
@@ -205,7 +205,7 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_EQ(1, c2.subcolumn(0).subcolumn_count());
 
     const TabletColumn& c2_1 = c2.subcolumn(0);
-    ASSERT_EQ("_c2_2", c2_1.subcolumn(0).name());
+    ASSERT_EQ("element", c2_1.subcolumn(0).name());
     ASSERT_EQ(kInvalidUniqueId, c2_1.subcolumn(0).unique_id());
     ASSERT_EQ(TYPE_VARCHAR, c2_1.subcolumn(0).type());
     ASSERT_FALSE(c2_1.subcolumn(0).is_key());

--- a/be/test/storage/tablet_meta_test.cpp
+++ b/be/test/storage/tablet_meta_test.cpp
@@ -214,7 +214,7 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_FALSE(c2_1.subcolumn(0).has_bitmap_index());
     ASSERT_FALSE(c2_1.subcolumn(0).has_default_value());
     ASSERT_EQ(10 + sizeof(OLAP_STRING_MAX_LENGTH), c2_1.subcolumn(0).length());
-    ASSERT_EQ(10, c2_1.subcolumn(0).index_length());
+    ASSERT_EQ(10 + sizeof(OLAP_STRING_MAX_LENGTH), c2_1.subcolumn(0).index_length());
     ASSERT_EQ(0, c2_1.subcolumn(0).subcolumn_count());
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Support convert Struct Type in thrift to protobuf.
This will be used in creating tablets. After this PR is applied, storage layer can accept FE's request to create struct type column.

This is related to the issue #15364 
