### PR TITLE
[BugFix] Fix primary key replicated storage flush fail

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -334,7 +334,7 @@ Status DeltaWriter::write_segment(const SegmentPB& segment_pb, butil::IOBuf& dat
                                                  segment_pb.segment_id(), _opt.tablet_id,
                                                  _replica_state_name(_replica_state)));
     }
-    VLOG(1) << "Flush segment tablet " << _opt.tablet_id << " segment id " << segment_pb.segment_id();
+    VLOG(1) << "Flush segment tablet " << _opt.tablet_id << " segment " << segment_pb.DebugString();
 
     return _rowset_writer->flush_segment(segment_pb, data);
 }

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -210,9 +210,15 @@ Status RowsetWriter::flush_segment(const SegmentPB& segment_pb, butil::IOBuf& da
         // 2. flush segment file
         auto writer = std::make_unique<SegmentFileWriter>(wfile.get());
 
-        size_t remaining_bytes = segment_pb.data_size();
+        butil::IOBuf segment_data;
+        int64_t remaining_bytes = data.cutn(&segment_data, segment_pb.data_size());
+        if (remaining_bytes != segment_pb.data_size()) {
+            return Status::InternalError(fmt::format("segment {} file size {} not equal attachment size {}",
+                                                     segment_pb.DebugString(), remaining_bytes,
+                                                     segment_pb.data_size()));
+        }
         while (remaining_bytes > 0) {
-            auto written_bytes = data.cut_into_writer(writer.get(), remaining_bytes);
+            auto written_bytes = segment_data.cut_into_writer(writer.get(), remaining_bytes);
             if (written_bytes < 0) {
                 return io::io_error(wfile->filename(), errno);
             }
@@ -257,9 +263,15 @@ Status RowsetWriter::flush_segment(const SegmentPB& segment_pb, butil::IOBuf& da
         // 2. flush delete file
         auto writer = std::make_unique<SegmentFileWriter>(wfile.get());
 
-        size_t remaining_bytes = segment_pb.delete_data_size();
+        butil::IOBuf delete_data;
+        int64_t remaining_bytes = data.cutn(&delete_data, segment_pb.delete_data_size());
+        if (remaining_bytes != segment_pb.delete_data_size()) {
+            return Status::InternalError(fmt::format("segment {} delete size {} not equal attachment size {}",
+                                                     segment_pb.DebugString(), remaining_bytes,
+                                                     segment_pb.delete_data_size()));
+        }
         while (remaining_bytes > 0) {
-            auto written_bytes = data.cut_into_writer(writer.get(), remaining_bytes);
+            auto written_bytes = delete_data.cut_into_writer(writer.get(), remaining_bytes);
             if (written_bytes < 0) {
                 return io::io_error(wfile->filename(), errno);
             }


### PR DESCRIPTION
flush segment/delete file sometimes fail since cut_into_writer write size is approximately, so that we need accurately cutn into IOBuf before write

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
