### PR TITLE
[BugFix] Use sort key to process predicates to get scan range while sort key is assigned.

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -185,7 +185,7 @@ Status LakeDataSource::open(RuntimeState* state) {
     cm.conjunct_ctxs_ptr = &_conjunct_ctxs;
     cm.tuple_desc = tuple_desc;
     cm.obj_pool = &_obj_pool;
-    cm.key_column_names = &thrift_lake_scan_node.key_column_name;
+    cm.key_column_names = &thrift_lake_scan_node.sort_key_column_names;
     cm.runtime_filters = _runtime_filters;
     cm.runtime_state = state;
 

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -465,7 +465,7 @@ Status OlapScanNode::_start_scan(RuntimeState* state) {
     cm.conjunct_ctxs_ptr = &_conjunct_ctxs;
     cm.tuple_desc = _tuple_desc;
     cm.obj_pool = _pool;
-    cm.key_column_names = &_olap_scan_node.key_column_name;
+    cm.key_column_names = &_olap_scan_node.sort_key_column_names;
     cm.runtime_filters = &_runtime_filter_collector;
     cm.runtime_state = state;
 

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -97,7 +97,7 @@ Status OlapScanContext::parse_conjuncts(RuntimeState* state, const std::vector<E
     cm.conjunct_ctxs_ptr = &_conjunct_ctxs;
     cm.tuple_desc = tuple_desc;
     cm.obj_pool = &_obj_pool;
-    cm.key_column_names = &thrift_olap_scan_node.key_column_name;
+    cm.key_column_names = &thrift_olap_scan_node.sort_key_column_names;
     cm.runtime_filters = runtime_bloom_filters;
     cm.runtime_state = state;
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -399,8 +399,11 @@ Status TabletReader::_to_seek_tuple(const TabletSchema& tablet_schema, const Ola
     Schema schema;
     std::vector<Datum> values;
     values.reserve(input.size());
+    const auto& sort_key_idxes = tablet_schema.sort_key_idxes();
+    DCHECK(sort_key_idxes.empty() || sort_key_idxes.size() >= input.size());
     for (size_t i = 0; i < input.size(); i++) {
-        auto f = std::make_shared<Field>(ChunkHelper::convert_field(i, tablet_schema.column(i)));
+        int idx = sort_key_idxes.empty() ? i : sort_key_idxes[i];
+        auto f = std::make_shared<Field>(ChunkHelper::convert_field(idx, tablet_schema.column(idx)));
         schema.append(f);
         values.emplace_back(Datum());
         if (input.is_null(i)) {
@@ -410,10 +413,10 @@ Status TabletReader::_to_seek_tuple(const TabletSchema& tablet_schema, const Ola
         // we treat it as VARCHAR, because the execution level CHAR is VARCHAR
         // CHAR type strings are truncated at the storage level after '\0'.
         if (f->type()->type() == TYPE_CHAR) {
-            RETURN_IF_ERROR(
-                    datum_from_string(get_type_info(TYPE_VARCHAR).get(), &values.back(), input.get_value(i), mempool));
+            RETURN_IF_ERROR(datum_from_string(get_type_info(TYPE_VARCHAR).get(), &values.back(), input.get_value(idx),
+                                              mempool));
         } else {
-            RETURN_IF_ERROR(datum_from_string(f->type().get(), &values.back(), input.get_value(i), mempool));
+            RETURN_IF_ERROR(datum_from_string(f->type().get(), &values.back(), input.get_value(idx), mempool));
         }
     }
     *tuple = SeekTuple(std::move(schema), std::move(values));

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -435,6 +435,7 @@ struct TOlapScanNode {
   25: optional bool sorted_by_keys_per_tablet = false
 
   26: optional list<Exprs.TExpr> bucket_exprs
+  27: optional list<string> sort_key_column_names
 }
 
 struct TJDBCScanNode {
@@ -458,6 +459,7 @@ struct TLakeScanNode {
   9: optional map<i32, i32> dict_string_id_to_int_ids
   // which columns only be used to filter data in the stage of scan data
   10: optional list<string> unused_output_column_name
+  11: optional list<string> sort_key_column_names
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/14441

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Under previous cases,  segment iterator use primary key as the filter when `WHERE` predicate be used, just scan a smaller range to speed up, it related to some range algorithm.
If sort key assigned, we should use sort key instead of primary key to process the predicates.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
