### PR TITLE
[BugFix] Modify solve hdfs uri contains empty space function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
@@ -66,7 +66,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
         String path = ObjectStorageUtils.formatObjectStoragePath(pathKey.getPath());
         List<RemoteFileDesc> fileDescs = Lists.newArrayList();
         try {
-            URI uri = new URI(path.replace(" ", "%20"));
+            URI uri = new Path(path).toUri();
             FileSystem fileSystem;
 
             if (!FeConstants.runningUnitTest) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveRemoteFileIOTest.java
@@ -58,5 +58,18 @@ public class HiveRemoteFileIOTest {
         Assert.assertEquals(2, blockDesc.getReplicaHostIds().length);
     }
 
+    @Test
+    public void testPathContainsEmptySpace() {
+        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
+        fileIO.setFileSystem(fs);
+        FeConstants.runningUnitTest = true;
+        String tableLocation = "hdfs://127.0.0.1:10000/hive.db / hive_tbl";
+        RemotePathKey pathKey = RemotePathKey.of(tableLocation, false);
+        Map<RemotePathKey, List<RemoteFileDesc>> remoteFileInfos = fileIO.getRemoteFiles(pathKey);
+        List<RemoteFileDesc> fileDescs = remoteFileInfos.get(pathKey);
+        Assert.assertNotNull(fileDescs);
+        Assert.assertEquals(1, fileDescs.size());
+    }
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/15671

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
when hdfs path has empty space, can not get hdfs filesystem, we need to solve it
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
