### PR TITLE
[Enhancement] use fingerprint to determine if skip version generating

### DIFF
--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -14,15 +14,11 @@
 # limitations under the License.
 
 import argparse
+import hashlib
 import os
 import subprocess
 
 from datetime import datetime
-
-def func(a, *args, **kwargs):
-    print(a)
-    print(args)
-    print(kwargs)
 
 def get_version():
     version = os.getenv("STARROCKS_VERSION")
@@ -34,7 +30,7 @@ def get_commit_hash():
     git_res = subprocess.Popen(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = git_res.communicate()
 
-    commit_hash = ''
+    commit_hash = u''
     if git_res.returncode == 0:
         commit_hash = out.decode('utf-8').strip()
     return commit_hash
@@ -70,15 +66,20 @@ def get_java_version():
         return out.decode('utf-8').replace("\"", "\\\"").strip()
     return "unknown jdk"
 
-def skip_write_if_commit_unchanged(file_name, file_content, commit_hash):
+def get_fingerprint(items):
+    if not isinstance(items, list):
+        items = [items]
+    return hashlib.md5(",".join(items).encode()).hexdigest()
+
+def skip_write_if_fingerprint_unchanged(file_name, file_content, fingerprint):
     if os.path.exists(file_name):
         with open(file_name) as fh:
             data = fh.read()
             import re
-            m = re.search("COMMIT_HASH: (?P<commit_hash>\w+)", data)
-            old_commit_hash = m.group('commit_hash') if m else None
-            print('gen_build_version.py {}: old commit = {}, new commit = {}'.format(file_name, old_commit_hash, commit_hash))
-            if old_commit_hash == commit_hash:
+            m = re.search(r"FINGERPRINT: (?P<fingerprint>\w+)", data)
+            old_fingerprint = m.group('fingerprint') if m else None
+            print('gen_build_version.py {}: old fingerprint = {}, new fingerprint = {}'.format(file_name, old_fingerprint, fingerprint))
+            if old_fingerprint == fingerprint:
                 return
     with open(file_name, 'w') as fh:
         fh.write(file_content)
@@ -103,7 +104,7 @@ package com.starrocks.common;
 // limitations under the License.
 
 // This is a generated file, DO NOT EDIT IT.
-// COMMIT_HASH: {COMMIT_HASH}
+// FINGERPRINT: {FINGERPRINT}
 
 public class Version {{
     public static final String STARROCKS_VERSION = "{VERSION}";
@@ -115,15 +116,17 @@ public class Version {{
     public static final String STARROCKS_JAVA_COMPILE_VERSION = "{JAVA_VERSION}";
 }}
 '''
-    file_content = file_format.format(VERSION = version, COMMIT_HASH = commit_hash,
-            BUILD_TYPE = build_type, BUILD_TIME = build_time, BUILD_USER=user, BUILD_HOST=host,
-            JAVA_VERSION = java_version)
+    fingerprint = get_fingerprint([version, commit_hash, build_type, user, host, java_version])
+    file_content = file_format.format(VERSION=version, COMMIT_HASH=commit_hash,
+                                      BUILD_TYPE=build_type, BUILD_TIME=build_time,
+                                      BUILD_USER=user, BUILD_HOST=host,
+                                      JAVA_VERSION=java_version, FINGERPRINT=fingerprint)
 
     file_name = java_path + "/com/starrocks/common/Version.java"
     d = os.path.dirname(file_name)
     if not os.path.exists(d):
         os.makedirs(d)
-    skip_write_if_commit_unchanged(file_name, file_content, commit_hash)
+    skip_write_if_fingerprint_unchanged(file_name, file_content, fingerprint)
 
 def generate_cpp_file(cpp_path, version, commit_hash, build_type, build_time, user, host):
     file_format = '''
@@ -142,7 +145,7 @@ def generate_cpp_file(cpp_path, version, commit_hash, build_type, build_time, us
 // limitations under the License.
 
 // NOTE: This is a generated file, DO NOT EDIT IT
-// COMMIT_HASH: {COMMIT_HASH}
+// FINGERPRINT: {FINGERPRINT}
 
 namespace starrocks {{
 
@@ -155,15 +158,16 @@ const char* STARROCKS_BUILD_HOST = "{BUILD_HOST}";
 }}
 
 '''
-    file_content = file_format.format(VERSION = version, COMMIT_HASH = commit_hash,
-            BUILD_TYPE = build_type, BUILD_TIME = build_time,
-            BUILD_USER = user, BUILD_HOST = host)
+    fingerprint = get_fingerprint([version, commit_hash, build_type, user, host])
+    file_content = file_format.format(VERSION=version, COMMIT_HASH=commit_hash,
+                                      BUILD_TYPE=build_type, BUILD_TIME=build_time,
+                                      BUILD_USER=user, BUILD_HOST=host, FINGERPRINT=fingerprint)
 
     file_name = cpp_path + "/version.cpp"
     d = os.path.dirname(file_name)
     if not os.path.exists(d):
         os.makedirs(d)
-    skip_write_if_commit_unchanged(file_name, file_content, commit_hash)
+    skip_write_if_fingerprint_unchanged(file_name, file_content, fingerprint)
 
 def main():
     parser = argparse.ArgumentParser()

--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -70,7 +70,16 @@ def get_java_version():
         return out.decode('utf-8').replace("\"", "\\\"").strip()
     return "unknown jdk"
 
-def write_file(file_name, file_content):
+def skip_write_if_commit_unchanged(file_name, file_content, commit_hash):
+    if os.path.exists(file_name):
+        with open(file_name) as fh:
+            data = fh.read()
+            import re
+            m = re.search("COMMIT_HASH: (?P<commit_hash>\w+)", data)
+            old_commit_hash = m.group('commit_hash') if m else None
+            print('gen_build_version.py {}: old commit = {}, new commit = {}'.format(file_name, old_commit_hash, commit_hash))
+            if old_commit_hash == commit_hash:
+                return
     with open(file_name, 'w') as fh:
         fh.write(file_content)
 
@@ -114,7 +123,7 @@ public class Version {{
     d = os.path.dirname(file_name)
     if not os.path.exists(d):
         os.makedirs(d)
-    write_file(file_name, file_content)
+    skip_write_if_commit_unchanged(file_name, file_content, commit_hash)
 
 def generate_cpp_file(cpp_path, version, commit_hash, build_type, build_time, user, host):
     file_format = '''
@@ -154,7 +163,7 @@ const char* STARROCKS_BUILD_HOST = "{BUILD_HOST}";
     d = os.path.dirname(file_name)
     if not os.path.exists(d):
         os.makedirs(d)
-    write_file(file_name, file_content)
+    skip_write_if_commit_unchanged(file_name, file_content, commit_hash)
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
[Enhancement] use fingerprint to determine if skip version generating

* use fingerprint to determine if needs to skip version file generating.
* current fingerprint is generated from all the parameters conjunction
  except `build_time`
* don't waste time on unnecessary recompile/relink. Be kind to ourselves.

Signed-off-by: Kevin Xiaohua Cai <caixiaohua@starrocks.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
