### PR TITLE
[Feature] Support map_from_arrays and row functions

### DIFF
--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -24,7 +24,7 @@ namespace starrocks {
 // format of Array type.
 // For example,
 //  map([1, 2], [3, 4]) will generate a map which value is {1=3,2=4}
-StatusOr<ColumnPtr> MapFunctions::map(FunctionContext* context, const Columns& columns) {
+StatusOr<ColumnPtr> MapFunctions::map_from_arrays(FunctionContext* context, const Columns& columns) {
     DCHECK_EQ(2, columns.size());
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 

--- a/be/src/exprs/map_functions.h
+++ b/be/src/exprs/map_functions.h
@@ -28,7 +28,7 @@ namespace starrocks {
 
 class MapFunctions {
 public:
-    DEFINE_VECTORIZED_FN(map);
+    DEFINE_VECTORIZED_FN(map_from_arrays);
 
     DEFINE_VECTORIZED_FN(map_size);
 

--- a/be/src/exprs/struct_functions.cpp
+++ b/be/src/exprs/struct_functions.cpp
@@ -18,7 +18,7 @@
 
 namespace starrocks {
 
-StatusOr<ColumnPtr> StructFunctions::struct_ctor(FunctionContext* context, const Columns& columns) {
+StatusOr<ColumnPtr> StructFunctions::row(FunctionContext* context, const Columns& columns) {
     Columns field_columns;
     for (auto& column : columns) {
         field_columns.emplace_back(column->clone());

--- a/be/src/exprs/struct_functions.h
+++ b/be/src/exprs/struct_functions.h
@@ -20,7 +20,7 @@ namespace starrocks {
 
 class StructFunctions {
 public:
-    DEFINE_VECTORIZED_FN(struct_ctor);
+    DEFINE_VECTORIZED_FN(row);
 };
 
 } // namespace starrocks

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -87,7 +87,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map) {
             input_values->append_datum(datum);
         }
     }
-    auto ret = MapFunctions::map(nullptr, {input_keys, input_values});
+    auto ret = MapFunctions::map_from_arrays(nullptr, {input_keys, input_values});
     EXPECT_TRUE(ret.ok());
     auto result = std::move(ret.value());
     EXPECT_EQ(6, result->size());
@@ -144,7 +144,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_mismatch1) {
             input_values->append_datum(datum);
         }
     }
-    auto ret = MapFunctions::map(nullptr, {input_keys, input_values});
+    auto ret = MapFunctions::map_from_arrays(nullptr, {input_keys, input_values});
     EXPECT_FALSE(ret.ok());
 }
 
@@ -175,7 +175,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_mismatch2) {
             input_values->append_datum(datum);
         }
     }
-    auto ret = MapFunctions::map(nullptr, {input_keys, input_values});
+    auto ret = MapFunctions::map_from_arrays(nullptr, {input_keys, input_values});
     EXPECT_FALSE(ret.ok());
 }
 

--- a/be/test/exprs/struct_functions_test.cpp
+++ b/be/test/exprs/struct_functions_test.cpp
@@ -22,7 +22,7 @@
 
 namespace starrocks {
 
-PARALLEL_TEST(StructFunctionsTest, test_struct_ctor) {
+PARALLEL_TEST(StructFunctionsTest, test_row) {
     Columns input_columns;
     for (int i = 0; i < 5; ++i) {
         TypeDescriptor type;
@@ -47,7 +47,7 @@ PARALLEL_TEST(StructFunctionsTest, test_struct_ctor) {
         input_columns[i]->append_datum({5 - i});
     }
 
-    auto ret = StructFunctions::struct_ctor(nullptr, input_columns);
+    auto ret = StructFunctions::row(nullptr, input_columns);
     ASSERT_TRUE(ret.ok());
     auto struct_col = std::move(ret).value();
     ASSERT_EQ(3, struct_col->size());

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -454,6 +454,7 @@
         + [json_query](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_query.md)
         + [json_string](./sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_string.md)
     + Map Functions
+      + [map_from_arrays](./sql-reference/sql-functions/map-functions/map_from_arrays.md)
       + [map_keys](./sql-reference/sql-functions/map-functions/map_keys.md)
       + [map_size](./sql-reference/sql-functions/map-functions/map_size.md)
       + [map_values](./sql-reference/sql-functions/map-functions/map_values.md)
@@ -551,6 +552,8 @@
       + [percentile_union](./sql-reference/sql-functions/percentile-functions/percentile_union.md)
     + Scalar Functions
       + [hll_cardinality](/sql-reference/sql-functions/scalar-functions/hll_cardinality.md)
+    + Struct Functions
+      + [row](/sql-reference/sql-functions/struct-functions/row.md)
     + Utility Functions
       + [current_version](./sql-reference/sql-functions/utility-functions/current_version.md)
       + [host_name](./sql-reference/sql-functions/utility-functions/host_name.md)

--- a/docs/sql-reference/sql-functions/map-functions/map_from_arrays.md
+++ b/docs/sql-reference/sql-functions/map-functions/map_from_arrays.md
@@ -1,0 +1,43 @@
+# map_from_arrays
+
+## Description
+
+Create a MAP value from the given pair of key item array and value item array.
+
+## Syntax
+
+```
+MAP map_from_arrays(ARRAY keys, ARRAY values)
+```
+
+## Parameters
+
+`keys`: To construct the keys of the result MAP. Now users must make sure the elements of keys are unique.
+`values`: To construct the values of the result MAP.
+
+## Return value
+
+Return a MAP which is consisted from the input keys and values.
+
+keys and values must have the same length, otherwise it will return an error.
+If keys or values is NULL, this function will return NULL.
+
+## Examples
+
+```Plaintext
+select map_from_arrays([1, 2], ['Star', 'Rocks']);
++--------------------------------------------+
+| map_from_arrays([1, 2], ['Star', 'Rocks']) |
++--------------------------------------------+
+| {1:"Star",2:"Rocks"}                       |
++--------------------------------------------+
+```
+
+```Plaintext
+select map_from_arrays([1, 2], NULL);
++-------------------------------+
+| map_from_arrays([1, 2], NULL) |
++-------------------------------+
+| NULL                          |
++-------------------------------+
+```

--- a/docs/sql-reference/sql-functions/struct-functions/row.md
+++ b/docs/sql-reference/sql-functions/struct-functions/row.md
@@ -1,0 +1,39 @@
+# row
+
+## Description
+
+Create an unnamed STRUCT/ROW value from the given values.
+
+## Syntax
+
+```
+STRUCT row(ANY val, ...)
+```
+
+## Parameters
+
+This function is a variable argument function. Callers should give at least one argument.
+
+## Return value
+
+Return a STRUCT value which is consisted from the input values.
+
+## Examples
+
+```Plaintext
+select row(1,"Star","Rocks");
++-------------------------+
+| row(1, 'Star', 'Rocks') |
++-------------------------+
+| {1,"Star","Rocks"}      |
++-------------------------+
+```
+
+```Plaintext
+select row("StarRocks", NULL);
++------------------------+
+| row('StarRocks', NULL) |
++------------------------+
+| {"StarRocks",null}     |
++------------------------+
+```

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -398,6 +398,9 @@ public class FunctionSet {
     public static final String ARRAY_MAP = "array_map";
     public static final String TRANSFORM = "transform";
 
+    // Struct functions:
+    public static final String ROW = "row";
+
     // JSON functions
     public static final Function JSON_QUERY_FUNC = new Function(
             new FunctionName(JSON_QUERY), new Type[] {Type.JSON, Type.VARCHAR}, Type.JSON, false);
@@ -461,7 +464,7 @@ public class FunctionSet {
     // This does not contain any user defined functions. All UDFs handle null values by themselves.
     private final ImmutableSet<String> notAlwaysNullResultWithNullParamFunctions =
             ImmutableSet.of(IF, CONCAT_WS, IFNULL, NULLIF, NULL_OR_EMPTY, COALESCE, BITMAP_HASH, PERCENTILE_HASH,
-                    HLL_HASH, JSON_ARRAY, JSON_OBJECT);
+                    HLL_HASH, JSON_ARRAY, JSON_OBJECT, ROW);
 
     // If low cardinality string column with global dict, for some string functions,
     // we could evaluate the function only with the dict content, not all string column data.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -144,10 +144,28 @@ public class PolymorphicFunctionAnalyzer {
         }
     }
 
+    private static class MapFromArraysDeduce implements java.util.function.Function<Type[], Type> {
+        @Override
+        public Type apply(Type[] types) {
+            ArrayType keyArrayType = (ArrayType) types[0];
+            ArrayType valueArrayType = (ArrayType) types[1];
+            return new MapType(keyArrayType.getItemType(), valueArrayType.getItemType());
+        }
+    }
+
+    private static class RowDeduce implements java.util.function.Function<Type[], Type> {
+        @Override
+        public Type apply(Type[] types) {
+            return new StructType(Arrays.asList(types));
+        }
+    }
+
     private static final ImmutableMap<String, java.util.function.Function<Type[], Type>> DEDUCE_RETURN_TYPE_FUNCTIONS
             = ImmutableMap.<String, java.util.function.Function<Type[], Type>>builder()
             .put("map_keys", new MapKeysDeduce())
             .put("map_values", new MapValuesDeduce())
+            .put("map_from_arrays", new MapFromArraysDeduce())
+            .put("row", new RowDeduce())
             .build();
 
     private static Function resolveByDeducingReturnType(Function fn, Type[] inputArgTypes) {

--- a/gensrc/script/vectorized/vectorized_functions.py
+++ b/gensrc/script/vectorized/vectorized_functions.py
@@ -828,4 +828,7 @@ vectorized_functions = [
     [170000, 'map_size', 'INT', ['ANY_MAP'], 'MapFunctions::map_size'],
     [170001, 'map_keys', 'ANY_ARRAY', ['ANY_MAP'], 'MapFunctions::map_keys'],
     [170002, 'map_values', 'ANY_ARRAY', ['ANY_MAP'], 'MapFunctions::map_values'],
+    [170003, 'map_from_arrays', 'ANY_MAP', ['ANY_ARRAY', 'ANY_ARRAY'], 'MapFunctions::map_from_arrays'],
+    # struct functions
+    [170500, 'row', 'ANY_STRUCT', ['ANY_ELEMENT', "..."], 'StructFunctions::row'],
 ]


### PR DESCRIPTION
After applying this change list, users can use row and map_from_arrays functions like the following.

```
mysql> select row([1,2], map_from_arrays([1,2],[3,4]), 5, 6, row(1,2,row(4,5,row(6,7,row(8,9)))));
+------------------------------------------------------------------------------------------------+
| row([1, 2], map_from_arrays([1, 2], [3, 4]), 5, 6, row(1, 2, row(4, 5, row(6, 7, row(8, 9))))) |
+------------------------------------------------------------------------------------------------+
| {[1,2],{1:3,2:4},5,6,{1,2,{4,5,{6,7,{8,9}}}}}                                                  |
+------------------------------------------------------------------------------------------------+
```

## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
