### PR TITLE
[Enhancement] Use thrift 0.17.0

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
@@ -42,6 +42,7 @@ import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TSocket;
@@ -140,7 +141,7 @@ public class GenericPool<VALUE extends org.apache.thrift.TServiceClient> {
                 LOG.debug("before create socket hostname={} key.port={} timeoutMs={}",
                         key.hostname, key.port, timeoutMs);
             }
-            TTransport transport = new TSocket(key.hostname, key.port, timeoutMs);
+            TTransport transport = new TSocket(TConfiguration.DEFAULT, key.hostname, key.port, timeoutMs);
             transport.open();
             TProtocol protocol = new TBinaryProtocol(transport);
             VALUE client = (VALUE) newInstance(className, protocol);

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerContext.java
@@ -50,4 +50,14 @@ public class ThriftServerContext implements ServerContext {
     public TNetworkAddress getClient() {
         return client;
     }
+
+    @Override
+    public <T> T unwrap(Class<T> aClass) {
+        return (T) aClass;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> aClass) {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerEventProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerEventProcessor.java
@@ -41,9 +41,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.server.ServerContext;
 import org.apache.thrift.server.TServerEventHandler;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.layered.TFramedTransport;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaStoreThriftClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaStoreThriftClient.java
@@ -151,14 +151,15 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.layered.TFramedTransport;
 
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
@@ -452,7 +453,12 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
                             throw new MetaException(e.toString());
                         }
                     } else {
-                        transport = new TSocket(store.getHost(), store.getPort(), clientSocketTimeout);
+                        try {
+                            transport = new TSocket(TConfiguration.DEFAULT, store.getHost(), store.getPort(), clientSocketTimeout);
+                        } catch (TTransportException e) {
+                            tte = e;
+                            throw new MetaException(e.toString());
+                        }
                     }
 
                     if (useSasl) {
@@ -492,7 +498,12 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
                         }
                     } else {
                         if (useFramedTransport) {
-                            transport = new TFramedTransport(transport);
+                            try {
+                                transport = new TFramedTransport(transport);
+                            } catch (TTransportException e) {
+                                tte = e;
+                                throw new MetaException(e.toString());
+                            }
                         }
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -302,9 +302,9 @@ public class TableQueryPlanAction extends RestBaseAction {
         tQueryPlanInfo.tablet_info = tabletInfo;
 
         // serialize TQueryPlanInfo and encode plan with Base64 to string in order to translate by json format
-        TSerializer serializer = new TSerializer();
         String opaquedQueryPlan;
         try {
+            TSerializer serializer = new TSerializer();
             byte[] queryPlanStream = serializer.serialize(tQueryPlanInfo);
             opaquedQueryPlan = Base64.getEncoder().encodeToString(queryPlanStream);
         } catch (TException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -192,8 +192,8 @@ public class FragmentNormalizer {
     public ByteBuffer normalizeExpr(Expr expr) {
         uncacheable = uncacheable || hasNonDeterministicFunctions(expr);
         TExpr texpr = expr.normalize(this);
-        TSerializer ser = new TSerializer(new TCompactProtocol.Factory());
         try {
+            TSerializer ser = new TSerializer(new TCompactProtocol.Factory());
             return ByteBuffer.wrap(ser.serialize(texpr));
         } catch (Exception ignored) {
             Preconditions.checkArgument(false);

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -827,9 +827,9 @@ public class PseudoBackend {
             if (shutdown) {
                 throw new RuntimeException("backend " + getId() + " shutdown");
             }
-            TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
             final TExecPlanFragmentParams params = new TExecPlanFragmentParams();
             try {
+                TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
                 deserializer.deserialize(params, request.getSerializedRequest());
             } catch (TException e) {
                 LOG.warn("error deserialize request", e);
@@ -861,9 +861,9 @@ public class PseudoBackend {
             if (shutdown) {
                 throw new RuntimeException("backend " + getId() + " shutdown");
             }
-            TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
             final TExecBatchPlanFragmentsParams params = new TExecBatchPlanFragmentsParams();
             try {
+                TDeserializer deserializer = new TDeserializer(new TBinaryProtocol.Factory());
                 deserializer.deserialize(params, request.getSerializedRequest());
             } catch (TException e) {
                 LOG.warn("error deserialize request", e);

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -354,7 +354,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.13.0</version>
+                <version>0.17.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->


### PR DESCRIPTION
## What type of PR is this：
- [x] Enhancement


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In Apache Thrift `0.9.3` to `0.13.0`, malicious RPC clients could send short messages which would result in a large memory allocation, potentially leading to denial of service.

Bump up the version to the latest `0.17.0`.

Tested both insert and select queries working for
* FE w/ thrift `0.13.0` and BE w/ thrift `0.17.0`
* FE w/ thrift `0.17.0` and BE w/ thrift `0.13.0`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [X] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
