### PR TITLE
[Enhancement] Return null for non existed struct subfield in parquet reader

### DIFF
--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -425,7 +425,9 @@ Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField*
 
                 auto it = field_name_2_pos.find(required_subfield_name);
                 if (it == field_name_2_pos.end()) {
-                    return Status::NotFound("Struct subfield name: " + required_subfield_name + " not found.");
+                    LOG(WARNING) << "Struct subfield name: " + required_subfield_name + " not found.";
+                    children_readers.emplace_back(nullptr);
+                    continue;
                 }
 
                 size_t parquet_pos = it->second;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
