### PR TITLE
[Enhancement] Reduce cache miss when evaluate lots of expr in aggregate

### DIFF
--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -62,7 +62,7 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
         }
         DCHECK_LE(chunk->num_rows(), runtime_state()->chunk_size());
 
-        RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
+        RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
 
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -67,7 +67,7 @@ StatusOr<ChunkPtr> AggregateBlockingSinkOperator::pull_chunk(RuntimeState* state
 }
 
 Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-    RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
+    RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
 
     bool agg_group_by_with_limit =
             (!_aggregator->is_none_group_by_exprs() &&     // has group by
@@ -86,19 +86,19 @@ Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const Chun
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
     }
     if (_aggregator->is_none_group_by_exprs()) {
-        _aggregator->compute_single_agg_state(chunk_size);
+        RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk.get(), chunk_size));
     } else {
         if (agg_group_by_with_limit) {
             // use `_aggregator->streaming_selection()` here to mark whether needs to filter key when compute agg states,
             // it's generated in `build_hash_map`
             size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection().data(), chunk_size);
             if (zero_count == chunk_size) {
-                _aggregator->compute_batch_agg_states(chunk_size);
+                RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk.get(), chunk_size));
             } else {
-                _aggregator->compute_batch_agg_states_with_selection(chunk_size);
+                RETURN_IF_ERROR(_aggregator->compute_batch_agg_states_with_selection(chunk.get(), chunk_size));
             }
         } else {
-            _aggregator->compute_batch_agg_states(chunk_size);
+            RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk.get(), chunk_size));
         }
     }
     _aggregator->update_num_input_rows(chunk_size);

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -54,7 +54,7 @@ StatusOr<ChunkPtr> AggregateDistinctBlockingSinkOperator::pull_chunk(RuntimeStat
 
 Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     DCHECK_LE(chunk->num_rows(), state->chunk_size());
-    RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
+    RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
 
     {
         SCOPED_TIMER(_aggregator->agg_compute_timer());

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -16,6 +16,7 @@
 
 #include <utility>
 
+#include "column/vectorized_fwd.h"
 #include "exec/aggregator.h"
 #include "exec/pipeline/operator.h"
 
@@ -45,13 +46,13 @@ public:
 
 private:
     // Invoked by push_chunk if current mode is TStreamingPreaggregationMode::FORCE_STREAMING
-    Status _push_chunk_by_force_streaming();
+    Status _push_chunk_by_force_streaming(const ChunkPtr& chunk);
 
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::FORCE_PREAGGREGATION
     Status _push_chunk_by_force_preaggregation(const size_t chunk_size);
 
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::AUTO
-    Status _push_chunk_by_auto(const size_t chunk_size);
+    Status _push_chunk_by_auto(const ChunkPtr& chunk, const size_t chunk_size);
 
     // It is used to perform aggregation algorithms shared by
     // AggregateDistinctStreamingSourceOperator. It is

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -45,13 +45,13 @@ public:
 
 private:
     // Invoked by push_chunk if current mode is TStreamingPreaggregationMode::FORCE_STREAMING
-    Status _push_chunk_by_force_streaming();
+    Status _push_chunk_by_force_streaming(ChunkPtr chunk);
 
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::FORCE_PREAGGREGATION
-    Status _push_chunk_by_force_preaggregation(const size_t chunk_size);
+    Status _push_chunk_by_force_preaggregation(ChunkPtr chunk, const size_t chunk_size);
 
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::AUTO
-    Status _push_chunk_by_auto(const size_t chunk_size);
+    Status _push_chunk_by_auto(ChunkPtr chunk, const size_t chunk_size);
 
     // It is used to perform aggregation algorithms shared by
     // AggregateStreamingSourceOperator. It is

--- a/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
@@ -57,7 +57,8 @@ Status SortedAggregateStreamingSinkOperator::push_chunk(RuntimeState* state, con
     _aggregator->update_num_input_rows(chunk_size);
     COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
 
-    RETURN_IF_ERROR(_aggregator->evaluate_exprs(chunk.get()));
+    RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
+    RETURN_IF_ERROR(_aggregator->evaluate_agg_fn_exprs(chunk.get()));
     _aggregator->streaming_compute_agg_state(chunk_size);
     return Status::OK();
 }

--- a/be/src/exec/stream/aggregate/stream_aggregator.cpp
+++ b/be/src/exec/stream/aggregate/stream_aggregator.cpp
@@ -148,7 +148,8 @@ Status StreamAggregator::_prepare_state_tables(RuntimeState* state) {
 
 Status StreamAggregator::process_chunk(StreamChunk* chunk) {
     size_t chunk_size = chunk->num_rows();
-    RETURN_IF_ERROR(_evaluate_exprs(chunk));
+    RETURN_IF_ERROR(_evaluate_group_by_exprs(chunk));
+    RETURN_IF_ERROR(evaluate_agg_fn_exprs(chunk));
 
     {
         SCOPED_TIMER(agg_compute_timer());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -51,6 +51,7 @@ import com.starrocks.sql.optimizer.rule.transformation.RewriteMinMaxAggToMetaSca
 import com.starrocks.sql.optimizer.rule.transformation.SemiReorderRule;
 import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule;
 import com.starrocks.sql.optimizer.rule.tree.ExchangeSortToMergeRule;
+import com.starrocks.sql.optimizer.rule.tree.ExtractAggregateColumn;
 import com.starrocks.sql.optimizer.rule.tree.PreAggregateTurnOnRule;
 import com.starrocks.sql.optimizer.rule.tree.PredicateReorderRule;
 import com.starrocks.sql.optimizer.rule.tree.PruneAggregateNodeRule;
@@ -423,6 +424,7 @@ public class Optimizer {
         // Reorder predicates
         result = new PredicateReorderRule(rootTaskContext.getOptimizerContext().getSessionVariable()).rewrite(result,
                 rootTaskContext);
+        result = new ExtractAggregateColumn().rewrite(result, rootTaskContext);
 
         result.setPlanCount(planCount);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ExtractAggregateColumn.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ExtractAggregateColumn.java
@@ -1,0 +1,173 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.task.TaskContext;
+
+import java.util.Map;
+import java.util.Set;
+
+public class ExtractAggregateColumn implements TreeRewriteRule {
+    ColumnRefFactory columnRefFactory = null;
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        columnRefFactory = taskContext.getOptimizerContext().getColumnRefFactory();
+        root.getOp().accept(new ExtractAggregateVisitor(), root, null);
+        return root;
+    }
+
+    public class ExtractAggregateVisitor extends OptExpressionVisitor<Void, Void> {
+        // TODO: remove this if BE aggregate node support dict mapping expr
+        private boolean hasDictMappingOperator(ScalarOperator operator) {
+            if (operator instanceof DictMappingOperator) {
+                return true;
+            }
+            for (ScalarOperator child : operator.getChildren()) {
+                if (hasDictMappingOperator(child)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private boolean hasNonColumnRefParameter(PhysicalHashAggregateOperator aggregateOperator) {
+            for (CallOperator value : aggregateOperator.getAggregations().values()) {
+                for (ScalarOperator child : value.getChildren()) {
+                    if (!child.isColumnRef()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private void rewriteAggregateOperator(PhysicalHashAggregateOperator aggregateOperator, Projection projection) {
+            Map<ColumnRefOperator, ScalarOperator> columnRefMap = projection.getColumnRefMap();
+            Map<ColumnRefOperator, ScalarOperator> rewriteMap = Maps.newHashMap();
+            // record the column has been extracted
+            Set<ColumnRefOperator> extractedColumns = Sets.newHashSet();
+
+            // sum(func(col1)), max(func(col1)) won't be extract to aggregate
+            for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregateOperator.getAggregations()
+                    .entrySet()) {
+                for (ScalarOperator child : entry.getValue().getChildren()) {
+                    if (!child.isColumnRef()) {
+                        return;
+                    }
+                    ColumnRefOperator childRef = (ColumnRefOperator) child;
+                    if (extractedColumns.contains(childRef)) {
+                        rewriteMap.remove(childRef);
+                    } else {
+                        ScalarOperator scalarOperator = columnRefMap.get(childRef);
+                        // TODO: remove this if fix meta scan bug
+                        if (scalarOperator == null) {
+                            return;
+                        }
+                        if (!scalarOperator.isColumnRef() && !hasDictMappingOperator(scalarOperator)) {
+                            rewriteMap.put(childRef, scalarOperator);
+                            extractedColumns.add(childRef);
+                        }
+                    }
+                }
+            }
+
+            // replace aggregate column
+            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(rewriteMap);
+            aggregateOperator.getAggregations().forEach((k, v) -> {
+                for (int i = 0; i < v.getChildren().size(); i++) {
+                    v.setChild(i, rewriter.rewrite(v.getChild(i)));
+                }
+            });
+
+            // get all used column
+            ColumnRefSet usedColumns = new ColumnRefSet();
+            for (ScalarOperator value : rewriteMap.values()) {
+                usedColumns.union(value.getUsedColumns());
+            }
+
+            // remove rewrite expression from projection
+            for (ColumnRefOperator columnRefOperator : rewriteMap.keySet()) {
+                columnRefMap.remove(columnRefOperator);
+            }
+
+            // common expression
+            if (!projection.getCommonSubOperatorMap().isEmpty()) {
+                final Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap =
+                        projection.getCommonSubOperatorMap();
+                for (ColumnRefOperator columnRefOperator : commonSubOperatorMap.keySet()) {
+                    if (usedColumns.contains(columnRefOperator)) {
+                        columnRefMap.put(columnRefOperator, columnRefOperator);
+                    }
+                }
+            }
+
+            // append used column
+            for (int columnId : usedColumns.getColumnIds()) {
+                final ColumnRefOperator columnRef = columnRefFactory.getColumnRef(columnId);
+                if (!columnRefMap.containsKey(columnRef)) {
+                    columnRefMap.put(columnRef, columnRef);
+                }
+            }
+        }
+
+        @Override
+        public Void visitPhysicalHashAggregate(OptExpression optExpression, Void context) {
+            PhysicalHashAggregateOperator aggOperator = (PhysicalHashAggregateOperator) optExpression.getOp();
+            // child has projection
+            Projection projection = optExpression.getInputs().get(0).getOp().getProjection();
+            if (projection != null && aggOperator.getGroupBys().isEmpty()) {
+
+                boolean unSupported = hasNonColumnRefParameter(aggOperator);
+
+                if (!unSupported) {
+                    rewriteAggregateOperator(aggOperator, projection);
+                }
+
+                if (projection.getColumnRefMap().isEmpty()) {
+                    optExpression.getInputs().get(0).getOp().setProjection(null);
+                }
+            }
+
+            for (OptExpression input : optExpression.getInputs()) {
+                input.getOp().accept(this, input, context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(OptExpression optExpression, Void context) {
+            for (OptExpression input : optExpression.getInputs()) {
+                input.getOp().accept(this, input, context);
+            }
+            return null;
+        }
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -47,6 +47,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         assertPlanContains(sql, "output: variance(1: v1)");
 
         sql = "select count_if(v1) from t0;";
-        assertPlanContains(sql, "<slot 4> : if(CAST(1: v1 AS BOOLEAN), 1, NULL)", "output: count(4: case)");
+        assertPlanContains(sql, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(if(CAST(1: v1 AS BOOLEAN), 1, NULL))");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -285,10 +285,10 @@ public class TrinoQueryTest extends TrinoTestBase {
         assertPlanContains(sql, "output: sum(2: v2)");
 
         sql = "select sum(case v1 when false then v2 when v2 then 1 else NULL end) from t0";
-        assertPlanContains(sql, "<slot 4> : CASE 1: v1 WHEN 0 THEN 2: v2 WHEN 2: v2 THEN 1 ELSE NULL END");
+        assertPlanContains(sql, "output: sum(CASE 1: v1 WHEN 0 THEN 2: v2 WHEN 2: v2 THEN 1 ELSE NULL END)");
 
         sql = "select count(case when v1 then 1 end) from t0";
-        assertPlanContains(sql, "<slot 4> : if(CAST(1: v1 AS BOOLEAN), 1, NULL)", "output: count(4: case)");
+        assertPlanContains(sql, "<slot 1> : 1: v1", "output: count(if(CAST(1: v1 AS BOOLEAN), 1, NULL))");
     }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1425,18 +1425,6 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  \n" +
                 "  0:MetaScan\n" +
                 "     Table: test_all_type");
-
-        sql = "select sum(t1a+t1b) from test_all_type [_META_]";
-        plan = getFragmentPlan(sql);
-        assertContains(plan, "2:AGGREGATE (update serialize)\n" +
-                "  |  output: sum(11: expr)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 11> : CAST(t1a AS DOUBLE) + CAST(t1b AS DOUBLE)\n" +
-                "  |  \n" +
-                "  0:MetaScan\n" +
-                "     Table: test_all_type");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
@@ -1460,6 +1459,23 @@ public class LowCardinalityTest extends PlanTestBase {
     }
 
     @Test
+    public void testExtractProject() throws Exception {
+        String sql;
+        String plan;
+
+        sql = "select max(upper(S_ADDRESS)), min(upper(S_ADDRESS)), max(S_ADDRESS), sum(S_SUPPKEY + 1) from supplier";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: max(16: upper), min(16: upper), max(15: S_ADDRESS), sum(CAST(1: S_SUPPKEY AS BIGINT) + 1)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 1> : 1: S_SUPPKEY\n" +
+                "  |  <slot 15> : 15: S_ADDRESS\n" +
+                "  |  <slot 16> : DictExpr(15: S_ADDRESS,[upper(<place-holder>)])");
+    }
+
+    @Test
     public void testCompoundPredicate() throws Exception {
         String sql = "select count(*) from supplier group by S_ADDRESS having " +
                 "if(S_ADDRESS > 'a' and S_ADDRESS < 'b', true, false)";
@@ -1471,7 +1487,6 @@ public class LowCardinalityTest extends PlanTestBase {
         sql = "select count(*) from supplier group by S_ADDRESS having " +
                 "if(not S_ADDRESS like '%a%' and S_ADDRESS < 'b', true, false)";
         plan = getVerboseExplain(sql);
-        System.out.println(plan);
         assertContains(plan,
                 "DictExpr(10: S_ADDRESS,[if((NOT (<place-holder> LIKE '%a%')) " +
                         "AND (<place-holder> < 'b'), TRUE, FALSE)])");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1157,9 +1157,8 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String sql =
                 "select count(t.a) from (select datediff(\"1981-09-06t03:40:33\", L_SHIPDATE) as a from lineitem) as t;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, " 1:Project\n" +
-                "  |  <slot 18> : datediff(CAST('1981-09-06t03:40:33' AS DATETIME), CAST(11: L_SHIPDATE AS DATETIME))\n" +
-                "  |  ");
+        assertContains(plan,
+                "output: count(datediff(CAST('1981-09-06t03:40:33' AS DATETIME), CAST(11: L_SHIPDATE AS DATETIME)))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -30,15 +30,20 @@ public class SetTest extends PlanTestBase {
     public void testValuesNodePredicate() throws Exception {
         String queryStr = "SELECT 1 AS z, MIN(a.x) FROM (select 1 as x) a WHERE abs(1) = 2";
         String explainString = getFragmentPlan(queryStr);
-        Assert.assertTrue(explainString.contains("  3:AGGREGATE (update finalize)\n" +
-                "  |  output: min(2: expr)\n" +
+        Assert.assertTrue(explainString.contains("  3:Project\n" +
+                "  |  <slot 3> : 3: min\n" +
+                "  |  <slot 4> : 1\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: min(1)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
-                "  2:Project\n" +
-                "  |  <slot 2> : 1\n" +
-                "  |  \n" +
                 "  1:SELECT\n" +
-                "  |  predicates: abs(1) = 2"));
+                "  |  predicates: abs(1) = 2\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL"));
     }
 
     @Test

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/three-join.sql
@@ -49,7 +49,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [nu
 [plan-4]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(subtract(multiply(22: L_EXTENDEDPRICE, subtract(1.0, 23: L_DISCOUNT)), multiply(14: PS_SUPPLYCOST, 21: L_QUANTITY)))}] group by [[]] having [null]
             INNER JOIN (join-predicate [36: cast = 37: cast AND 12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
                 CROSS JOIN (join-predicate [null] post-join-predicate [null])
                     SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
@@ -61,7 +61,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
 [plan-5]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(subtract(multiply(22: L_EXTENDEDPRICE, subtract(1.0, 23: L_DISCOUNT)), multiply(14: PS_SUPPLYCOST, 21: L_QUANTITY)))}] group by [[]] having [null]
             INNER JOIN (join-predicate [36: cast = 37: cast AND 12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
                 CROSS JOIN (join-predicate [null] post-join-predicate [null])
                     SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
@@ -74,7 +74,7 @@ AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [nul
 [plan-6]
 AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{35: sum=sum(subtract(multiply(22: L_EXTENDEDPRICE, subtract(1.0, 23: L_DISCOUNT)), multiply(14: PS_SUPPLYCOST, 21: L_QUANTITY)))}] group by [[]] having [null]
             INNER JOIN (join-predicate [12: PS_SUPPKEY = 19: L_SUPPKEY AND 11: PS_PARTKEY = 18: L_PARTKEY] post-join-predicate [null])
                 SCAN (columns[11: PS_PARTKEY, 12: PS_SUPPKEY, 14: PS_SUPPLYCOST] predicate[null])
                 EXCHANGE SHUFFLE[18]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q11.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q11.sql
@@ -140,7 +140,7 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
                 ASSERT LE 1
                     AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(42: sum)}] group by [[]] having [null]
                         EXCHANGE GATHER
-                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
+                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(multiply(25: PS_SUPPLYCOST, cast(24: PS_AVAILQTY as double)))}] group by [[]] having [null]
                                 INNER JOIN (join-predicate [31: S_NATIONKEY = 36: N_NATIONKEY] post-join-predicate [null])
                                     INNER JOIN (join-predicate [23: PS_SUPPKEY = 28: S_SUPPKEY] post-join-predicate [null])
                                         SCAN (columns[23: PS_SUPPKEY, 24: PS_AVAILQTY, 25: PS_SUPPLYCOST] predicate[null])
@@ -165,7 +165,7 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
                 ASSERT LE 1
                     AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(42: sum)}] group by [[]] having [null]
                         EXCHANGE GATHER
-                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
+                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(multiply(25: PS_SUPPLYCOST, cast(24: PS_AVAILQTY as double)))}] group by [[]] having [null]
                                 INNER JOIN (join-predicate [31: S_NATIONKEY = 36: N_NATIONKEY] post-join-predicate [null])
                                     INNER JOIN (join-predicate [23: PS_SUPPKEY = 28: S_SUPPKEY] post-join-predicate [null])
                                         SCAN (columns[23: PS_SUPPKEY, 24: PS_AVAILQTY, 25: PS_SUPPLYCOST] predicate[null])
@@ -190,7 +190,7 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
                 ASSERT LE 1
                     AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(42: sum)}] group by [[]] having [null]
                         EXCHANGE GATHER
-                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
+                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(multiply(25: PS_SUPPLYCOST, cast(24: PS_AVAILQTY as double)))}] group by [[]] having [null]
                                 INNER JOIN (join-predicate [23: PS_SUPPKEY = 28: S_SUPPKEY] post-join-predicate [null])
                                     SCAN (columns[23: PS_SUPPKEY, 24: PS_AVAILQTY, 25: PS_SUPPLYCOST] predicate[null])
                                     EXCHANGE BROADCAST
@@ -215,7 +215,7 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
                 ASSERT LE 1
                     AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(42: sum)}] group by [[]] having [null]
                         EXCHANGE GATHER
-                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
+                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(multiply(25: PS_SUPPLYCOST, cast(24: PS_AVAILQTY as double)))}] group by [[]] having [null]
                                 INNER JOIN (join-predicate [23: PS_SUPPKEY = 28: S_SUPPKEY] post-join-predicate [null])
                                     SCAN (columns[23: PS_SUPPKEY, 24: PS_AVAILQTY, 25: PS_SUPPLYCOST] predicate[null])
                                     EXCHANGE BROADCAST

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q14.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q14.sql
@@ -26,7 +26,7 @@ AGGREGATE ([GLOBAL] aggregate [{30: sum=sum(28: case), 31: sum=sum(29: expr)}] g
 [plan-2]
 AGGREGATE ([GLOBAL] aggregate [{30: sum=sum(30: sum), 31: sum=sum(31: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{30: sum=sum(28: case), 31: sum=sum(29: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{30: sum=sum(if(22: P_TYPE LIKE PROMO%, 34: multiply, 0.0)), 31: sum=sum(29: expr)}] group by [[]] having [null]
             INNER JOIN (join-predicate [18: P_PARTKEY = 2: L_PARTKEY] post-join-predicate [null])
                 SCAN (columns[18: P_PARTKEY, 22: P_TYPE] predicate[null])
                 EXCHANGE BROADCAST
@@ -35,7 +35,7 @@ AGGREGATE ([GLOBAL] aggregate [{30: sum=sum(30: sum), 31: sum=sum(31: sum)}] gro
 [plan-3]
 AGGREGATE ([GLOBAL] aggregate [{30: sum=sum(30: sum), 31: sum=sum(31: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{30: sum=sum(28: case), 31: sum=sum(29: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{30: sum=sum(if(22: P_TYPE LIKE PROMO%, 34: multiply, 0.0)), 31: sum=sum(29: expr)}] group by [[]] having [null]
             INNER JOIN (join-predicate [18: P_PARTKEY = 2: L_PARTKEY] post-join-predicate [null])
                 SCAN (columns[18: P_PARTKEY, 22: P_TYPE] predicate[null])
                 EXCHANGE SHUFFLE[2]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q19.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q19.sql
@@ -47,7 +47,7 @@ AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(28: expr)}] group by [[]] having [nu
 [plan-2]
 AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(29: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(28: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(multiply(6: L_EXTENDEDPRICE, subtract(1.0, 7: L_DISCOUNT)))}] group by [[]] having [null]
             INNER JOIN (join-predicate [2: L_PARTKEY = 18: P_PARTKEY AND 21: P_BRAND = Brand#45 AND 24: P_CONTAINER IN (SM CASE, SM BOX, SM PACK, SM PKG) AND 5: L_QUANTITY >= 5.0 AND 5: L_QUANTITY <= 15.0 AND 23: P_SIZE <= 5 OR 21: P_BRAND = Brand#11 AND 24: P_CONTAINER IN (MED BAG, MED BOX, MED PKG, MED PACK) AND 5: L_QUANTITY >= 15.0 AND 5: L_QUANTITY <= 25.0 AND 23: P_SIZE <= 10 OR 21: P_BRAND = Brand#21 AND 24: P_CONTAINER IN (LG CASE, LG BOX, LG PACK, LG PKG) AND 5: L_QUANTITY >= 25.0 AND 5: L_QUANTITY <= 35.0 AND 23: P_SIZE <= 15] post-join-predicate [null])
                 EXCHANGE SHUFFLE[2]
                     SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 14: L_SHIPINSTRUCT, 15: L_SHIPMODE] predicate[5: L_QUANTITY >= 5.0 AND 5: L_QUANTITY <= 35.0 AND 15: L_SHIPMODE IN (AIR, AIR REG) AND 14: L_SHIPINSTRUCT = DELIVER IN PERSON])

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q6.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q6.sql
@@ -18,6 +18,6 @@ AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(18: expr)}] group by [[]] having [nu
 [plan-2]
 AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(19: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{19: sum=sum(18: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{19: sum=sum(multiply(6: L_EXTENDEDPRICE, 7: L_DISCOUNT))}] group by [[]] having [null]
             SCAN (columns[5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 11: L_SHIPDATE] predicate[11: L_SHIPDATE >= 1995-01-01 AND 11: L_SHIPDATE < 1996-01-01 AND 7: L_DISCOUNT >= 0.02 AND 7: L_DISCOUNT <= 0.04 AND 5: L_QUANTITY < 24.0])
 [end]

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
@@ -123,17 +123,19 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 23
 
 22:AGGREGATE (update serialize)
-|  aggregate: sum[([35: expr, DECIMAL128(24,2), true]); args: DECIMAL128; result: DECIMAL128(38,2); args nullable: true; result nullable: true]
+|  aggregate: sum[(cast([22: ps_supplycost, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast([21: ps_availqty, INT, true] as DECIMAL128(9,0))); args: DECIMAL128; result: DECIMAL128(38,2); args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[1.0, 9999000.0, 0.0, 16.0, 1.0] ESTIMATE
 |
 21:Project
 |  output columns:
-|  35 <-> cast([22: ps_supplycost, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast([21: ps_availqty, INT, true] as DECIMAL128(9,0))
+|  21 <-> [21: ps_availqty, INT, true]
+|  22 <-> [22: ps_supplycost, DECIMAL64(15,2), true]
 |  cardinality: 3200000
 |  column statistics:
-|  * expr-->[1.0, 9999000.0, 0.0, 16.0, 99864.0] ESTIMATE
+|  * ps_availqty-->[1.0, 9999.0, 0.0, 4.0, 9999.0] ESTIMATE
+|  * ps_supplycost-->[1.0, 1000.0, 0.0, 8.0, 99864.0] ESTIMATE
 |
 20:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
@@ -43,7 +43,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 08
 
 7:AGGREGATE (update serialize)
-|  aggregate: sum[([26: case, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([27: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
+|  aggregate: sum[(if[(21: p_type LIKE 'PROMO%', [37: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([27: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[-Infinity, Infinity, 0.0, 16.0, 1.0] ESTIMATE
@@ -51,8 +51,9 @@ OutPut Exchange Id: 08
 |
 6:Project
 |  output columns:
-|  26 <-> if[(21: p_type LIKE 'PROMO%', [37: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]
+|  21 <-> [21: p_type, VARCHAR, true]
 |  27 <-> [37: multiply, DECIMAL128(33,4), true]
+|  37 <-> [37: multiply, DECIMAL128(33,4), true]
 |  common expressions:
 |  33 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
 |  34 <-> [7: l_discount, DECIMAL64(15,2), true]
@@ -61,7 +62,7 @@ OutPut Exchange Id: 08
 |  37 <-> [33: cast, DECIMAL128(15,2), true] * [36: cast, DECIMAL128(18,2), true]
 |  cardinality: 6653886
 |  column statistics:
-|  * case-->[-Infinity, Infinity, 0.0, 16.0, 3736521.0] ESTIMATE
+|  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 |
 5:HASH JOIN

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
@@ -56,17 +56,19 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 08
 
 7:AGGREGATE (update serialize)
-|  aggregate: sum[([26: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
+|  aggregate: sum[(cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast(1 - [7: l_discount, DECIMAL64(15,2), true] as DECIMAL128(18,2))); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 1.0] ESTIMATE
 |
 6:Project
 |  output columns:
-|  26 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast(1 - [7: l_discount, DECIMAL64(15,2), true] as DECIMAL128(18,2))
+|  6 <-> [6: l_extendedprice, DECIMAL64(15,2), true]
+|  7 <-> [7: l_discount, DECIMAL64(15,2), true]
 |  cardinality: 19277
 |  column statistics:
-|  * expr-->[810.9, 104949.5, 0.0, 16.0, 2856.1332873207584] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 2856.1332873207584] ESTIMATE
+|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
 5:HASH JOIN
 |  join op: INNER JOIN (PARTITIONED)

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
@@ -30,17 +30,19 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 03
 
 2:AGGREGATE (update serialize)
-|  aggregate: sum[([17: expr, DECIMAL128(30,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
+|  aggregate: sum[(cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast([7: l_discount, DECIMAL64(15,2), true] as DECIMAL128(15,2))); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[18.02, 4197.9800000000005, 0.0, 16.0, 1.0] ESTIMATE
 |
 1:Project
 |  output columns:
-|  17 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2)) * cast([7: l_discount, DECIMAL64(15,2), true] as DECIMAL128(15,2))
+|  6 <-> [6: l_extendedprice, DECIMAL64(15,2), true]
+|  7 <-> [7: l_discount, DECIMAL64(15,2), true]
 |  cardinality: 8142765
 |  column statistics:
-|  * expr-->[18.02, 4197.9800000000005, 0.0, 16.0, 3736520.0] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
+|  * l_discount-->[0.02, 0.04, 0.0, 8.0, 11.0] ESTIMATE
 |
 0:HdfsScanNode
 TABLE: lineitem

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-extract.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-extract.sql
@@ -22,7 +22,7 @@ where
 [result]
 AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(29: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(28: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(multiply(6: L_EXTENDEDPRICE, subtract(1.0, 7: L_DISCOUNT)))}] group by [[]] having [null]
             INNER JOIN (join-predicate [2: L_PARTKEY = 18: P_PARTKEY] post-join-predicate [null])
                 SCAN (columns[2: L_PARTKEY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 14: L_SHIPINSTRUCT] predicate[14: L_SHIPINSTRUCT = DELIVER IN PERSON])
                 EXCHANGE BROADCAST
@@ -55,7 +55,7 @@ where
 [result]
 AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(29: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(28: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(multiply(6: L_EXTENDEDPRICE, subtract(1.0, 7: L_DISCOUNT)))}] group by [[]] having [null]
             INNER JOIN (join-predicate [18: P_PARTKEY = 2: L_PARTKEY AND 21: P_BRAND = Brand#45 AND 24: P_CONTAINER IN (SM CASE, SM BOX, SM PACK, SM PKG) AND 5: L_QUANTITY >= 5.0 AND 5: L_QUANTITY <= 15.0 AND 23: P_SIZE >= 1 AND 23: P_SIZE <= 5 AND 15: L_SHIPMODE IN (AIR, AIR REG) AND 14: L_SHIPINSTRUCT = DELIVER IN PERSON OR 21: P_BRAND = Brand#11 AND 24: P_CONTAINER IN (MED BAG, MED BOX, MED PKG, MED PACK)] post-join-predicate [null])
                 SCAN (columns[2: L_PARTKEY, 5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 14: L_SHIPINSTRUCT, 15: L_SHIPMODE] predicate[null])
                 EXCHANGE BROADCAST

--- a/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
@@ -538,7 +538,7 @@ INNER JOIN (join-predicate [10: cast = 8: avg] post-join-predicate [null])
     EXCHANGE BROADCAST
         AGGREGATE ([GLOBAL] aggregate [{8: avg=avg(8: avg)}] group by [[]] having [8: avg IS NOT NULL]
             EXCHANGE GATHER
-                AGGREGATE ([LOCAL] aggregate [{8: avg=avg(7: expr)}] group by [[]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{8: avg=avg(add(5: v5, 1))}] group by [[]] having [null]
                     SCAN (columns[5: v5] predicate[null])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q11.sql
@@ -1,32 +1,3 @@
-[sql]
-select
-    ps_partkey,
-    sum(ps_supplycost * ps_availqty) as value
-from
-    partsupp,
-    supplier,
-    nation
-where
-    ps_suppkey = s_suppkey
-  and s_nationkey = n_nationkey
-  and n_name = 'PERU'
-group by
-    ps_partkey having
-    sum(ps_supplycost * ps_availqty) > (
-    select
-    sum(ps_supplycost * ps_availqty) * 0.0001000000
-    from
-    partsupp,
-    supplier,
-    nation
-    where
-    ps_suppkey = s_suppkey
-                  and s_nationkey = n_nationkey
-                  and n_name = 'PERU'
-    )
-order by
-    value desc ;
-[fragment statistics]
 PLAN FRAGMENT 0(F12)
 Output Exprs:1: PS_PARTKEY | 21: sum
 Input Partition: UNPARTITIONED
@@ -165,17 +136,19 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 22
 
 21:AGGREGATE (update serialize)
-|  aggregate: sum[([41: expr, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
+|  aggregate: sum[([25: PS_SUPPLYCOST, DOUBLE, false] * cast([24: PS_AVAILQTY, INT, false] as DOUBLE)); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[1.0, 9999000.0, 0.0, 8.0, 1.0] ESTIMATE
 |
 20:Project
 |  output columns:
-|  41 <-> [25: PS_SUPPLYCOST, DOUBLE, false] * cast([24: PS_AVAILQTY, INT, false] as DOUBLE)
+|  24 <-> [24: PS_AVAILQTY, INT, false]
+|  25 <-> [25: PS_SUPPLYCOST, DOUBLE, false]
 |  cardinality: 3200000
 |  column statistics:
-|  * expr-->[1.0, 9999000.0, 0.0, 8.0, 99864.0] ESTIMATE
+|  * PS_AVAILQTY-->[1.0, 9999.0, 0.0, 4.0, 9999.0] ESTIMATE
+|  * PS_SUPPLYCOST-->[1.0, 1000.0, 0.0, 8.0, 99864.0] ESTIMATE
 |
 19:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
@@ -334,5 +307,3 @@ cardinality: 1
 column statistics:
 * N_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
 * N_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
-[end]
-

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q14.sql
@@ -43,7 +43,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 07
 
 6:AGGREGATE (update serialize)
-|  aggregate: sum[([28: case, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([29: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
+|  aggregate: sum[(if[(22: P_TYPE LIKE 'PROMO%', [34: multiply, DOUBLE, false], 0.0); args: BOOLEAN,DOUBLE,DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([29: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[-Infinity, Infinity, 0.0, 8.0, 1.0] ESTIMATE
@@ -51,14 +51,15 @@ OutPut Exchange Id: 07
 |
 5:Project
 |  output columns:
-|  28 <-> if[(22: P_TYPE LIKE 'PROMO%', [34: multiply, DOUBLE, false], 0.0); args: BOOLEAN,DOUBLE,DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
+|  22 <-> [22: P_TYPE, VARCHAR, false]
 |  29 <-> [34: multiply, DOUBLE, false]
+|  34 <-> [34: multiply, DOUBLE, false]
 |  common expressions:
 |  33 <-> 1.0 - [7: L_DISCOUNT, DOUBLE, false]
 |  34 <-> [6: L_EXTENDEDPRICE, DOUBLE, false] * [33: subtract, DOUBLE, false]
 |  cardinality: 7013947
 |  column statistics:
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 932378.0] ESTIMATE
+|  * P_TYPE-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |
 4:HASH JOIN

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q6.sql
@@ -30,17 +30,19 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 03
 
 2:AGGREGATE (update serialize)
-|  aggregate: sum[([18: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
+|  aggregate: sum[([6: L_EXTENDEDPRICE, DOUBLE, false] * [7: L_DISCOUNT, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[NaN, NaN, 0.0, 8.0, 1.0] ESTIMATE
 |
 1:Project
 |  output columns:
-|  18 <-> [6: L_EXTENDEDPRICE, DOUBLE, false] * [7: L_DISCOUNT, DOUBLE, false]
+|  6 <-> [6: L_EXTENDEDPRICE, DOUBLE, false]
+|  7 <-> [7: L_DISCOUNT, DOUBLE, false]
 |  cardinality: 11504008
 |  column statistics:
-|  * expr-->[NaN, NaN, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_EXTENDEDPRICE-->[901.0, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
+|  * L_DISCOUNT-->[NaN, NaN, 0.0, 8.0, 11.0] ESTIMATE
 |
 0:OlapScanNode
 table: lineitem, rollup: lineitem

--- a/fe/fe-core/src/test/resources/sql/tpch/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q11.sql
@@ -43,7 +43,7 @@ TOP-N (order by [[21: sum DESC NULLS LAST]])
                 ASSERT LE 1
                     AGGREGATE ([GLOBAL] aggregate [{42: sum=sum(42: sum)}] group by [[]] having [null]
                         EXCHANGE GATHER
-                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(41: expr)}] group by [[]] having [null]
+                            AGGREGATE ([LOCAL] aggregate [{42: sum=sum(multiply(25: PS_SUPPLYCOST, cast(24: PS_AVAILQTY as double)))}] group by [[]] having [null]
                                 INNER JOIN (join-predicate [23: PS_SUPPKEY = 28: S_SUPPKEY] post-join-predicate [null])
                                     SCAN (columns[23: PS_SUPPKEY, 24: PS_AVAILQTY, 25: PS_SUPPLYCOST] predicate[null])
                                     EXCHANGE BROADCAST

--- a/fe/fe-core/src/test/resources/sql/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q14.sql
@@ -15,7 +15,7 @@ where
 [result]
 AGGREGATE ([GLOBAL] aggregate [{30: sum=sum(30: sum), 31: sum=sum(31: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{30: sum=sum(28: case), 31: sum=sum(29: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{30: sum=sum(if(22: P_TYPE LIKE PROMO%, 34: multiply, 0.0)), 31: sum=sum(29: expr)}] group by [[]] having [null]
             INNER JOIN (join-predicate [18: P_PARTKEY = 2: L_PARTKEY] post-join-predicate [null])
                 SCAN (columns[18: P_PARTKEY, 22: P_TYPE] predicate[null])
                 EXCHANGE SHUFFLE[2]

--- a/fe/fe-core/src/test/resources/sql/tpch/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q19.sql
@@ -37,7 +37,7 @@ where
 [result]
 AGGREGATE ([GLOBAL] aggregate [{29: sum=sum(29: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(28: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{29: sum=sum(multiply(6: L_EXTENDEDPRICE, subtract(1.0, 7: L_DISCOUNT)))}] group by [[]] having [null]
             INNER JOIN (join-predicate [18: P_PARTKEY = 2: L_PARTKEY AND 21: P_BRAND = Brand#45 AND 24: P_CONTAINER IN (SM CASE, SM BOX, SM PACK, SM PKG) AND 5: L_QUANTITY >= 5.0 AND 5: L_QUANTITY <= 15.0 AND 23: P_SIZE <= 5 OR 21: P_BRAND = Brand#11 AND 24: P_CONTAINER IN (MED BAG, MED BOX, MED PKG, MED PACK) AND 5: L_QUANTITY >= 15.0 AND 5: L_QUANTITY <= 25.0 AND 23: P_SIZE <= 10 OR 21: P_BRAND = Brand#21 AND 24: P_CONTAINER IN (LG CASE, LG BOX, LG PACK, LG PKG) AND 5: L_QUANTITY >= 25.0 AND 5: L_QUANTITY <= 35.0 AND 23: P_SIZE <= 15] post-join-predicate [null])
                 SCAN (columns[18: P_PARTKEY, 21: P_BRAND, 23: P_SIZE, 24: P_CONTAINER] predicate[21: P_BRAND IN (Brand#45, Brand#11, Brand#21) AND 23: P_SIZE <= 15 AND 24: P_CONTAINER IN (SM CASE, SM BOX, SM PACK, SM PKG, MED BAG, MED BOX, MED PKG, MED PACK, LG CASE, LG BOX, LG PACK, LG PKG) AND 23: P_SIZE >= 1])
                 EXCHANGE SHUFFLE[2]

--- a/fe/fe-core/src/test/resources/sql/tpch/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch/q6.sql
@@ -11,7 +11,7 @@ where
 [result]
 AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(19: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{19: sum=sum(18: expr)}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{19: sum=sum(multiply(6: L_EXTENDEDPRICE, 7: L_DISCOUNT))}] group by [[]] having [null]
             SCAN (columns[5: L_QUANTITY, 6: L_EXTENDEDPRICE, 7: L_DISCOUNT, 11: L_SHIPDATE] predicate[11: L_SHIPDATE >= 1995-01-01 AND 11: L_SHIPDATE < 1996-01-01 AND 7: L_DISCOUNT >= 0.02 AND 7: L_DISCOUNT <= 0.04 AND 5: L_QUANTITY < 24.0])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q11.sql
@@ -112,11 +112,12 @@ EXCHANGE ID: 22
 UNPARTITIONED
 
 21:AGGREGATE (update serialize)
-|  output: sum(41: expr)
+|  output: sum(25: PS_SUPPLYCOST * CAST(24: PS_AVAILQTY AS DOUBLE))
 |  group by:
 |
 20:Project
-|  <slot 41> : 25: PS_SUPPLYCOST * CAST(24: PS_AVAILQTY AS DOUBLE)
+|  <slot 24> : 24: PS_AVAILQTY
+|  <slot 25> : 25: PS_SUPPLYCOST
 |
 19:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q14.sql
@@ -37,12 +37,13 @@ EXCHANGE ID: 07
 UNPARTITIONED
 
 6:AGGREGATE (update serialize)
-|  output: sum(28: case), sum(29: expr)
+|  output: sum(if(22: P_TYPE LIKE 'PROMO%', 34: multiply, 0.0)), sum(29: expr)
 |  group by:
 |
 5:Project
-|  <slot 28> : if(22: P_TYPE LIKE 'PROMO%', 34: multiply, 0.0)
+|  <slot 22> : 22: P_TYPE
 |  <slot 29> : 34: multiply
+|  <slot 34> : 34: multiply
 |  common expressions:
 |  <slot 33> : 1.0 - 7: L_DISCOUNT
 |  <slot 34> : 6: L_EXTENDEDPRICE * 33: subtract
@@ -60,7 +61,6 @@ PREAGGREGATION: ON
 partitions=1/1
 rollup: part
 tabletRatio=10/10
-tabletList=10190,10192,10194,10196,10198,10200,10202,10204,10206,10208
 cardinality=20000000
 avgRowSize=33.0
 numNodes=0
@@ -85,7 +85,6 @@ PREDICATES: 11: L_SHIPDATE >= '1997-02-01', 11: L_SHIPDATE < '1997-03-01'
 partitions=1/1
 rollup: lineitem
 tabletRatio=20/20
-tabletList=10213,10215,10217,10219,10221,10223,10225,10227,10229,10231 ...
 cardinality=6653465
 avgRowSize=28.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q19.sql
@@ -56,11 +56,12 @@ EXCHANGE ID: 08
 UNPARTITIONED
 
 7:AGGREGATE (update serialize)
-|  output: sum(28: expr)
+|  output: sum(6: L_EXTENDEDPRICE * 1.0 - 7: L_DISCOUNT)
 |  group by:
 |
 6:Project
-|  <slot 28> : 6: L_EXTENDEDPRICE * 1.0 - 7: L_DISCOUNT
+|  <slot 6> : 6: L_EXTENDEDPRICE
+|  <slot 7> : 7: L_DISCOUNT
 |
 5:HASH JOIN
 |  join op: INNER JOIN (PARTITIONED)
@@ -87,7 +88,6 @@ PREDICATES: 21: P_BRAND IN ('Brand#45', 'Brand#11', 'Brand#21'), 23: P_SIZE <= 1
 partitions=1/1
 rollup: part
 tabletRatio=10/10
-tabletList=10190,10192,10194,10196,10198,10200,10202,10204,10206,10208
 cardinality=5714286
 avgRowSize=32.0
 numNodes=0
@@ -113,7 +113,6 @@ PREDICATES: 5: L_QUANTITY >= 5.0, 5: L_QUANTITY <= 35.0, 15: L_SHIPMODE IN ('AIR
 partitions=1/1
 rollup: lineitem
 tabletRatio=20/20
-tabletList=10213,10215,10217,10219,10221,10223,10225,10227,10229,10231 ...
 cardinality=26239067
 avgRowSize=67.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q6.sql
@@ -30,11 +30,12 @@ EXCHANGE ID: 03
 UNPARTITIONED
 
 2:AGGREGATE (update serialize)
-|  output: sum(18: expr)
+|  output: sum(6: L_EXTENDEDPRICE * 7: L_DISCOUNT)
 |  group by:
 |
 1:Project
-|  <slot 18> : 6: L_EXTENDEDPRICE * 7: L_DISCOUNT
+|  <slot 6> : 6: L_EXTENDEDPRICE
+|  <slot 7> : 7: L_DISCOUNT
 |
 0:OlapScanNode
 TABLE: lineitem
@@ -43,7 +44,6 @@ PREDICATES: 11: L_SHIPDATE >= '1995-01-01', 11: L_SHIPDATE < '1996-01-01', 7: L_
 partitions=1/1
 rollup: lineitem
 tabletRatio=20/20
-tabletList=10213,10215,10217,10219,10221,10223,10225,10227,10229,10231 ...
 cardinality=8142251
 avgRowSize=36.0
 numNodes=0


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#9118

## Problem Summary(Required) ：
1. move some function call expr from project node to aggregate node
2. evaluate function call expr before call aggregate node

cache miss 
before:
![image](https://user-images.githubusercontent.com/34912776/210054941-6e704712-5dad-46c8-8233-e60005481c74.png)
after:
![image](https://user-images.githubusercontent.com/34912776/210054959-13f975ab-5eb5-4f99-8352-2e66cc62fc40.png)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
