### PR TITLE
[Enhancement] remove sensitive info from create repo audit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -165,7 +165,6 @@ public class AstToStringBuilder {
             return sb.toString();
         }
 
-<<<<<<< HEAD
         public String visitCreateResourceStatement(CreateResourceStmt stmt, Void context) {
             StringBuilder sb = new StringBuilder();
             sb.append("CREATE EXTERNAL RESOURCE ").append(stmt.getResourceName());
@@ -173,7 +172,10 @@ public class AstToStringBuilder {
             sb.append(" PROPERTIES (");
             sb.append(new PrintableMap<String, String>(stmt.getProperties(), "=", true, false, true));
             sb.append(")");
-=======
+
+            return sb.toString();
+        }
+
         public String visitCreateRepositoryStatement(CreateRepositoryStmt stmt, Void context) {
             StringBuilder sb = new StringBuilder();
             sb.append("CREATE REPOSITORY ").append(stmt.getName());
@@ -184,7 +186,6 @@ public class AstToStringBuilder {
             sb.append(" PROPERTIES (");
             sb.append(new PrintableMap<String, String>(stmt.getProperties(), "=", true, false, true));
             sb.append(" )");
->>>>>>> 7596a4a0b (fix: remove sensative info from create repo audit)
             return sb.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -56,6 +56,7 @@ import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.BaseGrantRevokePrivilegeStmt;
 import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.DataDescription;
@@ -164,6 +165,7 @@ public class AstToStringBuilder {
             return sb.toString();
         }
 
+<<<<<<< HEAD
         public String visitCreateResourceStatement(CreateResourceStmt stmt, Void context) {
             StringBuilder sb = new StringBuilder();
             sb.append("CREATE EXTERNAL RESOURCE ").append(stmt.getResourceName());
@@ -171,6 +173,18 @@ public class AstToStringBuilder {
             sb.append(" PROPERTIES (");
             sb.append(new PrintableMap<String, String>(stmt.getProperties(), "=", true, false, true));
             sb.append(")");
+=======
+        public String visitCreateRepositoryStatement(CreateRepositoryStmt stmt, Void context) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("CREATE REPOSITORY ").append(stmt.getName());
+            sb.append(" WITH BROKER ").append(stmt.getBrokerName());
+            sb.append(" ON LOCATION \"").append(stmt.getLocation()).append("\"");
+
+
+            sb.append(" PROPERTIES (");
+            sb.append(new PrintableMap<String, String>(stmt.getProperties(), "=", true, false, true));
+            sb.append(" )");
+>>>>>>> 7596a4a0b (fix: remove sensative info from create repo audit)
             return sb.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRepositoryStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRepositoryStmt.java
@@ -67,4 +67,9 @@ public class CreateRepositoryStmt extends DdlStmt {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitCreateRepositoryStatement(this, context);
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRepositoryStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRepositoryStmtTest.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.analysis;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.analyzer.AstToStringBuilder;
+import com.starrocks.sql.ast.CreateRepositoryStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateRepositoryStmtTest {
+    private static StarRocksAssert starRocksAssert;
+    private static ConnectContext ctx;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("db1").useDatabase("tbl1");
+        ctx = new ConnectContext(null);
+        ctx.setGlobalStateMgr(AccessTestUtil.fetchAdminCatalog());
+    }
+
+
+    @Test
+    public void testToString() {
+        String sql = "CREATE REPOSITORY oss_repo\n" +
+                "WITH BROKER oss_broker\n" +
+                "ON LOCATION \"oss://starRocks_backup\"\n" +
+                "PROPERTIES\n" +
+                "(\n" +
+                "    \"fs.oss.accessKeyId\" = \"access_key_id\",\n" +
+                "    \"fs.oss.accessKeySecret\" = \"access_key_secret\",\n" +
+                "    \"fs.oss.endpoint\" = \"oss-cn-beijing.aliyuncs.com\"\n" +
+                ")";
+        ConnectContext ctx = starRocksAssert.getCtx();
+        CreateRepositoryStmt stmt = (CreateRepositoryStmt) com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
+        Assert.assertEquals("CREATE REPOSITORY oss_repo WITH BROKER oss_broker ON LOCATION \"oss://starRocks_backup\" " +
+                "PROPERTIES (\"fs.oss.accessKeyId\" = \"***\", \"fs.oss.accessKeySecret\" = \"***\", \"fs.oss.endpoint\" = \"oss-cn-beijing.aliyuncs.com\" )", AstToStringBuilder.toString(stmt));
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13324

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR removes sensitive key words from audit log of create repo stmt. The new output would be like
```
2022-11-15 20:45:32,777 [query] |Client=127.0.0.1:56422|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=db0|State=ERR|ErrorCode=|Time=10|ScanBytes=0|ScanRows=0|ReturnRows=0|CpuCostNs=0|MemCostBytes=0|StmtId=3|QueryId=2834574d-64f4-11ed-bbf0-52243889412b|IsQuery=false|feIp=172.17.0.1|Stmt=CREATE REPOSITORY `hdfs_repo` WITH BROKER `hdfs_broker` ON LOCATION "hdfs://hadoop-name-node:54310/path/to/repo/" PROPERTIES ( "username" = "user", "password" = "***" )|
```
in which the sensitive key words would be replaced by `***`.
Now, the sensitive key words include the following: 
```
password
kerberos_keytab_content
bos_secret_accesskey
fs.s3a.access.key
fs.s3a.secret.key
fs.oss.accessKeyId
fs.oss.accessKeySecret
fs.cosn.userinfo.secretId
fs.cosn.userinfo.secretKey
property.sasl.password

```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
