### PR TITLE
[BugFix] Fix Digit Identifier parse error to decimal lex bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4936,7 +4936,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitDereference(StarRocksParser.DereferenceContext ctx) {
         Expr base = (Expr) visit(ctx.base);
-        String fieldName = ((Identifier) visit(ctx.fieldName)).getValue();
+
+        String fieldName;
+        if (ctx.DOT_IDENTIFIER() != null) {
+            fieldName = ctx.DOT_IDENTIFIER().getText().substring(1);
+        } else {
+            fieldName = ((Identifier) visit(ctx.fieldName)).getValue();
+        }
 
         // Trick method
         // If left is SlotRef type, we merge fieldName to SlotRef
@@ -4950,10 +4956,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         } else {
             // If left is not a SlotRef, we can left must be an StructType,
             // and fieldName must be StructType's subfield name.
-            return new SubfieldExpr(
-                    (Expr) visit(ctx.base),
-                    ((Identifier) visit(ctx.fieldName)).getValue()
-            );
+            return new SubfieldExpr(base, fieldName);
         }
     }
 
@@ -5357,9 +5360,19 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     private QualifiedName getQualifiedName(StarRocksParser.QualifiedNameContext context) {
-        List<String> parts = visit(context.identifier(), Identifier.class).stream()
-                .map(Identifier::getValue)
-                .collect(Collectors.toList());
+        List<String> parts = new ArrayList<>();
+        for (ParseTree c : context.children) {
+            if (c instanceof TerminalNode) {
+                TerminalNode t = (TerminalNode) c;
+                if (t.getSymbol().getType() == StarRocksParser.DOT_IDENTIFIER) {
+                    parts.add(t.getText().substring(1));
+                }
+            } else if (c instanceof StarRocksParser.IdentifierContext) {
+                StarRocksParser.IdentifierContext identifierContext = (StarRocksParser.IdentifierContext) c;
+                Identifier identifier = (Identifier) visit(identifierContext);
+                parts.add(identifier.getValue());
+            }
+        }
 
         return QualifiedName.of(parts);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1714,7 +1714,7 @@ primaryExpression
     | primaryExpression COLLATE (identifier | string)                                     #collate
     | literalExpression                                                                   #literal
     | columnReference                                                                     #columnRef
-    | base = primaryExpression '.' fieldName = identifier                                 #dereference
+    | base = primaryExpression (DOT_IDENTIFIER | '.' fieldName = identifier )             #dereference
     | left = primaryExpression CONCAT right = primaryExpression                           #concat
     | operator = (MINUS_SYMBOL | PLUS_SYMBOL | BITNOT) primaryExpression                  #arithmeticUnary
     | operator = LOGICAL_NOT primaryExpression                                            #arithmeticUnary
@@ -2087,7 +2087,7 @@ decimalType
     ;
 
 qualifiedName
-    : identifier ('.' identifier)*
+    : identifier (DOT_IDENTIFIER | '.' identifier)*
     ;
 
 identifier

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
@@ -447,6 +447,12 @@ BACKQUOTED_IDENTIFIER
     : '`' ( ~'`' | '``' )* '`'
     ;
 
+// Prevent recognize string:         .123somelatin AS ((.123), DECIMAL_LITERAL), ((somelatin), IDENTIFIER)
+// it must recoginze:                .123somelatin AS ((.), DOT), (123somelatin, IDENTIFIER)
+DOT_IDENTIFIER
+    : '.' DIGIT_IDENTIFIER
+    ;
+
 fragment EXPONENT
     : 'E' [+-]? DIGIT+
     ;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -83,6 +83,21 @@ public class AnalyzeSingleTest {
     }
 
     @Test
+    public void testIdentifierStartWithDigit() {
+        StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse("select * from a.11b", 0).get(0);
+        Assert.assertEquals("SELECT * FROM a.11b", AstToStringBuilder.toString(statementBase));
+
+        statementBase = com.starrocks.sql.parser.SqlParser.parse("select a.11b.22c, * from a.11b", 0).get(0);
+        Assert.assertEquals("SELECT a.11b.22c, * FROM a.11b", AstToStringBuilder.toString(statementBase));
+
+        statementBase = com.starrocks.sql.parser.SqlParser.parse("select 00a.11b.22c, * from 00a.11b", 0).get(0);
+        Assert.assertEquals("SELECT 00a.11b.22c, * FROM 00a.11b", AstToStringBuilder.toString(statementBase));
+
+        statementBase = com.starrocks.sql.parser.SqlParser.parse("select 11b.* from 11b", 0).get(0);
+        Assert.assertEquals("SELECT 11b.* FROM 11b", AstToStringBuilder.toString(statementBase));
+    }
+
+    @Test
     public void testPrefix() {
         analyzeSuccess("select t0.v1 from t0");
         analyzeSuccess("select t0.*, v3, v2 from t0");
@@ -321,6 +336,9 @@ public class AnalyzeSingleTest {
                 AstToStringBuilder.toString(statement.getQueryRelation().getOutputExpression().get(0)));
 
         analyzeSuccess("select @@`sql_mode`");
+        analyzeSuccess("select @@SESSION.`sql_mode`");
+        analyzeSuccess("select @@SESSION.sql_mode");
+        analyzeSuccess("select @_123var");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1702

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
zh.111_a will be parsed as identifier dot decimal_literal identifier. This is not expected, so we added DOT_IDENTIFIER for direct parsing in Lexer
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
