### PR TITLE
[BugFix] Own short_key_encode result by LogicalSplitMorselQueue

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -449,10 +449,12 @@ bool LogicalSplitMorselQueue::_valid_range(const ShortKeyOptionPtr& lower, const
     }
 
     Slice lower_key;
+    std::string lower_key_payload;
     // Empty short key of start ShortKeyOption means it is the first splitted key range,
     // so use start original short key to compare.
     if (lower->tuple_key != nullptr) {
-        lower_key = lower->tuple_key->short_key_encode(_short_key_schema->num_fields(), KEY_MINIMAL_MARKER);
+        lower_key_payload = lower->tuple_key->short_key_encode(_short_key_schema->num_fields(), KEY_MINIMAL_MARKER);
+        lower_key = Slice(lower_key_payload);
     } else if (!lower->short_key.empty()) {
         lower_key = lower->short_key;
     } else {
@@ -460,10 +462,12 @@ bool LogicalSplitMorselQueue::_valid_range(const ShortKeyOptionPtr& lower, const
     }
 
     Slice upper_key;
+    std::string upper_key_payload;
     // Empty short key of end ShortKeyOption means it is the last splitted key range,
     // so use end original short key to compare.
     if (upper->tuple_key != nullptr) {
-        upper_key = upper->tuple_key->short_key_encode(_short_key_schema->num_fields(), KEY_MINIMAL_MARKER);
+        upper_key_payload = upper->tuple_key->short_key_encode(_short_key_schema->num_fields(), KEY_MINIMAL_MARKER);
+        upper_key = Slice(upper_key_payload);
     } else if (!upper->short_key.empty()) {
         upper_key = upper->short_key;
     } else {


### PR DESCRIPTION
Signed-off-by: ZiheLiu <ziheliu1024@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`TupleKey::short_key_encode` returns a `std::string`, but is assigned to `Slice`, which only references to the `std::string` not owns it. 


```
=================================================================
==4160==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f20b16c3180 at pc 0x00000a7f31d9 bp 0x7f20b16c2f80 sp 0x7f20b16c2730
READ of size 2 at 0x7f20b16c3180 thread T358 (pip_wg_executor)
    #0 0xa7f31d8 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) ../../.././libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:839
    #1 0xa7f37e8 in __interceptor_memcmp ../../.././libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:871
    #2 0xa7f37e8 in __interceptor_memcmp ../../.././libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:866
    #3 0xac16495 in starrocks::memcompare(char const*, unsigned long, char const*, unsigned long) /root/starrocks/be/src/util/memcmp.h:154
    #4 0xac165e3 in starrocks::Slice::compare(starrocks::Slice const&) const /root/starrocks/be/src/util/slice.h:247
    #5 0xbb314ae in starrocks::pipeline::LogicalSplitMorselQueue::_valid_range(std::unique_ptr<starrocks::ShortKeyOption, std::default_delete<starrocks::ShortKeyOption> > const&, std::unique_ptr<starrocks::ShortKeyOption, std::default_delete<starrocks::ShortKeyOption> > const&) const /root/starrocks/be/src/exec/pipeline/scan/morsel.cpp:475
    #6 0xbb300ab in starrocks::pipeline::LogicalSplitMorselQueue::try_get() /root/starrocks/be/src/exec/pipeline/scan/morsel.cpp:419
    #7 0xae131b4 in starrocks::pipeline::ScanOperator::_pickup_morsel(starrocks::RuntimeState*, int) /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:413
    #8 0xae1034f in starrocks::pipeline::ScanOperator::_try_to_trigger_next_scan(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:274
    #9 0xae0f63c in starrocks::pipeline::ScanOperator::pull_chunk(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:220
    #10 0xacf6355 in starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int) /root/starrocks/be/src/exec/pipeline/pipeline_driver.cpp:250
    #11 0x12aa4e76 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread() /root/starrocks/be/src/exec/pipeline/pipeline_driver_executor.cpp:144
    #12 0x12aa37ad in operator() /root/starrocks/be/src/exec/pipeline/pipeline_driver_executor.cpp:69
    #13 0x12aac8b1 in __invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /usr/include/c++/10.3.0/bits/invoke.h:60
    #14 0x12aabdb6 in __invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /usr/include/c++/10.3.0/bits/invoke.h:110
    #15 0x12aab0c0 in _M_invoke /usr/include/c++/10.3.0/bits/std_function.h:291
    #16 0xa99b00b in std::function<void ()>::operator()() const /usr/include/c++/10.3.0/bits/std_function.h:622
    #17 0x11a2f11f in starrocks::FunctionRunnable::run() /root/starrocks/be/src/util/threadpool.cpp:57
    #18 0x11a2bf21 in starrocks::ThreadPool::dispatch_thread() /root/starrocks/be/src/util/threadpool.cpp:549
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
