### PR TITLE
[BugFix] Fix backend not found bug when backend is alive

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
@@ -6,6 +6,7 @@ import com.clearspring.analytics.util.Lists;
 import com.google.common.collect.Queues;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,6 +41,10 @@ public class CoordinatorMonitor {
     }
 
     public boolean addDeadBackend(Long backendID) {
+        if (GlobalStateMgr.isCheckpointThread()) {
+            return false;
+        }
+        LOG.info("add backend {} to dead backend queue", backendID);
         return comingDeadBackendIDQueue.offer(backendID);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
@@ -4,6 +4,7 @@ package com.starrocks.qe;
 
 import com.clearspring.analytics.util.Lists;
 import com.google.common.collect.Queues;
+import com.starrocks.catalog.Catalog;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.server.GlobalStateMgr;
@@ -41,7 +42,7 @@ public class CoordinatorMonitor {
     }
 
     public boolean addDeadBackend(Long backendID) {
-        if (GlobalStateMgr.isCheckpointThread()) {
+        if (Catalog.isCheckpointThread()) {
             return false;
         }
         LOG.info("add backend {} to dead backend queue", backendID);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Queues;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.proto.PPlanFragmentCancelReason;
-import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/1597

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If backend status is changed to dead(alive=false), it will be added to CoordinatorMonitor, and all the running coordinators(load or query) related to that backend will be cancelled. But CoordinatorMonitor is a singleton object, checkpointer which replays history log and generates image will also update CoordinatorMonitor, it will cause the backend is marked to dead by mistake. 
To fix this bug, we should reject the checkpoint thread to update CoordinatorMonitor.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
