### PR TITLE
[BugFix] Init scan executor for compute node

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -266,37 +266,38 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _frontend_client_cache->init_metrics(StarRocksMetrics::instance()->metrics(), "frontend");
     _broker_client_cache->init_metrics(StarRocksMetrics::instance()->metrics(), "broker");
     _result_mgr->init();
+
+    int num_io_threads = config::pipeline_scan_thread_pool_thread_num <= 0
+                                 ? CpuInfo::num_cores()
+                                 : config::pipeline_scan_thread_pool_thread_num;
+
+    std::unique_ptr<ThreadPool> scan_worker_thread_pool_without_workgroup;
+    RETURN_IF_ERROR(ThreadPoolBuilder("pip_scan_io")
+                            .set_min_threads(0)
+                            .set_max_threads(num_io_threads)
+                            .set_max_queue_size(1000)
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                            .build(&scan_worker_thread_pool_without_workgroup));
+    _scan_executor_without_workgroup = new workgroup::ScanExecutor(
+            std::move(scan_worker_thread_pool_without_workgroup),
+            std::make_unique<workgroup::PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
+    _scan_executor_without_workgroup->initialize(num_io_threads);
+
+    std::unique_ptr<ThreadPool> scan_worker_thread_pool_with_workgroup;
+    RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_scan_io")
+                            .set_min_threads(0)
+                            .set_max_threads(num_io_threads)
+                            .set_max_queue_size(1000)
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                            .build(&scan_worker_thread_pool_with_workgroup));
+    _scan_executor_with_workgroup =
+            new workgroup::ScanExecutor(std::move(scan_worker_thread_pool_with_workgroup),
+                                        std::make_unique<workgroup::WorkGroupScanTaskQueue>(
+                                                workgroup::WorkGroupScanTaskQueue::SchedEntityType::OLAP));
+    _scan_executor_with_workgroup->initialize(num_io_threads);
+
     // it means acting as compute node while store_path is empty. some threads are not needed for that case.
     if (!store_paths.empty()) {
-        int num_io_threads = config::pipeline_scan_thread_pool_thread_num <= 0
-                                     ? CpuInfo::num_cores()
-                                     : config::pipeline_scan_thread_pool_thread_num;
-
-        std::unique_ptr<ThreadPool> scan_worker_thread_pool_without_workgroup;
-        RETURN_IF_ERROR(ThreadPoolBuilder("pip_scan_io")
-                                .set_min_threads(0)
-                                .set_max_threads(num_io_threads)
-                                .set_max_queue_size(1000)
-                                .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                                .build(&scan_worker_thread_pool_without_workgroup));
-        _scan_executor_without_workgroup = new workgroup::ScanExecutor(
-                std::move(scan_worker_thread_pool_without_workgroup),
-                std::make_unique<workgroup::PriorityScanTaskQueue>(config::pipeline_scan_thread_pool_queue_size));
-        _scan_executor_without_workgroup->initialize(num_io_threads);
-
-        std::unique_ptr<ThreadPool> scan_worker_thread_pool_with_workgroup;
-        RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_scan_io")
-                                .set_min_threads(0)
-                                .set_max_threads(num_io_threads)
-                                .set_max_queue_size(1000)
-                                .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
-                                .build(&scan_worker_thread_pool_with_workgroup));
-        _scan_executor_with_workgroup =
-                new workgroup::ScanExecutor(std::move(scan_worker_thread_pool_with_workgroup),
-                                            std::make_unique<workgroup::WorkGroupScanTaskQueue>(
-                                                    workgroup::WorkGroupScanTaskQueue::SchedEntityType::OLAP));
-        _scan_executor_with_workgroup->initialize(num_io_threads);
-
         Status status = _load_path_mgr->init();
         if (!status.ok()) {
             LOG(ERROR) << "load path mgr init failed." << status.get_error_msg();


### PR DESCRIPTION
Signed-off-by: ZiheLiu <ziheliu1024@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Scanning schema on the compute node will throw error:

```
*** Aborted at 1674546502 (unix time) try "date -d @1674546502" if you are using GNU date ***
PC: @          0x2d581aa starrocks::workgroup::ScanExecutor::submit()
*** SIGSEGV (@0x10) received by PID 7878 (TID 0x7f8eb9f16700) from PID 16; stack trace: ***
    @          0x59fe902 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f8f2b464630 (unknown)
    @          0x2d581aa starrocks::workgroup::ScanExecutor::submit()
    @          0x2d45bfc starrocks::pipeline::ScanOperator::_trigger_next_scan()
    @          0x2d4643d starrocks::pipeline::ScanOperator::_pickup_morsel()
    @          0x2d46645 starrocks::pipeline::ScanOperator::_try_to_trigger_next_scan()
    @          0x2d46864 starrocks::pipeline::ScanOperator::pull_chunk()
    @          0x2d245a3 starrocks::pipeline::PipelineDriver::process()
    @          0x4e5d3b7 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x48814ad starrocks::ThreadPool::dispatch_thread()
    @          0x487c23a starrocks::Thread::supervise_thread()
    @     0x7f8f2b45cea5 start_thread
    @     0x7f8f2aa779fd __clone
    @                0x0 (unknown)
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
