### PR TITLE
[UT] Fix metrics coredump

### DIFF
--- a/be/test/http/metrics_action_test.cpp
+++ b/be/test/http/metrics_action_test.cpp
@@ -46,6 +46,10 @@
 
 namespace starrocks {
 
+#ifdef USE_STAROS
+extern bool sDisableStarOSMetrics;
+#endif
+
 // Mock part
 const char* s_expect_response = nullptr;
 
@@ -60,12 +64,15 @@ public:
     void SetUp() override {
         _evhttp_req = evhttp_request_new(nullptr, nullptr);
 #ifdef USE_STAROS
-        // clear staros metrics to avoid confusing the test result.
-        staros::starlet::metrics::MetricsSystem::instance()->clear();
+        // disable staros metrics output to avoid confusing the test result.
+        sDisableStarOSMetrics = true;
 #endif
     }
 
     void TearDown() override {
+#ifdef USE_STAROS
+        sDisableStarOSMetrics = false;
+#endif
         if (_evhttp_req != nullptr) {
             evhttp_request_free(_evhttp_req);
         }


### PR DESCRIPTION
* don't clear staros metrics registry, which will cause SEGV, provide a flag to disable it temporarily if needed in UT mode.

Signed-off-by: Kevin Xiaohua Cai <caixiaohua@starrocks.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
