### PR TITLE
[Enhancement] Remove struct subfield colon separator and change struct subfield equals() behavior

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
@@ -139,11 +139,11 @@ public class StructField {
             return otherStructField.name == null && type.equals(otherStructField.type);
         }
 
-        // Both are named struct field
         if (otherStructField.name == null) {
             // If other struct field is not named struct field, return false directly.
             return false;
         }
+        // Both are named struct field
         return otherStructField.name.equals(name) && otherStructField.type.equals(type);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
@@ -26,10 +26,13 @@ import com.starrocks.thrift.TTypeNode;
  * comments of struct fields. We set comment to null to avoid compatibility issues.
  */
 public class StructField {
+    // If name is null, that means this StructFiled is unnamed.
     @SerializedName(value = "name")
     private final String name;
     @SerializedName(value = "type")
     private final Type type;
+
+    // comment is not used now, it's always null.
     @SerializedName(value = "comment")
     private final String comment;
     private int position;  // in struct
@@ -122,6 +125,9 @@ public class StructField {
         }
     }
 
+    // [Named vs Named] struct<a: INT, b: STRING> is equal to struct<a: INT, b: STRING>
+    // [Unnamed vs Unnamed] struct<INT, STRING> is equal to struct<INT, STRING>
+    // [Named vs Unnamed][Always false] struct<a: INT, b: STRING> is not equal to struct<INT, STRING>
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof StructField)) {
@@ -129,7 +135,14 @@ public class StructField {
         }
         StructField otherStructField = (StructField) other;
         if (name == null) {
-            return otherStructField.name == null && otherStructField.type.equals(type);
+            // If this() is unnamed struct field, other struct field must also be an unnamed struct field.
+            return otherStructField.name == null && type.equals(otherStructField.type);
+        }
+
+        // Both are named struct field
+        if (otherStructField.name == null) {
+            // If other struct field is not named struct field, return false directly.
+            return false;
         }
         return otherStructField.name.equals(name) && otherStructField.type.equals(type);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5576,9 +5576,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     public StructType getStructType(StarRocksParser.StructTypeContext context) {
         ArrayList<StructField> fields = new ArrayList<>();
-        List<StarRocksParser.ColumnNameTypeContext> typeLists =
-                context.columnNameTypeList().columnNameType();
-        for (StarRocksParser.ColumnNameTypeContext type : typeLists) {
+        List<StarRocksParser.SubfieldDescContext> subfields =
+                context.subfieldDescs().subfieldDesc();
+        for (StarRocksParser.SubfieldDescContext type : subfields) {
             fields.add(new StructField(type.identifier().getText(), getType(type.type()), null));
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5576,12 +5576,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     public StructType getStructType(StarRocksParser.StructTypeContext context) {
         ArrayList<StructField> fields = new ArrayList<>();
-        List<StarRocksParser.ColumnNameColonTypeContext> typeLists =
-                context.columnNameColonTypeList().columnNameColonType();
-        for (StarRocksParser.ColumnNameColonTypeContext type : typeLists) {
-            String comment = (type.comment() == null) ? null :
-                    ((StringLiteral) visit(type.comment().string())).getStringValue();
-            fields.add(new StructField(type.identifier().getText(), getType(type.type()), comment));
+        List<StarRocksParser.ColumnNameTypeContext> typeLists =
+                context.columnNameTypeList().columnNameType();
+        for (StarRocksParser.ColumnNameTypeContext type : typeLists) {
+            fields.add(new StructField(type.identifier().getText(), getType(type.type()), null));
         }
 
         return new StructType(fields);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2050,16 +2050,16 @@ mapType
     : MAP '<' type ',' type '>'
     ;
 
-columnNameType
+subfieldDesc
     : identifier type
     ;
 
-columnNameTypeList
-    : columnNameType (',' columnNameType)*
+subfieldDescs
+    : subfieldDesc (',' subfieldDesc)*
     ;
 
 structType
-    : STRUCT '<' columnNameTypeList '>'
+    : STRUCT '<' subfieldDescs '>'
     ;
 
 typeParameter

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2050,16 +2050,16 @@ mapType
     : MAP '<' type ',' type '>'
     ;
 
-columnNameColonType
-    : identifier ':' type comment?
+columnNameType
+    : identifier type
     ;
 
-columnNameColonTypeList
-    : columnNameColonType (',' columnNameColonType)*
+columnNameTypeList
+    : columnNameType (',' columnNameType)*
     ;
 
 structType
-    : STRUCT '<' columnNameColonTypeList '>'
+    : STRUCT '<' columnNameTypeList '>'
     ;
 
 typeParameter

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -270,9 +270,9 @@ public class AnalyzeCreateTableTest {
         analyzeSuccess("create external table table1 (col0 int, col1 array<map<int,int>>) " +
                 "engine=hive properties('key' = 'value')");
 
-        analyzeFail("create table table1 (col0 int, col1 array<struct<a: int>>) " +
+        analyzeFail("create table table1 (col0 int, col1 array<struct<a int>>) " +
                 "engine=olap distributed by hash(col0) buckets 10");
-        analyzeSuccess("create external table table1 (col0 int, col1 array<struct<a: int>>) " +
+        analyzeSuccess("create external table table1 (col0 int, col1 array<struct<a int>>) " +
                 "engine=hive properties('key' = 'value')");
 
         analyzeFail("create table table1 (col0 int, col1 map<int,int>) " +
@@ -280,9 +280,9 @@ public class AnalyzeCreateTableTest {
         analyzeSuccess("create external table table1 (col0 int, col1 map<int,int>) " +
                 "engine=hive properties('key' = 'value')");
 
-        analyzeFail("create table table1 (col0 int, col1 struct<a: int>) " +
+        analyzeFail("create table table1 (col0 int, col1 struct<a int>) " +
                 "engine=olap distributed by hash(col0) buckets 10");
-        analyzeSuccess("create external table table1 (col0 int, col1 struct<a: int>) " +
+        analyzeSuccess("create external table table1 (col0 int, col1 struct<a int>) " +
                 "engine=hive properties('key' = 'value')");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStructTest.java
@@ -40,10 +40,10 @@ public class AnalyzeStructTest {
         FeConstants.runningUnitTest = true;
         String createStructTableSql = "CREATE TABLE struct_a(\n" +
                 "a INT, \n" +
-                "b STRUCT<a: INT, c: INT COMMENT 'sub field comment'> COMMENT 'smith',\n" +
-                "c STRUCT<a: INT, b: DOUBLE>,\n" +
-                "d STRUCT<a: INT, b: ARRAY<STRUCT<a: INT, b: DOUBLE>>, c: STRUCT<a: INT> COMMENT 'aa'>,\n" +
-                "struct_a STRUCT<struct_a: STRUCT<struct_a: INT>, other: INT> COMMENT 'alias test'\n" +
+                "b STRUCT<a INT, c INT> COMMENT 'smith',\n" +
+                "c STRUCT<a INT, b DOUBLE>,\n" +
+                "d STRUCT<a INT, b ARRAY<STRUCT<a INT, b DOUBLE>>, c STRUCT<a INT>>,\n" +
+                "struct_a STRUCT<struct_a STRUCT<struct_a INT>, other INT> COMMENT 'alias test'\n" +
                 ") DISTRIBUTED BY HASH(`a`) BUCKETS 1\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\"\n" +
@@ -52,8 +52,8 @@ public class AnalyzeStructTest {
 
         String deeperStructTableSql = "CREATE TABLE deeper_table(\n" +
                 "a INT, \n" +
-                "b STRUCT<b: STRUCT<c: STRUCT<d: STRUCT<e: INT>>>>,\n" +
-                "struct_a STRUCT<struct_a: STRUCT<struct_a: INT>, other: INT>\n" +
+                "b STRUCT<b STRUCT<c STRUCT<d STRUCT<e INT>>>>,\n" +
+                "struct_a STRUCT<struct_a STRUCT<struct_a INT>, other INT>\n" +
                 ") DISTRIBUTED BY HASH(`a`) BUCKETS 1\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\"\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypeTest.java
@@ -41,8 +41,8 @@ public class StructTypeTest extends PlanTestBase {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         FeConstants.runningUnitTest = true;
         starRocksAssert.withTable("create table test(c0 INT, " +
-                "c1 struct<a:array<struct<b:int>>>," +
-                "c2 struct<a:int,b:double>) " +
+                "c1 struct<a array<struct<b int>>>," +
+                "c2 struct<a int,b double>) " +
                 " duplicate key(c0) distributed by hash(c0) buckets 1 " +
                 "properties('replication_num'='1');");
         FeConstants.runningUnitTest = false;
@@ -135,5 +135,38 @@ public class StructTypeTest extends PlanTestBase {
     public void testUnnamedStruct() {
         StructType type = new StructType(Lists.newArrayList(Type.INT, Type.DATETIME));
         Assert.assertEquals("STRUCT<int(11), datetime>", type.toSql());
+    }
+
+    @Test
+    public void testStructEquals() {
+        // test equals() for unnamed struct
+        StructType originType = new StructType(Lists.newArrayList(Type.INT, Type.VARCHAR));
+        StructType comparedType = new StructType(Lists.newArrayList(Type.INT, Type.VARCHAR));
+        Assert.assertEquals(originType, comparedType);
+        Assert.assertEquals(comparedType, originType);
+
+        comparedType = new StructType(Lists.newArrayList(Type.VARCHAR, Type.INT));
+        Assert.assertNotEquals(originType, comparedType);
+        Assert.assertNotEquals(comparedType, originType);
+
+        // test equals() for unnamed struct & named struct
+        StructField tmpField1 = new StructField("hello", Type.INT);
+        StructField tmpField2 = new StructField("world", Type.VARCHAR);
+        comparedType = new StructType(Lists.newArrayList(tmpField1, tmpField2));
+        Assert.assertNotEquals(originType, comparedType);
+        Assert.assertNotEquals(comparedType, originType);
+
+        // test equals() for named struct & named struct
+        StructField tmpField3 = new StructField("hello", Type.INT);
+        StructField tmpField4 = new StructField("world", Type.VARCHAR);
+        originType = new StructType(Lists.newArrayList(tmpField1, tmpField2));
+        comparedType = new StructType(Lists.newArrayList(tmpField3, tmpField4));
+        Assert.assertEquals(originType, comparedType);
+        Assert.assertEquals(comparedType, originType);
+
+        tmpField3 = new StructField("hello123", Type.INT);
+        comparedType = new StructType(Lists.newArrayList(tmpField3, tmpField4));
+        Assert.assertNotEquals(originType, comparedType);
+        Assert.assertNotEquals(comparedType, originType);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
