### PR TITLE
[Feature] Support more csv paramters for routine load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -206,23 +206,9 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     private static final String PROPS_JSONPATHS = "jsonpaths";
     private static final String PROPS_JSONROOT = "json_root";
 
-
-    public boolean isTrimspace() {
-        return trimspace;
-    }
-
+    // for csv
     protected boolean trimspace = false;
-
-    public byte getEnclose() {
-        return enclose;
-    }
-
     protected byte enclose = 0;
-
-    public byte getEscape() {
-        return escape;
-    }
-
     protected byte escape = 0;
 
     protected int currentTaskConcurrentNum;
@@ -398,6 +384,18 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     protected void writeUnlock() {
         lock.writeLock().unlock();
+    }
+
+    public boolean isTrimspace() {
+        return trimspace;
+    }
+
+    public byte getEnclose() {
+        return enclose;
+    }
+
+    public byte getEscape() {
+        return escape;
     }
 
     public String getName() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -213,12 +213,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     protected boolean trimspace = false;
 
-    public long getSkipheader() {
-        return skipheader;
-    }
-
-    protected long skipheader = 0;
-
     public byte getEnclose() {
         return enclose;
     }
@@ -336,7 +330,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             jobProperties.put(PROPS_JSONPATHS, "");
             jobProperties.put(PROPS_JSONROOT, "");
             this.trimspace = stmt.isTrimspace();
-            this.skipheader = stmt.getSkipheader();
             this.enclose = stmt.getEnclose();
             this.escape = stmt.getEscape();
         } else if (stmt.getFormat().equals("json")) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -206,6 +206,31 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     private static final String PROPS_JSONPATHS = "jsonpaths";
     private static final String PROPS_JSONROOT = "json_root";
 
+
+    public boolean isTrimspace() {
+        return trimspace;
+    }
+
+    protected boolean trimspace = false;
+
+    public long getSkipheader() {
+        return skipheader;
+    }
+
+    protected long skipheader = 0;
+
+    public byte getEnclose() {
+        return enclose;
+    }
+
+    protected byte enclose = 0;
+
+    public byte getEscape() {
+        return escape;
+    }
+
+    protected byte escape = 0;
+
     protected int currentTaskConcurrentNum;
     protected RoutineLoadProgress progress;
 
@@ -310,6 +335,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             jobProperties.put(PROPS_STRIP_OUTER_ARRAY, "false");
             jobProperties.put(PROPS_JSONPATHS, "");
             jobProperties.put(PROPS_JSONROOT, "");
+            this.trimspace = stmt.isTrimspace();
+            this.skipheader = stmt.getSkipheader();
+            this.enclose = stmt.getEnclose();
+            this.escape = stmt.getEscape();
         } else if (stmt.getFormat().equals("json")) {
             jobProperties.put(PROPS_FORMAT, "json");
             if (!Strings.isNullOrEmpty(stmt.getJsonPaths())) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -424,6 +424,10 @@ public class StreamLoadInfo {
             compressionType = CompressionUtils.findTCompressionByName(
                     routineLoadJob.getSessionVariables().get(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE));
         }
+        trimSpace = routineLoadJob.isTrimspace();
+        skipHeader = routineLoadJob.getSkipheader();
+        enclose = routineLoadJob.getEnclose();
+        escape = routineLoadJob.getEscape();
     }
 
     // used for stream load

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -61,7 +61,6 @@ public class StreamLoadInfo {
     private String mergeConditionStr;
     private ColumnSeparator columnSeparator;
     private RowDelimiter rowDelimiter;
-    private long skipHeader;
     private boolean trimSpace;
     private byte enclose;
     private byte escape;
@@ -137,9 +136,6 @@ public class StreamLoadInfo {
         return trimSpace;
     }
 
-    public long getSkipHeader() {
-        return skipHeader;
-    }
 
     public byte getEnclose() {
         return enclose;
@@ -311,9 +307,6 @@ public class StreamLoadInfo {
         if (request.isSetRowDelimiter()) {
             rowDelimiter = new RowDelimiter(request.getRowDelimiter());
         }
-        if (request.isSetSkipHeader()) {
-            skipHeader = request.getSkipHeader();
-        }
         if (request.isSetEnclose()) {
             enclose = request.getEnclose();
         }
@@ -425,7 +418,6 @@ public class StreamLoadInfo {
                     routineLoadJob.getSessionVariables().get(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE));
         }
         trimSpace = routineLoadJob.isTrimspace();
-        skipHeader = routineLoadJob.getSkipheader();
         enclose = routineLoadJob.getEnclose();
         escape = routineLoadJob.getEscape();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -61,6 +61,7 @@ public class StreamLoadInfo {
     private String mergeConditionStr;
     private ColumnSeparator columnSeparator;
     private RowDelimiter rowDelimiter;
+    private long skipHeader;
     private boolean trimSpace;
     private byte enclose;
     private byte escape;
@@ -136,6 +137,9 @@ public class StreamLoadInfo {
         return trimSpace;
     }
 
+    public long getSkipHeader() {
+        return skipHeader;
+    }
 
     public byte getEnclose() {
         return enclose;
@@ -306,6 +310,9 @@ public class StreamLoadInfo {
         }
         if (request.isSetRowDelimiter()) {
             rowDelimiter = new RowDelimiter(request.getRowDelimiter());
+        }
+        if (request.isSetSkipHeader()) {
+            skipHeader = request.getSkipHeader();
         }
         if (request.isSetEnclose()) {
             enclose = request.getEnclose();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -210,7 +210,6 @@ public class StreamLoadScanNode extends LoadScanNode {
             params.setRow_delimiter((byte) '\n');
         }
         params.setTrim_space(streamLoadInfo.getTrimSpace());
-        params.setSkip_header(streamLoadInfo.getSkipHeader());
         params.setEnclose(streamLoadInfo.getEnclose());
         params.setEscape(streamLoadInfo.getEscape());
         params.setStrict_mode(streamLoadInfo.isStrictMode());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -210,6 +210,7 @@ public class StreamLoadScanNode extends LoadScanNode {
             params.setRow_delimiter((byte) '\n');
         }
         params.setTrim_space(streamLoadInfo.getTrimSpace());
+        params.setSkip_header(streamLoadInfo.getSkipHeader());
         params.setEnclose(streamLoadInfo.getEnclose());
         params.setEscape(streamLoadInfo.getEscape());
         params.setStrict_mode(streamLoadInfo.isStrictMode());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -103,6 +103,12 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String JSONPATHS = "jsonpaths";
     public static final String JSONROOT = "json_root";
 
+    // csv properties
+    public static final String TRIMSPACE = "trimspace";
+    public static final String SKIPHEADER = "skipheader";
+    public static final String ENCLOSE = "enclose";
+    public static final String ESCAPE = "escape";
+
     // kafka type properties
     public static final String KAFKA_BROKER_LIST_PROPERTY = "kafka_broker_list";
     public static final String KAFKA_TOPIC_PROPERTY = "kafka_topic";
@@ -137,6 +143,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(LoadStmt.TIMEZONE)
             .add(LoadStmt.PARTIAL_UPDATE)
             .add(LoadStmt.MERGE_CONDITION)
+            .add(TRIMSPACE)
+            .add(SKIPHEADER)
+            .add(ENCLOSE)
+            .add(ESCAPE)
             .build();
 
     private static final ImmutableSet<String> KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -184,6 +194,30 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     private String jsonPaths = "";
     private String jsonRoot = ""; // MUST be a jsonpath string
     private boolean stripOuterArray = false;
+
+    public boolean isTrimspace() {
+        return trimspace;
+    }
+
+    private boolean trimspace = false;
+
+    public long getSkipheader() {
+        return skipheader;
+    }
+
+    private long skipheader = 0;
+
+    public byte getEnclose() {
+        return enclose;
+    }
+
+    private byte enclose = 0;
+
+    public byte getEscape() {
+        return escape;
+    }
+
+    private byte escape = 0;
 
     // kafka related properties
     private String kafkaBrokerList;
@@ -484,6 +518,12 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             }
         } else {
             format = "csv"; // default csv
+        }
+        if (format.equalsIgnoreCase("csv") || format.isEmpty()) {
+            trimspace = Boolean.valueOf(jobProperties.getOrDefault(TRIMSPACE, "false"));
+            skipheader = Long.valueOf(jobProperties.getOrDefault(SKIPHEADER, "0"));
+            enclose = (byte) jobProperties.getOrDefault(ENCLOSE, "0").charAt(0);
+            escape = (byte) jobProperties.getOrDefault(ESCAPE, "0").charAt(0);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -104,7 +104,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String JSONROOT = "json_root";
 
     // csv properties
-    public static final String TRIMSPACE = "trims_pace";
+    public static final String TRIMSPACE = "trim_space";
     public static final String ENCLOSE = "enclose";
     public static final String ESCAPE = "escape";
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -104,7 +104,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String JSONROOT = "json_root";
 
     // csv properties
-    public static final String TRIMSPACE = "trimspace";
+    public static final String TRIMSPACE = "trims_pace";
     public static final String ENCLOSE = "enclose";
     public static final String ESCAPE = "escape";
 
@@ -193,22 +193,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     private String jsonRoot = ""; // MUST be a jsonpath string
     private boolean stripOuterArray = false;
 
-    public boolean isTrimspace() {
-        return trimspace;
-    }
-
+    // for csv
     private boolean trimspace = false;
-
-    public byte getEnclose() {
-        return enclose;
-    }
-
     private byte enclose = 0;
-
-    public byte getEscape() {
-        return escape;
-    }
-
     private byte escape = 0;
 
     // kafka related properties
@@ -245,6 +232,18 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         this.jobProperties = jobProperties == null ? Maps.newHashMap() : jobProperties;
         this.typeName = typeName.toUpperCase();
         this.dataSourceProperties = dataSourceProperties;
+    }
+
+    public boolean isTrimspace() {
+        return trimspace;
+    }
+
+    public byte getEnclose() {
+        return enclose;
+    }
+
+    public byte getEscape() {
+        return escape;
     }
 
     public LabelName getLabelName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -512,8 +512,16 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         }
         if (format.equalsIgnoreCase("csv") || format.isEmpty()) {
             trimspace = Boolean.valueOf(jobProperties.getOrDefault(TRIMSPACE, "false"));
-            enclose = (byte) jobProperties.getOrDefault(ENCLOSE, "0").charAt(0);
-            escape = (byte) jobProperties.getOrDefault(ESCAPE, "0").charAt(0);
+            if (jobProperties.containsKey(ENCLOSE)) {
+                enclose = (byte) jobProperties.get(ENCLOSE).charAt(0);
+            } else {
+                enclose = 0;
+            }
+            if (jobProperties.containsKey(ESCAPE)) {
+                escape = (byte) jobProperties.get(ESCAPE).charAt(0);            
+            } else {
+                escape = 0;
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -105,7 +105,6 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     // csv properties
     public static final String TRIMSPACE = "trimspace";
-    public static final String SKIPHEADER = "skipheader";
     public static final String ENCLOSE = "enclose";
     public static final String ESCAPE = "escape";
 
@@ -144,7 +143,6 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(LoadStmt.PARTIAL_UPDATE)
             .add(LoadStmt.MERGE_CONDITION)
             .add(TRIMSPACE)
-            .add(SKIPHEADER)
             .add(ENCLOSE)
             .add(ESCAPE)
             .build();
@@ -200,12 +198,6 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     }
 
     private boolean trimspace = false;
-
-    public long getSkipheader() {
-        return skipheader;
-    }
-
-    private long skipheader = 0;
 
     public byte getEnclose() {
         return enclose;
@@ -521,7 +513,6 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         }
         if (format.equalsIgnoreCase("csv") || format.isEmpty()) {
             trimspace = Boolean.valueOf(jobProperties.getOrDefault(TRIMSPACE, "false"));
-            skipheader = Long.valueOf(jobProperties.getOrDefault(SKIPHEADER, "0"));
             enclose = (byte) jobProperties.getOrDefault(ENCLOSE, "0").charAt(0);
             escape = (byte) jobProperties.getOrDefault(ESCAPE, "0").charAt(0);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -350,6 +350,20 @@ public class CreateRoutineLoadStmtTest {
     }
 
     @Test
+    public void testAnalyzeCSVDefalultValue() throws Exception {
+        String createSQL = "CREATE ROUTINE LOAD db0.routine_load_1 ON t1 " +
+                "PROPERTIES(\"max_error_number\" = \"10\") " +
+                "FROM KAFKA(\"kafka_broker_list\" = \"xxx.xxx.xxx.xxx:xxx\",\"kafka_topic\" = \"topic_0\");";
+        ConnectContext ctx = starRocksAssert.getCtx();
+        CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) SqlParser.parse(createSQL, 32).get(0);
+        CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+        Assert.assertEquals(createRoutineLoadStmt.getMaxErrorNum(), 10);
+        Assert.assertEquals(createRoutineLoadStmt.getEnclose(), 0);
+        Assert.assertEquals(createRoutineLoadStmt.getEscape(), 0);
+        Assert.assertEquals(createRoutineLoadStmt.isTrimspace(), false);
+    }
+
+    @Test
     public void testKafkaOffset() {
 
         String jobName = "job1";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -339,7 +339,7 @@ public class CreateRoutineLoadStmtTest {
     @Test
     public void testAnalyzeCSVConfig() throws Exception {
         String createSQL = "CREATE ROUTINE LOAD db0.routine_load_1 ON t1 " +
-                "PROPERTIES(\"format\" = \"csv\", \"trimspace\"=\"true\", \"enclose\"=\"'\", \"escape\"=\"|\") " +
+                "PROPERTIES(\"format\" = \"csv\", \"trim_space\"=\"true\", \"enclose\"=\"'\", \"escape\"=\"|\") " +
                 "FROM KAFKA(\"kafka_broker_list\" = \"xxx.xxx.xxx.xxx:xxx\",\"kafka_topic\" = \"topic_0\");";
         ConnectContext ctx = starRocksAssert.getCtx();
         CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) SqlParser.parse(createSQL, 32).get(0);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -337,6 +337,19 @@ public class CreateRoutineLoadStmtTest {
     }
 
     @Test
+    public void testAnalyzeCSVConfig() throws Exception {
+        String createSQL = "CREATE ROUTINE LOAD db0.routine_load_1 ON t1 " +
+                "PROPERTIES(\"format\" = \"csv\", \"trimspace\"=\"true\", \"enclose\"=\"\'\", \"escape\"=\"\\\") " +
+                "FROM KAFKA(\"kafka_broker_list\" = \"xxx.xxx.xxx.xxx:xxx\",\"kafka_topic\" = \"topic_0\");";
+        ConnectContext ctx = starRocksAssert.getCtx();
+        CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) SqlParser.parse(createSQL, 32).get(0);
+        CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+        Assert.assertEquals(createRoutineLoadStmt.isTrimspace(), true);
+        Assert.assertEquals(createRoutineLoadStmt.getEnclose(), '\'');
+        Assert.assertEquals(createRoutineLoadStmt.getEscape(), '\\');
+    }
+
+    @Test
     public void testKafkaOffset() {
 
         String jobName = "job1";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -339,14 +339,14 @@ public class CreateRoutineLoadStmtTest {
     @Test
     public void testAnalyzeCSVConfig() throws Exception {
         String createSQL = "CREATE ROUTINE LOAD db0.routine_load_1 ON t1 " +
-                "PROPERTIES(\"format\" = \"csv\", \"trimspace\"=\"true\", \"enclose\"=\"\'\", \"escape\"=\"\\\") " +
+                "PROPERTIES(\"format\" = \"csv\", \"trimspace\"=\"true\", \"enclose\"=\"'\", \"escape\"=\"|\") " +
                 "FROM KAFKA(\"kafka_broker_list\" = \"xxx.xxx.xxx.xxx:xxx\",\"kafka_topic\" = \"topic_0\");";
         ConnectContext ctx = starRocksAssert.getCtx();
         CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) SqlParser.parse(createSQL, 32).get(0);
         CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
         Assert.assertEquals(createRoutineLoadStmt.isTrimspace(), true);
         Assert.assertEquals(createRoutineLoadStmt.getEnclose(), '\'');
-        Assert.assertEquals(createRoutineLoadStmt.getEscape(), '\\');
+        Assert.assertEquals(createRoutineLoadStmt.getEscape(), '|');
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR supports more CSV attributes for routine load, just like stream load.Please reference to https://github.com/StarRocks/starrocks/pull/13582. One thing to note is that for routine load, we do not support  skipheader attribute.
For example, you can perform the CSV import with the following command for routine load.
```
CREATE ROUTINE LOAD test.example_tbl1_ordertest1 ON example_tbl1
COLUMNS TERMINATED BY ",",
COLUMNS (order_id, pay_dt, customer_name, nationality, temp_gender, price)
PROPERTIES
(
    "desired_concurrent_number" = "5",
    "trim_space"="true",
    "enclose"="\'",
    "escape"="\\",
)
FROM KAFKA
(
   "kafka_broker_list"="...",
   "kafka_topic"="test_csv",
   "kafka_partitions"="0,1,2,3,4,5",
   "property.kafka_default_offsets"="OFFSET_END"
   ...
);
```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
