### PR TITLE
[BugFix] fix type casting from json to array

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1073,12 +1073,20 @@ public abstract class Type implements Cloneable {
             return true;
         } else if (from.isStringType() && to.isArrayType()) {
             return true;
-        } else if (from.isJsonType() && ARRAY_VARCHAR.equals(to)) {
+        } else if (from.isJsonType() && to.isArrayScalar()) {
             // now we only support cast json to one dimensional array
             return true;
         } else {
             return false;
         }
+    }
+
+    public boolean isArrayScalar() {
+        if (!isArrayType()) {
+            return false;
+        }
+        ArrayType array = (ArrayType) this;
+        return array.getItemType().isScalarType();
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -219,4 +219,18 @@ public class JsonTypeTest extends PlanTestBase {
                         "CAST(5: v_INT AS JSON), CAST(8: v_BOOLEAN AS JSON), " +
                         "CAST(9: v_DOUBLE AS JSON), CAST(11: v_VARCHAR AS JSON))");
     }
+
+    @Test
+    public void testCastJsonToArray() throws Exception {
+        assertPlanContains("select cast(json_array(1,2,3) as array<int>)",
+                "CAST(json_array(CAST(1 AS JSON), CAST(2 AS JSON), CAST(3 AS JSON)) AS ARRAY<INT>)");
+        assertPlanContains("select cast(json_array(1,2,3) as array<varchar>)",
+                "CAST(json_array(CAST(1 AS JSON), CAST(2 AS JSON), CAST(3 AS JSON)) AS ARRAY<VARCHAR>)");
+        assertPlanContains("select cast(json_array(1,2,3) as array<JSON>)",
+                "CAST(json_array(CAST(1 AS JSON), CAST(2 AS JSON), CAST(3 AS JSON)) AS ARRAY<JSON>)");
+
+        // Multi-dimension array casting is not supported
+        assertExceptionMessage("select cast(json_array(1,2,3) as array<array<int>>)",
+                "Invalid type cast from json to ARRAY<ARRAY<int(11)>> in sql `json_array(1, 2, 3)`");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Previously #11306 support the type casting from JSON to array
2. But #15103 turn off the type casting, which would report an error 
3. So we need to turn on the type casting only for scalar array, also known as one-dimension array


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
