### PR TITLE
[Feature] Support INT64 based timestamp for JNI connector

### DIFF
--- a/java-extensions/hudi-reader/pom.xml
+++ b/java-extensions/hudi-reader/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <java-extensions.home>${basedir}/../</java-extensions.home>
         <slf4j.version>1.7.32</slf4j.version>
-        <presto.hadoop.version>2.7.4-9</presto.hadoop.version>
+        <presto.hadoop.version>2.7.4-11</presto.hadoop.version>
         <presto.hive.version>3.0.0-8</presto.hive.version>
         <hudi.version>0.12.1</hudi.version>
         <fasterxml.version>2.13.4</fasterxml.version>

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiColumnValue.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiColumnValue.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.hudi.reader;
 
+import com.starrocks.jni.connector.ColumnType;
 import com.starrocks.jni.connector.ColumnValue;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
@@ -21,13 +22,18 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.io.LongWritable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.starrocks.hudi.reader.HudiScannerUtils.TIMESTAMP_UNIT_MAPPING;
 
 public class HudiColumnValue implements ColumnValue {
-    private Object fieldData;
-    private ObjectInspector fieldInspector;
+    private final Object fieldData;
+    private final ObjectInspector fieldInspector;
 
     HudiColumnValue(ObjectInspector fieldInspector, Object fieldData) {
         this.fieldInspector = fieldInspector;
@@ -71,6 +77,19 @@ public class HudiColumnValue implements ColumnValue {
     @Override
     public String getString() {
         return inspectObject().toString();
+    }
+
+    @Override
+    public String getTimestamp(ColumnType.TypeValue type) {
+        // INT64 timestamp type
+        if (HudiScannerUtils.isInt64Timestamp(type)) {
+            long datetime = ((LongWritable) fieldData).get();
+            TimeUnit timeUnit = TIMESTAMP_UNIT_MAPPING.get(type);
+            LocalDateTime localDateTime = HudiScannerUtils.getTimestamp(datetime, timeUnit, true);
+            return HudiScannerUtils.formatDateTime(localDateTime);
+        } else {
+            return inspectObject().toString();
+        }
     }
 
     @Override

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.hudi.reader;
+
+import com.starrocks.jni.connector.ColumnType;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class HudiScannerUtils {
+    private static final DateTimeFormatter DATETIME_FORMATTER;
+    public static final Map<String, String> MARK_TYPE_VALUE_MAPPING = new HashMap<>();
+    public static Map<ColumnType.TypeValue, TimeUnit> TIMESTAMP_UNIT_MAPPING = new HashMap<>();
+
+    static {
+        DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
+        // Date and time parts
+        builder.append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        DATETIME_FORMATTER = builder.toFormatter();
+
+        MARK_TYPE_VALUE_MAPPING.put("TimestampMicros", "timestamp");
+        MARK_TYPE_VALUE_MAPPING.put("TimestampMillis", "timestamp");
+
+        TIMESTAMP_UNIT_MAPPING.put(ColumnType.TypeValue.DATETIME_MICROS, TimeUnit.MICROSECONDS);
+        TIMESTAMP_UNIT_MAPPING.put(ColumnType.TypeValue.DATETIME_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    private static final long MILLI = 1000;
+    private static final long MICRO = 1_000_000;
+    private static final long NANO = 1_000_000_000;
+
+    public static LocalDateTime getTimestamp(long value, TimeUnit timeUnit, boolean isAdjustedToUTC) {
+
+        ZoneId zone = ZoneOffset.UTC;
+        if (isAdjustedToUTC) {
+            zone = ZoneId.systemDefault();
+        }
+        long seconds = 0L;
+        long nanoseconds = 0L;
+
+        switch (timeUnit) {
+            case MILLISECONDS:
+                seconds = value / MILLI;
+                nanoseconds = (value % MILLI) * MICRO;
+                break;
+
+            case MICROSECONDS:
+                seconds = value / MICRO;
+                nanoseconds = (value % MICRO) * MILLI;
+                break;
+
+            case NANOSECONDS:
+                seconds = value / NANO;
+                nanoseconds = (value % NANO);
+                break;
+            default:
+                break;
+        }
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(seconds, nanoseconds), zone);
+    }
+
+    public static String formatDateTime(LocalDateTime dateTime) {
+        return dateTime.format(DATETIME_FORMATTER);
+    }
+
+    public static boolean isInt64Timestamp(ColumnType.TypeValue type) {
+        return (type == ColumnType.TypeValue.DATETIME_MICROS
+                || type == ColumnType.TypeValue.DATETIME_MILLIS);
+    }
+}

--- a/java-extensions/java-utils/src/main/java/com/starrocks/utils/NativeMethodHelper.java
+++ b/java-extensions/java-utils/src/main/java/com/starrocks/utils/NativeMethodHelper.java
@@ -16,7 +16,7 @@ package com.starrocks.utils;
 
 /**
  * Note: All native methods has been registered by JNI launcher in BE.
- * This class must be loaded by {@link jdk.internal.loader.ClassLoaders.AppClassLoader} only
+ * This class must be loaded by {@link sun.misc.Launcher$AppClassLoader} only
  * and can not be loaded by any other independent class loader.
  */
 public final class NativeMethodHelper {

--- a/java-extensions/java-utils/src/main/java/com/starrocks/utils/loader/ChildFirstClassLoader.java
+++ b/java-extensions/java-utils/src/main/java/com/starrocks/utils/loader/ChildFirstClassLoader.java
@@ -69,9 +69,4 @@ public class ChildFirstClassLoader extends URLClassLoader {
             return parent.getResource(name);
         }
     }
-
-    @Override
-    public void addURL(URL url) {
-        super.addURL(url);
-    }
 }

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -32,7 +32,12 @@ public class ColumnType {
         STRING,
         BINARY,
         DATE,
+        // INT96 timestamp type, hive compatible (hive version < 4.x)
         DATETIME,
+        // INT64 timestamp type, TIMESTAMP(isAdjustedToUTC=true, unit=MICROS)
+        DATETIME_MICROS,
+        // INT64 timestamp type, TIMESTAMP(isAdjustedToUTC=true, unit=MILLIS)
+        DATETIME_MILLIS,
         DECIMAL,
         ARRAY,
         MAP,
@@ -61,6 +66,8 @@ public class ColumnType {
         PRIMITIVE_TYPE_VALUE_MAPPING.put("binary", TypeValue.BINARY);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("date", TypeValue.DATE);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("timestamp", TypeValue.DATETIME);
+        PRIMITIVE_TYPE_VALUE_MAPPING.put("TimestampMicros", TypeValue.DATETIME_MICROS);
+        PRIMITIVE_TYPE_VALUE_MAPPING.put("TimestampMillis", TypeValue.DATETIME_MILLIS);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("decimal", TypeValue.DECIMAL);
 
         PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.BYTE, 1);
@@ -201,9 +208,10 @@ public class ColumnType {
         parse(scanner);
     }
 
-    public boolean isString() {
-        return typeValue == TypeValue.STRING || typeValue == TypeValue.DATE || typeValue == TypeValue.DECIMAL ||
-                typeValue == TypeValue.BINARY || typeValue == TypeValue.DATETIME;
+    public boolean isByteStorageType() {
+        return typeValue == TypeValue.STRING || typeValue == TypeValue.DATE || typeValue == TypeValue.DECIMAL
+                || typeValue == TypeValue.BINARY || typeValue == TypeValue.DATETIME
+                || typeValue == TypeValue.DATETIME_MICROS || typeValue == TypeValue.DATETIME_MILLIS;
     }
 
     public boolean isArray() {
@@ -237,8 +245,12 @@ public class ColumnType {
                 return res;
             }
             case STRING:
+            case BINARY:
             case DECIMAL:
             case DATE:
+            case DATETIME:
+            case DATETIME_MICROS:
+            case DATETIME_MILLIS:
                 // [null | offset | data ]
                 return 3;
             default:

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnValue.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnValue.java
@@ -30,7 +30,7 @@ public interface ColumnValue {
     public double getDouble();
 
     public String getString();
-
+    public String getTimestamp(ColumnType.TypeValue type);
     public byte[] getBytes();
 
     public void unpackArray(List<ColumnValue> values);

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ConnectorScanner.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ConnectorScanner.java
@@ -86,7 +86,7 @@ public abstract class ConnectorScanner {
         offHeapTable.appendData(index, value);
     }
 
-    public int getTableSize() {
+    protected int getTableSize() {
         return tableSize;
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

- Fix the bug that the core-site.xml configuration is overwritten by presto-hadoop dependency. 
- Support INT64 based timestamp for JNI connector. This implementation is a bit tricky and is a bypass solution because  INT64 based timestamp is fully supported until hive version >= 4.0, details in [HIVE-21215](https://issues.apache.org/jira/browse/HIVE-21215)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
