### PR TITLE
[Refactor] Add a configure to enable and disable auto creating tablet

### DIFF
--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1402,7 +1402,9 @@ TEST_F(FileReaderTest, TestReadStructAbsentSubField) {
     c2.field_names.emplace_back("not_existed");
 
     SlotDesc slot_descs[] = {
-            {"c1", c1}, {"c2", c2}, {""},
+            {"c1", c1},
+            {"c2", c2},
+            {""},
     };
     ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1993,4 +1993,10 @@ public class Config extends ConfigBase {
 
     @ConfField
     public static long binlog_max_size = Long.MAX_VALUE; // no limit
+
+    /**
+     * Enable auto create tablet when creating table and add partition
+     **/
+    @ConfField(mutable = true)
+    public static boolean enable_auto_create_tablet = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1998,5 +1998,5 @@ public class Config extends ConfigBase {
      * Enable auto create tablet when creating table and add partition
      **/
     @ConfField(mutable = true)
-    public static boolean enable_auto_create_tablet = false;
+    public static boolean enable_auto_tablet_distribution = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1048,7 +1048,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 }
             }
         } else {
-            if (defaultDistributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH) {
+            if (defaultDistributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH
+                && config.enable_auto_create_tablet) {
                 HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
                 distributionInfo = new HashDistributionInfo(0, hashDistributionInfo.getDistributionColumns());
             } else {
@@ -1335,7 +1336,7 @@ public class LocalMetastore implements ConnectorMetadata {
             // get distributionInfo
             distributionInfo = getDistributionInfo(olapTable, addPartitionClause);
 
-            if (distributionInfo.getBucketNum() == 0) {
+            if (distributionInfo.getBucketNum() == 0 || config.enable_auto_create_tablet) {
                 int numBucket = calAvgBucketNumOfRecentPartitions(olapTable, 5);
                 distributionInfo.setBucketNum(numBucket);
             }
@@ -2076,7 +2077,7 @@ public class LocalMetastore implements ConnectorMetadata {
             olapTable = new ExternalOlapTable(db.getId(), tableId, tableName, baseSchema, keysType, partitionInfo,
                     distributionInfo, indexes, properties);
         } else {
-            if (distributionInfo.getBucketNum() == 0) {
+            if (distributionInfo.getBucketNum() == 0 || config.enable_auto_create_tablet) {
                 int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
                 distributionInfo.setBucketNum(bucketNum);
             }
@@ -3285,7 +3286,7 @@ public class LocalMetastore implements ConnectorMetadata {
         DistributionDesc distributionDesc = stmt.getDistributionDesc();
         Preconditions.checkNotNull(distributionDesc);
         DistributionInfo distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
-        if (distributionInfo.getBucketNum() == 0) {
+        if (distributionInfo.getBucketNum() == 0 || config.enable_auto_create_tablet) {
             int numBucket = CatalogUtils.calBucketNumAccordingToBackends();
             distributionInfo.setBucketNum(numBucket);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1049,7 +1049,7 @@ public class LocalMetastore implements ConnectorMetadata {
             }
         } else {
             if (defaultDistributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH
-                && config.enable_auto_tablet_distribution) {
+                    && Config.enable_auto_tablet_distribution) {
                 HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
                 distributionInfo = new HashDistributionInfo(0, hashDistributionInfo.getDistributionColumns());
             } else {
@@ -1336,7 +1336,7 @@ public class LocalMetastore implements ConnectorMetadata {
             // get distributionInfo
             distributionInfo = getDistributionInfo(olapTable, addPartitionClause);
 
-            if (distributionInfo.getBucketNum() == 0 || config.enable_auto_tablet_distribution) {
+            if (distributionInfo.getBucketNum() == 0 || Config.enable_auto_tablet_distribution) {
                 int numBucket = calAvgBucketNumOfRecentPartitions(olapTable, 5);
                 distributionInfo.setBucketNum(numBucket);
             }
@@ -2077,7 +2077,7 @@ public class LocalMetastore implements ConnectorMetadata {
             olapTable = new ExternalOlapTable(db.getId(), tableId, tableName, baseSchema, keysType, partitionInfo,
                     distributionInfo, indexes, properties);
         } else {
-            if (distributionInfo.getBucketNum() == 0 || config.enable_auto_tablet_distribution) {
+            if (distributionInfo.getBucketNum() == 0 || Config.enable_auto_tablet_distribution) {
                 int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
                 distributionInfo.setBucketNum(bucketNum);
             }
@@ -3286,7 +3286,7 @@ public class LocalMetastore implements ConnectorMetadata {
         DistributionDesc distributionDesc = stmt.getDistributionDesc();
         Preconditions.checkNotNull(distributionDesc);
         DistributionInfo distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
-        if (distributionInfo.getBucketNum() == 0 || config.enable_auto_tablet_distribution) {
+        if (distributionInfo.getBucketNum() == 0 || Config.enable_auto_tablet_distribution) {
             int numBucket = CatalogUtils.calBucketNumAccordingToBackends();
             distributionInfo.setBucketNum(numBucket);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1049,7 +1049,7 @@ public class LocalMetastore implements ConnectorMetadata {
             }
         } else {
             if (defaultDistributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH
-                && config.enable_auto_create_tablet) {
+                && config.enable_auto_tablet_distribution) {
                 HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
                 distributionInfo = new HashDistributionInfo(0, hashDistributionInfo.getDistributionColumns());
             } else {
@@ -1336,7 +1336,7 @@ public class LocalMetastore implements ConnectorMetadata {
             // get distributionInfo
             distributionInfo = getDistributionInfo(olapTable, addPartitionClause);
 
-            if (distributionInfo.getBucketNum() == 0 || config.enable_auto_create_tablet) {
+            if (distributionInfo.getBucketNum() == 0 || config.enable_auto_tablet_distribution) {
                 int numBucket = calAvgBucketNumOfRecentPartitions(olapTable, 5);
                 distributionInfo.setBucketNum(numBucket);
             }
@@ -2077,7 +2077,7 @@ public class LocalMetastore implements ConnectorMetadata {
             olapTable = new ExternalOlapTable(db.getId(), tableId, tableName, baseSchema, keysType, partitionInfo,
                     distributionInfo, indexes, properties);
         } else {
-            if (distributionInfo.getBucketNum() == 0 || config.enable_auto_create_tablet) {
+            if (distributionInfo.getBucketNum() == 0 || config.enable_auto_tablet_distribution) {
                 int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
                 distributionInfo.setBucketNum(bucketNum);
             }
@@ -3286,7 +3286,7 @@ public class LocalMetastore implements ConnectorMetadata {
         DistributionDesc distributionDesc = stmt.getDistributionDesc();
         Preconditions.checkNotNull(distributionDesc);
         DistributionInfo distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
-        if (distributionInfo.getBucketNum() == 0 || config.enable_auto_create_tablet) {
+        if (distributionInfo.getBucketNum() == 0 || config.enable_auto_tablet_distribution) {
             int numBucket = CatalogUtils.calBucketNumAccordingToBackends();
             distributionInfo.setBucketNum(numBucket);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CTASAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CTASAutoTabletTest.java
@@ -18,6 +18,7 @@ import com.starrocks.alter.AlterJobV2Test;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.server.GlobalStateMgr;
 import org.jetbrains.annotations.TestOnly;
@@ -30,6 +31,7 @@ public class CTASAutoTabletTest {
     @BeforeClass
     public static void setUp() throws Exception {
         // set some parameters to speedup test
+        Config.enable_auto_tablet_distribution = true;
         PseudoCluster.getOrCreateWithRandomPort(true, 3);
         GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
         PseudoCluster cluster = PseudoCluster.getInstance();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -18,6 +18,7 @@ import com.starrocks.alter.AlterJobV2Test;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -32,6 +33,7 @@ public class CreateTableAutoTabletTest {
     @BeforeClass
     public static void setUp() throws Exception {
         // set some parameters to speedup test
+        Config.enable_auto_tablet_distribution = true;
         PseudoCluster.getOrCreateWithRandomPort(true, 10);
         GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
         PseudoCluster cluster = PseudoCluster.getInstance();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/MaterializedViewAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/MaterializedViewAutoTabletTest.java
@@ -18,6 +18,7 @@ import com.starrocks.alter.AlterJobV2Test;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.server.GlobalStateMgr;
 import org.jetbrains.annotations.TestOnly;
@@ -30,6 +31,7 @@ public class MaterializedViewAutoTabletTest {
     @BeforeClass
     public static void setUp() throws Exception {
         // set some parameters to speedup test
+        Config.enable_auto_tablet_distribution = true;
         PseudoCluster.getOrCreateWithRandomPort(true, 32);
         GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
         PseudoCluster cluster = PseudoCluster.getInstance();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -62,6 +62,7 @@ public class CreateTableTest {
         UtFrameUtils.addMockBackend(10003);
         UtFrameUtils.addMockBackend(10004);
         Config.enable_strict_storage_medium_check = true;
+        Config.enable_auto_tablet_distribution = true;
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         // create database


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. If the user does not specify the tablet number upon creating a table or adding a partition, we will auto-determine the tablet distribution.
2. If the table exists, the user wants to use the feature. Change the enable_auto_tablet_distribution to true.
3. If the user wants to disable the auto distribution, specify the tablet num manually after setting enable_auto_tablet_distribution to false.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
