### PR TITLE
[Enhancement] optimize json parser

### DIFF
--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -146,6 +146,7 @@ public:
     bool is_slot_exist(SlotId id) const { return _slot_id_to_index.contains(id); }
     bool is_tuple_exist(TupleId id) const { return _tuple_id_to_index.contains(id); }
     void reset_slot_id_to_index() { _slot_id_to_index.clear(); }
+    size_t get_index_by_slot_id(SlotId slot_id) { return _slot_id_to_index[slot_id]; }
 
     void set_columns(const Columns& columns) { _columns = columns; }
 

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -81,6 +81,7 @@ StatusOr<ChunkPtr> JsonScanner::get_next() {
     SCOPED_RAW_TIMER(&_counter->total_ns);
     ChunkPtr src_chunk;
     RETURN_IF_ERROR(_create_src_chunk(&src_chunk));
+    src_chunk->reserve(_max_chunk_size);
 
     if (_cur_file_eof) {
         RETURN_IF_ERROR(_open_next_reader());
@@ -327,15 +328,21 @@ JsonReader::JsonReader(starrocks::RuntimeState* state, starrocks::ScannerCounter
           _scanner(scanner),
           _strict_mode(strict_mode),
           _file(std::move(file)),
-          _slot_descs(std::move(slot_descs)) {
+          _slot_descs(std::move(slot_descs)),
+          _op_col_index(-1) {
 #if BE_TEST
     raw::RawVector<char> buf(_buf_size);
     std::swap(buf, _buf);
 #endif
+    int index = 0;
     for (const auto& desc : _slot_descs) {
         if (desc == nullptr) {
             continue;
         }
+        if (UNLIKELY(desc->col_name() == "__op")) {
+            _op_col_index = index;
+        }
+        index++;
         _slot_desc_dict.emplace(desc->col_name(), desc);
     }
 }
@@ -493,31 +500,78 @@ Status JsonReader::_read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_
 }
 
 Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* row, Chunk* chunk) {
-    std::unordered_map<std::string_view, SlotDescriptor*> slot_desc_dict(_slot_desc_dict);
+    _parsed_columns.assign(chunk->num_columns(), false);
 
     try {
-        std::ostringstream oss;
+        uint32_t key_index = 0;
         for (auto field : *row) {
+            int column_index;
             std::string_view key = field.unescaped_key();
 
-            // look up key in the slot dict.
-            auto itr = slot_desc_dict.find(key);
-            if (itr == slot_desc_dict.end()) {
-                continue;
+            // _prev_parsed_position records the chunk column index for each key of previous parsed json object.
+            // For example, if previous json object is
+            // {
+            //      'a':1,
+            //      'b':2,
+            // }
+            // and key 'a' refers to the 1st column of chunk, key 'b' refers to the 2nd column of chunk,
+            // then _prev_parsed_position is [ {'a', 1, int}, {'b', 2, int}].
+            // At this time, suppose the next parsed json object is
+            // {
+            //      'a':10,
+            //      'b':15,
+            //      'c':25
+            // }
+            // through the _prev_parsed_position, we can know that the column index for 'a' is 1, and the column
+            // index for 'b' is 2. Since previous parsed json object doesn't contain 'c', key 'c' 's column index
+            // needs to be searched from the _slot_desc_dict, and if the key 'c' refers to the 3rd column of chunk,
+            // then we will update the _prev_parsed_position to be [{'a', 1, int}, {'b', 2, int}, {'c', 3, int}].
+            if (LIKELY(_prev_parsed_position.size() > key_index && _prev_parsed_position[key_index].key == key)) {
+                // obtain column_index from previous parsed position
+                column_index = _prev_parsed_position[key_index].column_index;
+                if (column_index < 0) {
+                    // column_index < 0 means key is not in the slot dict, and we will skip this field
+                    key_index++;
+                    continue;
+                }
+            } else {
+                // look up key in the slot dict.
+                auto itr = _slot_desc_dict.find(key);
+                if (itr == _slot_desc_dict.end()) {
+                    // parsed key of the json object is not in the slot dict, and we will skip this field
+                    if (_prev_parsed_position.size() <= key_index) {
+                        _prev_parsed_position.emplace_back(key);
+                    } else {
+                        _prev_parsed_position[key_index].key = key;
+                        _prev_parsed_position[key_index].column_index = -1;
+                    }
+                    key_index++;
+                    continue;
+                }
+
+                auto slot_desc = itr->second;
+
+                // update the prev parsed position
+                column_index = chunk->get_index_by_slot_id(slot_desc->id());
+                if (_prev_parsed_position.size() <= key_index) {
+                    _prev_parsed_position.emplace_back(key, column_index, slot_desc->type());
+                } else {
+                    _prev_parsed_position[key_index].key = key;
+                    _prev_parsed_position[key_index].column_index = column_index;
+                    _prev_parsed_position[key_index].type = slot_desc->type();
+                }
             }
 
-            auto slot_desc = itr->second;
-
-            auto column = chunk->get_column_by_slot_id(slot_desc->id());
-            const auto& col_name = slot_desc->col_name();
-
+            DCHECK(column_index >= 0);
+            _parsed_columns[column_index] = true;
+            auto& column = chunk->get_column_by_index(column_index);
             simdjson::ondemand::value val = field.value();
 
             // construct column with value.
-            RETURN_IF_ERROR(_construct_column(val, column.get(), slot_desc->type(), col_name));
+            RETURN_IF_ERROR(_construct_column(val, column.get(), _prev_parsed_position[key_index].type,
+                                              _prev_parsed_position[key_index].key));
 
-            // delete the written column.
-            slot_desc_dict.erase(key);
+            key_index++;
         }
     } catch (simdjson::simdjson_error& e) {
         auto err_msg = strings::Substitute("construct row in object order failed, error: $0",
@@ -526,22 +580,19 @@ Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* r
     }
 
     // append null to the column without data.
-    for (auto& pair : slot_desc_dict) {
-        auto& col_name = pair.first;
-        auto& slot_desc = pair.second;
-
-        auto column = chunk->get_column_by_slot_id(slot_desc->id());
-
-        if (col_name == "__op") {
-            // special treatment for __op column, fill default value '0' rather than null
-            if (column->is_binary()) {
-                std::ignore = column->append_strings(std::vector{Slice{"0"}});
+    for (int i = 0; i < chunk->num_columns(); i++) {
+        if (!_parsed_columns[i]) {
+            auto& column = chunk->get_column_by_index(i);
+            if (UNLIKELY(i == _op_col_index)) {
+                // special treatment for __op column, fill default value '0' rather than null
+                if (column->is_binary()) {
+                    std::ignore = column->append_strings(std::vector{Slice{"0"}});
+                } else {
+                    column->append_datum(Datum((uint8_t)0));
+                }
             } else {
-                column->append_datum(Datum((uint8_t)0));
+                column->append_nulls(1);
             }
-        } else {
-            // Column name not found, fill column with null.
-            column->append_nulls(1);
         }
     }
     return Status::OK();

--- a/be/src/exec/json_scanner.h
+++ b/be/src/exec/json_scanner.h
@@ -91,6 +91,16 @@ public:
 
     Status close();
 
+    struct PreviousParsedItem {
+        PreviousParsedItem(const std::string_view& key) : key(key), column_index(-1) {}
+        PreviousParsedItem(const std::string_view& key, int column_index, const TypeDescriptor& type)
+                : key(key), type(type), column_index(column_index) {}
+
+        std::string key;
+        TypeDescriptor type;
+        int column_index;
+    };
+
 private:
     template <typename ParserType>
     Status _read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_read);
@@ -126,6 +136,14 @@ private:
 
     std::unique_ptr<JsonParser> _parser;
     bool _empty_parser = true;
+
+    // record the chunk column position for previous parsed json object
+    std::vector<PreviousParsedItem> _prev_parsed_position;
+    // record the parsed column index for current json object
+    std::vector<uint8_t> _parsed_columns;
+    // record the "__op" column's index
+    int _op_col_index;
+
     // only used in unit test.
     // TODO: The semantics of Streaming Load And Routine Load is non-consistent.
     //       Import a json library supporting streaming parse.


### PR DESCRIPTION
For old json parser, when parsing a new json object, it will always create a new std::unordered_map
slot_desc_dict. In the process of parsing, the columns in slot_desc_dict will be removed gradually,
the remaining columns will be set null value.
This old parser is slow, it doesn't consider the fact that usually two consecutive json objects' fields positions
are same.
In this pr, we record the position for last parsed json object in _prev_parsed_position, in most case,
new json object's column position can be obtained from the _prev_parsed_position easily.
Besides, _parsed_columns record in current round, which column has been parsed. For those unparsed columns, we need to
set the null value.

Test result: a table with 670 varchar columns, we start a routine load to load 250,0000 records.
Before optimization, the time is 320s, around 7000 row/s
After optimization, the time is 137s, around 18000 row/s, improved by 2.5x

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15993

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
- [x] 2.5
- [ ] 2.4
- [ ] 2.3
- [ ] 2.2
