### PR TITLE
[BugFix] Fix limit db length to 509, and restore the limit of other names

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -118,7 +118,7 @@ public class CreateTableAutoTabletTest {
 
     @Test
     public void createBadDbName() {
-        String longDbName = new String(new char[1026]).replace('\0', 'a');
+        String longDbName = new String(new char[510]).replace('\0', 'a');
         String sql = "create database " + longDbName;
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, UtFrameUtils.createDefaultCtx());
@@ -126,5 +126,12 @@ public class CreateTableAutoTabletTest {
         } catch (Exception e) {
             Assert.assertEquals("Incorrect database name '" + longDbName + "'", e.getMessage());
         }
+    }
+
+    @Test
+    public void createLongDbName() throws Exception {
+        String longDbName = new String(new char[509]).replace('\0', 'a');
+        String sql = "create database " + longDbName;
+        UtFrameUtils.parseStmtWithNewParser(sql, UtFrameUtils.createDefaultCtx());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16225

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

![img_v2_190e137c-23bf-47ac-8785-cec9eb3d147g](https://user-images.githubusercontent.com/4392280/210768172-c99dd584-8779-4839-b35f-112946498f24.png)

The mysql protocol does not limit the length of the db, but the buffer of the mysql-client is 512+1,
minus the use and spaces, a total of 4 bytes, and finally can only limit the length of 509,
in order to be compatible with the mysql-client, the limit length is 509.

![piboKiBXEI](https://user-images.githubusercontent.com/4392280/210768213-432cfaeb-61b7-418e-92bc-7773a1309012.jpg)

Other restrictions should have reasonable requirements and be fully tested before opening, so restore the restrictions with other names to the default.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
