### PR TITLE
[Enhancement] Remove "broker." prefix for new properties in OutFileClause

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -132,7 +132,7 @@ public class OutFileClause implements ParseNode {
             return;
         }
 
-        getBrokerProperties();
+        setBrokerProperties();
         if (brokerDesc == null) {
             return;
         }
@@ -159,7 +159,7 @@ public class OutFileClause implements ParseNode {
         }
     }
 
-    private void getBrokerProperties() {
+    private void setBrokerProperties() {
         boolean outfile_without_broker = false;
         if (!properties.containsKey(PROP_BROKER_NAME)) {
             outfile_without_broker = true;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -36,7 +36,6 @@ package com.starrocks.analysis;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
@@ -52,14 +51,13 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 // For syntax select * from tbl INTO OUTFILE xxxx
 public class OutFileClause implements ParseNode {
     private static final Logger LOG = LogManager.getLogger(OutFileClause.class);
 
-    private static final String BROKER_PROP_PREFIX = "broker.";
+    // Old properties still use this prefix, new properties will not.
+    private static final String OLD_BROKER_PROP_PREFIX = "broker.";
     private static final String PROP_BROKER_NAME = "broker.name";
     private static final String PROP_COLUMN_SEPARATOR = "column_separator";
     private static final String PROP_LINE_DELIMITER = "line_delimiter";
@@ -134,8 +132,7 @@ public class OutFileClause implements ParseNode {
             return;
         }
 
-        Set<String> processedPropKeys = Sets.newHashSet();
-        getBrokerProperties(filePath, processedPropKeys);
+        getBrokerProperties();
         if (brokerDesc == null) {
             return;
         }
@@ -145,7 +142,6 @@ public class OutFileClause implements ParseNode {
                 throw new AnalysisException(PROP_COLUMN_SEPARATOR + " is only for CSV format");
             }
             columnSeparator = properties.get(PROP_COLUMN_SEPARATOR);
-            processedPropKeys.add(PROP_COLUMN_SEPARATOR);
         }
 
         if (properties.containsKey(PROP_LINE_DELIMITER)) {
@@ -153,7 +149,6 @@ public class OutFileClause implements ParseNode {
                 throw new AnalysisException(PROP_LINE_DELIMITER + " is only for CSV format");
             }
             rowDelimiter = properties.get(PROP_LINE_DELIMITER);
-            processedPropKeys.add(PROP_LINE_DELIMITER);
         }
 
         if (properties.containsKey(PROP_MAX_FILE_SIZE)) {
@@ -161,11 +156,10 @@ public class OutFileClause implements ParseNode {
             if (maxFileSizeBytes > MAX_FILE_SIZE_BYTES || maxFileSizeBytes < MIN_FILE_SIZE_BYTES) {
                 throw new AnalysisException("max file size should between 5MB and 2GB. Given: " + maxFileSizeBytes);
             }
-            processedPropKeys.add(PROP_MAX_FILE_SIZE);
         }
     }
 
-    private void getBrokerProperties(String filePath, Set<String> processedPropKeys) {
+    private void getBrokerProperties() {
         boolean outfile_without_broker = false;
         if (!properties.containsKey(PROP_BROKER_NAME)) {
             outfile_without_broker = true;
@@ -173,16 +167,19 @@ public class OutFileClause implements ParseNode {
         String brokerName = null;
         if (!outfile_without_broker) {
             brokerName = properties.get(PROP_BROKER_NAME);
-            processedPropKeys.add(PROP_BROKER_NAME);
         }
 
         Map<String, String> brokerProps = Maps.newHashMap();
         Iterator<Map.Entry<String, String>> iter = properties.entrySet().iterator();
         while (iter.hasNext()) {
             Map.Entry<String, String> entry = iter.next();
-            if (entry.getKey().startsWith(BROKER_PROP_PREFIX) && !entry.getKey().equals(PROP_BROKER_NAME)) {
-                brokerProps.put(entry.getKey().substring(BROKER_PROP_PREFIX.length()), entry.getValue());
-                processedPropKeys.add(entry.getKey());
+            if (!entry.getKey().equals(PROP_BROKER_NAME)) {
+                if (entry.getKey().startsWith(OLD_BROKER_PROP_PREFIX)) {
+                    brokerProps.put(entry.getKey().substring(OLD_BROKER_PROP_PREFIX.length()), entry.getValue());
+                } else {
+                    // Put new properties without "broker." prefix
+                    brokerProps.put(entry.getKey(), entry.getValue());
+                }
             }
         }
         if (!outfile_without_broker) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -170,16 +170,12 @@ public class OutFileClause implements ParseNode {
         }
 
         Map<String, String> brokerProps = Maps.newHashMap();
-        Iterator<Map.Entry<String, String>> iter = properties.entrySet().iterator();
-        while (iter.hasNext()) {
-            Map.Entry<String, String> entry = iter.next();
-            if (!entry.getKey().equals(PROP_BROKER_NAME)) {
-                if (entry.getKey().startsWith(OLD_BROKER_PROP_PREFIX)) {
-                    brokerProps.put(entry.getKey().substring(OLD_BROKER_PROP_PREFIX.length()), entry.getValue());
-                } else {
-                    // Put new properties without "broker." prefix
-                    brokerProps.put(entry.getKey(), entry.getValue());
-                }
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (entry.getKey().startsWith(OLD_BROKER_PROP_PREFIX)) {
+                brokerProps.put(entry.getKey().substring(OLD_BROKER_PROP_PREFIX.length()), entry.getValue());
+            } else {
+                // Put new properties without "broker." prefix
+                brokerProps.put(entry.getKey(), entry.getValue());
             }
         }
         if (!outfile_without_broker) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

New properties will no longer contain `broker.` prefix, but we have to be compatible with old properties.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
