### PR TITLE
[BugFix] only set not null for primary key column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/KeysDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/KeysDesc.java
@@ -41,6 +41,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.sql.analyzer.SemanticException;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -70,7 +71,7 @@ public class KeysDesc implements Writable {
     }
 
     public boolean containsCol(String colName) {
-        return keysColumnNames.contains(colName);
+        return keysColumnNames.stream().anyMatch(e -> StringUtils.equalsIgnoreCase(e, colName));
     }
 
     // new planner framework use SemanticException instead of AnalysisException, this code will remove in future

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -106,7 +106,7 @@ public class CTASAnalyzer {
             Expr originExpression = allFields.get(i).getOriginExpression();
             ColumnDef columnDef = new ColumnDef(finalColumnNames.get(i), new TypeDef(type), false,
                         null, originExpression.isNullable(), ColumnDef.DefaultValueDef.NOT_SET, "");
-            if (isPKTable) {
+            if (isPKTable && keysDesc.containsCol(finalColumnNames.get(i))) {
                 columnDef.setAllowNull(false);
             }
             createTableStmt.addColumnDef(columnDef);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For now, we cannot obatin the correct nullable info from both logical plan and excutable plan, so we cannot define the meta of cols in the create table statement based on the output cols of the query.
So we take a loose restriction for nullable info. Only cols in the primary key are non-nullable and the other cols are all nullable.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
