### PR TITLE
[Cherry-pick][BugFix] fix create agg meterialized view make BE exit (#13184)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CreateMaterializedViewStmt.java
@@ -507,7 +507,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
     private static void analyzeOrderByClause(CreateMaterializedViewStmt statement,
                                              SelectRelation selectRelation,
                                              int beginIndexOfAggregation) {
-        if (!selectRelation.hasOrderByClause()) {
+        if (!selectRelation.hasOrderByClause() || selectRelation.getGroupBy().size() != selectRelation.getOrderBy().size()) {
             supplyOrderColumn(statement);
             return;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -21,6 +21,7 @@
 
 package com.starrocks.sql.optimizer;
 
+import com.starrocks.analysis.CreateMaterializedViewStmt;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.FeConstants;
 import com.starrocks.utframe.StarRocksAssert;
@@ -1156,6 +1157,23 @@ public class MVRewriteTest {
         query = "select deptno, sum(case empid when 1 then salary when 2 then salary end) as ssalary from " +
                 EMPS_TABLE_NAME + " group by deptno";
         starRocksAssert.query(query).explainContains(QUERY_USE_EMPS_MV);
+    }
+
+    @Test
+    public void testCaseWhenAggWithPartialOrderBy() throws Exception {
+        String query = "select k6, k7 from all_type_table where k6 = 1 group by k6, k7";
+
+        String createMVSQL = "CREATE MATERIALIZED VIEW partial_order_by_mv AS " +
+                "SELECT k6, k7 FROM all_type_table GROUP BY k6, k7 ORDER BY k6";
+        CreateMaterializedViewStmt createMaterializedViewStmt =
+                (CreateMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(createMVSQL, starRocksAssert.getCtx());
+        createMaterializedViewStmt.getMVColumnItemList().forEach(k -> Assert.assertTrue(k.isKey()));
+
+        starRocksAssert.withMaterializedView(createMVSQL).query(query).explainContains("rollup: partial_order_by_mv");
+
+        String createMVSQL2 = "CREATE MATERIALIZED VIEW order_by_mv AS " +
+                "SELECT k6, k7 FROM all_type_table GROUP BY k6, k7 ORDER BY k6, k7";
+        starRocksAssert.withMaterializedView(createMVSQL2).query(query).explainContains("rollup: order_by_mv");
     }
 
     @Test


### PR DESCRIPTION
check the order-by columns must be identical to the group-by columns when create agg meterialized view

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1705

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
