### PR TITLE
[BugFix] Fix be crash because of dropping tablet

### DIFF
--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -351,4 +351,3 @@ struct hash<starrocks::TabletSegmentId> {
     }
 };
 } // namespace std
-       

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -305,6 +305,8 @@ struct RowsetId {
         }
     }
 
+    int64_t id() { return hi & LOW_56_BITS; }
+
     // std::unordered_map need this api
     bool operator==(const RowsetId& rhs) const { return hi == rhs.hi && mi == rhs.mi && lo == rhs.lo; }
 
@@ -349,3 +351,4 @@ struct hash<starrocks::TabletSegmentId> {
     }
 };
 } // namespace std
+       

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -290,6 +290,8 @@ public:
         }
     }
 
+    uint64_t refs_by_reader() { return _refs_by_reader; }
+
     static StatusOr<size_t> get_segment_num(const std::vector<RowsetSharedPtr>& rowsets) {
         size_t num_segments = 0;
         for (const auto& rowset : rowsets) {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -875,6 +875,15 @@ Status TabletManager::start_trash_sweep() {
             continue;
         }
 
+        if (tablet->updates() != nullptr) {
+            Status st = tablet->updates()->check_and_remove_rowset();
+            if (!st.ok()) {
+                LOG(WARNING) << "there are some rowsets still been referenced, drop tablet: " << tablet->tablet_id()
+                             << " later";
+                continue;
+            }
+        }
+
         bool remove_meta = false;
         TabletMeta tablet_meta;
         Status st = TabletMetaManager::get_tablet_meta(tablet->data_dir(), tablet->tablet_id(), tablet->schema_hash(),

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1457,7 +1457,6 @@ Status TabletManager::_move_tablet_directories_to_trash(const TabletSharedPtr& t
     if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
         RETURN_IF_ERROR(SnapshotManager::instance()->make_snapshot_on_tablet_meta(tablet));
     } else {
-        auto meta_file_path = fmt::format("{}/{}.hdr", tablet->schema_hash_path(), tablet->tablet_id());
         tablet->tablet_meta()->save(meta_file_path);
     }
     // move tablet directories to ${storage_root_path}/trash

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1457,6 +1457,7 @@ Status TabletManager::_move_tablet_directories_to_trash(const TabletSharedPtr& t
     if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
         RETURN_IF_ERROR(SnapshotManager::instance()->make_snapshot_on_tablet_meta(tablet));
     } else {
+        auto meta_file_path = fmt::format("{}/{}.hdr", tablet->schema_hash_path(), tablet->tablet_id());
         tablet->tablet_meta()->save(meta_file_path);
     }
     // move tablet directories to ${storage_root_path}/trash

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3279,7 +3279,6 @@ Status TabletUpdates::clear_meta() {
     }
     // Clear cached primary index.
     StorageEngine::instance()->update_manager()->index_cache().remove_by_key(_tablet.tablet_id());
-    _unused_rowsets.clear();
     STLClearObject(&_rowsets);
     STLClearObject(&_rowset_stats);
     // If this get cleared, every other thread that uses variable should recheck it's valid state after acquiring _lock

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2986,7 +2986,7 @@ Status TabletUpdates::check_and_remove_rowset() {
     if (!_unused_rowsets.empty()) {
         std::string msg =
                 strings::Substitute("some rowsets of tablet: $0 are still been referenced", _tablet.tablet_id());
-        LOG(WARNING) << "msg";
+        LOG(WARNING) << msg;
         return Status::InternalError(msg);
     }
     return Status::OK();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2982,7 +2982,6 @@ void TabletUpdates::_remove_unused_rowsets(bool drop_tablet) {
 }
 
 Status TabletUpdates::check_and_remove_rowset() {
-    std::lock_guard l1(_lock);
     _remove_unused_rowsets(true);
     if (!_unused_rowsets.empty()) {
         std::string msg =

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3234,7 +3234,6 @@ Status TabletUpdates::clear_meta() {
     // TODO: tablet is already marked to be deleted, so maybe don't need to clear unused rowsets here
     _remove_unused_rowsets();
     if (_unused_rowsets.get_size() != 0) {
-        //return Status::InternalError("some unused rowset cannot be removed");
         LOG(WARNING) << "_unused_rowsets is not empty, size: " << _unused_rowsets.get_size()
                      << " version_info: " << _debug_version_info(false);
     }

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -257,6 +257,8 @@ public:
     void to_rowset_meta_pb(const std::vector<RowsetMetaSharedPtr>& rowset_metas,
                            std::vector<RowsetMetaPB>& rowset_metas_pb);
 
+    Status check_and_remove_rowset();
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -353,7 +355,7 @@ private:
     Status _load_from_pb(const TabletUpdatesPB& updates);
 
     // thread-safe
-    void _remove_unused_rowsets();
+    void _remove_unused_rowsets(bool drop_tablet = false);
 
     // REQUIRE: |_lock| is held.
     void _to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const;

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -216,6 +216,11 @@ public:
         return _items.empty();
     }
 
+    void clear() {
+        std::lock_guard<Lock> l(_lock);
+        _items.clear();   
+    }
+
 protected:
     const size_t _capacity;
 

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -216,11 +216,6 @@ public:
         return _items.empty();
     }
 
-    void clear() {
-        std::lock_guard<Lock> l(_lock);
-        _items.clear();   
-    }
-
 protected:
     const size_t _capacity;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/15957

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When we try to drop tablet(by manual or after schema change), we will try to close expired rowsets before clear tablet meta if tablet is primary key table. And if expired rowsets are still been reference by other threads, close will fail and be will crash.

Anyway, if expired rowsets are still been referenced by other threads when we try to drop tablet, crash is not necessary and output some error log is enough, the expired rowsets will be close after release.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
