### PR TITLE
[BugFix] Null-safe-equals operator <=> incorrect behavior for null equals non-null

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
@@ -118,6 +118,28 @@ public class ImplicitCastRuleTest {
     }
 
     @Test
+    public void testEqualForNullBinaryPredicate() {
+        BinaryPredicateOperator[] ops = new BinaryPredicateOperator[] {
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
+                        ConstantOperator.createVarchar("a"),
+                        ConstantOperator.createNull(Type.DOUBLE)),
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
+                        ConstantOperator.createNull(Type.DOUBLE),
+                        ConstantOperator.createVarchar("a")),
+        };
+        for (BinaryPredicateOperator op : ops) {
+            ImplicitCastRule rule = new ImplicitCastRule();
+            ScalarOperator result = rule.apply(op, null);
+
+            assertTrue(result.getChild(0) instanceof ConstantOperator);
+            assertTrue(result.getChild(1) instanceof ConstantOperator);
+
+            assertEquals(PrimitiveType.VARCHAR, result.getChild(0).getType().getPrimitiveType());
+            assertEquals(PrimitiveType.VARCHAR, result.getChild(1).getType().getPrimitiveType());
+        }
+    }
+
+    @Test
     public void testCompoundPredicate() {
         CompoundPredicateOperator op =
                 new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND,


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
https://github.com/StarRocks/starrocks/issues/16057
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
