### PR TITLE
[Enhancement] [cherry-pick] load support fast cancel (#15514)

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -85,6 +85,13 @@ void LoadChannel::cancel() {
     }
 }
 
+void LoadChannel::abort() {
+    std::lock_guard l(_lock);
+    for (auto& it : _tablets_channels) {
+        it.second->abort();
+    }
+}
+
 void LoadChannel::remove_tablets_channel(int64_t index_id) {
     std::unique_lock l(_lock);
     _tablets_channels.erase(index_id);

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -72,6 +72,8 @@ public:
 
     void cancel();
 
+    void abort();
+
     time_t last_updated_time() const { return _last_updated_time.load(std::memory_order_relaxed); }
 
     const UniqueId& load_id() const { return _load_id; }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -124,6 +124,7 @@ void LoadChannelMgr::cancel(brpc::Controller* cntl, const PTabletWriterCancelReq
     UniqueId load_id(request.id());
     if (auto channel = remove_load_channel(load_id); channel != nullptr) {
         channel->cancel();
+        channel->abort();
     }
 }
 
@@ -168,6 +169,9 @@ Status LoadChannelMgr::_start_load_channels_clean() {
     // eg: MemTracker in load channel
     for (auto& channel : timeout_channels) {
         channel->cancel();
+    }
+    for (auto& channel : timeout_channels) {
+        channel->abort();
         LOG(INFO) << "Deleted timeout channel. load id=" << channel->load_id() << " timeout=" << channel->timeout();
     }
 

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -328,6 +328,12 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
 
 void LocalTabletsChannel::cancel() {
     for (auto& it : _delta_writers) {
+        it.second->cancel(Status::Cancelled("cancel"));
+    }
+}
+
+void LocalTabletsChannel::abort() {
+    for (auto& it : _delta_writers) {
         (void)it.second->abort();
     }
 }

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -58,6 +58,8 @@ public:
 
     void cancel() override;
 
+    void abort() override;
+
     MemTracker* mem_tracker() { return _mem_tracker; }
 
 private:

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -35,6 +35,8 @@ public:
 
     virtual void cancel() = 0;
 
+    virtual void abort() = 0;
+
 private:
     friend class RefCountedThreadSafe<TabletsChannel>;
     friend class LocalTabletsChannel;

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -106,13 +106,16 @@ void AsyncDeltaWriter::commit(AsyncDeltaWriterCallback* cb) {
     }
 }
 
+void AsyncDeltaWriter::cancel(const Status& st) {
+    _writer->cancel(st);
+}
+
 void AsyncDeltaWriter::abort(bool with_log) {
     Task task;
     task.abort = true;
     task.abort_with_log = with_log;
 
     bthread::TaskOptions options;
-    options.high_priority = true;
     int r = bthread::execution_queue_execute(_queue_id, task, &options);
     LOG_IF(WARNING, r != 0) << "Fail to execution_queue_execute: " << r;
 

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -54,6 +54,8 @@ public:
     // [thread-safe and wait-free]
     void abort(bool with_log = true);
 
+    void cancel(const Status& st);
+
     int64_t partition_id() const { return _writer->partition_id(); }
 
 private:

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -55,6 +55,8 @@ public:
     // [NOT thread-safe]
     [[nodiscard]] Status close();
 
+    void cancel(const Status& st);
+
     // Wait until all data have been flushed to disk, then create a new Rowset.
     // Prerequite: the DeltaWriter has been successfully `close()`d.
     // [NOT thread-safe]

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -63,8 +63,16 @@ Status FlushToken::submit(std::unique_ptr<vectorized::MemTable> memtable) {
     return _flush_token->submit(std::move(task));
 }
 
-void FlushToken::cancel() {
+void FlushToken::shutdown() {
     _flush_token->shutdown();
+}
+
+void FlushToken::cancel(const Status& st) {
+    if (st.ok()) return;
+    std::lock_guard l(_status_lock);
+    if (_status.ok()) {
+        _status = st;
+    }
 }
 
 Status FlushToken::wait() {

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -66,7 +66,9 @@ public:
 
     // error has happpens, so we cancel this token
     // And remove all tasks in the queue.
-    void cancel();
+    void shutdown();
+
+    void cancel(const Status& st);
 
     // wait all tasks in token to be completed.
     Status wait();


### PR DESCRIPTION
If the load task times out or the user terminates early, the resources used by load cannot be released immediately. So we need to support FastCancel and release resources as soon as possible.
This is the first pr: Modify the implement of cancel, only set status, will not be blocked by I/O, queue or other behavior.
