### PR TITLE
[BugFix] Use short key not full key when checking split lower and upper

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -448,17 +448,25 @@ bool LogicalSplitMorselQueue::_valid_range(const ShortKeyOptionPtr& lower, const
         return true;
     }
 
-    Slice lower_key = lower->short_key;
+    Slice lower_key;
     // Empty short key of start ShortKeyOption means it is the first splitted key range,
     // so use start original short key to compare.
-    if (lower_key.empty()) {
+    if (lower->tuple_key != nullptr) {
+        lower_key = lower->tuple_key->short_key_encode(_short_key_schema->num_fields(), KEY_MINIMAL_MARKER);
+    } else if (!lower->short_key.empty()) {
+        lower_key = lower->short_key;
+    } else {
         lower_key = *_block_ranges_per_seek_range[_range_idx].first;
     }
 
-    Slice upper_key = upper->short_key;
+    Slice upper_key;
     // Empty short key of end ShortKeyOption means it is the last splitted key range,
     // so use end original short key to compare.
-    if (upper_key.empty()) {
+    if (upper->tuple_key != nullptr) {
+        upper_key = upper->tuple_key->short_key_encode(_short_key_schema->num_fields(), KEY_MINIMAL_MARKER);
+    } else if (!upper->short_key.empty()) {
+        upper_key = upper->short_key;
+    } else {
         auto end_iter = _block_ranges_per_seek_range[_range_idx].second;
         --end_iter;
         upper_key = *end_iter;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16468

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Split tablet into multiple morsels logically
- For the unique and aggregate table.
- Split  each key range `[start, end]` to multiple sub **short** key ranges `[start, sub_short_key1)`, `[sub_short_key1, sub_short_key2)`, `[sub_short_key1, end]`, where `sub_short_key1` and `sub_short_key2` are the short key.

Constraint
1. All the `sub_short_key`s derived from a key range `[start, end]` are different from each other
2. All the `sub_short_key`s derived from a key range `[start, end]` are different from **the short key of** `start` and `end`.

With these two constraints, we could guarantee that all the sub short key ranges are different.
- If there is only one key range, then it is obviously true.
- If there is multiple key ranges, then each key range is a point + a range, such as the predicates `k1 in ('abc', 'abd') and k2 between '123' and '124'` is parsed to the key ranges `['abc123', 'abc124']` and `['abd123', 'abd124']`. There are two scenarios:
    - All the short key ranges are point and the same, such as `[ab, ab]` and `[ab, ab]`.
    - All the short key ranges are different, such as `[abc, abc]` and `[abd, abd]`, or `['abc123', 'abc124']` and `['abd123', 'abd124']`.

---

However, we only guarantee that `sub_short_key` is different from `start` and `end`, not the **short key** of `start` and `end`.
This will be wrong when there are multiple key ranges.
For example, as for `select count(1) from k1 in ('abca', 'abcb')`, assume that `VARCHAR` type use the top 3 bytes as short key. 
- Before this PR, we generate 4 sub short key range: `[abca, (abc)]`, `[(abc), abca]`, `[abcb, (abc)]`, `[(abc), abcb]`, where `[(abc), abca]` and `[(abc), abcb]` are overlapped.
- After this PR, we generate only 2 key range: `[abca, abca]` and `[abcb, abcb]`, because the short key of `abca` and `(abc)` are the same.
```
data:                    abb, abca, abcb            abcb,abcb,abcb
                             page1                     page2
short key:               abb                        abc
```


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
