### PR TITLE
[BugFix] broker hung when closing oss file

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerConfig.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/BrokerConfig.java
@@ -35,6 +35,15 @@ public class BrokerConfig extends ConfigBase {
     public static int broker_ipc_port = 8000;
 
     /**
+     * As is shown https://github.com/StarRocks/starrocks/pull/16648, broker may stuck in OSS close in some cases,
+     * this will lead to all following open/write request to broker stuck.
+     * To avoid this problem, we can set disable_broker_client_expiration_checking=true in apache_hdfs_broker.conf,
+     * and restart broker.
+     */
+    @ConfField
+    public static boolean disable_broker_client_expiration_checking = false;
+
+    /**
      * If the kerberos HDFS client is alive beyond this time,
      * client checker will destroy it to avoid kerberos token expire.
      * Set this value a little smaller than the actual token expire seconds,

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/ClientContextManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/ClientContextManager.java
@@ -41,7 +41,9 @@ public class ClientContextManager {
         clientContexts = new ConcurrentHashMap<>();
         fdToClientMap = new ConcurrentHashMap<>();
         this.executorService = executorService;
-        this.executorService.schedule(new CheckClientExpirationTask(), 0, TimeUnit.SECONDS);
+        if (!BrokerConfig.disable_broker_client_expiration_checking) {
+            this.executorService.schedule(new CheckClientExpirationTask(), 0, TimeUnit.SECONDS);
+        }
     }
     
     public void onPing(String clientId) {


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16647

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In some case, broker may hung when closing oss file, this will lead to all following open/write request stuck. Here we disable the check_client_expiration_task temporarily, after oss bug is fixed, we can turn on the flag again.

Jstack: 
![image](https://user-images.githubusercontent.com/31178013/212648070-c57e542c-442c-46c7-b2fe-e5311e7d1dd5.png)
![image](https://user-images.githubusercontent.com/31178013/212648090-f7eb02ed-f86e-4d61-9810-a20c2d23b9ee.png)

This problem may be introduced by #15606

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
- [x] 2.5
- [ ] 2.4
- [ ] 2.3
- [ ] 2.2
