### PR TITLE
[BugFix] fix issues in export sink operator

### DIFF
--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -44,7 +44,7 @@ public:
 private:
     void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) override;
 
-    Status _open_file_writer(int timeout_ms);
+    Status _open_file_writer();
 
     Status _gen_file_name(std::string* file_name);
 
@@ -67,6 +67,7 @@ Status ExportSinkIOBuffer::prepare(RuntimeState* state, RuntimeProfile* parent_p
     int ret = bthread::execution_queue_start<ChunkPtr>(_exec_queue_id.get(), &options,
                                                        &ExportSinkIOBuffer::execute_io_task, this);
     if (ret != 0) {
+        _exec_queue_id.reset();
         return Status::InternalError("start execution queue error");
     }
 
@@ -88,15 +89,15 @@ void ExportSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
     }
 
     if (_is_cancelled && !_is_finished) {
-        close(_state);
+        if (_num_pending_chunks == 0) {
+            close(_state);
+        }
         return;
     }
 
     if (_file_builder == nullptr) {
-        int query_timeout = _state->query_options().query_timeout;
-        int timeout_ms = query_timeout > 3600 ? 3600000 : query_timeout * 1000;
-        if (Status status = _open_file_writer(timeout_ms); !status.ok()) {
-            close(_state);
+        if (Status status = _open_file_writer(); !status.ok()) {
+            LOG(WARNING) << "open file write failed, error: " << status.to_string();
             _fragment_ctx->cancel(status);
             return;
         }
@@ -104,17 +105,18 @@ void ExportSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
     const auto& chunk = *iter;
     if (chunk == nullptr) {
         // this is the last chunk
+        DCHECK_EQ(_num_pending_chunks, 0);
         close(_state);
         return;
     }
     if (Status status = _file_builder->add_chunk(chunk.get()); !status.ok()) {
-        close(_state);
+        LOG(WARNING) << "add chunk to file builder failed, error: " << status.to_string();
         _fragment_ctx->cancel(status);
         return;
     }
 }
 
-Status ExportSinkIOBuffer::_open_file_writer(int timeout_ms) {
+Status ExportSinkIOBuffer::_open_file_writer() {
     std::unique_ptr<WritableFile> output_file;
     std::string file_name;
     RETURN_IF_ERROR(_gen_file_name(&file_name));
@@ -137,7 +139,7 @@ Status ExportSinkIOBuffer::_open_file_writer(int timeout_ms) {
                 return Status::InternalError("ExportSink broker_addresses empty");
             }
             const TNetworkAddress& broker_addr = _t_export_sink.broker_addresses[0];
-            BrokerFileSystem fs_broker(broker_addr, _t_export_sink.properties, timeout_ms);
+            BrokerFileSystem fs_broker(broker_addr, _t_export_sink.properties);
             ASSIGN_OR_RETURN(output_file, fs_broker.new_writable_file(options, file_path));
         }
         break;

--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -42,7 +42,7 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    void _process_chunk(bthread::TaskIterator<const ChunkPtr>& iter) override;
+    void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) override;
 
     Status _open_file_writer(int timeout_ms);
 
@@ -63,9 +63,9 @@ Status ExportSinkIOBuffer::prepare(RuntimeState* state, RuntimeProfile* parent_p
 
     bthread::ExecutionQueueOptions options;
     options.executor = SinkIOExecutor::instance();
-    _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<const ChunkPtr>>();
-    int ret = bthread::execution_queue_start<const ChunkPtr>(_exec_queue_id.get(), &options,
-                                                             &SinkIOBuffer::execute_io_task, this);
+    _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<ChunkPtr>>();
+    int ret = bthread::execution_queue_start<ChunkPtr>(_exec_queue_id.get(), &options,
+                                                       &ExportSinkIOBuffer::execute_io_task, this);
     if (ret != 0) {
         return Status::InternalError("start execution queue error");
     }
@@ -81,7 +81,7 @@ void ExportSinkIOBuffer::close(RuntimeState* state) {
     SinkIOBuffer::close(state);
 }
 
-void ExportSinkIOBuffer::_process_chunk(bthread::TaskIterator<const ChunkPtr>& iter) {
+void ExportSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
     --_num_pending_chunks;
     if (_is_finished) {
         return;

--- a/be/src/exec/pipeline/sink/file_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/file_sink_operator.cpp
@@ -45,7 +45,7 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    void _process_chunk(bthread::TaskIterator<const ChunkPtr>& iter) override;
+    void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) override;
 
     std::vector<ExprContext*> _output_expr_ctxs;
 
@@ -72,9 +72,9 @@ Status FileSinkIOBuffer::prepare(RuntimeState* state, RuntimeProfile* parent_pro
 
     bthread::ExecutionQueueOptions options;
     options.executor = SinkIOExecutor::instance();
-    _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<const ChunkPtr>>();
-    int ret = bthread::execution_queue_start<const ChunkPtr>(_exec_queue_id.get(), &options,
-                                                             &FileSinkIOBuffer::execute_io_task, this);
+    _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<ChunkPtr>>();
+    int ret = bthread::execution_queue_start<ChunkPtr>(_exec_queue_id.get(), &options,
+                                                       &FileSinkIOBuffer::execute_io_task, this);
     if (ret != 0) {
         _exec_queue_id.reset();
         return Status::InternalError("start execution queue error");
@@ -114,7 +114,7 @@ void FileSinkIOBuffer::close(RuntimeState* state) {
     SinkIOBuffer::close(state);
 }
 
-void FileSinkIOBuffer::_process_chunk(bthread::TaskIterator<const ChunkPtr>& iter) {
+void FileSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
     --_num_pending_chunks;
     // close is already done, just skip
     if (_is_finished) {

--- a/be/src/exec/pipeline/sink/mysql_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/mysql_table_sink_operator.cpp
@@ -43,7 +43,7 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    void _process_chunk(bthread::TaskIterator<const ChunkPtr>& iter) override;
+    void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) override;
 
     Status _open_mysql_table_writer();
 
@@ -62,9 +62,9 @@ Status MysqlTableSinkIOBuffer::prepare(RuntimeState* state, RuntimeProfile* pare
 
     bthread::ExecutionQueueOptions options;
     options.executor = SinkIOExecutor::instance();
-    _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<const ChunkPtr>>();
-    int ret = bthread::execution_queue_start<const ChunkPtr>(_exec_queue_id.get(), &options,
-                                                             &MysqlTableSinkIOBuffer::execute_io_task, this);
+    _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<ChunkPtr>>();
+    int ret = bthread::execution_queue_start<ChunkPtr>(_exec_queue_id.get(), &options,
+                                                       &MysqlTableSinkIOBuffer::execute_io_task, this);
     if (ret != 0) {
         _exec_queue_id.reset();
         return Status::InternalError("start execution queue error");
@@ -78,7 +78,7 @@ void MysqlTableSinkIOBuffer::close(RuntimeState* state) {
     SinkIOBuffer::close(state);
 }
 
-void MysqlTableSinkIOBuffer::_process_chunk(bthread::TaskIterator<const ChunkPtr>& iter) {
+void MysqlTableSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
     --_num_pending_chunks;
     if (_is_finished) {
         return;

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -79,7 +79,7 @@ public:
         return Status::OK();
     }
 
-    virtual bool is_finished() { return _is_finished; }
+    virtual bool is_finished() { return _is_finished && _num_pending_chunks == 0; }
 
     virtual void cancel_one_sinker() {
         _is_cancelled = true;
@@ -107,18 +107,20 @@ public:
         return _io_status;
     }
 
-    static int execute_io_task(void* meta, bthread::TaskIterator<const ChunkPtr>& iter) {
+    static int execute_io_task(void* meta, bthread::TaskIterator<ChunkPtr>& iter) {
         auto* sink_io_buffer = static_cast<SinkIOBuffer*>(meta);
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(sink_io_buffer->_state->query_mem_tracker_ptr().get());
         for (; iter; ++iter) {
             sink_io_buffer->_process_chunk(iter);
+            (*iter).reset();
         }
         return 0;
     }
 
 protected:
-    virtual void _process_chunk(bthread::TaskIterator<const ChunkPtr>& iter) = 0;
+    virtual void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) = 0;
 
-    std::unique_ptr<bthread::ExecutionQueueId<const ChunkPtr>> _exec_queue_id;
+    std::unique_ptr<bthread::ExecutionQueueId<ChunkPtr>> _exec_queue_id;
 
     std::atomic_int32_t _num_result_sinkers = 0;
     std::atomic_int64_t _num_pending_chunks = 0;

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -56,9 +56,6 @@ public:
     virtual Status prepare(RuntimeState* state, RuntimeProfile* parent_profile) = 0;
 
     virtual Status append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-        if (_is_cancelled) {
-            return Status::OK();
-        }
         if (Status status = get_io_status(); !status.ok()) {
             return status;
         }

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -56,6 +56,9 @@ public:
     virtual Status prepare(RuntimeState* state, RuntimeProfile* parent_profile) = 0;
 
     virtual Status append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+        if (_is_cancelled) {
+            return Status::OK();
+        }
         if (Status status = get_io_status(); !status.ok()) {
             return status;
         }
@@ -83,9 +86,6 @@ public:
 
     virtual void cancel_one_sinker() {
         _is_cancelled = true;
-        if (_exec_queue_id != nullptr) {
-            bthread::execution_queue_stop(*_exec_queue_id);
-        }
     }
 
     virtual void close(RuntimeState* state) {

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -81,9 +81,7 @@ public:
 
     virtual bool is_finished() { return _is_finished && _num_pending_chunks == 0; }
 
-    virtual void cancel_one_sinker() {
-        _is_cancelled = true;
-    }
+    virtual void cancel_one_sinker() { _is_cancelled = true; }
 
     virtual void close(RuntimeState* state) {
         _is_finished = true;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16568

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


fix some issues in export sink operator
1.  #16568

`SinkIOBuffer:: execute_io_task` is called in the async pipeline_sink_io threads. This function will access the `SinkIOBuffer` held by related sink operator. We need to ensure that all chunks are processed before closing sink operator. So I fixed all the places where `SinkIOBuffer` is used to solve this potential problem.

2. memory statistics problem

The chunks we put in the execution queue are allocated in our own threads, and their memory usage will be recorded in the mem tracker, but the release of the chunks is done internally in the execution queue, and we have no chance to update the mem tracker. So I made the following changes to actively release the memory after processing the chunk to ensure that the memory statistics are accurate.
![image](https://user-images.githubusercontent.com/3675229/212081400-e80ded8b-fc31-4549-b476-61a7ebdd39bf.png)

3. In the previous implementation, query_timeout was mistakenly used as the rpc timeout of BrokerFileSystem, which is unreasonable. I changed it to the default timeout(10s) in BrokerFileSystem.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
