### PR TITLE
[cherry-pick][branch-2.4][BugFix] Fix the error when getting the memory limit in cgroup v2 (#14838)

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -21,20 +21,34 @@
 
 #include "util/mem_info.h"
 
+#include <linux/magic.h>
+#include <sys/vfs.h>
+
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 
+#include "fs/fs_util.h"
 #include "gutil/strings/split.h"
+#include "util/errno.h"
 #include "util/pretty_printer.h"
 #include "util/string_parser.hpp"
 
 namespace starrocks {
 
+// CGROUP2_SUPER_MAGIC is the indication for cgroup v2
+// It is defined in kernel 4.5+
+// I copy the defintion from linux/magic.h in higher kernel
+#ifndef CGROUP2_SUPER_MAGIC
+#define CGROUP2_SUPER_MAGIC 0x63677270
+#endif
+
 bool MemInfo::_s_initialized = false;
 int64_t MemInfo::_s_physical_mem = -1;
 
 void MemInfo::init() {
+    set_memlimit_if_container();
+
     // Read from /proc/meminfo
     std::ifstream meminfo("/proc/meminfo", std::ios::in);
     std::string line;
@@ -81,6 +95,49 @@ std::string MemInfo::debug_string() {
     std::stringstream stream;
     stream << "Mem Info: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES) << std::endl;
     return stream.str();
+}
+
+void MemInfo::set_memlimit_if_container() {
+    // check if application is in docker container or not via /.dockerenv file
+    bool running_in_docker = fs::path_exist("/.dockerenv");
+    if (running_in_docker) {
+        struct statfs fs;
+        int err = statfs("/sys/fs/cgroup", &fs);
+        if (err < 0) {
+            LOG(WARNING) << "Fail to get file system statistics. err: " << errno_to_string(err);
+            return;
+        }
+
+        std::ifstream memoryLimit;
+        std::string line;
+        StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
+        if (fs.f_type == TMPFS_MAGIC) {
+            // cgroup v1
+            // Read from /sys/fs/cgroup/memory/memory.limit_in_bytes
+            memoryLimit.open("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+            getline(memoryLimit, line);
+            _s_physical_mem = StringParser::string_to_int<int64_t>(line.data(), line.size(), &result);
+        } else if (fs.f_type == CGROUP2_SUPER_MAGIC) {
+            // cgroup v2
+            // Read from /sys/fs/cgroup/memory/memory.max
+            memoryLimit.open("/sys/fs/cgroup/memory.max");
+            getline(memoryLimit, line);
+
+            if (line == "max") {
+                _s_physical_mem = std::numeric_limits<int64_t>::max();
+            } else {
+                _s_physical_mem = StringParser::string_to_int<int64_t>(line.data(), line.size(), &result);
+            }
+        }
+
+        if (result != StringParser::PARSE_SUCCESS) {
+            _s_physical_mem = std::numeric_limits<int64_t>::max();
+        }
+
+        if (memoryLimit.is_open()) {
+            memoryLimit.close();
+        }
+    }
 }
 
 } // namespace starrocks

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -45,6 +45,8 @@ public:
     static std::string debug_string();
 
 private:
+    static void set_memlimit_if_container();
+
     static bool _s_initialized;
     static int64_t _s_physical_mem;
 };

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -80,7 +80,7 @@ export_mem_limit_from_conf() {
         return 1
     fi
 
-    if [[ (-v mem_limit) && ($mem_limit -le $mem_total) ]]; then
+    if [[ (-v mem_limit) && ("$mem_limit" != "max") && ($mem_limit -le $mem_total) ]]; then
       mem_total=$mem_limit
     fi
 


### PR DESCRIPTION
Cgroup V1 in Centos7 store memory limit in `/sys/fs/cgroup/memory/memory.limit_in_bytes` Cgroup V2 in Ubuntu 22 store memory limit in `/sys/fs/cgroup/memory.max`

StarRocks encountered an error when running in docker installed Ubuntu 22.
```
cat: /sys/fs/cgroup/memory/memory.limit_in_bytes: No such file or directory
can't get mem info from /sys/fs/cgroup/memory/memory.limit_in_bytes
There is not /sys/fs/cgroup/memory/memory.limit_in_bytes file for a centos-7 base docker container.
E.g, running this command in a centos-7 based docker container got this error.
```

This pull request figures out a solution by checking the version of Cgroup. According to the Cgroup, the memory limit will be automatically parsed.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13584

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
