### PR TITLE
[BugFix] Refactor remove_expired_versions to limit max version count and fix protential concurrent call issues

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -434,9 +434,8 @@ void Tablet::delete_expired_inc_rowsets() {
 }
 
 void Tablet::delete_expired_stale_rowset() {
-    int64_t now = UnixSeconds();
     // Compute the end time to delete rowsets, when an expired rowset createtime older then this time, it will be deleted.
-    int64_t expired_stale_sweep_endtime = now - config::tablet_rowset_stale_sweep_time_sec;
+    int64_t expired_stale_sweep_endtime = UnixSeconds() - config::tablet_rowset_stale_sweep_time_sec;
 
     if (_updates) {
         _updates->remove_expired_versions(expired_stale_sweep_endtime);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1593,32 +1593,6 @@ void TabletUpdates::to_updates_pb(TabletUpdatesPB* updates_pb) const {
     _to_updates_pb_unlocked(updates_pb);
 }
 
-void TabletUpdates::_erase_expired_versions(int64_t expire_time,
-                                            std::vector<std::unique_ptr<EditVersionInfo>>* expire_list,
-                                            int64_t* min_readable_version) {
-    DCHECK(expire_list->empty());
-    std::lock_guard l(_lock);
-    if (_edit_version_infos.empty()) {
-        LOG(WARNING) << "tablet deleted when erase_expired_versions tablet:" << _tablet.tablet_id();
-        return;
-    }
-    // only keep at most one version which is before expire_time
-    int keep_index_min = _apply_version_idx;
-    while (keep_index_min > 0) {
-        if (_edit_version_infos[keep_index_min]->creation_time <= expire_time) {
-            break;
-        }
-        keep_index_min--;
-    }
-    for (int i = 0; i < keep_index_min; i++) {
-        expire_list->emplace_back(std::move(_edit_version_infos[i]));
-    }
-    auto n = expire_list->size();
-    _edit_version_infos.erase(_edit_version_infos.begin(), _edit_version_infos.begin() + n);
-    _apply_version_idx -= n;
-    *min_readable_version = _edit_version_infos[0]->version.major();
-}
-
 bool TabletUpdates::check_rowset_id(const RowsetId& rowset_id) const {
     // TODO(cbl): optimization: check multiple rowset_ids at once
     {
@@ -1640,15 +1614,6 @@ bool TabletUpdates::check_rowset_id(const RowsetId& rowset_id) const {
     return false;
 }
 
-std::set<uint32_t> TabletUpdates::_active_rowsets() {
-    std::set<uint32_t> ret;
-    std::lock_guard rl(_lock);
-    for (const auto& edit_version_info : _edit_version_infos) {
-        ret.insert(edit_version_info->rowsets.begin(), edit_version_info->rowsets.end());
-    }
-    return ret;
-}
-
 void TabletUpdates::remove_expired_versions(int64_t expire_time) {
     if (_error) {
         LOG(WARNING) << strings::Substitute(
@@ -1656,41 +1621,61 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
                 _error_msg);
         return;
     }
-    /// Remove expired versions from memory.
-    std::vector<std::unique_ptr<EditVersionInfo>> expired_edit_version_infos;
-    int64_t min_readable_version = 0;
-    _erase_expired_versions(expire_time, &expired_edit_version_infos, &min_readable_version);
 
-    if (!expired_edit_version_infos.empty()) {
-        int64_t tablet_id = 0;
+    size_t num_version_removed = 0;
+    size_t num_rowset_removed = 0;
+    uint64_t min_readable_version = 0;
+    // GC works that require locking
+    {
+        std::lock_guard l(_lock);
+        if (_edit_version_infos.empty()) {
+            LOG(WARNING) << "tablet deleted when erase_expired_versions tablet:" << _tablet.tablet_id();
+            return;
+        }
+
+        // only keep at most one version which is before expire_time
+        // also to prevent excessive memory usage of editversion array, limit edit version count to be less than
+        // config::tablet_max_versions
+        size_t keep_index_min = _apply_version_idx;
+        while (keep_index_min > 0) {
+            if (_edit_version_infos[keep_index_min]->creation_time <= expire_time ||
+                keep_index_min + config::tablet_max_versions < _edit_version_infos.size()) {
+                break;
+            }
+            keep_index_min--;
+        }
+        num_version_removed = keep_index_min;
+        if (num_version_removed > 0) {
+            _edit_version_infos.erase(_edit_version_infos.begin(), _edit_version_infos.begin() + num_version_removed);
+            _apply_version_idx -= num_version_removed;
+            // remove non-referenced rowsets
+            std::set<uint32_t> active_rowsets;
+            for (const auto& edit_version_info : _edit_version_infos) {
+                active_rowsets.insert(edit_version_info->rowsets.begin(), edit_version_info->rowsets.end());
+            }
+            std::lock_guard rl(_rowsets_lock);
+            std::lock_guard rsl(_rowset_stats_lock);
+            for (auto it = _rowsets.begin(); it != _rowsets.end();) {
+                if (active_rowsets.find(it->first) == active_rowsets.end()) {
+                    num_rowset_removed++;
+                    _rowset_stats.erase(it->first);
+                    (void)_unused_rowsets.blocking_put(std::move(it->second));
+                    it = _rowsets.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            min_readable_version = _edit_version_infos[0]->version.major();
+        }
+    }
+
+    // GC works that can be done outside of lock
+    if (num_version_removed > 0) {
         {
             std::unique_lock wrlock(_tablet.get_header_lock());
             _tablet.save_meta();
-            tablet_id = _tablet.tablet_id();
         }
-        std::set<uint32_t> unused_rid;
-        std::set<uint32_t> active_rid = _active_rowsets();
-        for (const auto& expired_edit_version_info : expired_edit_version_infos) {
-            VLOG(1) << "Removing expired version " << expired_edit_version_info->version.to_string() << " of tablet "
-                    << _tablet.tablet_id();
-            for (uint32_t expired_rid : expired_edit_version_info->rowsets) {
-                if (active_rid.count(expired_rid) == 0) {
-                    unused_rid.insert(expired_rid);
-                }
-            }
-        }
-        for (uint32_t id : unused_rid) {
-            std::lock_guard l(_rowsets_lock);
-            auto iter = _rowsets.find(id);
-            DCHECK(iter != _rowsets.end());
-            (void)_unused_rowsets.blocking_put(std::move(iter->second));
-            _rowsets.erase(iter);
-        }
-        for (uint32_t id : unused_rid) {
-            std::lock_guard l(_rowset_stats_lock);
-            _rowset_stats.erase(id);
-        }
-
+        auto tablet_id = _tablet.tablet_id();
         // Remove useless delete vectors.
         auto meta_store = _tablet.data_dir()->get_meta();
         auto res = TabletMetaManager::delete_del_vector_before_version(meta_store, tablet_id, min_readable_version);
@@ -1704,8 +1689,8 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
         LOG(INFO) << strings::Substitute(
                 "remove_expired_versions $0 time:$1 min_readable_version:$2 deletes: #version:$3 #rowset:$4 "
                 "#delvec:$5",
-                _debug_version_info(true), expire_time, min_readable_version, expired_edit_version_infos.size(),
-                unused_rid.size(), delvec_deleted);
+                _debug_version_info(true), expire_time, min_readable_version, num_version_removed, num_rowset_removed,
+                delvec_deleted);
     }
     _remove_unused_rowsets();
 }
@@ -3454,6 +3439,18 @@ Status TabletUpdates::get_rowsets_for_incremental_snapshot(const std::vector<int
         if (versions.empty()) {
             string msg = strings::Substitute("get_rowsets_for_snapshot: no version to clone $0 request_version:$1,",
                                              _debug_version_info(false), missing_version_ranges.back());
+            LOG(INFO) << msg;
+            return Status::NotFound(msg);
+        }
+        size_t num_rowset_full_clone = _edit_version_infos.back()->rowsets.size();
+        // TODO: make better estimates about incremental / full clone costs
+        // currently only consider number of rowsets, should also consider number of actual files and data size to
+        // reflect the actual cost
+        if (versions.size() >= config::tablet_max_versions || versions.size() >= num_rowset_full_clone * 20) {
+            string msg = strings::Substitute(
+                    "get_rowsets_for_snapshot: too many rowsets for incremental clone "
+                    "#rowset:$0 #rowset_for_full_clone:$1 $2",
+                    versions.size(), num_rowset_full_clone, _debug_version_info(false));
             LOG(INFO) << msg;
             return Status::NotFound(msg);
         }

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -318,14 +318,6 @@ private:
     Status _commit_compaction(std::unique_ptr<CompactionInfo>* info, const RowsetSharedPtr& rowset,
                               EditVersion* commit_version);
 
-    // Find all but the latest already-applied versions whose creation time is less than or
-    // equal to |expire_time|, then append them into |expire_list| and erase them from the
-    // in-memory version list.
-    void _erase_expired_versions(int64_t expire_time, std::vector<std::unique_ptr<EditVersionInfo>>* expire_list,
-                                 int64_t* min_readable_version);
-
-    std::set<uint32_t> _active_rowsets();
-
     void _stop_and_wait_apply_done();
 
     Status _do_compaction(std::unique_ptr<CompactionInfo>* pinfo);

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -877,9 +877,8 @@ Status EngineCloneTask::_finish_clone_primary(Tablet* tablet, const std::string&
     LOG(INFO) << "Linked " << clone_files.size() << " files from " << clone_dir << " to " << tablet_dir;
     // Note that |snapshot_meta| may be modified by `load_snapshot`.
     RETURN_IF_ERROR(tablet->updates()->load_snapshot(snapshot_meta));
-    if (snapshot_meta.snapshot_type() == SNAPSHOT_TYPE_FULL) {
-        tablet->updates()->remove_expired_versions(time(nullptr));
-    }
+    int64_t expired_stale_sweep_endtime = UnixSeconds() - config::tablet_rowset_stale_sweep_time_sec;
+    tablet->updates()->remove_expired_versions(expired_stale_sweep_endtime);
     LOG(INFO) << "Loaded snapshot of tablet " << tablet->tablet_id() << ", removing directory " << clone_dir;
     auto st = fs::remove_all(clone_dir);
     LOG_IF(WARNING, !st.ok()) << "Fail to remove clone directory " << clone_dir << ": " << st;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15844

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR refactors remove_expired_versions to resolve some bugs related to remove_expired_versions.
The first is BE crash in  remove_expired_versions, this may related to concurrent calls to remove_expired_versions.
```
*** SIGSEGV (@0x10) received by PID 19748 (TID 0x7fda3df81700) from PID 16; stack trace: ***
    @          0x4875742 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fe80d20f630 (unknown)
    @          0x2f8418c std::deque<>::emplace_back<>()
    @          0x2f97aea starrocks::TabletUpdates::remove_expired_versions()
    @          0x2f56930 starrocks::TabletManager::start_trash_sweep()
    @          0x2f12d17 starrocks::StorageEngine::_start_trash_sweep()
    @          0x312a143 starrocks::StorageEngine::_garbage_sweeper_thread_callback()
    @          0x6372460 execute_native_thread_routine
    @     0x7fe80d207ea5 start_thread
    @     0x7fe80c2feb0d __clone
```
The other is editversion array may get very large after incremental clone and GC process may not be able to GC them timely(because those versions are committed just now), so GC process should also remove versions to keep total versions count in the max_version_count limit even those versions may not got expired.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
