### PR TITLE
[Refactor] Unify the unit tests related names for BE and FE (#15667)

### DIFF
--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -32,39 +32,43 @@ usage() {
   echo "
 Usage: $0 <options>
   Optional options:
-     --clean                        clean and build ut
-     --run                          build and run ut
-     --gtest_filter                 specify test cases
+     --test  [TEST_NAME]            run specific test
+     --dry-run                      dry-run unit tests
+     --clean                        clean old unit tests before run
+     --with-gcov                    enable to build with gcov
      --with-aws                     enable to test aws
      --with-bench                   enable to build with benchmark
      --with-gcov                    enable to build with gcov
+     --module                       module to run uts
      --use-staros                   enable to build with staros
      -j                             build parallel
 
   Eg.
-    $0                              build ut
-    $0 --run                        build and run ut
-    $0 --run --gtest_filter scan*   build and run ut of specified cases
-    $0 --clean                      clean and build ut
-    $0 --clean --run                clean, build and run ut
-    $0 --clean --run --with-gcov    clean, build and run ut with gcov
+    $0                              run all unit tests
+    $0 --test CompactionUtilsTest   run compaction test
+    $0 --dry-run                    dry-run unit tests
+    $0 --clean                      clean old unit tests before run
     $0 --help                       display usage
   "
   exit 1
 }
 
+# -l run and -l gtest_filter only used for compatibility
 OPTS=$(getopt \
   -n $0 \
   -o '' \
-  -l 'run' \
+  -l 'test:' \
+  -l 'dry-run' \
   -l 'clean' \
-  -l "gtest_filter:" \
+  -l 'with-gcov' \
+  -l 'module:' \
   -l 'with-aws' \
   -l 'with-bench' \
   -l 'use-staros' \
-  -l 'with-gcov' \
   -o 'j:' \
   -l 'help' \
+  -l 'run' \
+  -l 'gtest_filter:' \
   -- "$@")
 
 if [ $? != 0 ] ; then
@@ -74,8 +78,9 @@ fi
 eval set -- "$OPTS"
 
 CLEAN=0
-RUN=0
-TEST_FILTER=*
+DRY_RUN=0
+TEST_NAME=*
+TEST_MODULE=".*"
 HELP=0
 WITH_AWS=OFF
 USE_STAROS=OFF
@@ -84,9 +89,12 @@ WITH_GCOV=OFF
 while true; do
     case "$1" in
         --clean) CLEAN=1 ; shift ;;
-        --run) RUN=1 ; shift ;;
-        --gtest_filter) TEST_FILTER=$2 ; shift 2;; 
-        --help) HELP=1 ; shift ;; 
+        --dry-run) DRY_RUN=1 ; shift ;;
+        --run) shift ;; # Option only for compatibility
+        --test) TEST_NAME=$2 ; shift 2;;
+        --gtest_filter) TEST_NAME=$2 ; shift 2;; # Option only for compatibility
+        --module) TEST_MODULE=$2; shift 2;;
+        --help) HELP=1 ; shift ;;
         --with-aws) WITH_AWS=ON; shift ;;
         --with-gcov) WITH_GCOV=ON; shift ;;
         --use-staros) USE_STAROS=ON; shift ;;
@@ -153,12 +161,11 @@ else
               -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
 fi
-time ${BUILD_SYSTEM} -j${PARALLEL}
+${BUILD_SYSTEM} -j${PARALLEL}
 
-if [ ${RUN} -ne 1 ]; then
-    echo "Finished"
-    exit 0
-fi
+echo "*********************************"
+echo "  Starting to Run BE Unit Tests  "
+echo "*********************************"
 
 echo "******************************"
 echo "    Running StarRocks BE Unittest    "
@@ -176,15 +183,6 @@ done
 mkdir -p $LOG_DIR
 mkdir -p ${UDF_RUNTIME_DIR}
 rm -f ${UDF_RUNTIME_DIR}/*
-
-if [ ${RUN} -ne 1 ]; then
-    echo "Finished"
-    exit 0
-fi
-
-echo "******************************"
-echo "    Running StarRocks BE Unittest    "
-echo "******************************"
 
 . ${STARROCKS_HOME}/bin/common.sh
 
@@ -223,10 +221,10 @@ export CLASSPATH=$STARROCKS_HOME/conf:$HADOOP_CLASSPATH:$CLASSPATH
 
 # ===========================================================
 
-export STARROCKS_TEST_BINARY_DIR=${STARROCKS_TEST_BINARY_DIR}/test/
+export STARROCKS_TEST_BINARY_DIR=${STARROCKS_TEST_BINARY_DIR}/test
 
 if [ $WITH_AWS = "OFF" ]; then
-    TEST_FILTER="$TEST_FILTER:-*S3*"
+    TEST_NAME="$TEST_NAME*:-*S3*"
 fi
 
 # prepare util test_data
@@ -239,17 +237,26 @@ test_files=`find ${STARROCKS_TEST_BINARY_DIR} -type f -perm -111 -name "*test" |
 
 # run cases in starrocks_test in parallel if has gtest-parallel script.
 # reference: https://github.com/google/gtest-parallel
-if [ -x ${GTEST_PARALLEL} ]; then
-    ${GTEST_PARALLEL} ${STARROCKS_TEST_BINARY_DIR}/starrocks_test --gtest_filter=${TEST_FILTER} --serialize_test_cases ${GTEST_PARALLEL_OPTIONS}
-else
-    ${STARROCKS_TEST_BINARY_DIR}/starrocks_test --gtest_filter=${TEST_FILTER}
+if [[ $TEST_MODULE == '.*'  || $TEST_MODULE == 'starrocks_test' ]]; then
+  echo "Run test: ${STARROCKS_TEST_BINARY_DIR}/starrocks_test"
+  if [ ${DRY_RUN} -eq 0 ]; then
+    if [ -x ${GTEST_PARALLEL} ]; then
+        ${GTEST_PARALLEL} ${STARROCKS_TEST_BINARY_DIR}/starrocks_test \
+            --gtest_catch_exceptions=0 --gtest_filter=${TEST_NAME} \
+            --serialize_test_cases ${GTEST_PARALLEL_OPTIONS}
+    else
+        ${STARROCKS_TEST_BINARY_DIR}/starrocks_test $GTEST_OPTIONS --gtest_filter=${TEST_NAME}
+    fi
+  fi
 fi
 
 for test in ${test_files[@]}
 do
-    file_name=${test##*/}
-    if [ -z $RUN_FILE ] || [ $file_name == $RUN_FILE ]; then
-        echo "=== Run $file_name ==="
-        $test --gtest_filter=${TEST_FILTER}
+    echo "Run test: $test"
+    if [ ${DRY_RUN} -eq 0 ]; then
+        file_name=${test##*/}
+        if [ -z $RUN_FILE ] || [ $file_name == $RUN_FILE ]; then
+            $test $GTEST_OPTIONS --gtest_filter=${TEST_NAME}
+        fi
     fi
 done

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -30,23 +30,31 @@ usage() {
   echo "
 Usage: $0 <options>
   Optional options:
-     --clean    clean and build ut
-     --run    build and run ut
+     --test [TEST_NAME]         run specific test
+     --dry-run                  dry-run unit tests
+     --coverage                 run coverage statistic tasks
+     --dumpcase [PATH]          run dump case and save to path
 
   Eg.
-    $0                      build and run ut
-    $0 --coverage           build and run coverage statistic
-    $0 --run xxx            build and run the specified class
+    $0                                          run all unit tests
+    $0 --test com.starrocks.utframe.Demo        run demo test
+    $0 --dry-run                                dry-run unit tests
+    $0 --coverage                               run coverage statistic tasks
+    $0 --dumpcase /home/disk1/                  run dump case and save to path
   "
   exit 1
 }
 
+# -l run only used for compatibility
 OPTS=$(getopt \
   -n $0 \
   -o '' \
+  -l 'test:' \
+  -l 'dry-run' \
   -l 'coverage' \
-  -l 'run' \
+  -l 'dumpcase' \
   -l 'help' \
+  -l 'run' \
   -- "$@")
 
 if [ $? != 0 ] ; then
@@ -56,15 +64,20 @@ fi
 eval set -- "$OPTS"
 
 HELP=0
-RUN=0
+DRY_RUN=0
+RUN_SPECIFIED_TEST=0
+TEST_NAME=*
 COVERAGE=0
 while true; do 
     case "$1" in
         --coverage) COVERAGE=1 ; shift ;;
-        --run) RUN=1 ; shift ;;
+        --test) RUN_SPECIFIED_TEST=1; TEST_NAME=$2; shift 2;;
+        --run) shift ;; # only used for compatibility
+        --dumpcase) DUMPCASE=1; shift ;;
+        --dry-run) DRY_RUN=1 ; shift ;;
         --help) HELP=1 ; shift ;; 
         --) shift ;  break ;;
-        *) ehco "Internal error" ; exit 1 ;;
+        *) echo "Internal error" ; exit 1 ;;
     esac
 done
 
@@ -73,11 +86,9 @@ if [ ${HELP} -eq 1 ]; then
     exit 0
 fi
 
-echo "Build Frontend UT"
-
-echo "******************************"
-echo "    Runing StarRocksFE Unittest    "
-echo "******************************"
+echo "*********************************"
+echo "  Starting to Run FE Unit Tests  "
+echo "*********************************"
 
 cd ${STARROCKS_HOME}/fe/
 mkdir -p build/compile
@@ -99,18 +110,21 @@ fi
 mkdir ut_ports
 
 if [ ${COVERAGE} -eq 1 ]; then
-    echo "Run coverage statistic"
+    echo "Run coverage statistic tasks"
     ant cover-test
 else
-    if [ ${RUN} -eq 1 ]; then
-        echo "Run the specified class: $1"
-        # eg:
-        # sh run-fe-ut.sh --run com.starrocks.utframe.Demo
-        # sh run-fe-ut.sh --run com.starrocks.utframe.Demo#testCreateDbAndTable+test2
-        # set trimStackTrace to false to show full stack when debugging specified class or case
-        ${MVN_CMD} test -DfailIfNoTests=false -DtrimStackTrace=false -D test=$1
+    if [ ${RUN_SPECIFIED_TEST} -eq 1 ]; then
+        echo "Run test: $TEST_NAME"
+        if [ $DRY_RUN -eq 0 ]; then
+            # ./run-fe-ut.sh --test com.starrocks.utframe.Demo
+            # ./run-fe-ut.sh --test com.starrocks.utframe.Demo#testCreateDbAndTable+test2
+            # set trimStackTrace to false to show full stack when debugging specified class or case
+            ${MVN_CMD} test -DfailIfNoTests=false -DtrimStackTrace=false -D test=$TEST_NAME
+        fi
     else    
-        echo "Run Frontend UT"
-        ${MVN_CMD} test -DfailIfNoTests=false -DtrimStackTrace=false
+        echo "Run All Frontend Unittests"
+        if [ $DRY_RUN -eq 0 ]; then
+            ${MVN_CMD} test -DfailIfNoTests=false -DtrimStackTrace=false
+        fi
     fi 
 fi


### PR DESCRIPTION
There are some inconsistencies between the unit tests of BE and FE This pull request unify the two scripts.
1. rename run-ut.sh to run-be-ut.sh
2. use parameter --test to run specified test `./run-fe-ut.sh --run [TEST_NAME]` `./run-fe-ut.sh --gtest_filter [TEST_NAME_WILDCARD]`
3. Add a new paramter --dry-run to only compile and build the unit tests `./run-fe-ut.sh --dry-run` `./run-be-ut.sh --dry-run`

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
