### PR TITLE
[BugFix] Complex shuffle join with aggregate bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -228,10 +228,10 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
             } else if ((leftDistributionDesc.isShuffle() || leftDistributionDesc.isShuffleEnforce()) &&
                     (rightDistributionDesc.isShuffle()) || rightDistributionDesc.isShuffleEnforce()) {
                 // shuffle join
-                return computeHashJoinDistributionPropertyInfo(node,
-                        computeShuffleJoinOutputProperty(node.getJoinType(), leftOnPredicateColumns, rightOnPredicateColumns),
-                        leftOnPredicateColumns,
-                        rightOnPredicateColumns, context);
+                PhysicalPropertySet outputProperty = computeShuffleJoinOutputProperty(node.getJoinType(),
+                        leftDistributionDesc.getColumns(), rightDistributionDesc.getColumns());
+                return computeHashJoinDistributionPropertyInfo(node, outputProperty,
+                        leftOnPredicateColumns, rightOnPredicateColumns, context);
             } else {
                 LOG.error("Children output property distribution error.left child property: {}, " +
                                 "right child property: {}, join node: {}",
@@ -247,8 +247,8 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
     }
 
     private PhysicalPropertySet computeShuffleJoinOutputProperty(JoinOperator joinType,
-                                                                 List<Integer> leftOnPredicateColumns,
-                                                                 List<Integer> rightOnPredicateColumns) {
+                                                                 List<Integer> leftShuffleColumns,
+                                                                 List<Integer> rightShuffleColumns) {
         Optional<HashDistributionDesc> requiredShuffleDesc = getRequiredShuffleDesc();
         if (!requiredShuffleDesc.isPresent()) {
             return PhysicalPropertySet.EMPTY;
@@ -256,7 +256,7 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
 
         // Get required properties for children.
         List<PhysicalPropertySet> requiredProperties =
-                computeShuffleJoinRequiredProperties(requirements, leftOnPredicateColumns, rightOnPredicateColumns);
+                computeShuffleJoinRequiredProperties(requirements, leftShuffleColumns, rightShuffleColumns);
         Preconditions.checkState(requiredProperties.size() == 2);
 
         // when it's a right join, we should use right input cols to derive the output property

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2693,4 +2693,37 @@ public class JoinTest extends PlanTestBase {
                 "  0:OlapScanNode\n" +
                 "     TABLE: t0");
     }
+
+    @Test
+    public void testShuffleAgg() throws Exception {
+        String sql = "select j0.* \n" +
+                "    from t6 j0 join[shuffle] t6 j1 on j0.v2 = j1.v2 and j0.v3 = j1.v3\n" +
+                "               join[shuffle] t6 j2 on j0.v2 = j2.v2 and j0.v3 = j2.v3 and j0.v4 = j2.v4\n" +
+                "               join[shuffle] (select v4,v2,v3 from t6 group by v4,v2,v3) j4 " +
+                "                             on j0.v2 =j4.v2 and j0.v3=j4.v3 and j0.v4 = j4.v4;\n" +
+                "\n";
+
+        connectContext.getSessionVariable().setNewPlanerAggStage(2);
+        String plan = getFragmentPlan(sql);
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+
+        assertContains(plan, "  15:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 14: v2\n" +
+                "  |  equal join conjunct: 3: v3 = 15: v3\n" +
+                "  |  equal join conjunct: 4: v4 = 16: v4\n" +
+                "  |  \n" +
+                "  |----14:EXCHANGE\n" +
+                "  |    \n" +
+                "  9:Project");
+        assertContains(plan, "  PARTITION: HASH_PARTITIONED: 14: v2, 15: v3, 16: v4\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 14\n" +
+                "    HASH_PARTITIONED: 14: v2, 15: v3\n" +
+                "\n" +
+                "  13:AGGREGATE (merge finalize)\n" +
+                "  |  group by: 16: v4, 14: v2, 15: v3");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -167,6 +167,20 @@ public class PlanTestBase {
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `t6` (\n" +
+                "  `v1` bigint NULL COMMENT \"\",\n" +
+                "  `v2` bigint NULL COMMENT \"\",\n" +
+                "  `v3` bigint NULL COMMENT \"\",\n" +
+                "  `v4` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`, `v2`, v3)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
+
         starRocksAssert.withTable("CREATE TABLE `colocate_t0` (\n" +
                 "  `v1` bigint NULL COMMENT \"\",\n" +
                 "  `v2` bigint NULL COMMENT \"\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -162,10 +162,12 @@ public class StatisticsCollectJobTest extends PlanTestBase {
         Assert.assertEquals(5, jobs.size());
         Assert.assertTrue(jobs.get(0) instanceof FullStatisticsCollectJob);
         FullStatisticsCollectJob fullStatisticsCollectJob = (FullStatisticsCollectJob) jobs.get(0);
-        Assert.assertEquals("[v1, v2, v3, v4, v5]", fullStatisticsCollectJob.getColumns().toString());
+        Assert.assertTrue("[pk, v1, v2][v1, v2, v3, v4, v5][v4, v5, v6][v1, v2, v3, v4, v5]".contains(
+                fullStatisticsCollectJob.getColumns().toString()));
         Assert.assertTrue(jobs.get(1) instanceof FullStatisticsCollectJob);
         fullStatisticsCollectJob = (FullStatisticsCollectJob) jobs.get(1);
-        Assert.assertEquals("[v4, v5, v6]", fullStatisticsCollectJob.getColumns().toString());
+        Assert.assertTrue("[pk, v1, v2][v1, v2, v3, v4, v5][v4, v5, v6][v1, v2, v3, v4, v5]".contains(
+                fullStatisticsCollectJob.getColumns().toString()));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
```
MySQL td> CREATE TABLE `t2` (
  `v1` bigint(20) NULL COMMENT "",
  `v2` bigint(20) NULL COMMENT "",
  `v3` bigint(20) NULL COMMENT "",
  `v4` bigint(20) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`v1`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`v1`) BUCKETS 3
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "DEFAULT",
"enable_persistent_index" = "false",
"replicated_storage" = "false",
"compression" = "LZ4"
);
Query OK, 0 rows affected
Time: 0.005s
MySQL td> 
MySQL td> set new_planner_agg_stage=2;
Query OK, 0 rows affected
Time: 0.005s
MySQL td>
MySQL td> explain select j0.* 
    from t2 j0 join[shuffle] t2 j1 on j0.v2 = j1.v2 and j0.v3 = j1.v3
               join[shuffle] t2 j2 on j0.v2 = j2.v2 and j0.v3 = j2.v3 and j0.v4 = j2.v4
               join[shuffle] (select v4,v2,v3 from t2 group by v4,v2,v3) j4 on j0.v2 =j4.v2 and j0.v3=j4.v3 and j0.v4 = j4.v4;

(1064, 'Unknown error')
MySQL td>
```

FE warn.log
```
2023-01-23 22:08:05,797 WARN (starrocks-mysql-nio-pool-10|959) [StmtExecutor.execute():522] execute Exception, sql select j0.*
    from t2 j0 join[shuffle] t2 j1 on j0.v2 = j1.v2 and j0.v3 = j1.v3
               join[shuffle] t2 j2 on j0.v2 = j2.v2 and j0.v3 = j2.v3 and j0.v4 = j2.v4
               join[shuffle] (select v4,v2,v3 from t2 group by v4,v2,v3) j4 on j0.v2 =j4.v2 and j0.v3=j4.v3 and j0.v4 = j4.v4
java.lang.IllegalStateException: null
        at com.google.common.base.Preconditions.checkState(Preconditions.java:494) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.sql.optimizer.rule.tree.PruneShuffleColumnRule$PruneShuffleColumnVisitor.prune(PruneShuffleColumnRule.java:109) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rule.tree.PruneShuffleColumnRule$PruneShuffleColumnVisitor.rewrite(PruneShuffleColumnRule.java:66) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rule.tree.PruneShuffleColumnRule.rewrite(PruneShuffleColumnRule.java:50) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.physicalRuleRewrite(Optimizer.java:396) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:169) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:91) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:95) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:66) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:37) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:373) [starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:313) [starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:430) [starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:676) [starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:55) [starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener$$Lambda$145/168539120.run(Unknown Source) [starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_41]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_41]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_41]
```

we can get the error plan when we ignore the check of PruneShuffleColumnRule.java:109
```
PLAN FRAGMENT 0
 OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3 | 4: v4
  PARTITION: HASH_PARTITIONED: 2: v2, 3: v3

  RESULT SINK

  16:Project
  |  <slot 1> : 1: v1
  |  <slot 2> : 2: v2
  |  <slot 3> : 3: v3
  |  <slot 4> : 4: v4
  |  
  15:HASH JOIN
  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))
  |  colocate: false, reason: 
  |  equal join conjunct: 2: v2 = 14: v2
  |  equal join conjunct: 3: v3 = 15: v3
  |  equal join conjunct: 4: v4 = 16: v4
  |  
  |----13:AGGREGATE (merge finalize)
  |        | group by: 16: v4, 14: v2, 15: v3
  |        |
  |        12:EXCHANGE
  |    
  9:Project
  |  <slot 1> : 1: v1
  |  <slot 2> : 2: v2
  |  <slot 3> : 3: v3
  |  <slot 4> : 4: v4
  |  
  8:HASH JOIN
  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))
  |  colocate: false, reason: 
  |  equal join conjunct: 2: v2 = 10: v2
  |  equal join conjunct: 3: v3 = 11: v3
  |  equal join conjunct: 4: v4 = 12: v4
  |  
  |----7:EXCHANGE
  |    
  5:Project
  |  <slot 1> : 1: v1
  |  <slot 2> : 2: v2
  |  <slot 3> : 3: v3
  |  <slot 4> : 4: v4
  |  
  4:HASH JOIN
  |  join op: INNER JOIN (PARTITIONED)
  |  colocate: false, reason: 
  |  equal join conjunct: 2: v2 = 6: v2
  |  equal join conjunct: 3: v3 = 7: v3
  |  
  |----3:EXCHANGE
  |    
  1:EXCHANGE

PLAN FRAGMENT 1
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 12
    HASH_PARTITIONED: 14: v2, 15: v3, 16: v4

  11:AGGREGATE (update serialize)
  |  STREAMING
  |  group by: 16: v4, 14: v2, 15: v3
  |  
  10:OlapScanNode
     TABLE: t6
     PREAGGREGATION: ON
     PREDICATES: 14: v2 IS NOT NULL, 15: v3 IS NOT NULL, 16: v4 IS NOT NULL
     partitions=0/1
     rollup: t6
     tabletRatio=0/0
     tabletList=
     cardinality=1
     avgRowSize=3.0
     numNodes=0

PLAN FRAGMENT 3
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 07
    HASH_PARTITIONED: 10: v2, 11: v3

  6:OlapScanNode
     TABLE: t6
     PREAGGREGATION: ON
     PREDICATES: 10: v2 IS NOT NULL, 11: v3 IS NOT NULL, 12: v4 IS NOT NULL
     partitions=0/1
     rollup: t6
     tabletRatio=0/0
     tabletList=
     cardinality=1
     avgRowSize=3.0
     numNodes=0

PLAN FRAGMENT 4
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 03
    HASH_PARTITIONED: 6: v2, 7: v3

  2:OlapScanNode
     TABLE: t6
     PREAGGREGATION: ON
     PREDICATES: 6: v2 IS NOT NULL, 7: v3 IS NOT NULL
     partitions=0/1
     rollup: t6
     tabletRatio=0/0
     tabletList=
     cardinality=1
     avgRowSize=2.0
     numNodes=0

PLAN FRAGMENT 5
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 01
    HASH_PARTITIONED: 2: v2, 3: v3

  0:OlapScanNode
     TABLE: t6
     PREAGGREGATION: ON
     PREDICATES: 2: v2 IS NOT NULL, 3: v3 IS NOT NULL, 4: v4 IS NOT NULL
     partitions=0/1
     rollup: t6
     tabletRatio=0/0
     tabletList=
     cardinality=1
     avgRowSize=4.0
     numNodes=0

``` 

The bug:
1. j0 Join j1 return: shuffle[2, 3]
2. (j0 Join j1) Join j2 return: shuffle[2, 3, 4]
3. agg return: shuffle[2, 3, 4]
4. j0, j1, j2, is shuffle by [2, 3], agg shuffle by [2, 3, 4], but generate 15:HASH JOIN(BUCKET_SHUFFLE)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
