### PR TITLE
[BugFix] Fix read_contents return false when reaching eos

### DIFF
--- a/be/src/util/file_util.h
+++ b/be/src/util/file_util.h
@@ -16,25 +16,43 @@
 
 #include <fstream>
 #include <string>
+#include <tuple>
 
 namespace starrocks {
 class FileUtil {
 public:
+    // Return true if it is correctly assigned, otherwise return false
     static bool read_whole_content(const std::string& path, std::string& dest);
 
+    // Return true if all values are correctly assigned, otherwise return false
     template <typename... Args>
     static bool read_contents(const std::string& path, Args&... values) {
         std::ifstream ifs;
         ifs.open(path);
-        if (!ifs.good()) {
-            return false;
-        }
 
-        (ifs >> ... >> values);
-
+        auto tvalues = std::forward_as_tuple(values...);
         bool ok = ifs.good();
-        ifs.close();
+        _constexpr_for<0, sizeof...(values), 1>([&ifs, &tvalues, &ok](auto i) {
+            ok &= ifs.good();
+            if (!ok) {
+                return;
+            }
+            ifs >> std::get<i>(tvalues);
+        });
+
+        if (ifs.is_open()) {
+            ifs.close();
+        }
         return ok;
+    }
+
+private:
+    template <auto Start, auto End, auto Inc, typename F>
+    static constexpr void _constexpr_for(F&& f) {
+        if constexpr (Start < End) {
+            f(std::integral_constant<decltype(Start), Start>());
+            _constexpr_for<Start + Inc, End, Inc>(f);
+        }
     }
 };
 }; // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -290,6 +290,7 @@ set(EXEC_FILES
         ./util/dynamic_cache_test.cpp
         ./util/exception_stack_test.cpp
         ./util/faststring_test.cpp
+        ./util/file_util_test.cpp
         ./util/filesystem_util_test.cpp
         ./util/frame_of_reference_coding_test.cpp
         ./util/json_util_test.cpp

--- a/be/test/util/file_util_test.cpp
+++ b/be/test/util/file_util_test.cpp
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/file_util.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace starrocks {
+
+TEST(FileUtilTest, test_read_whole_content) {
+    std::string name = std::tmpnam(nullptr);
+
+    std::string content;
+    ASSERT_FALSE(FileUtil::read_contents(name, content));
+
+    std::ofstream ofs;
+    ofs.open(name);
+    ASSERT_TRUE(ofs.good());
+    ofs.close();
+
+    ASSERT_TRUE(FileUtil::read_contents(name, content));
+
+    std::filesystem::remove(name);
+}
+
+TEST(FileUtilTest, test_read_contents) {
+    std::string name = std::tmpnam(nullptr);
+
+    int first = -1;
+    double second = -1;
+    long third = -1;
+    ASSERT_FALSE(FileUtil::read_contents(name, first, second, third));
+    ASSERT_EQ(-1, first);
+    ASSERT_EQ(-1, second);
+    ASSERT_EQ(-1, third);
+
+    std::ofstream ofs;
+    ofs.open(name);
+    ASSERT_TRUE(ofs.good());
+    ofs << "1 2.5 3";
+    ofs.close();
+    first = second = third = -1;
+    ASSERT_TRUE(FileUtil::read_contents(name, first, second, third));
+    ASSERT_EQ(1, first);
+    ASSERT_EQ(2.5, second);
+    ASSERT_EQ(3, third);
+
+    ofs.open(name);
+    ASSERT_TRUE(ofs.good());
+    ofs << "1 2.5";
+    ofs.close();
+    first = second = third = -1;
+    ASSERT_FALSE(FileUtil::read_contents(name, first, second, third));
+    ASSERT_EQ(1, first);
+    ASSERT_EQ(2.5, second);
+    ASSERT_EQ(-1, third);
+
+    std::filesystem::remove(name);
+}
+}; // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Introduced by #15587

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Assuming the file `test.txt` contains exactly two items, like belows:

```
item1 item2
```

Then you call `read_contents("test.txt", first, second)`, it will return false. Because after fetching two items, eof is reached, so `good()` will return false. But this process work normally, it should return true instead.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
