### PR TITLE
[BugFix] column names must be associated with slotIds when normalizing OlapScanNode accessing unpartitioned table(backport#16754)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -85,6 +85,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -788,34 +789,35 @@ public class OlapScanNode extends ScanNode {
         return partitions.subList(numPartitions - numHotIds, numPartitions).stream().map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
     }
-    private List<Expr> decomposeRangePredicates(FragmentNormalizer normalizer, TNormalPlanNode planNode, RangePartitionInfo rangePartitionInfo, List<Expr> conjuncts) {
-        List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
-        Set<Long> selectedPartIdSet = new HashSet<>(selectedPartitionIds);
-        selectedPartIdSet.removeAll(getHotPartitionIds(rangePartitionInfo));
 
-        Column column = partitionColumns.get(0);
+    private Optional<SlotId> associateSlotIdsWithColumns(FragmentNormalizer normalizer, TNormalPlanNode planNode,
+                                                         Optional<Column> optPartitionColumn) {
         List<SlotDescriptor> slots = normalizer.getExecPlan().getDescTbl().getTupleDesc(tupleIds.get(0)).getSlots();
         List<Pair<SlotId, String>> slotIdToColNames =
                 slots.stream().map(s -> new Pair<>(s.getId(), s.getColumn().getName()))
                         .collect(Collectors.toList());
 
-        SlotId slotId = slotIdToColNames.stream()
-                .filter(s -> s.second.equalsIgnoreCase(column.getName()))
-                .findFirst().map(s -> s.first).orElse(new SlotId(-1));
-
-        // slotId.isValid means that whereClause contains no predicates involving partition columns. so the query
-        // is equivalent to the query with a superset of all the partitions, so we needs add a fake slotId that
-        // represents the partition column to the slot remapping. for an example:
-        // table t0 is partition by dt and has there partitions:
-        //  p0=[2022-01-01, 2022-01-02),
-        //  p1=[2022-01-02, 2022-01-03),
-        //  p2=[2022-01-03, 2022-01-04).
-        // Q1: select count(*) from t0 will be performed p0,p1,p2. but dt is absent from OlapScanNode.
-        // Q2: select count(*) from t0 where dt between and '2022-01-01' and '2022-01-01' should use the partial result
-        // of Q1 on p0. but Q1 and Q2 has different SlotId re-mappings, so Q2's cache key cannot match the Q1's. so
-        // we should add a fake slotId represents the partition column when we re-map slotIds.
-        if (!slotId.isValid()) {
-            slotIdToColNames.add(new Pair<>(slotId, column.getName()));
+        Optional<SlotId> optPartitionSlotId = Optional.empty();
+        if (optPartitionColumn.isPresent()) {
+            Column column = optPartitionColumn.get();
+            SlotId slotId = slotIdToColNames.stream()
+                    .filter(s -> s.second.equalsIgnoreCase(column.getName()))
+                    .findFirst().map(s -> s.first).orElse(new SlotId(-1));
+            optPartitionSlotId = Optional.of(slotId);
+            // slotId.isValid means that whereClause contains no predicates involving partition columns. so the query
+            // is equivalent to the query with a superset of all the partitions, so we needs add a fake slotId that
+            // represents the partition column to the slot remapping. for an example:
+            // table t0 is partition by dt and has there partitions:
+            //  p0=[2022-01-01, 2022-01-02),
+            //  p1=[2022-01-02, 2022-01-03),
+            //  p2=[2022-01-03, 2022-01-04).
+            // Q1: select count(*) from t0 will be performed p0,p1,p2. but dt is absent from OlapScanNode.
+            // Q2: select count(*) from t0 where dt between and '2022-01-01' and '2022-01-01' should use the partial result
+            // of Q1 on p0. but Q1 and Q2 has different SlotId re-mappings, so Q2's cache key cannot match the Q1's. so
+            // we should add a fake slotId represents the partition column when we re-map slotIds.
+            if (!slotId.isValid()) {
+                slotIdToColNames.add(new Pair<>(slotId, column.getName()));
+            }
         }
         slotIdToColNames.sort(Pair.comparingBySecond());
         List<SlotId> slotIds = slotIdToColNames.stream().map(s -> s.first).collect(Collectors.toList());
@@ -824,13 +826,24 @@ public class OlapScanNode extends ScanNode {
         planNode.olap_scan_node.setRemapped_slot_ids(remappedSlotIds);
         planNode.olap_scan_node.setSelected_column(
                 slotIdToColNames.stream().map(c -> c.second).collect(Collectors.toList()));
+        return optPartitionSlotId;
+    }
 
+    private List<Expr> decomposeRangePredicates(FragmentNormalizer normalizer, TNormalPlanNode planNode,
+                                                RangePartitionInfo rangePartitionInfo, List<Expr> conjuncts) {
+        List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
+        Set<Long> selectedPartIdSet = new HashSet<>(selectedPartitionIds);
+        selectedPartIdSet.removeAll(getHotPartitionIds(rangePartitionInfo));
+
+        Column column = partitionColumns.get(0);
+        Optional<SlotId> optSlotId = associateSlotIdsWithColumns(normalizer, planNode, Optional.of(column));
         List<Map.Entry<Long, Range<PartitionKey>>> rangeMap = Lists.newArrayList();
         try {
             rangeMap = rangePartitionInfo.getSortedRangeMap(selectedPartIdSet);
         } catch (AnalysisException ignored) {
         }
-        return normalizer.getPartitionRangePredicates(conjuncts, rangeMap, rangePartitionInfo, slotId);
+        Preconditions.checkState(optSlotId.isPresent());
+        return normalizer.getPartitionRangePredicates(conjuncts, rangeMap, rangePartitionInfo, optSlotId.get());
     }
 
     @Override
@@ -845,6 +858,7 @@ public class OlapScanNode extends ScanNode {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
             conjuncts = decomposeRangePredicates(normalizer, planNode, rangePartitionInfo, conjuncts);
         } else {
+            associateSlotIdsWithColumns(normalizer, planNode, Optional.empty());
             normalizer.createSimpleRangeMap(getSelectedPartitionIds());
         }
         planNode.setConjuncts(normalizer.normalizeExprs(conjuncts));


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For aggregation queres on unpartitioned or multicolumn-partitioned table, when generating digest components of cache key,  the same digest is produced for different queries. for an exanmple:
```
-- create unpartitioned table
CREATE TABLE if not exists t9(
REGION_CODE VARCHAR NOT NULL,
REGION_NAME VARCHAR NOT NULL,
v1 INT NOT NULL,
v2 DECIMAL(7,2) NOT NULL
) ENGINE=OLAP
PRIMARY KEY(`REGION_CODE`, `REGION_NAME`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`REGION_CODE`, `REGION_NAME`) BUCKETS 10
PROPERTIES(
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "default"
);

-- Q1
select REGION_CODE, percentile_cont(v1, 0.5) from t9 group by 1;
-- Q2
select REGION_NAME, percentile_cont(v1, 0.5) from t9 group by 1;
```
Q1 and Q2 use different columns as group-by columns, so they should generated different digest, but when normalizing OlapScanNode during calculating digests, the slotIds of columns  are not associated with its column names mistakenly. different columns can have the same slotId in the structural-similar queries (like Q1 and Q2), if we only use slotIds and ignored the column names underlying these slotIds, the semantic-inequivalent queries will generated the same digest unexpectedly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
