### PR TITLE
[BugFix] Fix broker kerberos ticket timeout bug when there are broker load continuously

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerConfig.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerConfig.java
@@ -33,6 +33,9 @@ public class BrokerConfig extends ConfigBase {
     
     @ConfField
     public static int broker_ipc_port = 8000;
+
+    @ConfField
+    public static int kerberos_token_expire_seconds = 86000;
     
     @ConfField
     public static String sys_log_dir = System.getenv("BROKER_HOME") + "/log";

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerConfig.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerConfig.java
@@ -34,6 +34,12 @@ public class BrokerConfig extends ConfigBase {
     @ConfField
     public static int broker_ipc_port = 8000;
 
+    /**
+     * If the kerberos HDFS client is alive beyond this time,
+     * client checker will destroy it to avoid kerberos token expire.
+     * Set this value a little smaller than the actual token expire seconds,
+     * to make sure the client is destroyed before the timeout reaches.
+     */
     @ConfField
     public static int kerberos_token_expire_seconds = 86000;
     

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -437,7 +437,7 @@ public class FileSystemManager {
                 } else {
                     dfsFileSystem = FileSystem.get(pathUri.getUri(), conf);
                 }
-                fileSystem.setFileSystem(dfsFileSystem);
+                fileSystem.setFileSystem(dfsFileSystem, authentication.equals(AUTHENTICATION_KERBEROS));
             }
             return fileSystem;
         } catch (Exception e) {
@@ -994,7 +994,7 @@ public class FileSystemManager {
         public void run() {
             try {
                 for (BrokerFileSystem fileSystem : cachedFileSystem.values()) {
-                    if (fileSystem.isExpired(BrokerConfig.client_expire_seconds)) {
+                    if (fileSystem.isExpired()) {
                         logger.info("file system " + fileSystem + " is expired, close and remove it");
                         fileSystem.getLock().lock();
                         try {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16127

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The current broker has two types of kerberos token, one is the global, one unique to each HDFS client, access to HDFS will use each client unique token, and access to other components (such as kms) use the global. HDFS client unique token is not automatically refreshed, but HDFS client in the broker has an expiration time, if more than 5min is not used, the HDFS client will be destroyed. If there is a request the next time, a new client will be created, the kerberos login will be executed again, this is actually an indirect refresh token. But if there are access continuously, HDFS client will never be rebuilt, then the token will not be refreshed, it will time out after 1 day.
To fix this bug, destroy the client before token is expired.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
