### PR TITLE
[BugFix] Fix BE crash when TopN filter apply on Lowcardinality column

### DIFF
--- a/be/src/storage/olap_runtime_range_pruner.h
+++ b/be/src/storage/olap_runtime_range_pruner.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "runtime/global_dict/types_fwd_decl.h"
 
 namespace starrocks {
 class SlotDescriptor;
@@ -52,9 +53,10 @@ public:
 
     void set_predicate_parser(PredicateParser* parser) { _parser = parser; }
 
-    Status update_range_if_arrived(RuntimeFilterArrivedCallBack&& updater, size_t raw_read_rows) {
+    Status update_range_if_arrived(const ColumnIdToGlobalDictMap* global_dictmaps,
+                                   RuntimeFilterArrivedCallBack&& updater, size_t raw_read_rows) {
         if (_arrived_runtime_filters_masks.empty()) return Status::OK();
-        return _update(std::move(updater), raw_read_rows);
+        return _update(global_dictmaps, std::move(updater), raw_read_rows);
     }
 
 private:
@@ -66,11 +68,12 @@ private:
     size_t _raw_read_rows = 0;
 
     // get predicate
-    StatusOr<PredicatesPtrs> _get_predicates(size_t idx);
+    StatusOr<PredicatesPtrs> _get_predicates(const ColumnIdToGlobalDictMap* global_dictmaps, size_t idx);
 
     PredicatesRawPtrs _as_raw_predicates(const std::vector<std::unique_ptr<ColumnPredicate>>& predicates);
 
-    Status _update(RuntimeFilterArrivedCallBack&& updater, size_t raw_read_rows);
+    Status _update(const ColumnIdToGlobalDictMap* global_dictmaps, RuntimeFilterArrivedCallBack&& updater,
+                   size_t raw_read_rows);
 
     void _init(const UnarrivedRuntimeFilterList& params);
 };

--- a/be/src/storage/olap_runtime_range_pruner.hpp
+++ b/be/src/storage/olap_runtime_range_pruner.hpp
@@ -14,10 +14,14 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
+#include <utility>
 
 #include "exec/olap_common.h"
 #include "exprs/runtime_filter_bank.h"
+#include "runtime/global_dict/config.h"
+#include "runtime/runtime_state.h"
 #include "storage/column_predicate.h"
 #include "storage/olap_runtime_range_pruner.h"
 #include "storage/predicate_parser.h"
@@ -26,13 +30,14 @@ namespace starrocks {
 namespace detail {
 struct RuntimeColumnPredicateBuilder {
     template <LogicalType ptype>
-    StatusOr<std::vector<std::unique_ptr<ColumnPredicate>>> operator()(PredicateParser* parser,
+    StatusOr<std::vector<std::unique_ptr<ColumnPredicate>>> operator()(const ColumnIdToGlobalDictMap* global_dictmaps,
+                                                                       PredicateParser* parser,
                                                                        const RuntimeFilterProbeDescriptor* desc,
                                                                        const SlotDescriptor* slot) {
         // keep consistent with ColumnRangeBuilder
         if constexpr (ptype == TYPE_TIME || ptype == TYPE_NULL || ptype == TYPE_JSON || pt_is_float<ptype> ||
                       pt_is_binary<ptype>) {
-            CHECK(false) << "unreachable path";
+            DCHECK(false) << "unreachable path";
             return Status::NotSupported("unreachable path");
         } else {
             std::vector<std::unique_ptr<ColumnPredicate>> preds;
@@ -58,26 +63,18 @@ struct RuntimeColumnPredicateBuilder {
 
             const JoinRuntimeFilter* rf = desc->runtime_filter();
 
-            const RuntimeBloomFilter<mapping_type>* filter = down_cast<const RuntimeBloomFilter<mapping_type>*>(rf);
-
-            using ValueType = typename RunTimeTypeTraits<mapping_type>::CppType;
-            SQLFilterOp min_op;
-            if (filter->left_open_interval()) {
-                min_op = to_olap_filter_type(TExprOpcode::GE, false);
+            // applied global-dict optimized column
+            if constexpr (ptype == TYPE_VARCHAR) {
+                auto cid = parser->column_id(*slot);
+                if (auto iter = global_dictmaps->find(cid); iter != global_dictmaps->end()) {
+                    _build_minmax_range<RangeType, value_type, LowCardDictType, GlobalDictCodeDecoder>(range, rf,
+                                                                                                       iter->second);
+                } else {
+                    _build_minmax_range<RangeType, value_type, mapping_type, DummyDecoder>(range, rf, nullptr);
+                }
             } else {
-                min_op = to_olap_filter_type(TExprOpcode::GT, false);
+                _build_minmax_range<RangeType, value_type, mapping_type, DummyDecoder>(range, rf, nullptr);
             }
-            ValueType min_value = filter->min_value();
-            range.add_range(min_op, static_cast<value_type>(min_value));
-
-            SQLFilterOp max_op;
-            if (filter->right_open_interval()) {
-                max_op = to_olap_filter_type(TExprOpcode::LE, false);
-            } else {
-                max_op = to_olap_filter_type(TExprOpcode::LT, false);
-            }
-            ValueType max_value = filter->max_value();
-            range.add_range(max_op, static_cast<value_type>(max_value));
 
             std::vector<TCondition> filters;
             range.to_olap_filter(filters);
@@ -97,19 +94,93 @@ struct RuntimeColumnPredicateBuilder {
             return preds;
         }
     }
+
+private:
+    template <class InputType>
+    struct DummyDecoder {
+        DummyDecoder(std::nullptr_t) {}
+        auto decode(InputType input) const { return input; }
+    };
+    template <class InputType>
+    struct GlobalDictCodeDecoder {
+        GlobalDictCodeDecoder(const GlobalDictMap* dict_map) : _dict_map(dict_map) {}
+        Slice decode(DictId input) const {
+            for (const auto& [k, v] : *_dict_map) {
+                if (v == input) {
+                    return k;
+                }
+            }
+            if (input < 0) {
+                return Slice::min_value();
+            } else {
+                return Slice::max_value();
+            }
+        }
+
+    private:
+        const GlobalDictMap* _dict_map;
+    };
+
+    template <class RuntimeFilter, class Decoder>
+    struct MinMaxParser {
+        MinMaxParser(const RuntimeFilter* runtime_filter_, Decoder* decoder)
+                : runtime_filter(runtime_filter_), decoder(decoder) {}
+        auto min_value() {
+            auto code = runtime_filter->min_value();
+            return decoder->decode(code);
+        }
+        auto max_value() {
+            auto code = runtime_filter->max_value();
+            return decoder->decode(code);
+        }
+
+    private:
+        const RuntimeFilter* runtime_filter;
+        const Decoder* decoder;
+    };
+
+    template <class Range, class value_type, LogicalType mapping_type, template <class> class Decoder, class... Args>
+    void _build_minmax_range(Range& range, const JoinRuntimeFilter* rf, Args&&... args) {
+        const RuntimeBloomFilter<mapping_type>* filter = down_cast<const RuntimeBloomFilter<mapping_type>*>(rf);
+        using DecoderType = Decoder<typename RunTimeTypeTraits<mapping_type>::CppType>;
+        DecoderType decoder(std::forward<Args>(args)...);
+        MinMaxParser<RuntimeBloomFilter<mapping_type>, DecoderType> parser(filter, &decoder);
+        SQLFilterOp min_op;
+        if (filter->left_open_interval()) {
+            min_op = to_olap_filter_type(TExprOpcode::GE, false);
+        } else {
+            min_op = to_olap_filter_type(TExprOpcode::GT, false);
+        }
+        auto min_value = parser.min_value();
+        range.add_range(min_op, static_cast<value_type>(min_value));
+
+        SQLFilterOp max_op;
+        if (filter->right_open_interval()) {
+            max_op = to_olap_filter_type(TExprOpcode::LE, false);
+        } else {
+            max_op = to_olap_filter_type(TExprOpcode::LT, false);
+        }
+
+        auto max_value = parser.max_value();
+        range.add_range(max_op, static_cast<value_type>(max_value));
+    }
 };
 } // namespace detail
 
-inline Status OlapRuntimeScanRangePruner::_update(RuntimeFilterArrivedCallBack&& updater, size_t raw_read_rows) {
+inline Status OlapRuntimeScanRangePruner::_update(const ColumnIdToGlobalDictMap* global_dictmaps,
+                                                  RuntimeFilterArrivedCallBack&& updater, size_t raw_read_rows) {
     if (_arrived_runtime_filters_masks.empty()) {
         return Status::OK();
     }
     for (size_t i = 0; i < _arrived_runtime_filters_masks.size(); ++i) {
+        // 1. runtime filter arrived
+        // 2. runtime filter updated and read rows greater than rf_update_threhold
+        // we will filter by index
         if (auto rf = _unarrived_runtime_filters[i]->runtime_filter()) {
             size_t rf_version = rf->rf_version();
             if (_arrived_runtime_filters_masks[i] == 0 ||
                 (rf_version > _rf_versions[i] && raw_read_rows - _raw_read_rows > rf_update_threhold)) {
-                ASSIGN_OR_RETURN(auto predicates, _get_predicates(i));
+                ASSIGN_OR_RETURN(auto predicates, _get_predicates(global_dictmaps, i));
                 auto raw_predicates = _as_raw_predicates(predicates);
                 if (!raw_predicates.empty()) {
                     RETURN_IF_ERROR(updater(raw_predicates.front()->column_id(), raw_predicates));
@@ -124,14 +195,15 @@ inline Status OlapRuntimeScanRangePruner::_update(RuntimeFilterArrivedCallBack&&
     return Status::OK();
 }
 
-inline auto OlapRuntimeScanRangePruner::_get_predicates(size_t idx) -> StatusOr<PredicatesPtrs> {
+inline auto OlapRuntimeScanRangePruner::_get_predicates(const ColumnIdToGlobalDictMap* global_dictmaps, size_t idx)
+        -> StatusOr<PredicatesPtrs> {
     auto rf = _unarrived_runtime_filters[idx]->runtime_filter();
     if (rf->has_null()) return PredicatesPtrs{};
     // convert to olap filter
     auto slot_desc = _slot_descs[idx];
     return type_dispatch_predicate<StatusOr<PredicatesPtrs>>(slot_desc->type().type, false,
-                                                             detail::RuntimeColumnPredicateBuilder(), _parser,
-                                                             _unarrived_runtime_filters[idx], slot_desc);
+                                                             detail::RuntimeColumnPredicateBuilder(), global_dictmaps,
+                                                             _parser, _unarrived_runtime_filters[idx], slot_desc);
 }
 
 inline auto OlapRuntimeScanRangePruner::_as_raw_predicates(

--- a/be/src/storage/predicate_parser.cpp
+++ b/be/src/storage/predicate_parser.cpp
@@ -96,4 +96,8 @@ StatusOr<ColumnPredicate*> PredicateParser::parse_expr_ctx(const SlotDescriptor&
     return ColumnExprPredicate::make_column_expr_predicate(type_info, column_id, state, expr_ctx, &slot_desc);
 }
 
+uint32_t PredicateParser::column_id(const SlotDescriptor& slot_desc) {
+    return _schema.field_index(slot_desc.col_name());
+}
+
 } // namespace starrocks

--- a/be/src/storage/predicate_parser.h
+++ b/be/src/storage/predicate_parser.h
@@ -44,6 +44,8 @@ public:
     StatusOr<ColumnPredicate*> parse_expr_ctx(const SlotDescriptor& slot_desc, RuntimeState*,
                                               ExprContext* expr_ctx) const;
 
+    uint32_t column_id(const SlotDescriptor& slot_desc);
+
 private:
     const TabletSchema& _schema;
 };

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -396,6 +396,7 @@ Status SegmentIterator::_init() {
 
 Status SegmentIterator::_try_to_update_ranges_by_runtime_filter() {
     return _opts.runtime_range_pruner.update_range_if_arrived(
+            _opts.global_dictmaps,
             [this](auto cid, const PredicateList& predicates) {
                 const ColumnPredicate* del_pred;
                 auto iter = _del_predicates.find(cid);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes the stack:
```
*** Aborted at 1672899729 (unix time) try "date -d @1672899729" if you are using GNU date ***
PC: @     0x7f8d1ee0fa7c pthread_kill
*** SIGABRT (@0x3eb002fc98b) received by PID 3131787 (TID 0x7f8832f0b640) from PID 3131787; stack trace: ***
    @         0x1803398a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f8d1edbb520 (unknown)
    @     0x7f8d1ee0fa7c pthread_kill
    @     0x7f8d1edbb476 raise
    @     0x7f8d1eda17f3 abort
    @     0x7f8d1eda171b (unknown)
    @     0x7f8d1edb2e96 __assert_fail
    @          0xf520323 down_cast<>()
    @         0x15850062 _ZN9starrocks6detail29RuntimeColumnPredicateBuilder17_build_scan_rangeINS_16ColumnValueRangeINS_5SliceEEES4_LNS_11LogicalTypeE17ENS1_12MinMa
xParserEDnEEvRT_PKNS_17JoinRuntimeFilterEPT3_
    @         0x158420b8 starrocks::detail::RuntimeColumnPredicateBuilder::operator()<>()
    @         0x1582e06b starrocks::type_dispatch_predicate<>()
    @         0x15826fc6 starrocks::OlapRuntimeScanRangePruner::_get_predicates()
    @         0x158265c3 starrocks::OlapRuntimeScanRangePruner::_update()
    @         0x15825525 starrocks::OlapRuntimeScanRangePruner::update_range_if_arrived()
    @         0x1580a4ee starrocks::SegmentIterator::_try_to_update_ranges_by_runtime_filter()
    @         0x15811b50 starrocks::SegmentIterator::do_get_next()
    @          0xe907b77 starrocks::ChunkIterator::get_next()
    @         0x15fd69dc starrocks::SegmentIteratorWrapper::do_get_next()
    @          0xe907b77 starrocks::ChunkIterator::get_next()
    @         0x15948001 starrocks::TimedChunkIterator::do_get_next()
    @          0xe907b77 starrocks::ChunkIterator::get_next()
    @         0x15cda991 starrocks::TabletReader::do_get_next()
    @          0xe907b77 starrocks::ChunkIterator::get_next()
    @         0x103e484f starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage()
    @         0x103e36db starrocks::pipeline::OlapChunkSource::_read_chunk()
    @         0x103608e3 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @         0x103a05c7 _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlvE_clEv
    @         0x103a6002 _ZSt13__invoke_implIvRZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @         0x103a5ea3 _ZSt10__invoke_rIvRZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES8_E4typeEOS9_DpOSA_
    @         0x103a59ee _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS1_12RuntimeStateEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0xe3f83aa std::function<>::operator()()
    @         0x106eb70d starrocks::workgroup::ScanExecutor::worker_thread()
start time: Thu Jan 5 02:22:21 PM CST 2023
```

reproduce case: https://github.com/StarRocks/StarRocksTest/pull/1720

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
