### PR TITLE
[BugFix] Show resource group with empty classifiers

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -27,6 +27,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -136,7 +137,10 @@ public class ResourceGroup implements Writable {
     }
 
     public List<List<String>> show() {
-        return classifiers.stream().map(c -> this.showClassifier(c)).collect(Collectors.toList());
+        if (classifiers.isEmpty()) {
+            return Collections.singletonList(showClassifier(new ResourceGroupClassifier()));
+        }
+        return classifiers.stream().map(this::showClassifier).collect(Collectors.toList());
     }
 
     public String getName() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -318,7 +318,7 @@ public class ResourceGroupStmtTest {
                 .map(row -> getClassifierId(row.get(row.size() - 1))).collect(Collectors.toList());
         rows = rows.stream().peek(row -> {
             if (row.get(0).equals(rgName)) {
-                row.set(9, "(weight=0.0)");
+                row.set(row.size() - 1, "(weight=0.0)");
             }
         }).distinct().collect(Collectors.toList());
         String ids = String.join(",", classifierIds);
@@ -353,7 +353,7 @@ public class ResourceGroupStmtTest {
                 // not last classifier of the rg, remove it
                 it.remove();
             } else {
-                row.set(9, "(weight=0.0)");
+                row.set(row.size() - 1, "(weight=0.0)");
             }
             String alterSql = String.format("ALTER RESOURCE GROUP %s DROP (%s)", rgName, id);
             starRocksAssert.executeResourceGroupDdlSql(alterSql);
@@ -372,7 +372,7 @@ public class ResourceGroupStmtTest {
         String rgName = "rg2";
         rows = rows.stream().peek(row -> {
             if (row.get(0).equals(rgName)) {
-                row.set(9, "(weight=0.0)");
+                row.set(row.size() - 1, "(weight=0.0)");
             }
         }).distinct().collect(Collectors.toList());
         String alterSql = String.format("ALTER RESOURCE GROUP %s DROP ALL", rgName);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -16,8 +16,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -314,7 +316,11 @@ public class ResourceGroupStmtTest {
         String rgName = rows.get(0).get(0);
         List<String> classifierIds = rows.stream().filter(row -> row.get(0).equals(rgName))
                 .map(row -> getClassifierId(row.get(row.size() - 1))).collect(Collectors.toList());
-        rows = rows.stream().filter(row -> !row.get(0).equals(rgName)).collect(Collectors.toList());
+        rows = rows.stream().peek(row -> {
+            if (row.get(0).equals(rgName)) {
+                row.set(9, "(weight=0.0)");
+            }
+        }).distinct().collect(Collectors.toList());
         String ids = String.join(",", classifierIds);
         String alterSql = String.format("ALTER RESOURCE GROUP %s DROP (%s)", rgName, ids);
         starRocksAssert.executeResourceGroupDdlSql(alterSql);
@@ -330,6 +336,9 @@ public class ResourceGroupStmtTest {
         createResourceGroups();
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
         Random rand = new Random();
+        Map<String, Integer> classifierCount = new HashMap<>();
+        rows.forEach(row -> classifierCount
+                .compute(row.get(0), (rg, countClassifier) -> countClassifier == null ? 1 : countClassifier + 1));
         Iterator<List<String>> it = rows.iterator();
         while (it.hasNext()) {
             List<String> row = it.next();
@@ -339,7 +348,13 @@ public class ResourceGroupStmtTest {
             String rgName = row.get(0);
             String classifier = row.get(row.size() - 1);
             String id = getClassifierId(classifier);
-            it.remove();
+            Integer count = classifierCount.computeIfPresent(rgName, (rg, countClassifier) -> countClassifier - 1);
+            if (count != 0) {
+                // not last classifier of the rg, remove it
+                it.remove();
+            } else {
+                row.set(9, "(weight=0.0)");
+            }
             String alterSql = String.format("ALTER RESOURCE GROUP %s DROP (%s)", rgName, id);
             starRocksAssert.executeResourceGroupDdlSql(alterSql);
         }
@@ -355,7 +370,11 @@ public class ResourceGroupStmtTest {
         createResourceGroups();
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
         String rgName = "rg2";
-        rows = rows.stream().filter(row -> !row.get(0).equals(rgName)).collect(Collectors.toList());
+        rows = rows.stream().peek(row -> {
+            if (row.get(0).equals(rgName)) {
+                row.set(9, "(weight=0.0)");
+            }
+        }).distinct().collect(Collectors.toList());
         String alterSql = String.format("ALTER RESOURCE GROUP %s DROP ALL", rgName);
         starRocksAssert.executeResourceGroupDdlSql(alterSql);
         String expect = rowsToString(rows);
@@ -405,7 +424,9 @@ public class ResourceGroupStmtTest {
 
         starRocksAssert.executeResourceGroupDdlSql("ALTER RESOURCE GROUP rg1 DROP ALL;");
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg1");
-        Assert.assertTrue(rows.isEmpty());
+        String actual = rowsToString(rows);
+        String expect = "rg1|10|20.0%|0|0|0|11|NORMAL|(weight=0.0)";
+        Assert.assertEquals(actual, expect);
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         assertResourceGroupNotExist("rg1");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15930 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
show resource group with empty classifiers for reuse

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
