### PR TITLE
[BugFix] fix mv with count distinct rewrite bug for 2.5

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -122,6 +122,7 @@ import com.starrocks.sql.optimizer.rule.transformation.ScalarApply2JoinRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitAggregateRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitLimitRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitTopNRule;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.AggregateAggregateScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.AggregateJoinRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.AggregateScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.OnlyJoinRule;
@@ -345,7 +346,8 @@ public class RuleSet {
 
         REWRITE_RULES.put(RuleSetType.SINGLE_TABLE_MV_REWRITE, ImmutableList.of(
                 OnlyScanRule.getInstance(),
-                AggregateScanRule.getInstance()
+                AggregateScanRule.getInstance(),
+                AggregateAggregateScanRule.getInstance()
         ));
 
         REWRITE_RULES.put(RuleSetType.MULTI_TABLE_MV_REWRITE, ImmutableList.of(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -15,7 +15,6 @@ import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
-import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -53,19 +52,8 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
 
     @Override
     public boolean isValidPlan(OptExpression expression) {
-        if (expression == null) {
-            return false;
-        }
-        Operator op = expression.getOp();
-        if (!(op instanceof LogicalAggregationOperator)) {
-            return false;
-        }
-        LogicalAggregationOperator agg = (LogicalAggregationOperator) op;
-        if (!agg.getType().equals(AggType.GLOBAL)) {
-            return false;
-        }
         // TODO: to support grouping set/rollup/cube
-        return MvUtils.isLogicalSPJ(expression.inputAt(0));
+        return MvUtils.isLogicalSPJG(expression);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -164,12 +164,20 @@ public class MvUtils {
     }
 
     public static boolean isLogicalSPJG(OptExpression root) {
+        return isLogicalSPJG(root, 0);
+    }
+
+    public static boolean isLogicalSPJG(OptExpression root, int level) {
         if (root == null) {
             return false;
         }
         Operator operator = root.getOp();
         if (!(operator instanceof LogicalAggregationOperator)) {
-            return false;
+            if (level == 0) {
+                return false;
+            } else {
+                return isLogicalSPJ(root);
+            }
         }
         LogicalAggregationOperator agg = (LogicalAggregationOperator) operator;
         if (agg.getType() != AggType.GLOBAL) {
@@ -177,7 +185,7 @@ public class MvUtils {
         }
 
         OptExpression child = root.inputAt(0);
-        return isLogicalSPJ(child);
+        return isLogicalSPJG(child, level + 1);
     }
 
     public static boolean isLogicalSPJ(OptExpression root) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateAggregateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateAggregateScanRule.java
@@ -14,7 +14,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 
 /*
  *
- * Here is the rule for pattern Aggregate-Scan
+ * Here is the rule for pattern Aggregate-Aggregate-Scan
  *
  */
 public class AggregateAggregateScanRule extends SingleTableRewriteBaseRule {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateAggregateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateAggregateScanRule.java
@@ -1,0 +1,44 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
+
+import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.AggregatedMaterializedViewRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+
+/*
+ *
+ * Here is the rule for pattern Aggregate-Scan
+ *
+ */
+public class AggregateAggregateScanRule extends SingleTableRewriteBaseRule {
+    private static AggregateAggregateScanRule INSTANCE = new AggregateAggregateScanRule();
+
+    public AggregateAggregateScanRule() {
+        super(RuleType.TF_MV_AGGREGATE_SCAN_RULE, Pattern.create(OperatorType.LOGICAL_AGGR)
+                .addChildren(Pattern.create(OperatorType.LOGICAL_AGGR).addChildren(Pattern.create(OperatorType.PATTERN_SCAN))));
+    }
+
+    public static AggregateAggregateScanRule getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        if (!MvUtils.isLogicalSPJG(input)) {
+            return false;
+        }
+        return super.check(input, context);
+    }
+
+    @Override
+    public MaterializedViewRewriter getMaterializedViewRewrite(MaterializationContext mvContext) {
+        return new AggregatedMaterializedViewRewriter(mvContext);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -813,6 +813,61 @@ public class MvRewriteOptimizationTest {
         PlanTestBase.assertContains(plan12, "agg_join_mv_5");
 
         dropMv("test", "agg_join_mv_5");
+
+        createAndRefreshMv("test", "agg_mv_9", "create materialized view agg_mv_9" +
+                " distributed by hash(`deptno`) as select deptno," +
+                " count(distinct empid) as num" +
+                " from emps group by deptno");
+
+        String query25 = "select deptno, count(distinct empid) from emps group by deptno";
+        String plan25 = getFragmentPlan(query25);
+        PlanTestBase.assertContains(plan25, "agg_mv_9");
+        dropMv("test", "agg_mv_9");
+
+        starRocksAssert.withTable("CREATE TABLE `test_table_1` (\n" +
+                "  `dt` date NULL COMMENT \"\",\n" +
+                "  `experiment_id` bigint(20) NULL COMMENT \"\",\n" +
+                "  `hour` varchar(65533) NULL COMMENT \"\",\n" +
+                "  `player_id` varchar(65533) NULL COMMENT \"\",\n" +
+                "  `metric_value` double NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`dt`, `experiment_id`, `hour`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(PARTITION p202207 VALUES [(\"2022-07-01\"), (\"2022-08-01\")),\n" +
+                "PARTITION p202208 VALUES [(\"2022-08-01\"), (\"2022-09-01\")),\n" +
+                "PARTITION p202209 VALUES [(\"2022-09-01\"), (\"2022-10-01\")),\n" +
+                "PARTITION p202210 VALUES [(\"2022-10-01\"), (\"2022-11-01\")))\n" +
+                "DISTRIBUTED BY HASH(`player_id`) BUCKETS 160 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");");
+        cluster.runSql("test", "insert into test_table_1 values('2022-07-01', 1, '08:00:00', 'player_id_1', 20.0)");
+        cluster.runSql("test", "insert into test_table_1 values('2022-08-01', 1, '08:00:00', 'player_id_1', 20.0)");
+        cluster.runSql("test", "insert into test_table_1 values('2022-09-01', 1, '08:00:00', 'player_id_1', 20.0)");
+        cluster.runSql("test", "insert into test_table_1 values('2022-10-01', 1, '08:00:00', 'player_id_1', 20.0)");
+
+        createAndRefreshMv("test", "agg_mv_10", "create materialized view agg_mv_10" +
+                " distributed by hash(experiment_id)\n" +
+                " refresh manual\n" +
+                " as\n" +
+                " SELECT `dt`, `experiment_id`," +
+                "       count(DISTINCT `player_id`) AS `count_distinct_player_id`\n" +
+                " FROM `test_table_1`\n" +
+                " GROUP BY `dt`, `experiment_id`;");
+
+        String query26 = "SELECT `dt`, `experiment_id`," +
+                " count(DISTINCT `player_id`) AS `count_distinct_player_id`\n" +
+                "FROM `test_table_1`\n" +
+                "GROUP BY `dt`, `experiment_id`";
+        String plan26 = getFragmentPlan(query26);
+        PlanTestBase.assertContains(plan26, "agg_mv_10");
+        dropMv("test", "agg_mv_10");
+        starRocksAssert.dropTable("test_table_1");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16558 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
fix mv with count distinct rewrite bug. the bug is that mv rewrite conflicts with TF_REWRITE_GROUP_BY_COUNT_DISTINCT rule which generates agg-agg-scan pattern plan.
mv rewriter does not support this pattern. fix it by adding new agg-agg-scan pattern rewrite rule.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
