### PR TITLE
[BugFix] Fix projection may reuse column ref when prune union empty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionEmptyRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionEmptyRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
@@ -25,6 +24,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.CloneOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
@@ -89,7 +89,13 @@ public class PruneUnionEmptyRule extends TransformationRule {
         for (List<ColumnRefOperator> childOutputColumn : unionOperator.getChildOutputColumns()) {
             if (newInputs.get(0).getOutputColumns().isIntersect(new ColumnRefSet(childOutputColumn))) {
                 for (int i = 0; i < unionOperator.getOutputColumnRefOp().size(); i++) {
-                    projectMap.put(unionOperator.getOutputColumnRefOp().get(i), childOutputColumn.get(i));
+                    ColumnRefOperator unionOutputColumn = unionOperator.getOutputColumnRefOp().get(i);
+                    // TODO: if we implement COW in BE, we could remove it
+                    if (unionOutputColumn.isColumnRef() && projectMap.containsValue(childOutputColumn.get(i))) {
+                        projectMap.put(unionOutputColumn, new CloneOperator(childOutputColumn.get(i)));
+                    } else {
+                        projectMap.put(unionOutputColumn, childOutputColumn.get(i));
+                    }
                 }
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionEmptyRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneUnionEmptyRule.java
@@ -91,7 +91,7 @@ public class PruneUnionEmptyRule extends TransformationRule {
                 for (int i = 0; i < unionOperator.getOutputColumnRefOp().size(); i++) {
                     ColumnRefOperator unionOutputColumn = unionOperator.getOutputColumnRefOp().get(i);
                     // TODO: if we implement COW in BE, we could remove it
-                    if (unionOutputColumn.isColumnRef() && projectMap.containsValue(childOutputColumn.get(i))) {
+                    if (childOutputColumn.get(i).isColumnRef() && projectMap.containsValue(childOutputColumn.get(i))) {
                         projectMap.put(unionOutputColumn, new CloneOperator(childOutputColumn.get(i)));
                     } else {
                         projectMap.put(unionOutputColumn, childOutputColumn.get(i));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1337,6 +1337,19 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  <dict id 16> : <string id 15>"));
         Assert.assertTrue(plan.contains("  2:Project\n" +
                 "  |  <slot 16> : 16: t1a"));
+
+        // COW Case
+        sql = "SELECT 'all', 'allx' where 1 = 2 union all select distinct S_ADDRESS, S_ADDRESS from supplier;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:Project\n" +
+                "  |  <slot 14> : 8\n" +
+                "  |  <slot 15> : clone(8)\n" +
+                "  |  \n" +
+                "  2:Decode\n" +
+                "  |  <dict id 16> : <string id 8>\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  group by: 16: S_ADDRESS");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1331,8 +1331,10 @@ public class LowCardinalityTest extends PlanTestBase {
 
     @Test
     public void testProjectWithUnionEmptySet() throws Exception {
-        String sql = "select t1a from test_all_type group by t1a union all select v4 from t1 where false";
-        String plan = getFragmentPlan(sql);
+        String sql;
+        String plan;
+        sql = "select t1a from test_all_type group by t1a union all select v4 from t1 where false";
+        plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  3:Decode\n" +
                 "  |  <dict id 16> : <string id 15>"));
         Assert.assertTrue(plan.contains("  2:Project\n" +
@@ -1350,6 +1352,21 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  \n" +
                 "  1:AGGREGATE (update finalize)\n" +
                 "  |  group by: 16: S_ADDRESS");
+
+        sql = "SELECT 'all', 'all', 'all', 'all' where 1 = 2 union all " +
+                "select distinct S_ADDRESS, S_SUPPKEY + 1, S_SUPPKEY + 1, S_ADDRESS + 1 from supplier;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:Project\n" +
+                "  |  <slot 20> : 9: S_ADDRESS\n" +
+                "  |  <slot 21> : 24: cast\n" +
+                "  |  <slot 22> : CAST(15: expr AS VARCHAR)\n" +
+                "  |  <slot 23> : CAST(16: expr AS VARCHAR)\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 24> : CAST(15: expr AS VARCHAR)\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  group by: 9: S_ADDRESS, 15: expr, 16: expr");
+
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/16624
for the query:
```
explain SELECT 'all' , 'all2' where 1 = 2 union all select distinct k1, k1 from tmp ;
```
reuse column ref will generate a plan:
```
+---------------------------------+
| Explain String                  |
+---------------------------------+
| PLAN FRAGMENT 0                 |
|  OUTPUT EXPRS:8: cast | 9: cast |
|   PARTITION: UNPARTITIONED      |
|                                 |
|   RESULT SINK                   |
|                                 |
|   3:EXCHANGE                    |
|                                 |
| PLAN FRAGMENT 1                 |
|  OUTPUT EXPRS:                  |
|   PARTITION: RANDOM             |
|                                 |
|   STREAM DATA SINK              |
|     EXCHANGE ID: 03             |
|     UNPARTITIONED               |
|                                 |
|   2:Project                     |
|   |  <slot 8> : 6: k1           |
|   |  <slot 9> : 6: k1           |
|   |                             |
|   1:AGGREGATE (update finalize) |
|   |  group by: 6: k1            |
|   |                             |
|   0:OlapScanNode                |
|      TABLE: tmp                 |
|      PREAGGREGATION: ON         |
|      partitions=1/1             |
|      rollup: tmp                |
|      tabletRatio=2/2            |
|      tabletList=10184,10186     |
|      cardinality=65536          |
|      avgRowSize=2.0             |
|      numNodes=0                 |
+---------------------------------+
```

which will cause low-cardinality optimize got a wrong plan


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
