### PR TITLE
[BugFix] Offset+limit overflows and yields a negative result

### DIFF
--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -45,7 +45,8 @@ Status ChunksSorterHeapSort::update(RuntimeState* state, const ChunkPtr& chunk) 
     int row_sz = chunk_holder->value()->chunk->num_rows();
     if (_sort_heap == nullptr) {
         _sort_heap = std::make_unique<CommonCursorSortHeap>(detail::ChunkCursorComparator(_sort_desc));
-        _sort_heap->reserve(_number_of_rows_to_sort());
+        // avoid exaggerated limit + offset, for an example select * from t order by col limit 9223372036854775800,1
+        _sort_heap->reserve(std::min<size_t>(_number_of_rows_to_sort(), 10'000'000ul));
         // build heap
         size_t direct_push = std::min<size_t>(_number_of_rows_to_sort(), row_sz);
         size_t i = 0;

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -404,7 +404,8 @@ Status ChunksSorterTopn::_merge_sort_common(ChunkPtr& big_chunk, DataSegments& s
     Columns left_columns = _merged_segment.order_by_columns;
 
     Permutation merged_perm;
-    merged_perm.reserve(rows_to_keep);
+    // avoid exaggerated limit + offset, for an example select * from t order by col limit 9223372036854775800,1
+    merged_perm.reserve(std::min<size_t>(rows_to_keep, 10'000'000ul));
 
     RETURN_IF_ERROR(merge_sorted_chunks_two_way(_sort_desc, {left_chunk, left_columns}, {right_chunk, right_columns},
                                                 &merged_perm));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.operator.logical;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -38,6 +39,9 @@ public class LogicalLimitOperator extends LogicalOperator {
 
     public LogicalLimitOperator(long limit, long offset, Phase phase) {
         super(OperatorType.LOGICAL_LIMIT);
+        Preconditions.checkState(limit < 0 || limit + offset >= 0,
+                String.format("limit(%d) + offset(%d) is too large and yields an overflow result(%d)", limit, offset,
+                        limit + offset));
         this.limit = limit;
         this.offset = offset;
         this.phase = phase;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNRule.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -50,6 +51,9 @@ public class SplitTopNRule extends TransformationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalTopNOperator src = (LogicalTopNOperator) input.getOp();
 
+        Preconditions.checkState(src.getLimit() < 0 || src.getLimit() + src.getOffset() >= 0,
+                String.format("limit(%d) + offset(%d) is too large and yields an overflow result(%d)", src.getLimit(),
+                        src.getOffset(), src.getLimit() + src.getOffset()));
         long limit = src.getLimit() + src.getOffset();
         LogicalTopNOperator partialSort = new LogicalTopNOperator(
                 src.getOrderByElements(), limit, Operator.DEFAULT_OFFSET, SortPhase.PARTIAL);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/16924
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Exaggerated large offset and limit values in queries leads incorrect limit and offset of TopN operators in Plan. both offset and limit are long-typed, so offset(9223372036854775807) + limit(1) overflows and yields -9223372036854775808.

When offset + limit does not overflows but yields a very large value, BE will reserve memory far beyond its requirement for PartitionSortSinkOperators, so we use empirical value(10'000'000ul) to cap the large value.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
