### PR TITLE
[BugFix] Fix query use jsonTye between-and decimalV3Type failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -389,6 +389,7 @@ public class ScalarType extends Type implements Cloneable {
             case DATE:
             case DATETIME:
             case TIME:
+            case JSON:
                 return DOUBLE;
             default:
                 return INVALID;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -99,6 +99,9 @@ public class JsonTypeTest extends PlanTestBase {
 
     @Test
     public void testPredicateImplicitCast() throws Exception {
+        assertPlanContains("select parse_json('1') between 0.5 and 0.9",
+                "CAST(3: parse_json AS DOUBLE)");
+
         List<String> operators = Arrays.asList("<", "<=", "=", ">=", "!=");
         for (String operator : operators) {
             assertPlanContains(String.format("select parse_json('1') %s 1", operator),


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16056 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
support jsonType implicit cast to double when meet decimalV3Type
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
