### PR TITLE
[BugFix][cherry-pick][branch-2.4] BE crash when ingesting data from nested array to json

### DIFF
--- a/be/src/exec/vectorized/arrow_to_json_converter.cpp
+++ b/be/src/exec/vectorized/arrow_to_json_converter.cpp
@@ -19,10 +19,14 @@ using namespace arrow;
 using ArrowStatus = Status;
 
 // Convert multi-row Array to JsonColumn
-static Status convert_multi_arrow_list(const ListArray* array, JsonColumn* output);
-static Status convert_multi_arrow_struct(const StructArray* array, JsonColumn* output);
-static Status convert_multi_arrow_map(const MapArray* array, JsonColumn* output);
-static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* output);
+static Status convert_multi_arrow_list(const ListArray* array, JsonColumn* output, size_t array_start_idx,
+                                       size_t num_elements);
+static Status convert_multi_arrow_struct(const StructArray* array, JsonColumn* output, size_t array_start_idx,
+                                         size_t num_elements);
+static Status convert_multi_arrow_map(const MapArray* array, JsonColumn* output, size_t array_start_idx,
+                                      size_t num_elements);
+static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* output, size_t array_start_idx,
+                                            size_t num_elements);
 
 // Convert a single row in Array to json
 static Status convert_single_arrow_list(const ListArray* array, int offset, vpack::Builder* builder);
@@ -63,8 +67,9 @@ static enable_if_number<TypeClass, Status> convert_arrow_to_json_array(const Num
     M(Type::FLOAT)               \
     M(Type::DOUBLE)
 
-static Status convert_multi_arrow_list(const ListArray* array, JsonColumn* output) {
-    for (int i = 0; i < array->length(); i++) {
+static Status convert_multi_arrow_list(const ListArray* array, JsonColumn* output, size_t array_start_idx,
+                                       size_t num_elements) {
+    for (int i = array_start_idx; i < array_start_idx + num_elements; i++) {
         vpack::Builder builder;
         RETURN_IF_ERROR(convert_single_arrow_list(array, i, &builder));
         JsonValue json(builder.slice());
@@ -73,8 +78,9 @@ static Status convert_multi_arrow_list(const ListArray* array, JsonColumn* outpu
     return Status::OK();
 }
 
-static Status convert_multi_arrow_struct(const StructArray* array, JsonColumn* output) {
-    for (int i = 0; i < array->length(); i++) {
+static Status convert_multi_arrow_struct(const StructArray* array, JsonColumn* output, size_t array_start_idx,
+                                         size_t num_elements) {
+    for (int i = array_start_idx; i < array_start_idx + num_elements; i++) {
         vpack::Builder builder;
         RETURN_IF_ERROR(convert_single_arrow_struct(array, i, &builder));
         JsonValue json(builder.slice());
@@ -83,8 +89,9 @@ static Status convert_multi_arrow_struct(const StructArray* array, JsonColumn* o
     return Status::OK();
 }
 
-static Status convert_multi_arrow_map(const MapArray* array, JsonColumn* output) {
-    for (int i = 0; i < array->length(); i++) {
+static Status convert_multi_arrow_map(const MapArray* array, JsonColumn* output, size_t array_start_idx,
+                                      size_t num_elements) {
+    for (int i = array_start_idx; i < array_start_idx + num_elements; i++) {
         vpack::Builder builder;
         RETURN_IF_ERROR(convert_single_arrow_map(array, i, &builder));
         JsonValue json(builder.slice());
@@ -93,28 +100,29 @@ static Status convert_multi_arrow_map(const MapArray* array, JsonColumn* output)
     return Status::OK();
 }
 
-static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* output) {
+static Status convert_multi_arrow_primitive(const Array* array, JsonColumn* output, size_t array_start_idx,
+                                            size_t num_elements) {
     auto type_id = array->type_id();
 
-#define M(type)                                                                \
-    case type: {                                                               \
-        using TypeClass = TypeIdTraits<type>::Type;                            \
-        using ArrayType = TypeTraits<TypeClass>::ArrayType;                    \
-        auto real_array = down_cast<const ArrayType*>(array);                  \
-        for (int i = 0; i < array->length(); i++) {                            \
-            vpack::Builder builder;                                            \
-            if (arrow::is_signed_integer(type)) {                              \
-                JsonValue json = JsonValue::from_int(real_array->Value(i));    \
-                output->append(std::move(json));                               \
-            } else if (arrow::is_unsigned_integer(type)) {                     \
-                JsonValue json = JsonValue::from_uint(real_array->Value(i));   \
-                output->append(std::move(json));                               \
-            } else if (is_floating(type)) {                                    \
-                JsonValue json = JsonValue::from_double(real_array->Value(i)); \
-                output->append(std::move(json));                               \
-            }                                                                  \
-        }                                                                      \
-        break;                                                                 \
+#define M(type)                                                                  \
+    case type: {                                                                 \
+        using TypeClass = TypeIdTraits<type>::Type;                              \
+        using ArrayType = TypeTraits<TypeClass>::ArrayType;                      \
+        auto real_array = down_cast<const ArrayType*>(array);                    \
+        for (int i = array_start_idx; i < array_start_idx + num_elements; i++) { \
+            vpack::Builder builder;                                              \
+            if (arrow::is_signed_integer(type)) {                                \
+                JsonValue json = JsonValue::from_int(real_array->Value(i));      \
+                output->append(std::move(json));                                 \
+            } else if (arrow::is_unsigned_integer(type)) {                       \
+                JsonValue json = JsonValue::from_uint(real_array->Value(i));     \
+                output->append(std::move(json));                                 \
+            } else if (is_floating(type)) {                                      \
+                JsonValue json = JsonValue::from_double(real_array->Value(i));   \
+                output->append(std::move(json));                                 \
+            }                                                                    \
+        }                                                                        \
+        break;                                                                   \
     }
 
     switch (type_id) {
@@ -308,22 +316,22 @@ static Status convert_arrow_to_json_array(const BooleanArray* array, vpack::Buil
 
 // Convert array to a json column
 // Support all arrow types, including primitive types and nested data types
-Status convert_arrow_to_json(const Array* array, JsonColumn* output) {
+Status convert_arrow_to_json(const Array* array, JsonColumn* output, size_t array_start_idx, size_t num_elements) {
     // std::cerr << "convert_arrow_to_json: " << array->type()->ToString() << std::endl;
     auto type = array->type_id();
     switch (type) {
     case Type::LIST:
-        return convert_multi_arrow_list(down_cast<const ListArray*>(array), output);
+        return convert_multi_arrow_list(down_cast<const ListArray*>(array), output, array_start_idx, num_elements);
     case Type::STRUCT:
-        return convert_multi_arrow_struct(down_cast<const StructArray*>(array), output);
+        return convert_multi_arrow_struct(down_cast<const StructArray*>(array), output, array_start_idx, num_elements);
     case Type::MAP:
-        return convert_multi_arrow_map(down_cast<const MapArray*>(array), output);
+        return convert_multi_arrow_map(down_cast<const MapArray*>(array), output, array_start_idx, num_elements);
 
     case Type::STRING:
     case Type::BOOL:
 #define M(type) \
     case type:  \
-        return convert_multi_arrow_primitive(array, output);
+        return convert_multi_arrow_primitive(array, output, array_start_idx, num_elements);
 
         APPLY_FOR_ALL_NUMERIC(M)
 #undef M

--- a/be/src/exec/vectorized/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/vectorized/arrow_to_starrocks_converter.cpp
@@ -655,7 +655,8 @@ struct ArrowConverter<AT, PT, is_nullable, is_strict, DateOrDateTimeATGuard<AT>,
 };
 
 // Convert nested arrow type(Map,List,Struct...) to Json
-Status convert_arrow_to_json(const arrow::Array* array, JsonColumn* output);
+Status convert_arrow_to_json(const arrow::Array* array, JsonColumn* output, size_t array_start_idx,
+                             size_t num_elements);
 
 template <ArrowTypeId AT, PrimitiveType PT, bool is_nullable, bool is_strict>
 struct ArrowConverter<AT, PT, is_nullable, is_strict, JsonGuard<PT>> {
@@ -665,7 +666,7 @@ struct ArrowConverter<AT, PT, is_nullable, is_strict, JsonGuard<PT>> {
         auto* json_column = down_cast<JsonColumn*>(column);
         json_column->reserve(column->size() + num_elements);
 
-        return convert_arrow_to_json(array, json_column);
+        return convert_arrow_to_json(array, json_column, array_start_idx, num_elements);
     }
 };
 


### PR DESCRIPTION
Signed-off-by: xyz <a997647204@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16375

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In each iteration, convert_array_to_column of ParquetScanner will read 4096 rows, however, convert_arrow_to_json will read all rowss from array, if parquet's row length is larger than 4096, BE will crash. Crash Reason: for nullable arraycolumn, nullable column is 4096 row and data column is larger than 4096 rows, size check will fail.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [] I have checked the version labels which the pr will be auto backported to target branch
  - [] 2.5
  - [] 2.4
  - [ ] 2.3
  - [ ] 2.2
