### PR TITLE
[Enhancement] [cherry-pick] OlapTableSink of non-pipeline engine support fast cancel (#15398)

### DIFF
--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -55,6 +55,11 @@ public:
 
     virtual Status send_chunk(RuntimeState* state, vectorized::Chunk* chunk);
 
+    virtual void cancel() {
+        // TODO: Currently only OlapTableSink supports FastCancel,
+        //  other types of Sink need to be fully tested before adding.
+    }
+
     // Releases all resources that were allocated in prepare()/send().
     // Further send() calls are illegal after calling close().
     // It must be okay to call this multiple times. Subsequent calls should

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1004,6 +1004,13 @@ bool OlapTableSink::is_close_done() {
     return _close_done;
 }
 
+void OlapTableSink::cancel() {
+    Status st = Status::Cancelled("cancel");
+    for (auto& index_channel : _channels) {
+        index_channel->for_each_node_channel([&st](NodeChannel* ch) { ch->cancel(st); });
+    }
+}
+
 Status OlapTableSink::close(RuntimeState* state, Status close_status) {
     if (close_status.ok()) {
         SCOPED_TIMER(_profile->total_time_counter());

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -277,6 +277,8 @@ public:
 
     Status prepare(RuntimeState* state) override;
 
+    void cancel() override;
+
     // sync open interface
     Status open(RuntimeState* state) override;
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -353,6 +353,11 @@ void PlanFragmentExecutor::cancel() {
     LOG(INFO) << "cancel(): fragment_instance_id=" << print_id(_runtime_state->fragment_instance_id());
     DCHECK(_prepared);
     _runtime_state->set_is_cancelled(true);
+
+    if (_sink != nullptr) {
+        _sink->cancel();
+    }
+
     _runtime_state->exec_env()->stream_mgr()->cancel(_runtime_state->fragment_instance_id());
     _runtime_state->exec_env()->result_mgr()->cancel(_runtime_state->fragment_instance_id());
 


### PR DESCRIPTION
Cancel first, and then close wait. Currently only OlapTableSink supports FastCancel, other types of Sink need to be fully tested before adding.

