### PR TITLE
[BugFix] Use data columns to get column statistics instead of all columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/external/hive/HiveMetaClient.java
@@ -467,8 +467,10 @@ public class HiveMetaClient {
         Map<String, List<ColumnStatisticsObj>> partitionColumnStats;
         try (AutoCloseClient client = getClient()) {
             // there is only non-partition-key column stats in hive metastore
+            List<String> dataColumnNames = new ArrayList<>(columnNames);
+            dataColumnNames.removeAll(partColumnNames);
             partitionColumnStats =
-                    client.hiveClient.getPartitionColumnStatistics(dbName, tableName, partNames, columnNames);
+                    client.hiveClient.getPartitionColumnStatistics(dbName, tableName, partNames, dataColumnNames);
         } catch (Exception e) {
             throw new DdlException("get partition column statistics from hive metastore failed: " + e.getMessage());
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Use data columns to get column statistics instead of all columns.

Aliyun DLF will throw a exception if the column list containing the partition columns is passed as the 4th parameter to the method `getPartitionColumnStatistics` because DLF has more strict column validation steps
```
[StatisticsCalculator.estimateHMSTableScanColumns():324] Failed to xxx get table column. error : com.starrocks.common.DdlException: get table level column stats failed: com.starrocks.common.DdlException: get partition column statistics from hive metastore failed: Action: GET_PARTITION_COLUMN_STATISTICS ErrorCode: InvalidInput Message: invalid column name: day RequestId: A7xxxx
```

This issue has been resolved in #11461 , so make a simple fix here in branch-2.4 and before

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
