### PR TITLE
[BugFix] Fix unstable UT testUpdateResourceUsage and SetPasswordTest

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/SetPasswordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/SetPasswordTest.java
@@ -52,6 +52,8 @@ import com.starrocks.sql.ast.SetPassVar;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,8 +65,6 @@ import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 public class SetPasswordTest {
 
     private Auth auth;
-    @Mocked
-    public GlobalStateMgr globalStateMgr;
     @Mocked
     private Analyzer analyzer;
     @Mocked
@@ -79,19 +79,20 @@ public class SetPasswordTest {
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException, AnalysisException {
         auth = new Auth();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Auth getAuth() {
+                return auth;
+            }
+
+            @Mock
+            public EditLog getEditLog() {
+                return editLog;
+            }
+        };
+
         new Expectations() {
             {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                globalStateMgr.getAuth();
-                minTimes = 0;
-                result = auth;
-
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
 
                 editLog.logCreateUser((PrivInfo) any);
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -36,6 +36,8 @@ import com.starrocks.thrift.TUpdateResourceUsageRequest;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.thrift.TException;
 import org.junit.AfterClass;
@@ -67,27 +69,25 @@ public class FrontendServiceImplTest {
     @Test
     public void testUpdateResourceUsage() throws TException {
         QueryQueueManager queryQueueManager = QueryQueueManager.getInstance();
-        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
         Backend backend = new Backend();
         long backendId = 0;
         int numRunningQueries = 1;
         long memLimitBytes = 3;
         long memUsedBytes = 2;
         int cpuUsedPermille = 300;
-        new Expectations(systemInfoService, queryQueueManager) {
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public Backend getBackend(long id) {
+                if (id == backendId) {
+                    return backend;
+                }
+                return null;
+            }
+        };
+        new Expectations(queryQueueManager) {
             {
                 queryQueueManager.maybeNotifyAfterLock();
                 times = 1;
-            }
-
-            {
-                systemInfoService.getBackend(backendId);
-                result = backend;
-            }
-
-            {
-                systemInfoService.getBackend(anyLong);
-                result = null;
             }
         };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
#15452 adds a new UT in `FrontendServiceImplTest`, which invokes `createMinStarRocksCluster` in `FrontendServiceImplTest::beforeClass`, which will call `GlobalStateMgr.getCurrentSystemInfo().getBackendIds` in daemon.

`FrontendServiceImplTest::testUpdateResourceUsage` mocks the object  `GlobalStateMgr.getCurrentSystemInfo()`, but doesn't mock the method `getBackendIds`.
Therefore, when calling `getBackendIds` by daemon, the UT will fail.

Use `MockUp` to only mock the specific methods, not the object.
`SetPasswordTest` is similar as it.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
