### PR TITLE
[Refactor][Cherry-pick][Branch-2.5] Fix the wrong log when preCommit failed (#16167)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -31,10 +31,10 @@ public class FeNameFormat {
 
     private static final String LABEL_REGEX = "^[-\\w]{1,128}$";
     public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
-    // The mysql protocol does not limit the length of the db, but the buffer of the mysql-client is 512+1,
-    // minus the use and spaces, a total of 4 bytes, and finally can only limit the length of 509,
-    // in order to be compatible with the mysql-client, the limit length is 509.
-    public static final String DB_NAME_REGEX = "^[a-zA-Z]\\w{0,508}$|^_[a-zA-Z0-9]\\w{0,507}$";
+
+    // The length length of db name is 256
+    public static final String DB_NAME_REGEX = "^[a-zA-Z]\\w{0,255}$|^_[a-zA-Z0-9]\\w{0,254}$";
+
     public static final String TABLE_NAME_REGEX = "^[^\0]{1,1024}$";
     // Now we can not accept all characters because current design of delete save delete cond contains column name,
     // so it can not distinguish whether it is an operator or a column name

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -176,7 +176,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                             failedReplicaInfoSB.append(
                                     String.format("%d:{be:%d %s V:%d LFV:%d},", replica.getId(), tabletBackend,
                                             backend == null ? "" : backend.getHost(), replica.getVersion(),
-                                            replica.getLastSuccessVersion()));
+                                            replica.getLastFailedVersion()));
                             // not remove rollup task here, because the commit maybe failed
                             // remove rollup task when commit successfully
                             errorReplicaIds.add(replica.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -105,7 +105,7 @@ public class CreateTableAutoTabletTest {
 
     @Test
     public void createBadDbName() {
-        String longDbName = new String(new char[510]).replace('\0', 'a');
+        String longDbName = new String(new char[257]).replace('\0', 'a');
         String sql = "create database " + longDbName;
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, UtFrameUtils.createDefaultCtx());
@@ -117,7 +117,7 @@ public class CreateTableAutoTabletTest {
 
     @Test
     public void createLongDbName() throws Exception {
-        String longDbName = new String(new char[509]).replace('\0', 'a');
+        String longDbName = new String(new char[256]).replace('\0', 'a');
         String sql = "create database " + longDbName;
         UtFrameUtils.parseStmtWithNewParser(sql, UtFrameUtils.createDefaultCtx());
     }


### PR DESCRIPTION
The preCommit() call the getLastSuccessVersion() wrong. Should call the getLastFailedVersion() instead.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16225

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
