### PR TITLE
[BugFix] adapt to load resource mapping catalog when image is eof with old version

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -222,17 +222,13 @@ public class CatalogMgr {
             }
             checksum ^= catalogCount;
             LOG.info("finished replaying CatalogMgr from image");
-
-            LOG.info("start to replay resource mapping catalog");
-            loadResourceMappingCatalog();
-            LOG.info("finished replaying resource mapping catalogs from resources");
         } catch (EOFException e) {
             LOG.info("no CatalogMgr to replay.");
         }
         return checksum;
     }
 
-    private void loadResourceMappingCatalog() throws DdlException {
+    public void loadResourceMappingCatalog() {
         List<Resource> resources = GlobalStateMgr.getCurrentState().getResourceMgr().getNeedMappingCatalogResources();
         for (Resource resource : resources) {
             Map<String, String> properties = Maps.newHashMap(resource.getProperties());
@@ -244,7 +240,11 @@ public class CatalogMgr {
             String catalogName = getResourceMappingCatalogName(resource.getName(), type);
             properties.put("type", type);
             properties.put(HIVE_METASTORE_URIS, resource.getHiveMetastoreURIs());
-            createCatalog(type, catalogName, "mapping " + type + " catalog", properties);
+            try {
+                createCatalog(type, catalogName, "mapping " + type + " catalog", properties);
+            } catch (Exception e) {
+                LOG.error("Failed to load resource mapping inside catalog {}", catalogName, e);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1499,6 +1499,10 @@ public class GlobalStateMgr {
             resourceMgr = ResourceMgr.read(in);
         }
         LOG.info("finished replay resources from image");
+
+        LOG.info("start to replay resource mapping catalog");
+        catalogMgr.loadResourceMappingCatalog();
+        LOG.info("finished replaying resource mapping catalogs from resources");
         return checksum;
     }
 


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
we will create external catalog with resource when fe is restarting. but if we upgrade from 2.2 to 2.5. image is eof and it doesn't execute load catalogs. so we adjust the position of creating resource mapping catalog.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
