### PR TITLE
[BugFix] create_cast_expr encounter unexpected null causing crash

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1609,6 +1609,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
     return nullptr;
 }
 
+// NOTE: should return error status to avoid null in ASSIGN_OR_RETURN, otherwise causing crash
 StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(ObjectPool* pool, const TExprNode& node,
                                                                             const TypeDescriptor& from_type,
                                                                             const TypeDescriptor& to_type,
@@ -1652,7 +1653,6 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
     }
     auto res = create_primitive_cast(pool, node, from_type.type, to_type.type, allow_throw_exception);
     if (res == nullptr) {
-        // should return error status to return in ASSIGN_OR_RETURN
         return Status::NotSupported(fmt::format("vectorized engine not support cast {} to {}.",
                                                 from_type.debug_string(), to_type.debug_string()));
     }

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1638,7 +1638,7 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
     }
     if (from_type.is_struct_type() && to_type.is_struct_type()) {
         if (from_type.children.size() != to_type.children.size()) {
-            return nullptr;
+            return Status::NotSupported("vectorized engine not support cast struct with different number of children.");
         }
         std::vector<std::unique_ptr<Expr>> field_casts{from_type.children.size()};
         for (int i = 0; i < from_type.children.size(); ++i) {
@@ -1650,8 +1650,13 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
         }
         return std::make_unique<CastStructExpr>(node, std::move(field_casts));
     }
-    std::unique_ptr<Expr> result(
-            create_primitive_cast(pool, node, from_type.type, to_type.type, allow_throw_exception));
+    auto res = create_primitive_cast(pool, node, from_type.type, to_type.type, allow_throw_exception);
+    if (res == nullptr) {
+        // should return error status to return in ASSIGN_OR_RETURN
+        return Status::NotSupported(fmt::format("vectorized engine not support cast {} to {}.",
+                                                from_type.debug_string(), to_type.debug_string()));
+    }
+    std::unique_ptr<Expr> result(res);
     return std::move(result);
 }
 

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2022,4 +2022,14 @@ TEST_F(VectorizedCastExprTest, json_to_array) {
     EXPECT_EQ(R"([])", cast_json_to_array(cast_expr, TYPE_JSON, R"( {"a": 1} )"));
 }
 
+TEST_F(VectorizedCastExprTest, unsupported_test) {
+    // can't cast array<bool> to bool rather than crash
+    expr_node.child_type = gen_array_type_desc(to_thrift(LogicalType::TYPE_BOOLEAN));
+    expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    ASSERT_TRUE(expr == nullptr);
+}
+
 } // namespace starrocks

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2023,9 +2023,10 @@ TEST_F(VectorizedCastExprTest, json_to_array) {
 }
 
 TEST_F(VectorizedCastExprTest, unsupported_test) {
-    // can't cast array<bool> to bool rather than crash
-    expr_node.child_type = gen_array_type_desc(to_thrift(LogicalType::TYPE_BOOLEAN));
-    expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+    // can't cast arry<array<int>> to array<bool> rather than crash
+    expr_node.child_type = to_thrift(LogicalType::TYPE_ARRAY);
+    expr_node.child_type_desc = gen_multi_array_type_desc(to_thrift(TYPE_INT), 2);
+    expr_node.type = gen_multi_array_type_desc(to_thrift(TYPE_BOOLEAN), 1);
 
     std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -830,8 +830,8 @@ public class ExpressionAnalyzer {
                 }
                 // force the second array be of Type.ARRAY_BOOLEAN
                 if (!Type.canCastTo(node.getChild(1).getType(), Type.ARRAY_BOOLEAN)) {
-                    throw new SemanticException("The second input of array_filter " + node.getChild(1).toString() +
-                            "  cannot cast to ARRAY<BOOL>");
+                    throw new SemanticException("The second input of array_filter " +
+                            node.getChild(1).getType().toString() + "  can't cast to ARRAY<BOOL>");
                 }
                 node.setChild(1, new CastExpr(Type.ARRAY_BOOLEAN, node.getChild(1)));
                 argumentTypes[1] = Type.ARRAY_BOOLEAN;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -829,6 +829,10 @@ public class ExpressionAnalyzer {
                             " should be an array or a lambda function.");
                 }
                 // force the second array be of Type.ARRAY_BOOLEAN
+                if (!Type.canCastTo(node.getChild(1).getType(), Type.ARRAY_BOOLEAN)) {
+                    throw new SemanticException("The second input of array_filter " + node.getChild(1).toString() +
+                            "  cannot cast to ARRAY<BOOL>");
+                }
                 node.setChild(1, new CastExpr(Type.ARRAY_BOOLEAN, node.getChild(1)));
                 argumentTypes[1] = Type.ARRAY_BOOLEAN;
                 fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
array_filter encounters BE crash, introuduced by https://github.com/StarRocks/starrocks/pull/16117

```
mysql> select array_filter([1],[[1]]) ;
ERROR 1064 (HY000): Backend not found. Check if any backend is down or not. backend: [172.26.92.195 alive: false inBlacklist: true]
```
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

create_cast_expr encounter unexpected null causing crash, so change return null to error status.

results:
```
mysql> select array_filter([1],[[1]]) ;
ERROR 1064 (HY000): Vectorized engine does not support the operator, cast from INVALID to ARRAY failed, maybe use switch function

```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
