### PR TITLE
[BugFix] DictMappingRewriter support compoundPredicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -1107,6 +1107,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
         @Override
         public Void visitCompoundPredicate(CompoundPredicateOperator predicate, CouldApplyDictOptimizeContext context) {
             if (predicate.isNot()) {
+                context.canDictOptBeApplied = false;
                 context.stopOptPropagateUpward = true;
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -1106,6 +1106,10 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
 
         @Override
         public Void visitCompoundPredicate(CompoundPredicateOperator predicate, CouldApplyDictOptimizeContext context) {
+            if (predicate.isNot()) {
+                context.stopOptPropagateUpward = true;
+                return null;
+            }
             couldApply(predicate, context);
             context.worthApplied |= context.canDictOptBeApplied;
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -57,6 +57,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -1099,6 +1100,13 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
         @Override
         public Void visitLikePredicateOperator(LikePredicateOperator predicate, CouldApplyDictOptimizeContext context) {
             predicate.getChild(0).accept(this, context);
+            context.worthApplied |= context.canDictOptBeApplied;
+            return null;
+        }
+
+        @Override
+        public Void visitCompoundPredicate(CompoundPredicateOperator predicate, CouldApplyDictOptimizeContext context) {
+            couldApply(predicate, context);
             context.worthApplied |= context.canDictOptBeApplied;
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
@@ -221,6 +222,11 @@ public class DictMappingRewriter {
         public ScalarOperator visitLikePredicateOperator(LikePredicateOperator operator, RewriterContext context) {
             operator.setChild(0, operator.getChild(0).accept(this, context));
             return operator;
+        }
+
+        @Override
+        public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator operator, RewriterContext context) {
+            return rewriteForScalarOperator(operator, context);
         }
 
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
@@ -226,11 +226,6 @@ public class DictMappingRewriter {
 
         @Override
         public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator operator, RewriterContext context) {
-            if (operator.isNot()) {
-                context.hasAppliedOperator = false;
-                context.hasUnsupportedOperator = true;
-                return visit(operator, context);
-            }
             return rewriteForScalarOperator(operator, context);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
@@ -226,6 +226,11 @@ public class DictMappingRewriter {
 
         @Override
         public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator operator, RewriterContext context) {
+            if (operator.isNot()) {
+                context.hasAppliedOperator = false;
+                context.hasUnsupportedOperator = true;
+                return visit(operator, context);
+            }
             return rewriteForScalarOperator(operator, context);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1400,4 +1400,11 @@ public class LowCardinalityTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertFalse(plan.contains("Decode"));
     }
+
+    @Test
+    public void testCompoundPredicate() throws Exception {
+        String sql = "select count(*) from supplier group by S_ADDRESS having if(S_ADDRESS > 'a' and S_ADDRESS < 'b', true, false)";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "DictExpr(10: S_ADDRESS,[if((<place-holder> > 'a') AND (<place-holder> < 'b'), TRUE, FALSE)])");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1126,7 +1126,7 @@ public class LowCardinalityTest extends PlanTestBase {
         // TODO:
         sql = "select S_ADDRESS not like '%key%' from supplier";
         plan = getVerboseExplain(sql);
-        Assert.assertFalse(plan.contains(" dict_col=S_ADDRESS"));
+        Assert.assertFalse(plan, plan.contains(" dict_col=S_ADDRESS"));
 
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         sql = "select count(distinct S_ADDRESS), count(distinct S_NAME) as a from supplier_nullable";
@@ -1407,6 +1407,15 @@ public class LowCardinalityTest extends PlanTestBase {
                 "if(S_ADDRESS > 'a' and S_ADDRESS < 'b', true, false)";
         String plan = getVerboseExplain(sql);
         assertContains(plan,
-                "DictExpr(10: S_ADDRESS,[if((<place-holder> > 'a') AND (<place-holder> < 'b'), TRUE, FALSE)])");
+                "DictExpr(10: S_ADDRESS,[if((<place-holder> > 'a') " +
+                        "AND (<place-holder> < 'b'), TRUE, FALSE)])");
+
+        sql = "select count(*) from supplier group by S_ADDRESS having " +
+                "if(not S_ADDRESS like '%a%' and S_ADDRESS < 'b', true, false)";
+        plan = getVerboseExplain(sql);
+        System.out.println(plan);
+        assertContains(plan,
+                "DictExpr(10: S_ADDRESS,[if((NOT (<place-holder> LIKE '%a%')) " +
+                        "AND (<place-holder> < 'b'), TRUE, FALSE)])");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1403,8 +1403,10 @@ public class LowCardinalityTest extends PlanTestBase {
 
     @Test
     public void testCompoundPredicate() throws Exception {
-        String sql = "select count(*) from supplier group by S_ADDRESS having if(S_ADDRESS > 'a' and S_ADDRESS < 'b', true, false)";
+        String sql = "select count(*) from supplier group by S_ADDRESS having " +
+                "if(S_ADDRESS > 'a' and S_ADDRESS < 'b', true, false)";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "DictExpr(10: S_ADDRESS,[if((<place-holder> > 'a') AND (<place-holder> < 'b'), TRUE, FALSE)])");
+        assertContains(plan,
+                "DictExpr(10: S_ADDRESS,[if((<place-holder> > 'a') AND (<place-holder> < 'b'), TRUE, FALSE)])");
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15243

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For predicate like `if(S_ADDRESS > 'a' and S_ADDRESS < 'b', true, false)`,  the if func is supported to optimize, but its child `S_ADDRESS > 'a' and S_ADDRESS < 'b'` blocked the rewrite process. The pr enable it. 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
