### PR TITLE
[BugFix] Can't ingest data via starrrocks external table from starrocks' lower version to higher version

### DIFF
--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -60,9 +60,9 @@ struct TSetSessionParams {
 struct TAuthenticateParams {
     1: required string user
     2: required string passwd
-    3: required string host
-    4: required string db_name
-    5: required list<string> table_names;
+    3: optional string host
+    4: optional string db_name
+    5: optional list<string> table_names;
 }
 
 struct TColumnDesc {


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In #11871,  to support authentication for StarRocks external table, we add three fields in thrift struct `TAuthenticateParams`: `host`, `db_name` and `table_names`, and they are marked `required` which leads to a compatible problem. Denote the starrocks before #11871 as `v1`, and starrocks after #11871 as `v2`, and we can ingesting data to `v1` via  the starrocks external table on `v2` , but can't ingest data to `v2` via external table on `v1`. The exception is as follows

![image](https://user-images.githubusercontent.com/11382970/210310744-0c3bddb6-0be2-40b2-8ffa-43f56b8ea087.png)
#11871 adds `host`, `db_name` and `table_names` to `TAuthenticateParams` as `required`
```
struct TAuthenticateParams {
    1: required string user
    2: required string passwd
    3: required string host
    4: required string db_name
    5: required list<string> table_names;
}
```

The reason is that
* external table on `v1` will issue a RPC to `v2` to request the meta of destination table
* The RPC carries a parameter `TAuthenticateParams` created on `v1` which not contains fields `host`, `db_name` and `table_names`
* thrift requires these fields on `v2`, so the RPC failed
* when ingesting data from `v2` to `v1`, the RPC created on `v2` does not carry `TAuthenticateParams`, so there is no problem

## How to fix it
Mark `host`, `db_name` and `table_names` in `TAuthenticateParams` as `optional`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
