### PR TITLE
[Refactor] Using Filter for duplicated Column::Filter

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -18,6 +18,7 @@
 
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
 #include "gutil/bits.h"
 #include "gutil/casts.h"
 #include "gutil/strings/fastmem.h"
@@ -279,7 +280,7 @@ MutableColumnPtr ArrayColumn::clone_empty() const {
     return create_mutable(_elements->clone_empty(), UInt32Column::create());
 }
 
-size_t ArrayColumn::filter_range(const Column::Filter& filter, size_t from, size_t to) {
+size_t ArrayColumn::filter_range(const Filter& filter, size_t from, size_t to) {
     DCHECK_EQ(size(), to);
     auto* offsets = reinterpret_cast<uint32_t*>(_offsets->mutable_raw_data());
     uint32_t elements_start = offsets[from];

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -19,6 +19,7 @@
 #include "column/column.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
 
 namespace starrocks {
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include "column/bytes.h"
+#include "column/vectorized_fwd.h"
 #include "common/logging.h"
 #include "gutil/bits.h"
 #include "gutil/casts.h"
@@ -411,7 +412,7 @@ ColumnPtr BinaryColumnBase<T>::cut(size_t start, size_t length) const {
 }
 
 template <typename T>
-size_t BinaryColumnBase<T>::filter_range(const Column::Filter& filter, size_t from, size_t to) {
+size_t BinaryColumnBase<T>::filter_range(const Filter& filter, size_t from, size_t to) {
     auto start_offset = from;
     auto result_offset = from;
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -17,6 +17,7 @@
 #include "column/bytes.h"
 #include "column/column.h"
 #include "column/datum.h"
+#include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "util/slice.h"
 
@@ -227,7 +228,7 @@ public:
     MutableColumnPtr clone_empty() const override { return BinaryColumnBase<T>::create_mutable(); }
 
     ColumnPtr cut(size_t start, size_t length) const;
-    size_t filter_range(const Column::Filter& filter, size_t start, size_t to) override;
+    size_t filter_range(const Filter& filter, size_t start, size_t to) override;
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -309,7 +309,6 @@ public:
 
     // REQUIRES: size of |filter| equals to the size of this column.
     // Removes elements that don't match the filter.
-    using Filter = Buffer<uint8_t>;
     inline size_t filter(const Filter& filter) {
         DCHECK_EQ(size(), filter.size());
         return filter_range(filter, 0, filter.size());

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -94,8 +94,7 @@ void ColumnHelper::merge_filters(const Columns& columns, Filter* __restrict filt
     }
 }
 
-void ColumnHelper::merge_two_filters(Filter* __restrict filter, const uint8_t* __restrict selected,
-                                     bool* all_zero) {
+void ColumnHelper::merge_two_filters(Filter* __restrict filter, const uint8_t* __restrict selected, bool* all_zero) {
     uint8_t* data = filter->data();
     size_t num_rows = filter->size();
     for (size_t i = 0; i < num_rows; i++) {

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -35,7 +35,7 @@ NullColumnPtr ColumnHelper::one_size_not_null_column = NullColumn::create(1, 0);
 
 NullColumnPtr ColumnHelper::one_size_null_column = NullColumn::create(1, 1);
 
-Column::Filter& ColumnHelper::merge_nullable_filter(Column* column) {
+Filter& ColumnHelper::merge_nullable_filter(Column* column) {
     if (column->is_nullable()) {
         auto* nullable_column = down_cast<NullableColumn*>(column);
         auto nulls = nullable_column->null_column_data().data();
@@ -53,7 +53,7 @@ Column::Filter& ColumnHelper::merge_nullable_filter(Column* column) {
     }
 }
 
-void ColumnHelper::merge_two_filters(const ColumnPtr& column, Column::Filter* __restrict filter, bool* all_zero) {
+void ColumnHelper::merge_two_filters(const ColumnPtr& column, Filter* __restrict filter, bool* all_zero) {
     if (column->is_nullable()) {
         auto* nullable_column = as_raw_column<NullableColumn>(column);
 
@@ -81,7 +81,7 @@ void ColumnHelper::merge_two_filters(const ColumnPtr& column, Column::Filter* __
     }
 }
 
-void ColumnHelper::merge_filters(const Columns& columns, Column::Filter* __restrict filter) {
+void ColumnHelper::merge_filters(const Columns& columns, Filter* __restrict filter) {
     DCHECK_GT(columns.size(), 0);
 
     // All filters must be the same length, there is no const filter
@@ -94,7 +94,7 @@ void ColumnHelper::merge_filters(const Columns& columns, Column::Filter* __restr
     }
 }
 
-void ColumnHelper::merge_two_filters(Column::Filter* __restrict filter, const uint8_t* __restrict selected,
+void ColumnHelper::merge_two_filters(Filter* __restrict filter, const uint8_t* __restrict selected,
                                      bool* all_zero) {
     uint8_t* data = filter->data();
     size_t num_rows = filter->size();
@@ -106,7 +106,7 @@ void ColumnHelper::merge_two_filters(Column::Filter* __restrict filter, const ui
     }
 }
 
-void ColumnHelper::or_two_filters(Column::Filter* __restrict filter, const uint8_t* __restrict selected) {
+void ColumnHelper::or_two_filters(Filter* __restrict filter, const uint8_t* __restrict selected) {
     or_two_filters(filter->size(), filter->data(), selected);
 }
 

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -27,6 +27,7 @@
 
 #include "column/const_column.h"
 #include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
 #include "gutil/bits.h"
 #include "gutil/casts.h"
 #include "gutil/cpu.h"
@@ -45,17 +46,17 @@ public:
     // The result column is not nullable uint8 column
     // For nullable uint8 column, we merge it's null column and data column
     // Used in ExecNode::eval_conjuncts
-    static Column::Filter& merge_nullable_filter(Column* column);
+    static Filter& merge_nullable_filter(Column* column);
 
     // merge column with filter, and save result to filer.
     // `all_zero` means, after merging, if there is only zero value in filter.
-    static void merge_two_filters(const ColumnPtr& column, Column::Filter* __restrict filter, bool* all_zero = nullptr);
-    static void merge_filters(const Columns& columns, Column::Filter* __restrict filter);
-    static void merge_two_filters(Column::Filter* __restrict filter, const uint8_t* __restrict selected,
+    static void merge_two_filters(const ColumnPtr& column, Filter* __restrict filter, bool* all_zero = nullptr);
+    static void merge_filters(const Columns& columns, Filter* __restrict filter);
+    static void merge_two_filters(Filter* __restrict filter, const uint8_t* __restrict selected,
                                   bool* all_zero = nullptr);
 
     // Like merge_filters but use OR operator to merge them
-    static void or_two_filters(Column::Filter* __restrict filter, const uint8_t* __restrict selected);
+    static void or_two_filters(Filter* __restrict filter, const uint8_t* __restrict selected);
     static void or_two_filters(size_t count, uint8_t* __restrict filter, const uint8_t* __restrict selected);
     static size_t count_nulls(const ColumnPtr& col);
 
@@ -332,7 +333,7 @@ public:
     static bool is_all_const(ColumnsConstIterator const& begin, ColumnsConstIterator const& end);
     static size_t compute_bytes_size(ColumnsConstIterator const& begin, ColumnsConstIterator const& end);
     template <typename T, bool avx512f>
-    static size_t t_filter_range(const Column::Filter& filter, T* data, size_t from, size_t to) {
+    static size_t t_filter_range(const Filter& filter, T* data, size_t from, size_t to) {
         auto start_offset = from;
         auto result_offset = from;
 
@@ -447,7 +448,7 @@ public:
     }
 
     template <typename T>
-    static size_t filter_range(const Column::Filter& filter, T* data, size_t from, size_t to) {
+    static size_t filter_range(const Filter& filter, T* data, size_t from, size_t to) {
         if (base::CPU::instance()->has_avx512f()) {
             return t_filter_range<T, true>(filter, data, from, to);
         } else {
@@ -456,7 +457,7 @@ public:
     }
 
     template <typename T>
-    static size_t filter(const Column::Filter& filter, T* data) {
+    static size_t filter(const Filter& filter, T* data) {
         return filter_range(filter, data, 0, filter.size());
     }
 

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
 #include "simd/simd.h"
 #include "util/coding.h"
 
@@ -75,7 +76,7 @@ int64_t ConstColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return 0;
 }
 
-size_t ConstColumn::filter_range(const Column::Filter& filter, size_t from, size_t to) {
+size_t ConstColumn::filter_range(const Filter& filter, size_t from, size_t to) {
     size_t count = SIMD::count_nonzero(&filter[from], to - from);
     this->resize(from + count);
     return from + count;

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -16,6 +16,7 @@
 
 #include "column/column.h"
 #include "column/datum.h"
+#include "column/vectorized_fwd.h"
 #include "common/logging.h"
 
 namespace starrocks {
@@ -172,7 +173,7 @@ public:
 
     MutableColumnPtr clone_empty() const override { return create_mutable(_data->clone_empty(), 0); }
 
-    size_t filter_range(const Column::Filter& filter, size_t from, size_t to) override;
+    size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -16,6 +16,7 @@
 
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
 #include "exec/sorting/sort_helper.h"
 #include "gutil/casts.h"
 #include "runtime/large_int_value.h"
@@ -99,7 +100,7 @@ Status FixedLengthColumnBase<T>::update_rows(const Column& src, const uint32_t* 
 }
 
 template <typename T>
-size_t FixedLengthColumnBase<T>::filter_range(const Column::Filter& filter, size_t from, size_t to) {
+size_t FixedLengthColumnBase<T>::filter_range(const Filter& filter, size_t from, size_t to) {
     auto size = ColumnHelper::filter_range<T>(filter, _data.data(), from, to);
     this->resize(size);
     return size;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -19,6 +19,7 @@
 
 #include "column/column.h"
 #include "column/datum.h"
+#include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "runtime/decimalv2_value.h"
 #include "types/date_value.hpp"
@@ -180,7 +181,7 @@ public:
 
     MutableColumnPtr clone_empty() const override { return this->create_mutable(); }
 
-    size_t filter_range(const Column::Filter& filter, size_t from, size_t to) override;
+    size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -19,6 +19,7 @@
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
 #include "gutil/bits.h"
 #include "gutil/casts.h"
 #include "gutil/strings/fastmem.h"
@@ -287,7 +288,7 @@ MutableColumnPtr MapColumn::clone_empty() const {
     return create_mutable(_keys->clone_empty(), _values->clone_empty(), UInt32Column::create());
 }
 
-size_t MapColumn::filter_range(const Column::Filter& filter, size_t from, size_t to) {
+size_t MapColumn::filter_range(const Filter& filter, size_t from, size_t to) {
     DCHECK_EQ(size(), to);
     auto* offsets = reinterpret_cast<uint32_t*>(_offsets->mutable_raw_data());
     uint32_t elements_start = offsets[from];

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -18,6 +18,7 @@
 
 #include "column/column.h"
 #include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
 
 namespace starrocks {
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -15,6 +15,7 @@
 #include "column/nullable_column.h"
 
 #include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
 #include "gutil/strings/fastmem.h"
 #include "simd/simd.h"
@@ -222,7 +223,7 @@ Status NullableColumn::update_rows(const Column& src, const uint32_t* indexes) {
     return Status::OK();
 }
 
-size_t NullableColumn::filter_range(const Column::Filter& filter, size_t from, size_t to) {
+size_t NullableColumn::filter_range(const Filter& filter, size_t from, size_t to) {
     auto s1 = _data_column->filter_range(filter, from, to);
     if (!_has_null) {
         _null_column->resize(s1);

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
 #include "common/logging.h"
 
 namespace starrocks {
@@ -194,7 +195,7 @@ public:
     size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, size_t start,
                                        size_t count) override;
 
-    size_t filter_range(const Column::Filter& filter, size_t from, size_t to) override;
+    size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -14,6 +14,7 @@
 
 #include "column/object_column.h"
 
+#include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
 #include "types/bitmap_value.h"
 #include "types/hll.h"
@@ -197,7 +198,7 @@ uint32_t ObjectColumn<T>::serialize_size(size_t idx) const {
 }
 
 template <typename T>
-size_t ObjectColumn<T>::filter_range(const Column::Filter& filter, size_t from, size_t to) {
+size_t ObjectColumn<T>::filter_range(const Filter& filter, size_t from, size_t to) {
     size_t old_sz = size();
     size_t new_sz = from;
     for (auto i = from; i < to; ++i) {

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -18,6 +18,7 @@
 
 #include "column/column.h"
 #include "column/datum.h"
+#include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
 #include "types/bitmap_value.h"
 #include "types/hll.h"
@@ -138,7 +139,7 @@ public:
 
     ColumnPtr clone_shared() const override;
 
-    size_t filter_range(const Column::Filter& filter, size_t from, size_t to) override;
+    size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 

--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -84,7 +84,7 @@ size_t fill_null_column(const arrow::Array* array, size_t array_start_idx, size_
     return null_count;
 }
 
-void fill_filter(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column::Filter* filter,
+void fill_filter(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Filter* filter,
                  size_t column_start_idx) {
     DCHECK_EQ(filter->size(), column_start_idx + num_elements);
     auto* filter_data = (&filter->front()) + column_start_idx;
@@ -867,7 +867,7 @@ struct ArrowListConverter {
 
     static Status convert_list(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                                size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
-                               Column::Filter* column_filter, ArrowConvertContext* ctx,
+                               Filter* column_filter, ArrowConvertContext* ctx,
                                const TypeDescriptor* type_desc) {
         auto* col_array = down_cast<ArrayColumn*>(column);
         UInt32Column* col_offsets = col_array->offsets_column().get() + column_start_idx;
@@ -937,7 +937,7 @@ struct ArrowListConverter {
 
     static Status convert_list_with_null(const arrow::Array* array, size_t array_start_idx, size_t num_elements,
                                          Column* column, size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
-                                         Column::Filter* column_filter, ArrowConvertContext* ctx,
+                                         Filter* column_filter, ArrowConvertContext* ctx,
                                          const TypeDescriptor* type_desc) {
         auto nullable_column = down_cast<NullableColumn*>(column);
         auto null_column = nullable_column->mutable_null_column();
@@ -948,7 +948,7 @@ struct ArrowListConverter {
     }
 
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
-                        size_t column_start_idx, [[maybe_unused]] uint8_t* null_data, Column::Filter* column_filter,
+                        size_t column_start_idx, [[maybe_unused]] uint8_t* null_data, Filter* column_filter,
                         ArrowConvertContext* ctx, const TypeDescriptor* type_desc) {
         if (column->is_nullable()) {
             return convert_list_with_null(array, array_start_idx, num_elements, column, column_start_idx, null_data,

--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -866,9 +866,8 @@ struct ArrowListConverter {
     }
 
     static Status convert_list(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
-                               size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
-                               Filter* column_filter, ArrowConvertContext* ctx,
-                               const TypeDescriptor* type_desc) {
+                               size_t column_start_idx, [[maybe_unused]] uint8_t* null_data, Filter* column_filter,
+                               ArrowConvertContext* ctx, const TypeDescriptor* type_desc) {
         auto* col_array = down_cast<ArrayColumn*>(column);
         UInt32Column* col_offsets = col_array->offsets_column().get() + column_start_idx;
 

--- a/be/src/exec/arrow_to_starrocks_converter.h
+++ b/be/src/exec/arrow_to_starrocks_converter.h
@@ -68,8 +68,7 @@ typedef Status (*ConvertFunc)(const arrow::Array* array, size_t array_start_idx,
 // or simd optimization to speed up construction of each layer.
 typedef Status (*ListConvertFunc)(const arrow::Array* array, size_t array_start_idx, size_t num_elements,
                                   Column* column, size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
-                                  Filter* column_filter, ArrowConvertContext* ctx,
-                                  const TypeDescriptor* type_desc);
+                                  Filter* column_filter, ArrowConvertContext* ctx, const TypeDescriptor* type_desc);
 
 typedef Status (*ListCheckDepthFunc)(const arrow::Array* array, size_t expected_depth);
 

--- a/be/src/exec/arrow_to_starrocks_converter.h
+++ b/be/src/exec/arrow_to_starrocks_converter.h
@@ -51,7 +51,7 @@ size_t fill_null_column(const arrow::Array* array, size_t array_start_idx, size_
 
 // fill filter's range [column_start_idx, column_start_idx + num_elements) with
 // array's range [array_start, array_start_idx + num_elements).
-void fill_filter(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column::Filter* filter,
+void fill_filter(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Filter* filter,
                  size_t column_start_idx);
 
 // ConvertFunc is used to fill column's range [column_start_idx, column_start_idx + num_elements)
@@ -68,7 +68,7 @@ typedef Status (*ConvertFunc)(const arrow::Array* array, size_t array_start_idx,
 // or simd optimization to speed up construction of each layer.
 typedef Status (*ListConvertFunc)(const arrow::Array* array, size_t array_start_idx, size_t num_elements,
                                   Column* column, size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
-                                  Column::Filter* column_filter, ArrowConvertContext* ctx,
+                                  Filter* column_filter, ArrowConvertContext* ctx,
                                   const TypeDescriptor* type_desc);
 
 typedef Status (*ListCheckDepthFunc)(const arrow::Array* array, size_t expected_depth);

--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -191,7 +191,7 @@ std::vector<JoinRuntimeFilter*>* ChunksSorterHeapSort::runtime_filters(ObjectPoo
 }
 
 template <LogicalType TYPE>
-void ChunksSorterHeapSort::_do_filter_data_for_type(detail::ChunkHolder* chunk_holder, Column::Filter* filter,
+void ChunksSorterHeapSort::_do_filter_data_for_type(detail::ChunkHolder* chunk_holder, Filter* filter,
                                                     int row_sz) {
     const auto& top_cursor = _sort_heap->top();
     const int cursor_rid = top_cursor.row_id();
@@ -273,7 +273,7 @@ int ChunksSorterHeapSort::_filter_data(detail::ChunkHolder* chunk_holder, int ro
     const int cursor_rid = top_cursor.row_id();
     const int column_sz = top_cursor.data_segment()->order_by_columns.size();
 
-    Column::Filter filter(row_sz);
+    Filter filter(row_sz);
 
     // For single column special optimization
     if (_do_filter_data) {

--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -191,8 +191,7 @@ std::vector<JoinRuntimeFilter*>* ChunksSorterHeapSort::runtime_filters(ObjectPoo
 }
 
 template <LogicalType TYPE>
-void ChunksSorterHeapSort::_do_filter_data_for_type(detail::ChunkHolder* chunk_holder, Filter* filter,
-                                                    int row_sz) {
+void ChunksSorterHeapSort::_do_filter_data_for_type(detail::ChunkHolder* chunk_holder, Filter* filter, int row_sz) {
     const auto& top_cursor = _sort_heap->top();
     const int cursor_rid = top_cursor.row_id();
 

--- a/be/src/exec/chunks_sorter_heap_sort.h
+++ b/be/src/exec/chunks_sorter_heap_sort.h
@@ -260,7 +260,7 @@ private:
     int _filter_data(detail::ChunkHolder* chunk_holder, int row_sz);
 
     template <LogicalType TYPE>
-    void _do_filter_data_for_type(detail::ChunkHolder* chunk_holder, Column::Filter* filter, int row_sz);
+    void _do_filter_data_for_type(detail::ChunkHolder* chunk_holder, Filter* filter, int row_sz);
 
     std::vector<JoinRuntimeFilter*> _runtime_filter;
 
@@ -269,7 +269,7 @@ private:
             detail::SortingHeap<detail::ChunkRowCursor, CursorContainer, detail::ChunkCursorComparator>;
 
     std::unique_ptr<CommonCursorSortHeap> _sort_heap = nullptr;
-    std::function<void(detail::ChunkHolder*, Column::Filter*, int)> _do_filter_data;
+    std::function<void(detail::ChunkHolder*, Filter*, int)> _do_filter_data;
 
     const size_t _offset;
     const size_t _limit;

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -40,6 +40,7 @@
 #include <sstream>
 
 #include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
 #include "common/compiler_util.h"
 #include "common/object_pool.h"
 #include "common/status.h"
@@ -592,8 +593,8 @@ void ExecNode::debug_string(int indentation_level, std::stringstream* out) const
 }
 
 Status eager_prune_eval_conjuncts(const std::vector<ExprContext*>& ctxs, Chunk* chunk) {
-    Column::Filter filter(chunk->num_rows(), 1);
-    Column::Filter* raw_filter = &filter;
+    Filter filter(chunk->num_rows(), 1);
+    Filter* raw_filter = &filter;
 
     // prune chunk when pruned size is large enough
     // these constants are just came up without any specific reason.
@@ -667,11 +668,11 @@ Status ExecNode::eval_conjuncts(const std::vector<ExprContext*>& ctxs, Chunk* ch
     if (!apply_filter) {
         DCHECK(filter_ptr) << "Must provide a filter if not apply it directly";
     }
-    FilterPtr filter(new Column::Filter(chunk->num_rows(), 1));
+    FilterPtr filter(new Filter(chunk->num_rows(), 1));
     if (filter_ptr != nullptr) {
         *filter_ptr = filter;
     }
-    Column::Filter* raw_filter = filter.get();
+    Filter* raw_filter = filter.get();
 
     for (auto* ctx : ctxs) {
         ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate(chunk));

--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -19,6 +19,7 @@
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/hash_set.h"
+#include "column/vectorized_fwd.h"
 #include "fs/fs.h"
 #include "fs/fs_broker.h"
 #include "fs/fs_hdfs.h"
@@ -159,7 +160,7 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::ChunkPtr& src, star
 
     int ctx_index = 0;
     int before_rows = cast->num_rows();
-    Column::Filter filter(cast->num_rows(), 1);
+    Filter filter(cast->num_rows(), 1);
 
     // CREATE ROUTINE LOAD routine_load_job_1
     // on table COLUMNS (k1,k2,k3=k1)

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -723,8 +723,7 @@ Status HashJoinNode::_probe_remain(ChunkPtr* chunk, bool& eos) {
     return Status::OK();
 }
 
-Status HashJoinNode::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all,
-                                                     bool& hit_all) {
+Status HashJoinNode::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all, bool& hit_all) {
     filter_all = false;
     hit_all = false;
     filter.assign((*chunk)->num_rows(), 1);

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -723,7 +723,7 @@ Status HashJoinNode::_probe_remain(ChunkPtr* chunk, bool& eos) {
     return Status::OK();
 }
 
-Status HashJoinNode::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all,
+Status HashJoinNode::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all,
                                                      bool& hit_all) {
     filter_all = false;
     hit_all = false;
@@ -762,7 +762,7 @@ Status HashJoinNode::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Fi
 }
 
 void HashJoinNode::_process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
-                                                   bool filter_all, bool hit_all, const Column::Filter& filter) {
+                                                   bool filter_all, bool hit_all, const Filter& filter) {
     if (filter_all) {
         for (size_t i = start_column; i < start_column + column_count; i++) {
             auto* null_column = ColumnHelper::as_raw_column<NullableColumn>((*chunk)->columns()[i]);
@@ -794,7 +794,7 @@ Status HashJoinNode::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, si
                                                              size_t column_count) {
     bool filter_all = false;
     bool hit_all = false;
-    Column::Filter filter;
+    Filter filter;
 
     RETURN_IF_ERROR(_calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all));
     _process_row_for_other_conjunct(chunk, start_column, column_count, filter_all, hit_all, filter);
@@ -808,7 +808,7 @@ Status HashJoinNode::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, si
 Status HashJoinNode::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
     bool filter_all = false;
     bool hit_all = false;
-    Column::Filter filter;
+    Filter filter;
 
     RETURN_IF_ERROR(_calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all));
 
@@ -821,7 +821,7 @@ Status HashJoinNode::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
 Status HashJoinNode::_process_right_anti_join_with_other_conjunct(ChunkPtr* chunk) {
     bool filter_all = false;
     bool hit_all = false;
-    Column::Filter filter;
+    Filter filter;
 
     RETURN_IF_ERROR(_calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all));
 

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -16,6 +16,7 @@
 
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
 #include "exec/exec_node.h"
 #include "exec/join_hash_map.h"
 #include "util/phmap/phmap.h"
@@ -72,9 +73,9 @@ private:
 
     Status _evaluate_build_keys(const ChunkPtr& chunk);
 
-    Status _calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all, bool& hit_all);
+    Status _calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all, bool& hit_all);
     static void _process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
-                                                bool filter_all, bool hit_all, const Column::Filter& filter);
+                                                bool filter_all, bool hit_all, const Filter& filter);
 
     Status _process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count);
     Status _process_semi_join_with_other_conjunct(ChunkPtr* chunk);

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -346,8 +346,7 @@ Status HashJoiner::_build(RuntimeState* state) {
     return Status::OK();
 }
 
-Status HashJoiner::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all,
-                                                   bool& hit_all) {
+Status HashJoiner::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all, bool& hit_all) {
     filter_all = false;
     hit_all = false;
     filter.assign((*chunk)->num_rows(), 1);

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -346,7 +346,7 @@ Status HashJoiner::_build(RuntimeState* state) {
     return Status::OK();
 }
 
-Status HashJoiner::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all,
+Status HashJoiner::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all,
                                                    bool& hit_all) {
     filter_all = false;
     hit_all = false;
@@ -385,7 +385,7 @@ Status HashJoiner::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filt
 }
 
 void HashJoiner::_process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
-                                                 bool filter_all, bool hit_all, const Column::Filter& filter) {
+                                                 bool filter_all, bool hit_all, const Filter& filter) {
     if (filter_all) {
         for (size_t i = start_column; i < start_column + column_count; i++) {
             auto* null_column = ColumnHelper::as_raw_column<NullableColumn>((*chunk)->columns()[i]);
@@ -416,7 +416,7 @@ void HashJoiner::_process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_c
 Status HashJoiner::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count) {
     bool filter_all = false;
     bool hit_all = false;
-    Column::Filter filter;
+    Filter filter;
 
     RETURN_IF_ERROR(_calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all));
     _process_row_for_other_conjunct(chunk, start_column, column_count, filter_all, hit_all, filter);
@@ -430,7 +430,7 @@ Status HashJoiner::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, size
 Status HashJoiner::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
     bool filter_all = false;
     bool hit_all = false;
-    Column::Filter filter;
+    Filter filter;
 
     _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
 
@@ -443,7 +443,7 @@ Status HashJoiner::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
 Status HashJoiner::_process_right_anti_join_with_other_conjunct(ChunkPtr* chunk) {
     bool filter_all = false;
     bool hit_all = false;
-    Column::Filter filter;
+    Filter filter;
 
     _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
 

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -18,6 +18,7 @@
 
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "exec/exec_node.h"
 #include "exec/hash_join_node.h"
@@ -241,9 +242,9 @@ private:
 
     StatusOr<ChunkPtr> _pull_probe_output_chunk(RuntimeState* state);
 
-    Status _calc_filter_for_other_conjunct(ChunkPtr* chunk, Column::Filter& filter, bool& filter_all, bool& hit_all);
+    Status _calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all, bool& hit_all);
     static void _process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
-                                                bool filter_all, bool hit_all, const Column::Filter& filter);
+                                                bool filter_all, bool hit_all, const Filter& filter);
 
     Status _process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count);
     Status _process_semi_join_with_other_conjunct(ChunkPtr* chunk);

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -17,6 +17,7 @@
 #include <column/chunk.h>
 #include <runtime/descriptors.h>
 
+#include "column/vectorized_fwd.h"
 #include "exec/hash_join_node.h"
 #include "serde/column_array_serde.h"
 #include "simd/simd.h"
@@ -495,7 +496,7 @@ void JoinHashTable::append_chunk(RuntimeState* state, const ChunkPtr& chunk, con
     _table_items->row_count += chunk->num_rows();
 }
 
-void JoinHashTable::remove_duplicate_index(Column::Filter* filter) {
+void JoinHashTable::remove_duplicate_index(Filter* filter) {
     if (_hash_map_type == JoinHashMapType::empty) {
         switch (_table_items->join_type) {
         case TJoinOp::LEFT_OUTER_JOIN:
@@ -665,7 +666,7 @@ size_t JoinHashTable::_get_size_of_fixed_and_contiguous_type(LogicalType data_ty
     }
 }
 
-void JoinHashTable::_remove_duplicate_index_for_left_outer_join(Column::Filter* filter) {
+void JoinHashTable::_remove_duplicate_index_for_left_outer_join(Filter* filter) {
     size_t row_count = filter->size();
 
     for (size_t i = 0; i < row_count; i++) {
@@ -687,7 +688,7 @@ void JoinHashTable::_remove_duplicate_index_for_left_outer_join(Column::Filter* 
     }
 }
 
-void JoinHashTable::_remove_duplicate_index_for_left_semi_join(Column::Filter* filter) {
+void JoinHashTable::_remove_duplicate_index_for_left_semi_join(Filter* filter) {
     size_t row_count = filter->size();
     for (size_t i = 0; i < row_count; i++) {
         if ((*filter)[i] == 1) {
@@ -700,7 +701,7 @@ void JoinHashTable::_remove_duplicate_index_for_left_semi_join(Column::Filter* f
     }
 }
 
-void JoinHashTable::_remove_duplicate_index_for_left_anti_join(Column::Filter* filter) {
+void JoinHashTable::_remove_duplicate_index_for_left_anti_join(Filter* filter) {
     size_t row_count = filter->size();
     for (size_t i = 0; i < row_count; i++) {
         if (_probe_state->probe_match_index[_probe_state->probe_index[i]] == 0) {
@@ -716,7 +717,7 @@ void JoinHashTable::_remove_duplicate_index_for_left_anti_join(Column::Filter* f
     }
 }
 
-void JoinHashTable::_remove_duplicate_index_for_right_outer_join(Column::Filter* filter) {
+void JoinHashTable::_remove_duplicate_index_for_right_outer_join(Filter* filter) {
     size_t row_count = filter->size();
     for (size_t i = 0; i < row_count; i++) {
         if ((*filter)[i] == 1) {
@@ -725,7 +726,7 @@ void JoinHashTable::_remove_duplicate_index_for_right_outer_join(Column::Filter*
     }
 }
 
-void JoinHashTable::_remove_duplicate_index_for_right_semi_join(Column::Filter* filter) {
+void JoinHashTable::_remove_duplicate_index_for_right_semi_join(Filter* filter) {
     size_t row_count = filter->size();
     for (size_t i = 0; i < row_count; i++) {
         if ((*filter)[i] == 1) {
@@ -738,7 +739,7 @@ void JoinHashTable::_remove_duplicate_index_for_right_semi_join(Column::Filter* 
     }
 }
 
-void JoinHashTable::_remove_duplicate_index_for_right_anti_join(Column::Filter* filter) {
+void JoinHashTable::_remove_duplicate_index_for_right_anti_join(Filter* filter) {
     size_t row_count = filter->size();
     for (size_t i = 0; i < row_count; i++) {
         if ((*filter)[i] == 1) {
@@ -747,7 +748,7 @@ void JoinHashTable::_remove_duplicate_index_for_right_anti_join(Column::Filter* 
     }
 }
 
-void JoinHashTable::_remove_duplicate_index_for_full_outer_join(Column::Filter* filter) {
+void JoinHashTable::_remove_duplicate_index_for_full_outer_join(Filter* filter) {
     size_t row_count = filter->size();
     for (size_t i = 0; i < row_count; i++) {
         if (_probe_state->probe_match_index[_probe_state->probe_index[i]] == 0) {

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -25,6 +25,7 @@
 #include "column/chunk.h"
 #include "column/column_hash.h"
 #include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
 #include "util/phmap/phmap.h"
 
 #if defined(__aarch64__)
@@ -703,7 +704,7 @@ public:
     size_t get_build_column_count() const { return _table_items->build_column_count; }
     size_t get_bucket_size() const { return _table_items->bucket_size; }
 
-    void remove_duplicate_index(Column::Filter* filter);
+    void remove_duplicate_index(Filter* filter);
 
     int64_t mem_usage();
 
@@ -713,13 +714,13 @@ private:
 
     Status _upgrade_key_columns_if_overflow();
 
-    void _remove_duplicate_index_for_left_outer_join(Column::Filter* filter);
-    void _remove_duplicate_index_for_left_semi_join(Column::Filter* filter);
-    void _remove_duplicate_index_for_left_anti_join(Column::Filter* filter);
-    void _remove_duplicate_index_for_right_outer_join(Column::Filter* filter);
-    void _remove_duplicate_index_for_right_semi_join(Column::Filter* filter);
-    void _remove_duplicate_index_for_right_anti_join(Column::Filter* filter);
-    void _remove_duplicate_index_for_full_outer_join(Column::Filter* filter);
+    void _remove_duplicate_index_for_left_outer_join(Filter* filter);
+    void _remove_duplicate_index_for_left_semi_join(Filter* filter);
+    void _remove_duplicate_index_for_left_anti_join(Filter* filter);
+    void _remove_duplicate_index_for_right_outer_join(Filter* filter);
+    void _remove_duplicate_index_for_right_semi_join(Filter* filter);
+    void _remove_duplicate_index_for_right_anti_join(Filter* filter);
+    void _remove_duplicate_index_for_full_outer_join(Filter* filter);
 
     std::unique_ptr<JoinHashMapForEmpty> _empty = nullptr;
     std::unique_ptr<JoinHashMapForDirectMapping(TYPE_BOOLEAN)> _keyboolean = nullptr;

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -16,6 +16,7 @@
 
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
 #include "exprs/cast_expr.h"
 #include "exprs/column_ref.h"
 #include "fs/fs_broker.h"

--- a/be/src/exec/parquet_scanner.h
+++ b/be/src/exec/parquet_scanner.h
@@ -75,7 +75,7 @@ private:
     std::vector<ConvertFunc> _conv_funcs;
     std::vector<Expr*> _cast_exprs;
     ObjectPool _pool;
-    Column::Filter _chunk_filter;
+    Filter _chunk_filter;
     ArrowConvertContext _conv_ctx;
 };
 

--- a/be/src/exprs/condition_expr.cpp
+++ b/be/src/exprs/condition_expr.cpp
@@ -35,7 +35,7 @@ namespace starrocks {
 template <bool isConstC0, bool isConst1, LogicalType Type>
 struct SelectIfOP {
     static ColumnPtr eval(ColumnPtr& value0, ColumnPtr& value1, ColumnPtr& selector, const TypeDescriptor& type_desc) {
-        [[maybe_unused]] Column::Filter& select_vec = ColumnHelper::merge_nullable_filter(selector.get());
+        [[maybe_unused]] Filter& select_vec = ColumnHelper::merge_nullable_filter(selector.get());
         [[maybe_unused]] auto* input_data0 = ColumnHelper::get_data_column(value0.get());
         [[maybe_unused]] auto* input_data1 = ColumnHelper::get_data_column(value1.get());
 

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -19,6 +19,7 @@
 #include "column/const_column.h"
 #include "column/nullable_column.h"
 #include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "common/object_pool.h"
 #include "gen_cpp/PlanNodes_types.h"
@@ -184,8 +185,8 @@ public:
 
     class RunningContext {
     public:
-        Column::Filter selection;
-        Column::Filter merged_selection;
+        Filter selection;
+        Filter merged_selection;
         bool use_merged_selection;
         std::vector<uint32_t> hash_values;
         const std::vector<int32_t>* bucketseq_to_partition;
@@ -697,7 +698,7 @@ private:
     template <bool hash_partition = false>
     void _t_evaluate(Column* input_column, RunningContext* ctx) const {
         size_t size = input_column->size();
-        Column::Filter& _selection_filter = ctx->use_merged_selection ? ctx->merged_selection : ctx->selection;
+        Filter& _selection_filter = ctx->use_merged_selection ? ctx->merged_selection : ctx->selection;
         _selection_filter.resize(size);
         uint8_t* _selection = _selection_filter.data();
 

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -26,6 +26,7 @@
 #include "column/array_column.h"
 #include "column/map_column.h"
 #include "column/struct_column.h"
+#include "column/vectorized_fwd.h"
 #include "exprs/cast_expr.h"
 #include "exprs/literal.h"
 #include "formats/orc/fill_function.h"
@@ -524,7 +525,7 @@ Status OrcChunkReader::_fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescri
     if (_broker_load_mode) {
         // always allocate load filter. it's much easier to use in fill chunk function.
         if (_broker_load_filter == nullptr) {
-            _broker_load_filter = std::make_shared<Column::Filter>(_read_chunk_size);
+            _broker_load_filter = std::make_shared<Filter>(_read_chunk_size);
         }
         _broker_load_filter->assign(_batch->numElements, 1);
     }

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -18,6 +18,7 @@
 #include <orc/OrcFile.hh>
 
 #include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
@@ -98,7 +99,7 @@ public:
     size_t get_num_rows_filtered() const { return _num_rows_filtered; }
     bool get_broker_load_mode() const { return _broker_load_mode; }
     bool get_strict_mode() const { return _strict_mode; }
-    std::shared_ptr<Column::Filter> get_broker_load_fiter() { return _broker_load_filter; }
+    std::shared_ptr<Filter> get_broker_load_fiter() { return _broker_load_filter; }
 
     void set_hive_column_names(const std::vector<std::string>* v) {
         if (v != nullptr && v->size() != 0) {
@@ -191,7 +192,7 @@ private:
     // fields related to broker load.
     bool _broker_load_mode;
     bool _strict_mode;
-    std::shared_ptr<Column::Filter> _broker_load_filter;
+    std::shared_ptr<Filter> _broker_load_filter;
     size_t _num_rows_filtered;
     const std::vector<std::string>* _hive_column_names = nullptr;
     bool _case_sensitive = false;

--- a/be/src/runtime/global_dict/parser.h
+++ b/be/src/runtime/global_dict/parser.h
@@ -38,7 +38,7 @@ struct DictOptimizeContext {
     bool result_nullable = false;
     // size: DICT_DECODE_MAX_SIZE + 1
     std::vector<int16_t> code_convert_map;
-    Column::Filter filter;
+    Filter filter;
     // for no-string column convert map
     ColumnPtr convert_column;
 };

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -175,7 +175,7 @@ PARALLEL_TEST(ArrayColumnTest, test_filter) {
             column->append_datum(DatumArray{i, i * 2});
         }
 
-        Column::Filter filter(N, 1);
+        Filter filter(N, 1);
 
         column->filter_range(filter, 0, N);
         column->filter_range(filter, N / 10, N);
@@ -259,7 +259,7 @@ PARALLEL_TEST(ArrayColumnTest, test_filter) {
             column->append_datum(DatumArray{i, i * 2});
         }
 
-        Column::Filter filter(N, 0);
+        Filter filter(N, 0);
         for (int i = 0; i < 32; i++) {
             filter[i] = i % 2;
         }
@@ -300,7 +300,7 @@ PARALLEL_TEST(ArrayColumnTest, test_filter) {
             }
             column->append_datum(array);
         }
-        Column::Filter filter(4096);
+        Filter filter(4096);
         for (int i = 0; i < 4096; i++) {
             filter[i] = i % 2;
         }
@@ -335,7 +335,7 @@ PARALLEL_TEST(ArrayColumnTest, test_filter) {
             column->append_datum(DatumArray{DatumArray{i * 3, i * 3 + 1}, DatumArray{i * 2, i * 2 + 1}});
         }
 
-        Column::Filter filter(N, 1);
+        Filter filter(N, 1);
         column->filter_range(filter, 0, N);
         column->filter_range(filter, N / 10, N);
         column->filter_range(filter, N / 2, N);

--- a/be/test/column/avx_numeric_column.h
+++ b/be/test/column/avx_numeric_column.h
@@ -17,6 +17,7 @@
 #include <immintrin.h>
 
 #include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
 
 namespace starrocks {
 class AvxNumericColumn {
@@ -69,7 +70,7 @@ public:
         }
     }
 
-    void progma_filter(const std::vector<int32_t>& data, const Column::Filter& filter, size_t result_size_hint,
+    void progma_filter(const std::vector<int32_t>& data, const Filter& filter, size_t result_size_hint,
                        std::vector<int32_t>& result) {
         if (result_size_hint != 0) {
             result.reserve(result_size_hint > 0 ? result_size_hint : data.size());
@@ -83,7 +84,7 @@ public:
         }
     }
 
-    void filter(const std::vector<int32_t>& data, const Column::Filter& filter, size_t result_size_hint,
+    void filter(const std::vector<int32_t>& data, const Filter& filter, size_t result_size_hint,
                 std::vector<int32_t>& result) {
         if (result_size_hint != 0) {
             result.reserve(result_size_hint > 0 ? result_size_hint : data.size());

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -20,6 +20,7 @@
 #include "column/const_column.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
 #include "testutil/parallel_test.h"
 
 namespace starrocks {
@@ -139,7 +140,7 @@ PARALLEL_TEST(BinaryColumnTest, test_filter) {
         column->append(std::to_string(i));
     }
 
-    Column::Filter filter;
+    Filter filter;
     for (int k = 0; k < 100; ++k) {
         filter.push_back(k % 2);
     }

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -19,6 +19,7 @@
 #include "column/column_helper.h"
 #include "column/const_column.h"
 #include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
 #include "exec/sorting/sorting.h"
 
 namespace starrocks {
@@ -59,7 +60,7 @@ TEST(FixedLengthColumnTest, test_basic) {
             column->append(i);
         }
 
-        Column::Filter filter;
+        Filter filter;
         for (int i = 0; i < 100; ++i) {
             filter.push_back(i % 2);
         }
@@ -137,7 +138,7 @@ TEST(FixedLengthColumnTest, test_nullable) {
             }
         }
 
-        Column::Filter filter;
+        Filter filter;
         for (int k = 0; k < 50; ++k) {
             filter.push_back(0);
         }

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -272,7 +272,7 @@ PARALLEL_TEST(JsonColumnTest, test_filter) {
         json_column->append(JsonValue::parse(json_str).value());
     }
 
-    Column::Filter filter(N, 1);
+    Filter filter(N, 1);
     json_column->filter_range(filter, 0, N);
     ASSERT_EQ(N, json_column->size());
 }

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -239,7 +239,7 @@ PARALLEL_TEST(MapColumnTest, test_filter) {
             column->append_datum(DatumMap{{i, i + 1}});
         }
 
-        Column::Filter filter(N, 1);
+        Filter filter(N, 1);
 
         column->filter_range(filter, 0, N);
         column->filter_range(filter, N / 10, N);
@@ -319,7 +319,7 @@ PARALLEL_TEST(MapColumnTest, test_filter) {
             column->append_datum(DatumMap{{i, i * 2}});
         }
 
-        Column::Filter filter(N, 0);
+        Filter filter(N, 0);
         for (int i = 0; i < 32; i++) {
             filter[i] = i % 2;
         }
@@ -358,7 +358,7 @@ PARALLEL_TEST(MapColumnTest, test_filter) {
             }
             column->append_datum(map);
         }
-        Column::Filter filter(4096);
+        Filter filter(4096);
         for (int i = 0; i < 4096; i++) {
             filter[i] = i % 2;
         }
@@ -395,7 +395,7 @@ PARALLEL_TEST(MapColumnTest, test_filter) {
             column->append_datum(DatumMap{{i, DatumArray{i + 1, i + 2}}, {i + 1, DatumArray{i + 1, i + 2}}});
         }
 
-        Column::Filter filter(N, 1);
+        Filter filter(N, 1);
         column->filter_range(filter, 0, N);
         column->filter_range(filter, N / 10, N);
         column->filter_range(filter, N / 2, N);

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -18,6 +18,7 @@
 
 #include "column/column_helper.h"
 #include "column/const_column.h"
+#include "column/vectorized_fwd.h"
 #include "exprs/percentile_functions.h"
 #include "runtime/types.h"
 #include "types/hll.h"
@@ -34,7 +35,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
-        Column::Filter filter(100, 1);
+        Filter filter(100, 1);
         c->filter(filter);
         ASSERT_EQ(100, c->size());
     }
@@ -43,7 +44,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
         auto c = HyperLogLogColumn::create();
         c->resize(100);
 
-        Column::Filter filter(100, 0);
+        Filter filter(100, 0);
         c->filter(filter);
         ASSERT_EQ(0, c->size());
     }
@@ -53,7 +54,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
-        Column::Filter filter(100, 1);
+        Filter filter(100, 1);
         for (int i = 90; i < 100; i++) {
             filter[i] = 0;
         }
@@ -66,7 +67,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
-        Column::Filter filter(100, 1);
+        Filter filter(100, 1);
         for (int i = 0; i < 10; i++) {
             filter[i] = 0;
         }
@@ -79,7 +80,7 @@ TEST(ObjectColumnTest, HLL_test_filter) {
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
-        Column::Filter filter(100, 1);
+        Filter filter(100, 1);
         for (int i = 0; i < 100; i++) {
             filter[i] = i % 2;
         }
@@ -96,7 +97,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
-        Column::Filter filter(100, 1);
+        Filter filter(100, 1);
         c->filter_range(filter, 0, 100);
         ASSERT_EQ(100, c->size());
     }
@@ -105,7 +106,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
         auto c = HyperLogLogColumn::create();
         c->resize(100);
 
-        Column::Filter filter(100, 0);
+        Filter filter(100, 0);
         c->filter_range(filter, 0, 100);
         ASSERT_EQ(0, c->size());
     }
@@ -115,7 +116,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
-        Column::Filter filter(100, 0);
+        Filter filter(100, 0);
         c->filter_range(filter, 90, 100);
         ASSERT_EQ(90, c->size());
     }
@@ -125,7 +126,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
-        Column::Filter filter(100, 0);
+        Filter filter(100, 0);
         c->filter_range(filter, 0, 10);
         ASSERT_EQ(90, c->size());
     }
@@ -135,7 +136,7 @@ TEST(ObjectColumnTest, HLL_test_filter_range) {
         c->resize(100);
         ASSERT_EQ(100, c->size());
 
-        Column::Filter filter(100, 0);
+        Filter filter(100, 0);
         c->filter_range(filter, 20, 32);
         ASSERT_EQ(88, c->size());
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [X] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`Filter` already defined in [column/vectorized_fwd.h](https://github.com/StarRocks/starrocks/blob/main/be/src/column/vectorized_fwd.h#L112), so remove the duplicated definition of `Column::Filter`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
