### PR TITLE
[Enhancement][Cherry-pick][Branch-2.4] Make schema changed table not to be moved to trash 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -76,7 +76,7 @@ public class TabletInvertedIndex {
     // replica id -> tablet id
     private Map<Long, Long> replicaToTabletMap = Maps.newHashMap();
 
-    private Set<Long> truncatedTablets = Sets.newHashSet();
+    private Set<Long> forceDeleteTablets = Sets.newHashSet();
 
     // tablet id -> (backend id -> replica)
     private Table<Long, Long, Replica> replicaMetaTable = HashBasedTable.create();
@@ -409,16 +409,16 @@ public class TabletInvertedIndex {
         }
     }
 
-    public boolean tabletTruncated(long tabletId) {
-        return truncatedTablets.contains(tabletId);
+    public boolean tabletForceDelete(long tabletId) {
+        return forceDeleteTablets.contains(tabletId);
     }
 
-    public void markTabletTruncated(long tabletId) {
-        truncatedTablets.add(tabletId);
+    public void markTabletForceDelete(long tabletId) {
+        forceDeleteTablets.add(tabletId);
     }
     
-    public void eraseTabletTruncated(long tabletId) {
-        truncatedTablets.remove(tabletId);
+    public void eraseTabletForceDelete(long tabletId) {
+        forceDeleteTablets.remove(tabletId);
     }
 
     public void deleteTablet(long tabletId) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -810,8 +810,8 @@ public class ReportHandler extends Daemon {
                 // continue to report them to FE forever and add some processing overhead(the tablet report
                 // process is protected with DB S lock).
                 addDropReplicaTask(batchTask, backendId, tabletId,
-                        -1 /* Unknown schema hash */, "not found in meta", invertedIndex.tabletTruncated(tabletId));
-                invertedIndex.eraseTabletTruncated(tabletId);
+                        -1 /* Unknown schema hash */, "not found in meta", invertedIndex.tabletForceDelete(tabletId));
+                invertedIndex.eraseTabletForceDelete(tabletId);
                 ++deleteFromBackendCounter;
                 --maxTaskSendPerBe;
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4266,7 +4266,7 @@ public class LocalMetastore implements ConnectorMetadata {
             // happening is small, and the trash data will be deleted by BE anyway, but we need to find a better
             // solution.
             if (!isReplay) {
-                GlobalStateMgr.getCurrentInvertedIndex().markTabletTruncated(tabletId);
+                GlobalStateMgr.getCurrentInvertedIndex().markTabletForceDelete(tabletId);
             }
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13651

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When a table schema change is complete, the old table is moved to the trash directory, which takes up a lot of disk space. This PR fixes this issue.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
