### PR TITLE
[BugFix] fix redundant submitting for agent task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
@@ -182,6 +182,9 @@ public class AgentBatchTask implements Runnable {
                     agentTaskRequests.add(toAgentTaskRequest(task));
                 }
                 client.submit_tasks(agentTaskRequests);
+                for (AgentTask task : tasks) {
+                    task.setSubmitted(true);
+                }
                 if (LOG.isDebugEnabled()) {
                     for (AgentTask task : tasks) {
                         LOG.debug("send task: type[{}], backend[{}], signature[{}]",

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTask.java
@@ -57,6 +57,7 @@ public abstract class AgentTask {
     // some of are not.
     // so whether the task is finished depends on caller's logic, not the value of this member.
     protected boolean isFinished = false;
+    protected boolean isSubmitted = false;
     protected long createTime;
     protected String traceParent;
 
@@ -157,7 +158,14 @@ public abstract class AgentTask {
         return isFinished;
     }
 
+    public void setSubmitted(boolean isSubmitted) {
+        this.isSubmitted = isSubmitted;
+    }
+
     public boolean shouldResend(long currentTimeMillis) {
+        if (!isSubmitted) {
+            return false;
+        }
         return createTime == -1 || currentTimeMillis - createTime > Config.agent_task_resend_wait_time_ms;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes redundant submitting for agent task.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

agentTask is created, then was put into a thread pool and waiting to schedule. 

When agentTasks are created but not really be submmitted to be.During this period, if fe receive report from be, fe will resend tasks.

When resend redundent realtime push tasks, will cause trash data in be disk.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
