### PR TITLE
[Enhancement] Reduce memory usage in full sorter

### DIFF
--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -23,6 +23,7 @@
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/datum_tuple.h"
+#include "column/vectorized_fwd.h"
 #include "common/config.h"
 #include "exec/chunks_sorter.h"
 #include "exec/chunks_sorter_full_sort.h"
@@ -284,7 +285,7 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Logical
         }
         ASSERT_TRUE(eos);
         ASSERT_EQ(expected_rows, actual_rows);
-        sorter->finish(suite._runtime_state.get());
+        sorter->done(suite._runtime_state.get());
     }
     state.counters["rows_sorted"] += item_processed;
     state.counters["data_size"] += data_size;
@@ -413,13 +414,13 @@ static void do_merge_columnwise(benchmark::State& state, int num_runs, bool null
     int64_t num_rows = 0;
     SortDescs sort_desc(std::vector<int>{1, 1, 1}, std::vector<int>{-1, -1, -1});
     for (auto _ : state) {
-        std::vector<ChunkPtr> inputs;
+        std::vector<ChunkUniquePtr> inputs;
         size_t input_rows = num_runs * chunk1->num_rows();
         for (int i = 0; i < num_runs; i++) {
             if (i % 2 == 0) {
-                inputs.push_back(chunk1);
+                inputs.push_back(chunk1->clone_unique());
             } else {
-                inputs.push_back(chunk2);
+                inputs.push_back(chunk2->clone_unique());
             }
         }
         SortedRuns merged;

--- a/be/src/exec/chunks_sorter.cpp
+++ b/be/src/exec/chunks_sorter.cpp
@@ -162,16 +162,6 @@ void ChunksSorter::setup_runtime(RuntimeProfile* profile) {
     profile->add_info_string("SortType", _is_topn ? "TopN" : "All");
 }
 
-Status ChunksSorter::finish(RuntimeState* state) {
-    TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(done(state)));
-    _is_sink_complete = true;
-    return Status::OK();
-}
-
-bool ChunksSorter::sink_complete() {
-    return _is_sink_complete;
-}
-
 StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk, TupleDescriptor* materialized_tuple_desc,
                                                                const SortExecExprs& sort_exec_exprs,
                                                                const std::vector<OrderByType>& order_by_types) {

--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -111,20 +111,14 @@ public:
     virtual Status update(RuntimeState* state, const ChunkPtr& chunk) = 0;
     // Finish seeding Chunk, and get sorted data with top OFFSET rows have been skipped.
     virtual Status done(RuntimeState* state) = 0;
+
     // get_next only works after done().
     virtual Status get_next(ChunkPtr* chunk, bool* eos) = 0;
 
     virtual std::vector<JoinRuntimeFilter*>* runtime_filters(ObjectPool* pool) { return nullptr; }
 
-    // Return sorted data in multiple runs(Avoid merge them into a big chunk)
-    virtual SortedRuns get_sorted_runs() = 0;
-
     // Return accurate output rows of this operator
     virtual size_t get_output_rows() const = 0;
-
-    Status finish(RuntimeState* state);
-
-    bool sink_complete();
 
     virtual int64_t mem_usage() const = 0;
 
@@ -145,8 +139,6 @@ protected:
     RuntimeProfile::Counter* _sort_timer = nullptr;
     RuntimeProfile::Counter* _merge_timer = nullptr;
     RuntimeProfile::Counter* _output_timer = nullptr;
-
-    std::atomic<bool> _is_sink_complete = false;
 };
 
 namespace detail {

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "column/vectorized_fwd.h"
 #include "exec/chunks_sorter.h"
 #include "exec/sorting/merge.h"
 #include "gtest/gtest_prod.h"
@@ -40,7 +41,6 @@ public:
     Status done(RuntimeState* state) override;
     Status get_next(ChunkPtr* chunk, bool* eos) override;
 
-    SortedRuns get_sorted_runs() override;
     size_t get_output_rows() const override;
 
     int64_t mem_usage() const override;
@@ -54,11 +54,11 @@ private:
     Status _partial_sort(RuntimeState* state, bool done);
     Status _merge_sorted(RuntimeState* state);
 
-    size_t _total_rows = 0;               // Total rows of sorting data
-    Permutation _sort_permutation;        // Temp permutation for sorting
-    ChunkPtr _unsorted_chunk;             // Unsorted chunk, accumulate it to a larger chunk
-    std::vector<ChunkPtr> _sorted_chunks; // Partial sorted, but not merged
-    SortedRuns _merged_runs;              // After merge
+    size_t _total_rows = 0;                     // Total rows of sorting data
+    Permutation _sort_permutation;              // Temp permutation for sorting
+    ChunkPtr _unsorted_chunk;                   // Unsorted chunk, accumulate it to a larger chunk
+    std::vector<ChunkUniquePtr> _sorted_chunks; // Partial sorted, but not merged
+    SortedRuns _merged_runs;                    // After merge
 
     // TODO: further tunning the buffer parameter
     static constexpr size_t kMaxBufferedChunkSize = 1024000;   // Max buffer 1024000 rows

--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -111,10 +111,6 @@ Status ChunksSorterHeapSort::update(RuntimeState* state, const ChunkPtr& chunk) 
     return Status::OK();
 }
 
-SortedRuns ChunksSorterHeapSort::get_sorted_runs() {
-    return {SortedRun(_merged_segment.chunk, _merged_segment.order_by_columns)};
-}
-
 size_t ChunksSorterHeapSort::get_output_rows() const {
     return _merged_segment.chunk->num_rows();
 }

--- a/be/src/exec/chunks_sorter_heap_sort.h
+++ b/be/src/exec/chunks_sorter_heap_sort.h
@@ -247,7 +247,6 @@ public:
         return _sort_heap->size() * _sort_heap->top().data_segment()->mem_usage() / first_rows;
     }
 
-    SortedRuns get_sorted_runs() override;
     size_t get_output_rows() const override;
 
     void setup_runtime(RuntimeProfile* profile) override;

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -139,13 +139,9 @@ Status ChunksSorterTopn::get_next(ChunkPtr* chunk, bool* eos) {
     size_t count = std::min(size_t(_state->chunk_size()), _merged_segment.chunk->num_rows() - _next_output_row);
     chunk->reset(_merged_segment.chunk->clone_empty(count).release());
     (*chunk)->append_safe(*_merged_segment.chunk, _next_output_row, count);
-    (*chunk)->downgrade();
+    RETURN_IF_ERROR((*chunk)->downgrade());
     _next_output_row += count;
     return Status::OK();
-}
-
-SortedRuns ChunksSorterTopn::get_sorted_runs() {
-    return {SortedRun(_merged_segment.chunk, _merged_segment.order_by_columns)};
 }
 
 size_t ChunksSorterTopn::get_output_rows() const {

--- a/be/src/exec/chunks_sorter_topn.h
+++ b/be/src/exec/chunks_sorter_topn.h
@@ -72,7 +72,6 @@ public:
     // get_next only works after done().
     Status get_next(ChunkPtr* chunk, bool* eos) override;
 
-    SortedRuns get_sorted_runs() override;
     size_t get_output_rows() const override;
 
     int64_t mem_usage() const override { return _raw_chunks.mem_usage() + _merged_segment.mem_usage(); }

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -88,7 +88,7 @@ Status PartitionSortSinkOperator::set_finishing(RuntimeState* state) {
         _is_finished = true;
         return Status::Cancelled("runtime state is cancelled");
     }
-    RETURN_IF_ERROR(_chunks_sorter->finish(state));
+    RETURN_IF_ERROR(_chunks_sorter->done(state));
 
     // Current partition sort is ended, and
     // the last call will drive LocalMergeSortSourceOperator to work.

--- a/be/src/exec/sorting/merge.h
+++ b/be/src/exec/sorting/merge.h
@@ -158,7 +158,7 @@ class SimpleChunkSortCursor;
 Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& left, const SortedRun& right,
                                    Permutation* output);
 Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext*>* sort_exprs,
-                           const std::vector<ChunkPtr>& chunks, SortedRuns* output);
+                           std::vector<ChunkUniquePtr>& chunks, SortedRuns* output);
 Status merge_sorted_cursor_cascade(const SortDescs& sort_desc,
                                    std::vector<std::unique_ptr<SimpleChunkSortCursor>>&& cursors,
                                    const ChunkConsumer& consumer);

--- a/be/src/exec/sorting/merge_column.cpp
+++ b/be/src/exec/sorting/merge_column.cpp
@@ -294,7 +294,7 @@ SortedRun::SortedRun(const ChunkPtr& ichunk, const std::vector<ExprContext*>* ex
 }
 
 void SortedRun::reset() {
-    chunk->reset();
+    chunk.reset();
     orderby.clear();
     range = {};
 }
@@ -468,7 +468,7 @@ Status merge_sorted_chunks_two_way(const SortDescs& sort_desc, const SortedRun& 
 }
 
 Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext*>* sort_exprs,
-                           const std::vector<ChunkPtr>& chunks, SortedRuns* output) {
+                           std::vector<ChunkUniquePtr>& chunks, SortedRuns* output) {
     std::vector<std::unique_ptr<SimpleChunkSortCursor>> cursors;
     std::vector<size_t> chunk_index(chunks.size(), 0);
 
@@ -486,7 +486,7 @@ Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext
                         return false;
                     }
                     chunk_index[i]++;
-                    *output = chunks[i]->clone_unique();
+                    *output = std::move(chunks[i]);
                     return true;
                 },
                 sort_exprs));


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
avoid copy and reserve extra chunk when merge sorted chunks

for such query in SSB-100G
```
select lo_orderkey,     lo_linenumber,     lo_custkey,     row_number()  over (partition by lo_partkey)  from lineorder limit 10;
```
baseline: 52G
patched: 30.0G

key change:

save about 10G
```
void SortedRun::reset() {
    chunk.reset();
    orderby.clear();
    range = {};
}
```

save about 10G
```
Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext*>* sort_exprs,
                           std::vector<ChunkUniquePtr>& chunks, SortedRuns* output) {
    std::vector<std::unique_ptr<SimpleChunkSortCursor>> cursors;
    std::vector<size_t> chunk_index(chunks.size(), 0);

	@@ -486,7 +486,7 @@ Status merge_sorted_chunks(const SortDescs& descs, const std::vector<ExprContext
                        return false;
                    }
                    chunk_index[i]++;
                    *output = std::move(chunks[i]);
                    return true;
                },
                sort_exprs));
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
