### PR TITLE
[BugFix] Check juicefs schema when identifying hdfs path to support read juicefs by hdfs scanner

### DIFF
--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -60,7 +60,7 @@ inline bool is_s3_uri(std::string_view uri) {
 }
 
 inline bool is_hdfs_uri(std::string_view uri) {
-    return starts_with(uri, "hdfs://") || starts_with(uri, "viewfs://");
+    return starts_with(uri, "hdfs://") || starts_with(uri, "viewfs://") || starts_with(uri, "jfs://");
 }
 
 inline bool is_posix_uri(std::string_view uri) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR mainly solve the following two problems when visiting juicefs:

* The juicefs schema, looks like 'jfs://', is not resolved correctly now, which results in the juicefs file will be visited as local file. To avoiding the problem of "not found", we check juicefs schema when identifying hdfs path, to support read juicefs by hdfs scanner.
* As the GetReadStatistics is not supported in juicefs hadoop sdk, which will cause the be crash when visiting juicefs. So we avoid to call this function for juicefs.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
