### PR TITLE
[BugFix] Fix bitnot largeint cast

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
@@ -64,8 +64,6 @@ public class ArithmeticExpr extends Expr {
             .put(Operator.BITAND.getName(), Operator.BITAND)
             .put(Operator.BITOR.getName(), Operator.BITOR)
             .put(Operator.BITXOR.getName(), Operator.BITXOR)
-            .put(Operator.BITNOT.getName(), Operator.BITNOT)
-            .put(Operator.FACTORIAL.getName(), Operator.FACTORIAL)
             .put(Operator.BIT_SHIFT_LEFT.getName(), Operator.BIT_SHIFT_LEFT)
             .put(Operator.BIT_SHIFT_RIGHT.getName(), Operator.BIT_SHIFT_RIGHT)
             .put(Operator.BIT_SHIFT_RIGHT_LOGICAL.getName(), Operator.BIT_SHIFT_RIGHT_LOGICAL)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1363,4 +1363,11 @@ public class ExpressionTest extends PlanTestBase {
         assertContains(plan, "PREDICATES: ((1: v1 IN (3, 4, 5)) OR (1: v1 = 2: v2)) OR (1: v1 = 3: v3)");
     }
 
+    @Test
+    public void testBitNotLargeInt() throws Exception {
+        String sql = "select bitnot(cast(power(-2,127) as largeint)+1);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "~ CAST(power(-2.0, 127.0) AS LARGEINT) + 1");
+    }
+
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

https://github.com/StarRocks/StarRocksTest/issues/1733

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3

before https://github.com/StarRocks/starrocks/pull/15757
 
the plan for `select bitnot(cast(power(-2,127) as largeint)+1);` was:

```
~ CAST(power(-2.0, 127.0) AS LARGEINT) + 1
```

but after that commit, the plan was:

```
~ CAST(CAST(power(-2.0, 127.0) AS LARGEINT) + 1 AS BIGINT)
```
**The reason is  we shouldn't handle bitnot by ArithmeticExpr when Analyze.**