### PR TITLE
[BugFix] array_filter[nullable_col, null] results' null col is not set

### DIFF
--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -4667,6 +4667,7 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
     ArrayFilter filter;
     auto dest_column = filter.process(nullptr, {src_column, src_column2});
     ASSERT_TRUE(dest_column->get(0).get_array().empty());
+
     // array is null
     dest_column = filter.process(nullptr, {src_column2, src_column});
     ASSERT_TRUE(dest_column->only_null());
@@ -4674,6 +4675,16 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
     // all null
     dest_column = filter.process(nullptr, {src_column2, src_column2});
     ASSERT_TRUE(dest_column->only_null());
+
+    // src is nullable & bool_array is null
+    auto src_column_nullable = ColumnHelper::create_column(TYPE_ARRAY_TINYINT, true);
+    src_column_nullable->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
+    src_column_nullable->append_datum(Datum());
+    dest_column = filter.process(nullptr, {src_column_nullable, src_column2});
+    auto null_data = ColumnHelper::as_raw_column<NullableColumn>(dest_column)->immutable_null_column_data().data();
+    ASSERT_TRUE(null_data.size() == 2);
+    ASSERT_TRUE(!null_data[0]);
+    ASSERT_TRUE(null_data[1]);
 }
 
 TEST_F(ArrayFunctionsTest, array_distinct_only_null) {

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -4682,7 +4682,7 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
     src_column_nullable->append_datum(Datum());
     dest_column = filter.process(nullptr, {src_column_nullable, src_column2});
     auto null_data = ColumnHelper::as_raw_column<NullableColumn>(dest_column)->immutable_null_column_data().data();
-    ASSERT_TRUE(null_data->null_column_data().size() == 2);
+    ASSERT_TRUE(null_data->size() == 2);
     ASSERT_TRUE(!null_data[0]);
     ASSERT_TRUE(null_data[1]);
 }

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -4682,7 +4682,7 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
     src_column_nullable->append_datum(Datum());
     dest_column = filter.process(nullptr, {src_column_nullable, src_column2});
     auto null_data = ColumnHelper::as_raw_column<NullableColumn>(dest_column)->immutable_null_column_data().data();
-    ASSERT_TRUE(null_data.size() == 2);
+    ASSERT_TRUE(null_data->null_column_data().size() == 2);
     ASSERT_TRUE(!null_data[0]);
     ASSERT_TRUE(null_data[1]);
 }

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -4681,10 +4681,10 @@ TEST_F(ArrayFunctionsTest, array_filter_with_onlynull) {
     src_column_nullable->append_datum(DatumArray{(int8_t)5, (int8_t)3, (int8_t)6});
     src_column_nullable->append_datum(Datum());
     dest_column = filter.process(nullptr, {src_column_nullable, src_column2});
-    auto null_data = ColumnHelper::as_raw_column<NullableColumn>(dest_column)->immutable_null_column_data().data();
-    ASSERT_TRUE(null_data->size() == 2);
-    ASSERT_TRUE(!null_data[0]);
-    ASSERT_TRUE(null_data[1]);
+    auto null_data = ColumnHelper::as_raw_column<NullableColumn>(dest_column)->immutable_null_column_data();
+    ASSERT_TRUE(null_data.size() == 2);
+    ASSERT_TRUE(!null_data.data()[0]);
+    ASSERT_TRUE(null_data.data()[1]);
 }
 
 TEST_F(ArrayFunctionsTest, array_distinct_only_null) {


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

array_filter[nullable_col, null] results' null col is not set, and it causes crash.

before
```
crash
```
after
```
mysql> select c5, array_filter(c5,null) from array_sort_null;
+---------------------------+------------------------+
| c5                        | array_filter(c5, NULL) |
+---------------------------+------------------------+
| ["222feds","中文",null]   | []                     |
+---------------------------+------------------------+
1 row in set (0.02 sec)
```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
