### PR TITLE
[Enhancement] Support query rewrite based on mv for external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -33,11 +33,13 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.Pair;
+import com.starrocks.common.UserException;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.connector.PartitionUtil;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -630,6 +632,10 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
                 asyncRefreshContext.step == 0 && null == asyncRefreshContext.timeUnit;
     }
 
+    public boolean isForceExternalTableQueryRewrite() {
+        return tableProperty.getForceExternalTableQueryRewrite();
+    }
+
     public boolean shouldTriggeredRefreshBy(String dbName, String tableName) {
         if (!isLoadTriggeredRefresh()) {
             return false;
@@ -744,6 +750,13 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
             sb.append(properties.get(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)).append("\"");
         }
 
+        // force_external_table_query_rewrite
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
+            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(
+                    PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE).append("\" = \"");
+            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)).append("\"");
+        }
+
         sb.append("\n)");
         String define = this.getSimpleDefineSql();
         if (StringUtils.isEmpty(define) || !simple) {
@@ -810,14 +823,22 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
 
     public Set<String> getPartitionNamesToRefreshForMv() {
         PartitionInfo partitionInfo = getPartitionInfo();
+
+        boolean forceExternalTableQueryRewrite = isForceExternalTableQueryRewrite();
         if (partitionInfo instanceof SinglePartitionInfo) {
             // for non-partitioned materialized view
             for (BaseTableInfo tableInfo : baseTableInfos) {
                 Table table = tableInfo.getTable();
-                // if there is one external table, just return empty sets
-                // because that we can not judge whether mv based on external table is update-to-date
+
+                // we can not judge whether mv based on external table is update-to-date,
+                // because we do not know that any changes in external table.
                 if (!table.isLocalTable()) {
-                    return Sets.newHashSet();
+                    if (forceExternalTableQueryRewrite) {
+                        // if forceExternalTableQueryRewrite set to true, no partition need to refresh for mv.
+                        continue;
+                    } else {
+                        return getPartitionNames();
+                    }
                 }
                 Set<String> partitionNames = getUpdatedPartitionNamesOfTable(table, true);
                 if (!partitionNames.isEmpty()) {
@@ -829,7 +850,7 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
             // 1. dropped partitions
             // 2. newly added partitions
             // 3. partitions loaded with new data
-            return getUpdatedPartitionNamesForPartitionBy();
+            return getPartitionNamesToRefreshForPartitionedMv();
         } else {
             throw UnsupportedException.unsupportedException("unsupported partition info type:"
                     + partitionInfo.getClass().getName());
@@ -837,15 +858,21 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
         return Sets.newHashSet();
     }
 
-    private Set<String> getUpdatedPartitionNamesForPartitionBy() {
+    private Set<String> getPartitionNamesToRefreshForPartitionedMv() {
         Expr partitionExpr = getPartitionRefTableExprs().get(0);
         Pair<Table, Column> partitionInfo = getPartitionTableAndColumn();
         // if non-partition-by table has changed, should refresh all mv partitions
         Table partitionTable = partitionInfo.first;
+        boolean forceExternalTableQueryRewrite = isForceExternalTableQueryRewrite();
         for (BaseTableInfo tableInfo : baseTableInfos) {
             Table table = tableInfo.getTable();
             if (!table.isLocalTable()) {
-                return Sets.newHashSet();
+                if (forceExternalTableQueryRewrite) {
+                    // if forceExternalTableQueryRewrite set to true, no partition need to refresh for mv.
+                    continue;
+                } else {
+                    return getPartitionNames();
+                }
             }
             if (table.getTableIdentifier().equals(partitionTable.getTableIdentifier())) {
                 continue;
@@ -855,13 +882,16 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
                 return getPartitionNames();
             }
         }
-        // from here, partitionTable must be OlapTable or MaterializedView
-        OlapTable basePartitionTable = (OlapTable) partitionTable;
-
         // check partition-by table
         Set<String> needRefreshMvPartitionNames = Sets.newHashSet();
-
-        Map<String, Range<PartitionKey>> basePartitionMap = basePartitionTable.getRangePartitionMap();
+        Map<String, Range<PartitionKey>> basePartitionMap;
+        try {
+            basePartitionMap = PartitionUtil.getPartitionRange(partitionTable,
+                    partitionInfo.second);
+        } catch (UserException e) {
+            LOG.warn("Materialized view compute partition difference with base table failed.", e);
+            return getPartitionNames();
+        }
         Map<String, Range<PartitionKey>> mvPartitionMap = getRangePartitionMap();
         PartitionDiff partitionDiff = getPartitionDiff(partitionExpr, partitionInfo.second,
                 basePartitionMap, mvPartitionMap);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -93,6 +93,11 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // Indicates which tables do not listen to auto refresh events when load
     private List<TableName> excludedTriggerTables;
 
+    // This property only applies to materialized views,
+    // The mv which base table is external table would be query rewrite even the mv data is not up to date
+    // when this property is set to true.
+    private boolean forceExternalTableQueryRewrite = false;
+
     private boolean isInMemory = false;
 
     private boolean enablePersistentIndex = false;
@@ -230,6 +235,13 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildForceExternalTableQueryRewrite() {
+        forceExternalTableQueryRewrite =
+                Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE,
+                        "false"));
+        return this;
+    }
+
     public TableProperty buildInMemory() {
         isInMemory = Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_INMEMORY, "false"));
         return this;
@@ -318,6 +330,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
         this.excludedTriggerTables = excludedTriggerTables;
     }
 
+    public boolean getForceExternalTableQueryRewrite() {
+        return this.forceExternalTableQueryRewrite;
+    }
+
+    public void setForceExternalTableQueryRewrite(boolean forceExternalTableQueryRewrite) {
+        this.forceExternalTableQueryRewrite = forceExternalTableQueryRewrite;
+    }
+
     public boolean isInMemory() {
         return isInMemory;
     }
@@ -389,5 +409,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildPartitionRefreshNumber();
         buildExcludedTriggerTables();
         buildReplicatedStorage();
+        buildForceExternalTableQueryRewrite();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -131,6 +131,7 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT  = "auto_refresh_partitions_limit";
     public static final String PROPERTIES_PARTITION_REFRESH_NUMBER  = "partition_refresh_number";
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
+    public static final String PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE = "force_external_table_query_rewrite";
 
     public static DataProperty analyzeDataProperty(Map<String, String> properties, DataProperty oldDataProperty)
             throws AnalysisException {
@@ -290,6 +291,16 @@ public class PropertyAnalyzer {
             properties.remove(PROPERTIES_EXCLUDED_TRIGGER_TABLES);
         }
         return tables;
+    }
+
+    public static boolean analyzeForceExternalTableQueryRewrite(Map<String, String> properties) {
+        boolean forceExternalTableQueryRewrite = false;
+        if (properties != null && properties.containsKey(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
+            forceExternalTableQueryRewrite = Boolean.parseBoolean(properties.
+                        get(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE));
+            properties.remove(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
+        }
+        return forceExternalTableQueryRewrite;
     }
 
     public static Short analyzeReplicationNum(Map<String, String> properties, short oldReplicationNum)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -30,15 +30,18 @@ import com.starrocks.catalog.HudiPartitionKey;
 import com.starrocks.catalog.IcebergPartitionKey;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.NullablePartitionKey;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
+import com.starrocks.common.UserException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.PartitionValue;
+import com.starrocks.sql.common.DmlException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.FileUtils;
 
@@ -192,12 +195,24 @@ public class PartitionUtil {
         return Pair.create(partitionNames, partitionColumns);
     }
 
+    public static Map<String, Range<PartitionKey>> getPartitionRange(Table table, Column partitionColumn)
+            throws UserException {
+        if (table.isLocalTable()) {
+            return ((OlapTable) table).getRangePartitionMap();
+        } else if (table.isHiveTable() || table.isHudiTable() || table.isIcebergTable()) {
+            return PartitionUtil.getPartitionRangeFromPartitionList(table, partitionColumn);
+        } else {
+            throw new DmlException("Can not get partition range from table with type : %s", table.getType());
+        }
+    }
+
     // Map partition values to partition ranges, eg
     // [NULL,1992-01-01,1992-01-02,1992-01-03]
     //               ||
     //               \/
     // [0000-01-01, 1992-01-01),[1992-01-01, 1992-01-02),[1992-01-02, 1992-01-03),[1993-01-03, MAX_VALUE)
-    public static Map<String, Range<PartitionKey>> getPartitionRange(Table table, Column partitionColumn)
+    public static Map<String, Range<PartitionKey>> getPartitionRangeFromPartitionList(Table table,
+                                                                                      Column partitionColumn)
             throws AnalysisException {
         Map<String, Range<PartitionKey>> partitionRangeMap = new LinkedHashMap<>();
         Pair<List<String>, List<Column>> partitionPair = getPartitionNamesAndColumns(table);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -373,17 +373,6 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         return Pair.create(null, null);
     }
 
-    private Map<String, Range<PartitionKey>> getPartitionRange(Table table, Column partitionColumn)
-            throws UserException {
-        if (table.isLocalTable()) {
-            return ((OlapTable) table).getRangePartitionMap();
-        } else if (table.isHiveTable() || table.isHudiTable() || table.isIcebergTable()) {
-            return PartitionUtil.getPartitionRange(table, partitionColumn);
-        } else {
-            throw new DmlException("Can not get partition range from table with type : %s", table.getType());
-        }
-    }
-
     private void syncPartitionsForExpr() {
         Expr partitionExpr = getPartitionExpr();
         Pair<Table, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
@@ -397,7 +386,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         Map<String, Range<PartitionKey>> mvPartitionMap = materializedView.getRangePartitionMap();
         database.readLock();
         try {
-            basePartitionMap = getPartitionRange(partitionBaseTable, partitionColumn);
+            basePartitionMap = PartitionUtil.getPartitionRange(partitionBaseTable, partitionColumn);
             if (partitionExpr instanceof SlotRef) {
                 partitionDiff = SyncPartitionUtils.calcSyncSamePartition(basePartitionMap, mvPartitionMap);
             } else if (partitionExpr instanceof FunctionCallExpr) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3390,6 +3390,14 @@ public class LocalMetastore implements ConnectorMetadata {
                         .put(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES, tableSb.toString());
                 materializedView.getTableProperty().setExcludedTriggerTables(tables);
             }
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
+                boolean forceExternalTableQueryReWrite = PropertyAnalyzer.
+                        analyzeForceExternalTableQueryRewrite(properties);
+                materializedView.getTableProperty().getProperties().
+                        put(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE,
+                                String.valueOf(forceExternalTableQueryReWrite));
+                materializedView.getTableProperty().setForceExternalTableQueryRewrite(forceExternalTableQueryReWrite);
+            }
             if (!properties.isEmpty()) {
                 // here, all properties should be checked
                 throw new DdlException("Unknown properties: " + properties);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -317,7 +317,8 @@ public class Optimizer {
                 && !rootTaskContext.getOptimizerContext().getCandidateMvs().isEmpty()) {
             // now add single table materialized view rewrite rules in rule based rewrite phase to boost optimization
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
-            // external table need to to re-compute scanOperatorPredicates
+            // external table need to to re-compute scanOperatorPredicates because of the predicates of scan operator
+            // may changed
             ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PARTITION_PRUNE);
         }
         return tree.getInputs().get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -316,6 +316,8 @@ public class Optimizer {
                 && sessionVariable.isEnableRuleBasedMaterializedViewRewrite()) {
             // now add single table materialized view rewrite rules in rule based rewrite phase to boost optimization
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
+            // external table need to to re-compute scanOperatorPredicates
+            ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PARTITION_PRUNE);
         }
         return tree.getInputs().get(0);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -313,7 +313,8 @@ public class Optimizer {
 
         if (!optimizerConfig.isRuleSetTypeDisable(RuleSetType.SINGLE_TABLE_MV_REWRITE)
                 && sessionVariable.isEnableMaterializedViewRewrite()
-                && sessionVariable.isEnableRuleBasedMaterializedViewRewrite()) {
+                && sessionVariable.isEnableRuleBasedMaterializedViewRewrite()
+                && !rootTaskContext.getOptimizerContext().getCandidateMvs().isEmpty()) {
             // now add single table materialized view rewrite rules in rule based rewrite phase to boost optimization
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
             // external table need to to re-compute scanOperatorPredicates

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ScanOperatorPredicates.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ScanOperatorPredicates.java
@@ -84,6 +84,16 @@ public class ScanOperatorPredicates {
         return minMaxColumnRefMap;
     }
 
+    public void clear() {
+        idToPartitionKey.clear();
+        selectedPartitionIds.clear();
+        partitionConjuncts.clear();
+        noEvalPartitionConjuncts.clear();
+        nonPartitionConjuncts.clear();
+        minMaxConjuncts.clear();
+        minMaxColumnRefMap.clear();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoteScanPartitionPruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoteScanPartitionPruneRule.java
@@ -96,6 +96,8 @@ public class RemoteScanPartitionPruneRule extends TransformationRule {
                                    Map<ColumnRefOperator, Set<Long>> columnToNullPartitions)
             throws AnalysisException {
         Table table = operator.getTable();
+        // RemoteScanPartitionPruneRule may be run multiple times, such like after MaterializedViewRewriter rewrite，
+        // the predicates of scan operator may changed, it need to re-compute the ScanOperatorPredicates.
         operator.getScanOperatorPredicates().clear();
         if (table instanceof HiveMetaStoreTable) {
             HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoteScanPartitionPruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoteScanPartitionPruneRule.java
@@ -96,6 +96,7 @@ public class RemoteScanPartitionPruneRule extends TransformationRule {
                                    Map<ColumnRefOperator, Set<Long>> columnToNullPartitions)
             throws AnalysisException {
         Table table = operator.getTable();
+        operator.getScanOperatorPredicates().clear();
         if (table instanceof HiveMetaStoreTable) {
             HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
             List<Column> partitionColumns = hmsTable.getPartitionColumns();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Range;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.MaxLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveMetaStoreTable;
 import com.starrocks.catalog.IcebergTable;
@@ -31,6 +32,7 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.iceberg.ScalarOperatorToIcebergExpr;
@@ -545,7 +547,14 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 double max;
                 if (minLiteral instanceof DateLiteral) {
                     DateLiteral minDateLiteral = (DateLiteral) minLiteral;
-                    DateLiteral maxDateLiteral = (DateLiteral) maxLiteral;
+                    DateLiteral maxDateLiteral;
+                    try {
+                        maxDateLiteral = maxLiteral instanceof MaxLiteral ? new DateLiteral(Type.DATE, true) :
+                                (DateLiteral) maxLiteral;
+                    } catch (AnalysisException e) {
+                        LOG.warn("get max date literal failed, msg : " + e.getMessage());
+                        return null;
+                    }
                     min = Utils.getLongFromDateTime(minDateLiteral.toLocalDateTime());
                     max = Utils.getLongFromDateTime(maxDateLiteral.toLocalDateTime());
                 } else {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -156,6 +156,10 @@ public class PartitionUtilTest {
                 table.getType();
                 result = Table.TableType.HIVE;
                 minTimes = 0;
+
+                table.isHiveTable();
+                result = true;
+                minTimes = 0;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
+import com.starrocks.common.UserException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HivePartitionName;
@@ -139,7 +140,7 @@ public class PartitionUtilTest {
     }
 
     @Test
-    public void testGetPartitionRange(@Mocked Table table) throws AnalysisException {
+    public void testGetPartitionRange(@Mocked Table table) throws UserException {
         Column partitionColumn = new Column("date", Type.DATE);
         List<String> partitionNames = ImmutableList.of("date=2022-08-02", "date=2022-08-19", "date=2022-08-21",
                 "date=2022-09-01", "date=2022-10-01", "date=2022-12-02");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -27,6 +27,7 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
@@ -55,6 +56,7 @@ public class MvRewriteOptimizationTest {
         GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
         cluster = PseudoCluster.getInstance();
         connectContext = UtFrameUtils.createDefaultCtx();
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase("test").useDatabase("test");
 
@@ -281,6 +283,37 @@ public class MvRewriteOptimizationTest {
         connectContext.getSessionVariable().setEnableMaterializedViewRewrite(true);
     }
 
+    @Test
+    public void testHiveSingleTableEqualPredicateRewrite() throws Exception {
+        createAndRefreshMv("test", "hive_mv_1",
+                "create materialized view hive_mv_1 distributed by hash(s_suppkey) " +
+                        "PROPERTIES (\n" +
+                        "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                        ") " +
+                        " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey = 5");
+        String query = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey = 5";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "hive_mv_1");
+
+        String query2 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey = 6";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertNotContains(plan2, "hive_mv_1");
+
+        String query3 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey > 5";
+        String plan3 = getFragmentPlan(query3);
+        PlanTestBase.assertNotContains(plan3, "hive_mv_1");
+
+        String query4 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5";
+        String plan4 = getFragmentPlan(query4);
+        PlanTestBase.assertNotContains(plan4, "hive_mv_1");
+
+        String query5 = "select s_suppkey, s_name, s_address, (s_acctbal + 1) * 2 from hive0.tpch.supplier where s_suppkey = 5";
+        String plan5 = getFragmentPlan(query5);
+        PlanTestBase.assertContains(plan5, "hive_mv_1");
+
+        dropMv("test", "hive_mv_1");
+    }
+
     public void testSingleTableRangePredicateRewrite() throws Exception {
         starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewUnionRewrite(false);
         createAndRefreshMv("test", "mv_1",
@@ -388,6 +421,47 @@ public class MvRewriteOptimizationTest {
         dropMv("test", "mv_3");
     }
 
+    @Test
+    public void testHiveSingleTableRangePredicateRewrite() throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewUnionRewrite(false);
+        createAndRefreshMv("test", "hive_mv_1",
+                "create materialized view hive_mv_1 distributed by hash(s_suppkey) " +
+                        "PROPERTIES (\n" +
+                        "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                        ") " +
+                        " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5");
+        String query = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "hive_mv_1");
+
+        String query2 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 4";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertContains(plan2, "hive_mv_1");
+
+        String query3 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey <= 5";
+        String plan3 = getFragmentPlan(query3);
+        PlanTestBase.assertNotContains(plan3, "hive_mv_1");
+
+        String query4 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey > 5";
+        String plan4 = getFragmentPlan(query4);
+        PlanTestBase.assertNotContains(plan4, "hive_mv_1");
+
+        String query5 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey = 4";
+        String plan5 = getFragmentPlan(query5);
+        PlanTestBase.assertContains(plan5, "hive_mv_1");
+
+        String query6 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey between 3 and 4";
+        String plan6 = getFragmentPlan(query6);
+        PlanTestBase.assertContains(plan6, "hive_mv_1");
+
+        String query7 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5 and " +
+                "s_acctbal > 100.0";
+        String plan7 = getFragmentPlan(query7);
+        PlanTestBase.assertContains(plan7, "hive_mv_1");
+
+        dropMv("test", "hive_mv_1");
+    }
+
     public void testSingleTableResidualPredicateRewrite() throws Exception {
         createAndRefreshMv("test", "mv_1",
                 "create materialized view mv_1 distributed by hash(empid)" +
@@ -396,6 +470,22 @@ public class MvRewriteOptimizationTest {
         String plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "mv_1");
         dropMv("test", "mv_1");
+    }
+
+    @Test
+    public void testHiveSingleTableResidualPredicateRewrite() throws Exception {
+        createAndRefreshMv("test", "hive_mv_1",
+                "create materialized view hive_mv_1 distributed by hash(s_suppkey) " +
+                        "PROPERTIES (\n" +
+                        "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                        ") " +
+                        " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where " +
+                        "s_suppkey * s_acctbal > 100 and s_name like \"%abc%\"");
+        String query = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where " +
+                "s_suppkey * s_acctbal > 100 and s_name like \"%abc%\"";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "hive_mv_1");
+        dropMv("test", "hive_mv_1");
     }
 
     public void testMultiMvsForSingleTable() throws Exception {
@@ -654,6 +744,88 @@ public class MvRewriteOptimizationTest {
     }
 
     @Test
+    public void testHiveJoinMvRewrite() throws Exception {
+        createAndRefreshMv("test", "hive_join_mv_1", "create materialized view hive_join_mv_1" +
+                " distributed by hash(s_suppkey)" +
+                "PROPERTIES (\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                ") " +
+                " as " +
+                " SELECT s_suppkey , s_name, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation" +
+                " on s_nationkey = n_nationkey" +
+                " where s_suppkey < 100");
+
+        String query1 = "SELECT (s_suppkey + 1) * 2, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation on s_nationkey = n_nationkey where s_suppkey < 100";
+        String plan1 = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan1, "hive_join_mv_1");
+
+        String query2 = "SELECT (s_suppkey + 1) * 2, n_name, n_comment" +
+                " from hive0.tpch.supplier join hive0.tpch.nation on s_nationkey = n_nationkey where s_suppkey < 100";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertNotContains(plan2, "hive_join_mv_1");
+
+        String query3 = "SELECT (s_suppkey + 1) * 2, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation on s_nationkey = n_nationkey where s_suppkey = 99";
+        String plan3 = getFragmentPlan(query3);
+        PlanTestBase.assertContains(plan3, "hive_join_mv_1");
+
+        connectContext.getSessionVariable().setEnableMaterializedViewUnionRewrite(false);
+        String query4 = "SELECT (s_suppkey + 1) * 2, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation on s_nationkey = n_nationkey where s_suppkey < 101";
+        String plan4 = getFragmentPlan(query4);
+        PlanTestBase.assertNotContains(plan4, "hive_join_mv_1");
+
+        String query5 = "SELECT (s_suppkey + 1) * 2, n_name from hive0.tpch.supplier join hive0.tpch.nation on " +
+                "s_nationkey = n_nationkey where s_suppkey < 100 and s_suppkey > 10";
+        String plan5 = getFragmentPlan(query5);
+        PlanTestBase.assertContains(plan5, "hive_join_mv_1");
+
+        String query6 = "SELECT (s_suppkey + 1) * 2, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation on s_nationkey = n_nationkey";
+        String plan6 = getFragmentPlan(query6);
+        PlanTestBase.assertNotContains(plan6, "hive_join_mv_1");
+
+        dropMv("test", "hive_join_mv_1");
+
+        createAndRefreshMv("test", "hive_join_mv_2", "create materialized view hive_join_mv_2" +
+                " distributed by hash(s_nationkey)" +
+                "PROPERTIES (\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                ") " +
+                " as " +
+                " SELECT s_nationkey , s_name, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation" +
+                " on s_nationkey = n_nationkey" +
+                " where s_nationkey <= 100");
+
+        // test on equivalence classes for output and predicates
+        String query7 = "SELECT (n_nationkey + 1) * 2, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation on s_nationkey = n_nationkey where n_nationkey < 100";
+        String plan7 = getFragmentPlan(query7);
+        PlanTestBase.assertContains(plan7, "hive_join_mv_2");
+
+        String query8 = "SELECT (n_nationkey + 1) * 2, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation on s_nationkey = n_nationkey where n_nationkey < 10";
+        String plan8 = getFragmentPlan(query8);
+        PlanTestBase.assertContains(plan8, "hive_join_mv_2");
+
+        String query9 = "SELECT (n_nationkey + 1) * 2, n_name" +
+                " from hive0.tpch.supplier join hive0.tpch.nation on s_nationkey = n_nationkey where n_nationkey = 100";
+        String plan9 = getFragmentPlan(query9);
+        PlanTestBase.assertContains(plan9, "hive_join_mv_2");
+
+        String query10 = "SELECT (n_nationkey + 1) * 2, n_name from hive0.tpch.supplier join hive0.tpch.nation on " +
+                "s_nationkey = n_nationkey where n_nationkey between 10 and 20";
+        String plan10 = getFragmentPlan(query10);
+        PlanTestBase.assertContains(plan10, "hive_join_mv_2");
+
+        dropMv("test", "hive_join_mv_2");
+    }
+
+
+    @Test
     public void testAggregateMvRewrite() throws Exception {
         starRocksAssert.getCtx().getSessionVariable().setOptimizerExecuteTimeout(300000000);
 
@@ -899,6 +1071,66 @@ public class MvRewriteOptimizationTest {
         PlanTestBase.assertContains(plan24, "agg_mv_8");
 
         dropMv("test", "agg_mv_8");
+    }
+
+    @Test
+    public void testHiveAggregateMvRewrite() throws Exception {
+        createAndRefreshMv("test", "hive_agg_join_mv_1", "create materialized view hive_agg_join_mv_1" +
+                " distributed by hash(s_nationkey)" +
+                "PROPERTIES (\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                ") " +
+                " as " +
+                " SELECT s_nationkey , n_name, sum(s_acctbal) as total_sum" +
+                " from hive0.tpch.supplier join hive0.tpch.nation" +
+                " on s_nationkey = n_nationkey" +
+                " where s_nationkey < 100 " +
+                "group by s_nationkey , n_name");
+
+        String query1 = " SELECT s_nationkey , n_name, sum(s_acctbal) as total_sum" +
+                " from hive0.tpch.supplier join hive0.tpch.nation" +
+                " on s_nationkey = n_nationkey" +
+                " where s_nationkey = 1 " +
+                "group by s_nationkey , n_name";
+        String plan1 = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan1, "hive_agg_join_mv_1");
+
+        String query2 = " SELECT s_nationkey , n_name, sum(s_acctbal) as total_sum" +
+                " from hive0.tpch.supplier join hive0.tpch.nation" +
+                " on s_nationkey = n_nationkey" +
+                " where s_nationkey < 100 " +
+                "group by s_nationkey , n_name";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertContains(plan2, "hive_agg_join_mv_1");
+
+        String query3 = " SELECT s_nationkey , sum(s_acctbal) as total_sum" +
+                " from hive0.tpch.supplier join hive0.tpch.nation" +
+                " on s_nationkey = n_nationkey" +
+                " where s_nationkey < 99 " +
+                "group by s_nationkey";
+        String plan3 = getFragmentPlan(query3);
+        PlanTestBase.assertContains(plan3, "hive_agg_join_mv_1");
+    }
+
+    @Test
+    public void testHiveUnionRewrite() throws Exception {
+        connectContext.getSessionVariable().setEnableMaterializedViewUnionRewrite(true);
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
+        createAndRefreshMv("test", "hive_union_mv_1",
+                "create materialized view hive_union_mv_1 distributed by hash(s_suppkey) " +
+                        "PROPERTIES (\n" +
+                        "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                        ") " +
+                        " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5");
+        String query1 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 10";
+        String plan1 = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan1, "0:UNION");
+        PlanTestBase.assertContains(plan1, "hive_union_mv_1");
+        PlanTestBase.assertContains(plan1, "1:HdfsScanNode\n" +
+                "     TABLE: supplier\n" +
+                "     NON-PARTITION PREDICATES: 13: s_suppkey < 10, 13: s_suppkey > 4");
+
+        dropMv("test", "hive_union_mv_1");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#11116
Fixes #15791 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
 Support query rewrite based on mv for external table，the query rewriting function is the same as that of the inner table, like single table rewrite, join rewrite, aggregate rewrite and union rewrite.
In order to make query rewrite based on mv for external table to take effect, it need to add a property **force_external_table_query_rewrite** for now. it use like this :
```
create materialized view ex_agg_join_mv
distributed by hash(empid)
REFRESH MANUAL
PROPERTIES (
"force_external_table_query_rewrite" = "true"
) 
as
select emps.empid, depts.name, sum(salary) as total_salary from `hive_catalog`.`ywb`.emps join `hive_catalog`.`ywb`.depts on emps.deptno = depts.deptno
group by emps.empid, depts.name
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
