### PR TITLE
[Enhancement] Get accurate build type on make time

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -123,6 +123,12 @@ if(NOT ${MAKE_GENSRC_RESULT} EQUAL 0 AND NOT APPLE)
     message(FATAL_ERROR "Failed to build ${BASE_DIR}/../gensrc/")
 endif()
 
+#
+set(BUILD_VERSION_CC ${CMAKE_BINARY_DIR}/build_version.cc)
+configure_file(${SRC_DIR}/common/build_version.cc.in ${BUILD_VERSION_CC} @ONLY)
+add_library(build_version OBJECT ${BUILD_VERSION_CC})
+target_include_directories(build_version PRIVATE ${SRC_DIR}/common)
+
 # Add common cmake prefix path and link library path
 list(APPEND CMAKE_PREFIX_PATH ${THIRDPARTY_DIR}/lib/cmake)
 list(APPEND CMAKE_PREFIX_PATH ${THIRDPARTY_DIR}/lib64/cmake)
@@ -600,6 +606,7 @@ set(STARROCKS_DEPENDENCIES ${STARROCKS_DEPENDENCIES}
 set(STARROCKS_DEPENDENCIES
     ${STARROCKS_DEPENDENCIES}
     ${WL_START_GROUP}
+    build_version
     rocksdb
     libs2
     snappy

--- a/be/src/common/build_version.cc.in
+++ b/be/src/common/build_version.cc.in
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "version.h"
+
+namespace starrocks {
+
+const char* STARROCKS_BUILD_TYPE = "@CMAKE_BUILD_TYPE@";
+
+} // namespace starrocks

--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -151,7 +151,6 @@ namespace starrocks {{
 
 const char* STARROCKS_VERSION = "{VERSION}";
 const char* STARROCKS_COMMIT_HASH = "{COMMIT_HASH}";
-const char* STARROCKS_BUILD_TYPE = "{BUILD_TYPE}";
 const char* STARROCKS_BUILD_TIME = "{BUILD_TIME}";
 const char* STARROCKS_BUILD_USER = "{BUILD_USER}";
 const char* STARROCKS_BUILD_HOST = "{BUILD_HOST}";


### PR DESCRIPTION
Signed-off-by: dorianzheng <xingzhengde72@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Before this diff, we get build type from environment variable. However, most user won't set env variable, so we will get `UNKNOWN` build type. This diff try to get build type from cmake file which is accurate.
```
./show_be_version.sh
UNKNOWN ASAN (build 87eec03)
Built on 2023-01-05 00:16:49 by zhengzhiquan@localhost
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
