### PR TITLE
[BugFix] Check juicefs schema when identifying hdfs path to support read juicefs by hdfs scanner

### DIFF
--- a/be/src/util/hdfs_util.cpp
+++ b/be/src/util/hdfs_util.cpp
@@ -14,6 +14,7 @@ namespace starrocks {
 
 static const char* kFileSysPrefixHdfs = "hdfs://";
 static const char* kFileSysPrefixViewfs = "viewfs://";
+static const char* kFileSysPrefixJuicefs = "jfs://";
 static const char* kFileSysPrefixS3 = "s3a://";
 static const char* KFileSysPrefixOSS = "oss://";
 
@@ -83,7 +84,8 @@ static bool is_specific_path(const char* path, const char* specific_prefix) {
 }
 
 bool is_hdfs_path(const char* path) {
-    return is_specific_path(path, kFileSysPrefixHdfs) || is_specific_path(path, kFileSysPrefixViewfs);
+    return is_specific_path(path, kFileSysPrefixHdfs) || is_specific_path(path, kFileSysPrefixViewfs) ||
+                            is_specific_path(path, kFileSysPrefixJuicefs);
 }
 
 bool is_s3a_path(const char* path) {

--- a/be/src/util/hdfs_util.cpp
+++ b/be/src/util/hdfs_util.cpp
@@ -85,7 +85,7 @@ static bool is_specific_path(const char* path, const char* specific_prefix) {
 
 bool is_hdfs_path(const char* path) {
     return is_specific_path(path, kFileSysPrefixHdfs) || is_specific_path(path, kFileSysPrefixViewfs) ||
-                            is_specific_path(path, kFileSysPrefixJuicefs);
+           is_specific_path(path, kFileSysPrefixJuicefs);
 }
 
 bool is_s3a_path(const char* path) {

--- a/be/src/util/hdfs_util.h
+++ b/be/src/util/hdfs_util.h
@@ -14,7 +14,7 @@ Status get_namenode_from_path(const std::string& path, std::string* namenode);
 std::string get_bucket_from_namenode(const std::string& namenode);
 std::string get_endpoint_from_oss_bucket(const std::string& default_bucket, std::string* bucket);
 
-// Returns true if the path refers to a location on an HDFS filesystem.
+// Returns true if the path refers to a location on an HDFS compatible filesystem.
 bool is_hdfs_path(const char* path);
 
 // Returns true if the path refers to a location on object storage filesystem.


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR mainly solve the following two problems when visiting juicefs:
* The juicefs schema, looks like 'jfs://', is not resolved correctly now, which results in the juicefs file will be visited as local file. To avoiding the problem of "not found", we check juicefs schema when identifying hdfs path, to support read juicefs by hdfs scanner.
* As the `GetReadStatistics` is not supported in juicefs hadoop sdk, which will cause the be crash when visiting juicefs. So we avoid to call this function for juicefs.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
