### PR TITLE
[Refactor] Remove some of the dependencies on ExecEnv::GetInstance()

### DIFF
--- a/be/src/runtime/lake_tablets_channel.h
+++ b/be/src/runtime/lake_tablets_channel.h
@@ -22,7 +22,11 @@ class LoadChannel;
 class MemTracker;
 struct TabletsChannelKey;
 
-std::shared_ptr<TabletsChannel> new_lake_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,
-                                                         MemTracker* mem_tracker);
+namespace lake {
+class TabletManager;
+}
+
+std::shared_ptr<TabletsChannel> new_lake_tablets_channel(LoadChannel* load_channel, lake::TabletManager* tablet_manager,
+                                                         const TabletsChannelKey& key, MemTracker* mem_tracker);
 
 } // namespace starrocks

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -100,8 +100,12 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
         }
         if (_tablets_channels.find(index_id) == _tablets_channels.end()) {
             TabletsChannelKey key(request.id(), index_id);
-            channel = is_lake_tablet ? new_lake_tablets_channel(this, key, _mem_tracker.get())
-                                     : new_local_tablets_channel(this, key, _mem_tracker.get());
+            if (is_lake_tablet) {
+                auto tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
+                channel = new_lake_tablets_channel(this, tablet_mgr, key, _mem_tracker.get());
+            } else {
+                channel = new_local_tablets_channel(this, key, _mem_tracker.get());
+            }
             if (st = channel->open(request, _schema); st.ok()) {
                 _tablets_channels.insert({index_id, std::move(channel)});
             }

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -38,9 +38,9 @@ public:
     // Undocemented rule of bthread that -1(0xFFFFFFFFFFFFFFFF) is an invalid ExecutionQueueId
     constexpr static uint64_t kInvalidQueueId = (uint64_t)-1;
 
-    AsyncDeltaWriterImpl(int64_t tablet_id, int64_t txn_id, int64_t partition_id,
+    AsyncDeltaWriterImpl(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
                          const std::vector<SlotDescriptor*>* slots, MemTracker* mem_tracker)
-            : _writer(DeltaWriter::create(tablet_id, txn_id, partition_id, slots, mem_tracker)),
+            : _writer(DeltaWriter::create(tablet_manager, tablet_id, txn_id, partition_id, slots, mem_tracker)),
               _queue_id{kInvalidQueueId},
               _open_mtx(),
               _status(),
@@ -226,10 +226,11 @@ int64_t AsyncDeltaWriter::txn_id() const {
     return _impl->txn_id();
 }
 
-std::unique_ptr<AsyncDeltaWriter> AsyncDeltaWriter::create(int64_t tablet_id, int64_t txn_id, int64_t partition_id,
+std::unique_ptr<AsyncDeltaWriter> AsyncDeltaWriter::create(TabletManager* tablet_manager, int64_t tablet_id,
+                                                           int64_t txn_id, int64_t partition_id,
                                                            const std::vector<SlotDescriptor*>* slots,
                                                            MemTracker* mem_tracker) {
-    auto impl = new AsyncDeltaWriterImpl(tablet_id, txn_id, partition_id, slots, mem_tracker);
+    auto impl = new AsyncDeltaWriterImpl(tablet_manager, tablet_id, txn_id, partition_id, slots, mem_tracker);
     return std::make_unique<AsyncDeltaWriter>(impl);
 }
 

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -34,6 +34,7 @@ class Chunk;
 namespace starrocks::lake {
 
 class AsyncDeltaWriterImpl;
+class TabletManager;
 
 // AsyncDeltaWriter is a wrapper on DeltaWriter to support non-blocking async write.
 // All submitted tasks will be executed in the FIFO order.
@@ -44,8 +45,8 @@ public:
     using Ptr = std::unique_ptr<AsyncDeltaWriter>;
     using Callback = std::function<void(Status st)>;
 
-    // |slots| and |mem_tracker| must outlive the AsyncDeltaWriter
-    static Ptr create(int64_t tablet_id, int64_t txn_id, int64_t partition_id,
+    // |tablet_manager|、|slots| and |mem_tracker| must outlive the AsyncDeltaWriter
+    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
                       const std::vector<SlotDescriptor*>* slots, MemTracker* mem_tracker);
 
     explicit AsyncDeltaWriter(AsyncDeltaWriterImpl* impl) : _impl(impl) {}

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -29,6 +29,7 @@ class Chunk;
 namespace starrocks::lake {
 
 class DeltaWriterImpl;
+class TabletManager;
 class TabletWriter;
 
 class DeltaWriter {
@@ -38,11 +39,14 @@ public:
     using Ptr = std::unique_ptr<DeltaWriter>;
 
     // for load
-    static Ptr create(int64_t tablet_id, int64_t txn_id, int64_t partition_id,
+    // Does NOT take the ownership of |tablet_manager|、|slots| and |mem_tracker|
+    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
                       const std::vector<SlotDescriptor*>* slots, MemTracker* mem_tracker);
 
     // for schema change
-    static Ptr create(int64_t tablet_id, int64_t max_buffer_size, MemTracker* mem_tracker);
+    // Does NOT take the ownership of |tablet_manager| and |mem_tracker|
+    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t max_buffer_size,
+                      MemTracker* mem_tracker);
 
     explicit DeltaWriter(DeltaWriterImpl* impl) : _impl(impl) {}
 

--- a/be/src/storage/lake/schema_change.h
+++ b/be/src/storage/lake/schema_change.h
@@ -22,12 +22,16 @@
 
 namespace starrocks::lake {
 
+class TabletManager;
+
 class SchemaChangeHandler {
 public:
-    SchemaChangeHandler() = default;
+    explicit SchemaChangeHandler(TabletManager* tablet_manager) : _tablet_manager(tablet_manager) {}
     ~SchemaChangeHandler() = default;
 
     Status process_alter_tablet(const TAlterTabletReqV2& request);
+
+    DISALLOW_COPY_AND_MOVE(SchemaChangeHandler);
 
 private:
     struct SchemaChangeParams {
@@ -42,6 +46,8 @@ private:
 
     Status do_process_alter_tablet(const TAlterTabletReqV2& request);
     Status convert_historical_rowsets(const SchemaChangeParams& sc_params, TxnLogPB_OpSchemaChange* op_schema_change);
+
+    TabletManager* _tablet_manager;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/task/engine_alter_tablet_task.cpp
+++ b/be/src/storage/task/engine_alter_tablet_task.cpp
@@ -60,7 +60,7 @@ Status EngineAlterTabletTask::execute() {
 
     Status res;
     if (_alter_tablet_req.tablet_type == TTabletType::TABLET_TYPE_LAKE) {
-        lake::SchemaChangeHandler handler;
+        lake::SchemaChangeHandler handler(ExecEnv::GetInstance()->lake_tablet_manager());
         res = handler.process_alter_tablet(_alter_tablet_req);
     } else {
         SchemaChangeHandler handler;


### PR DESCRIPTION
The hidden dependency on `ExecEnv::GetInstance()` make it difficult to write unit tests.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
