### PR TITLE
[BugFix] correct errors of NOT(EQ_FOR_NULL) expr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1173,7 +1173,7 @@ abstract public class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
                 // otherwise we may recurse infinitely.
                 Method m = root.getChild(0).getClass().getDeclaredMethod(NEGATE_FN);
                 return pushNegationToOperands(root.getChild(0).negate());
-            } catch (NoSuchMethodException e) {
+            } catch (NoSuchMethodException|IllegalStateException e) {
                 // The 'negate' function is not implemented. Break the recursion.
                 return root;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -42,7 +42,6 @@ public class BinaryPredicateOperator extends PredicateOperator {
                     .put(BinaryType.LT, BinaryType.GE)
                     .put(BinaryType.GE, BinaryType.LT)
                     .put(BinaryType.GT, BinaryType.LE)
-                    .put(BinaryType.EQ_FOR_NULL, BinaryType.NE)
                     .build();
 
     private final BinaryType type;
@@ -134,7 +133,11 @@ public class BinaryPredicateOperator extends PredicateOperator {
     }
 
     public BinaryPredicateOperator negative() {
-        return new BinaryPredicateOperator(BINARY_NEGATIVE_MAP.get(this.getBinaryType()), this.getChildren());
+        if (BINARY_NEGATIVE_MAP.containsKey(this.getBinaryType())) {
+            return new BinaryPredicateOperator(BINARY_NEGATIVE_MAP.get(this.getBinaryType()), this.getChildren());
+        } else {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/StarRocks/starrocks/issues/16806

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
NOT(EQ_FOR_NULL) exprs are handled in incorrect ways. 
1. (Q1) When analyzing where clause, BinaryPredicate.negate can success convert NOT(EQ) into NE, but fails to convert NOT(EQ_FOR_NULL) predicates since NE_FOR_NULL is absent, instead FE reports error msg "Not implemented". 
2. (Q2) When SimplifiedPredicateRule tries to reduce NOT(EQ_FOR_NULL) predicates, it convert the predicate into NE mistakenly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
