### PR TITLE
[Enhancement] optimize sequential reading binary column performance

### DIFF
--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -1,6 +1,13 @@
 #include "storage/rowset/binary_plain_page.h"
 
+#include <cstring>
+
 #include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "gutil/casts.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -40,7 +47,21 @@ Status BinaryPlainPageDecoder<Type>::next_batch(const SparseRange& range, Column
         if (dst->append_strings(strs)) {
             return Status::OK();
         }
+    } else if constexpr (Type == TYPE_VARCHAR) {
+        bool append_status = true;
+        while (to_read > 0) {
+            _cur_idx = iter.begin();
+            Range r = iter.next(to_read);
+            size_t end = _cur_idx + r.span_size();
+            append_status &= append_range(_cur_idx, end, dst);
+            to_read -= r.span_size();
+            _cur_idx = end;
+        }
+        if (append_status) {
+            return Status::OK();
+        }
     } else {
+        // other types
         while (to_read > 0) {
             _cur_idx = iter.begin();
             Range r = iter.next(to_read);
@@ -59,6 +80,60 @@ Status BinaryPlainPageDecoder<Type>::next_batch(const SparseRange& range, Column
         }
     }
     return Status::InvalidArgument("Column::append_strings() not supported");
+}
+
+template <LogicalType Type>
+bool BinaryPlainPageDecoder<Type>::append_range(uint32_t idx, uint32_t end, Column* dst) const {
+    if constexpr (Type == TYPE_VARCHAR) {
+        DCHECK(dst->is_binary());
+        auto data_column = ColumnHelper::get_data_column(dst);
+        auto& bytes = down_cast<BinaryColumn*>(data_column)->get_bytes();
+        auto& offsets = down_cast<BinaryColumn*>(data_column)->get_offset();
+        DCHECK_GE(offsets.size(), 1);
+
+        uint32_t begin_offset = offsets.back();
+        size_t current_offset_sz = offsets.size();
+        offsets.resize(current_offset_sz + end - idx);
+
+        const uint32_t page_data_offset = offset_uncheck(idx);
+        // vectorized loop
+        for (uint32_t i = idx; i < end - 1; i++) {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+            auto offset = _offsets_ptr[i + 1];
+#else
+            // direct call offset_uncheck() will break auto-vectorized
+            // maybe we can remove this condition compile after we upgrade the toolchain
+            auto offset = offset_uncheck(i + 1);
+#endif
+            uint32_t current_offset = offset - page_data_offset + begin_offset;
+            offsets[current_offset_sz++] = current_offset;
+        }
+
+        for (uint32_t i = end - 1; i < end; i++) {
+            uint32_t current_offset = offset(i + 1) - page_data_offset + begin_offset;
+            offsets[current_offset_sz++] = current_offset;
+        }
+
+        size_t append_bytes_length = offsets.back() - begin_offset;
+        size_t old_bytes_size = bytes.size();
+        bytes.resize(old_bytes_size + append_bytes_length);
+        // TODO: need did some optimize for large memory copy
+        memcpy(bytes.data() + old_bytes_size, _data.get_data() + offset(idx), append_bytes_length);
+
+        if (dst->is_nullable()) {
+            auto& null_data = down_cast<NullableColumn*>(dst)->null_column_data();
+            size_t null_data_size = null_data.size();
+            down_cast<NullableColumn*>(dst)->null_column_data().resize(null_data_size + end - idx, 0);
+        }
+
+#ifndef NDEBUG
+        dst->check_or_die();
+#endif
+        return true;
+    } else {
+        DCHECK(false) << "unreachable path";
+        return false;
+    }
 }
 
 template class BinaryPlainPageDecoder<TYPE_CHAR>;

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -85,7 +85,6 @@ Status BinaryPlainPageDecoder<Type>::next_batch(const SparseRange& range, Column
 template <LogicalType Type>
 bool BinaryPlainPageDecoder<Type>::append_range(uint32_t idx, uint32_t end, Column* dst) const {
     if constexpr (Type == TYPE_VARCHAR) {
-        DCHECK(dst->is_binary());
         auto data_column = ColumnHelper::get_data_column(dst);
         auto& bytes = down_cast<BinaryColumn*>(data_column)->get_bytes();
         auto& offsets = down_cast<BinaryColumn*>(data_column)->get_offset();

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -201,6 +201,7 @@ public:
         _num_elems = decode_fixed32_le((const uint8_t*)&_data[_data.get_size() - sizeof(uint32_t)]);
         _offsets_pos =
                 static_cast<uint32_t>(_data.get_size()) - (_num_elems + 1) * static_cast<uint32_t>(sizeof(uint32_t));
+        _offsets_ptr = reinterpret_cast<uint32_t*>(_data.data + _offsets_pos);
 
         _parsed = true;
 
@@ -216,6 +217,8 @@ public:
     Status next_batch(size_t* count, Column* dst) override;
 
     Status next_batch(const SparseRange& range, Column* dst) override;
+
+    bool append_range(uint32_t idx, uint32_t end, Column* dst) const;
 
     uint32_t count() const override {
         DCHECK(_parsed);
@@ -263,17 +266,16 @@ public:
 
 private:
     // Return the offset within '_data' where the string value with index 'idx' can be found.
-    uint32_t offset(int idx) const {
-        if (idx >= _num_elems) {
-            return _offsets_pos;
-        }
-        return offset_uncheck(idx);
-    }
+    uint32_t offset(int idx) const { return idx < _num_elems ? offset_uncheck(idx) : _offsets_pos; }
 
     uint32_t offset_uncheck(int idx) const {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+        return _offsets_ptr[idx];
+#else
         const uint32_t pos = _offsets_pos + idx * static_cast<uint32_t>(sizeof(uint32_t));
         const auto* const p = reinterpret_cast<const uint8_t*>(&_data[pos]);
         return decode_fixed32_le(p);
+#endif
     }
 
     Slice _data;
@@ -282,6 +284,7 @@ private:
 
     uint32_t _num_elems;
     uint32_t _offsets_pos;
+    uint32_t* _offsets_ptr = nullptr;
 
     // Index of the currently seeked element in the page.
     uint32_t _cur_idx;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
1. reduce call string_at_index and copy Slice (mainly)
2. use memcpy instead of vector->insert();

if all of read data read from page cache. we will again about 10% performance improvement when parse binary plain page

test SQL:
SSB 100g 4BE 1FE (16c)
```
select count(s_address) from lineorder_flat;
```
baseline: 0.08 patched: 0.06 disable page cache

hits 1BE 1FE (16c)
```
 SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10 ;
```
baseline: 1.20 patched: 1.10

perf:
baseline:
```
  22.67%  starrocks_be        [.] LZ4_decompress_safe                                                                                        ◆
  14.28%  libc-2.26.so        [.] __memcpy_ssse3                                                                                             ▒
   8.24%  starrocks_be        [.] starrocks::BinaryPlainPageDecoder<(starrocks::LogicalType)17>::next_batch                                  ▒
   5.53%  [kernel]            [k] copy_user_enhanced_fast_string                                                                             ▒
   3.76%  libc-2.26.so        [.] __memmove_ssse3    
```
patched:
```
  39.59%  starrocks_be        [.] LZ4_decompress_safe
  12.11%  libc-2.26.so        [.] __memcpy_ssse3
   4.78%  libc-2.26.so        [.] __memmove_ssse3
   4.76%  [kernel]            [k] copy_user_enhanced_fast_string
   4.41%  starrocks_be        [.] starrocks::crc32c::Extend
   3.74%  starrocks_be        [.] starrocks::LikePredicate::constant_substring_fn
   2.89%  starrocks_be        [.] std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned ch
   1.90%  starrocks_be        [.] starrocks::BinaryColumnBase<unsigned int>::filter_range
   1.71%  starrocks_be        [.] starrocks::BinaryColumnPredicateCmpBase<(starrocks::LogicalType)17,
   1.52%  [vdso]              [.] 0x0000000000000768
   0.96%  starrocks_be        [.] starrocks::pipeline::PipelineDriverPoller::run_internal
   0.80%  [kernel]            [k] find_get_pages_contig
   0.64%  starrocks_be        [.] LZ4_decompress_fast
   0.64%  starrocks_be        [.] starrocks::BinaryPlainPageDecoder<(starrocks::LogicalType)17>::appe
   0.54%  starrocks_be        [.] jemalloc_usable_size
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
