### PR TITLE
[BugFix] BE crash when ingesting data from nested array to json

### DIFF
--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -668,7 +668,8 @@ struct ArrowConverter<AT, PT, is_nullable, is_strict, DateOrDateTimeATGuard<AT>,
 };
 
 // Convert nested arrow type(Map,List,Struct...) to Json
-Status convert_arrow_to_json(const arrow::Array* array, JsonColumn* output);
+Status convert_arrow_to_json(const arrow::Array* array, JsonColumn* output, size_t array_start_idx,
+                             size_t num_elements);
 
 template <ArrowTypeId AT, LogicalType PT, bool is_nullable, bool is_strict>
 struct ArrowConverter<AT, PT, is_nullable, is_strict, JsonGuard<PT>> {
@@ -678,7 +679,7 @@ struct ArrowConverter<AT, PT, is_nullable, is_strict, JsonGuard<PT>> {
         auto* json_column = down_cast<JsonColumn*>(column);
         json_column->reserve(column->size() + num_elements);
 
-        return convert_arrow_to_json(array, json_column);
+        return convert_arrow_to_json(array, json_column, array_start_idx, num_elements);
     }
 };
 

--- a/be/test/exec/test_data/parquet_data/issue_16375.py
+++ b/be/test/exec/test_data/parquet_data/issue_16375.py
@@ -1,0 +1,36 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pyarrow import json
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+# Generate parquet file for testing
+
+output = "./issue_16375.parquet"
+
+data = [
+    pa.array(range(4097), type=pa.int32()),
+    pa.array(
+        [[["1"]] for i in range(4097)],
+        type=pa.list_(pa.list_(pa.string())),
+    ),
+]
+
+columns = [
+    "c0",
+    "c1"
+]
+table = pa.Table.from_arrays(data, columns)
+pq.write_table(table, output)


### PR DESCRIPTION

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16375

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In each iteration, convert_array_to_column of ParquetScanner will read 4096 rows, however, convert_arrow_to_json will read all rowss from array, if parquet's row length is larger than 4096, BE will crash. Crash Reason: for nullable arraycolumn, nullable column is 4096 row and data column is larger than 4096 rows, size check will fail.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
