### PR TITLE
[Refactor] Remove the dependency of QueryAnalyzer for BinlogScanNode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/BinlogScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/BinlogScanNode.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.TupleDescriptor;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -27,7 +26,6 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
-import com.starrocks.catalog.Type;
 import com.starrocks.common.UserException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -50,11 +48,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static com.starrocks.thrift.PlanNodesConstants.BINLOG_OP_COLUMN_NAME;
-import static com.starrocks.thrift.PlanNodesConstants.BINLOG_SEQ_ID_COLUMN_NAME;
-import static com.starrocks.thrift.PlanNodesConstants.BINLOG_TIMESTAMP_COLUMN_NAME;
-import static com.starrocks.thrift.PlanNodesConstants.BINLOG_VERSION_COLUMN_NAME;
 
 /**
  * BinlogScanNode read data from binlog of SR table
@@ -208,14 +201,5 @@ public class BinlogScanNode extends ScanNode {
     @Override
     public boolean canDoReplicatedJoin() {
         return false;
-    }
-
-    public static List<Column> appendBinlogMetaColumns(List<Column> schema) {
-        List<Column> columns = new ArrayList<>(schema);
-        columns.add(new Column(BINLOG_OP_COLUMN_NAME, Type.TINYINT));
-        columns.add(new Column(BINLOG_VERSION_COLUMN_NAME, Type.BIGINT));
-        columns.add(new Column(BINLOG_SEQ_ID_COLUMN_NAME, Type.BIGINT));
-        columns.add(new Column(BINLOG_TIMESTAMP_COLUMN_NAME, Type.BIGINT));
-        return columns;
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [X] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`QueryAnalyzer` imports the class `BinlogScanNode` to use `appendBinlogMetaColumns`, but  it's improper for `QueryAnalyzer` to depend on `planner` package because we first analyze the sql, then build the plan. So just move the definition of `appendBinlogMetaColumns` to `QueryAnalyzer`


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
