### PR TITLE
[BugFix] Account finalization cost to scheduler

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -33,6 +33,7 @@
 #include "util/phmap/phmap.h"
 
 namespace starrocks {
+
 namespace query_cache {
 class MultilaneOperator;
 using MultilaneOperatorRawPtr = MultilaneOperator*;
@@ -46,6 +47,7 @@ using DriverPtr = std::shared_ptr<PipelineDriver>;
 using Drivers = std::vector<DriverPtr>;
 using IterateImmutableDriverFunc = std::function<void(DriverConstRawPtr)>;
 using ImmutableDriverPredicateFunc = std::function<bool(DriverConstRawPtr)>;
+class DriverQueue;
 
 enum DriverState : uint32_t {
     NOT_READY = 0,
@@ -202,6 +204,8 @@ public:
     void finalize(RuntimeState* runtime_state, DriverState state);
     DriverAcct& driver_acct() { return _driver_acct; }
     DriverState driver_state() const { return _state; }
+
+    void increment_schedule_times();
 
     void set_driver_state(DriverState state) {
         if (state == _state) {
@@ -381,6 +385,7 @@ public:
     const workgroup::WorkGroup* workgroup() const;
     void set_workgroup(workgroup::WorkGroupPtr wg);
 
+    void set_in_queue(DriverQueue* in_queue) { _in_queue = in_queue; }
     size_t get_driver_queue_level() const { return _driver_queue_level; }
     void set_driver_queue_level(size_t driver_queue_level) { _driver_queue_level = driver_queue_level; }
 
@@ -394,6 +399,14 @@ public:
     bool is_epoch_finished() { return _state == DriverState::EPOCH_FINISH; }
 
 protected:
+    PipelineDriver()
+            : _operators(),
+              _query_ctx(nullptr),
+              _fragment_ctx(nullptr),
+              _pipeline(nullptr),
+              _source_node_id(0),
+              _driver_id(0) {}
+
     // Yield PipelineDriver when maximum time in nano-seconds has spent in current execution round.
     static constexpr int64_t YIELD_MAX_TIME_SPENT = 100'000'000L;
     // Yield PipelineDriver when maximum time in nano-seconds has spent in current execution round,
@@ -409,6 +422,7 @@ protected:
     void _close_operators(RuntimeState* runtime_state);
 
     // Update metrics when the driver yields.
+    void _update_driver_acct(size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent);
     void _update_statistics(size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent);
     void _update_overhead_timer();
 
@@ -443,6 +457,7 @@ protected:
     phmap::flat_hash_map<int32_t, OperatorStage> _operator_stages;
 
     workgroup::WorkGroupPtr _workgroup = nullptr;
+    DriverQueue* _in_queue = nullptr;
     // The index of QuerySharedDriverQueue._queues which this driver belongs to.
     size_t _driver_queue_level = 0;
     std::atomic<bool> _in_ready_queue{false};

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -106,6 +106,8 @@ void GlobalDriverExecutor::_worker_thread() {
         auto* query_ctx = driver->query_ctx();
         auto* fragment_ctx = driver->fragment_ctx();
 
+        driver->increment_schedule_times();
+
         SCOPED_SET_TRACE_INFO(driver->driver_id(), query_ctx->query_id(), fragment_ctx->fragment_instance_id());
 
         SET_THREAD_LOCAL_QUERY_TRACE_CONTEXT(query_ctx->query_trace(), fragment_ctx->fragment_instance_id(), driver);

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -51,6 +51,7 @@ void QuerySharedDriverQueue::put_back(const DriverRawPtr driver) {
         std::lock_guard<std::mutex> lock(_global_mutex);
         _queues[level].put(driver);
         driver->set_in_ready_queue(true);
+        driver->set_in_queue(this);
         _cv.notify_one();
         ++_num_drivers;
     }
@@ -66,6 +67,7 @@ void QuerySharedDriverQueue::put_back(const std::vector<DriverRawPtr>& drivers) 
     for (int i = 0; i < drivers.size(); i++) {
         _queues[levels[i]].put(drivers[i]);
         drivers[i]->set_in_ready_queue(true);
+        drivers[i]->set_in_queue(this);
         _cv.notify_one();
     }
     _num_drivers += drivers.size();
@@ -343,6 +345,7 @@ void WorkGroupDriverQueue::_put_back(const DriverRawPtr driver) {
     auto* wg_entity = driver->workgroup()->driver_sched_entity();
     wg_entity->set_in_queue(this);
     wg_entity->queue()->put_back(driver);
+    driver->set_in_queue(this);
 
     if (_wg_entities.find(wg_entity) == _wg_entities.end()) {
         _enqueue_workgroup<from_executor>(wg_entity);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16432

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When a large query is finalized, especially when it is cancelled and resource group is enabled, the other small query will wait a long time.

The reason is that, finalization cost of driver isn't accounted in `driver_queue`. For exmaple, there is a group `rg1` executing a large query and finalizing and a group `rg2` executing a small query like `select 1`. If `rg1.vruntime` < `rg2.vruntime`, then all the drivers of this large query will be finalized before executing `select 1` in `rg2.

Therefore, account the finalization cost time to `driver_queue`.

## Test case
rg1 executes large queries and rg2 executes select 1.
```
# would fail by OOM
mysqlslap --concurrency=8  \
           --iterations=1  \
           --number-of-queries="100000"      \
           --query="tpcds/query04.sql"   \
           --delimiter=";" -h <host>  -P <port> -u rg1 -p123456  --create-schema=tpcds_100g

mysqlslap --concurrency=1  \
           --iterations=100  \
           --number-of-queries="1"      \
           --query="select 1 from dual"   \
           --delimiter=";" -h <host>  -P <port> -u rg2 -p123456  --create-schema=tpcds_100g
```

Before this PR, enabling resource group costs 20s and disabling resource group costs 4s.
After this PR, enabling and disabling costs 0.3s.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
