### PR TITLE
[Enhancement] Optimize ExportExportingSubTask Retry Strategy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -335,6 +335,87 @@ public class OlapScanNode extends ScanNode {
         }
     }
 
+    // update TScanRangeLocations based on the latest olapTable tablet distributions, 
+    // this function will make sure the version of each TScanRangeLocations doesn't change.
+    public List<TScanRangeLocations> updateScanRangeLocations(List<TScanRangeLocations> locations) throws UserException {
+        if (selectedPartitionIds.size() == 0) {
+            throw new UserException("Scan node's partition is empty");
+        }
+        List<TScanRangeLocations> newLocations = Lists.newArrayList();
+        for (TScanRangeLocations location: locations) {
+            TInternalScanRange internalScanRange = location.scan_range.internal_scan_range;
+            String expectedSchemaHashStr = internalScanRange.getSchema_hash();
+            String expectedVersionStr = internalScanRange.getVersion();
+            long tabletId = internalScanRange.getTablet_id();
+            int expectedSchemaHash = Integer.parseInt(expectedSchemaHashStr);
+            long expectedVersion = Long.parseLong(expectedVersionStr);
+            Long partitionId = internalScanRange.partition_id;
+            
+            final Partition partition = olapTable.getPartition(partitionId);
+            final MaterializedIndex selectedTable = partition.getIndex(selectedIndexId);
+            final Tablet selectedTablet = selectedTable.getTablet(tabletId);
+            if (selectedTablet == null) {
+                throw new UserException("Tablet " +  tabletId + " doesn't exist in partition " + partitionId);
+            }
+
+            int schemaHash = olapTable.getSchemaHashByIndexId(selectedTable.getId());
+            if (schemaHash != expectedSchemaHash) {
+                throw new UserException("Tablet " +  tabletId + " schema hash " + schemaHash + " has changed, doesn't equal to expected schema hash " + expectedSchemaHash);
+            }
+
+            // random shuffle List && only collect one copy
+            List<Replica> allQueryableReplicas = Lists.newArrayList();
+            List<Replica> localReplicas = Lists.newArrayList();
+            selectedTablet.getQueryableReplicas(allQueryableReplicas, localReplicas,
+                expectedVersion, -1, schemaHash);
+            if (allQueryableReplicas.isEmpty()) {
+                String replicaInfos = ((LocalTablet) selectedTablet).getReplicaInfos();
+                LOG.error("no queryable replica found in tablet {}. visible version {} replicas:{}",
+                        tabletId, expectedVersion, replicaInfos);
+                throw new UserException(
+                        "Failed to get scan range, no queryable replica found in tablet: " + tabletId + " " +
+                                replicaInfos);
+            }
+
+            TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
+            TInternalScanRange internalRange = new TInternalScanRange();
+            internalRange.setDb_name("");
+            internalRange.setSchema_hash(expectedSchemaHashStr);
+            internalRange.setVersion(expectedVersionStr);
+            internalRange.setVersion_hash("0");
+            internalRange.setTablet_id(tabletId);
+            internalRange.setPartition_id(partition.getId());
+
+            List<Replica> replicas = allQueryableReplicas;
+
+            Collections.shuffle(replicas);
+            boolean tabletIsNull = true;
+            for (Replica replica : replicas) {
+                Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(replica.getBackendId());
+                if (backend == null) {
+                    LOG.debug("replica {} not exists", replica.getBackendId());
+                    continue;
+                }
+                String ip = backend.getHost();
+                int port = backend.getBePort();
+                TScanRangeLocation scanRangeLocation = new TScanRangeLocation(new TNetworkAddress(ip, port));
+                scanRangeLocation.setBackend_id(replica.getBackendId());
+                scanRangeLocations.addToLocations(scanRangeLocation);
+                internalRange.addToHosts(new TNetworkAddress(ip, port));
+                tabletIsNull = false;
+            }
+            if (tabletIsNull) {
+                throw new UserException(tabletId + "have no alive replicas");
+            }
+            TScanRange scanRange = new TScanRange();
+            scanRange.setInternal_scan_range(internalRange);
+            scanRangeLocations.setScan_range(scanRange);
+
+            newLocations.add(scanRangeLocations);
+        }        
+        return newLocations;
+    }
+
     public void addScanRangeLocations(Partition partition,
                                       MaterializedIndex index,
                                       List<Tablet> tablets,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -344,6 +344,10 @@ public class Coordinator {
         return trackingUrl;
     }
 
+    public long getStartTime() {
+        return this.queryGlobals.getTimestamp_ms();
+    }
+
     public void setExecMemoryLimit(long execMemoryLimit) {
         this.queryOptions.setMem_limit(execMemoryLimit);
     }


### PR DESCRIPTION

Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16455

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For olap table, it may have multiple replica for each tablet.
Current ExportExportingSubTask retry will run the same coord(plan fragment) again, however, if the tablet we want has already been reblanced, or if the tablet version we want has been compacted, retry will definitely fail because we will still try to load the same tablet.
To increase the probability of success of retry, we need reset the coord, generate a new plan fragment, and select a new replica for each tablet based on the latest distribution.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
- [x] 2.5
- [ ] 2.4
- [ ] 2.3
- [ ] 2.2
