### PR TITLE
[Feature] Add MapConstructor in backend

### DIFF
--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -16,9 +16,110 @@
 
 #include "column/array_column.h"
 #include "column/map_column.h"
-#include "column/type_traits.h"
+#include "common/logging.h"
 
 namespace starrocks {
+
+// Used to construct a Map type value from keys and values. Input keys and values are in the
+// format of Array type.
+// For example,
+//  map([1, 2], [3, 4]) will generate a map which value is {1=3,2=4}
+StatusOr<ColumnPtr> MapFunctions::map(FunctionContext* context, const Columns& columns) {
+    DCHECK_EQ(2, columns.size());
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+
+    auto& keys_column = columns[0];
+    NullColumn* keys_null = nullptr;
+    ArrayColumn* keys_data = nullptr;
+    if (keys_column->is_nullable()) {
+        auto keys = down_cast<NullableColumn*>(keys_column.get());
+        keys_null = keys->null_column().get();
+        keys_data = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(keys));
+    } else {
+        keys_data = down_cast<ArrayColumn*>(keys_column.get());
+    }
+
+    auto& values_column = columns[1];
+    NullColumn* values_null = nullptr;
+    ArrayColumn* values_data = nullptr;
+    if (values_column->is_nullable()) {
+        auto values = down_cast<NullableColumn*>(values_column.get());
+        values_null = values->null_column().get();
+        values_data = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(values));
+    } else {
+        values_data = down_cast<ArrayColumn*>(values_column.get());
+    }
+
+    auto& keys_offsets = keys_data->offsets().get_data();
+    auto& values_offsets = values_data->offsets().get_data();
+    auto num_rows = keys_data->size();
+    if (!keys_column->has_null() && !values_column->has_null()) {
+        size_t num_equals = 0;
+        // NOTE: only need to check the accumulated offset of each element
+        for (int i = 1; i <= num_rows; ++i) {
+            num_equals += (keys_offsets[i] == values_offsets[i]);
+        }
+        if (num_equals != num_rows) {
+            return Status::InvalidArgument("Key and value arrays must be the same length");
+        }
+        auto copied_key_elements = keys_data->elements().clone_shared();
+        auto copied_value_elements = values_data->elements().clone_shared();
+        auto copied_offsets = keys_data->offsets().clone_shared();
+        return MapColumn::create(std::move(copied_key_elements), std::move(copied_value_elements),
+                                 std::static_pointer_cast<UInt32Column>(copied_offsets));
+    } else {
+        // build the null column
+        NullColumnPtr null_column;
+        if (keys_null != nullptr) {
+            if (values_null != nullptr) {
+                null_column = std::static_pointer_cast<NullColumn>(keys_null->clone_shared());
+                ColumnHelper::or_two_filters(num_rows, null_column->get_data().data(), values_null->get_data().data());
+            } else {
+                null_column = std::static_pointer_cast<NullColumn>(keys_null->clone_shared());
+            }
+        } else {
+            null_column = std::static_pointer_cast<NullColumn>(values_null->clone_shared());
+        }
+        // check and construct offset column
+        auto& null_bits = null_column->get_data();
+        uint32_t offset = 0;
+        auto map_offsets_column = UInt32Column::create();
+        for (int i = 0; i < num_rows; ++i) {
+            map_offsets_column->append(offset);
+            if (!null_bits[i]) {
+                auto num_elements = keys_data->get_element_size(i);
+                if (num_elements != values_data->get_element_size(i)) {
+                    return Status::InvalidArgument("Key and value arrays must be the same length");
+                }
+                offset += num_elements;
+            }
+        }
+        map_offsets_column->append(offset);
+        // copy key and value elements
+        auto map_key_elements = keys_data->elements().clone_empty();
+        auto map_value_elements = values_data->elements().clone_empty();
+        int row = 0;
+        while (row < num_rows) {
+            // skip continuous nulls;
+            while (row < num_rows && null_bits[row]) {
+                row++;
+            }
+            uint32_t prev_row = row;
+            while (row < num_rows && !null_bits[row]) {
+                row++;
+            }
+            if (row > prev_row) {
+                map_key_elements->append(keys_data->elements(), keys_offsets[prev_row],
+                                         keys_offsets[row] - keys_offsets[prev_row]);
+                map_value_elements->append(values_data->elements(), values_offsets[prev_row],
+                                           values_offsets[row] - values_offsets[prev_row]);
+            }
+        }
+        auto map_column = MapColumn::create(std::move(map_key_elements), std::move(map_value_elements),
+                                            std::static_pointer_cast<UInt32Column>(map_offsets_column));
+        return NullableColumn::create(std::move(map_column), std::move(null_column));
+    }
+}
 
 StatusOr<ColumnPtr> MapFunctions::map_size(FunctionContext* context, const Columns& columns) {
     DCHECK_EQ(1, columns.size());

--- a/be/src/exprs/map_functions.h
+++ b/be/src/exprs/map_functions.h
@@ -28,6 +28,8 @@ namespace starrocks {
 
 class MapFunctions {
 public:
+    DEFINE_VECTORIZED_FN(map);
+
     DEFINE_VECTORIZED_FN(map_size);
 
     DEFINE_VECTORIZED_FN(map_keys);

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -22,6 +22,163 @@
 
 namespace starrocks {
 
+PARALLEL_TEST(MapFunctionsTest, test_map) {
+    TypeDescriptor input_keys_type;
+    input_keys_type.type = LogicalType::TYPE_ARRAY;
+    input_keys_type.children.emplace_back(LogicalType::TYPE_INT);
+
+    TypeDescriptor input_values_type;
+    input_values_type.type = LogicalType::TYPE_ARRAY;
+    input_values_type.children.emplace_back(LogicalType::TYPE_VARCHAR);
+
+    auto input_keys = ColumnHelper::create_column(input_keys_type, true);
+    // keys:   [[1,2,3], NULL, [4,5], [6,7], NULL, [9]]
+    // values: [[a,b,c], [d],   NULL, [f,g], NULL, [h]]
+    {
+        // [1,2,3]
+        {
+            DatumArray datum{1, 2, 3};
+            input_keys->append_datum(datum);
+        }
+        // NULL
+        input_keys->append_nulls(1);
+        // [4, 5]
+        {
+            DatumArray datum{4, 5};
+            input_keys->append_datum(datum);
+        }
+        // [6, 7]
+        {
+            DatumArray datum{6, 7};
+            input_keys->append_datum(datum);
+        }
+        // NULL
+        input_keys->append_nulls(1);
+        // [9]
+        {
+            DatumArray datum{9};
+            input_keys->append_datum(datum);
+        }
+    }
+    auto input_values = ColumnHelper::create_column(input_values_type, true);
+    {
+        // [a,b,c]
+        {
+            DatumArray datum{"a", "b", "c"};
+            input_values->append_datum(datum);
+        }
+        // [d]
+        {
+            DatumArray datum{"d"};
+            input_values->append_datum(datum);
+        }
+        // NULL
+        input_values->append_nulls(1);
+        // [f,g]
+        {
+            DatumArray datum{"f", "g"};
+            input_values->append_datum(datum);
+        }
+        // NULL
+        input_values->append_nulls(1);
+        // [h]
+        {
+            DatumArray datum{"h"};
+            input_values->append_datum(datum);
+        }
+    }
+    auto ret = MapFunctions::map(nullptr, {input_keys, input_values});
+    EXPECT_TRUE(ret.ok());
+    auto result = std::move(ret.value());
+    EXPECT_EQ(6, result->size());
+
+    EXPECT_STREQ("{1:'a',2:'b',3:'c'}", result->debug_item(0).c_str());
+    EXPECT_TRUE(result->is_null(1));
+    EXPECT_TRUE(result->is_null(2));
+    EXPECT_STREQ("{6:'f',7:'g'}", result->debug_item(3).c_str());
+    EXPECT_TRUE(result->is_null(4));
+    EXPECT_STREQ("{9:'h'}", result->debug_item(5).c_str());
+}
+
+PARALLEL_TEST(MapFunctionsTest, test_map_mismatch1) {
+    TypeDescriptor input_keys_type;
+    input_keys_type.type = LogicalType::TYPE_ARRAY;
+    input_keys_type.children.emplace_back(LogicalType::TYPE_INT);
+
+    TypeDescriptor input_values_type;
+    input_values_type.type = LogicalType::TYPE_ARRAY;
+    input_values_type.children.emplace_back(LogicalType::TYPE_VARCHAR);
+
+    auto input_keys = ColumnHelper::create_column(input_keys_type, true);
+    // keys:   [[1,2,3], NULL, [4,5]]
+    // values: [[a,b,c], [d],  [h]]
+    {
+        // [1,2,3]
+        {
+            DatumArray datum{1, 2, 3};
+            input_keys->append_datum(datum);
+        }
+        // NULL
+        input_keys->append_nulls(1);
+        // [4, 5]
+        {
+            DatumArray datum{4, 5};
+            input_keys->append_datum(datum);
+        }
+    }
+    auto input_values = ColumnHelper::create_column(input_values_type, true);
+    {
+        // [a,b,c]
+        {
+            DatumArray datum{"a", "b", "c"};
+            input_values->append_datum(datum);
+        }
+        // [d]
+        {
+            DatumArray datum{"d"};
+            input_values->append_datum(datum);
+        }
+        // [h]
+        {
+            DatumArray datum{"h"};
+            input_values->append_datum(datum);
+        }
+    }
+    auto ret = MapFunctions::map(nullptr, {input_keys, input_values});
+    EXPECT_FALSE(ret.ok());
+}
+
+PARALLEL_TEST(MapFunctionsTest, test_map_mismatch2) {
+    TypeDescriptor input_keys_type;
+    input_keys_type.type = LogicalType::TYPE_ARRAY;
+    input_keys_type.children.emplace_back(LogicalType::TYPE_INT);
+
+    TypeDescriptor input_values_type;
+    input_values_type.type = LogicalType::TYPE_ARRAY;
+    input_values_type.children.emplace_back(LogicalType::TYPE_VARCHAR);
+
+    auto input_keys = ColumnHelper::create_column(input_keys_type, true);
+    // keys:   [[1,2,3]]
+    // values: [[a]]
+    {
+        // [1,2,3]
+        {
+            DatumArray datum{1, 2, 3};
+            input_keys->append_datum(datum);
+        }
+    }
+    auto input_values = ColumnHelper::create_column(input_values_type, true);
+    {
+        // [a]
+        {
+            DatumArray datum{"a"};
+            input_values->append_datum(datum);
+        }
+    }
+    auto ret = MapFunctions::map(nullptr, {input_keys, input_values});
+    EXPECT_FALSE(ret.ok());
+}
+
 PARALLEL_TEST(MapFunctionsTest, test_map_function) {
     TypeDescriptor type_map_int_int;
     type_map_int_int.type = LogicalType::TYPE_MAP;

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -217,7 +217,7 @@ TEST_F(ThreadPoolTest, TestRace) {
         CountDownLatch l(1);
         // CountDownLatch::count_down has multiple overloaded version,
         // so an cast is needed to use std::bind
-        ASSERT_TRUE(_pool->submit_func(std::bind((void(CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
+        ASSERT_TRUE(_pool->submit_func(std::bind((void (CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
         l.wait();
         // Sleeping a different amount in each iteration makes it more likely to hit
         // the bug.


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Implement Map Constructor in Backend.
This function constructs a map from the key array and value array. For example: 
map([1,2], [3,4]) will construct a map {1:3,2:4}