### PR TITLE
[BugFix] add MVActiveChecker for external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVActiveChecker.java
@@ -47,7 +47,6 @@ public class MVActiveChecker extends LeaderDaemon {
         List<String> dbNames = GlobalStateMgr.getCurrentState().getMetadataMgr().
                 listDbNames(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
 
-        long startMillis = System.currentTimeMillis();
         for (String dbName : dbNames) {
             Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                     dbName);
@@ -71,8 +70,5 @@ public class MVActiveChecker extends LeaderDaemon {
                 }
             }
         }
-
-        long duration = System.currentTimeMillis() - startMillis;
-        LOG.info("[MVActiveChecker] finish check all materialized view in {}ms", duration);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVActiveChecker.java
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.util.LeaderDaemon;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public class MVActiveChecker extends LeaderDaemon {
+    private static final long EXECUTOR_INTERVAL_MILLIS = 10000;
+    private static final Logger LOG = LogManager.getLogger(MVJobExecutor.class);
+
+    public MVActiveChecker() {
+        super("MV Active Checker", EXECUTOR_INTERVAL_MILLIS);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        try {
+            runImpl();
+        } catch (Throwable e) {
+            LOG.error("Failed to run the MVActiveChecker ", e);
+        }
+    }
+
+    private void runImpl() {
+        List<String> dbNames = GlobalStateMgr.getCurrentState().getMetadataMgr().
+                listDbNames(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+
+        long startMillis = System.currentTimeMillis();
+        for (String dbName : dbNames) {
+            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    dbName);
+            for (MaterializedView mv : db.getMaterializedViews()) {
+                for (MaterializedView.BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
+                    Table table = baseTableInfo.getTable();
+                    if (table == null) {
+                        LOG.warn("tableName :{} do not exist. set materialized view:{} to invalid",
+                                baseTableInfo.getTableName(), mv.getId());
+                        mv.setActive(false);
+                        continue;
+                    }
+                    if (table instanceof MaterializedView && !((MaterializedView) table).isActive()) {
+                        LOG.warn("tableName :{} is invalid. set materialized view:{} to invalid",
+                                baseTableInfo.getTableName(), mv.getId());
+                        mv.setActive(false);
+                        continue;
+                    }
+                    MvId mvId = new MvId(db.getId(), mv.getId());
+                    table.addRelatedMaterializedView(mvId);
+                }
+            }
+        }
+
+        long duration = System.currentTimeMillis() - startMillis;
+        LOG.info("[MVActiveChecker] finish check all materialized view in {}ms", duration);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -209,6 +209,7 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.mv.MVActiveChecker;
 import com.starrocks.scheduler.mv.MVJobExecutor;
 import com.starrocks.scheduler.mv.MVManager;
 import com.starrocks.sql.ast.AddPartitionClause;
@@ -428,6 +429,7 @@ public class GlobalStateMgr {
     private RoutineLoadTaskScheduler routineLoadTaskScheduler;
 
     private MVJobExecutor mvMVJobExecutor;
+    private MVActiveChecker mvActiveChecker;
 
     private SmallFileMgr smallFileMgr;
 
@@ -624,6 +626,7 @@ public class GlobalStateMgr {
         this.routineLoadScheduler = new RoutineLoadScheduler(routineLoadManager);
         this.routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadManager);
         this.mvMVJobExecutor = new MVJobExecutor();
+        this.mvActiveChecker = new MVActiveChecker();
 
         this.smallFileMgr = new SmallFileMgr();
 
@@ -1217,6 +1220,8 @@ public class GlobalStateMgr {
         // ES state store
         esRepository.start();
         starRocksRepository.start();
+        // materialized view active checker
+        mvActiveChecker.start();
 
         if (Config.enable_hms_events_incremental_sync) {
             metastoreEventsProcessor.start();


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16742 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
add MVActiveChecker for external table. external tables' metas are not persistent, 
so the check should be done every time when cache is refresh.
now it is done by async, which will be optimized later
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
