### PR TITLE
[Enhancement] return the actual root cause message to client when getting remote file failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
@@ -81,7 +81,9 @@ public class RemotePathKey {
         final StringBuilder sb = new StringBuilder("RemotePathKey{");
         sb.append("path='").append(path).append('\'');
         sb.append(", isRecursive=").append(isRecursive);
-        sb.append(", hudiTableLocation=").append(hudiTableLocation);
+        if (hudiTableLocation.isPresent()) {
+            sb.append(", hudiTableLocation=").append(hudiTableLocation);
+        }
         sb.append('}');
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
@@ -96,7 +96,8 @@ public class HiveRemoteFileIO implements RemoteFileIO {
             }
         } catch (Exception e) {
             LOG.error("Failed to get hive remote file's metadata on path: {}", path, e);
-            throw new StarRocksConnectorException("Failed to get hive remote file's metadata on path: %s", pathKey);
+            throw new StarRocksConnectorException("Failed to get hive remote file's metadata on path: %s. msg: %s",
+                    pathKey, e.getMessage());
         }
 
         return resultPartitions.put(pathKey, fileDescs).build();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -96,7 +96,8 @@ public class HudiRemoteFileIO implements RemoteFileIO {
             }
         } catch (Exception e) {
             LOG.error("Failed to get hudi remote file's metadata on path: {}", partitionPath, e);
-            throw new StarRocksConnectorException("Failed to get hudi remote file's metadata on path: %s", pathKey);
+            throw new StarRocksConnectorException("Failed to get hudi remote file's metadata on path: %s. msg: %s",
+                    pathKey, e.getMessage());
         }
         return resultPartitions.put(pathKey, fileDescs).build();
     }


### PR DESCRIPTION


## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
eg:
`ERROR 1064 (HY000): Failed to get remote files, msg: com.starrocks.connector.exception.StarRocksConnectorException: Failed to get hive remote file's metadata on path: RemotePathKey{path='oss://xxxx/hive_hdfs_decimal_hdfs_csv', isRecursive=false}. msg: java.lang.ClassNotFoundException: Class org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem not found`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
