### PR TITLE
[Refactor] limit Local exchange buffer size by memory usage rather than by row count

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -919,4 +919,7 @@ CONF_String(exception_stack_black_list, "apache::thrift::,ue2::,arangodb::");
 
 CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache=128M}");
 
+// limit local exchange buffer's size per driver
+CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
+
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -919,7 +919,7 @@ CONF_String(exception_stack_black_list, "apache::thrift::,ue2::,arangodb::");
 
 CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache=128M}");
 
-// limit local exchange buffer's size per driver
+// limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
 
 } // namespace starrocks::config

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -99,6 +99,15 @@ class PartitionExchanger final : public LocalExchanger {
             return _partition_row_indexes_start_points[partition_id + 1];
         }
 
+        size_t partition_memory_usage(size_t partition_id) {
+            if (partition_id >= _partition_memory_usage.size() || partition_id < 0) {
+                throw std::runtime_error(fmt::format("invalid index {} to get partition memory usage, whose size = {}.",
+                                                     partition_id, _partition_memory_usage.size()));
+            } else {
+                return _partition_memory_usage[partition_id];
+            }
+        }
+
     private:
         LocalExchangeSourceOperatorFactory* _source;
         const TPartitionType::type _part_type;
@@ -113,6 +122,7 @@ class PartitionExchanger final : public LocalExchanger {
         // It will easy to get number of rows belong to one channel by doing
         // _partition_row_indexes_start_points[i + 1] - _partition_row_indexes_start_points[i]
         std::vector<size_t> _partition_row_indexes_start_points;
+        std::vector<size_t> _partition_memory_usage;
         std::unique_ptr<Shuffler> _shuffler;
     };
 

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -25,26 +25,26 @@ class LocalExchangeMemoryManager {
 public:
     // default value 128MB and 128GB
     LocalExchangeMemoryManager(size_t max_input_dop)
-            : _max_memory_bytes_per_driver(128 * 1024 * 1024UL), _max_memory_bytes(128 * 1024 * 1024 * 1024UL) {
+            : _max_memory_usage_per_driver(128 * 1024 * 1024UL), _max_memory_usage(128 * 1024 * 1024 * 1024UL) {
         if (config::local_exchange_buffer_mem_limit_per_driver > 0) {
-            _max_memory_bytes_per_driver = config::local_exchange_buffer_mem_limit_per_driver;
+            _max_memory_usage_per_driver = config::local_exchange_buffer_mem_limit_per_driver;
         } else {
             LOG(WARNING) << "invalid config::local_exchange_buffer_mem_limit_per_driver "
                          << config::local_exchange_buffer_mem_limit_per_driver;
         }
-        size_t res = max_input_dop * _max_memory_bytes_per_driver;
-        _max_memory_bytes = (res > _max_memory_bytes || res <= 0) ? _max_memory_bytes : res;
+        size_t res = max_input_dop * _max_memory_usage_per_driver;
+        _max_memory_usage = (res > _max_memory_usage || res <= 0) ? _max_memory_usage : res;
     }
 
-    void update_memory_usage(size_t memory_bytes) { _memory_bytes += memory_bytes; }
+    void update_memory_usage(size_t memory_usage) { _memory_usage += memory_usage; }
 
-    size_t get_memory_limit_per_driver() const { return _max_memory_bytes_per_driver; }
+    size_t get_memory_limit_per_driver() const { return _max_memory_usage_per_driver; }
 
-    bool is_full() const { return _memory_bytes >= _max_memory_bytes; }
+    bool is_full() const { return _memory_usage >= _max_memory_usage; }
 
 private:
-    size_t _max_memory_bytes;
-    size_t _max_memory_bytes_per_driver;
-    std::atomic<size_t> _memory_bytes{0};
+    size_t _max_memory_usage;
+    size_t _max_memory_usage_per_driver;
+    std::atomic<size_t> _memory_usage{0};
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -23,9 +23,7 @@ namespace starrocks::pipeline {
 // Manage the memory usage for local exchange
 class LocalExchangeMemoryManager {
 public:
-    // default value 128MB and 128GB
-    LocalExchangeMemoryManager(size_t max_input_dop)
-            : _max_memory_usage_per_driver(128 * 1024 * 1024UL), _max_memory_usage(128 * 1024 * 1024 * 1024UL) {
+    LocalExchangeMemoryManager(size_t max_input_dop) {
         if (config::local_exchange_buffer_mem_limit_per_driver > 0) {
             _max_memory_usage_per_driver = config::local_exchange_buffer_mem_limit_per_driver;
         } else {
@@ -43,8 +41,8 @@ public:
     bool is_full() const { return _memory_usage >= _max_memory_usage; }
 
 private:
-    size_t _max_memory_usage;
-    size_t _max_memory_usage_per_driver;
+    size_t _max_memory_usage = 128 * 1024 * 1024 * 1024UL; // 128GB
+    size_t _max_memory_usage_per_driver = 128 * 1024 * 1024UL; // 128MB
     std::atomic<size_t> _memory_usage{0};
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -41,7 +41,7 @@ public:
     bool is_full() const { return _memory_usage >= _max_memory_usage; }
 
 private:
-    size_t _max_memory_usage = 128 * 1024 * 1024 * 1024UL; // 128GB
+    size_t _max_memory_usage = 128 * 1024 * 1024 * 1024UL;     // 128GB
     size_t _max_memory_usage_per_driver = 128 * 1024 * 1024UL; // 128MB
     std::atomic<size_t> _memory_usage{0};
 };

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -24,29 +24,28 @@ namespace starrocks::pipeline {
 class LocalExchangeMemoryManager {
 public:
     LocalExchangeMemoryManager(size_t max_input_dop) {
-        int64_t limit_bytes = 128 * 1024 * 1024UL; // 128 MB
+        size_t res = max_input_dop * get_memory_limit_per_driver();
+        const size_t MAX_MEM_LIMIT = 128 * 1024 * 1024 * 1024UL; // 128GB limit
+        _max_memory_bytes = (res > MAX_MEM_LIMIT || res <= 0) ? MAX_MEM_LIMIT : res;
+    }
+
+    void update_memory_usage(size_t memory_bytes) { _memory_bytes += memory_bytes; }
+
+    size_t get_memory_limit_per_driver() {
+        size_t limit_bytes = 128 * 1024 * 1024UL; // 128 MB
         if (config::local_exchange_buffer_mem_limit_per_driver > 0) {
             limit_bytes = config::local_exchange_buffer_mem_limit_per_driver;
         } else {
             LOG(WARNING) << "invalid config::local_exchange_buffer_mem_limit_per_driver "
                          << config::local_exchange_buffer_mem_limit_per_driver;
         }
-        int64_t res = max_input_dop * limit_bytes;
-        const int64_t MAX_MEM_LIMIT = 128 * 1024 * 1024 * 1024UL; // 128GB limit
-        _max_memory_bytes = (res > MAX_MEM_LIMIT || res <= 0) ? MAX_MEM_LIMIT : res;
+        return limit_bytes;
     }
-
-    void update_memory_usage(int64_t memory_bytes) { _memory_bytes += memory_bytes; }
-
-    int64_t get_memory_usage() const { return _memory_bytes; }
 
     bool is_full() const { return _memory_bytes >= _max_memory_bytes; }
 
-    // consume the buffered data to avoid the buffer being full for a long time when the chunk's size is too large.
-    bool should_output() const { return _memory_bytes >= _max_memory_bytes * 0.8; };
-
 private:
-    int64_t _max_memory_bytes;
-    std::atomic<int64_t> _memory_bytes{0};
+    size_t _max_memory_bytes;
+    std::atomic<size_t> _memory_bytes{0};
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -47,7 +47,6 @@ public:
 
 private:
     int64_t _max_memory_bytes;
-    // an estimated value for partitioned shuffle, as it reconstructs chunks.
     std::atomic<int64_t> _memory_bytes{0};
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -33,27 +33,17 @@ public:
         }
         int64_t res = max_input_dop * limit_bytes;
         const int64_t MAX_MEM_LIMIT = 128 * 1024 * 1024 * 1024UL; // 128GB limit
-        _max_memory_bytes = res > MAX_MEM_LIMIT or res <= 0 ? MAX_MEM_LIMIT : res;
+        _max_memory_bytes = (res > MAX_MEM_LIMIT || res <= 0) ? MAX_MEM_LIMIT : res;
     }
 
-    void update_memory_usage(int64_t memory_bytes) {
-        LOG(WARNING) << "local exchange " << (memory_bytes > 0 ? " + " : " - ") << std::to_string(memory_bytes)
-                     << " left " << std::to_string(_memory_bytes);
-        _memory_bytes += memory_bytes;
-    }
+    void update_memory_usage(int64_t memory_bytes) { _memory_bytes += memory_bytes; }
 
     int64_t get_memory_usage() const { return _memory_bytes; }
 
     bool is_full() const { return _memory_bytes >= _max_memory_bytes; }
 
     // consume the buffered data to avoid the buffer being full for a long time when the chunk's size is too large.
-    bool should_output() const {
-        if (_memory_bytes >= _max_memory_bytes * 0.8) {
-            LOG(WARNING) << _memory_bytes << " >= " << _max_memory_bytes * 0.8 << " in local exchange";
-            return true;
-        }
-        return false;
-    };
+    bool should_output() const { return _memory_bytes >= _max_memory_bytes * 0.8; };
 
 private:
     int64_t _max_memory_bytes;

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -31,7 +31,7 @@ public:
             LOG(WARNING) << "config::local_exchange_buffer_mem_limit_per_driver <= 0";
         }
         size_t res = max_input_dop * limit_bytes;
-        size_t MAX_MEM_LIMIT = 8 * 1024 * 1024 * 1024; // 8G limit
+        const size_t MAX_MEM_LIMIT = 8 * 1024 * 1024 * 1024UL; // 8G limit
         _max_memory_bytes = res > MAX_MEM_LIMIT or res <= 0 ? MAX_MEM_LIMIT : res;
     }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -43,7 +43,12 @@ public:
     bool is_full() const { return _memory_bytes >= _max_memory_bytes; }
 
     // consume the buffered data to avoid the buffer being full for a long time when the chunk's size is too large.
-    bool should_output() const { return _memory_bytes >= _max_memory_bytes * 0.8; };
+    bool should_output() const {
+        if (_memory_bytes >= _max_memory_bytes * 0.8) {
+            LOG(WARNING) << _memory_bytes << " >= " << _max_memory_bytes * 0.8 << " in local exchange";
+        }
+        return false;
+    };
 
 private:
     size_t _max_memory_bytes;

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -31,7 +31,7 @@ public:
             LOG(WARNING) << "config::local_exchange_buffer_mem_limit_per_driver <= 0";
         }
         size_t res = max_input_dop * limit_bytes;
-        constexpr size_t MAX_MEM_LIMIT = 8589934592; // 8G limit
+        size_t MAX_MEM_LIMIT = 8 * 1024 * 1024 * 1024; // 8G limit
         _max_memory_bytes = res > MAX_MEM_LIMIT or res <= 0 ? MAX_MEM_LIMIT : res;
     }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -24,14 +24,15 @@ namespace starrocks::pipeline {
 class LocalExchangeMemoryManager {
 public:
     LocalExchangeMemoryManager(size_t max_input_dop) {
-        size_t limit_bytes = 64 * 1024 * 1024; // 64 MB
+        size_t limit_bytes = 128 * 1024 * 1024UL; // 128 MB
         if (config::local_exchange_buffer_mem_limit_per_driver > 0) {
             limit_bytes = config::local_exchange_buffer_mem_limit_per_driver;
         } else {
-            LOG(WARNING) << "config::local_exchange_buffer_mem_limit_per_driver <= 0";
+            LOG(WARNING) << "invalid config::local_exchange_buffer_mem_limit_per_driver "
+                         << config::local_exchange_buffer_mem_limit_per_driver;
         }
         size_t res = max_input_dop * limit_bytes;
-        const size_t MAX_MEM_LIMIT = 8 * 1024 * 1024 * 1024UL; // 8G limit
+        const size_t MAX_MEM_LIMIT = 128 * 1024 * 1024 * 1024UL; // 128GB limit
         _max_memory_bytes = res > MAX_MEM_LIMIT or res <= 0 ? MAX_MEM_LIMIT : res;
     }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -16,6 +16,8 @@
 
 #include <atomic>
 
+#include "common/config.h"
+
 namespace starrocks::pipeline {
 // Manage the memory usage for local exchange
 class LocalExchangeMemoryManager {

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -41,6 +41,9 @@ public:
 
     bool is_full() const { return _memory_bytes >= _max_memory_bytes; }
 
+    // consume the buffered data to avoid the buffer being full for a long time when the chunk's size is too large.
+    bool should_output() const { return _memory_bytes >= _max_memory_bytes * 0.8; };
+
 private:
     size_t _max_memory_bytes;
     // an estimated value for partitioned shuffle, as it reconstructs chunks.

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -18,16 +18,29 @@
 
 namespace starrocks::pipeline {
 // Manage the memory usage for local exchange
-// TODO(KKS): Should use the real chunk memory usage, not chunk row number
-// Use row number because it's hard to control very big bitmap column memory usage
 class LocalExchangeMemoryManager {
 public:
-    LocalExchangeMemoryManager(int32_t max_row_count) : _max_row_count(max_row_count) {}
-    void update_row_count(int32_t row_count) { _row_count += row_count; }
-    bool is_full() const { return _row_count >= _max_row_count; }
+    LocalExchangeMemoryManager(size_t max_input_dop) {
+        size_t limit_bytes = 64 * 1024 * 1024; // 64 MB
+        if (config::local_exchange_buffer_mem_limit_per_driver > 0) {
+            limit_bytes = config::local_exchange_buffer_mem_limit_per_driver;
+        } else {
+            LOG(WARNING) << "config::local_exchange_buffer_mem_limit_per_driver <= 0";
+        }
+        auto res = max_input_dop * limit_bytes;
+        constexpr size_t MAX_MEM_LIMIT = 8589934592; // 8G limit
+        _memory_bytes = res > MAX_MEM_LIMIT or res <= 0 ? MAX_MEM_LIMIT : res;
+    }
+
+    void update_memory_usage(size_t memory_bytes) { _memory_bytes += memory_bytes; }
+
+    size_t get_memory_usage() const { return _memory_bytes; }
+
+    bool is_full() const { return _memory_bytes >= _max_memory_bytes; }
 
 private:
-    int32_t _max_row_count;
-    std::atomic<int32_t> _row_count{0};
+    size_t _max_memory_bytes;
+    // an estimated value for partitioned shuffle, as it reconstructs chunks.
+    std::atomic<size_t> _memory_bytes{0};
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -17,6 +17,7 @@
 #include <atomic>
 
 #include "common/config.h"
+#include "common/logging.h"
 
 namespace starrocks::pipeline {
 // Manage the memory usage for local exchange

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -30,9 +30,9 @@ public:
         } else {
             LOG(WARNING) << "config::local_exchange_buffer_mem_limit_per_driver <= 0";
         }
-        auto res = max_input_dop * limit_bytes;
+        size_t res = max_input_dop * limit_bytes;
         constexpr size_t MAX_MEM_LIMIT = 8589934592; // 8G limit
-        _memory_bytes = res > MAX_MEM_LIMIT or res <= 0 ? MAX_MEM_LIMIT : res;
+        _max_memory_bytes = res > MAX_MEM_LIMIT or res <= 0 ? MAX_MEM_LIMIT : res;
     }
 
     void update_memory_usage(size_t memory_bytes) { _memory_bytes += memory_bytes; }

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -26,7 +26,7 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk) {
     if (_is_finished) {
         return Status::OK();
     }
-    _memory_manager->update_row_count(chunk->num_rows());
+    _memory_manager->update_memory_usage(chunk->memory_usage());
     _full_chunk_queue.emplace(std::move(chunk));
 
     return Status::OK();
@@ -40,7 +40,7 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, std::shared_ptr<st
     if (_is_finished) {
         return Status::OK();
     }
-    _memory_manager->update_row_count(size);
+    _memory_manager->update_memory_usage(chunk->bytes_usage(from, size));
     _partition_chunk_queue.emplace(std::move(chunk), std::move(indexes), from, size);
     _partition_rows_num += size;
 
@@ -75,7 +75,7 @@ Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     // clear _partition_chunk_queue
     { [[maybe_unused]] typeof(_partition_chunk_queue) tmp = std::move(_partition_chunk_queue); }
     // Subtract the number of rows of buffered chunks from row_count of _memory_manager and make it unblocked.
-    _memory_manager->update_row_count(-(full_rows_num + _partition_rows_num));
+    _memory_manager->update_memory_usage(-_memory_manager->get_memory_usage());
     _partition_rows_num = 0;
     return Status::OK();
 }
@@ -85,7 +85,7 @@ StatusOr<ChunkPtr> LocalExchangeSourceOperator::pull_chunk(RuntimeState* state) 
     if (chunk == nullptr) {
         chunk = _pull_shuffle_chunk(state);
     }
-    _memory_manager->update_row_count(-(static_cast<int32_t>(chunk->num_rows())));
+    _memory_manager->update_memory_usage(-(static_cast<size_t>(chunk->memory_usage())));
     return std::move(chunk);
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -56,6 +56,12 @@ bool LocalExchangeSourceOperator::is_finished() const {
 bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
+    if (_memory_manager->should_output()) {
+        if (_partition_rows_num > 0 && _partition_rows_num < _factory->runtime_state()->chunk_size()) {
+            LOG(WARNING) << "local exchange should output although row size is small = " << _partition_rows_num;
+        }
+    }
+
     return !_full_chunk_queue.empty() || _partition_rows_num >= _factory->runtime_state()->chunk_size() ||
            (_is_finished && _partition_rows_num > 0) || _memory_manager->should_output();
 }

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -57,7 +57,7 @@ bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
     return !_full_chunk_queue.empty() || _partition_rows_num >= _factory->runtime_state()->chunk_size() ||
-           (_is_finished && _partition_rows_num > 0);
+           (_is_finished && _partition_rows_num > 0) || _memory_manager->should_output();
 }
 
 Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -56,20 +56,9 @@ bool LocalExchangeSourceOperator::is_finished() const {
 bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
-    if (!_full_chunk_queue.empty() || _partition_rows_num >= _factory->runtime_state()->chunk_size() ||
-        (_is_finished && _partition_rows_num > 0)) {
-        return true;
-    } else {
-        if (_memory_manager->should_output()) {
-            if (_partition_rows_num > 0 && _partition_rows_num < _factory->runtime_state()->chunk_size()) {
-                LOG(WARNING) << "local exchange should output although row size is small = " << _partition_rows_num;
-            } else {
-                LOG(WARNING) << "local exchange unknown";
-            }
-            return true;
-        }
-    }
-    return false;
+    return !_full_chunk_queue.empty() || _partition_rows_num >= _factory->runtime_state()->chunk_size() ||
+           (_is_finished && _partition_rows_num > 0) ||
+           ((!_full_chunk_queue.empty() || _partition_rows_num > 0) && _memory_manager->should_output());
 }
 
 Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -26,8 +26,12 @@ class LocalExchangeSourceOperator final : public SourceOperator {
     class PartitionChunk {
     public:
         PartitionChunk(ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes, const uint32_t from,
-                       const uint32_t size)
-                : chunk(std::move(chunk)), indexes(std::move(indexes)), from(from), size(size) {}
+                       const uint32_t size, const size_t memory_usage)
+                : chunk(std::move(chunk)),
+                  indexes(std::move(indexes)),
+                  from(from),
+                  size(size),
+                  memory_usage(memory_usage) {}
 
         PartitionChunk(const PartitionChunk&) = delete;
 
@@ -37,6 +41,7 @@ class LocalExchangeSourceOperator final : public SourceOperator {
         std::shared_ptr<std::vector<uint32_t>> indexes;
         const uint32_t from;
         const uint32_t size;
+        const size_t memory_usage;
     };
 
 public:
@@ -47,7 +52,8 @@ public:
 
     Status add_chunk(ChunkPtr chunk);
 
-    Status add_chunk(ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes, uint32_t from, uint32_t size);
+    Status add_chunk(ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes, uint32_t from, uint32_t size,
+                     size_t memory_bytes);
 
     bool has_output() const override;
 
@@ -67,10 +73,15 @@ private:
 
     ChunkPtr _pull_shuffle_chunk(RuntimeState* state);
 
+    bool _local_buffer_almost_full() const {
+        return _local_memory_usage >= _memory_manager->get_memory_limit_per_driver() * 0.8;
+    }
+
     bool _is_finished = false;
     std::queue<ChunkPtr> _full_chunk_queue;
     std::queue<PartitionChunk> _partition_chunk_queue;
-    int64_t _partition_rows_num = 0;
+    size_t _partition_rows_num = 0;
+    size_t _local_memory_usage = 0;
 
     // TODO(KKS): make it lock free
     mutable std::mutex _chunk_lock;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -758,14 +758,13 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
             std::vector<OpFactories> pred_operators_list;
             pred_operators_list.push_back(fragment_ctx->pipelines().back()->get_op_factories());
 
-            size_t max_row_count = 0;
+            size_t max_input_dop = 0;
             auto* source_operator =
                     down_cast<SourceOperatorFactory*>(fragment_ctx->pipelines().back()->get_op_factories()[0].get());
-            max_row_count += source_operator->degree_of_parallelism() * runtime_state->chunk_size();
+            max_input_dop += source_operator->degree_of_parallelism();
 
             auto pseudo_plan_node_id = context->next_pseudo_plan_node_id();
-            auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(
-                    max_row_count * PipelineBuilderContext::localExchangeBufferChunks());
+            auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_input_dop);
             auto local_exchange_source = std::make_shared<LocalExchangeSourceOperatorFactory>(
                     context->next_operator_id(), pseudo_plan_node_id, mem_mgr);
             local_exchange_source->set_runtime_state(runtime_state);

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -31,8 +31,7 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_broadcast_exchange(R
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * num_receivers *
-                                                                kLocalExchangeBufferChunks);
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(num_receivers);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);
@@ -72,9 +71,8 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    int buffer_size =
-            std::max(num_receivers, static_cast<int>(source_op->degree_of_parallelism())) * kLocalExchangeBufferChunks;
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(state->chunk_size() * buffer_size);
+    int max_input_dop = std::max(num_receivers, static_cast<int>(source_op->degree_of_parallelism()));
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_input_dop);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);
@@ -134,8 +132,7 @@ OpFactories PipelineBuilderContext::_do_maybe_interpolate_local_shuffle_exchange
 
     // To make sure at least one partition source operator is ready to output chunk before sink operators are full.
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(shuffle_partitions_num * state->chunk_size() *
-                                                                kLocalExchangeBufferChunks);
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(shuffle_partitions_num);
     auto local_shuffle_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_shuffle_source->set_runtime_state(state);
@@ -167,14 +164,14 @@ OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(RuntimeState* 
     }
 
     // Approximately, each pred driver can output state->chunk_size() rows at the same time.
-    size_t max_row_count = 0;
+    size_t max_input_dop = 0;
     for (const auto& pred_ops : pred_operators_list) {
         auto* source_op = source_operator(pred_ops);
-        max_row_count += source_op->degree_of_parallelism() * state->chunk_size();
+        max_input_dop += source_op->degree_of_parallelism();
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_row_count * kLocalExchangeBufferChunks);
+    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_input_dop);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

local exchange buffer's size limits the sink's speed, causing low memory usage in some cases. This PR will increase CPU usage from 40+% to 90+% for some agg queries limited by network.

besides, it alleviates the limit of exchange's scalability with dop.
```
select host_name() h,exchange_speed(ss_customer_sk,ss_quantity,ss_sales_price), count(*) from store_sales where ss_customer_sk is not null group by ss_customer_sk;
```
<meta charset="utf-8"><div data-page-id="CDC9dn54Voz89KxfQGScj6zanMb" data-docx-has-block-data="true"><div>

dop | 0 | 16 | 32
-- | -- | -- | --
before | 41.53 | 57.72 | 141.95
after | 44.253504 | 44.71 | 51.35

</div></div><span data-lark-record-data="{&quot;isCut&quot;:false,&quot;rootId&quot;:&quot;CDC9dn54Voz89KxfQGScj6zanMb&quot;,&quot;parentId&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;blockIds&quot;:[640,642,644,646,648,650,652,654,656,658,660,662],&quot;recordIds&quot;:[&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;],&quot;recordMap&quot;:{&quot;NgO0dCYuSo0SMQxSO9TcDO6gn0e&quot;:{&quot;id&quot;:&quot;NgO0dCYuSo0SMQxSO9TcDO6gn0e&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;AWyIdU0aYossGwxbHVXcNszSnbN&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;AWyIdU0aYossGwxbHVXcNszSnbN&quot;:{&quot;id&quot;:&quot;AWyIdU0aYossGwxbHVXcNszSnbN&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;NgO0dCYuSo0SMQxSO9TcDO6gn0e&quot;,&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;dop&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0*1+3&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;abbreviation-data&quot;,&quot;{\&quot;id\&quot;:\&quot;ac4ee74c-f062-498b-8e46-50839c546556\&quot;,\&quot;abbr_ids\&quot;:\&quot;enterprise_7160956291072966660\&quot;,\&quot;is_visible\&quot;:1,\&quot;is_first\&quot;:1}&quot;],&quot;1&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:2}},&quot;folded&quot;:false}},&quot;UkcMdKC2kouIa8xiSwzccorWnad&quot;:{&quot;id&quot;:&quot;UkcMdKC2kouIa8xiSwzccorWnad&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;GmCWdASowoSIEUx2NQRc8scknde&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;GmCWdASowoSIEUx2NQRc8scknde&quot;:{&quot;id&quot;:&quot;GmCWdASowoSIEUx2NQRc8scknde&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;UkcMdKC2kouIa8xiSwzccorWnad&quot;,&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;0&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+1&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false}},&quot;FIsKdMaoeo4wSCxYf8fcGzrdnng&quot;:{&quot;id&quot;:&quot;FIsKdMaoeo4wSCxYf8fcGzrdnng&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;SyMqdCUyAoAQeuxiWOHcfoarn1g&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;SyMqdCUyAoAQeuxiWOHcfoarn1g&quot;:{&quot;id&quot;:&quot;SyMqdCUyAoAQeuxiWOHcfoarn1g&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;FIsKdMaoeo4wSCxYf8fcGzrdnng&quot;,&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;16&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+2&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false}},&quot;J0GedGsuoomCC0xsZTyc2h0dnQg&quot;:{&quot;id&quot;:&quot;J0GedGsuoomCC0xsZTyc2h0dnQg&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;BCSmdUYwUoyewgxsHIdcwWiBnCd&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;BCSmdUYwUoyewgxsHIdcwWiBnCd&quot;:{&quot;id&quot;:&quot;BCSmdUYwUoyewgxsHIdcwWiBnCd&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;J0GedGsuoomCC0xsZTyc2h0dnQg&quot;,&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;32&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+2&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false}},&quot;JAW6dMcaCoEqskxKyA5cN5lxncc&quot;:{&quot;id&quot;:&quot;JAW6dMcaCoEqskxKyA5cN5lxncc&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;AIYsdwicuoQOyExG40KcLwuGnHd&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;AIYsdwicuoQOyExG40KcLwuGnHd&quot;:{&quot;id&quot;:&quot;AIYsdwicuoQOyExG40KcLwuGnHd&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;JAW6dMcaCoEqskxKyA5cN5lxncc&quot;,&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;before&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+6&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false}},&quot;S8m0dos80omo4ExLbDtcDLzNnCg&quot;:{&quot;id&quot;:&quot;S8m0dos80omo4ExLbDtcDLzNnCg&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;KAW8deQ4woossoxLFWBconyXnhT&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;KAW8deQ4woossoxLFWBconyXnhT&quot;:{&quot;id&quot;:&quot;KAW8deQ4woossoxLFWBconyXnhT&quot;,&quot;snapshot&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;41.53&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+5&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false,&quot;parent_id&quot;:&quot;S8m0dos80omo4ExLbDtcDLzNnCg&quot;}},&quot;JIIidWUWKoUcKsxWymdcHqwZnre&quot;:{&quot;id&quot;:&quot;JIIidWUWKoUcKsxWymdcHqwZnre&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;SYSSdeW0goCSMAxY5Zyc4hUlnPb&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;SYSSdeW0goCSMAxY5Zyc4hUlnPb&quot;:{&quot;id&quot;:&quot;SYSSdeW0goCSMAxY5Zyc4hUlnPb&quot;,&quot;snapshot&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;57.72&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+5&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false,&quot;parent_id&quot;:&quot;JIIidWUWKoUcKsxWymdcHqwZnre&quot;}},&quot;X8g4dAm2AocGWux8N11cnbz8nsb&quot;:{&quot;id&quot;:&quot;X8g4dAm2AocGWux8N11cnbz8nsb&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;T8e6diikkoMS8sxWI5PcarXknme&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;T8e6diikkoMS8sxWI5PcarXknme&quot;:{&quot;id&quot;:&quot;T8e6diikkoMS8sxWI5PcarXknme&quot;,&quot;snapshot&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;141.95&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+6&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false,&quot;parent_id&quot;:&quot;X8g4dAm2AocGWux8N11cnbz8nsb&quot;}},&quot;DKucduOweo6IGIxIX2ncaOVOn3b&quot;:{&quot;id&quot;:&quot;DKucduOweo6IGIxIX2ncaOVOn3b&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;RMKCdwMQUoWC0sxd7xacetygnNH&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;RMKCdwMQUoWC0sxd7xacetygnNH&quot;:{&quot;id&quot;:&quot;RMKCdwMQUoWC0sxd7xacetygnNH&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;DKucduOweo6IGIxIX2ncaOVOn3b&quot;,&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;after&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+5&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false}},&quot;C4w4diMiioaQ8ExOuGqcZQwLnUc&quot;:{&quot;id&quot;:&quot;C4w4diMiioaQ8ExOuGqcZQwLnUc&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;V0QMdAOguoMCMoxiQFJcRPRQnzd&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;V0QMdAOguoMCMoxiQFJcRPRQnzd&quot;:{&quot;id&quot;:&quot;V0QMdAOguoMCMoxiQFJcRPRQnzd&quot;,&quot;snapshot&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;44.253504 &quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+a&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false,&quot;parent_id&quot;:&quot;C4w4diMiioaQ8ExOuGqcZQwLnUc&quot;}},&quot;LSOadeikUo0aSQxa6HTczaWCn1d&quot;:{&quot;id&quot;:&quot;LSOadeikUo0aSQxa6HTczaWCn1d&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;SUoSdGE4Co2EYcxKiZAc947Zn9c&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;SUoSdGE4Co2EYcxKiZAc947Zn9c&quot;:{&quot;id&quot;:&quot;SUoSdGE4Co2EYcxKiZAc947Zn9c&quot;,&quot;snapshot&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;44.71&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+5&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false,&quot;parent_id&quot;:&quot;LSOadeikUo0aSQxa6HTczaWCn1d&quot;}},&quot;J8guduiWWo0soEx6a3zckouenog&quot;:{&quot;id&quot;:&quot;J8guduiWWo0soEx6a3zckouenog&quot;,&quot;snapshot&quot;:{&quot;parent_id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;type&quot;:&quot;table_cell&quot;,&quot;children&quot;:[&quot;MSWIdo2csocaeQx0QuNcgrYjnwe&quot;],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;}},&quot;MSWIdo2csocaeQx0QuNcgrYjnwe&quot;:{&quot;id&quot;:&quot;MSWIdo2csocaeQx0QuNcgrYjnwe&quot;,&quot;snapshot&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;text&quot;:{&quot;initialAttributedTexts&quot;:{&quot;text&quot;:{&quot;0&quot;:&quot;51.35&quot;},&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+5&quot;}},&quot;apool&quot;:{&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7115230360346050564&quot;]},&quot;nextNum&quot;:1}},&quot;folded&quot;:false,&quot;parent_id&quot;:&quot;J8guduiWWo0soEx6a3zckouenog&quot;}},&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;:{&quot;id&quot;:&quot;HOYad0CMuo2UysxQzSUcvXaVnBb&quot;,&quot;snapshot&quot;:{&quot;type&quot;:&quot;table&quot;,&quot;children&quot;:[],&quot;comments&quot;:[],&quot;author&quot;:&quot;7115230360346050564&quot;,&quot;columns_id&quot;:[&quot;colf6043245-12f9-4607-be60-9ce3aee2e464&quot;,&quot;col05ac4133-670e-4fc3-83e2-991a1d12dedf&quot;,&quot;colfc79e9d1-8182-46a7-8f40-b60b2d849a40&quot;,&quot;col74fe6183-8186-4555-a292-1a152b271d31&quot;],&quot;rows_id&quot;:[&quot;row37a34112-4976-4f06-aaa1-259dd4c0f385&quot;,&quot;row43959954-737a-42ee-974a-6896a7908c76&quot;,&quot;row8de96261-d61d-41bf-9569-e6df12bc7182&quot;],&quot;column_set&quot;:{&quot;colf6043245-12f9-4607-be60-9ce3aee2e464&quot;:{&quot;column_width&quot;:100},&quot;col05ac4133-670e-4fc3-83e2-991a1d12dedf&quot;:{&quot;column_width&quot;:100},&quot;colfc79e9d1-8182-46a7-8f40-b60b2d849a40&quot;:{&quot;column_width&quot;:100},&quot;col74fe6183-8186-4555-a292-1a152b271d31&quot;:{&quot;column_width&quot;:100}},&quot;cell_set&quot;:{&quot;row37a34112-4976-4f06-aaa1-259dd4c0f385colf6043245-12f9-4607-be60-9ce3aee2e464&quot;:{&quot;block_id&quot;:&quot;NgO0dCYuSo0SMQxSO9TcDO6gn0e&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row37a34112-4976-4f06-aaa1-259dd4c0f385col05ac4133-670e-4fc3-83e2-991a1d12dedf&quot;:{&quot;block_id&quot;:&quot;UkcMdKC2kouIa8xiSwzccorWnad&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row37a34112-4976-4f06-aaa1-259dd4c0f385colfc79e9d1-8182-46a7-8f40-b60b2d849a40&quot;:{&quot;block_id&quot;:&quot;FIsKdMaoeo4wSCxYf8fcGzrdnng&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row37a34112-4976-4f06-aaa1-259dd4c0f385col74fe6183-8186-4555-a292-1a152b271d31&quot;:{&quot;block_id&quot;:&quot;J0GedGsuoomCC0xsZTyc2h0dnQg&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row43959954-737a-42ee-974a-6896a7908c76colf6043245-12f9-4607-be60-9ce3aee2e464&quot;:{&quot;block_id&quot;:&quot;JAW6dMcaCoEqskxKyA5cN5lxncc&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row43959954-737a-42ee-974a-6896a7908c76col05ac4133-670e-4fc3-83e2-991a1d12dedf&quot;:{&quot;block_id&quot;:&quot;S8m0dos80omo4ExLbDtcDLzNnCg&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row43959954-737a-42ee-974a-6896a7908c76colfc79e9d1-8182-46a7-8f40-b60b2d849a40&quot;:{&quot;block_id&quot;:&quot;JIIidWUWKoUcKsxWymdcHqwZnre&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row43959954-737a-42ee-974a-6896a7908c76col74fe6183-8186-4555-a292-1a152b271d31&quot;:{&quot;block_id&quot;:&quot;X8g4dAm2AocGWux8N11cnbz8nsb&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row8de96261-d61d-41bf-9569-e6df12bc7182colf6043245-12f9-4607-be60-9ce3aee2e464&quot;:{&quot;block_id&quot;:&quot;DKucduOweo6IGIxIX2ncaOVOn3b&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row8de96261-d61d-41bf-9569-e6df12bc7182col05ac4133-670e-4fc3-83e2-991a1d12dedf&quot;:{&quot;block_id&quot;:&quot;C4w4diMiioaQ8ExOuGqcZQwLnUc&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row8de96261-d61d-41bf-9569-e6df12bc7182colfc79e9d1-8182-46a7-8f40-b60b2d849a40&quot;:{&quot;block_id&quot;:&quot;LSOadeikUo0aSQxa6HTczaWCn1d&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}},&quot;row8de96261-d61d-41bf-9569-e6df12bc7182col74fe6183-8186-4555-a292-1a152b271d31&quot;:{&quot;block_id&quot;:&quot;J8guduiWWo0soEx6a3zckouenog&quot;,&quot;merge_info&quot;:{&quot;row_span&quot;:1,&quot;col_span&quot;:1}}},&quot;parent_id&quot;:&quot;CDC9dn54Voz89KxfQGScj6zanMb&quot;}}},&quot;payloadMap&quot;:{&quot;AWyIdU0aYossGwxbHVXcNszSnbN&quot;:{&quot;level&quot;:1},&quot;GmCWdASowoSIEUx2NQRc8scknde&quot;:{&quot;level&quot;:1},&quot;SyMqdCUyAoAQeuxiWOHcfoarn1g&quot;:{&quot;level&quot;:1},&quot;BCSmdUYwUoyewgxsHIdcwWiBnCd&quot;:{&quot;level&quot;:1},&quot;AIYsdwicuoQOyExG40KcLwuGnHd&quot;:{&quot;level&quot;:1},&quot;KAW8deQ4woossoxLFWBconyXnhT&quot;:{&quot;level&quot;:1},&quot;SYSSdeW0goCSMAxY5Zyc4hUlnPb&quot;:{&quot;level&quot;:1},&quot;T8e6diikkoMS8sxWI5PcarXknme&quot;:{&quot;level&quot;:1},&quot;RMKCdwMQUoWC0sxd7xacetygnNH&quot;:{&quot;level&quot;:1},&quot;V0QMdAOguoMCMoxiQFJcRPRQnzd&quot;:{&quot;level&quot;:1},&quot;SUoSdGE4Co2EYcxKiZAc947Zn9c&quot;:{&quot;level&quot;:1},&quot;MSWIdo2csocaeQx0QuNcgrYjnwe&quot;:{&quot;level&quot;:1}},&quot;extra&quot;:{&quot;mention_page_title&quot;:{},&quot;external_mention_url&quot;:{}},&quot;isKeepQuoteContainer&quot;:false,&quot;selection&quot;:[{&quot;id&quot;:640,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;NgO0dCYuSo0SMQxSO9TcDO6gn0e&quot;},{&quot;id&quot;:642,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;UkcMdKC2kouIa8xiSwzccorWnad&quot;},{&quot;id&quot;:644,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;FIsKdMaoeo4wSCxYf8fcGzrdnng&quot;},{&quot;id&quot;:646,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;J0GedGsuoomCC0xsZTyc2h0dnQg&quot;},{&quot;id&quot;:648,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;JAW6dMcaCoEqskxKyA5cN5lxncc&quot;},{&quot;id&quot;:650,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;S8m0dos80omo4ExLbDtcDLzNnCg&quot;},{&quot;id&quot;:652,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;JIIidWUWKoUcKsxWymdcHqwZnre&quot;},{&quot;id&quot;:654,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;X8g4dAm2AocGWux8N11cnbz8nsb&quot;},{&quot;id&quot;:656,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;DKucduOweo6IGIxIX2ncaOVOn3b&quot;},{&quot;id&quot;:658,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;C4w4diMiioaQ8ExOuGqcZQwLnUc&quot;},{&quot;id&quot;:660,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;LSOadeikUo0aSQxa6HTczaWCn1d&quot;},{&quot;id&quot;:662,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;J8guduiWWo0soEx6a3zckouenog&quot;}],&quot;pasteFlag&quot;:&quot;d7a781e6-55d1-42e5-b338-cf4ab4937f88&quot;}" data-lark-record-format="docx/record" class="lark-record-clipboard"></span>

## Checklist:

- [x] I have added test cases for my bug fix or my new feature (munually test by setting `local_exchange_buffer_mem_limit_per_driver` to 1 to mock woking on large chunks)
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
