### PR TITLE
[Enhancement] Support array type for Trino parser on starrocks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -26,6 +26,7 @@ import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.CaseExpr;
 import com.starrocks.analysis.CaseWhenClause;
 import com.starrocks.analysis.CastExpr;
+import com.starrocks.analysis.CollectionElementExpr;
 import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.DecimalLiteral;
@@ -53,6 +54,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.ExceptRelation;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
@@ -72,6 +74,7 @@ import com.starrocks.sql.parser.ParsingException;
 import io.trino.sql.tree.AliasedRelation;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
+import io.trino.sql.tree.ArrayConstructor;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BooleanLiteral;
@@ -119,6 +122,7 @@ import io.trino.sql.tree.SingleColumn;
 import io.trino.sql.tree.SortItem;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SubqueryExpression;
+import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.Table;
 import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.Union;
@@ -130,6 +134,7 @@ import io.trino.sql.tree.WindowSpecification;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -420,6 +425,24 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
             return new SelectListItem(qualifiedNameToTableName(target.getQualifiedName()));
         }
         return new SelectListItem(null);
+    }
+
+    @Override
+    protected ParseNode visitArrayConstructor(ArrayConstructor node, ParseTreeContext context) {
+        List<Expr> exprs;
+        if (node.getValues() != null) {
+            exprs = visit(node.getValues(), context, Expr.class);
+        } else {
+            exprs = Collections.emptyList();
+        }
+        return new ArrayExpr(null, exprs);
+    }
+
+    @Override
+    protected ParseNode visitSubscriptExpression(SubscriptExpression node, ParseTreeContext context) {
+        Expr value = (Expr) visit(node.getBase(), context);
+        Expr index = (Expr) visit(node.getIndex(), context);
+        return new CollectionElementExpr(value, index);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/FunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/FunctionCallTransformer.java
@@ -14,11 +14,13 @@
 
 package com.starrocks.connector.parser.trino;
 
+import com.clearspring.analytics.util.Lists;
 import com.google.common.base.Preconditions;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.sql.ast.AstVisitor;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,28 +31,42 @@ import java.util.stream.Collectors;
  * Before transform, it need to use match to check whether the FunctionCallTransformer can work.
  */
 public class FunctionCallTransformer {
-    private final String fnName;
     private final FunctionCallExpr targetCall;
-    private final PlaceholderExpr[] placeholderExprs;
+    private final List<PlaceholderExpr> placeholderExprs;
     private final int argNums;
+    private final boolean variableArgument;
 
     public FunctionCallTransformer(FunctionCallExpr targetCall, int argNums) {
-        this.fnName = targetCall.getFnName().getFunction();
+        this(targetCall, false, argNums);
+    }
+
+    public FunctionCallTransformer(FunctionCallExpr targetCall, boolean variableArgument) {
+        this(targetCall, variableArgument, 0);
+    }
+
+    private FunctionCallTransformer(FunctionCallExpr targetCall, boolean variableArgument, int argNums) {
         this.targetCall = targetCall;
         this.argNums = argNums;
-        this.placeholderExprs = new PlaceholderExpr[argNums];
+        this.variableArgument = variableArgument;
+        if (variableArgument) {
+            this.placeholderExprs = Lists.newArrayList();
+        } else {
+            this.placeholderExprs = Arrays.asList(new PlaceholderExpr[argNums]);
+        }
         init();
     }
 
     private void init() {
         // collect the all placeholderExprs which defined by targetCall
-        new PlaceholderCollector(placeholderExprs).visit(targetCall);
+        new PlaceholderCollector(placeholderExprs, variableArgument).visit(targetCall);
     }
 
     private static class PlaceholderCollector extends AstVisitor<Void, Void> {
-        private final PlaceholderExpr[] placeholderExprs;
-        public PlaceholderCollector(PlaceholderExpr[] placeholderExprs) {
+        private final List<PlaceholderExpr> placeholderExprs;
+        private final boolean variableArgument;
+        public PlaceholderCollector(List<PlaceholderExpr> placeholderExprs, boolean vararg) {
             this.placeholderExprs = placeholderExprs;
+            this.variableArgument = vararg;
         }
 
         @Override
@@ -63,18 +79,30 @@ public class FunctionCallTransformer {
 
         @Override
         public Void visitPlaceholderExpr(PlaceholderExpr node, Void context) {
-            placeholderExprs[node.getIndex() - 1] = node;
+            if (!variableArgument) {
+                placeholderExprs.set(node.getIndex() - 1, node);
+            } else {
+                placeholderExprs.add(node);
+            }
             return null;
         }
     }
 
     public boolean match(List<Expr> sourceArguments) {
         List<Class<? extends Expr>> argTypes = sourceArguments.stream().map(Expr::getClass).collect(Collectors.toList());
+        if (variableArgument) {
+            for (Class<? extends Expr> argType : argTypes) {
+                if (!placeholderExprs.get(0).getClazz().isAssignableFrom(argType)) {
+                    return false;
+                }
+            }
+            return true;
+        }
         if (sourceArguments.size() != argNums) {
             return false;
         }
         for (int index = 0; index < argNums; ++index) {
-            if (!placeholderExprs[index].getClazz().isAssignableFrom(argTypes.get(index))) {
+            if (!placeholderExprs.get(index).getClazz().isAssignableFrom(argTypes.get(index))) {
                 return false;
             }
         }
@@ -82,21 +110,35 @@ public class FunctionCallTransformer {
     }
 
     public Expr transform(List<Expr> sourceArguments) {
-        return new FunctionCallRewriter(placeholderExprs, sourceArguments).visit(targetCall);
+        return new FunctionCallRewriter(placeholderExprs, variableArgument, sourceArguments).visit(targetCall.clone());
     }
 
     private static class FunctionCallRewriter extends AstVisitor<Expr, Void> {
         private final List<Expr> sourceArguments;
+        private boolean variableArgument;
 
-        public FunctionCallRewriter(PlaceholderExpr[] placeholderExprs, List<Expr> sourceArguments) {
-            Preconditions.checkState(placeholderExprs.length == sourceArguments.size());
+        public FunctionCallRewriter(List<PlaceholderExpr> placeholderExprs, boolean varargs, List<Expr> sourceArguments) {
+            this.variableArgument = varargs;
+            if (!varargs) {
+                Preconditions.checkState(placeholderExprs.size() == sourceArguments.size());
+            }
             this.sourceArguments = sourceArguments;
         }
 
         @Override
         public Expr visitExpression(Expr node, Void context) {
-            for (int index = 0; index < node.getChildren().size(); ++index) {
-                node.setChild(index, visit(node.getChild(index)));
+            if (!variableArgument) {
+                for (int index = 0; index < node.getChildren().size(); ++index) {
+                    node.setChild(index, visit(node.getChild(index)));
+                }
+            } else {
+                // If variableArgument is true, use all source arguments to replace placeholders.
+                if (node.getChildren().stream().anyMatch(child -> child instanceof PlaceholderExpr)) {
+                    node.clearChildren();
+                    for (Expr sourceArgument : sourceArguments) {
+                        node.addChild(sourceArgument);
+                    }
+                }
             }
             return node;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.parser.trino;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -22,6 +23,7 @@ import com.starrocks.analysis.CaseWhenClause;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IntLiteral;
+import com.starrocks.sql.ast.ArrayExpr;
 
 import java.util.List;
 import java.util.Map;
@@ -61,6 +63,7 @@ public class Trino2SRFunctionCallTransformer {
 
     private static void registerAllFunctionTransformer() {
         registerAggregateFunctionTransformer();
+        registerArrayFunctionTransformer();
         // todo： support more function transform
     }
 
@@ -99,15 +102,54 @@ public class Trino2SRFunctionCallTransformer {
                         new PlaceholderExpr(1, Expr.class), new IntLiteral(1L))), null))));
     }
 
+    private static void registerArrayFunctionTransformer() {
+        // 1. array_union -> array_distinct(array_concat(x, y))
+        registerFunctionTransformer("array_union", 2, new FunctionCallExpr("array_distinct",
+                ImmutableList.of(new FunctionCallExpr("array_concat", ImmutableList.of(
+                        new PlaceholderExpr(1, Expr.class), new PlaceholderExpr(2, Expr.class)
+                )))));
+
+        // 2. concat -> array_concat
+        registerFunctionTransformerWithVarArgs("concat", "array_concat",
+                ImmutableList.of(ArrayExpr.class));
+
+        // 3. contains -> array_contains
+        registerFunctionTransformer("contains", 2, "array_contains",
+                ImmutableList.of(Expr.class, Expr.class));
+
+        // 4. contains_sequence -> array_contains_all
+        registerFunctionTransformer("contains_sequence", 2, "array_contains_all",
+                ImmutableList.of(Expr.class, Expr.class));
+
+        // 5. slice -> array_slice
+        registerFunctionTransformer("slice", 3, "array_slice",
+                ImmutableList.of(Expr.class, Expr.class, Expr.class));
+    }
+
     private static void registerFunctionTransformer(String trinoFnName, int trinoFnArgNums, String starRocksFnName,
                                                     List<Class<? extends Expr>> starRocksArgumentsClass) {
         FunctionCallExpr starRocksFunctionCall = buildStarRocksFunctionCall(starRocksFnName, starRocksArgumentsClass);
         registerFunctionTransformer(trinoFnName, trinoFnArgNums, starRocksFunctionCall);
     }
 
+    private static void registerFunctionTransformerWithVarArgs(String trinoFnName, String starRocksFnName,
+                                                    List<Class<? extends Expr>> starRocksArgumentsClass) {
+        Preconditions.checkState(starRocksArgumentsClass.size() == 1);
+        FunctionCallExpr starRocksFunctionCall = buildStarRocksFunctionCall(starRocksFnName, starRocksArgumentsClass);
+        registerFunctionTransformerWithVarArgs(trinoFnName, starRocksFunctionCall);
+    }
+
     private static void registerFunctionTransformer(String trinoFnName, int trinoFnArgNums,
                                                     FunctionCallExpr starRocksFunctionCall) {
         FunctionCallTransformer transformer = new FunctionCallTransformer(starRocksFunctionCall, trinoFnArgNums);
+
+        List<FunctionCallTransformer> transformerList = TRANSFORMER_MAP.computeIfAbsent(trinoFnName,
+                k -> Lists.newArrayList());
+        transformerList.add(transformer);
+    }
+
+    private static void registerFunctionTransformerWithVarArgs(String trinoFnName, FunctionCallExpr starRocksFunctionCall) {
+        FunctionCallTransformer transformer = new FunctionCallTransformer(starRocksFunctionCall, true);
 
         List<FunctionCallTransformer> transformerList = TRANSFORMER_MAP.computeIfAbsent(trinoFnName,
                 k -> Lists.newArrayList());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -50,4 +50,25 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         assertPlanContains(sql, "  2:AGGREGATE (update finalize)\n" +
                 "  |  output: count(if(CAST(1: v1 AS BOOLEAN), 1, NULL))");
     }
+
+    @Test
+    public void testArrayFnTransform() throws Exception {
+        String sql = "select array_union(c1, c2) from test_array";
+        assertPlanContains(sql, "array_distinct(array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR>)))");
+
+        sql = "select concat(array[1,2,3], array[4,5,6]) from test_array";
+        assertPlanContains(sql, "array_concat(ARRAY<tinyint(4)>[1,2,3], ARRAY<tinyint(4)>[4,5,6])");
+
+        sql = "select contains(array[1,2,3], 1)";
+        assertPlanContains(sql, "array_contains(ARRAY<tinyint(4)>[1,2,3], 1)");
+
+        sql = "select contains_sequence(c1, array['1','2']) from test_array";
+        assertPlanContains(sql, "array_contains_all(2: c1, ARRAY<varchar>['1','2'])");
+
+        sql = "select contains_sequence(c1, array['1','2']) from test_array";
+        assertPlanContains(sql, "array_contains_all(2: c1, ARRAY<varchar>['1','2'])");
+
+        sql = "select slice(array[1,2,3,4], 2, 2)";
+        assertPlanContains(sql, "array_slice(ARRAY<tinyint(4)>[1,2,3,4], 2, 2)");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -133,8 +133,9 @@ public class TrinoQueryTest extends TrinoTestBase {
                 "  |  order by: 3: v3 ASC\n" +
                 "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING");
 
-        sql = "select first_value(v1) over(partition by v2 order by v3 range between unbounded preceding and unbounded " +
-                "following) from t0";
+        sql =
+                "select first_value(v1) over(partition by v2 order by v3 range between unbounded preceding and unbounded " +
+                        "following) from t0";
         assertPlanContains(sql, "3:ANALYTIC\n" +
                 "  |  functions: [, first_value(1: v1), ]\n" +
                 "  |  partition by: 2: v2\n" +
@@ -169,12 +170,14 @@ public class TrinoQueryTest extends TrinoTestBase {
                 "  |  order by: 3: v3 ASC\n" +
                 "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
 
-        sql = "select sum(v1) over(partition by v2 order by v3 range between unbounded preceding and unbounded following) " +
-                "from t0";
+        sql =
+                "select sum(v1) over(partition by v2 order by v3 range between unbounded preceding and unbounded following) " +
+                        "from t0";
         assertPlanContains(sql, "window: RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING");
 
-        sql = "select count(v1) over(partition by v2 order by v3 rows between unbounded preceding and unbounded following) " +
-                "from t0";
+        sql =
+                "select count(v1) over(partition by v2 order by v3 rows between unbounded preceding and unbounded following) " +
+                        "from t0";
         assertPlanContains(sql, "window: ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING");
 
         sql = "select min(v1) over(partition by v2 order by v3 rows current row) from t0";
@@ -185,6 +188,77 @@ public class TrinoQueryTest extends TrinoTestBase {
 
         sql = "select min(v1) over(partition by v2 order by v3 rows 10 PRECEDING) from t0";
         assertPlanContains(sql, "window: ROWS BETWEEN 10 PRECEDING AND CURRENT ROW");
+    }
+
+    @Test
+    public void testSelectArray() throws Exception {
+        String sql = "select c1[1] from test_array";
+        assertPlanContains(sql, "<slot 4> : 2: c1[1]");
+
+        sql = "select c0, sum(c2[1]) from test_array group by c0";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 1> : 1: c0\n" +
+                "  |  <slot 4> : 3: c2[1]");
+
+        sql = "select distinct c2 from test_array order by c2[1];";
+        assertPlanContains(sql, "2:Project\n" +
+                "  |  <slot 3> : 3: c2\n" +
+                "  |  <slot 4> : 3: c2[1]");
+        sql = "select array[array[1,2],array[3,4]][1][2]";
+        assertPlanContains(sql, "ARRAY<ARRAY<tinyint(4)>>[[1,2],[3,4]][1][2]");
+
+        sql = "select array[][1]";
+        assertPlanContains(sql, "ARRAY<unknown type: NULL_TYPE>[][1]");
+
+        sql = "select array[v1 = 1, v2 = 2, true] from t0";
+        assertPlanContains(sql, "<slot 4> : ARRAY<boolean>[1: v1 = 1,2: v2 = 2,TRUE]");
+
+        sql = "select array[v1,v2] from t0";
+        assertPlanContains(sql, "ARRAY<bigint(20)>[1: v1,2: v2]");
+
+
+        sql = "select array[NULL][1] + 1, array[1,2,3][1] + array[array[1,2,3],array[1,1,1]][2][2];";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 2> : NULL\n" +
+                "  |  <slot 3> : CAST(ARRAY<tinyint(4)>[1,2,3][1] AS SMALLINT) + CAST(ARRAY<ARRAY<tinyint(4)>>" +
+                "[[1,2,3],[1,1,1]][2][2] AS SMALLINT)");
+
+        sql = "select c0, c2[1] + array[1,2,3][1] as v, sum(c2[1]) from test_array group by c0, v order by v";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 1> : 1: c0\n" +
+                "  |  <slot 4> : CAST(3: c2[1] AS BIGINT) + CAST(ARRAY<tinyint(4)>[1,2,3][1] AS BIGINT)\n" +
+                "  |  <slot 5> : 3: c2[1]");
+    }
+
+
+    @Test
+    public void testSelectArrayFunction() throws Exception {
+        String sql =  "select array_distinct(c1) from test_array";
+        assertPlanContains(sql, "array_distinct(2: c1)");
+
+        sql =  "select array_intersect(c1, array['star','rocks']) from test_array";
+        assertPlanContains(sql, "array_intersect(2: c1, ARRAY<varchar>['star','rocks'])");
+
+        sql = "select array_join(c1, '_') from test_array";
+        assertPlanContains(sql, "array_join(2: c1, '_')");
+
+        sql = "select array_max(c1) from test_array";
+        assertPlanContains(sql, "array_max(2: c1)");
+
+        sql = "select array_min(c1) from test_array";
+        assertPlanContains(sql, "array_min(2: c1)");
+
+        sql = "select array_position(array[1,2,3], 2) from test_array";
+        assertPlanContains(sql, "array_position(ARRAY<tinyint(4)>[1,2,3], 2)");
+
+        sql = "select array_remove(array[1,2,3], 2) from test_array";
+        assertPlanContains(sql, "array_remove(ARRAY<tinyint(4)>[1,2,3], 2)");
+
+        sql = "select array_sort(c1) from test_array";
+        assertPlanContains(sql, "array_sort(2: c1)");
+
+        sql =  "select arrays_overlap(c1, array['star','rocks']) from test_array";
+        assertPlanContains(sql, "arrays_overlap(2: c1, ARRAY<varchar>['star','rocks'])");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
@@ -262,6 +262,12 @@ public class TrinoTestBase {
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
 
+        starRocksAssert.withTable("create table test_array(c0 INT, " +
+                "c1 array<varchar(65533)>, " +
+                "c2 array<int>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+
         connectContext.getSessionVariable().setSqlDialect("trino");
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#14825

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Support query array type for Trino parser on starrocks
2. Support some array function transform
3. Support transform trino function with variable arguments, such like concat(array1,array2,....)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
