### PR TITLE
[Enhancement] Replace BitSet with RoaringBitMap to lower memory usage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/IMTCreator.java
@@ -86,7 +86,7 @@ class IMTCreator {
         // Duplicate/Primary Key
         Map<Integer, String> columnNames = plan.getOutputColumns().stream().collect(
                 Collectors.toMap(ColumnRefOperator::getId, ColumnRefOperator::getName));
-        Set<String> keyColumns = key.columns.getStream().mapToObj(columnNames::get).collect(Collectors.toSet());
+        Set<String> keyColumns = key.columns.getStream().map(columnNames::get).collect(Collectors.toSet());
         for (Column col : columns) {
             col.setIsKey(keyColumns.contains(col.getName()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefSet.java
@@ -12,54 +12,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.base;
 
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import org.roaringbitmap.RoaringBitmap;
 
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 // BitSet used to accelerate column processing
 public class ColumnRefSet implements Cloneable {
-    public BitSet bitSet;
+    public RoaringBitmap bitSet;
 
     public ColumnRefSet() {
-        bitSet = new BitSet();
+        bitSet = new RoaringBitmap();
     }
 
     public ColumnRefSet(int id) {
-        bitSet = new BitSet();
-        bitSet.set(id);
+        bitSet = new RoaringBitmap();
+        bitSet.add(id);
     }
 
     public ColumnRefSet(Collection<ColumnRefOperator> refs) {
-        bitSet = new BitSet();
+        bitSet = new RoaringBitmap();
         for (ColumnRefOperator ref : refs) {
-            bitSet.set(ref.getId());
+            bitSet.add(ref.getId());
         }
     }
 
     public int[] getColumnIds() {
-        return bitSet.stream().toArray();
+        return bitSet.toArray();
     }
 
-    public IntStream getStream() {
-        return bitSet.stream();
+    public Stream<Integer> getStream() {
+        Spliterator<Integer> spliterator = Spliterators.spliteratorUnknownSize(bitSet.iterator(), Spliterator.ORDERED);
+        return StreamSupport.stream(spliterator, false);
     }
 
     public int getFirstId() {
-        return bitSet.stream().findFirst().getAsInt();
+        return bitSet.first();
     }
 
     @Override
     public ColumnRefSet clone() {
         try {
             ColumnRefSet result = (ColumnRefSet) super.clone();
-            result.bitSet = (BitSet) bitSet.clone();
+            result.bitSet = bitSet.clone();
             return result;
         } catch (CloneNotSupportedException e) {
             throw new InternalError(e);
@@ -81,16 +84,16 @@ public class ColumnRefSet implements Cloneable {
     }
 
     public int size() {
-        return bitSet.cardinality();
+        return bitSet.getCardinality();
     }
 
     // The meaning is same with SQL Union Operation
     public void union(int id) {
-        bitSet.set(id);
+        bitSet.add(id);
     }
 
     public void union(ColumnRefOperator ref) {
-        bitSet.set(ref.getId());
+        bitSet.add(ref.getId());
     }
 
     public void union(Collection<ColumnRefOperator> refs) {
@@ -128,11 +131,16 @@ public class ColumnRefSet implements Cloneable {
     }
 
     public boolean isIntersect(ColumnRefSet other) {
-        return bitSet.intersects(other.bitSet);
+        for (int id : other.bitSet) {
+            if (this.bitSet.contains(id)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public int cardinality() {
-        return bitSet.cardinality();
+        return bitSet.getCardinality();
     }
 
     public boolean isEmpty() {
@@ -155,27 +163,27 @@ public class ColumnRefSet implements Cloneable {
     }
 
     public boolean contains(ColumnRefOperator ref) {
-        return bitSet.get(ref.getId());
+        return bitSet.contains(ref.getId());
     }
 
     public boolean contains(int id) {
-        return bitSet.get(id);
+        return bitSet.contains(id);
     }
 
     public boolean containsAll(ColumnRefSet rhs) {
-        return rhs.bitSet.stream().allMatch(bit -> bitSet.get(bit));
+        return this.bitSet.contains(rhs.bitSet);
     }
 
     public boolean containsAny(ColumnRefSet rhs) {
-        return rhs.bitSet.stream().anyMatch(bit -> bitSet.get(bit));
+        return isIntersect(rhs);
     }
 
     public boolean containsAll(List<Integer> rhs) {
-        return rhs.stream().allMatch(bit -> bitSet.get(bit));
+        return rhs.stream().allMatch(id -> bitSet.contains(id));
     }
 
     public List<ColumnRefOperator> getColumnRefOperators(ColumnRefFactory columnRefFactory) {
-        return getStream().mapToObj(columnRefFactory::getColumnRef).collect(Collectors.toList());
+        return getStream().map(columnRefFactory::getColumnRef).collect(Collectors.toList());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
@@ -164,7 +164,7 @@ public class LogicalJoinOperator extends LogicalOperator {
             candidate.intersect(required);
         }
         return Utils.findSmallestColumnRef(
-                candidate.getStream().mapToObj(columnRefFactory::getColumnRef).collect(Collectors.toList()));
+                candidate.getStream().map(columnRefFactory::getColumnRef).collect(Collectors.toList()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOperator.java
@@ -54,7 +54,7 @@ public abstract class LogicalOperator extends Operator {
             outputCandidates.intersect(requiredCandidates);
         }
         return Utils.findSmallestColumnRef(outputCandidates.getStream().
-                mapToObj(columnRefFactory::getColumnRef).collect(Collectors.toList()));
+                map(columnRefFactory::getColumnRef).collect(Collectors.toList()));
     }
 
     // lineage means the merge of operator's column ref map, which is used to track

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -364,7 +364,7 @@ public abstract class JoinOrder {
         if (exprInfo.expr.getOp().getProjection() != null) {
             projection.putAll(exprInfo.expr.getOp().getProjection().getColumnRefMap());
         } else {
-            exprInfo.expr.getOutputColumns().getStream().mapToObj(context.getColumnRefFactory()::getColumnRef)
+            exprInfo.expr.getOutputColumns().getStream().map(context.getColumnRefFactory()::getColumnRef)
                     .forEach(c -> projection.put(c, c));
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -109,7 +109,7 @@ public class ReorderJoinRule extends Rule {
                 innerJoinRoot.getInputs().forEach(opt -> outputColumns.union(opt.getOutputColumns()));
 
                 projectMap.putAll(outputColumns.getStream()
-                        .mapToObj(context.getColumnRefFactory()::getColumnRef)
+                        .map(context.getColumnRefFactory()::getColumnRef)
                         .collect(Collectors.toMap(Function.identity(), Function.identity())));
             } else {
                 outputColumns.union(oldRoot.getProjection().getOutputColumns());
@@ -253,7 +253,7 @@ public class ReorderJoinRule extends Rule {
                 joinOperator = new LogicalJoinOperator.Builder()
                         .withOperator((LogicalJoinOperator) optExpression.getOp())
                         .setProjection(new Projection(newOutputColumns.getStream()
-                                .mapToObj(optimizerContext.getColumnRefFactory()::getColumnRef)
+                                .map(optimizerContext.getColumnRefFactory()::getColumnRef)
                                 .collect(Collectors.toMap(Function.identity(), Function.identity())),
                                 new HashMap<>()))
                         .build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/KeyInference.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/KeyInference.java
@@ -240,7 +240,7 @@ public class KeyInference extends OptExpressionVisitor<KeyInference.KeyPropertyS
         }
 
         public String format(Map<Integer, String> colMap) {
-            String colNames = columns.getStream().mapToObj(colMap::get).collect(Collectors.joining(","));
+            String colNames = columns.getStream().map(colMap::get).collect(Collectors.joining(","));
             return "Key{" +
                     "unique=" + unique +
                     ", columns=" + colNames +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateLimitZeroRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateLimitZeroRule.java
@@ -48,7 +48,7 @@ public class EliminateLimitZeroRule extends TransformationRule {
         ColumnRefSet outputColumnIds =
                 ((LogicalLimitOperator) input.getOp()).getOutputColumns(new ExpressionContext(input));
 
-        List<ColumnRefOperator> outputColumns = outputColumnIds.getStream().mapToObj(
+        List<ColumnRefOperator> outputColumns = outputColumnIds.getStream().map(
                 id -> context.getColumnRefFactory().getColumnRef(id)).collect(Collectors.toList());
         LogicalValuesOperator emptyOperator = new LogicalValuesOperator(
                 outputColumns,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinAggRule.java
@@ -179,7 +179,7 @@ public class PushDownJoinAggRule extends TransformationRule {
             newJoinBuilder.setProjection(null);
         } else {
             newJoinBuilder.setProjection(
-                    new Projection(newJoinPruneOutPutColumns.getStream().mapToObj(factory::getColumnRef)
+                    new Projection(newJoinPruneOutPutColumns.getStream().map(factory::getColumnRef)
                             .collect(Collectors.toMap(Function.identity(), Function.identity())), new HashMap<>()));
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnExpressionToChildProject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnExpressionToChildProject.java
@@ -105,7 +105,7 @@ public class PushDownJoinOnExpressionToChildProject extends TransformationRule {
                 .build(), input.getInputs());
 
         if (!leftProjectMaps.isEmpty()) {
-            leftProjectMaps.putAll(leftOutputColumns.getStream().boxed()
+            leftProjectMaps.putAll(leftOutputColumns.getStream()
                     .map(columnRefId -> context.getColumnRefFactory().getColumnRef(columnRefId))
                     .collect(Collectors.toMap(Function.identity(), Function.identity())));
 
@@ -115,7 +115,7 @@ public class PushDownJoinOnExpressionToChildProject extends TransformationRule {
         }
 
         if (!rightProjectMaps.isEmpty()) {
-            rightProjectMaps.putAll(rightOutputColumns.getStream().boxed()
+            rightProjectMaps.putAll(rightOutputColumns.getStream()
                     .map(columnRefId -> context.getColumnRefFactory().getColumnRef(columnRefId))
                     .collect(Collectors.toMap(Function.identity(), Function.identity())));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2JoinRule.java
@@ -100,7 +100,7 @@ public class QuantifiedApply2JoinRule extends TransformationRule {
 
         joinExpression.getInputs().addAll(input.getInputs());
 
-        Map<ColumnRefOperator, ScalarOperator> outputColumns = input.getOutputColumns().getStream().mapToObj(
+        Map<ColumnRefOperator, ScalarOperator> outputColumns = input.getOutputColumns().getStream().map(
                 id -> context.getColumnRefFactory().getColumnRef(id)
         ).collect(Collectors.toMap(Function.identity(), Function.identity()));
         return Lists.newArrayList(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
@@ -180,7 +180,7 @@ public class RewriteGroupingSetsByCTERule extends TransformationRule {
         if (consumeOutputMap.isEmpty()) {
             List<ColumnRefOperator> outputColumns =
                     produceOperator.getOutputColumns(new ExpressionContext(cteProduce)).getStream().
-                            mapToObj(factory::getColumnRef).collect(Collectors.toList());
+                            map(factory::getColumnRef).collect(Collectors.toList());
             ColumnRefOperator smallestColumn = Utils.findSmallestColumnRef(outputColumns);
             ColumnRefOperator consumeOutput =
                     factory.create(smallestColumn, smallestColumn.getType(), smallestColumn.isNullable());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -420,7 +420,7 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
         if (consumeOutputMap.isEmpty()) {
             List<ColumnRefOperator> outputColumns =
                     produceOperator.getOutputColumns(new ExpressionContext(cteProduce)).getStream().
-                            mapToObj(factory::getColumnRef).collect(Collectors.toList());
+                            map(factory::getColumnRef).collect(Collectors.toList());
             ColumnRefOperator smallestColumn = Utils.findSmallestColumnRef(outputColumns);
             ColumnRefOperator consumeOutput =
                     factory.create(smallestColumn, smallestColumn.getType(), smallestColumn.isNullable());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
@@ -142,14 +142,14 @@ public class SemiReorderRule extends TransformationRule {
         Map<ColumnRefOperator, ScalarOperator> projectMap = new HashMap<>();
         if (newSemiOutputColumns.isEmpty()) {
             ColumnRefOperator smallestColumnRef = Utils.findSmallestColumnRef(
-                    leftChildInputColumns.getStream().mapToObj(context.getColumnRefFactory()::getColumnRef)
+                    leftChildInputColumns.getStream().map(context.getColumnRefFactory()::getColumnRef)
                             .collect(Collectors.toList())
             );
             projectMap.put(smallestColumnRef, smallestColumnRef);
         } else {
             projectMap = newSemiOutputColumns.getStream()
                     .filter(c -> newTopJoin.getRequiredChildInputColumns().contains(c))
-                    .mapToObj(context.getColumnRefFactory()::getColumnRef)
+                    .map(context.getColumnRefFactory()::getColumnRef)
                     .collect(Collectors.toMap(Function.identity(), Function.identity()));
         }
 
@@ -172,7 +172,7 @@ public class SemiReorderRule extends TransformationRule {
             Map<ColumnRefOperator, ScalarOperator> expressionProject;
             if (leftChildJoinRightChild.getOp().getProjection() == null) {
                 expressionProject = leftChildJoinRightChild.getOutputColumns().getStream()
-                        .mapToObj(id -> context.getColumnRefFactory().getColumnRef(id))
+                        .map(id -> context.getColumnRefFactory().getColumnRef(id))
                         .collect(Collectors.toMap(Function.identity(), Function.identity()));
             } else {
                 expressionProject = Maps.newHashMap(leftChildJoinRightChild.getOp().getProjection().getColumnRefMap());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -210,7 +210,7 @@ public class SplitAggregateRule extends TransformationRule {
                 singleDistinctFunctionPos++;
                 if (kv.getValue().isDistinct()) {
                     distinctColumns = kv.getValue().getUsedColumns().getStream().
-                            mapToObj(id -> context.getColumnRefFactory().getColumnRef(id)).collect(Collectors.toList());
+                            map(id -> context.getColumnRefFactory().getColumnRef(id)).collect(Collectors.toList());
                     break;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
@@ -132,7 +132,7 @@ class PushDownAggregateCollector extends OptExpressionVisitor<Void, AggregatePus
 
         // add filter columns in groupBys
         LogicalFilterOperator filter = (LogicalFilterOperator) optExpression.getOp();
-        filter.getRequiredChildInputColumns().getStream().mapToObj(factory::getColumnRef)
+        filter.getRequiredChildInputColumns().getStream().map(factory::getColumnRef)
                 .forEach(v -> context.groupBys.put(v, v));
         return processChild(optExpression, context);
     }
@@ -173,7 +173,7 @@ class PushDownAggregateCollector extends OptExpressionVisitor<Void, AggregatePus
             if (aggInput instanceof CaseWhenOperator) {
                 CaseWhenOperator caseWhen = (CaseWhenOperator) aggInput;
                 for (ScalarOperator condition : caseWhen.getAllConditionClause()) {
-                    condition.getUsedColumns().getStream().mapToObj(factory::getColumnRef)
+                    condition.getUsedColumns().getStream().map(factory::getColumnRef)
                             .forEach(v -> context.groupBys.put(v, v));
                 }
 
@@ -200,7 +200,7 @@ class PushDownAggregateCollector extends OptExpressionVisitor<Void, AggregatePus
                     return visit(optExpression, context);
                 }
 
-                aggInput.getChild(0).getUsedColumns().getStream().mapToObj(factory::getColumnRef)
+                aggInput.getChild(0).getUsedColumns().getStream().map(factory::getColumnRef)
                         .forEach(v -> context.groupBys.put(v, v));
                 aggInput.setChild(0, ConstantOperator.createBoolean(false));
             }
@@ -300,7 +300,7 @@ class PushDownAggregateCollector extends OptExpressionVisitor<Void, AggregatePus
             } else if (childOutput.isIntersect(groupByUseColumns)) {
                 // e.g. group by abs(a + b), we can derive group by a
                 Map<ColumnRefOperator, ScalarOperator> rewriteMap = groupByUseColumns.getStream()
-                        .filter(c -> !childOutput.contains(c)).mapToObj(factory::getColumnRef)
+                        .filter(c -> !childOutput.contains(c)).map(factory::getColumnRef)
                         .collect(Collectors.toMap(k -> k, k -> ConstantOperator.createNull(k.getType())));
                 ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(rewriteMap);
                 childContext.groupBys.put(entry.getKey(), rewriter.rewrite(entry.getValue()));
@@ -308,13 +308,13 @@ class PushDownAggregateCollector extends OptExpressionVisitor<Void, AggregatePus
         }
 
         if (join.getOnPredicate() != null) {
-            join.getOnPredicate().getUsedColumns().getStream().mapToObj(factory::getColumnRef)
+            join.getOnPredicate().getUsedColumns().getStream().map(factory::getColumnRef)
                     .filter(childOutput::contains)
                     .forEach(c -> childContext.groupBys.put(c, c));
         }
 
         if (join.getPredicate() != null) {
-            join.getPredicate().getUsedColumns().getStream().mapToObj(factory::getColumnRef)
+            join.getPredicate().getUsedColumns().getStream().map(factory::getColumnRef)
                     .filter(childOutput::contains)
                     .forEach(v -> childContext.groupBys.put(v, v));
         }
@@ -479,7 +479,7 @@ class PushDownAggregateCollector extends OptExpressionVisitor<Void, AggregatePus
 
         List<ColumnStatistic>[] cards = new List[] {lower, medium, high};
 
-        groupBys.getStream().mapToObj(factory::getColumnRef)
+        groupBys.getStream().map(factory::getColumnRef)
                 .map(s -> ExpressionStatisticCalculator.calculate(s, statistics))
                 .forEach(s -> cards[groupByCardinality(s, statistics.getOutputRowCount())].add(s));
 
@@ -492,7 +492,7 @@ class PushDownAggregateCollector extends OptExpressionVisitor<Void, AggregatePus
 
         String aggStr = context.aggregations.values().stream().map(CallOperator::toString)
                 .collect(Collectors.joining(", "));
-        String groupStr = groupBys.getStream().mapToObj(String::valueOf).collect(Collectors.joining(", "));
+        String groupStr = groupBys.getStream().map(String::valueOf).collect(Collectors.joining(", "));
 
         LOG.debug("Push down aggregation[" + aggStr + "]" +
                 " group by[" + groupStr + "]," +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
@@ -119,7 +119,7 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
         }
 
         LogicalFilterOperator filter = (LogicalFilterOperator) optExpression.getOp();
-        filter.getRequiredChildInputColumns().getStream().mapToObj(factory::getColumnRef)
+        filter.getRequiredChildInputColumns().getStream().map(factory::getColumnRef)
                 .forEach(v -> context.groupBys.put(v, v));
         return processChild(optExpression, context);
     }
@@ -153,7 +153,7 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
         ColumnRefSet refSet = new ColumnRefSet();
         context.groupBys.values().forEach(v -> refSet.union(v.getUsedColumns()));
         context.groupBys.clear();
-        refSet.getStream().mapToObj(factory::getColumnRef).forEach(k -> context.groupBys.put(k, k));
+        refSet.getStream().map(factory::getColumnRef).forEach(k -> context.groupBys.put(k, k));
 
         // rewrite aggregation & push down expression
         // special case-when/if only push down values
@@ -176,7 +176,7 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
             if (isCaseWhen) {
                 CaseWhenOperator caseWhen = (CaseWhenOperator) aggExpr;
                 for (ScalarOperator condition : caseWhen.getAllConditionClause()) {
-                    condition.getUsedColumns().getStream().mapToObj(factory::getColumnRef)
+                    condition.getUsedColumns().getStream().map(factory::getColumnRef)
                             .forEach(v -> context.groupBys.put(v, v));
                 }
 
@@ -204,7 +204,7 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
                 originProjectMap.put(key, new CaseWhenOperator(key.getType(), caseWhen));
             } else if (isIfFn) {
                 CallOperator ifFn = (CallOperator) aggExpr;
-                ifFn.getChild(0).getUsedColumns().getStream().mapToObj(factory::getColumnRef)
+                ifFn.getChild(0).getUsedColumns().getStream().map(factory::getColumnRef)
                         .forEach(v -> context.groupBys.put(v, v));
 
                 for (int i = 1; i < ifFn.getChildren().size(); i++) {
@@ -332,12 +332,12 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
 
         if (join.getOnPredicate() != null) {
             join.getOnPredicate().getUsedColumns().getStream().filter(childOutput::contains)
-                    .mapToObj(factory::getColumnRef).forEach(c -> childContext.groupBys.put(c, c));
+                    .map(factory::getColumnRef).forEach(c -> childContext.groupBys.put(c, c));
         }
 
         if (join.getPredicate() != null) {
             join.getPredicate().getUsedColumns().getStream().filter(childOutput::contains)
-                    .mapToObj(factory::getColumnRef).forEach(v -> childContext.groupBys.put(v, v));
+                    .map(factory::getColumnRef).forEach(v -> childContext.groupBys.put(v, v));
         }
 
         return process(joinOpt.inputAt(child), childContext);
@@ -419,7 +419,7 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
             context.groupBys.values().stream()
                     .map(rewriter::rewrite)
                     .map(ScalarOperator::getUsedColumns)
-                    .forEach(c -> c.getStream().mapToObj(factory::getColumnRef)
+                    .forEach(c -> c.getStream().map(factory::getColumnRef)
                             .forEach(ref -> childContext.groupBys.put(ref, ref)));
             childContexts.add(childContext);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1193,9 +1193,9 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             ColumnRefSet leftChildColumns = predicateOperator.getChild(0).getUsedColumns();
             ColumnRefSet rightChildColumns = predicateOperator.getChild(1).getUsedColumns();
             Set<Integer> leftChildRelationIds =
-                    leftChildColumns.getStream().mapToObj(columnRefFactory::getRelationId).collect(Collectors.toSet());
+                    leftChildColumns.getStream().map(columnRefFactory::getRelationId).collect(Collectors.toSet());
             Set<Integer> rightChildRelationIds =
-                    rightChildColumns.getStream().mapToObj(columnRefFactory::getRelationId)
+                    rightChildColumns.getStream().map(columnRefFactory::getRelationId)
                             .collect(Collectors.toSet());
 
             // Check that the predicate is complex, such as t1.a + t2.b = t3.c is complex predicate

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2139,7 +2139,7 @@ public class PlanFragmentBuilder {
                 }
 
                 outputColumns.except(new ArrayList<>(node.getProjection().getCommonSubOperatorMap().keySet()));
-                joinNode.setOutputSlots(outputColumns.getStream().boxed().collect(Collectors.toList()));
+                joinNode.setOutputSlots(outputColumns.getStream().collect(Collectors.toList()));
             }
 
             joinNode.setDistributionMode(distributionMode);
@@ -2735,7 +2735,7 @@ public class PlanFragmentBuilder {
                 }
 
                 outputColumns.except(new ArrayList<>(node.getProjection().getCommonSubOperatorMap().keySet()));
-                joinNode.setOutputSlots(outputColumns.getStream().boxed().collect(Collectors.toList()));
+                joinNode.setOutputSlots(outputColumns.getStream().collect(Collectors.toList()));
             }
 
             joinNode.setDistributionMode(distributionMode);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16331

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, we use `BitSet` to store `ColumnRefOperator::id`. When the query is complex with so many expression, the total number of ColumnRefOperator will reach the level of million, which causing `BitSet` use much more memory to store few ids.

So we gona to replace the `BitSet` to `RoaringBitMap` which will use much less memory when storing a few number of of big ids.

## Experiment

### Benchmark

This is a simple benchmark test on the performance of `BitSet` and `RoaringBitMap`. And the result says that though the `BitSet` may consume more memory but it is 2 times faster than the `RoaringBitMap`(source code of this test is: [BitsetBenchmark.txt](https://github.com/StarRocks/starrocks/files/10399457/BitsetBenchmark.txt))

```
Benchmark                           Mode  Cnt       Score      Error  Units
BitsetBenchmark.testBitSet1         avgt    5      48.457 ±    6.307  ns/op
BitsetBenchmark.testBitSet2         avgt    5     325.111 ±   40.300  ns/op
BitsetBenchmark.testBitSet3         avgt    5    2654.798 ±  122.511  ns/op
BitsetBenchmark.testBitSet4         avgt    5  163690.184 ± 6331.800  ns/op
BitsetBenchmark.testRoaringBitMap1  avgt    5      71.587 ±    2.727  ns/op
BitsetBenchmark.testRoaringBitMap2  avgt    5    1548.434 ±   28.347  ns/op
BitsetBenchmark.testRoaringBitMap3  avgt    5    6811.395 ±  490.314  ns/op
BitsetBenchmark.testRoaringBitMap4  avgt    5  320894.614 ± 4390.426  ns/op
```

### Complex query

This is another experiment on the plan time(specifically, optimizer time usage) usage of the first 10 sql of tpcds. As the result shows, the impact on performance is negligible

|  | BitSet | RoaringBitMap |
|:--|:--|:--|
| Q1 | 11ms | 15ms |
| Q2 | 10ms | 11ms |
| Q3 | 3ms | 4ms |
| Q4 | 47ms | 39ms |
| Q5 | 11ms | 11ms |
| Q6 | 15ms | 12ms |
| Q7 | 28ms | 24ms |
| Q8 | 8ms | 8ms |
| Q9 | 6ms | 7ms |
| Q10 | 13ms | 13ms |

### Concurrent simple query

This is the test result of the parallel situation

* tpch100g
* `select * from lineitem limit 1`
* 3be + 1fe with machine specification 16c/64G
* times: total 10240 across all the parallelism

| Parallelism | BitSet | RoaringBitMap |
|:--|:--|:--|
| 16 | 17.159s | 17.008s |
| 32 | 16.110s | 16.008s |
| 64 | 16.738s | 17.047s |
| 128 | 17.628s | 17.378s |
| 256 | 17.607s | 17.249s |

### Conclusion

Given the above experiments, we can draw the conclusion that the deduction in bitmap performance is negligible when considering the whole query performance

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
