### PR TITLE
[Feature] lake pk table support dup publish, multi cluster and add memory tracker

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -305,12 +305,12 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
         }
 #if defined(USE_STAROS) && !defined(BE_TEST)
         _lake_location_provider = new lake::StarletLocationProvider();
-        _lake_update_manager = new lake::UpdateManager(_lake_location_provider);
+        _lake_update_manager = new lake::UpdateManager(_lake_location_provider, update_mem_tracker());
         _lake_tablet_manager = new lake::TabletManager(_lake_location_provider, _lake_update_manager,
                                                        config::lake_metadata_cache_limit);
 #elif defined(BE_TEST)
         _lake_location_provider = new lake::FixedLocationProvider(_store_paths.front().path);
-        _lake_update_manager = new lake::UpdateManager(_lake_location_provider);
+        _lake_update_manager = new lake::UpdateManager(_lake_location_provider, update_mem_tracker());
         _lake_tablet_manager = new lake::TabletManager(_lake_location_provider, _lake_update_manager,
                                                        config::lake_metadata_cache_limit);
 #endif

--- a/be/src/storage/del_vector.cpp
+++ b/be/src/storage/del_vector.cpp
@@ -120,4 +120,12 @@ void DelVector::_update_stats() {
     }
 }
 
+void DelVector::copy_from(const DelVector& delvec) {
+    _loaded = delvec._loaded;
+    _version = delvec._version;
+    _cardinality = delvec._cardinality;
+    _memory_usage = delvec._memory_usage;
+    _roaring = std::make_unique<Roaring>(*delvec._roaring);
+}
+
 } // namespace starrocks

--- a/be/src/storage/del_vector.h
+++ b/be/src/storage/del_vector.h
@@ -59,6 +59,8 @@ public:
 
     Roaring* roaring() { return _roaring.get(); }
 
+    void copy_from(const DelVector& delvec);
+
 private:
     void _add_dels(const std::vector<uint32_t>& dels);
 

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -260,8 +260,6 @@ static StatusOr<std::set<std::string>> find_orphan_datafiles(TabletManager* tabl
         }
     };
 
-    // record missed tsid range
-    std::vector<TabletSegmentIdRange> missed_tsid_ranges;
     for (const auto& filename : tablet_metadatas) {
         auto location = join_path(metadata_root_location, filename);
         auto res = tablet_mgr->get_tablet_metadata(location, false);
@@ -277,10 +275,6 @@ static StatusOr<std::set<std::string>> find_orphan_datafiles(TabletManager* tabl
             check_rowset(rowset);
         }
         check_delvecs(metadata->id(), metadata->delvec_meta());
-        if (is_primary_key(metadata.get())) {
-            // find missed tsid range, only used in pk table
-            find_missed_tsid_range(metadata.get(), missed_tsid_ranges);
-        }
     }
 
     for (const auto& filename : txn_logs) {

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -249,7 +249,7 @@ static StatusOr<std::set<std::string>> find_orphan_datafiles(TabletManager* tabl
 
     auto check_delvecs = [&](int64_t tablet_id, const DelvecMetadataPB& delvec_meta) {
         for (const auto& delvec : delvec_meta.delvecs()) {
-            std::string delvec_name = tablet_delvec_filename(tablet_id, delvec.page().version());
+            std::string delvec_name = tablet_delvec_filename(tablet_id, delvec.second.version());
             datafiles.erase(delvec_name);
         }
     };

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -106,6 +106,7 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
         }
     }
     _tablet_id = tablet->id();
+    _data_version = base_version;
     if (watch.elapsed_time() > /*10ms=*/10 * 1000 * 1000) {
         LOG(INFO) << "LakePrimaryIndex load cost(ms): " << watch.elapsed_time() / 1000000;
     }

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -28,6 +28,8 @@ namespace lake {
 class Tablet;
 class MetaFileBuilder;
 
+enum CheckVersionResult { SUCCESS = 0, ADVANCE = 1, EXPIRED = 2 };
+
 class LakePrimaryIndex : public PrimaryIndex {
 public:
     LakePrimaryIndex() : PrimaryIndex() {}
@@ -41,9 +43,24 @@ public:
     Status lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                      const MetaFileBuilder* builder);
 
+    CheckVersionResult check_data_version(int64_t base_version) {
+        if (base_version == _data_version) {
+            return CheckVersionResult::SUCCESS;
+        } else if (base_version < _data_version) {
+            return CheckVersionResult::EXPIRED;
+        } else {
+            return CheckVersionResult::ADVANCE;
+        }
+    }
+    void update_data_version(int64_t version) { _data_version = version; }
+
 private:
     Status _do_lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);
+
+private:
+    // We don't support multi version in PrimaryIndex yet, but we will record latest data version for some checking
+    int64_t _data_version = 0;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -28,8 +28,6 @@ namespace lake {
 class Tablet;
 class MetaFileBuilder;
 
-enum CheckVersionResult { SUCCESS = 0, ADVANCE = 1, EXPIRED = 2 };
-
 class LakePrimaryIndex : public PrimaryIndex {
 public:
     LakePrimaryIndex() : PrimaryIndex() {}
@@ -43,15 +41,7 @@ public:
     Status lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                      const MetaFileBuilder* builder);
 
-    CheckVersionResult check_data_version(int64_t base_version) {
-        if (base_version == _data_version) {
-            return CheckVersionResult::SUCCESS;
-        } else if (base_version < _data_version) {
-            return CheckVersionResult::EXPIRED;
-        } else {
-            return CheckVersionResult::ADVANCE;
-        }
-    }
+    int64_t data_version() const { return _data_version; }
     void update_data_version(int64_t version) { _data_version = version; }
 
 private:

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -48,9 +48,8 @@ void MetaFileBuilder::append_delvec(DelVectorPtr delvec, uint32_t segment_id) {
         _buf.insert(_buf.end(), delvec_str.begin(), delvec_str.end());
         const uint64_t size = _buf.size() - offset;
         DCHECK(_delvecs.find(segment_id) == _delvecs.end());
-        _delvecs[segment_id].set_segment_id(segment_id);
-        _delvecs[segment_id].mutable_page()->set_offset(offset);
-        _delvecs[segment_id].mutable_page()->set_size(size);
+        _delvecs[segment_id].set_offset(offset);
+        _delvecs[segment_id].set_size(size);
     }
 }
 
@@ -90,14 +89,14 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
     while (delvec_it != _tablet_meta->mutable_delvec_meta()->mutable_delvecs()->end()) {
         bool need_del = false;
         for (const auto& range : delete_delvec_sid_range) {
-            if (delvec_it->segment_id() >= range.first && delvec_it->segment_id() <= range.second) {
+            if (delvec_it->first >= range.first && delvec_it->first <= range.second) {
                 need_del = true;
                 break;
             }
         }
         if (need_del) {
             // free cache
-            _tablet.tablet_mgr()->erase_metacache(delvec_cache_key(_tablet_meta->id(), delvec_it->page()));
+            _tablet.tablet_mgr()->erase_metacache(delvec_cache_key(_tablet_meta->id(), delvec_it->second));
             delvec_it = _tablet_meta->mutable_delvec_meta()->mutable_delvecs()->erase(delvec_it);
             delvec_erase_cnt++;
         } else {
@@ -120,26 +119,26 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
 
 Status MetaFileBuilder::_finalize_delvec(int64_t version) {
     if (!is_primary_key(_tablet_meta.get())) return Status::OK();
-    const size_t delvec_size = _tablet_meta->delvec_meta().delvecs_size();
-    for (size_t i = 0; i < delvec_size; i++) {
-        auto* each_delvec = _tablet_meta->mutable_delvec_meta()->mutable_delvecs(i);
-        auto iter = _delvecs.find(each_delvec->segment_id());
+    // 1. update delvec page in meta
+    for (auto&& each_delvec : *(_tablet_meta->mutable_delvec_meta()->mutable_delvecs())) {
+        auto iter = _delvecs.find(each_delvec.first);
         if (iter != _delvecs.end()) {
             // erase old version delvec from cache
-            // free cache
-            _tablet.tablet_mgr()->erase_metacache(delvec_cache_key(_tablet_meta->id(), each_delvec->page()));
-            each_delvec->mutable_page()->set_version(version);
-            each_delvec->mutable_page()->set_offset(iter->second.page().offset());
-            each_delvec->mutable_page()->set_size(iter->second.page().size());
+            _tablet.tablet_mgr()->erase_metacache(delvec_cache_key(_tablet_meta->id(), each_delvec.second));
+            each_delvec.second.set_version(version);
+            each_delvec.second.set_offset(iter->second.offset());
+            each_delvec.second.set_size(iter->second.size());
             _delvecs.erase(iter);
         }
     }
+
+    // 2. insert new delvec to meta
     for (auto&& each_delvec : _delvecs) {
-        each_delvec.second.mutable_page()->set_version(version);
-        _tablet_meta->mutable_delvec_meta()->add_delvecs()->CopyFrom(each_delvec.second);
+        each_delvec.second.set_version(version);
+        (*_tablet_meta->mutable_delvec_meta()->mutable_delvecs())[each_delvec.first] = each_delvec.second;
     }
 
-    // write to delvec file
+    // 3. write to delvec file
     if (_buf.size() > 0) {
         MonotonicStopWatch watch;
         watch.start();
@@ -179,9 +178,9 @@ StatusOr<bool> MetaFileBuilder::find_delvec(const TabletSegmentId& tsid, DelVect
     if (iter != _delvecs.end()) {
         (*pdelvec) = std::make_shared<DelVector>();
         // read delvec from write buf
-        RETURN_IF_ERROR((*pdelvec)->load(iter->second.page().version(),
-                                         reinterpret_cast<const char*>(_buf.data()) + iter->second.page().offset(),
-                                         iter->second.page().size()));
+        RETURN_IF_ERROR((*pdelvec)->load(iter->second.version(),
+                                         reinterpret_cast<const char*>(_buf.data()) + iter->second.offset(),
+                                         iter->second.size()));
         return true;
     }
     return false;
@@ -240,41 +239,42 @@ Status MetaFileReader::get_del_vec(TabletManager* tablet_mgr, uint32_t segment_i
     if (_access_file == nullptr) return _err_status;
     if (!_load) return Status::InternalError("meta file reader not loaded");
     const LocationProvider* location_provider = tablet_mgr->location_provider();
-    for (const auto& each_delvec : _tablet_meta->delvec_meta().delvecs()) {
-        if (each_delvec.segment_id() == segment_id) {
-            MonotonicStopWatch watch;
-            watch.start();
-            VLOG(2) << fmt::format("MetaFileReader get_del_vec {} segid {}",
-                                   _tablet_meta->delvec_meta().ShortDebugString(), segment_id);
-            std::string buf;
-            raw::stl_string_resize_uninitialized(&buf, each_delvec.page().size());
-            // read from delvec file by each_delvec.page().version()
-            const std::string filepath =
-                    location_provider->tablet_delvec_location(_tablet_meta->id(), each_delvec.page().version());
-            // find in cache
-            std::string cache_key = delvec_cache_key(_tablet_meta->id(), each_delvec.page());
-            DelVectorPtr delvec_cache_ptr = tablet_mgr->lookup_delvec(cache_key);
-            if (delvec_cache_ptr != nullptr) {
-                delvec->copy_from(*delvec_cache_ptr);
-                return Status::OK();
-            }
-            RandomAccessFileOptions opts{.skip_fill_local_cache = true};
-            auto rf = fs::new_random_access_file(opts, filepath);
-            if (!rf.ok()) {
-                return rf.status();
-            }
-            RETURN_IF_ERROR((*rf)->read_at_fully(each_delvec.page().offset(), buf.data(), each_delvec.page().size()));
-            // parse delvec
-            RETURN_IF_ERROR(delvec->load(each_delvec.page().version(), buf.data(), each_delvec.page().size()));
-            // put in cache
-            delvec_cache_ptr = std::make_shared<DelVector>();
-            delvec_cache_ptr->copy_from(*delvec);
-            tablet_mgr->cache_delvec(cache_key, delvec_cache_ptr);
-            if (watch.elapsed_time() > /*10ms=*/10 * 1000 * 1000) {
-                LOG(INFO) << "MetaFileReader read delvec cost(ms): " << watch.elapsed_time() / 1000000;
-            }
+    // find delvec by segment id
+    auto iter = _tablet_meta->delvec_meta().delvecs().find(segment_id);
+    if (iter != _tablet_meta->delvec_meta().delvecs().end()) {
+        // found it!
+        MonotonicStopWatch watch;
+        watch.start();
+        VLOG(2) << fmt::format("MetaFileReader get_del_vec {} segid {}", _tablet_meta->delvec_meta().ShortDebugString(),
+                               segment_id);
+        std::string buf;
+        raw::stl_string_resize_uninitialized(&buf, iter->second.size());
+        // read from delvec file by each_delvec.version()
+        const std::string filepath =
+                location_provider->tablet_delvec_location(_tablet_meta->id(), iter->second.version());
+        // find in cache
+        std::string cache_key = delvec_cache_key(_tablet_meta->id(), iter->second);
+        DelVectorPtr delvec_cache_ptr = tablet_mgr->lookup_delvec(cache_key);
+        if (delvec_cache_ptr != nullptr) {
+            delvec->copy_from(*delvec_cache_ptr);
             return Status::OK();
         }
+        RandomAccessFileOptions opts{.skip_fill_local_cache = true};
+        auto rf = fs::new_random_access_file(opts, filepath);
+        if (!rf.ok()) {
+            return rf.status();
+        }
+        RETURN_IF_ERROR((*rf)->read_at_fully(iter->second.offset(), buf.data(), iter->second.size()));
+        // parse delvec
+        RETURN_IF_ERROR(delvec->load(iter->second.version(), buf.data(), iter->second.size()));
+        // put in cache
+        delvec_cache_ptr = std::make_shared<DelVector>();
+        delvec_cache_ptr->copy_from(*delvec);
+        tablet_mgr->cache_delvec(cache_key, delvec_cache_ptr);
+        if (watch.elapsed_time() > /*10ms=*/10 * 1000 * 1000) {
+            LOG(INFO) << "MetaFileReader read delvec cost(ms): " << watch.elapsed_time() / 1000000;
+        }
+        return Status::OK();
     }
     VLOG(2) << fmt::format("MetaFileReader get_del_vec not found, segmentid {} tablet_meta {}", segment_id,
                            _tablet_meta->delvec_meta().ShortDebugString());

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -55,7 +55,7 @@ private:
     std::shared_ptr<TabletMetadata> _tablet_meta;
     UpdateManager* _update_mgr;
     Buffer<uint8_t> _buf;
-    std::unordered_map<uint32_t, DelvecPairPB> _delvecs;
+    std::unordered_map<uint32_t, DelvecPagePB> _delvecs;
     bool _has_finalized = false;
 };
 

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -35,12 +35,14 @@ class UpdateManager;
 class MetaFileBuilder {
 public:
     explicit MetaFileBuilder(Tablet tablet, std::shared_ptr<TabletMetadata> metadata_ptr);
-
-    //// for PK table
+    // append delvec to builder's buffer
     void append_delvec(DelVectorPtr delvec, uint32_t segment_id);
+    // handle txn log
     void apply_opwrite(const TxnLogPB_OpWrite& op_write);
     void apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
+    // finalize will generate and sync final meta state to storage.
     Status finalize();
+    // find delvec in builder's buffer, used for batch txn log precess.
     StatusOr<bool> find_delvec(const TabletSegmentId& tsid, DelVectorPtr* pdelvec) const;
     // when apply or finalize fail, need to clear primary index cache
     void handle_failure();
@@ -54,6 +56,7 @@ private:
     UpdateManager* _update_mgr;
     Buffer<uint8_t> _buf;
     std::unordered_map<uint32_t, DelvecPairPB> _delvecs;
+    bool _has_finalized = false;
 };
 
 class MetaFileReader {
@@ -61,8 +64,7 @@ public:
     explicit MetaFileReader(const std::string& filepath, bool fill_cache);
     ~MetaFileReader() {}
     Status load();
-    Status get_del_vec(LocationProvider* location_provider, uint32_t segment_id, DelVector* delvec,
-                       int64_t* latest_version);
+    Status get_del_vec(TabletManager* tablet_mgr, uint32_t segment_id, DelVector* delvec);
     StatusOr<TabletMetadataPtr> get_meta();
 
 private:
@@ -77,7 +79,6 @@ bool is_primary_key(const TabletMetadata& metadata);
 
 // TODO(yixin): cache rowset_rssid_to_path
 void rowset_rssid_to_path(const TabletMetadata& metadata, std::unordered_map<uint32_t, std::string>& rssid_to_path);
-void find_missed_tsid_range(TabletMetadata* metadata, std::vector<TabletSegmentIdRange>& tsid_ranges);
 
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -30,12 +30,6 @@
 
 namespace starrocks::lake {
 
-using ChunkChanger = ChunkChanger;
-using ChunkPtr = ChunkPtr;
-using Schema = Schema;
-using SchemaChangeUtils = SchemaChangeUtils;
-using TabletReaderParams = TabletReaderParams;
-
 class SchemaChange {
 public:
     explicit SchemaChange(TabletManager* tablet_manager) : _tablet_manager(tablet_manager) {}
@@ -123,8 +117,8 @@ public:
     Status process(RowsetPtr rowset, RowsetMetadata* new_rowset_metadata) override;
 
 private:
-    size_t _memory_limitation;
-    size_t _max_buffer_size;
+    size_t _memory_limitation = 0;
+    size_t _max_buffer_size = 0;
     std::unique_ptr<std::vector<uint32_t>> _selective;
 };
 

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -380,8 +380,8 @@ Status SchemaChangeHandler::convert_historical_rowsets(const SchemaChangeParams&
     // copy delete vector files if necessary
     if (op_schema_change->linked_segment() && base_metadata->has_delvec_meta()) {
         for (const auto& delvec : base_metadata->delvec_meta().delvecs()) {
-            auto src = base_tablet->delvec_location(delvec.page().version());
-            auto dst = new_tablet->delvec_location(delvec.page().version());
+            auto src = base_tablet->delvec_location(delvec.second.version());
+            auto dst = new_tablet->delvec_location(delvec.second.version());
             RETURN_IF_ERROR(fs::copy_file(src, dst));
         }
         op_schema_change->mutable_delvec_meta()->CopyFrom(base_metadata->delvec_meta());

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -507,20 +507,6 @@ StatusOr<double> publish(Tablet* tablet, int64_t base_version, int64_t new_versi
     auto log_applier = new_txn_log_applier(*tablet, new_metadata, new_version);
 
     RETURN_IF_ERROR(log_applier->init());
-    auto check_st = log_applier->check_meta_version();
-    if (!check_st.ok()) {
-        if (check_st.is_already_exist()) {
-            // return the new tablet meta score
-            auto target_metadata_or = tablet->get_metadata(new_version);
-            if (target_metadata_or.ok()) {
-                return compaction_score(**target_metadata_or);
-            } else {
-                return target_metadata_or.status();
-            }
-        } else {
-            return check_st;
-        }
-    }
 
     // Apply txn logs
     int64_t alter_version = -1;

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -42,6 +42,8 @@ using TxnLogIter = MetadataIterator<TxnLogPtr>;
 
 class TabletManager {
     friend class Tablet;
+    friend class MetaFileBuilder;
+    friend class MetaFileReader;
 
 public:
     // Does NOT take the ownership of |location_provider| and |location_provider| must outlive
@@ -146,7 +148,7 @@ public:
     UpdateManager* update_mgr();
 
 private:
-    using CacheValue = std::variant<TabletMetadataPtr, TxnLogPtr, TabletSchemaPtr, SegmentPtr>;
+    using CacheValue = std::variant<TabletMetadataPtr, TxnLogPtr, TabletSchemaPtr, SegmentPtr, DelVectorPtr>;
 
     static std::string tablet_schema_cache_key(int64_t tablet_id);
     static void cache_value_deleter(const CacheKey& /*key*/, void* value) { delete static_cast<CacheValue*>(value); }
@@ -165,6 +167,8 @@ private:
     TabletSchemaPtr lookup_tablet_schema(std::string_view key);
     SegmentPtr lookup_segment(std::string_view key);
     void cache_segment(std::string_view key, SegmentPtr segment);
+    DelVectorPtr lookup_delvec(std::string_view key);
+    void cache_delvec(std::string_view key, DelVectorPtr delvec);
 
     LocationProvider* _location_provider;
     std::unique_ptr<Cache> _metacache;

--- a/be/src/storage/lake/tablet_metadata.h
+++ b/be/src/storage/lake/tablet_metadata.h
@@ -24,6 +24,4 @@ using TabletMetadata = TabletMetadataPB;
 using TabletMetadataPtr = std::shared_ptr<TabletMetadata>;
 using MutableTabletMetadataPtr = std::shared_ptr<TabletMetadata>;
 
-using DelvecPair = DelvecPairPB;
-
 } // namespace starrocks::lake

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -55,18 +55,15 @@ public:
         auto [iter, ok] = _s_schema_change_set.insert(_tablet.id());
         if (ok) {
             _inited = true;
-            return Status::OK();
+            return check_meta_version();
         } else {
             return Status::InternalError("primary key does not support concurrent log applying");
         }
     }
 
-    Status check_meta_version() override {
+    Status check_meta_version() {
         // check tablet meta
-        if (!_tablet.update_mgr()->check_meta_version(_tablet, _base_version, _new_version)) {
-            LOG(WARNING) << "lake check_meta_version version " << _base_version << " already exist";
-            return Status::AlreadyExist("version already exist");
-        }
+        RETURN_IF_ERROR(_tablet.update_mgr()->check_meta_version(_tablet, _base_version));
         _check_meta_version_succ = true;
         return Status::OK();
     }

--- a/be/src/storage/lake/txn_log_applier.h
+++ b/be/src/storage/lake/txn_log_applier.h
@@ -32,6 +32,8 @@ public:
 
     virtual Status init() { return Status::OK(); }
 
+    virtual Status check_meta_version() { return Status::OK(); }
+
     virtual Status apply(const TxnLogPB& tnx_log) = 0;
 
     virtual Status finish() = 0;

--- a/be/src/storage/lake/txn_log_applier.h
+++ b/be/src/storage/lake/txn_log_applier.h
@@ -32,8 +32,6 @@ public:
 
     virtual Status init() { return Status::OK(); }
 
-    virtual Status check_meta_version() { return Status::OK(); }
-
     virtual Status apply(const TxnLogPB& tnx_log) = 0;
 
     virtual Status finish() = 0;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/lake/update_manager.h"
 
+#include "fs/fs_util.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/del_vector.h"
 #include "storage/lake/location_provider.h"
@@ -23,10 +24,23 @@
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/tablet_manager.h"
+#include "util/pretty_printer.h"
 
 namespace starrocks {
 
 namespace lake {
+
+UpdateManager::UpdateManager(LocationProvider* location_provider, MemTracker* mem_tracker)
+        : _index_cache(std::numeric_limits<size_t>::max()),
+          _update_state_cache(std::numeric_limits<size_t>::max()),
+          _location_provider(location_provider) {
+    _update_mem_tracker = mem_tracker;
+    _update_state_mem_tracker = std::make_unique<MemTracker>(-1, "lake_rowset_update_state", mem_tracker);
+    _index_cache_mem_tracker = std::make_unique<MemTracker>(-1, "lake_index_cache", mem_tracker);
+
+    _index_cache.set_mem_tracker(_index_cache_mem_tracker.get());
+    _update_state_cache.set_mem_tracker(_update_state_mem_tracker.get());
+}
 
 Status LakeDelvecLoader::load(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec) {
     return _update_mgr->get_del_vec(tsid, version, _pk_builder, pdelvec);
@@ -105,7 +119,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             tsid.tablet_id = tablet->id();
             tsid.segment_id = rssid;
             DelVectorPtr old_del_vec;
-            RETURN_IF_ERROR(get_latest_del_vec(tsid, base_version, builder, &old_del_vec));
+            RETURN_IF_ERROR(get_del_vec(tsid, base_version, builder, &old_del_vec));
             new_del_vecs[idx].first = rssid;
             old_del_vec->add_dels_as_new_version(new_delete.second, metadata.version(), &(new_del_vecs[idx].second));
             size_t cur_old = old_del_vec->cardinality();
@@ -141,6 +155,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             "base_ver:$6 new_ver:$7 cost:$8",
             tablet->id(), rowset_id, upserts.size(), state.deletes().size(), new_del, total_del, base_version,
             metadata.version(), cost_str.str());
+    _print_memory_stats();
 
     return Status::OK();
 }
@@ -246,22 +261,6 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
     return Status::OK();
 }
 
-Status UpdateManager::get_latest_del_vec(const TabletSegmentId& tsid, int64_t base_version,
-                                         const MetaFileBuilder* builder, DelVectorPtr* pdelvec) {
-    // 1. find in meta builder first
-    auto found = builder->find_delvec(tsid, pdelvec);
-    if (!found.ok()) {
-        return found.status();
-    }
-    if (*found) {
-        return Status::OK();
-    }
-    // 2. find in file
-    (*pdelvec).reset(new DelVector());
-    int64_t latest_version = 0;
-    return get_del_vec_in_meta(tsid, base_version, pdelvec->get(), &latest_version);
-}
-
 Status UpdateManager::get_del_vec(const TabletSegmentId& tsid, int64_t version, const MetaFileBuilder* builder,
                                   DelVectorPtr* pdelvec) {
     if (builder != nullptr) {
@@ -275,19 +274,16 @@ Status UpdateManager::get_del_vec(const TabletSegmentId& tsid, int64_t version, 
         }
     }
     (*pdelvec).reset(new DelVector());
-    int64_t latest_version = 0;
     // 2. find in delvec file
-    RETURN_IF_ERROR(get_del_vec_in_meta(tsid, version, pdelvec->get(), &latest_version));
-    return Status::OK();
+    return get_del_vec_in_meta(tsid, version, pdelvec->get());
 }
 
 // get delvec in meta file
-Status UpdateManager::get_del_vec_in_meta(const TabletSegmentId& tsid, int64_t meta_ver, DelVector* delvec,
-                                          int64_t* latest_version) {
+Status UpdateManager::get_del_vec_in_meta(const TabletSegmentId& tsid, int64_t meta_ver, DelVector* delvec) {
     std::string filepath = _location_provider->tablet_metadata_location(tsid.tablet_id, meta_ver);
     MetaFileReader reader(filepath, false);
     RETURN_IF_ERROR(reader.load());
-    RETURN_IF_ERROR(reader.get_del_vec(_location_provider, tsid.segment_id, delvec, latest_version));
+    RETURN_IF_ERROR(reader.get_del_vec(_tablet_mgr, tsid.segment_id, delvec));
     return Status::OK();
 }
 
@@ -387,6 +383,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
             " total_deletes:$3 total_rows:$4 base_ver:$5 new_ver:$6 cost:$7",
             tablet->id(), op_compaction.input_rowsets_size(), max_rowset_id, total_deletes, total_rows, base_version,
             metadata.version(), cost_str.str());
+    _print_memory_stats();
 
     return Status::OK();
 }
@@ -399,6 +396,55 @@ void UpdateManager::remove_primary_index_cache(uint32_t tablet_id) {
         succ = true;
     }
     LOG(WARNING) << "Lake update manager remove primary index cache, tablet_id: " << tablet_id << " , succ: " << succ;
+}
+
+bool UpdateManager::check_meta_version(const Tablet& tablet, int64_t base_version, int64_t new_version) {
+    auto index_entry = _index_cache.get(tablet.id());
+    if (index_entry == nullptr) {
+        // if primary index not in cache, check tablet meta directly
+        if (fs::path_exist(tablet.metadata_location(new_version))) {
+            return false;
+        } else {
+            return true;
+        }
+    } else {
+        auto& index = index_entry->value();
+        CheckVersionResult res = index.check_data_version(base_version);
+        if (res == CheckVersionResult::SUCCESS) {
+            // success
+            _index_cache.release(index_entry);
+            return true;
+        } else if (res == CheckVersionResult::ADVANCE) {
+            // advance, remove index and return success
+            _index_cache.remove(index_entry);
+            LOG(WARNING) << "Lake check_meta_version and remove primary index cache, tablet_id: " << tablet.id();
+            return true;
+        } else {
+            _index_cache.release(index_entry);
+            return false;
+        }
+    }
+}
+
+void UpdateManager::update_primary_index_data_version(const Tablet& tablet, int64_t version) {
+    auto index_entry = _index_cache.get(tablet.id());
+    if (index_entry != nullptr) {
+        auto& index = index_entry->value();
+        index.update_data_version(version);
+        _index_cache.release(index_entry);
+    }
+}
+
+void UpdateManager::_print_memory_stats() {
+    static std::atomic<int64_t> last_print_ts;
+    if (time(nullptr) > last_print_ts.load() + kPrintMemoryStatsInterval && _update_mem_tracker != nullptr) {
+        LOG(INFO) << strings::Substitute("[lake update manager memory]index:$0 update_state:$1 total:$2/$3",
+                                         PrettyPrinter::print_bytes(_index_cache_mem_tracker->consumption()),
+                                         PrettyPrinter::print_bytes(_update_state_mem_tracker->consumption()),
+                                         PrettyPrinter::print_bytes(_update_mem_tracker->consumption()),
+                                         PrettyPrinter::print_bytes(_update_mem_tracker->limit()));
+        last_print_ts.store(time(nullptr));
+    }
 }
 
 } // namespace lake

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -90,9 +90,8 @@ public:
     // publish failed later, need to clear primary index.
     void remove_primary_index_cache(uint32_t tablet_id);
 
-    // if check_meta_version return true, continue handle publish version request, or just return publish version success,
-    // because this publish version have been processed.
-    bool check_meta_version(const Tablet& tablet, int64_t base_version, int64_t new_version);
+    // if base version != index.data_version, need to clear index cache
+    Status check_meta_version(const Tablet& tablet, int64_t base_version);
 
     // update primary index data version when meta file finalize success.
     void update_primary_index_data_version(const Tablet& tablet, int64_t version);

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -48,11 +48,9 @@ private:
 
 class UpdateManager {
 public:
-    UpdateManager(LocationProvider* location_provider)
-            : _index_cache(std::numeric_limits<size_t>::max()),
-              _update_state_cache(std::numeric_limits<size_t>::max()),
-              _location_provider(location_provider) {}
+    UpdateManager(LocationProvider* location_provider, MemTracker* mem_tracker = nullptr);
     ~UpdateManager() {}
+    void set_tablet_mgr(TabletManager* tablet_mgr) { _tablet_mgr = tablet_mgr; }
     void set_cache_expire_ms(int64_t expire_ms) { _cache_expire_ms = expire_ms; }
 
     int64_t get_cache_expire_ms() const { return _cache_expire_ms; }
@@ -75,13 +73,8 @@ public:
     Status get_del_vec(const TabletSegmentId& tsid, int64_t version, const MetaFileBuilder* builder,
                        DelVectorPtr* pdelvec);
 
-    // get latest delvec
-    Status get_latest_del_vec(const TabletSegmentId& tsid, int64_t base_version, const MetaFileBuilder* builder,
-                              DelVectorPtr* pdelvec);
-
     // get delvec from tablet meta file
-    Status get_del_vec_in_meta(const TabletSegmentId& tsid, int64_t meta_ver, DelVector* delvec,
-                               int64_t* latest_version);
+    Status get_del_vec_in_meta(const TabletSegmentId& tsid, int64_t meta_ver, DelVector* delvec);
     // set delvec cache
     Status set_cached_del_vec(const std::vector<std::pair<TabletSegmentId, DelVectorPtr>>& cache_delvec_updates,
                               int64_t version);
@@ -97,12 +90,22 @@ public:
     // publish failed later, need to clear primary index.
     void remove_primary_index_cache(uint32_t tablet_id);
 
+    // if check_meta_version return true, continue handle publish version request, or just return publish version success,
+    // because this publish version have been processed.
+    bool check_meta_version(const Tablet& tablet, int64_t base_version, int64_t new_version);
+
+    // update primary index data version when meta file finalize success.
+    void update_primary_index_data_version(const Tablet& tablet, int64_t version);
+
     void expire_cache();
 
 private:
     Status _do_update(std::uint32_t rowset_id, std::int32_t upsert_idx, const std::vector<ColumnUniquePtr>& upserts,
                       PrimaryIndex& index, std::int64_t tablet_id, DeletesMap* new_deletes);
+    // print memory tracker state
+    void _print_memory_stats();
 
+    static const size_t kPrintMemoryStatsInterval = 300; // 5min
 private:
     // default 6min
     int64_t _cache_expire_ms = 360000;
@@ -111,8 +114,14 @@ private:
 
     // rowset cache
     DynamicCache<string, RowsetUpdateState> _update_state_cache;
-    std::atomic<int64_t> _last_clear_expired_cache_millis{0};
-    LocationProvider* _location_provider;
+    std::atomic<int64_t> _last_clear_expired_cache_millis = 0;
+    LocationProvider* _location_provider = nullptr;
+    TabletManager* _tablet_mgr = nullptr;
+
+    // memory checkers
+    MemTracker* _update_mem_tracker = nullptr;
+    std::unique_ptr<MemTracker> _index_cache_mem_tracker;
+    std::unique_ptr<MemTracker> _update_state_mem_tracker;
 };
 
 } // namespace lake

--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -156,12 +156,13 @@ public:
     }
 
     // remove an object get/get_or_create'ed earlier
-    void remove(Entry* entry) {
+    bool remove(Entry* entry) {
         std::lock_guard<std::mutex> lg(_lock);
         entry->_ref--;
         if (entry->_ref != 1) {
             LOG(ERROR) << "remove() failed: cache entry ref != 1 " << entry->_value;
             DCHECK(false);
+            return false;
         } else {
             _map.erase(entry->key());
             _list.erase(entry->_handle);
@@ -169,6 +170,7 @@ public:
             _size -= entry->_size;
             if (_mem_tracker) _mem_tracker->release(entry->_size);
             delete entry;
+            return true;
         }
     }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -186,6 +186,7 @@ set(EXEC_FILES
         ./storage/lake/tablet_reader_test.cpp
         ./storage/lake/tablet_writer_test.cpp
         ./storage/lake/primary_key_compaction_task_test.cpp
+        ./storage/lake/primary_key_publish_test.cpp
         ./storage/rowset_update_state_test.cpp
         ./storage/rowset/rowset_test.cpp
         ./storage/rowset/binary_dict_page_test.cpp

--- a/be/test/storage/lake/gc_test.cpp
+++ b/be/test/storage/lake/gc_test.cpp
@@ -355,7 +355,7 @@ TEST_F(GCTest, test_delvec_gc) {
         metadata->set_version(1);
         metadata->set_next_rowset_id(1);
         for (int i = 1; i < 5; i++) {
-            metadata->mutable_delvec_meta()->add_delvecs()->mutable_page()->set_version(i);
+            (*metadata->mutable_delvec_meta()->mutable_delvecs())[i].set_version(i);
         }
         ASSERT_OK(tablet_manager_1->put_tablet_metadata(metadata));
     }

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -119,9 +119,8 @@ TEST_F(MetaFileTest, test_delvec_rw) {
     EXPECT_TRUE(reader2.load().ok());
     auto meta_st = reader2.get_meta();
     EXPECT_TRUE(meta_st.ok());
-    DelvecPairPB delvecpb = (*meta_st)->delvec_meta().delvecs(0);
-    EXPECT_EQ(delvecpb.segment_id(), segment_id);
-    EXPECT_EQ(delvecpb.page().version(), version);
+    DelvecPagePB delvec_pagepb = (*meta_st)->delvec_meta().delvecs()[segment_id];
+    EXPECT_EQ(delvec_pagepb.version(), version);
     // 5. update delvec
     metadata->set_version(version2);
     MetaFileBuilder builder2(metadata, s_update_manager.get());

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -111,7 +111,7 @@ TEST_F(MetaFileTest, test_delvec_rw) {
     EXPECT_TRUE(reader.load().ok());
     DelVector after_delvec;
     int64_t latest_version;
-    EXPECT_TRUE(reader.get_del_vec(s_location_provider.get(), segment_id, &after_delvec, &latest_version).ok());
+    EXPECT_TRUE(reader.get_del_vec(s_tablet_manager.get(), segment_id, &after_delvec, &latest_version).ok());
     EXPECT_EQ(before_delvec, after_delvec.save());
     EXPECT_EQ(version, latest_version);
     // 4. read meta

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1,0 +1,404 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/meta_file.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/rowset/segment.h"
+#include "storage/rowset/segment_iterator.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+using VSchema = starrocks::Schema;
+using VChunk = starrocks::Chunk;
+
+class TestLocationProvider : public LocationProvider {
+public:
+    explicit TestLocationProvider(std::string dir) : _dir(dir) {}
+
+    std::set<int64_t> owned_tablets() const override { return _owned_shards; }
+
+    std::string root_location(int64_t tablet_id) const override { return _dir; }
+
+    Status list_root_locations(std::set<std::string>* roots) const override {
+        roots->insert(_dir);
+        return Status::OK();
+    }
+
+    void set_failed(bool f) { _set_failed = f; }
+
+    std::set<int64_t> _owned_shards;
+    std::string _dir;
+    bool _set_failed = false;
+};
+
+class PrimaryKeyPublishTest : public testing::Test {
+public:
+    PrimaryKeyPublishTest() {
+        _location_provider = std::make_unique<TestLocationProvider>(kTestGroupPath);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
+
+        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_next_rowset_id(1);
+        _location_provider->_owned_shards.insert(_tablet_metadata->id());
+
+        _backup_location_provider = _tablet_manager->TEST_set_location_provider(_location_provider.get());
+
+        _parent_mem_tracker = std::make_unique<MemTracker>(-1);
+        _mem_tracker = std::make_unique<MemTracker>(-1, "", _parent_mem_tracker.get());
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+            c1->set_aggregation("REPLACE");
+        }
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(*_tablet_schema));
+    }
+
+    void SetUp() override {
+        (void)fs::remove_all(kTestGroupPath);
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kTxnLogDirectoryName)));
+        CHECK_OK(_tablet_manager->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+        tablet.delete_txn_log(_txn_id);
+        _txn_id++;
+        (void)ExecEnv::GetInstance()->lake_tablet_manager()->TEST_set_location_provider(_backup_location_provider);
+        (void)fs::remove_all(kTestGroupPath);
+    }
+
+    VChunk generate_data(int64_t chunk_size, int shift) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i + shift * chunk_size;
+        }
+        auto rng = std::default_random_engine{};
+        std::shuffle(v0.begin(), v0.end(), rng);
+        for (int i = 0; i < chunk_size; i++) {
+            v1[i] = v0[i] * 3;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        return VChunk({c0, c1}, _schema);
+    }
+
+    int64_t read(int64_t version) {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        auto chunk = ChunkHelper::new_chunk(*_schema, 128);
+        int64_t ret = 0;
+        while (true) {
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            ret += chunk->num_rows();
+            chunk->reset();
+        }
+        return ret;
+    }
+
+protected:
+    constexpr static const char* const kTestGroupPath = "test_lake_primary_key";
+    constexpr static const int kChunkSize = 12;
+
+    std::unique_ptr<TestLocationProvider> _location_provider;
+    LocationProvider* _backup_location_provider;
+    std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<UpdateManager> _update_manager;
+    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::unique_ptr<MemTracker> _parent_mem_tracker;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<VSchema> _schema;
+    int64_t _txn_id = 1231;
+    int64_t _partition_id = 4561;
+};
+
+TEST_F(PrimaryKeyPublishTest, test_write_read_success) {
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+
+    VChunk chunk0({c0, c1}, _schema);
+    auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+    std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer());
+    ASSERT_OK(writer->open());
+
+    // write segment #1
+    ASSERT_OK(writer->write(chunk0));
+    ASSERT_OK(writer->finish());
+
+    // write txnlog
+    int64_t logs[1];
+    logs[0] = _txn_id;
+    auto txn_log = std::make_shared<TxnLog>();
+    txn_log->set_tablet_id(_tablet_metadata->id());
+    txn_log->set_txn_id(_txn_id++);
+    auto op_write = txn_log->mutable_op_write();
+    for (auto& f : writer->files()) {
+        op_write->mutable_rowset()->add_segments(std::move(f));
+    }
+    op_write->mutable_rowset()->set_num_rows(writer->num_rows());
+    op_write->mutable_rowset()->set_data_size(writer->data_size());
+    op_write->mutable_rowset()->set_overlapped(false);
+
+    ASSERT_OK(_tablet_manager->put_txn_log(txn_log));
+
+    writer->close();
+
+    ASSIGN_OR_ABORT(auto score, _tablet_manager->publish_version(_tablet_metadata->id(), 1, 2, logs, 1));
+    EXPECT_TRUE(score > 0.0);
+
+    // read at version 2
+    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(2, *_schema));
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    ASSERT_OK(reader->get_next(read_chunk_ptr.get()));
+    ASSERT_EQ(k0.size(), read_chunk_ptr->num_rows());
+
+    for (int i = 0, sz = k0.size(); i < sz; i++) {
+        EXPECT_EQ(k0[i], read_chunk_ptr->get(i)[0].get_int32());
+        EXPECT_EQ(v0[i], read_chunk_ptr->get(i)[1].get_int32());
+    }
+}
+
+TEST_F(PrimaryKeyPublishTest, test_write_multitime_check_result) {
+    auto chunk0 = generate_data(kChunkSize, 0);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, read(version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+}
+
+TEST_F(PrimaryKeyPublishTest, test_write_fail_retry) {
+    std::vector<Chunk> chunks;
+    for (int i = 0; i < 5; i++) {
+        chunks.push_back(generate_data(kChunkSize, i));
+    }
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // write success
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    // write failed
+    for (int i = 3; i < 5; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(tablet_id));
+        auto txn_log_st = tablet.get_txn_log(_txn_id);
+        EXPECT_TRUE(txn_log_st.ok());
+        auto& txn_log = txn_log_st.value();
+        ASSIGN_OR_ABORT(auto base_metadata, tablet.get_metadata(version));
+        auto new_metadata = std::make_shared<TabletMetadata>(*base_metadata);
+        new_metadata->set_version(version + 1);
+        std::unique_ptr<MetaFileBuilder> builder = std::make_unique<MetaFileBuilder>(tablet, new_metadata);
+        // update primary table state, such as primary index
+        ASSERT_OK(tablet.update_mgr()->publish_primary_key_tablet(txn_log->op_write(), *new_metadata, &tablet,
+                                                                  builder.get(), version));
+        // if builder.finalize fail, remove primary index cache and retry
+        builder->handle_failure();
+    }
+    // write success
+    for (int i = 3; i < 5; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * 5, read(version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
+}
+
+TEST_F(PrimaryKeyPublishTest, test_publish_multi_times) {
+    auto chunk0 = generate_data(kChunkSize, 0);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, read(version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    // duplicate publish
+    ASSERT_OK(_tablet_manager->publish_version(tablet_id, version - 1, version, &_txn_id, 1).status());
+    // publish using old version
+    ASSERT_OK(_tablet_manager->publish_version(tablet_id, version - 2, version - 1, &_txn_id, 1).status());
+    // advince publish should fail, because version + 1 don't exist
+    ASSERT_ERROR(_tablet_manager->publish_version(tablet_id, version + 1, version + 2, &_txn_id, 1).status());
+    ASSERT_EQ(kChunkSize, read(version));
+}
+
+TEST_F(PrimaryKeyPublishTest, test_publish_concurrent) {
+    auto chunk0 = generate_data(kChunkSize, 0);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // start to publish using multi thread
+        std::vector<std::thread> workers;
+        for (int i = 0; i < 5; i++) {
+            workers.emplace_back(
+                    [&]() { (void)_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1); });
+        }
+        for (auto& t : workers) {
+            t.join();
+        }
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, read(version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -45,7 +45,8 @@ class DuplicateTabletReaderTest : public testing::Test {
 public:
     DuplicateTabletReaderTest() {
         _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
-        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), nullptr, 0);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 0);
         _tablet_metadata = std::make_unique<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
@@ -95,6 +96,7 @@ protected:
 
     std::unique_ptr<FixedLocationProvider> _location_provider;
     std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<UpdateManager> _update_manager;
     std::unique_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<VSchema> _schema;
@@ -189,7 +191,8 @@ class AggregateTabletReaderTest : public testing::Test {
 public:
     AggregateTabletReaderTest() {
         _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
-        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), nullptr, 0);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 0);
         _tablet_metadata = std::make_unique<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
@@ -240,6 +243,7 @@ protected:
 
     std::unique_ptr<FixedLocationProvider> _location_provider;
     std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<UpdateManager> _update_manager;
     std::unique_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<VSchema> _schema;
@@ -357,7 +361,8 @@ class DuplicateTabletReaderWithDeleteTest : public testing::Test {
 public:
     DuplicateTabletReaderWithDeleteTest() {
         _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
-        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), nullptr, 0);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 0);
         _tablet_metadata = std::make_unique<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
@@ -407,6 +412,7 @@ protected:
 
     std::unique_ptr<FixedLocationProvider> _location_provider;
     std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<UpdateManager> _update_manager;
     std::unique_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<VSchema> _schema;

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -47,7 +47,8 @@ class LakeTabletWriterTest : public testing::Test, public testing::WithParamInte
 public:
     LakeTabletWriterTest() {
         _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
-        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), nullptr, 0);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 0);
         _tablet_metadata = std::make_unique<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
@@ -98,6 +99,7 @@ protected:
 
     std::unique_ptr<FixedLocationProvider> _location_provider;
     std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<UpdateManager> _update_manager;
     std::unique_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<VSchema> _schema;

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -34,13 +34,10 @@ message DelvecCacheKeyPB {
     optional DelvecPagePB delvec_page = 2;
 }
 
-// from segment to delvec page
-message DelvecPairPB {
-    optional uint32 segment_id = 1;
-    optional DelvecPagePB page = 2;
+message DelvecMetadataPB {
+    // from segment id to delvec page
+    map<uint32, DelvecPagePB> delvecs = 1;
 }
-
-message DelvecMetadataPB { repeated DelvecPairPB delvecs = 1; }
 
 message RowsetMetadataPB {
     optional uint32 id = 1;

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -29,6 +29,11 @@ message DelvecPagePB {
     optional uint64 size = 3;
 }
 
+message DelvecCacheKeyPB {
+    optional int64 id = 1;
+    optional DelvecPagePB delvec_page = 2;
+}
+
 // from segment to delvec page
 message DelvecPairPB {
     optional uint32 segment_id = 1;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14853

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. Add data version to lake primary index, and do some version check before handle txn logs. By this, we can support multi cluster and also handle same publish twice.
2. Add memory tracker to lake update manager to monitor the memory states of lake pk table.
3. Using meta cache to cache delvec.
4. Using Map in proto to record from segment id to delvec.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
