### PR TITLE
[BugFix] avoid cost overflow

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -50,6 +50,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -338,8 +339,10 @@ public class CostModel {
 
             double leftSize = leftStatistics.getOutputSize(context.getChildOutputColumns(0));
             double rightSize = rightStatistics.getOutputSize(context.getChildOutputColumns(1));
-            double cpuCost = leftSize * rightSize + StatsConstants.CROSS_JOIN_COST_PENALTY;
-            double memCost = rightSize * StatsConstants.CROSS_JOIN_COST_PENALTY * 2;
+            double cpuCost = StatisticUtils.multiplyOutputSize(leftSize, rightSize)
+                    + StatsConstants.CROSS_JOIN_COST_PENALTY;
+            double memCost = StatisticUtils.multiplyOutputSize(rightSize,
+                    StatsConstants.CROSS_JOIN_COST_PENALTY * 2);
 
             // Right cross join could not be parallelized, so apply more punishment
             if (join.getJoinType().isRightJoin()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -342,7 +342,7 @@ public class CostModel {
             double cpuCost = StatisticUtils.multiplyOutputSize(leftSize, rightSize)
                     + StatsConstants.CROSS_JOIN_COST_PENALTY;
             double memCost = StatisticUtils.multiplyOutputSize(rightSize,
-                    StatsConstants.CROSS_JOIN_COST_PENALTY * 2);
+                    StatsConstants.CROSS_JOIN_COST_PENALTY * 2D);
 
             // Right cross join could not be parallelized, so apply more punishment
             if (join.getJoinType().isRightJoin()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -275,11 +275,16 @@ public abstract class JoinOrder {
         double cost = exprInfo.expr.getStatistics().getOutputRowCount();
         exprInfo.rowCount = cost;
         if (exprInfo.leftChildExpr != null) {
-            cost += exprInfo.leftChildExpr.bestExprInfo.cost;
-            cost += exprInfo.rightChildExpr.bestExprInfo.cost;
+            cost = cost > (StatsConstants.MAXIMUM_COST - exprInfo.leftChildExpr.bestExprInfo.cost) ?
+                    StatsConstants.MAXIMUM_COST : cost + exprInfo.leftChildExpr.bestExprInfo.cost;
+
+            cost = cost > (StatsConstants.MAXIMUM_COST - exprInfo.rightChildExpr.bestExprInfo.cost) ?
+                    StatsConstants.MAXIMUM_COST : cost + exprInfo.rightChildExpr.bestExprInfo.cost;
+
             LogicalJoinOperator joinOperator = (LogicalJoinOperator) exprInfo.expr.getOp();
             if (penaltyCross && joinOperator.getJoinType().isCrossJoin()) {
-                cost *= StatsConstants.CROSS_JOIN_COST_PENALTY;
+                cost = cost > (StatsConstants.MAXIMUM_COST / StatsConstants.CROSS_JOIN_COST_PENALTY) ?
+                        StatsConstants.MAXIMUM_COST : cost * StatsConstants.CROSS_JOIN_COST_PENALTY;
             }
         }
         exprInfo.cost = cost;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.statistic.StatsConstants;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -124,7 +125,13 @@ public class Statistics {
             // Due to the influence of the default filter coefficient,
             // the number of calculated rows may be less than 1.
             // The minimum value of rowCount is set to 1, and values less than 1 are meaningless.
-            this.outputRowCount = Math.max(1, outputRowCount);
+            if (outputRowCount < 1D) {
+                this.outputRowCount = 1D;
+            } else if (outputRowCount > StatsConstants.MAXIMUM_ROW_COUNT) {
+                this.outputRowCount = StatsConstants.MAXIMUM_ROW_COUNT;
+            } else {
+                this.outputRowCount = outputRowCount;
+            }
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -125,7 +125,6 @@ import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOperator;
 import com.starrocks.statistic.BasicStatsMeta;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
-import com.starrocks.statistic.StatisticUtils;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -125,6 +125,7 @@ import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOperator;
 import com.starrocks.statistic.BasicStatsMeta;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
+import com.starrocks.statistic.StatisticUtils;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
@@ -794,7 +795,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         crossBuilder.addColumnStatistics(rightStatistics.getOutputColumnsStatistics(context.getChildOutputColumns(1)));
         double leftRowCount = leftStatistics.getOutputRowCount();
         double rightRowCount = rightStatistics.getOutputRowCount();
-        double crossRowCount = leftRowCount * rightRowCount;
+        double crossRowCount = StatisticUtils.multiplyRowCount(leftRowCount, rightRowCount);
         crossBuilder.setOutputRowCount(crossRowCount);
 
         List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(leftStatistics.getUsedColumns(),

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -263,4 +263,28 @@ public class StatisticUtils {
         }
         return columns;
     }
+
+    public static double multiplyRowCount(double left, double right) {
+        left = left > StatsConstants.MAXIMUM_ROW_COUNT ? StatsConstants.MAXIMUM_ROW_COUNT : left;
+        right = right > StatsConstants.MAXIMUM_ROW_COUNT ? StatsConstants.MAXIMUM_ROW_COUNT : right;
+        double result;
+        if (left > StatsConstants.MAXIMUM_ROW_COUNT / right) {
+            result = StatsConstants.MAXIMUM_ROW_COUNT;
+        } else {
+            result = left * right;
+        }
+        return result;
+    }
+
+    public static double multiplyOutputSize(double left, double right) {
+        left = left > StatsConstants.MAXIMUM_OUTPUT_SIZE ? StatsConstants.MAXIMUM_OUTPUT_SIZE : left;
+        right = right > StatsConstants.MAXIMUM_OUTPUT_SIZE ? StatsConstants.MAXIMUM_OUTPUT_SIZE : right;
+        double result;
+        if (left > StatsConstants.MAXIMUM_OUTPUT_SIZE / right) {
+            result = StatsConstants.MAXIMUM_OUTPUT_SIZE;
+        } else {
+            result = left * right;
+        }
+        return result;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -34,6 +34,8 @@ public class StatsConstants {
     public static final int CROSS_JOIN_RIGHT_COST_PENALTY = 1000 * 10000;
     public static final int BROADCAST_JOIN_MEM_EXCEED_PENALTY = 1000;
 
+    public static final double MAXIMUM_COST = Double.MAX_VALUE * 0.8;
+
     //Statistics collection threshold
     public static final String STATISTIC_AUTO_COLLECT_RATIO = "statistic_auto_collect_ratio";
     public static final String STATISTIC_SAMPLE_COLLECT_ROWS = "statistic_sample_collect_rows";

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -34,7 +34,11 @@ public class StatsConstants {
     public static final int CROSS_JOIN_RIGHT_COST_PENALTY = 1000 * 10000;
     public static final int BROADCAST_JOIN_MEM_EXCEED_PENALTY = 1000;
 
-    public static final double MAXIMUM_COST = Double.MAX_VALUE * 0.8;
+    public static final double MAXIMUM_COST = Double.MAX_VALUE / Math.pow(10, 50);
+
+    public static final double MAXIMUM_ROW_COUNT = Double.MAX_VALUE / Math.pow(10, 100);
+
+    public static final double MAXIMUM_OUTPUT_SIZE = Double.MAX_VALUE / Math.pow(10, 80);
 
     //Statistics collection threshold
     public static final String STATISTIC_AUTO_COLLECT_RATIO = "statistic_auto_collect_ratio";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1375,4 +1375,24 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "  |  STREAMING\n" +
                 "  |  group by: 2: P_NAME");
     }
+
+    @Test
+    public void testManyCrossJoin() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
+        String sql = "select t1.LO_ORDERKEY from lineorder_new_l t1 join lineorder_new_l t2 " +
+                "join lineorder_new_l t3 join lineorder_new_l t4 join lineorder_new_l t5 join lineorder_new_l t6 " +
+                "join lineorder_new_l t7 join lineorder_new_l t8 join lineorder_new_l t9 join lineorder_new_l t10 " +
+                "join lineorder_new_l t11 join lineorder_new_l t12 join lineorder_new_l t13 join lineorder_new_l t14 " +
+                "join lineorder_new_l t15 join lineorder_new_l t16 join lineorder_new_l t17 join lineorder_new_l t18 " +
+                "join lineorder_new_l t19 join lineorder_new_l t20 join lineorder_new_l t21 join lineorder_new_l t22 " +
+                "join lineorder_new_l t23 join lineorder_new_l t24 join lineorder_new_l t25 join lineorder_new_l t26 " +
+                "join lineorder_new_l t27 join lineorder_new_l t28 join lineorder_new_l t29 join lineorder_new_l t30 " +
+                "join lineorder_new_l t31 join lineorder_new_l t32 join lineorder_new_l t33 join lineorder_new_l t34 " +
+                "join lineorder_new_l t35 join lineorder_new_l t36 join lineorder_new_l t37 join lineorder_new_l t38";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "148:Project\n" +
+                "  |  output columns:\n" +
+                "  |  1 <-> [1: LO_ORDERKEY, INT, false]\n" +
+                "  |  cardinality: 9223372036854775807");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15475 #15185

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When there is a lot of cross join, the cost increases rapidly and easily touch the maximum value of double type.  There are three places where easily occured the overflow error.
1. calculating cross join cost in join reorder phase
2. calculating cross join output row count in calculating statistics phase
3. calculating cross join outputSize in enforce and record cost phase

This pr limits the maximum cost/rowCount/outputSize to avoid the problem of overflow.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
