### PR TITLE
[Enhancement] [cherry-pick] segment replicate executor support fast cancel (#15969)

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -49,7 +49,7 @@ DeltaWriter::~DeltaWriter() {
         _flush_token->shutdown();
     }
     if (_replicate_token != nullptr) {
-        _replicate_token->cancel();
+        _replicate_token->shutdown();
     }
     switch (get_state()) {
     case kUninitialized:
@@ -480,6 +480,9 @@ void DeltaWriter::cancel(const Status& st) {
     if (_flush_token != nullptr) {
         _flush_token->cancel(st);
     }
+    if (_replicate_token != nullptr) {
+        _replicate_token->cancel(st);
+    }
 }
 
 void DeltaWriter::abort(bool with_log) {
@@ -491,7 +494,7 @@ void DeltaWriter::abort(bool with_log) {
         _flush_token->shutdown();
     }
     if (_replicate_token != nullptr) {
-        _replicate_token->cancel();
+        _replicate_token->shutdown();
     }
     VLOG(1) << "Aborted delta writer. tablet_id: " << _tablet->tablet_id();
 }

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -219,10 +219,14 @@ Status ReplicateToken::submit(std::unique_ptr<SegmentPB> segment, bool eos) {
     return _replicate_token->submit(std::move(task));
 }
 
-void ReplicateToken::cancel() {
+void ReplicateToken::cancel(const Status& st) {
     for (auto& channel : _replicate_channels) {
         channel->cancel();
     }
+    set_status(st);
+}
+
+void ReplicateToken::shutdown() {
     _replicate_token->shutdown();
 }
 

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -73,7 +73,9 @@ public:
 
     // when error has happpens, so we cancel this token
     // and remove all tasks in the queue.
-    void cancel();
+    void cancel(const Status& st);
+
+    void shutdown();
 
     // wait all tasks in token to be completed.
     Status wait();


### PR DESCRIPTION
Make cancel non-blocking, otherwise once it gets stuck due to flush slow or network reasons, it will block the cancel of other DeltaWriter
