### PR TITLE
[BugFix][CherryPick][Branch-2.3] Fix be crash because of dropping tablet (#15959)

### DIFF
--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -499,6 +499,8 @@ struct RowsetId {
         }
     }
 
+    int64_t id() { return hi & LOW_56_BITS; }
+
     // std::unordered_map need this api
     bool operator==(const RowsetId& rhs) const { return hi == rhs.hi && mi == rhs.mi && lo == rhs.lo; }
 

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -250,6 +250,8 @@ public:
         }
     }
 
+    uint64_t refs_by_reader() { return _refs_by_reader; }
+
     static StatusOr<size_t> get_segment_num(const std::vector<RowsetSharedPtr>& rowsets) {
         size_t num_segments = 0;
         for (int i = 0; i < rowsets.size(); i++) {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -941,6 +941,15 @@ Status TabletManager::start_trash_sweep() {
             continue;
         }
 
+        if (tablet->updates() != nullptr) {
+            Status st = tablet->updates()->check_and_remove_rowset();
+            if (!st.ok()) {
+                LOG(WARNING) << "there are some rowsets still been referenced, drop tablet: " << tablet->tablet_id()
+                             << " later";
+                continue;
+            }
+        }
+
         bool remove_meta = false;
         TabletMeta tablet_meta;
         Status st = TabletMetaManager::get_tablet_meta(tablet->data_dir(), tablet->tablet_id(), tablet->schema_hash(),

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2389,14 +2389,24 @@ Status TabletUpdates::_convert_from_base_rowset(const std::shared_ptr<Tablet>& b
     return rowset_writer->flush();
 }
 
-void TabletUpdates::_remove_unused_rowsets() {
+void TabletUpdates::_remove_unused_rowsets(bool drop_tablet) {
     size_t removed = 0;
     std::vector<RowsetSharedPtr> skipped_rowsets;
     RowsetSharedPtr rowset;
     while (_unused_rowsets.try_get(&rowset) == 1) {
         if (rowset.use_count() > 1) {
-            LOG(WARNING) << "rowset " << rowset->rowset_id() << " still been referenced"
-                         << " tablet:" << _tablet.tablet_id();
+            if (drop_tablet) {
+                LOG(WARNING) << "rowset " << rowset->rowset_id() << " still been referenced"
+                             << " tablet:" << _tablet.tablet_id() << " rowset_id:" << rowset->rowset_id().id()
+                             << " use_count: " << rowset.use_count() << " refs_by_reader:" << rowset->refs_by_reader()
+                             << " version:" << rowset->version();
+            } else {
+                VLOG(1) << "rowset " << rowset->rowset_id() << " still been referenced"
+                        << " tablet:" << _tablet.tablet_id() << " rowset_id:" << rowset->rowset_id().id()
+                        << " use_count: " << rowset.use_count() << " refs_by_reader:" << rowset->refs_by_reader()
+                        << " version:" << rowset->version();
+            }
+
             skipped_rowsets.emplace_back(std::move(rowset));
             continue;
         }
@@ -2426,6 +2436,17 @@ void TabletUpdates::_remove_unused_rowsets() {
     if (removed > 0) {
         LOG(INFO) << "_remove_unused_rowsets remove " << removed << " rowsets, tablet:" << _tablet.tablet_id();
     }
+}
+
+Status TabletUpdates::check_and_remove_rowset() {
+    _remove_unused_rowsets(true);
+    if (!_unused_rowsets.empty()) {
+        std::string msg =
+                strings::Substitute("some rowsets of tablet: $0 are still been referenced", _tablet.tablet_id());
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
+    return Status::OK();
 }
 
 void TabletUpdates::_to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const {
@@ -2692,7 +2713,8 @@ Status TabletUpdates::clear_meta() {
     // TODO: tablet is already marked to be deleted, so maybe don't need to clear unused rowsets here
     _remove_unused_rowsets();
     if (_unused_rowsets.get_size() != 0) {
-        return Status::InternalError("some unused rowset cannot be removed");
+        LOG(WARNING) << "_unused_rowsets is not empty, size: " << _unused_rowsets.get_size()
+                     << " version_info: " << _debug_version_info(false);
     }
 
     WriteBatch wb;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -221,6 +221,8 @@ public:
     void to_rowset_meta_pb(const std::vector<RowsetMetaSharedPtr>& rowset_metas,
                            std::vector<RowsetMetaPB>& rowset_metas_pb);
 
+    Status check_and_remove_rowset();
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -305,7 +307,7 @@ private:
     Status _load_from_pb(const TabletUpdatesPB& updates);
 
     // thread-safe
-    void _remove_unused_rowsets();
+    void _remove_unused_rowsets(bool drop_tablet = false);
 
     // REQUIRE: |_lock| is held.
     void _to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/15957

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When we try to drop tablet(by manual or after schema change), we will try to close expired rowsets before clear tablet meta if tablet is primary key table. And if expired rowsets are still been reference by other threads, close will fail and be will crash.

Anyway, if expired rowsets are still been referenced by other threads when we try to drop tablet, crash is not necessary and output some error log is enough, the expired rowsets will be close after release.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
