### PR TITLE
[BugFix] Set name of MetaScanOperator

### DIFF
--- a/be/src/exec/lake_meta_scan_node.cpp
+++ b/be/src/exec/lake_meta_scan_node.cpp
@@ -23,7 +23,9 @@
 namespace starrocks {
 
 LakeMetaScanNode::LakeMetaScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : MetaScanNode(pool, tnode, descs) {}
+        : MetaScanNode(pool, tnode, descs) {
+    _name = "lake_meta_scan";
+}
 
 Status LakeMetaScanNode::open(RuntimeState* state) {
     if (!_is_init) {

--- a/be/src/exec/meta_scan_node.h
+++ b/be/src/exec/meta_scan_node.h
@@ -30,7 +30,7 @@ public:
 
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status prepare(RuntimeState* state) override;
-    ;
+
     Status close(RuntimeState* state) override;
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
 

--- a/be/src/exec/olap_meta_scan_node.cpp
+++ b/be/src/exec/olap_meta_scan_node.cpp
@@ -23,7 +23,9 @@
 namespace starrocks {
 
 OlapMetaScanNode::OlapMetaScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
-        : MetaScanNode(pool, tnode, descs) {}
+        : MetaScanNode(pool, tnode, descs) {
+    _name = "olap_meta_scan";
+}
 
 Status OlapMetaScanNode::open(RuntimeState* state) {
     if (!_is_init) {


### PR DESCRIPTION
Signed-off-by: ZiheLiu <ziheliu1024@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16938.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`ScanOperator` sets name as `ScanNode::_name`, but `OlapMetaScanOperator` and `LakeMetaScanNode` don't set `ScanNode::_name`, which causes the name of `MetaScanOperator` is lost in profile.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
