### PR TITLE
[BugFix][cherry-pick] Fix the thrift library conflict in some cases by linking the required cachelib dependencies statically

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -144,9 +144,9 @@ set(BOOST_ROOT ${THIRDPARTY_DIR})
 set(Boost_NO_WARN_NEW_VERSIONS ON)
 
 if (NOT APPLE)
-    find_package(Boost 1.75.0 REQUIRED COMPONENTS thread regex program_options)
+    find_package(Boost 1.75.0 REQUIRED COMPONENTS thread regex program_options filesystem context)
 else()
-    find_package(Boost 1.75.0 COMPONENTS thread regex program_options)
+    find_package(Boost 1.75.0 COMPONENTS thread regex program_options filesystem context)
 endif()
 include_directories(${Boost_INCLUDE_DIRS})
 message(STATUS ${Boost_LIBRARIES})
@@ -154,14 +154,9 @@ message(STATUS ${Boost_LIBRARIES})
 set(GPERFTOOLS_HOME "${THIRDPARTY_DIR}/gperftools")
 
 # Set all libraries
-if (${WITH_BLOCK_CACHE} STREQUAL "ON")
-    set(CACHELIB_DIR "$ENV{CACHELIB_DIR}")
-    add_library(gflags STATIC IMPORTED)
-    set_target_properties(gflags PROPERTIES IMPORTED_LOCATION ${CACHELIB_DIR}/lib/libgflags_debug.a)
-else()
-    add_library(gflags STATIC IMPORTED)
-    set_target_properties(gflags PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libgflags.a)
-endif()
+
+add_library(gflags STATIC IMPORTED)
+set_target_properties(gflags PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libgflags.a)
 
 add_library(glog STATIC IMPORTED)
 set_target_properties(glog PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libglog.a)
@@ -329,6 +324,45 @@ set_target_properties(opentelemetry_resources PROPERTIES IMPORTED_LOCATION ${THI
 
 add_library(opentelemetry_exporter_jaeger_trace STATIC IMPORTED GLOBAL)
 set_target_properties(opentelemetry_exporter_jaeger_trace PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libopentelemetry_exporter_jaeger_trace.a)
+
+# cachelib
+set(CACHELIB_DEPENDENCIES
+    cachelib_common
+    cachelib_allocator
+    cachelib_datatype
+    cachelib_navy
+    cachelib_shm
+    folly
+    fmtd
+    thriftcpp2
+    thrift-core
+    thriftmetadata
+    thriftfrozen2
+    thriftprotocol
+    thrifttype
+    transport
+    rpcmetadata
+    thriftanyrep
+    thrifttyperep
+    thriftannotation
+    concurrency
+    async
+    wangle
+)
+
+if (${WITH_BLOCK_CACHE} STREQUAL "ON")
+    LINK_LIBRARIES(${THIRDPARTY_DIR}/cachelib/deps/lib64/libunwind.so)
+    LINK_LIBRARIES(${THIRDPARTY_DIR}/cachelib/deps/lib64/liblzma.so)
+    foreach(dep ${CACHELIB_DEPENDENCIES})
+        add_library(${dep} STATIC IMPORTED)
+        set(location "${THIRDPARTY_DIR}/cachelib/lib/lib${dep}.a")
+        if(NOT EXISTS ${location})
+            set(location "${THIRDPARTY_DIR}/cachelib/lib64/lib${dep}.a")
+        endif()
+        set_target_properties(${dep} PROPERTIES IMPORTED_LOCATION "${location}")
+        message(STATUS "add cachelib dependency: ${location}")
+    endforeach()
+endif()
 
 if ("${USE_STAROS}" STREQUAL "ON")
      find_package(protobuf CONFIG REQUIRED)
@@ -654,6 +688,16 @@ set(STARROCKS_DEPENDENCIES
     opentelemetry_exporter_jaeger_trace
     ${WL_END_GROUP}
 )
+
+if (${WITH_BLOCK_CACHE} STREQUAL "ON")
+    set(STARROCKS_DEPENDENCIES
+        ${STARROCKS_DEPENDENCIES}
+        ${WL_START_GROUP}
+        ${Boost_LIBRARIES}
+        ${CACHELIB_DEPENDENCIES}
+        ${WL_END_GROUP}
+    )
+endif()
 
 if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86_64")
     set(STARROCKS_DEPENDENCIES

--- a/be/src/block_cache/CMakeLists.txt
+++ b/be/src/block_cache/CMakeLists.txt
@@ -15,32 +15,8 @@ add_library(BlockCache STATIC
     ${CACHE_FILES}
 )
 
-set(CACHELIB_DIR "$ENV{CACHELIB_DIR}")
-message(STATUS "cachelib dir: ${CACHELIB_DIR}")
-
-add_library(Glog STATIC IMPORTED)
-set_target_properties(Glog PROPERTIES IMPORTED_LOCATION ${CACHELIB_DIR}/lib64/libglogd.a)
-LINK_LIBRARIES(${CACHELIB_DIR}/lib64/libfmtd.so)
-
+set(CACHELIB_DIR ${THIRDPARTY_DIR}/cachelib)
 link_directories(${CACHELIB_DIR}/deps/lib64)
 
-list(INSERT CMAKE_PREFIX_PATH 0 ${CACHELIB_DIR}/lib/cmake)
-list(INSERT CMAKE_PREFIX_PATH 0 ${CACHELIB_DIR}/lib64/cmake)
-list(INSERT CMAKE_PREFIX_PATH 0 ${CACHELIB_DIR}/cmake)
-message(STATUS "cmake prefix path: ${CMAKE_PREFIX_PATH}")
-
-set(CMAKE_MODULE_PATH ${CMAKE_PREFIX_PATH})
-message(STATUS "cmake module path: ${CMAKE_MODULE_PATH}")
-
-#find_package(gflags CONFIG nothreads_static)
-#target_link_libraries(BlockCache gflags::gflags)
-
-find_package(cachelib CONFIG REQUIRED PATHS /tmp/cachelib/deps)
-
-set(CACHELIB_INCLUDE_DIR ${CACHELIB_DIR}/include)
-include_directories(BEFORE ${CACHELIB_INCLUDE_DIR})
-include_directories(BEFORE ${CACHELIB_DIR}/deps/include)
-message(STATUS "cachelib include path: ${CACHELIB_INCLUDE_DIR}")
-
-target_link_libraries(BlockCache cachelib)
-#target_link_options(BlockCache PUBLIC "LINKER:--copy-dt-needed-entries")
+include_directories(AFTER ${CACHELIB_DIR}/include)
+include_directories(AFTER ${CACHELIB_DIR}/deps/include)

--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -10,8 +10,7 @@ namespace starrocks {
 
 Status FbCacheLib::init(const CacheOptions& options) {
     Cache::Config config;
-    config.setCacheSize(options.mem_space_size).setCacheName("default cache").setAccessConfig({25, 10});
-    config.enableCachePersistence(options.meta_path).validate();
+    config.setCacheSize(options.mem_space_size).setCacheName("default cache").setAccessConfig({25, 10}).validate();
 
     std::vector<std::string> nvm_files;
     if (!options.disk_spaces.empty()) {
@@ -31,26 +30,8 @@ Status FbCacheLib::init(const CacheOptions& options) {
         config.enableNvmCache(nvmConfig);
     }
 
-    try {
-        _cache = std::make_unique<Cache>(Cache::SharedMemAttach, config);
-        LOG(INFO) << "block cache is restored successfully";
-    } catch (const std::exception& e) {
-        // Attaching failed. Create a new one but make sure that
-        // the old cache is destroyed before creating a new one.
-        // This allows us to release any held resources (such as
-        // open file descriptors and associated fcntl locks).
-        _cache.reset();
-        LOG(INFO) << "couldn't attach to block cache: " << e.what() << ", creating a new one";
-
-        // Clean meta and data files
-        nvm_files.emplace_back(options.meta_path + "/metadata");
-        nvm_files.emplace_back(options.meta_path + "/NvmCacheState");
-        FileSystemUtil::remove_paths(nvm_files);
-
-        _cache = std::make_unique<Cache>(Cache::SharedMemNew, config);
-        _default_pool = _cache->addPool("default pool", _cache->getCacheMemoryStats().cacheSize);
-    }
-
+    _cache = std::make_unique<Cache>(config);
+    _default_pool = _cache->addPool("default pool", _cache->getCacheMemoryStats().cacheSize);
     return Status::OK();
 }
 

--- a/be/src/block_cache/fb_cachelib.h
+++ b/be/src/block_cache/fb_cachelib.h
@@ -2,6 +2,18 @@
 
 #pragma once
 
+// The following macros only used to avoid some variable and function conflicts
+// caused by cachelib and related dependencies, and these macros will be removed
+// once the cachelib be deprecated.
+
+#ifndef MAP_HUGE_SHIFT
+#define MAP_HUGE_SHIFT 0
+#endif
+
+#ifndef JEMALLOC_NO_RENAME
+#define JEMALLOC_NO_RENAME 1
+#endif
+
 #include <cachelib/allocator/CacheAllocator.h>
 
 #include "block_cache/kv_cache.h"

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -157,5 +157,5 @@ export_shared_envvars() {
 # Export cachelib libraries
 export_cachelib_lib_path() {
     CACHELIB_DIR=$STARROCKS_HOME/lib/cachelib
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CACHELIB_DIR/lib:$CACHELIB_DIR/lib64:$CACHELIB_DIR/deps/lib:$CACHELIB_DIR/deps/lib64
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CACHELIB_DIR/lib64
 }

--- a/bin/meta_tool.sh
+++ b/bin/meta_tool.sh
@@ -6,5 +6,6 @@ curdir=`cd "$curdir"; pwd`
 export STARROCKS_HOME=`cd "$curdir/.."; pwd`
 export LD_LIBRARY_PATH=$STARROCKS_HOME/lib/jvm/amd64/server:$STARROCKS_HOME/lib/jvm/amd64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$STARROCKS_HOME/lib/hadoop/native:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$STARROCKS_HOME/lib/cachelib/lib64
 
 ${STARROCKS_HOME}/lib/starrocks_be meta_tool "$@"

--- a/build.sh
+++ b/build.sh
@@ -376,11 +376,8 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_THIRDPARTY}/installed/hadoop/lib/native ${STARROCKS_OUTPUT}/be/lib/hadoop/
 
     if [ "${WITH_BLOCK_CACHE}" == "ON"  ]; then
-        mkdir -p ${STARROCKS_OUTPUT}/be/lib/cachelib/deps
-        cp -r -p ${CACHELIB_DIR}/lib ${STARROCKS_OUTPUT}/be/lib/cachelib/
-        cp -r -p ${CACHELIB_DIR}/lib64 ${STARROCKS_OUTPUT}/be/lib/cachelib/
-        cp -r -p ${CACHELIB_DIR}/deps/lib ${STARROCKS_OUTPUT}/be/lib/cachelib/deps/
-        cp -r -p ${CACHELIB_DIR}/deps/lib64 ${STARROCKS_OUTPUT}/be/lib/cachelib/deps/
+        mkdir -p ${STARROCKS_OUTPUT}/be/lib/cachelib
+        cp -r -p ${CACHELIB_DIR}/deps/lib64 ${STARROCKS_OUTPUT}/be/lib/cachelib/
     fi
 
     # note: do not use oracle jdk to avoid commercial dispute

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -327,10 +327,10 @@ FAST_FLOAT_SOURCE="fast-float-3.5.1"
 FAST_FLOAT_MD5SUM="adb3789b99f47e0cd971b4d90727d4d0"
 
 # cachelib
-CACHELIB_DOWNLOAD="https://cdn-thirdparty.starrocks.com/cachelib/cachelib-20221213.tar.gz"
+CACHELIB_DOWNLOAD="https://cdn-thirdparty.starrocks.com/cachelib/cachelib-20230117.tar.gz"
 CACHELIB_NAME="cachelib.tar.gz"
 CACHELIB_SOURCE="cachelib"
-CACHELIB_MD5SUM="0741b8a9b0bd41f3b5798ca08e34bb61"
+CACHELIB_MD5SUM="9ed7137220d25b6c591966fdcb03208e"
 
 # streamvbyte
 STREAMVBYTE_DOWNLOAD="https://github.com/lemire/streamvbyte/archive/refs/tags/v0.5.1.tar.gz"


### PR DESCRIPTION


## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When linking the cachelib dynamically by find_package, all related libraries will be linked. While some of them are not required in our usage scenarios, and even lead to dependency conflicts in some environments.

So, we choose to only link the required cachelib dependencies statically to avoid unnecessary conflicts. Also, with this change, it is no need to package lots of dynamic libraries in our be output.

(cherry-pick from #16674)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
