### PR TITLE
[BugFix] local shuffle on ConnectorScan should use BUCKET_SHUFFLE_HASH_PARTITIONED

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -44,6 +44,8 @@ public:
     BalancedChunkBuffer& get_chunk_buffer() { return _chunk_buffer; }
     ActiveInputSet& get_active_inputs() { return _active_inputs; }
 
+    TPartitionType::type partition_type() const override { return TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED; }
+
 private:
     // TODO: refactor the OlapScanContext, move them into the context
     BalancedChunkBuffer _chunk_buffer;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16230.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
As for LocalHashBucket Join and Colocate Join, the partition type of left Scan and right Exchange should both be `BUCKET_SHUFFLE_HASH_PARTITIONED`, so `OlapScanOperator::partition_type` returns `BUCKET_SHUFFLE_HASH_PARTITIONED`.
However,  the table with decoupled storage and compute doesn't use `OlapScanOperator`, but `ConnectorScanOperator`.

Therefore, local shuffle on `ConnectorScan` should also use `BUCKET_SHUFFLE_HASH_PARTITIONED`.
```
    LocalHashBucket Join
   /                     \
Scan                     Exchange
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
