### PR TITLE
[BugFix] fixup one-phase aggregation fails to use query cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -302,20 +302,11 @@ public class FragmentNormalizer {
                 return false;
             }
             TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
-            //TSerializer serializer1 = new TSerializer(new TJSONProtocol.Factory());
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            //MessageDigest digest2 = MessageDigest.getInstance("SHA-256");
 
             for (TNormalPlanNode node : normalizedPlanNodes) {
                 byte[] data = serializer.serialize(node);
                 digest.update(data);
-                /*
-                String s = new String(serializer1.serialize(node));
-                digest2.update(data);
-                System.out.println(String.format("%d.%s:%s,%s", node.getNode_id(), node.getNode_type().toString(),
-                        toHexString(digest2.digest()), s));
-                digest2.reset();
-                 */
             }
             List<SlotId> slotIds = cachePointNode.getOutputSlotIds(execPlan.getDescTbl());
             List<Integer> remappedSlotIds = remapSlotIds(slotIds);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -251,7 +251,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     }
 
     public void setAssignScanRangesPerDriverSeq(boolean assignScanRangesPerDriverSeq) {
-        this.assignScanRangesPerDriverSeq = assignScanRangesPerDriverSeq;
+        this.assignScanRangesPerDriverSeq |= assignScanRangesPerDriverSeq;
     }
 
     public boolean isForceAssignScanRangesPerDriverSeq() {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
These two daily cases fails:
nosetests-3.4 -s --with-xunit --xunit-file=./result/test_query_cache_one_phase_only_one_tablet_py_TestQueryCacheOnePhaseOnlyOneTablet_test_query_cache_one_phase_only_one_tablet.xml --verbose case/system_case/test_dql/test_query_cache/test_query_cache_one_phase_only_one_tablet.py:TestQueryCacheOnePhaseOnlyOneTablet.test_query_cache_one_phase_only_one_tablet --nologcapture

nosetests-3.4 -s --with-xunit --xunit-file=./result/test_query_cache_one_phase_only_one_partition_group_by_py_TestQueryCacheOnePhaseOnlyOnePartitionGroupBy_test_query_cache_one_phase_only_one_partition_group_by.xml --verbose case/system_case/test_dql/test_query_cache/test_query_cache_one_phase_only_one_partition_group_by.py:TestQueryCacheOnePhaseOnlyOnePartitionGroupBy.test_query_cache_one_phase_only_one_partition_group_by --nologcapture

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For one-phase agg, ScanRanges must be assigned to each driver sequences, FragmentNormalizer flip the flag.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
