### PR TITLE
[BugFix] Preventing sample statistics error caused by too many tasks being executed at one time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -45,10 +45,6 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         this.partitionIdList = partitionIdList;
     }
 
-    public List<Long> getPartitionIdList() {
-        return partitionIdList;
-    }
-
     @Override
     public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
         long finishedSQLNum = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -149,7 +149,9 @@ public abstract class StatisticsCollectJob {
                 splitSize = columns.size();
             }
         }
-        return (int) splitSize;
+        // Supports a maximum of 1024 tasks for a union,
+        // preventing unexpected situations caused by too many tasks being executed at one time
+        return (int) Math.min(1024, splitSize);
     }
 
     protected String build(VelocityContext context, String template) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15880

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Because there are too many tasks in Union at the same time, the sql of parser is too long, and StackOverflowError may appear
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
