### PR TITLE
[cherry-pick][Branch-2.4][BugFix] Fix the version fall back when the RPC lag (#16841)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -332,22 +332,6 @@ public class Replica implements Writable {
                 this.lastSuccessVersion, this.minReadableVersion, dataSize, rowCount);
     }
 
-    public void updateVersionInfoForRecovery(
-            long newVersion,
-            long lastFailedVersion,
-            long lastSuccessVersion) {
-
-        LOG.warn("update replica {} on backend {}'s version for recovery. version: {}."
-                        + " last failed version: {}:{}, last success version: {}:{}",
-                this.id, this.backendId, this.version, newVersion,
-                this.lastFailedVersion, lastFailedVersion,
-                this.lastSuccessVersion, lastSuccessVersion);
-
-        this.version = newVersion;
-        this.lastFailedVersion = lastFailedVersion;
-        this.lastSuccessVersion = lastSuccessVersion;
-    }
-
     /* last failed version:  LFV
      * last success version: LSV
      * version:              V

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1011,27 +1011,6 @@ public class ReportHandler extends Daemon {
                                 }
                                 break;
                             }
-
-                            if (replica.getVersion() > tTabletInfo.getVersion()) {
-                                LOG.warn("recover for replica {} of tablet {} on backend {}",
-                                        replica.getId(), tabletId, backendId);
-                                if (replica.getVersion() == tTabletInfo.getVersion() + 1) {
-                                    // this missing version is the last version of this replica
-                                    replica.updateVersionInfoForRecovery(
-                                            tTabletInfo.getVersion(), /* set version to BE report version */
-                                            replica.getVersion(), /* set LFV to current FE version */
-                                            tTabletInfo.getVersion()); /* set LSV to BE report version */
-                                } else {
-                                    // this missing version is a hole
-                                    replica.updateVersionInfoForRecovery(
-                                            tTabletInfo.getVersion(), /* set version to BE report version */
-                                            tTabletInfo.getVersion() + 1, /* LFV */
-                                            /* remain LSV unchanged, which should be equal to replica.version */
-                                            replica.getLastSuccessVersion());
-                                }
-                                // no need to write edit log, if FE crashed, this will be recovered again
-                                break;
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If the replica version in the FE catches up to 10, it should reject the smaller version(less than 10) reported by RPC. The PRC may lag due to the high traffic network jam.  If the report is not rejected, the version falling back results in the commit error like the following.
```
 Commit failed. txn: 1002 table: test1 tablet: 10016 quorum: 0<1 errorReplicas: 10017:{be:10002 172.26.92.139 V:9 LFV:10},]}}, msg={replay end load job}
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
