### PR TITLE
[Enhancement] Optimize csv scanner and byte buffer

### DIFF
--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -245,7 +245,6 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
     const int capacity = _state->chunk_size();
     DCHECK_EQ(0, chunk->num_rows());
     Status status;
-    CSVRow row;
 
     int num_columns = chunk->num_columns();
     _column_raw_ptrs.resize(num_columns);
@@ -325,6 +324,7 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
             break;
         }
     }
+    row.columns.clear();
     return chunk->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");
 }
 
@@ -333,7 +333,6 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
     DCHECK_EQ(0, chunk->num_rows());
     Status status;
     CSVReader::Record record;
-    CSVReader::Fields fields;
 
     int num_columns = chunk->num_columns();
     _column_raw_ptrs.resize(num_columns);
@@ -397,6 +396,7 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
         }
         num_rows += !has_error;
     }
+    fields.clear();
     return chunk->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");
 }
 

--- a/be/src/exec/csv_scanner.h
+++ b/be/src/exec/csv_scanner.h
@@ -80,6 +80,8 @@ private:
     CSVReaderPtr _curr_reader;
     std::vector<ConverterPtr> _converters;
     bool _use_v2;
+    CSVReader::Fields fields;
+    CSVRow row;
 };
 
 } // namespace starrocks

--- a/be/src/util/byte_buffer.h
+++ b/be/src/util/byte_buffer.h
@@ -39,6 +39,7 @@
 #include <memory>
 
 #include "common/logging.h"
+#include "gutil/strings/fastmem.h"
 
 namespace starrocks {
 
@@ -54,12 +55,12 @@ struct ByteBuffer {
     ~ByteBuffer() { delete[] ptr; }
 
     void put_bytes(const char* data, size_t size) {
-        memcpy(ptr + pos, data, size);
+        strings::memcpy_inlined(ptr + pos, data, size);
         pos += size;
     }
 
     void get_bytes(char* data, size_t size) {
-        memcpy(data, ptr + pos, size);
+        strings::memcpy_inlined(data, ptr + pos, size);
         pos += size;
         DCHECK(pos <= limit);
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16771

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Memcpy is used very frequently in bytebuffer,
the performance of strings::memcpy_inlined is better than memcpy,
we replace the old memcpy to new memcpy.
  
In my test, clickbench stream load improve from 8m55s to 8m31s. 

Besides, CSVReader::Fields fields, CSVRow row is frequently reused in csv scanner, 
we can maintain them in CSVScanner class. Thus reduce the cost to create a new vector and resize it if 
there are a lot of columns.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
- [ ] 2.5
- [ ] 2.4
- [ ] 2.3
- [ ] 2.2
