### PR TITLE
[Enhancement] support "select into outfile" without properties

### DIFF
--- a/be/src/runtime/file_result_writer.h
+++ b/be/src/runtime/file_result_writer.h
@@ -48,7 +48,6 @@ class RuntimeProfile;
 class WritableFile;
 
 struct ResultFileOptions {
-    bool is_local_file;
     std::string file_path;
     TFileFormatType::type file_format;
     std::string column_separator;
@@ -67,17 +66,14 @@ struct ResultFileOptions {
         row_delimiter = t_opt.__isset.row_delimiter ? t_opt.row_delimiter : "\n";
         max_file_size_bytes = t_opt.__isset.max_file_size_bytes ? t_opt.max_file_size_bytes : max_file_size_bytes;
 
-        is_local_file = true;
         if (t_opt.__isset.broker_addresses) {
             broker_addresses = t_opt.broker_addresses;
-            is_local_file = false;
         }
         if (t_opt.__isset.hdfs_write_buffer_size_kb) {
             write_buffer_size_kb = t_opt.hdfs_write_buffer_size_kb;
         }
         if (t_opt.__isset.hdfs_properties) {
             hdfs_properties = t_opt.hdfs_properties;
-            is_local_file = false;
         }
         if (t_opt.__isset.use_broker) {
             use_broker = t_opt.use_broker;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -128,10 +128,6 @@ public class OutFileClause implements ParseNode {
     }
 
     private void analyzeProperties() throws AnalysisException {
-        if (properties == null || properties.isEmpty()) {
-            return;
-        }
-
         setBrokerProperties();
         if (brokerDesc == null) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -554,9 +554,15 @@ public class HdfsFsManager {
                 if (cloudConfiguration != null) {
                     cloudConfiguration.applyToConfiguration(conf);
                 } else {
-                    conf.set(FS_S3A_ACCESS_KEY, accessKey);
-                    conf.set(FS_S3A_SECRET_KEY, secretKey);
-                    conf.set(FS_S3A_ENDPOINT, endpoint);
+                    if (!accessKey.isEmpty()) {
+                        conf.set(FS_S3A_ACCESS_KEY, accessKey);
+                    }
+                    if (!secretKey.isEmpty()) {
+                        conf.set(FS_S3A_SECRET_KEY, secretKey);
+                    }
+                    if (!endpoint.isEmpty()) {
+                        conf.set(FS_S3A_ENDPOINT, endpoint);
+                    }
                     // Only set ssl for origin logic
                     conf.set(FS_S3A_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
                     if (awsCredProvider != null) {
@@ -633,9 +639,15 @@ public class HdfsFsManager {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
                 Configuration conf = new ConfigurationWrap();
-                conf.set(FS_KS3_ACCESS_KEY, accessKey);
-                conf.set(FS_KS3_SECRET_KEY, secretKey);
-                conf.set(FS_KS3_ENDPOINT, endpoint);
+                if (!accessKey.isEmpty()) {
+                    conf.set(FS_KS3_ACCESS_KEY, accessKey);
+                }
+                if (!secretKey.isEmpty()) {
+                    conf.set(FS_KS3_SECRET_KEY, secretKey);
+                }
+                if (!endpoint.isEmpty()) {
+                    conf.set(FS_KS3_ENDPOINT, endpoint);
+                }
                 conf.set(FS_KS3_IMPL, "com.ksyun.kmr.hadoop.fs.ks3.Ks3FileSystem");
                 conf.set(FS_KS3_IMPL_DISABLE_CACHE, disableCache);
                 conf.set(FS_KS3_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
@@ -706,9 +718,15 @@ public class HdfsFsManager {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
                 Configuration conf = new ConfigurationWrap();
-                conf.set(FS_OBS_ACCESS_KEY, accessKey);
-                conf.set(FS_OBS_SECRET_KEY, secretKey);
-                conf.set(FS_OBS_ENDPOINT, endpoint);
+                if (!accessKey.isEmpty()) {
+                    conf.set(FS_OBS_ACCESS_KEY, accessKey);
+                }
+                if (!secretKey.isEmpty()) {
+                    conf.set(FS_OBS_SECRET_KEY, secretKey);
+                }
+                if (!endpoint.isEmpty()) {
+                    conf.set(FS_OBS_ENDPOINT, endpoint);
+                }
                 conf.set(FS_OBS_IMPL, "org.apache.hadoop.fs.obs.OBSFileSystem");
                 conf.set(FS_OBS_IMPL_DISABLE_CACHE, disableCache);
                 conf.set(FS_OBS_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
@@ -777,9 +795,17 @@ public class HdfsFsManager {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
                 Configuration conf = new ConfigurationWrap();
-                conf.set(FS_OSS_ACCESS_KEY, accessKey);
-                conf.set(FS_OSS_SECRET_KEY, secretKey);
-                conf.set(FS_OSS_ENDPOINT, endpoint);
+                if (!accessKey.isEmpty()) {
+                    conf.set(FS_OSS_ACCESS_KEY, accessKey);
+                }
+
+                if (!secretKey.isEmpty()) {
+                    conf.set(FS_OSS_SECRET_KEY, secretKey);
+                }
+
+                if (!endpoint.isEmpty()) {
+                    conf.set(FS_OSS_ENDPOINT, endpoint);
+                }
                 conf.set(FS_OSS_IMPL, "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem");
                 conf.set(FS_OSS_IMPL_DISABLE_CACHE, disableCache);
                 conf.set(FS_OSS_CONNECTION_SSL_ENABLED, connectionSSLEnabled);
@@ -842,9 +868,16 @@ public class HdfsFsManager {
                 LOG.info("could not find file system for path " + path + " create a new one");
                 // create a new filesystem
                 Configuration conf = new ConfigurationWrap();
-                conf.set(FS_COS_ACCESS_KEY, accessKey);
-                conf.set(FS_COS_SECRET_KEY, secretKey);
-                conf.set(FS_COS_ENDPOINT, endpoint);
+                if (!accessKey.isEmpty()) {
+                    conf.set(FS_COS_ACCESS_KEY, accessKey);
+                }
+                if (!secretKey.isEmpty()) {
+                    conf.set(FS_COS_SECRET_KEY, secretKey);
+                }
+                if (!endpoint.isEmpty()) {
+                    conf.set(FS_COS_ENDPOINT, endpoint);
+                }
+
                 conf.set(FS_COS_IMPL, "org.apache.hadoop.fs.CosFileSystem");
                 conf.set(FS_COS_IMPL_DISABLE_CACHE, disableCache);
                 conf.set(FS_COS_CONNECTION_SSL_ENABLED, connectionSSLEnabled);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -80,6 +80,8 @@ public class AnalyzeSingleTest {
                 "(\"broker.name\" = \"my_broker\"," +
                 "\"broker.hadoop.security.authentication\" = \"kerberos\"," +
                 "\"line_delimiter\" = \"\n\", \"max_file_size\" = \"100MB\");");
+
+        analyzeSuccess("SELECT v1,v2,v3 FROM t0  INTO OUTFILE \"hdfs://path/to/result_\" FORMAT AS CSV");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
I want to support "select into outfile" with parquet format. So I think there is no need to set properties in every sql.
this pr major changes：
1. "select into outfile" can be used without properties.
2. Without properties, use the default ak/sk in fe/conf/core-site.xml 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
