### PR TITLE
[Refactor][Cherry-pick][Branch-2.3] Fix the wrong log when preCommit failed (#16167)

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -52,8 +52,6 @@ export_mem_limit_from_conf() {
         fi
     done < $1
 
-<<<<<<< HEAD
-=======
     cgroup_version=$(stat -fc %T /sys/fs/cgroup)
     if [ -f /.dockerenv ] && [ "$cgroup_version" == "tmpfs" ]; then
         mem_limit=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes | awk '{printf $1}')
@@ -75,12 +73,15 @@ export_mem_limit_from_conf() {
         fi
     fi
 
->>>>>>> 25573ed69 ([BugFix] Get right path of memory.max (#15199))
     # read /proc/meminfo to fetch total memory of machine
     mem_total=$(cat /proc/meminfo |grep 'MemTotal' |awk -F : '{print $2}' |sed 's/^[ \t]*//g' | awk '{printf $1}')
     if [ "$mem_total" == "" ]; then
         echo "can't get mem info from /proc/meminfo"
         return 1
+    fi
+
+    if [[ (-v mem_limit) && ($mem_limit -le $mem_total) ]]; then
+      mem_total=$mem_limit
     fi
 
     if [ "$mem_limit_is_set" == "false" ]; then

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -24,14 +24,18 @@ package com.starrocks.common;
 import com.google.common.base.Strings;
 import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.mysql.privilege.Role;
-import com.starrocks.system.SystemInfoService;
 
 public class FeNameFormat {
     private FeNameFormat() {}
 
     private static final String LABEL_REGEX = "^[-\\w]{1,128}$";
     public static final String COMMON_NAME_REGEX = "^[a-zA-Z]\\w{0,63}$|^_[a-zA-Z0-9]\\w{0,62}$";
-    // Now we can not accept all characters because current design of delete save delete cond contains column name
+
+    // The length length of db name is 256
+    public static final String DB_NAME_REGEX = "^[a-zA-Z]\\w{0,255}$|^_[a-zA-Z0-9]\\w{0,254}$";
+
+    public static final String TABLE_NAME_REGEX = "^[^\0]{1,1024}$";
+    // Now we can not accept all characters because current design of delete save delete cond contains column name,
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation
     private static final String COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,64}$";
@@ -41,17 +45,8 @@ public class FeNameFormat {
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
 
-    public static void checkClusterName(String clusterName) throws AnalysisException {
-        if (Strings.isNullOrEmpty(clusterName) || !clusterName.matches(COMMON_NAME_REGEX)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_CLUSTER_NAME, clusterName);
-        }
-        if (clusterName.equalsIgnoreCase(SystemInfoService.DEFAULT_CLUSTER)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_CLUSTER_NAME, clusterName);
-        }
-    }
-
     public static void checkDbName(String dbName) throws AnalysisException {
-        if (Strings.isNullOrEmpty(dbName) || !dbName.matches(COMMON_NAME_REGEX)) {
+        if (Strings.isNullOrEmpty(dbName) || !dbName.matches(DB_NAME_REGEX)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
         }
     }


### PR DESCRIPTION
The preCommit() call the getLastSuccessVersion() wrong. Should call the getLastFailedVersion() instead.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16225

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
