### PR TITLE
[BugFix] Fix replicated storage load deadlock when large tablets has no data

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -211,13 +211,12 @@ void LoadChannel::abort() {
     }
 }
 
-void LoadChannel::abort(int64_t index_id, int64_t tablet_id) {
-    std::lock_guard l(_lock);
-    auto it = _tablets_channels.find(index_id);
-    if (it != _tablets_channels.end()) {
-        auto local_tablets_channel = down_cast<LocalTabletsChannel*>(it->second.get());
+void LoadChannel::abort(int64_t index_id, const std::vector<int64_t>& tablet_ids) {
+    auto channel = get_tablets_channel(index_id);
+    if (channel != nullptr) {
+        auto local_tablets_channel = down_cast<LocalTabletsChannel*>(channel.get());
         if (local_tablets_channel != nullptr) {
-            local_tablets_channel->abort(tablet_id);
+            local_tablets_channel->abort(tablet_ids);
         }
     }
 }

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -92,7 +92,7 @@ public:
 
     void abort();
 
-    void abort(int64_t index_id, int64_t tablet_id);
+    void abort(int64_t index_id, const std::vector<int64_t>& tablet_ids);
 
     time_t last_updated_time() const { return _last_updated_time.load(std::memory_order_relaxed); }
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -163,8 +163,16 @@ void LoadChannelMgr::cancel(brpc::Controller* cntl, const PTabletWriterCancelReq
     if (request.has_tablet_id()) {
         auto channel = _find_load_channel(load_id);
         if (channel != nullptr) {
-            channel->cancel();
-            channel->abort(request.index_id(), request.tablet_id());
+            channel->abort(request.index_id(), {request.tablet_id()});
+        }
+    } else if (request.tablet_ids_size() > 0) {
+        auto channel = _find_load_channel(load_id);
+        if (channel != nullptr) {
+            std::vector<int64_t> tablet_ids;
+            for (auto& tablet_id : request.tablet_ids()) {
+                tablet_ids.emplace_back(tablet_id);
+            }
+            channel->abort(request.index_id(), tablet_ids);
         }
     } else {
         if (auto channel = remove_load_channel(load_id); channel != nullptr) {

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -43,6 +43,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/txn_manager.h"
+#include "util/brpc_stub_cache.h"
 #include "util/compression/block_compression.h"
 #include "util/faststring.h"
 #include "util/starrocks_metrics.h"
@@ -146,7 +147,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
                 return;
             } else {
                 // already success
-                LOG(INFO) << "packet_seq " << request.packet_seq()
+                LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
+                          << " packet_seq " << request.packet_seq()
                           << " in PTabletWriterAddChunkRequest already success";
                 response->mutable_status()->set_status_code(TStatusCode::OK);
                 return;
@@ -154,7 +156,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         } else {
             // receive packet before sliding window
             if (request.packet_seq() <= _senders[request.sender_id()].last_sliding_packet_seq) {
-                LOG(INFO) << "packet_seq " << request.packet_seq()
+                LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
+                          << " packet_seq " << request.packet_seq()
                           << " in PTabletWriterAddChunkRequest less than last success packet_seq "
                           << _senders[request.sender_id()].last_sliding_packet_seq;
                 response->mutable_status()->set_status_code(TStatusCode::OK);
@@ -226,30 +229,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     // be executed ahead of the write requests submitted by other senders.
     if (request.eos() && _close_sender(request.partition_ids().data(), request.partition_ids_size()) == 0) {
         close_channel = true;
-        std::stringstream commit_tablets;
-        commit_tablets << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
-                       << " commit tablets: ";
-        std::stringstream abort_tablets;
-        abort_tablets << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
-                      << " abort tablets: ";
-        std::lock_guard l1(_partitions_ids_lock);
-        for (auto& [tablet_id, delta_writer] : _delta_writers) {
-            (void)tablet_id;
-            // Secondary replica will commit by Primary replica
-            if (delta_writer->replica_state() != Secondary) {
-                if (UNLIKELY(_partition_ids.count(delta_writer->partition_id()) == 0)) {
-                    // no data load, abort txn without printing log
-                    delta_writer->abort(false);
-                    abort_tablets << tablet_id << ", ";
-                } else {
-                    auto cb = new WriteCallback(context);
-                    delta_writer->commit(cb);
-                    commit_tablets << tablet_id << ", ";
-                }
-            }
-        }
-        LOG(INFO) << commit_tablets.str();
-        LOG(INFO) << abort_tablets.str();
+        _commit_tablets(request, context);
     }
 
     // Must reset the context pointer before waiting on the |count_down_latch|,
@@ -279,14 +259,16 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
                     auto t1 = std::chrono::steady_clock::now();
                     if (std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000 >
                         request.timeout_ms()) {
-                        LOG(INFO) << "wait tablet " << tablet_id << " secondary replica finish timeout "
+                        LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
+                                  << " wait tablet " << tablet_id << " secondary replica finish timeout "
                                   << request.timeout_ms() << "ms still in state " << state;
                         timeout = true;
                         break;
                     }
 
                     if (i % 6000 == 0) {
-                        LOG(INFO) << "wait tablet " << tablet_id << " secondary replica finish already "
+                        LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
+                                  << " wait tablet " << tablet_id << " secondary replica finish already "
                                   << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000
                                   << "ms still in state " << state;
                     }
@@ -338,6 +320,73 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     response->set_execution_time_us(last_execution_time_us +
                                     std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
     response->set_wait_lock_time_us(0); // We didn't measure the lock wait time, just give the caller a fake time
+}
+
+void LocalTabletsChannel::_commit_tablets(const PTabletWriterAddChunkRequest& request,
+                                          std::shared_ptr<LocalTabletsChannel::WriteContext> context) {
+    vector<int64_t> commit_tablet_ids;
+    std::unordered_map<int64_t, std::vector<int64_t>> node_id_to_abort_tablets;
+    {
+        std::lock_guard l1(_partitions_ids_lock);
+        for (auto& [tablet_id, delta_writer] : _delta_writers) {
+            // Secondary replica will commit/abort by Primary replica
+            if (delta_writer->replica_state() != Secondary) {
+                if (UNLIKELY(_partition_ids.count(delta_writer->partition_id()) == 0)) {
+                    // no data load, abort txn without printing log
+                    delta_writer->abort(false);
+
+                    // secondary replicas need abort by primary replica
+                    if (_is_replicated_storage) {
+                        auto& replicas = delta_writer->replicas();
+                        for (int i = 1; i < replicas.size(); ++i) {
+                            node_id_to_abort_tablets[replicas[i].node_id()].emplace_back(tablet_id);
+                        }
+                    }
+                } else {
+                    auto cb = new WriteCallback(context);
+                    delta_writer->commit(cb);
+                    commit_tablet_ids.emplace_back(tablet_id);
+                }
+            }
+        }
+    }
+    string commit_tablet_id_list_str;
+    JoinInts(commit_tablet_ids, ",", &commit_tablet_id_list_str);
+    LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id()) << " commit "
+              << commit_tablet_ids.size() << " tablets: " << commit_tablet_id_list_str;
+
+    // abort seconary replicas located on other nodes
+    for (auto& [node_id, tablet_ids] : node_id_to_abort_tablets) {
+        auto& endpoint = _node_id_to_endpoint[node_id];
+        auto stub = ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(endpoint.host(), endpoint.port());
+        if (stub == nullptr) {
+            auto msg =
+                    fmt::format("Failed to Connect node {} {}:{} failed.", node_id, endpoint.host(), endpoint.port());
+            LOG(WARNING) << msg;
+            continue;
+        }
+
+        PTabletWriterCancelRequest cancel_request;
+        *cancel_request.mutable_id() = request.id();
+        cancel_request.set_sender_id(0);
+        cancel_request.mutable_tablet_ids()->CopyFrom({tablet_ids.begin(), tablet_ids.end()});
+        cancel_request.set_txn_id(_txn_id);
+        cancel_request.set_index_id(_index_id);
+
+        auto closure = new ReusableClosure<PTabletWriterCancelResult>();
+
+        closure->ref();
+        closure->cntl.set_timeout_ms(request.timeout_ms());
+
+        string node_abort_tablet_id_list_str;
+        JoinInts(tablet_ids, ",", &node_abort_tablet_id_list_str);
+
+        stub->tablet_writer_cancel(&closure->cntl, &cancel_request, &closure->result, closure);
+
+        VLOG(1) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id()) << " Cancel "
+                << tablet_ids.size() << " tablets " << node_abort_tablet_id_list_str << " request to "
+                << endpoint.host() << ":" << endpoint.port();
+    }
 }
 
 int LocalTabletsChannel::_close_sender(const int64_t* partitions, size_t partitions_size) {
@@ -400,6 +449,9 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);
+                if (_node_id_to_endpoint.count(replica.node_id()) == 0) {
+                    _node_id_to_endpoint[replica.node_id()] = replica;
+                }
             }
             if (options.replicas.size() > 0 && options.replicas[0].node_id() == options.node_id) {
                 options.replica_state = Primary;
@@ -464,11 +516,17 @@ void LocalTabletsChannel::abort() {
               << " tablet_ids:" << tablet_id_list_str;
 }
 
-void LocalTabletsChannel::abort(int64_t tablet_id) {
-    auto it = _delta_writers.find(tablet_id);
-    if (it != _delta_writers.end()) {
-        it->second->abort(true);
+void LocalTabletsChannel::abort(const std::vector<int64_t>& tablet_ids) {
+    for (auto tablet_id : tablet_ids) {
+        auto it = _delta_writers.find(tablet_id);
+        if (it != _delta_writers.end()) {
+            it->second->abort(true);
+        }
     }
+    string tablet_id_list_str;
+    JoinInts(tablet_ids, ",", &tablet_id_list_str);
+    LOG(INFO) << "cancel LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << _key.id
+              << " index_id: " << _key.index_id << " tablet_ids:" << tablet_id_list_str;
 }
 
 StatusOr<std::shared_ptr<LocalTabletsChannel::WriteContext>> LocalTabletsChannel::_create_write_context(

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -56,7 +56,7 @@ public:
 
     void abort() override;
 
-    void abort(int64_t tablet_id);
+    void abort(const std::vector<int64_t>& tablet_ids);
 
     MemTracker* mem_tracker() { return _mem_tracker; }
 
@@ -153,6 +153,9 @@ private:
 
     int _close_sender(const int64_t* partitions, size_t partitions_size);
 
+    void _commit_tablets(const PTabletWriterAddChunkRequest& request,
+                         std::shared_ptr<LocalTabletsChannel::WriteContext> context);
+
     LoadChannel* _load_channel;
 
     TabletsChannelKey _key;
@@ -182,6 +185,8 @@ private:
     std::unique_ptr<MemPool> _mem_pool;
 
     bool _is_replicated_storage = false;
+
+    std::unordered_map<int64_t, PNetworkAddress> _node_id_to_endpoint;
 };
 
 std::shared_ptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -92,9 +92,11 @@ Status AsyncDeltaWriter::_init() {
     if (int r = bthread::execution_queue_start(&_queue_id, &opts, _execute, _writer.get()); r != 0) {
         return Status::InternalError(fmt::format("fail to create bthread execution queue: {}", r));
     }
-    _segment_flush_executor = StorageEngine::instance()->segment_flush_executor()->create_flush_token(_writer);
-    if (_segment_flush_executor == nullptr) {
-        return Status::InternalError("SegmentFlushExecutor init failed");
+    if (replica_state() == Secondary) {
+        _segment_flush_executor = StorageEngine::instance()->segment_flush_executor()->create_flush_token(_writer);
+        if (_segment_flush_executor == nullptr) {
+            return Status::InternalError("SegmentFlushExecutor init failed");
+        }
     }
     return Status::OK();
 }

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -88,6 +88,8 @@ public:
 
     State get_state() const { return _writer->get_state(); }
 
+    const std::vector<PNetworkAddress>& replicas() const { return _writer->replicas(); }
+
 private:
     struct private_type {
         explicit private_type(int) {}

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -334,6 +334,8 @@ Status DeltaWriter::write_segment(const SegmentPB& segment_pb, butil::IOBuf& dat
                                                  segment_pb.segment_id(), _opt.tablet_id,
                                                  _replica_state_name(_replica_state)));
     }
+    VLOG(1) << "Flush segment tablet " << _opt.tablet_id << " segment id " << segment_pb.segment_id();
+
     return _rowset_writer->flush_segment(segment_pb, data);
 }
 
@@ -517,7 +519,9 @@ void DeltaWriter::abort(bool with_log) {
     if (_replicate_token != nullptr) {
         _replicate_token->cancel();
     }
-    VLOG(1) << "Aborted delta writer. tablet_id: " << _tablet->tablet_id();
+
+    VLOG(1) << "Aborted delta writer. tablet_id: " << _tablet->tablet_id() << " txn_id: " << _opt.txn_id
+            << " load_id: " << print_id(_opt.load_id);
 }
 
 int64_t DeltaWriter::partition_id() const {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -18,6 +18,7 @@
 #include "column/vectorized_fwd.h"
 #include "common/tracer.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "gen_cpp/olap_common.pb.h"
 #include "gutil/macros.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/segment_flush_executor.h"
@@ -114,6 +115,8 @@ public:
     int64_t partition_id() const;
 
     int64_t node_id() const { return _opt.node_id; }
+
+    const std::vector<PNetworkAddress>& replicas() const { return _opt.replicas; }
 
     const Tablet* tablet() const { return _tablet.get(); }
 

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -106,6 +106,9 @@ Status ReplicateChannel::async_segment(SegmentPB* segment, butil::IOBuf& data, b
                                        std::vector<std::unique_ptr<PTabletInfo>>* failed_tablet_infos) {
     RETURN_IF_ERROR(_st);
 
+    VLOG(1) << "Async tablet " << _opt->tablet_id << " segment id " << (segment == nullptr ? -1 : segment->segment_id())
+            << " eos " << eos << " to [" << _host << ":" << _port;
+
     // 1. init sync channel
     _st = _init();
     RETURN_IF_ERROR(_st);
@@ -121,8 +124,9 @@ Status ReplicateChannel::async_segment(SegmentPB* segment, butil::IOBuf& data, b
         RETURN_IF_ERROR(_wait_response(replicate_tablet_infos, failed_tablet_infos));
     }
 
-    VLOG(1) << "Async tablet " << _opt->tablet_id << " segment id " << (segment == nullptr ? -1 : segment->segment_id())
-            << " eos " << eos << " to [" << _host << ":" << _port << "] res " << _closure->result.DebugString();
+    VLOG(1) << "Asynced tablet " << _opt->tablet_id << " segment id "
+            << (segment == nullptr ? -1 : segment->segment_id()) << " eos " << eos << " to [" << _host << ":" << _port
+            << "] res " << _closure->result.DebugString();
 
     return _st;
 }
@@ -188,22 +192,6 @@ void ReplicateChannel::cancel() {
     // cancel rpc request, accelerate the release of related resources
     // Cancel an already-cancelled call_id has no effect.
     _closure->cancel();
-
-    PTabletWriterCancelRequest request;
-    request.set_allocated_id(const_cast<starrocks::PUniqueId*>(&_opt->load_id));
-    request.set_sender_id(0);
-    request.set_tablet_id(_opt->tablet_id);
-    request.set_txn_id(_opt->txn_id);
-    request.set_index_id(_opt->index_id);
-
-    auto closure = new ReusableClosure<PTabletWriterCancelResult>();
-
-    closure->ref();
-    closure->cntl.set_timeout_ms(_opt->timeout_ms);
-    _stub->tablet_writer_cancel(&closure->cntl, &request, &closure->result, closure);
-    request.release_id();
-
-    VLOG(1) << "Cancel request " << debug_string();
 }
 
 ReplicateToken::ReplicateToken(std::unique_ptr<ThreadPoolToken> replicate_pool_token, const DeltaWriterOptions* opt)

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -248,6 +248,7 @@ message PTabletWriterCancelRequest {
     required int32 sender_id = 3;
     optional int64 txn_id = 4;
     optional int64 tablet_id = 5;
+    repeated int64 tablet_ids = 6;
 };
 
 message PTabletWriterCancelResult {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15961

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. fix replicated storage abort deadlock since large tablets has no data
2. optimize abort performance by merge all abort requests sent to a node into one request

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
