### PR TITLE
[Refactor] refactor auto streaming agg to avoid worst cases

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -31,6 +31,40 @@
 
 namespace starrocks {
 
+std::string AggrAutoContext::get_auto_state_string(const AggrAutoState& state) {
+    switch (state) {
+    case INIT_BUILD:
+        return "INIT_BUILD";
+    case ADJUST:
+        return "ADJUST";
+    case PASS_THROUGH:
+        return "PASS_THROUGH";
+    case FORCE_BUILD:
+        return "FORCE_BUILD";
+    case BUILD:
+        return "BUILD";
+    case SELECTIVE_BUILD:
+        return "SELECTIVE_BUILD";
+    }
+    return "UNKNOWN";
+}
+
+void AggrAutoContext::update_continuous_limit() {
+    continuous_limit = continuous_limit * 2 > ContinuousUpperLimit ? ContinuousUpperLimit : continuous_limit * 2;
+}
+
+size_t AggrAutoContext::get_continuous_limit() {
+    return continuous_limit;
+}
+
+bool AggrAutoContext::high_reduction(const size_t agg_count, const size_t chunk_size) {
+    return agg_count >= HighReduction * chunk_size;
+}
+
+bool AggrAutoContext::low_reduction(const size_t agg_count, const size_t chunk_size) {
+    return agg_count <= LowReduction * chunk_size;
+}
+
 Status init_udaf_context(int64_t fid, const std::string& url, const std::string& checksum, const std::string& symbol,
                          FunctionContext* context);
 

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -33,18 +33,18 @@ namespace starrocks {
 
 std::string AggrAutoContext::get_auto_state_string(const AggrAutoState& state) {
     switch (state) {
-    case INIT_BUILD:
-        return "INIT_BUILD";
+    case INIT_PREAGG:
+        return "INIT_PREAGG";
     case ADJUST:
         return "ADJUST";
     case PASS_THROUGH:
         return "PASS_THROUGH";
-    case FORCE_BUILD:
-        return "FORCE_BUILD";
-    case BUILD:
-        return "BUILD";
-    case SELECTIVE_BUILD:
-        return "SELECTIVE_BUILD";
+    case FORCE_PREAGG:
+        return "FORCE_PREAGG";
+    case PREAGG:
+        return "PREAGG";
+    case SELECTIVE_PREAGG:
+        return "SELECTIVE_PREAGG";
     }
     return "UNKNOWN";
 }

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -57,11 +57,11 @@ size_t AggrAutoContext::get_continuous_limit() {
     return continuous_limit;
 }
 
-bool AggrAutoContext::high_reduction(const size_t agg_count, const size_t chunk_size) {
+bool AggrAutoContext::is_high_reduction(const size_t agg_count, const size_t chunk_size) {
     return agg_count >= HighReduction * chunk_size;
 }
 
-bool AggrAutoContext::low_reduction(const size_t agg_count, const size_t chunk_size) {
+bool AggrAutoContext::is_low_reduction(const size_t agg_count, const size_t chunk_size) {
     return agg_count <= LowReduction * chunk_size;
 }
 

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -140,11 +140,11 @@ enum AggrAutoState { INIT_BUILD = 0, ADJUST, PASS_THROUGH, FORCE_BUILD, BUILD, S
 
 struct AggrAutoContext {
     constexpr static size_t ContinuousUpperLimit = 100000;
-    constexpr static  int BuildLimit = 3;
-    constexpr static  double LowReduction = 0.3;
-    constexpr static  double HighReduction = 0.8;
-    constexpr static  size_t MaxHtSize = 100 * 1024 * 1024;
-    constexpr static  int AdjustLimit = 5;
+    constexpr static int BuildLimit = 3;
+    constexpr static double LowReduction = 0.3;
+    constexpr static double HighReduction = 0.8;
+    constexpr static size_t MaxHtSize = 100 * 1024 * 1024;
+    constexpr static int AdjustLimit = 5;
     std::string get_auto_state_string(const AggrAutoState& state);
     size_t get_continuous_limit();
     void update_continuous_limit();
@@ -157,7 +157,6 @@ struct AggrAutoContext {
     size_t build_count = 0;
     size_t selective_build_count = 0;
     size_t continuous_limit = 1000;
-
 };
 
 struct StreamingHtMinReductionEntry {

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -139,13 +139,14 @@ enum AggrMode {
 enum AggrAutoState { INIT_PREAGG = 0, ADJUST, PASS_THROUGH, FORCE_PREAGG, PREAGG, SELECTIVE_PREAGG };
 
 struct AggrAutoContext {
-    constexpr static size_t ContinuousUpperLimit = 100000;
+    constexpr static size_t ContinuousUpperLimit = 10000;
     constexpr static int ForcePreaggLimit = 3;
     constexpr static int PreaggLimit = 100;
+    constexpr static int AdjustLimit = 100;
     constexpr static double LowReduction = 0.3;
     constexpr static double HighReduction = 0.8;
     constexpr static size_t MaxHtSize = 128 * 1024 * 1024; // 128 MB
-    constexpr static int AdjustLimit = 5;
+    constexpr static int StableLimit = 5;
     std::string get_auto_state_string(const AggrAutoState& state);
     size_t get_continuous_limit();
     void update_continuous_limit();

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -140,10 +140,11 @@ enum AggrAutoState { INIT_PREAGG = 0, ADJUST, PASS_THROUGH, FORCE_PREAGG, PREAGG
 
 struct AggrAutoContext {
     constexpr static size_t ContinuousUpperLimit = 100000;
-    constexpr static int PreaggLimit = 3;
+    constexpr static int ForcePreaggLimit = 3;
+    constexpr static int PreaggLimit = 100;
     constexpr static double LowReduction = 0.3;
     constexpr static double HighReduction = 0.8;
-    constexpr static size_t MaxHtSize = 100 * 1024 * 1024;
+    constexpr static size_t MaxHtSize = 128 * 1024 * 1024; // 128 MB
     constexpr static int AdjustLimit = 5;
     std::string get_auto_state_string(const AggrAutoState& state);
     size_t get_continuous_limit();

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -143,9 +143,9 @@ struct AggrAutoContext {
     constexpr static int ForcePreaggLimit = 3;
     constexpr static int PreaggLimit = 100;
     constexpr static int AdjustLimit = 100;
-    constexpr static double LowReduction = 0.3;
-    constexpr static double HighReduction = 0.8;
-    constexpr static size_t MaxHtSize = 128 * 1024 * 1024; // 128 MB
+    constexpr static double LowReduction = 0.2;
+    constexpr static double HighReduction = 0.9;
+    constexpr static size_t MaxHtSize = 64 * 1024 * 1024; // 64 MB
     constexpr static int StableLimit = 5;
     std::string get_auto_state_string(const AggrAutoState& state);
     size_t get_continuous_limit();
@@ -158,7 +158,7 @@ struct AggrAutoContext {
     size_t force_preagg_count = 0;
     size_t preagg_count = 0;
     size_t selective_preagg_count = 0;
-    size_t continuous_limit = 1000;
+    size_t continuous_limit = 100;
 };
 
 struct StreamingHtMinReductionEntry {

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -419,9 +419,7 @@ public:
     void convert_hash_set_to_chunk(int32_t chunk_size, ChunkPtr* chunk);
 
 protected:
-    bool _reached_limit() {
-        return _limit != -1 && _num_rows_returned >= _limit;
-    }
+    bool _reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
 
     bool _use_intermediate_as_input() {
         if (is_pending_reset_state()) {
@@ -453,22 +451,12 @@ protected:
     ChunkPtr _build_output_chunk(const Columns& group_by_columns, const Columns& agg_result_columns,
                                  bool use_intermediate);
 
-    void _set_passthrough(bool flag) {
-        _is_passthrough = flag;
-    }
-    bool is_passthrough() const {
-        return _is_passthrough;
-    }
+    void _set_passthrough(bool flag) { _is_passthrough = flag; }
+    bool is_passthrough() const { return _is_passthrough; }
 
-    void begin_pending_reset_state() {
-        _is_pending_reset_state = true;
-    }
-    void end_pending_reset_state() {
-        _is_pending_reset_state = false;
-    }
-    bool is_pending_reset_state() {
-        return _is_pending_reset_state;
-    }
+    void begin_pending_reset_state() { _is_pending_reset_state = true; }
+    void end_pending_reset_state() { _is_pending_reset_state = false; }
+    bool is_pending_reset_state() { return _is_pending_reset_state; }
 
     void _reset_groupby_exprs();
     Status _evaluate_group_by_exprs(Chunk* chunk);

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -139,14 +139,14 @@ enum AggrMode {
 enum AggrAutoState { INIT_PREAGG = 0, ADJUST, PASS_THROUGH, FORCE_PREAGG, PREAGG, SELECTIVE_PREAGG };
 
 struct AggrAutoContext {
-    constexpr static size_t ContinuousUpperLimit = 10000;
-    constexpr static int ForcePreaggLimit = 3;
-    constexpr static int PreaggLimit = 100;
-    constexpr static int AdjustLimit = 100;
-    constexpr static double LowReduction = 0.2;
-    constexpr static double HighReduction = 0.9;
-    constexpr static size_t MaxHtSize = 64 * 1024 * 1024; // 64 MB
-    constexpr static int StableLimit = 5;
+    static constexpr size_t ContinuousUpperLimit = 10000;
+    static constexpr int ForcePreaggLimit = 3;
+    static constexpr int PreaggLimit = 100;
+    static constexpr int AdjustLimit = 100;
+    static constexpr double LowReduction = 0.2;
+    static constexpr double HighReduction = 0.9;
+    static constexpr size_t MaxHtSize = 64 * 1024 * 1024; // 64 MB
+    static constexpr int StableLimit = 5;
     std::string get_auto_state_string(const AggrAutoState& state);
     size_t get_continuous_limit();
     void update_continuous_limit();

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -149,8 +149,8 @@ struct AggrAutoContext {
     std::string get_auto_state_string(const AggrAutoState& state);
     size_t get_continuous_limit();
     void update_continuous_limit();
-    bool high_reduction(const size_t agg_count, const size_t chunk_size);
-    bool low_reduction(const size_t agg_count, const size_t chunk_size);
+    bool is_high_reduction(const size_t agg_count, const size_t chunk_size);
+    bool is_low_reduction(const size_t agg_count, const size_t chunk_size);
     size_t init_preagg_count = 0;
     size_t adjust_count = 0;
     size_t pass_through_count = 0;

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -136,7 +136,7 @@ enum AggrMode {
     AM_STREAMING_POST_CACHE
 };
 
-enum AggrAutoState { INIT_BUILD = 0, ADJUST, PASS_THROUGH, FORCE_BUILD, BUILD, SELECTIVE_BUILD };
+enum AggrAutoState { INIT_PREAGG = 0, ADJUST, PASS_THROUGH, FORCE_PREAGG, PREAGG, SELECTIVE_PREAGG };
 
 struct AggrAutoContext {
     constexpr static size_t ContinuousUpperLimit = 100000;
@@ -150,12 +150,12 @@ struct AggrAutoContext {
     void update_continuous_limit();
     bool high_reduction(const size_t agg_count, const size_t chunk_size);
     bool low_reduction(const size_t agg_count, const size_t chunk_size);
-    size_t init_build_count = 0;
+    size_t init_preagg_count = 0;
     size_t adjust_count = 0;
     size_t pass_through_count = 0;
-    size_t force_build_count = 0;
-    size_t build_count = 0;
-    size_t selective_build_count = 0;
+    size_t force_preagg_count = 0;
+    size_t preagg_count = 0;
+    size_t selective_preagg_count = 0;
     size_t continuous_limit = 1000;
 };
 

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -140,7 +140,7 @@ enum AggrAutoState { INIT_PREAGG = 0, ADJUST, PASS_THROUGH, FORCE_PREAGG, PREAGG
 
 struct AggrAutoContext {
     constexpr static size_t ContinuousUpperLimit = 100000;
-    constexpr static int BuildLimit = 3;
+    constexpr static int PreaggLimit = 3;
     constexpr static double LowReduction = 0.3;
     constexpr static double HighReduction = 0.8;
     constexpr static size_t MaxHtSize = 100 * 1024 * 1024;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -58,7 +58,9 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const Chu
         RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
     } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_PREAGGREGATION) {
         RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk, chunk->num_rows()));
-    } else {
+    } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::AUTO_NEW) {
+        RETURN_IF_ERROR(_push_chunk_by_auto_new(chunk, chunk->num_rows()));
+    }else {
         RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk->num_rows()));
     }
     RETURN_IF_ERROR(_aggregator->check_has_error());
@@ -145,6 +147,203 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
 
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     }
+    return Status::OK();
+}
+Status AggregateStreamingSinkOperator::_push_chunk_by_auto_new(ChunkPtr chunk, const size_t chunk_size) {
+    size_t allocated_bytes = _aggregator->hash_map_variant().allocated_memory_usage(_aggregator->mem_pool());
+    const size_t continuous_limit = _auto_context.get_continuous_limit();
+    switch (_auto_state) {
+    case AggrAutoState::INIT_BUILD: {
+        size_t real_capacity =
+                _aggregator->hash_map_variant().capacity() - _aggregator->hash_map_variant().capacity() / 8;
+        size_t remain_size = real_capacity - _aggregator->hash_map_variant().size();
+        bool ht_needs_expansion = remain_size < chunk_size;
+        _auto_context.init_build_count++;
+        if (!ht_needs_expansion ||
+            _aggregator->should_expand_preagg_hash_tables(_aggregator->num_input_rows(), chunk_size, allocated_bytes,
+                                                          _aggregator->hash_map_variant().size())) {
+            // hash table is not full or allow expand the hash table according reduction rate
+            SCOPED_TIMER(_aggregator->agg_compute_timer());
+            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
+            if (_aggregator->is_none_group_by_exprs()) {
+                _aggregator->compute_single_agg_state(chunk.get(), chunk_size);
+            } else {
+                _aggregator->compute_batch_agg_states(chunk.get(), chunk_size);
+            }
+
+            _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
+            TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
+
+            break;
+        } else {
+            _auto_state = AggrAutoState::ADJUST;
+            _auto_context.adjust_count = 0;
+            LOG(INFO) << "auto agg: " << _auto_context.get_auto_state_string(AggrAutoState::INIT_BUILD) << " "
+                      << _auto_context.init_build_count << " -> " << _auto_context.get_auto_state_string(_auto_state);
+        }
+    }
+    case AggrAutoState::ADJUST: {
+        _auto_context.adjust_count++;
+        {
+            SCOPED_TIMER(_aggregator->agg_compute_timer());
+            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map_with_selection(chunk_size));
+        }
+
+        size_t agg_count = SIMD::count_zero(_aggregator->streaming_selection());
+        if (_auto_context.adjust_count < continuous_limit && _auto_context.low_reduction(agg_count, chunk_size)) {
+
+            SCOPED_TIMER(_aggregator->streaming_timer());
+            ChunkPtr chunk = std::make_shared<Chunk>();
+            _aggregator->output_chunk_by_streaming(&chunk);
+            _aggregator->offer_chunk_to_buffer(chunk);
+
+            _auto_context.pass_through_count++;
+            _auto_context.build_count = 0;
+            _auto_context.selective_build_count = 0;
+            if (_auto_context.pass_through_count == AggrAutoContext::AdjustLimit) {
+                _auto_state = AggrAutoState::PASS_THROUGH;
+                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " low reduction "
+                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
+                          << _auto_context.get_auto_state_string(_auto_state);
+            }
+
+        } else if (_auto_context.adjust_count < continuous_limit &&
+                   _auto_context.high_reduction(agg_count, chunk_size) &&
+                   allocated_bytes < AggrAutoContext::MaxHtSize) {
+            {
+                SCOPED_TIMER(_aggregator->agg_compute_timer());
+                TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
+                if (_aggregator->is_none_group_by_exprs()) {
+                    _aggregator->compute_single_agg_state(chunk_size);
+                } else {
+                    _aggregator->compute_batch_agg_states(chunk_size);
+                }
+
+                _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
+                TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
+            }
+
+            _auto_context.build_count++;
+            _auto_context.pass_through_count = 0;
+            _auto_context.selective_build_count = 0;
+            if (_auto_context.build_count == AggrAutoContext::AdjustLimit) {
+                _auto_state = AggrAutoState::BUILD;
+                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " high reduction "
+                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
+                          << _auto_context.get_auto_state_string(_auto_state);
+            }
+        } else {
+            {
+                SCOPED_TIMER(_aggregator->agg_compute_timer());
+                _aggregator->compute_batch_agg_states_with_selection(chunk_size);
+            }
+            {
+                SCOPED_TIMER(_aggregator->streaming_timer());
+                ChunkPtr chunk = std::make_shared<Chunk>();
+                _aggregator->output_chunk_by_streaming_with_selection(&chunk);
+                _aggregator->offer_chunk_to_buffer(chunk);
+            }
+            _auto_context.selective_build_count++;
+            _auto_context.pass_through_count = 0;
+            _auto_context.build_count = 0;
+            if (_auto_context.selective_build_count == AggrAutoContext::AdjustLimit) {
+                _auto_state = AggrAutoState::SELECTIVE_BUILD;
+                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " "
+                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST)
+                          << _auto_context.get_auto_state_string(_auto_state);
+            }
+        }
+        break;
+    }
+    case AggrAutoState::PASS_THROUGH: {
+        _auto_context.pass_through_count++;
+        {
+            SCOPED_TIMER(_aggregator->streaming_timer());
+            ChunkPtr chunk = std::make_shared<Chunk>();
+            _aggregator->output_chunk_by_streaming(&chunk);
+            _aggregator->offer_chunk_to_buffer(chunk);
+        }
+        if (_auto_context.pass_through_count > continuous_limit) {
+            if (allocated_bytes < AggrAutoContext::MaxHtSize) {
+                _auto_state = AggrAutoState::FORCE_BUILD;
+                _auto_context.pass_through_count = 0;
+                _auto_context.build_count = 0;
+            } else {
+                _auto_state = AggrAutoState::ADJUST;
+                _auto_context.pass_through_count = 0;
+                _auto_context.adjust_count = 0;
+            }
+            LOG(INFO) << "auto agg: continuous " << continuous_limit << " "
+                      << _auto_context.get_auto_state_string(AggrAutoState::PASS_THROUGH) << " -> "
+                      << _auto_context.get_auto_state_string(_auto_state);
+            _auto_context.update_continuous_limit();
+        }
+        break;
+    }
+    case AggrAutoState::FORCE_BUILD:
+    case AggrAutoState::BUILD: {
+        _auto_context.build_count++;
+        {
+            SCOPED_TIMER(_aggregator->agg_compute_timer());
+            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
+            if (_aggregator->is_none_group_by_exprs()) {
+                _aggregator->compute_single_agg_state(chunk_size);
+            } else {
+                _aggregator->compute_batch_agg_states(chunk_size);
+            }
+
+            _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
+            TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
+        }
+        if (_auto_state == AggrAutoState::FORCE_BUILD) {
+            if (_auto_context.build_count > AggrAutoContext::BuildLimit) {
+                _auto_state = AggrAutoState::ADJUST;
+                _auto_context.build_count = 0;
+                _auto_context.adjust_count = 0;
+                LOG(INFO) << "auto agg: " << _auto_context.get_auto_state_string(AggrAutoState::FORCE_BUILD) << " -> "
+                          << _auto_context.get_auto_state_string(_auto_state);
+            }
+        } else {
+            if (_auto_context.build_count > AggrAutoContext::AdjustLimit + AggrAutoContext::BuildLimit) {
+                _auto_state = AggrAutoState::ADJUST;
+                _auto_context.build_count = 0;
+                _auto_context.adjust_count = 0;
+                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit + AggrAutoContext::BuildLimit
+                          << " " << _auto_context.get_auto_state_string(AggrAutoState::BUILD) << " -> "
+                          << _auto_context.get_auto_state_string(_auto_state);
+            }
+        }
+        break;
+    }
+    case AggrAutoState::SELECTIVE_BUILD: {
+        _auto_context.selective_build_count++;
+        {
+            SCOPED_TIMER(_aggregator->agg_compute_timer());
+            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map_with_selection(chunk_size));
+        }
+        {
+            SCOPED_TIMER(_aggregator->agg_compute_timer());
+            _aggregator->compute_batch_agg_states_with_selection(chunk_size);
+        }
+        {
+            SCOPED_TIMER(_aggregator->streaming_timer());
+            ChunkPtr chunk = std::make_shared<Chunk>();
+            _aggregator->output_chunk_by_streaming_with_selection(&chunk);
+            _aggregator->offer_chunk_to_buffer(chunk);
+        }
+        if (_auto_context.selective_build_count > continuous_limit) {
+            _auto_state = AggrAutoState::ADJUST;
+            _auto_context.selective_build_count = 0;
+            _auto_context.adjust_count = 0;
+            LOG(INFO) << "auto agg: continuous " << continuous_limit << " "
+                      << _auto_context.get_auto_state_string(AggrAutoState::SELECTIVE_BUILD) << " -> "
+                      << _auto_context.get_auto_state_string(_auto_state);
+            _auto_context.update_continuous_limit();
+        }
+        break;
+    }
+    }
+    COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -60,7 +60,7 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const Chu
         RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk, chunk->num_rows()));
     } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::AUTO_NEW) {
         RETURN_IF_ERROR(_push_chunk_by_auto_new(chunk, chunk->num_rows()));
-    }else {
+    } else {
         RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk->num_rows()));
     }
     RETURN_IF_ERROR(_aggregator->check_has_error());
@@ -91,7 +91,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(Chunk
     return Status::OK();
 }
 
-Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const size_t chunk_size) {
+Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const size_t chunk_size) {
     // TODO: calc the real capacity of hashtable, will add one interface in the class of habletable
     size_t real_capacity = _aggregator->hash_map_variant().capacity() - _aggregator->hash_map_variant().capacity() / 8;
     size_t remain_size = real_capacity - _aggregator->hash_map_variant().size();
@@ -104,9 +104,9 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
         SCOPED_TIMER(_aggregator->agg_compute_timer());
         TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
         if (_aggregator->is_none_group_by_exprs()) {
-            RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk.get(), chunk_size));
+            _aggregator->compute_single_agg_state(chunk_size);
         } else {
-            RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk.get(), chunk_size));
+            _aggregator->compute_batch_agg_states(chunk_size);
         }
 
         _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
@@ -114,41 +114,46 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
 
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     } else {
-        {
-            SCOPED_TIMER(_aggregator->agg_compute_timer());
-            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map_with_selection(chunk_size));
-        }
-
-        size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection());
-        // very poor aggregation
-        if (zero_count == 0) {
-            SCOPED_TIMER(_aggregator->streaming_timer());
-            ChunkPtr res = std::make_shared<Chunk>();
-            RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(chunk.get(), &res));
-            _aggregator->offer_chunk_to_buffer(res);
-        }
-        // very high aggregation
-        else if (zero_count == _aggregator->streaming_selection().size()) {
-            SCOPED_TIMER(_aggregator->agg_compute_timer());
-            RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk.get(), chunk_size));
-        } else {
-            // middle cases, first aggregate locally and output by stream
-            {
-                SCOPED_TIMER(_aggregator->agg_compute_timer());
-                RETURN_IF_ERROR(_aggregator->compute_batch_agg_states_with_selection(chunk.get(), chunk_size));
-            }
-            {
-                SCOPED_TIMER(_aggregator->streaming_timer());
-                ChunkPtr res = std::make_shared<Chunk>();
-                RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming_with_selection(chunk.get(), &res));
-                _aggregator->offer_chunk_to_buffer(res);
-            }
-        }
-
+        RETURN_IF_ERROR(_push_chunk_by_selective_preaggregation(chunk_size, true));
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     }
     return Status::OK();
 }
+
+Status AggregateStreamingSinkOperator::_push_chunk_by_selective_preaggregation(const size_t chunk_size,
+                                                                               bool need_build) {
+    if (need_build) {
+        SCOPED_TIMER(_aggregator->agg_compute_timer());
+        TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map_with_selection(chunk_size));
+    }
+
+    size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection());
+    // very poor aggregation
+    if (zero_count == 0) {
+        SCOPED_TIMER(_aggregator->streaming_timer());
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        _aggregator->output_chunk_by_streaming(&chunk);
+        _aggregator->offer_chunk_to_buffer(chunk);
+    }
+    // very high aggregation
+    else if (zero_count == _aggregator->streaming_selection().size()) {
+        SCOPED_TIMER(_aggregator->agg_compute_timer());
+        _aggregator->compute_batch_agg_states(chunk_size);
+    } else {
+        // middle cases, first aggregate locally and output by stream
+        {
+            SCOPED_TIMER(_aggregator->agg_compute_timer());
+            _aggregator->compute_batch_agg_states_with_selection(chunk_size);
+        }
+        {
+            SCOPED_TIMER(_aggregator->streaming_timer());
+            ChunkPtr chunk = std::make_shared<Chunk>();
+            _aggregator->output_chunk_by_streaming_with_selection(&chunk);
+            _aggregator->offer_chunk_to_buffer(chunk);
+        }
+    }
+}
+
 Status AggregateStreamingSinkOperator::_push_chunk_by_auto_new(ChunkPtr chunk, const size_t chunk_size) {
     size_t allocated_bytes = _aggregator->hash_map_variant().allocated_memory_usage(_aggregator->mem_pool());
     const size_t continuous_limit = _auto_context.get_continuous_limit();
@@ -178,8 +183,8 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto_new(ChunkPtr chunk, c
         } else {
             _auto_state = AggrAutoState::ADJUST;
             _auto_context.adjust_count = 0;
-            LOG(INFO) << "auto agg: " << _auto_context.get_auto_state_string(AggrAutoState::INIT_BUILD) << " "
-                      << _auto_context.init_build_count << " -> " << _auto_context.get_auto_state_string(_auto_state);
+            VLOG_ROW << "auto agg: " << _auto_context.get_auto_state_string(AggrAutoState::INIT_BUILD) << " "
+                     << _auto_context.init_build_count << " -> " << _auto_context.get_auto_state_string(_auto_state);
         }
     }
     case AggrAutoState::ADJUST: {
@@ -191,153 +196,100 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto_new(ChunkPtr chunk, c
 
         size_t agg_count = SIMD::count_zero(_aggregator->streaming_selection());
         if (_auto_context.adjust_count < continuous_limit && _auto_context.low_reduction(agg_count, chunk_size)) {
-
-            SCOPED_TIMER(_aggregator->streaming_timer());
-            ChunkPtr chunk = std::make_shared<Chunk>();
-            _aggregator->output_chunk_by_streaming(&chunk);
-            _aggregator->offer_chunk_to_buffer(chunk);
-
+            RETURN_IF_ERROR(_push_chunk_by_force_streaming());
             _auto_context.pass_through_count++;
             _auto_context.build_count = 0;
             _auto_context.selective_build_count = 0;
             if (_auto_context.pass_through_count == AggrAutoContext::AdjustLimit) {
                 _auto_state = AggrAutoState::PASS_THROUGH;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " low reduction "
-                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
-                          << _auto_context.get_auto_state_string(_auto_state);
+                VLOG_ROW << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " low reduction "
+                         << agg_count * 1.0 / chunk_size << " "
+                         << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
+                         << _auto_context.get_auto_state_string(_auto_state);
             }
 
         } else if (_auto_context.adjust_count < continuous_limit &&
                    _auto_context.high_reduction(agg_count, chunk_size) &&
                    allocated_bytes < AggrAutoContext::MaxHtSize) {
-            {
-                SCOPED_TIMER(_aggregator->agg_compute_timer());
-                TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
-                if (_aggregator->is_none_group_by_exprs()) {
-                    _aggregator->compute_single_agg_state(chunk_size);
-                } else {
-                    _aggregator->compute_batch_agg_states(chunk_size);
-                }
-
-                _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
-                TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
-            }
+            //TODO rebuilding is OK?
+            RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk_size));
 
             _auto_context.build_count++;
             _auto_context.pass_through_count = 0;
             _auto_context.selective_build_count = 0;
             if (_auto_context.build_count == AggrAutoContext::AdjustLimit) {
                 _auto_state = AggrAutoState::BUILD;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " high reduction "
-                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
-                          << _auto_context.get_auto_state_string(_auto_state);
+                VLOG_ROW << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " high reduction "
+                         << agg_count * 1.0 / chunk_size << " "
+                         << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
+                         << _auto_context.get_auto_state_string(_auto_state);
             }
         } else {
-            {
-                SCOPED_TIMER(_aggregator->agg_compute_timer());
-                _aggregator->compute_batch_agg_states_with_selection(chunk_size);
-            }
-            {
-                SCOPED_TIMER(_aggregator->streaming_timer());
-                ChunkPtr chunk = std::make_shared<Chunk>();
-                _aggregator->output_chunk_by_streaming_with_selection(&chunk);
-                _aggregator->offer_chunk_to_buffer(chunk);
-            }
+            RETURN_IF_ERROR(_push_chunk_by_selective_preaggregation(chunk_size, false));
             _auto_context.selective_build_count++;
             _auto_context.pass_through_count = 0;
             _auto_context.build_count = 0;
             if (_auto_context.selective_build_count == AggrAutoContext::AdjustLimit) {
                 _auto_state = AggrAutoState::SELECTIVE_BUILD;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " "
-                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST)
-                          << _auto_context.get_auto_state_string(_auto_state);
+                VLOG_ROW << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " "
+                         << _auto_context.get_auto_state_string(AggrAutoState::ADJUST)
+                         << _auto_context.get_auto_state_string(_auto_state);
             }
         }
         break;
     }
     case AggrAutoState::PASS_THROUGH: {
+        RETURN_IF_ERROR(_push_chunk_by_force_streaming());
         _auto_context.pass_through_count++;
-        {
-            SCOPED_TIMER(_aggregator->streaming_timer());
-            ChunkPtr chunk = std::make_shared<Chunk>();
-            _aggregator->output_chunk_by_streaming(&chunk);
-            _aggregator->offer_chunk_to_buffer(chunk);
-        }
         if (_auto_context.pass_through_count > continuous_limit) {
-            if (allocated_bytes < AggrAutoContext::MaxHtSize) {
-                _auto_state = AggrAutoState::FORCE_BUILD;
-                _auto_context.pass_through_count = 0;
-                _auto_context.build_count = 0;
-            } else {
-                _auto_state = AggrAutoState::ADJUST;
-                _auto_context.pass_through_count = 0;
-                _auto_context.adjust_count = 0;
-            }
-            LOG(INFO) << "auto agg: continuous " << continuous_limit << " "
-                      << _auto_context.get_auto_state_string(AggrAutoState::PASS_THROUGH) << " -> "
-                      << _auto_context.get_auto_state_string(_auto_state);
+            _auto_state =
+                    allocated_bytes < AggrAutoContext::MaxHtSize ? AggrAutoState::FORCE_BUILD : AggrAutoState::ADJUST;
+            _auto_context.pass_through_count = 0;
+            _auto_context.build_count = 0;
+            _auto_context.adjust_count = 0;
+
+            VLOG_ROW << "auto agg: continuous " << continuous_limit << " "
+                     << _auto_context.get_auto_state_string(AggrAutoState::PASS_THROUGH) << " -> "
+                     << _auto_context.get_auto_state_string(_auto_state);
             _auto_context.update_continuous_limit();
         }
         break;
     }
     case AggrAutoState::FORCE_BUILD:
     case AggrAutoState::BUILD: {
+        RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk_size));
         _auto_context.build_count++;
-        {
-            SCOPED_TIMER(_aggregator->agg_compute_timer());
-            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
-            if (_aggregator->is_none_group_by_exprs()) {
-                _aggregator->compute_single_agg_state(chunk_size);
-            } else {
-                _aggregator->compute_batch_agg_states(chunk_size);
-            }
-
-            _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
-            TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
-        }
         if (_auto_state == AggrAutoState::FORCE_BUILD) {
             if (_auto_context.build_count > AggrAutoContext::BuildLimit) {
                 _auto_state = AggrAutoState::ADJUST;
                 _auto_context.build_count = 0;
                 _auto_context.adjust_count = 0;
-                LOG(INFO) << "auto agg: " << _auto_context.get_auto_state_string(AggrAutoState::FORCE_BUILD) << " -> "
-                          << _auto_context.get_auto_state_string(_auto_state);
+                VLOG_ROW << "auto agg: continuous " << AggrAutoContext::BuildLimit << " "
+                         << _auto_context.get_auto_state_string(AggrAutoState::FORCE_BUILD) << " -> "
+                         << _auto_context.get_auto_state_string(_auto_state);
             }
         } else {
             if (_auto_context.build_count > AggrAutoContext::AdjustLimit + AggrAutoContext::BuildLimit) {
                 _auto_state = AggrAutoState::ADJUST;
                 _auto_context.build_count = 0;
                 _auto_context.adjust_count = 0;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit + AggrAutoContext::BuildLimit
-                          << " " << _auto_context.get_auto_state_string(AggrAutoState::BUILD) << " -> "
-                          << _auto_context.get_auto_state_string(_auto_state);
+                VLOG_ROW << "auto agg: continuous " << AggrAutoContext::AdjustLimit + AggrAutoContext::BuildLimit << " "
+                         << _auto_context.get_auto_state_string(AggrAutoState::BUILD) << " -> "
+                         << _auto_context.get_auto_state_string(_auto_state);
             }
         }
         break;
     }
     case AggrAutoState::SELECTIVE_BUILD: {
+        RETURN_IF_ERROR(_push_chunk_by_selective_preaggregation(chunk_size, true));
         _auto_context.selective_build_count++;
-        {
-            SCOPED_TIMER(_aggregator->agg_compute_timer());
-            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map_with_selection(chunk_size));
-        }
-        {
-            SCOPED_TIMER(_aggregator->agg_compute_timer());
-            _aggregator->compute_batch_agg_states_with_selection(chunk_size);
-        }
-        {
-            SCOPED_TIMER(_aggregator->streaming_timer());
-            ChunkPtr chunk = std::make_shared<Chunk>();
-            _aggregator->output_chunk_by_streaming_with_selection(&chunk);
-            _aggregator->offer_chunk_to_buffer(chunk);
-        }
         if (_auto_context.selective_build_count > continuous_limit) {
             _auto_state = AggrAutoState::ADJUST;
             _auto_context.selective_build_count = 0;
             _auto_context.adjust_count = 0;
-            LOG(INFO) << "auto agg: continuous " << continuous_limit << " "
-                      << _auto_context.get_auto_state_string(AggrAutoState::SELECTIVE_BUILD) << " -> "
-                      << _auto_context.get_auto_state_string(_auto_state);
+            VLOG_ROW << "auto agg: continuous " << continuous_limit << " "
+                     << _auto_context.get_auto_state_string(AggrAutoState::SELECTIVE_BUILD) << " -> "
+                     << _auto_context.get_auto_state_string(_auto_state);
             _auto_context.update_continuous_limit();
         }
         break;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -58,8 +58,6 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const Chu
         RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
     } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_PREAGGREGATION) {
         RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk, chunk->num_rows()));
-    } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::AUTO_NEW) {
-        RETURN_IF_ERROR(_push_chunk_by_auto_new(chunk, chunk->num_rows()));
     } else {
         RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk->num_rows()));
     }
@@ -88,35 +86,6 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(Chunk
     TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
-    return Status::OK();
-}
-
-Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const size_t chunk_size) {
-    // TODO: calc the real capacity of hashtable, will add one interface in the class of habletable
-    size_t real_capacity = _aggregator->hash_map_variant().capacity() - _aggregator->hash_map_variant().capacity() / 8;
-    size_t remain_size = real_capacity - _aggregator->hash_map_variant().size();
-    bool ht_needs_expansion = remain_size < chunk_size;
-    size_t allocated_bytes = _aggregator->hash_map_variant().allocated_memory_usage(_aggregator->mem_pool());
-    if (!ht_needs_expansion ||
-        _aggregator->should_expand_preagg_hash_tables(_aggregator->num_input_rows(), chunk_size, allocated_bytes,
-                                                      _aggregator->hash_map_variant().size())) {
-        // hash table is not full or allow expand the hash table according reduction rate
-        SCOPED_TIMER(_aggregator->agg_compute_timer());
-        TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
-        if (_aggregator->is_none_group_by_exprs()) {
-            RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk.get(), chunk_size));
-        } else {
-            RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk.get(), chunk_size));
-        }
-
-        _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
-        TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
-
-        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
-    } else {
-        RETURN_IF_ERROR(_push_chunk_by_selective_preaggregation(chunk, chunk_size, true));
-        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
-    }
     return Status::OK();
 }
 
@@ -156,7 +125,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_selective_preaggregation(C
     return Status::OK();
 }
 
-Status AggregateStreamingSinkOperator::_push_chunk_by_auto_new(ChunkPtr chunk, const size_t chunk_size) {
+Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const size_t chunk_size) {
     size_t allocated_bytes = _aggregator->hash_map_variant().allocated_memory_usage(_aggregator->mem_pool());
     const size_t continuous_limit = _auto_context.get_continuous_limit();
     switch (_auto_state) {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -182,7 +182,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
         }
 
         size_t agg_count = SIMD::count_zero(_aggregator->streaming_selection());
-        if (_auto_context.adjust_count < continuous_limit && _auto_context.low_reduction(agg_count, chunk_size)) {
+        if (_auto_context.adjust_count < continuous_limit && _auto_context.is_low_reduction(agg_count, chunk_size)) {
             RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
             _auto_context.pass_through_count++;
             _auto_context.preagg_count = 0;
@@ -196,7 +196,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             }
 
         } else if (_auto_context.adjust_count < continuous_limit &&
-                   _auto_context.high_reduction(agg_count, chunk_size) &&
+                   _auto_context.is_high_reduction(agg_count, chunk_size) &&
                    allocated_bytes < AggrAutoContext::MaxHtSize) {
             RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk, chunk_size));
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -170,8 +170,8 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
         } else {
             _auto_state = AggrAutoState::ADJUST;
             _auto_context.adjust_count = 0;
-            LOG(INFO) << "auto agg: " << _auto_context.get_auto_state_string(AggrAutoState::INIT_PREAGG) << " "
-                      << _auto_context.init_preagg_count << " -> " << _auto_context.get_auto_state_string(_auto_state);
+            VLOG_ROW << "auto agg: " << _auto_context.get_auto_state_string(AggrAutoState::INIT_PREAGG) << " "
+                     << _auto_context.init_preagg_count << " -> " << _auto_context.get_auto_state_string(_auto_state);
         }
     }
     case AggrAutoState::ADJUST: {
@@ -189,10 +189,10 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             _auto_context.selective_preagg_count = 0;
             if (_auto_context.pass_through_count == AggrAutoContext::StableLimit) {
                 _auto_state = AggrAutoState::PASS_THROUGH;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::StableLimit << " low reduction "
-                          << agg_count * 1.0 / chunk_size << " "
-                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
-                          << _auto_context.get_auto_state_string(_auto_state);
+                VLOG_ROW << "auto agg: continuous " << AggrAutoContext::StableLimit << " low reduction "
+                         << agg_count * 1.0 / chunk_size << " "
+                         << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
+                         << _auto_context.get_auto_state_string(_auto_state);
             }
 
         } else if (_auto_context.adjust_count < continuous_limit &&
@@ -206,10 +206,10 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             if (_auto_context.preagg_count == AggrAutoContext::StableLimit) {
                 _auto_state = AggrAutoState::PREAGG;
                 _auto_context.preagg_count = 0;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::StableLimit << " high reduction "
-                          << agg_count * 1.0 / chunk_size << " "
-                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
-                          << _auto_context.get_auto_state_string(_auto_state);
+                VLOG_ROW << "auto agg: continuous " << AggrAutoContext::StableLimit << " high reduction "
+                         << agg_count * 1.0 / chunk_size << " "
+                         << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
+                         << _auto_context.get_auto_state_string(_auto_state);
             }
         } else {
             RETURN_IF_ERROR(_push_chunk_by_selective_preaggregation(chunk, chunk_size, false));
@@ -218,9 +218,9 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             _auto_context.preagg_count = 0;
             if (_auto_context.selective_preagg_count == AggrAutoContext::StableLimit) {
                 _auto_state = AggrAutoState::SELECTIVE_PREAGG;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::StableLimit << " "
-                          << _auto_context.get_auto_state_string(AggrAutoState::ADJUST)
-                          << _auto_context.get_auto_state_string(_auto_state);
+                VLOG_ROW << "auto agg: continuous " << AggrAutoContext::StableLimit << " "
+                         << _auto_context.get_auto_state_string(AggrAutoState::ADJUST)
+                         << _auto_context.get_auto_state_string(_auto_state);
             }
         }
         break;
@@ -235,9 +235,9 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             _auto_context.preagg_count = 0;
             _auto_context.adjust_count = 0;
 
-            LOG(INFO) << "auto agg: continuous " << continuous_limit << " "
-                      << _auto_context.get_auto_state_string(AggrAutoState::PASS_THROUGH) << " -> "
-                      << _auto_context.get_auto_state_string(_auto_state);
+            VLOG_ROW << "auto agg: continuous " << continuous_limit << " "
+                     << _auto_context.get_auto_state_string(AggrAutoState::PASS_THROUGH) << " -> "
+                     << _auto_context.get_auto_state_string(_auto_state);
             _auto_context.update_continuous_limit();
         }
         break;
@@ -253,8 +253,8 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             _auto_state = AggrAutoState::ADJUST;
             _auto_context.preagg_count = 0;
             _auto_context.adjust_count = 0;
-            LOG(INFO) << "auto agg: continuous " << AggrAutoContext::PreaggLimit << " " << current_state << " -> "
-                      << _auto_context.get_auto_state_string(_auto_state);
+            VLOG_ROW << "auto agg: continuous " << AggrAutoContext::PreaggLimit << " " << current_state << " -> "
+                     << _auto_context.get_auto_state_string(_auto_state);
         }
         break;
     }
@@ -265,9 +265,9 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             _auto_state = AggrAutoState::ADJUST;
             _auto_context.selective_preagg_count = 0;
             _auto_context.adjust_count = 0;
-            LOG(INFO) << "auto agg: continuous " << continuous_limit << " "
-                      << _auto_context.get_auto_state_string(AggrAutoState::SELECTIVE_PREAGG) << " -> "
-                      << _auto_context.get_auto_state_string(_auto_state);
+            VLOG_ROW << "auto agg: continuous " << continuous_limit << " "
+                     << _auto_context.get_auto_state_string(AggrAutoState::SELECTIVE_PREAGG) << " -> "
+                     << _auto_context.get_auto_state_string(_auto_state);
             _auto_context.update_continuous_limit();
         }
         break;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -127,8 +127,8 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_selective_preaggregation(C
 
 /* A state machine autoly chooses different preaggregation modes. If the initial preaggregation cannot insert
  * more data into hash table, the state shifts from INIT_PREAGG to ADJUST. The ADJUST state has 3 branches:
- * (1) If continuous AggrAutoContext::AdjustLimit chunks are lowly aggregated, shifting to PASS_THROUGH state;
- * (2) Else if continuous AggrAutoContext::AdjustLimit chunks are highly aggregated, shifting to PREAGG state;
+ * (1) If continuous AggrAutoContext::StableLimit chunks are lowly aggregated, shifting to PASS_THROUGH state;
+ * (2) Else if continuous AggrAutoContext::StableLimit chunks are highly aggregated, shifting to PREAGG state;
  * (3) otherwise or the ADJUST state sustains continuous_limit times, shifting to SELECTIVE_PREAGG state.
  *
  * PASS_THROUGH state sustains continuous_limit times, it will force doing preaggregation if the hash table's size <
@@ -187,9 +187,9 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             _auto_context.pass_through_count++;
             _auto_context.preagg_count = 0;
             _auto_context.selective_preagg_count = 0;
-            if (_auto_context.pass_through_count == AggrAutoContext::AdjustLimit) {
+            if (_auto_context.pass_through_count == AggrAutoContext::StableLimit) {
                 _auto_state = AggrAutoState::PASS_THROUGH;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " low reduction "
+                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::StableLimit << " low reduction "
                           << agg_count * 1.0 / chunk_size << " "
                           << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
                           << _auto_context.get_auto_state_string(_auto_state);
@@ -203,10 +203,10 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             _auto_context.preagg_count++;
             _auto_context.pass_through_count = 0;
             _auto_context.selective_preagg_count = 0;
-            if (_auto_context.preagg_count == AggrAutoContext::AdjustLimit) {
+            if (_auto_context.preagg_count == AggrAutoContext::StableLimit) {
                 _auto_state = AggrAutoState::PREAGG;
                 _auto_context.preagg_count = 0;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " high reduction "
+                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::StableLimit << " high reduction "
                           << agg_count * 1.0 / chunk_size << " "
                           << _auto_context.get_auto_state_string(AggrAutoState::ADJUST) << " -> "
                           << _auto_context.get_auto_state_string(_auto_state);
@@ -216,9 +216,9 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(ChunkPtr chunk, const
             _auto_context.selective_preagg_count++;
             _auto_context.pass_through_count = 0;
             _auto_context.preagg_count = 0;
-            if (_auto_context.selective_preagg_count == AggrAutoContext::AdjustLimit) {
+            if (_auto_context.selective_preagg_count == AggrAutoContext::StableLimit) {
                 _auto_state = AggrAutoState::SELECTIVE_PREAGG;
-                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::AdjustLimit << " "
+                LOG(INFO) << "auto agg: continuous " << AggrAutoContext::StableLimit << " "
                           << _auto_context.get_auto_state_string(AggrAutoState::ADJUST)
                           << _auto_context.get_auto_state_string(_auto_state);
             }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -56,6 +56,8 @@ private:
 
     Status _push_chunk_by_auto_new(ChunkPtr chunk, const size_t chunk_size);
 
+    Status _push_chunk_by_selective_preaggregation(const size_t chunk_size, bool need_build);
+
     // It is used to perform aggregation algorithms shared by
     // AggregateStreamingSourceOperator. It is
     // - prepared at SinkOperator::prepare(),

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -25,7 +25,8 @@ public:
     AggregateStreamingSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                                    AggregatorPtr aggregator)
             : Operator(factory, id, "aggregate_streaming_sink", plan_node_id, driver_sequence),
-              _aggregator(std::move(aggregator)) {
+              _aggregator(std::move(aggregator)),
+              _auto_state(AggrAutoState::INIT_BUILD) {
         _aggregator->set_aggr_phase(AggrPhase1);
         _aggregator->ref();
     }
@@ -53,6 +54,8 @@ private:
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::AUTO
     Status _push_chunk_by_auto(ChunkPtr chunk, const size_t chunk_size);
 
+    Status _push_chunk_by_auto_new(ChunkPtr chunk, const size_t chunk_size);
+
     // It is used to perform aggregation algorithms shared by
     // AggregateStreamingSourceOperator. It is
     // - prepared at SinkOperator::prepare(),
@@ -61,6 +64,8 @@ private:
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;
+    AggrAutoState _auto_state;
+    AggrAutoContext _auto_context;
 };
 
 class AggregateStreamingSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -56,7 +56,7 @@ private:
 
     Status _push_chunk_by_auto_new(ChunkPtr chunk, const size_t chunk_size);
 
-    Status _push_chunk_by_selective_preaggregation(const size_t chunk_size, bool need_build);
+    Status _push_chunk_by_selective_preaggregation(ChunkPtr chunk, const size_t chunk_size, bool need_build);
 
     // It is used to perform aggregation algorithms shared by
     // AggregateStreamingSourceOperator. It is

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -54,8 +54,6 @@ private:
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::AUTO
     Status _push_chunk_by_auto(ChunkPtr chunk, const size_t chunk_size);
 
-    Status _push_chunk_by_auto_new(ChunkPtr chunk, const size_t chunk_size);
-
     Status _push_chunk_by_selective_preaggregation(ChunkPtr chunk, const size_t chunk_size, bool need_build);
 
     // It is used to perform aggregation algorithms shared by

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -26,7 +26,7 @@ public:
                                    AggregatorPtr aggregator)
             : Operator(factory, id, "aggregate_streaming_sink", plan_node_id, driver_sequence),
               _aggregator(std::move(aggregator)),
-              _auto_state(AggrAutoState::INIT_BUILD) {
+              _auto_state(AggrAutoState::INIT_PREAGG) {
         _aggregator->set_aggr_phase(AggrPhase1);
         _aggregator->ref();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -225,10 +225,8 @@ public class AggregationNode extends PlanNode {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.FORCE_STREAMING);
         } else if (streamingPreaggregationMode.equalsIgnoreCase("force_preaggregation")) {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.FORCE_PREAGGREGATION);
-        } else if (streamingPreaggregationMode.equalsIgnoreCase("auto_new")) {
-            msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO_NEW);
         } else {
-            msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO_NEW);
+            msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO);
         }
 
         msg.agg_node.setAgg_func_set_version(FeConstants.AGG_FUNC_VERSION);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -225,9 +225,12 @@ public class AggregationNode extends PlanNode {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.FORCE_STREAMING);
         } else if (streamingPreaggregationMode.equalsIgnoreCase("force_preaggregation")) {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.FORCE_PREAGGREGATION);
+        } else if (streamingPreaggregationMode.equalsIgnoreCase("auto_new")) {
+            msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO_NEW);
         } else {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO);
         }
+
         msg.agg_node.setAgg_func_set_version(FeConstants.AGG_FUNC_VERSION);
         msg.agg_node.setInterpolate_passthrough(
                 useStreamingPreagg && ConnectContext.get().getSessionVariable().isInterpolatePassthrough());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -228,7 +228,7 @@ public class AggregationNode extends PlanNode {
         } else if (streamingPreaggregationMode.equalsIgnoreCase("auto_new")) {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO_NEW);
         } else {
-            msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO);
+            msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO_NEW);
         }
 
         msg.agg_node.setAgg_func_set_version(FeConstants.AGG_FUNC_VERSION);

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -470,8 +470,7 @@ struct TEqJoinCondition {
 enum TStreamingPreaggregationMode {
   AUTO,
   FORCE_STREAMING,
-  FORCE_PREAGGREGATION,
-  AUTO_NEW
+  FORCE_PREAGGREGATION
 }
 
 enum TJoinOp {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -470,7 +470,8 @@ struct TEqJoinCondition {
 enum TStreamingPreaggregationMode {
   AUTO,
   FORCE_STREAMING,
-  FORCE_PREAGGREGATION
+  FORCE_PREAGGREGATION,
+  AUTO_NEW
 }
 
 enum TJoinOp {


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

the new auto strategy is shown as a state machine:

![image](https://user-images.githubusercontent.com/6490813/210695872-d51a184f-872f-46f6-b759-7b7c000305c5.png)


```
/* A state machine autoly chooses different preaggregation modes. If the initial preaggregation cannot insert
 * more data into hash table, the state shifts from INIT_PREAGG to ADJUST. The ADJUST state has 3 branches:
 * (1) If continuous AggrAutoContext::AdjustLimit chunks are lowly aggregated, shifting to PASS_THROUGH state;
 * (2) Else if continuous AggrAutoContext::AdjustLimit chunks are highly aggregated, shifting to PREAGG state;
 * (3) otherwise or the ADJUST state sustains continuous_limit times, shifting to SELECTIVE_PREAGG state.
 *
 * PASS_THROUGH state sustains continuous_limit times, it will force doing preaggregation if the hash table's size <
 * MaxHtSize, otherwise it will go to ADJUST state. Doing FORCE_PREAGG aims freshening the hash table with new coming
 * rows, helping to aggregating new coming chunks with limiting the size of hash table.
 *
 * FORCE_PREAGG/PREAGG state aggregates AggrAutoContext::PreaggLimit chunks, then going to ADJUST state. PreaggLimit
 * should be small enough to limit the size of hash table.
 *
 * SELECTIVE_PREAGG state aggregates continuous_limit chunks, then shifting to ADJUST state.
 */
(force_preagg is enabled when pass_through > C_LIMIT)
C_LIMIT : continuous_limit
P_LIMIT : preaggregation_limit

```


### results:
auto_new is more efficient than auto, and near to force_streaming.
besides, [TPCDS-10t reduces 100s, without effects on other benchmark(tpch/tpcds-1t)](https://starrocks.feishu.cn/sheets/shtcnrRwymB5DqGR5iypQ2HOY7m).

```
mysql> set pipeline_dop = 16;
Query OK, 0 rows affected (0.01 sec)

mysql> set streaming_preaggregation_mode = auto;
Query OK, 0 rows affected (0.00 sec)

mysql> select max(csales) tpcds_cmax from ( select ss_customer_sk,sum(ss_quantity*ss_sales_price) csales from store_sales where ss_customer_sk is not null  group by ss_customer_sk ) t1;
+-------------+
| tpcds_cmax  |
+-------------+
| 12959806.59 |
+-------------+
1 row in set (1 min 24.23 sec)

mysql> set streaming_preaggregation_mode = auto_new;
Query OK, 0 rows affected (0.00 sec)

mysql> select max(csales) tpcds_cmax from ( select ss_customer_sk,sum(ss_quantity*ss_sales_price) csales from store_sales where ss_customer_sk is not null  group by ss_customer_sk ) t1;
+-------------+
| tpcds_cmax  |
+-------------+
| 12959806.59 |
+-------------+
1 row in set (1 min 9.89 sec)

mysql> set streaming_preaggregation_mode = force_streaming;
Query OK, 0 rows affected (0.01 sec)

mysql> select max(csales) tpcds_cmax from ( select ss_customer_sk,sum(ss_quantity*ss_sales_price) csales from store_sales where ss_customer_sk is not null  group by ss_customer_sk ) t1;
+-------------+
| tpcds_cmax  |
+-------------+
| 12959806.59 |
+-------------+
1 row in set (1 min 9.80 sec)

mysql> set new_planner_agg_stage = 1;
Query OK, 0 rows affected (0.00 sec)

mysql> select max(csales) tpcds_cmax from ( select ss_customer_sk,sum(ss_quantity*ss_sales_price) csales from store_sales where ss_customer_sk is not null  group by ss_customer_sk ) t1;
+-------------+
| tpcds_cmax  |
+-------------+
| 12959806.59 |
+-------------+
1 row in set (57.63 sec)
```


## Checklist:

- [x] I have added test cases for my bug fix or my new feature (manually test on benchmark tpch/tpcds)
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
