### PR TITLE
[Enhancement] segment replicate executor support fast cancel

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -61,7 +61,7 @@ DeltaWriter::~DeltaWriter() {
         _flush_token->shutdown();
     }
     if (_replicate_token != nullptr) {
-        _replicate_token->cancel();
+        _replicate_token->shutdown();
     }
     switch (get_state()) {
     case kUninitialized:
@@ -504,6 +504,9 @@ void DeltaWriter::cancel(const Status& st) {
     if (_flush_token != nullptr) {
         _flush_token->cancel(st);
     }
+    if (_replicate_token != nullptr) {
+        _replicate_token->cancel(st);
+    }
 }
 
 void DeltaWriter::abort(bool with_log) {
@@ -515,7 +518,7 @@ void DeltaWriter::abort(bool with_log) {
         _flush_token->shutdown();
     }
     if (_replicate_token != nullptr) {
-        _replicate_token->cancel();
+        _replicate_token->shutdown();
     }
     VLOG(1) << "Aborted delta writer. tablet_id: " << _tablet->tablet_id();
 }

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -231,10 +231,14 @@ Status ReplicateToken::submit(std::unique_ptr<SegmentPB> segment, bool eos) {
     return _replicate_token->submit(std::move(task));
 }
 
-void ReplicateToken::cancel() {
+void ReplicateToken::cancel(const Status& st) {
     for (auto& channel : _replicate_channels) {
         channel->cancel();
     }
+    set_status(st);
+}
+
+void ReplicateToken::shutdown() {
     _replicate_token->shutdown();
 }
 

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -83,7 +83,9 @@ public:
 
     // when error has happpens, so we cancel this token
     // and remove all tasks in the queue.
-    void cancel();
+    void cancel(const Status& st);
+
+    void shutdown();
 
     // wait all tasks in token to be completed.
     Status wait();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15513 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Make cancel non-blocking, otherwise once it gets stuck due to `flush slow` or network reasons, it will block the `cancel` of  other `DeltaWriter`;

Same as https://github.com/StarRocks/starrocks/pull/15514

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
