### PR TITLE
[Enhancement] Flush persistent index in advance to reduce memory usage during data load of primary key

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -900,6 +900,7 @@ CONF_Bool(block_cache_checksum_enable, "true");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
+CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -901,6 +901,7 @@ CONF_Bool(block_cache_checksum_enable, "true");
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
+CONF_mInt64(max_tmp_l1_num, "10");
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -57,7 +57,6 @@ constexpr size_t kL0SnapshotSizeMax = 1 * 1024 * 1024;
 constexpr size_t kL0SnapshotSizeMax = 16 * 1024 * 1024;
 #endif
 constexpr size_t kLongKeySize = 64;
-constexpr size_t kFlushL1SizeMax = 200 * 1024 * 1024;
 
 const char* const kIndexFileMagic = "IDX1";
 
@@ -658,8 +657,6 @@ public:
             uint64_t hash = FixedKeyHash<KeySize>()(key);
             if (auto [it, inserted] = _map.emplace_with_hash(hash, key, value); inserted) {
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
-                //not_found->key_idxes.emplace_back((uint32_t)idx);
-                //not_found->hashes.emplace_back(hash);
             } else {
                 auto old_value = it->second;
                 nfound += old_value.get_value() != NullIndexValue;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2019,7 +2019,6 @@ Status ImmutableIndex::_get_in_fixlen_shard(size_t shard_idx, size_t n, const Sl
         uint8_t* bucket_pos = (*shard)->pages[bucket_info.pageid].pack(bucket_info.packid);
         auto nele = bucket_info.size;
         auto ncandidates = get_matched_tag_idxes(bucket_pos, nele, h.tag(), candidate_idxes);
-        //auto key_idx = keys_info.key_idxes[i];
         auto key_idx = keys_info.key_infos[i].first;
         const auto* fixed_key_probe = (const uint8_t*)keys[key_idx].data;
         auto kv_pos = bucket_pos + pad(nele, kPackSize);
@@ -2050,7 +2049,6 @@ Status ImmutableIndex::_get_in_varlen_shard(size_t shard_idx, size_t n, const Sl
         uint8_t* bucket_pos = (*shard)->pages[bucket_info.pageid].pack(bucket_info.packid);
         auto nele = bucket_info.size;
         auto ncandidates = get_matched_tag_idxes(bucket_pos, nele, h.tag(), candidate_idxes);
-        //auto key_idx = keys_info.key_idxes[i];
         auto key_idx = keys_info.key_infos[i].first;
         const auto* key_probe = reinterpret_cast<const uint8_t*>(keys[key_idx].data);
         auto offset_pos = bucket_pos + pad(nele, kPackSize);
@@ -2099,7 +2097,6 @@ Status ImmutableIndex::_check_not_exist_in_fixlen_shard(size_t shard_idx, size_t
         auto& bucket_info = (*shard)->bucket(pageid, bucketid);
         uint8_t* bucket_pos = (*shard)->pages[bucket_info.pageid].pack(bucket_info.packid);
         auto nele = bucket_info.size;
-        //auto key_idx = keys_info.key_idxes[i];
         auto key_idx = keys_info.key_infos[i].first;
         auto ncandidates = get_matched_tag_idxes(bucket_pos, nele, h.tag(), candidate_idxes);
         const auto* fixed_key_probe = (const uint8_t*)keys[key_idx].data;
@@ -2122,14 +2119,12 @@ Status ImmutableIndex::_check_not_exist_in_varlen_shard(size_t shard_idx, size_t
     DCHECK(shard_info.key_size == 0);
     uint8_t candidate_idxes[kBucketSizeMax];
     for (size_t i = 0; i < keys_info.size(); i++) {
-        //IndexHash h(keys_info.hashes[i]);
         IndexHash h(keys_info.key_infos[i].second);
         auto pageid = h.page() % shard_info.npage;
         auto bucketid = h.bucket() % shard_info.nbucket;
         auto& bucket_info = (*shard)->bucket(pageid, bucketid);
         uint8_t* bucket_pos = (*shard)->pages[bucket_info.pageid].pack(bucket_info.packid);
         auto nele = bucket_info.size;
-        //auto key_idx = keys_info.key_idxes[i];
         auto key_idx = keys_info.key_infos[i].first;
         auto ncandidates = get_matched_tag_idxes(bucket_pos, nele, h.tag(), candidate_idxes);
         const auto* key_probe = reinterpret_cast<const uint8_t*>(keys[key_idx].data);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3249,6 +3249,14 @@ Status PersistentIndex::_merge_compaction() {
         return Status::InternalError("cannot do merge_compaction without l1");
     }
     // if _l0 is empty() and _l1_vec only has one _l1, we can rename it directly
+    if (_l0->size() == 0) {
+        if (!_has_l1 && _l1_vec.size() == 1) {
+            const std::string idx_file_path =
+                    strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
+            const std::string idx_file_path_tmp = _l1_vec[0]->_file->filename();
+            return FileSystem::Default()->rename_file(idx_file_path_tmp, idx_file_path);
+        }
+    }
     auto writer = std::make_unique<ImmutableIndexWriter>();
     const std::string idx_file_path =
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -464,7 +464,6 @@ ImmutableIndexWriter::~ImmutableIndexWriter() {
 Status ImmutableIndexWriter::init(const string& idx_file_path, const EditVersion& version) {
     _version = version;
     _idx_file_path = idx_file_path;
-    //_idx_file_path = strings::Substitute("$0/index.l1.$1.$2", dir, version.major(), version.minor());
     _idx_file_path_tmp = _idx_file_path + ".tmp";
     ASSIGN_OR_RETURN(_fs, FileSystem::CreateSharedFromString(_idx_file_path_tmp));
     WritableFileOptions wblock_opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
@@ -621,8 +620,6 @@ public:
             if (iter == _map.end()) {
                 values[idx] = NullIndexValue;
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
-                //not_found->key_idxes.emplace_back((uint32_t)idx);
-                //not_found->hashes.emplace_back(hash);
             } else {
                 values[idx] = iter->second;
                 nfound += iter->second.get_value() != NullIndexValue;
@@ -641,8 +638,6 @@ public:
             uint64_t hash = FixedKeyHash<KeySize>()(key);
             if (auto [it, inserted] = _map.emplace_with_hash(hash, key, value); inserted) {
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
-                //not_found->key_idxes.emplace_back((uint32_t)idx);
-                //not_found->hashes.emplace_back(hash);
             } else {
                 auto old_value = it->second;
                 old_values[idx] = old_value;
@@ -899,8 +894,6 @@ public:
             if (iter == _set.end()) {
                 values[idx] = NullIndexValue;
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
-                //not_found->key_idxes.emplace_back((uint32_t)idx);
-                //not_found->hashes.emplace_back(hash);
             } else {
                 const auto& composite_key = *iter;
                 auto value = UNALIGNED_LOAD64(composite_key.data() + composite_key.size() - kIndexValueSize);
@@ -925,8 +918,6 @@ public:
             uint64_t hash = StringHasher2()(composite_key);
             if (auto [it, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
-                //not_found->key_idxes.emplace_back((uint32_t)idx);
-                //not_found->hashes.emplace_back(hash);
                 _total_kv_pairs_usage += composite_key.size();
             } else {
                 const auto& old_compose_key = *it;
@@ -954,8 +945,6 @@ public:
             uint64_t hash = StringHasher2()(composite_key);
             if (auto [it, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
-                //not_found->key_idxes.emplace_back((uint32_t)idx);
-                //not_found->hashes.emplace_back(hash);
                 _total_kv_pairs_usage += composite_key.size();
             } else {
                 const auto& old_compose_key = *it;
@@ -1006,8 +995,6 @@ public:
             if (auto [it, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
                 old_values[idx] = NullIndexValue;
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
-                //not_found->key_idxes.emplace_back((uint32_t)idx);
-                //not_found->hashes.emplace_back(hash);
                 _total_kv_pairs_usage += composite_key.size();
             } else {
                 auto& old_compose_key = *it;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -71,8 +71,6 @@ struct KeysInfo {
                             std::back_inserter(infos), [](auto& a, auto& b) { return a.first < b.first; });
         key_infos.swap(infos);
     }
-
-    //void swap(KeysInfo& input) { key_infos.swap(input.key_infos); }
 };
 
 struct KVRef {
@@ -184,10 +182,6 @@ public:
     virtual void clear() = 0;
 
     virtual size_t memory_usage() = 0;
-
-    virtual void update_overlap_info(size_t overlap_size, size_t overlap_usage) = 0;
-
-    virtual size_t overlap_size() = 0;
 
     static StatusOr<std::unique_ptr<MutableIndex>> create(size_t key_size);
 
@@ -308,9 +302,6 @@ public:
 
     void clear();
 
-    Status update_overlap_info(size_t key_size, size_t num_overlap, const Slice* keys, const IndexValue* values,
-                               const KeysInfo& keys_info, bool erase);
-
     static StatusOr<std::unique_ptr<ShardByLengthMutableIndex>> create(size_t key_size, const std::string& path);
 
 private:
@@ -385,18 +376,6 @@ private:
     Status _get_kvs_for_shard(std::vector<std::vector<KVRef>>& kvs_by_shard, size_t shard_idx, uint32_t shard_bits,
                               std::unique_ptr<ImmutableIndexShard>* shard) const;
 
-    /*
-    Status _get_in_fixlen_shard(size_t shard_idx, size_t n, const Slice* keys, const KeysInfo& keys_info,
-                                IndexValue* values, size_t* num_found,
-                                std::unique_ptr<ImmutableIndexShard>* shard) const;
-
-    Status _get_in_varlen_shard(size_t shard_idx, size_t n, const Slice* keys, const KeysInfo& keys_info,
-                                IndexValue* values, size_t* num_found,
-                                std::unique_ptr<ImmutableIndexShard>* shard) const;
-
-    Status _get_in_shard(size_t shard_idx, size_t n, const Slice* keys, const KeysInfo& keys_info, IndexValue* values,
-                         size_t* num_found) const;
-    */
     Status _get_in_fixlen_shard(size_t shard_idx, size_t n, const Slice* keys, const KeysInfo& keys_info,
                                 IndexValue* values, KeysInfo* found_keys_info,
                                 std::unique_ptr<ImmutableIndexShard>* shard) const;
@@ -447,6 +426,8 @@ public:
     Status write_shard_as_rawbuff(const ImmutableIndex::ShardInfo& old_shard_info, ImmutableIndex* immutable_index);
 
     Status finish();
+
+    size_t total_kv_size() { return _total_kv_size; }
 
 private:
     EditVersion _version;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -60,8 +60,6 @@ static_assert(sizeof(IndexValue) == kIndexValueSize);
 uint64_t key_index_hash(const void* data, size_t len);
 
 struct KeysInfo {
-    //std::vector<uint32_t> key_idxes;
-    //std::vector<uint64_t> hashes;
     std::vector<std::pair<uint32_t, uint64_t>> key_infos;
     size_t size() const { return key_infos.size(); }
 
@@ -333,8 +331,6 @@ public:
     // |values|: value array for return values
     // |num_found|: add the number of keys found in L1 to this argument
     // |key_size|: the key size of keys array
-    //Status get(size_t n, const Slice* keys, const KeysInfo& keys_info, IndexValue* values, size_t* num_found,
-    //           size_t key_size) const;
     Status get(size_t n, const Slice* keys, const KeysInfo& keys_info, IndexValue* values, KeysInfo* found_keys_info,
                size_t key_size) const;
 
@@ -590,7 +586,6 @@ private:
     // _l1_version is used to get l1 file name, update in on_committed
     EditVersion _l1_version;
     std::unique_ptr<ShardByLengthMutableIndex> _l0;
-    //std::unique_ptr<ImmutableIndex> _l1;
     // add all l1 into vector
     std::vector<std::unique_ptr<ImmutableIndex>> _l1_vec;
     bool _has_l1 = false;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -564,7 +564,7 @@ public:
     Status try_replace(size_t n, const Slice* keys, const IndexValue* values, const uint32_t max_src_rssid,
                        std::vector<uint32_t>* failed);
 
-    Status flush_tmp_l1();
+    Status flush_advance();
 
     std::vector<int8_t> test_get_move_buckets(size_t target, const uint8_t* bucket_packs_in_page);
 

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1097,8 +1097,8 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_varlen_to_immutable) {
         keys_slice[i] = Slice(keys[i].data(), keys[i].size());
     }
     std::string l1_file_path = kPersistentIndexDir + "/index.l1.1.0";
-    auto flush_st = index.test_flush_varlen_to_immutable_index(l1_file_path, version, N, keys_slice.data(),
-                                                               values.data());
+    auto flush_st =
+            index.test_flush_varlen_to_immutable_index(l1_file_path, version, N, keys_slice.data(), values.data());
     if (!flush_st.ok()) {
         LOG(WARNING) << flush_st;
     }
@@ -1509,6 +1509,120 @@ PARALLEL_TEST(PersistentIndexTest, test_get_move_buckets) {
         }
         ASSERT_TRUE(find_target >= target);
     }
+    ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
+}
+
+PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
+    config::l0_max_mem_usage = 1048576;
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_flush_l1_advance";
+    const std::string kIndexFile = "./PersistentIndexTest_test_flush_l1_advance/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    using Key = std::string;
+    PersistentIndexMetaPB index_meta;
+    const int N = 500000;
+    vector<Key> keys(N);
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    key_slices.reserve(N);
+
+    for (int i = 0; i < N; i++) {
+        keys[i] = "test_varlen_" + std::to_string(i);
+        values.emplace_back(i);
+        key_slices.emplace_back(keys[i]);
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    {
+        EditVersion version(0, 0);
+        index_meta.set_key_size(0);
+        index_meta.set_size(0);
+        version.to_pb(index_meta.mutable_version());
+        MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+        IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+        version.to_pb(snapshot_meta->mutable_version());
+
+        PersistentIndex index(kPersistentIndexDir);
+        ASSERT_OK(index.load(index_meta));
+        ASSERT_OK(index.prepare(EditVersion(1, 0)));
+        const int N = 100000;
+        for (int i = 0; i < 5; i++) {
+            vector<Key> keys(N);
+            vector<Slice> key_slices;
+            vector<IndexValue> values;
+            key_slices.reserve(N);
+            for (int j = 0; j < N; j++) {
+                keys[j] = "test_varlen_" + std::to_string(i * N + j);
+                values.emplace_back(i * N + j);
+                key_slices.emplace_back(keys[j]);
+            }
+            ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
+            std::vector<IndexValue> get_values(N);
+            ASSERT_OK(index.get(N, key_slices.data(), get_values.data()));
+            for (int j = 0; j < N; j++) {
+                ASSERT_EQ(values[j], get_values[j]);
+            }
+        }
+        ASSERT_OK(index.commit(&index_meta));
+        ASSERT_OK(index.on_commited());
+    }
+
+    {
+        // reload persistent index
+        PersistentIndex index(kPersistentIndexDir);
+        ASSERT_OK(index.load(index_meta));
+        std::vector<IndexValue> get_values(keys.size());
+        ASSERT_OK(index.get(N, key_slices.data(), get_values.data()));
+        for (int i = 0; i < N; i++) {
+            if (values[i].get_value() != get_values[i].get_value()) {
+                LOG(INFO) << "values[" << i << "] is " << values[i].get_value() << ", get_values[" << i << "] is "
+                          << get_values[i].get_value();
+            }
+            ASSERT_EQ(values[i], get_values[i]);
+        }
+    }
+
+    {
+        PersistentIndex index(kPersistentIndexDir);
+        ASSERT_OK(index.load(index_meta));
+        ASSERT_OK(index.prepare(EditVersion(2, 0)));
+        const int N = 100000;
+        for (int i = 0; i < 5; i++) {
+            vector<IndexValue> values;
+            key_slices.reserve(N);
+            for (int j = 0; j < N; j++) {
+                values.emplace_back(i * j);
+            }
+            std::vector<IndexValue> old_values(N);
+            ASSERT_OK(index.upsert(N, key_slices.data(), values.data(), old_values.data()));
+            std::vector<IndexValue> get_values(N);
+            ASSERT_OK(index.get(N, key_slices.data(), get_values.data()));
+            for (int j = 0; j < N; j++) {
+                ASSERT_EQ(values[j], get_values[j]);
+            }
+        }
+        ASSERT_OK(index.commit(&index_meta));
+        ASSERT_OK(index.on_commited());
+    }
+
+    {
+        // reload persistent index
+        const int N = 100000;
+        PersistentIndex index(kPersistentIndexDir);
+        ASSERT_OK(index.load(index_meta));
+        std::vector<IndexValue> get_values(N);
+        ASSERT_OK(index.get(N, key_slices.data(), get_values.data()));
+        for (int i = 0; i < N; i++) {
+            ASSERT_EQ(values[i].get_value() * 4, get_values[i].get_value());
+        }
+    }
+
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -62,7 +62,6 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
     size_t get_num_found = 0;
     ASSERT_TRUE(idx->get(key_slices.data(), get_values.data(), &get_not_found, &get_num_found, idxes).ok());
     ASSERT_EQ(keys.size(), get_num_found);
-    //ASSERT_EQ(get_not_found.key_idxes.size(), 0);
     ASSERT_EQ(get_not_found.size(), 0);
     for (int i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
@@ -102,7 +101,6 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
                         .ok());
     ASSERT_EQ(erase_num_found, (N + 2) / 3);
     // N+2 not found
-    //ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
     ASSERT_EQ(erase_not_found.size(), 1);
 
     // test upsert
@@ -132,7 +130,6 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
                             &upsert_num_found, idxes)
                         .ok());
     ASSERT_EQ(upsert_num_found, expect_exists);
-    //ASSERT_EQ(upsert_not_found.key_idxes.size(), expect_not_found);
     ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
@@ -161,7 +158,6 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
     size_t get_num_found = 0;
     ASSERT_TRUE(idx->get(key_slices.data(), get_values.data(), &get_not_found, &get_num_found, idxes).ok());
     ASSERT_EQ(keys.size(), get_num_found);
-    //ASSERT_EQ(get_not_found.key_idxes.size(), 0);
     ASSERT_EQ(get_not_found.size(), 0);
     for (int i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
@@ -200,7 +196,6 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
                         .ok());
     ASSERT_EQ(erase_num_found, (N + 2) / 3);
     // N+2 not found
-    //ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
     ASSERT_EQ(erase_not_found.size(), 1);
 
     // test upsert
@@ -230,7 +225,6 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
                             &upsert_num_found, idxes)
                         .ok());
     ASSERT_EQ(upsert_num_found, expect_exists);
-    //ASSERT_EQ(upsert_not_found.key_idxes.size(), expect_not_found);
     ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
@@ -274,7 +268,6 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
     size_t get_num_found = 0;
     ASSERT_TRUE(idx->get(key_slices.data(), get_values.data(), &get_not_found, &get_num_found, idxes).ok());
     ASSERT_EQ(keys.size(), get_num_found);
-    //ASSERT_EQ(get_not_found.key_idxes.size(), 0);
     ASSERT_EQ(get_not_found.size(), 0);
     for (int i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
@@ -320,7 +313,6 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
                         .ok());
     ASSERT_EQ(erase_num_found, N / 2);
     // N+2 not found
-    //ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
     ASSERT_EQ(erase_not_found.size(), 1);
 
     // test upsert
@@ -1048,21 +1040,17 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     auto& idx_loaded = st_load.value();
     KeysInfo keys_info;
     for (size_t i = 0; i < N; i++) {
-        //keys_info.key_idxes.emplace_back(i);
         uint64_t h = key_index_hash(&keys[i], sizeof(Key));
-        //keys_info.hashes.emplace_back(h);
         keys_info.key_infos.emplace_back(i, h);
     }
     vector<IndexValue> get_values(N);
     //size_t num_found = 0;
     KeysInfo found_keys_info;
     auto st_get = idx_loaded->get(N, key_slices.data(), keys_info, get_values.data(), &found_keys_info, sizeof(Key));
-    //auto st_get = idx_loaded->get(N, key_slices.data(), keys_info, get_values.data(), &num_found, sizeof(Key));
     if (!st_get.ok()) {
         LOG(WARNING) << st_get;
     }
     ASSERT_TRUE(st_get.ok());
-    //ASSERT_EQ(N, num_found);
     ASSERT_EQ(N, found_keys_info.size());
     for (size_t i = 0; i < N; i++) {
         ASSERT_EQ(values[i], get_values[i]);
@@ -1104,7 +1092,6 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_varlen_to_immutable) {
     }
     ASSERT_TRUE(flush_st.ok());
 
-    //std::string l1_file_path = kPersistentIndexDir + "/index.l1.1.0";
     ASSIGN_OR_ABORT(auto rf, fs->new_random_access_file(l1_file_path));
     auto st_load = ImmutableIndex::load(std::move(rf));
     if (!st_load.ok()) {
@@ -1114,21 +1101,16 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_varlen_to_immutable) {
     auto& idx_loaded = st_load.value();
     KeysInfo keys_info;
     for (size_t i = 0; i < N; i++) {
-        //keys_info.key_idxes.emplace_back(i);
         uint64_t h = key_index_hash(keys[i].data(), keys[i].size());
-        //keys_info.hashes.emplace_back(h);
         keys_info.key_infos.emplace_back(i, h);
     }
     vector<IndexValue> get_values(N);
-    //size_t num_found = 0;
-    //auto st_get = idx_loaded->get(N, keys_slice.data(), keys_info, get_values.data(), &num_found, 0);
     KeysInfo found_keys_info;
     auto st_get = idx_loaded->get(N, keys_slice.data(), keys_info, get_values.data(), &found_keys_info, 0);
     if (!st_get.ok()) {
         LOG(WARNING) << st_get;
     }
     ASSERT_TRUE(st_get.ok());
-    //ASSERT_EQ(N, num_found);
     ASSERT_EQ(N, found_keys_info.size());
     for (size_t i = 0; i < N; i++) {
         ASSERT_EQ(values[i], get_values[i]);

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1022,7 +1022,7 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     ASSERT_TRUE(idx->insert(key_slices.data(), values.data(), idxes).ok());
 
     auto writer = std::make_unique<ImmutableIndexWriter>();
-    ASSERT_TRUE(writer->init("./index.l1.1.1", EditVersion(1, 1)).ok());
+    ASSERT_TRUE(writer->init("./index.l1.1.1", EditVersion(1, 1), false).ok());
 
     auto [nshard, npage_hint] = MutableIndex::estimate_nshard_and_npage((sizeof(Key) + 8) * N);
     auto nbucket = MutableIndex::estimate_nbucket(sizeof(Key), N, nshard, npage_hint);

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -62,7 +62,8 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
     size_t get_num_found = 0;
     ASSERT_TRUE(idx->get(key_slices.data(), get_values.data(), &get_not_found, &get_num_found, idxes).ok());
     ASSERT_EQ(keys.size(), get_num_found);
-    ASSERT_EQ(get_not_found.key_idxes.size(), 0);
+    //ASSERT_EQ(get_not_found.key_idxes.size(), 0);
+    ASSERT_EQ(get_not_found.size(), 0);
     for (int i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }
@@ -101,7 +102,8 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
                         .ok());
     ASSERT_EQ(erase_num_found, (N + 2) / 3);
     // N+2 not found
-    ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
+    //ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
+    ASSERT_EQ(erase_not_found.size(), 1);
 
     // test upsert
     vector<Key> upsert_keys(N, 0);
@@ -130,7 +132,8 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
                             &upsert_num_found, idxes)
                         .ok());
     ASSERT_EQ(upsert_num_found, expect_exists);
-    ASSERT_EQ(upsert_not_found.key_idxes.size(), expect_not_found);
+    //ASSERT_EQ(upsert_not_found.key_idxes.size(), expect_not_found);
+    ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
 PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
@@ -158,7 +161,8 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
     size_t get_num_found = 0;
     ASSERT_TRUE(idx->get(key_slices.data(), get_values.data(), &get_not_found, &get_num_found, idxes).ok());
     ASSERT_EQ(keys.size(), get_num_found);
-    ASSERT_EQ(get_not_found.key_idxes.size(), 0);
+    //ASSERT_EQ(get_not_found.key_idxes.size(), 0);
+    ASSERT_EQ(get_not_found.size(), 0);
     for (int i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }
@@ -196,7 +200,8 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
                         .ok());
     ASSERT_EQ(erase_num_found, (N + 2) / 3);
     // N+2 not found
-    ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
+    //ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
+    ASSERT_EQ(erase_not_found.size(), 1);
 
     // test upsert
     vector<Key> upsert_keys(N);
@@ -225,7 +230,8 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
                             &upsert_num_found, idxes)
                         .ok());
     ASSERT_EQ(upsert_num_found, expect_exists);
-    ASSERT_EQ(upsert_not_found.key_idxes.size(), expect_not_found);
+    //ASSERT_EQ(upsert_not_found.key_idxes.size(), expect_not_found);
+    ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
 static std::string gen_random_string_of_random_length(size_t floor, size_t ceil) {
@@ -268,7 +274,8 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
     size_t get_num_found = 0;
     ASSERT_TRUE(idx->get(key_slices.data(), get_values.data(), &get_not_found, &get_num_found, idxes).ok());
     ASSERT_EQ(keys.size(), get_num_found);
-    ASSERT_EQ(get_not_found.key_idxes.size(), 0);
+    //ASSERT_EQ(get_not_found.key_idxes.size(), 0);
+    ASSERT_EQ(get_not_found.size(), 0);
     for (int i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }
@@ -313,7 +320,8 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
                         .ok());
     ASSERT_EQ(erase_num_found, N / 2);
     // N+2 not found
-    ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
+    //ASSERT_EQ(erase_not_found.key_idxes.size(), 1);
+    ASSERT_EQ(erase_not_found.size(), 1);
 
     // test upsert
     vector<Key> upsert_keys(N);
@@ -1022,7 +1030,7 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     ASSERT_TRUE(idx->insert(key_slices.data(), values.data(), idxes).ok());
 
     auto writer = std::make_unique<ImmutableIndexWriter>();
-    ASSERT_TRUE(writer->init(".", EditVersion(1, 1)).ok());
+    ASSERT_TRUE(writer->init("./index.l1.1.1", EditVersion(1, 1)).ok());
 
     auto [nshard, npage_hint] = MutableIndex::estimate_nshard_and_npage((sizeof(Key) + 8) * N);
     auto nbucket = MutableIndex::estimate_nbucket(sizeof(Key), N, nshard, npage_hint);
@@ -1040,18 +1048,22 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     auto& idx_loaded = st_load.value();
     KeysInfo keys_info;
     for (size_t i = 0; i < N; i++) {
-        keys_info.key_idxes.emplace_back(i);
+        //keys_info.key_idxes.emplace_back(i);
         uint64_t h = key_index_hash(&keys[i], sizeof(Key));
-        keys_info.hashes.emplace_back(h);
+        //keys_info.hashes.emplace_back(h);
+        keys_info.key_infos.emplace_back(i, h);
     }
     vector<IndexValue> get_values(N);
-    size_t num_found = 0;
-    auto st_get = idx_loaded->get(N, key_slices.data(), keys_info, get_values.data(), &num_found, sizeof(Key));
+    //size_t num_found = 0;
+    KeysInfo found_keys_info;
+    auto st_get = idx_loaded->get(N, key_slices.data(), keys_info, get_values.data(), &found_keys_info, sizeof(Key));
+    //auto st_get = idx_loaded->get(N, key_slices.data(), keys_info, get_values.data(), &num_found, sizeof(Key));
     if (!st_get.ok()) {
         LOG(WARNING) << st_get;
     }
     ASSERT_TRUE(st_get.ok());
-    ASSERT_EQ(N, num_found);
+    //ASSERT_EQ(N, num_found);
+    ASSERT_EQ(N, found_keys_info.size());
     for (size_t i = 0; i < N; i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }
@@ -1084,14 +1096,15 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_varlen_to_immutable) {
         values[i] = i;
         keys_slice[i] = Slice(keys[i].data(), keys[i].size());
     }
-    auto flush_st = index.test_flush_varlen_to_immutable_index(kPersistentIndexDir, version, N, keys_slice.data(),
+    std::string l1_file_path = kPersistentIndexDir + "/index.l1.1.0";
+    auto flush_st = index.test_flush_varlen_to_immutable_index(l1_file_path, version, N, keys_slice.data(),
                                                                values.data());
     if (!flush_st.ok()) {
         LOG(WARNING) << flush_st;
     }
     ASSERT_TRUE(flush_st.ok());
 
-    std::string l1_file_path = kPersistentIndexDir + "/index.l1.1.0";
+    //std::string l1_file_path = kPersistentIndexDir + "/index.l1.1.0";
     ASSIGN_OR_ABORT(auto rf, fs->new_random_access_file(l1_file_path));
     auto st_load = ImmutableIndex::load(std::move(rf));
     if (!st_load.ok()) {
@@ -1101,18 +1114,22 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_varlen_to_immutable) {
     auto& idx_loaded = st_load.value();
     KeysInfo keys_info;
     for (size_t i = 0; i < N; i++) {
-        keys_info.key_idxes.emplace_back(i);
+        //keys_info.key_idxes.emplace_back(i);
         uint64_t h = key_index_hash(keys[i].data(), keys[i].size());
-        keys_info.hashes.emplace_back(h);
+        //keys_info.hashes.emplace_back(h);
+        keys_info.key_infos.emplace_back(i, h);
     }
     vector<IndexValue> get_values(N);
-    size_t num_found = 0;
-    auto st_get = idx_loaded->get(N, keys_slice.data(), keys_info, get_values.data(), &num_found, 0);
+    //size_t num_found = 0;
+    //auto st_get = idx_loaded->get(N, keys_slice.data(), keys_info, get_values.data(), &num_found, 0);
+    KeysInfo found_keys_info;
+    auto st_get = idx_loaded->get(N, keys_slice.data(), keys_info, get_values.data(), &found_keys_info, 0);
     if (!st_get.ok()) {
         LOG(WARNING) << st_get;
     }
     ASSERT_TRUE(st_get.ok());
-    ASSERT_EQ(N, num_found);
+    //ASSERT_EQ(N, num_found);
+    ASSERT_EQ(N, found_keys_info.size());
     for (size_t i = 0; i < N; i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -70,4 +70,5 @@ message PersistentIndexMetaPB {
     // only store a version to get file name
     EditVersionPB l1_version = 5;
     uint32 format_version = 6;
+    uint64 usage =7;
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

StarRocks supports real-time scenarios with PrimaryKey table, but the primary index of PrimaryKey table maybe cost a lot of memory, so we developed persistent index. PrimaryKey with persistent index will not use a lot of memory even if the data of table is very large. However, persistent index may alloc a large memory first if the import data size is very large which maybe cause apply failed.

This pr aims to resolve the large memory need during a large load of PrimaryKey table with persistent index.  If the memory usage of persistent index is too large, we will flush it to a tmp_l1 and clear the memory until all data is written into persistent index and we will merge all the tmp_l1 to a new l1 at last.

In my test env, one BE with one HDD, using BrokerLoad, create a table with 7 columns, 20 buckets:
```
CREATE TABLE `batch_flush_test` (
  `col_1` bigint(20) NOT NULL COMMENT "",
  `col_2` bigint(20) NOT NULL COMMENT "",
  `col_3` bigint(20) NOT NULL COMMENT "",
  `col_4` bigint(20) NOT NULL COMMENT "",
  `col_5` bigint(20) NOT NULL COMMENT "",
  `col_6` varchar(150) NULL COMMENT "",
  `col_7` varchar(150) NULL COMMENT ""
) ENGINE=OLAP 
PRIMARY KEY(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`col_1`, `col_2`) BUCKETS 20 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "V2",
"enable_persistent_index" = "true",
"compression" = "LZ4"
);
```
|PrimaryKey Length| RowNum|BucketNum| Column Num|  Load time(s)| Apply time(ms)| Peak UpdateMemory usage | Note |
|---------------------|-----------|--------------------|------------------------------|----|-----|-----|----|
|40 Bytes| 1Billion | 20 |  7 |  3514| 566379| 63.3G | branch-main |
|40 Bytes| 1Billion | 20 |  7 | 3334| 585724| 2.06G| branch-opt |


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
