### PR TITLE
[BugFix] Use member comparison to implement operator==

### DIFF
--- a/be/src/exec/query_cache/lane_arbiter.h
+++ b/be/src/exec/query_cache/lane_arbiter.h
@@ -49,9 +49,7 @@ public:
         // reduce the retention time of the data inside multilane operators in order to reduce summit memory usage
         int64_t assign_seqno;
         bool operator==(const LaneAssignment& rhs) const {
-            typedef __int128 int128_t;
-            static_assert(sizeof(LaneAssignment) == sizeof(int128_t));
-            return *(int128_t*)this == *(int128_t*)&rhs;
+            return lane_owner == rhs.lane_owner && assign_seqno == rhs.assign_seqno;
         }
         bool operator!=(const LaneAssignment& rhs) const { return !(*this == rhs); }
     };


### PR DESCRIPTION
* using int128_t under clang compiler, the comparison will be optimized to use `vmovdqa` instruction which requires the operand to be 16-bytes aligned. LaneAssignment doesn't have such alignment guarantee, which a runtime SEGV will happen.
* only happens using clang with O1 or higher optimazation.

Signed-off-by: Kevin Xiaohua Cai <caixiaohua@starrocks.com>

## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [X] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
