### PR TITLE
[BugFix] [cherry-pick] Don't try catch the memory alloc of brpc transmit_chunk (#16047)

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -354,14 +354,12 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         closure->cntl.request_attachment().append(request.attachment);
 
         if (bthread_self()) {
-            TRY_CATCH_BAD_ALLOC(
-                    request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure));
+            request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
         } else {
             // When the driver worker thread sends request and creates the protobuf request,
             // also use process_mem_tracker to record the memory of the protobuf request.
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
-            TRY_CATCH_BAD_ALLOC(
-                    request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure));
+            request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
         }
 
         return Status::OK();

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -289,8 +289,7 @@ Status DataStreamSender::Channel::_do_send_chunk_rpc(PTransmitChunkParams* reque
     _chunk_closure->cntl.Reset();
     _chunk_closure->cntl.set_timeout_ms(_brpc_timeout_ms);
     _chunk_closure->cntl.request_attachment().append(attachment);
-    TRY_CATCH_BAD_ALLOC(
-            _brpc_stub->transmit_chunk(&_chunk_closure->cntl, request, &_chunk_closure->result, _chunk_closure));
+    _brpc_stub->transmit_chunk(&_chunk_closure->cntl, request, &_chunk_closure->result, _chunk_closure);
     _request_seq++;
     return Status::OK();
 }


### PR DESCRIPTION
If the bthread may be switched, don't rely on thread local variables to throw bad alloc, otherwise it will be crash.