### PR TITLE
[BugFix][Cherry-pick][Branch-2.5] Fix key index out of bound in schema of _do_merge_horizontally

### DIFF
--- a/be/src/storage/rowset_merger.h
+++ b/be/src/storage/rowset_merger.h
@@ -15,7 +15,7 @@ struct MergeConfig {
     CompactionAlgorithm algorithm = HORIZONTAL_COMPACTION;
 };
 
-// heap based rowset merger used for updatable tablet's compaction
+// heap based rowset merger used for updatable tabl·et's compaction
 
 Status compaction_merge_rowsets(Tablet& tablet, int64_t version, const vector<RowsetSharedPtr>& rowsets,
                                 RowsetWriter* writer, const MergeConfig& cfg);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/13935

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

potential array index out of bound. should be an iota array of sort key indexes, not sort key indexes directly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
