### PR TITLE
[Tool] Add benchmark case for shuffle chunk on large cluster

### DIFF
--- a/be/src/bench/CMakeLists.txt
+++ b/be/src/bench/CMakeLists.txt
@@ -15,3 +15,4 @@
 ADD_BE_BENCH(${SRC_DIR}/bench/chunks_sorter_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/runtime_filter_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/csv_reader_bench)
+ADD_BE_BENCH(${SRC_DIR}/bench/shuffle_chunk_bench)

--- a/be/src/bench/shuffle_chunk_bench.cpp
+++ b/be/src/bench/shuffle_chunk_bench.cpp
@@ -1,0 +1,218 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include <benchmark/benchmark.h>
+#include <testutil/assert.h>
+
+#include <memory>
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/datum_tuple.h"
+#include "common/config.h"
+#include "runtime/chunk_cursor.h"
+#include "runtime/runtime_state.h"
+#include "runtime/types.h"
+
+namespace starrocks::vectorized {
+
+class ShuffleChunkPerf {
+public:
+    void SetUp() {}
+    void TearDown() {}
+
+    ShuffleChunkPerf(int chunk_count, int column_count, int node_count, int src_chunk_size, int null_percent)
+            : _chunk_count(chunk_count),
+              _column_count(column_count),
+              _node_count(node_count),
+              _src_chunk_size(src_chunk_size),
+              _null_percent(null_percent) {}
+
+    void init_types();
+    ChunkPtr init_src_chunk();
+    void init_dest_chunks();
+    void reset_dest_chunks();
+    ChunkPtr init_dest_chunk();
+    ColumnPtr init_src_column(const TypeDescriptor& type);
+    ColumnPtr init_src_key_column(const TypeDescriptor& type);
+    ColumnPtr init_dest_column(const TypeDescriptor& type);
+    void do_hash(const ColumnPtr& col);
+    void do_shuffle(const Chunk& src_chunk);
+    void do_bench(benchmark::State& state);
+
+private:
+    int _chunk_count = 400;
+    int _column_count = 400;
+    int _node_count = 140;
+    int _src_chunk_size = 4096;
+    int _dest_chunk_size = 4096;
+    int _null_percent = 100;
+    std::vector<TypeDescriptor> _types;
+    std::vector<ChunkPtr> _src_chunks;
+    std::vector<ChunkPtr> _dest_chunks;
+    std::vector<uint32_t> _shuffle_idxs;
+    std::vector<uint32_t> _select_idxs;
+};
+
+void ShuffleChunkPerf::init_types() {
+    _types.resize(_column_count);
+    for (int i = 0; i < _column_count; i++) {
+        _types[i] = TypeDescriptor::create_varchar_type(1024);
+    }
+}
+
+ColumnPtr ShuffleChunkPerf::init_src_column(const TypeDescriptor& type) {
+    ColumnPtr c1 = ColumnHelper::create_column(type, true);
+    c1->reserve(_src_chunk_size);
+    auto* nullable_col = down_cast<NullableColumn*>(c1.get());
+    for (int k = 0; k < _src_chunk_size; k++) {
+        int v = rand();
+        if (v % 100 < _null_percent) {
+            nullable_col->append_default();
+        } else {
+            nullable_col->append_datum(Datum("str123" + std::to_string(v)));
+        }
+    }
+    return c1;
+}
+
+ColumnPtr ShuffleChunkPerf::init_src_key_column(const TypeDescriptor& type) {
+    ColumnPtr c1 = ColumnHelper::create_column(type, true);
+    c1->reserve(_src_chunk_size);
+    auto* nullable_col = down_cast<NullableColumn*>(c1.get());
+    for (int k = 0; k < _src_chunk_size; k++) {
+        int v = rand();
+        nullable_col->append_datum(Datum("str123" + std::to_string(v)));
+    }
+    return c1;
+}
+
+ColumnPtr ShuffleChunkPerf::init_dest_column(const TypeDescriptor& type) {
+    auto c1 = ColumnHelper::create_column(type, true);
+    c1->reserve(_dest_chunk_size);
+    return c1;
+}
+
+ChunkPtr ShuffleChunkPerf::init_src_chunk() {
+    auto chunk = std::make_unique<Chunk>();
+    auto col = init_src_key_column(_types[0]);
+    chunk->append_column(col, 0);
+    for (int i = 1; i < _column_count; i++) {
+        col = init_src_column(_types[i]);
+        chunk->append_column(col, i);
+    }
+    return chunk;
+}
+
+void ShuffleChunkPerf::init_dest_chunks() {
+    for (int i = 0; i < _node_count; i++) {
+        if (_dest_chunks[i] == nullptr) {
+            _dest_chunks[i] = init_dest_chunk();
+        }
+    }
+}
+
+void ShuffleChunkPerf::reset_dest_chunks() {
+    for (int i = 0; i < _node_count; i++) {
+        if (_dest_chunks[i]->num_rows() > _dest_chunk_size) {
+            _dest_chunks[i].reset();
+        }
+    }
+}
+
+ChunkPtr ShuffleChunkPerf::init_dest_chunk() {
+    auto chunk = std::make_unique<Chunk>();
+    for (int i = 0; i < _column_count; i++) {
+        auto col = init_dest_column(_types[i]);
+        chunk->append_column(col, i);
+    }
+    return chunk;
+}
+
+void ShuffleChunkPerf::do_hash(const ColumnPtr& col) {
+    _shuffle_idxs.resize(_src_chunk_size);
+
+    col->crc32_hash(&_shuffle_idxs[0], 0, _src_chunk_size);
+    for (int i = 0; i < _src_chunk_size; i++) {
+        _shuffle_idxs[i] = _shuffle_idxs[i] % _node_count;
+    }
+}
+
+void ShuffleChunkPerf::do_shuffle(const Chunk& src_chunk) {
+    for (int n = 0; n < _node_count; n++) {
+        _select_idxs.resize(0);
+        for (int i = 0; i < _shuffle_idxs.size(); i++) {
+            if (_shuffle_idxs[i] == n) {
+                _select_idxs.emplace_back(i);
+            }
+        }
+        _dest_chunks[n]->append_selective(src_chunk, _select_idxs.data(), 0, _select_idxs.size());
+    }
+}
+
+void ShuffleChunkPerf::do_bench(benchmark::State& state) {
+    init_types();
+    _dest_chunks.resize(_node_count, nullptr);
+
+    state.ResumeTiming();
+
+    for (int i = 0; i < _chunk_count; i++) {
+        state.PauseTiming();
+        ChunkPtr src_chunk = init_src_chunk();
+        state.ResumeTiming();
+
+        do_hash(src_chunk->columns()[0]);
+
+        init_dest_chunks();
+
+        do_shuffle(*src_chunk);
+
+        reset_dest_chunks();
+    }
+    state.PauseTiming();
+}
+
+static void bench_func(benchmark::State& state) {
+    int chunk_count = state.range(0);
+    int column_count = state.range(1);
+    int node_count = state.range(2);
+    int src_chunk_size = state.range(3);
+    int null_percent = state.range(4);
+
+    ShuffleChunkPerf perf(chunk_count, column_count, node_count, src_chunk_size, null_percent);
+    perf.do_bench(state);
+}
+
+static void process_args(benchmark::internal::Benchmark* b) {
+    // chunk_count, column_count, node_count, src_chunk_size, null percent
+    b->Args({400, 400, 140, 4096, 80});
+
+    // node
+    b->Args({400, 400, 70, 4096, 80});
+    b->Args({400, 400, 20, 4096, 80});
+    b->Args({400, 400, 10, 4096, 80});
+    b->Args({400, 400, 3, 4096, 80});
+
+    // column
+    b->Args({800, 200, 140, 4096, 80});
+    b->Args({1600, 100, 140, 4096, 80});
+    b->Args({16000, 10, 140, 4096, 80});
+
+    // chunk size
+    b->Args({200, 400, 140, 8192, 80});
+    b->Args({100, 400, 140, 16384, 80});
+    b->Args({50, 400, 140, 32768, 80});
+    b->Args({25, 400, 140, 65536, 80});
+
+    // null percent
+    b->Args({400, 400, 140, 4096, 0});
+    b->Args({400, 400, 70, 4096, 0});
+    b->Args({400, 400, 20, 4096, 0});
+    b->Args({400, 400, 10, 4096, 0});
+    b->Args({400, 400, 3, 4096, 0});
+}
+
+BENCHMARK(bench_func)->Apply(process_args);
+
+} // namespace starrocks::vectorized
+
+BENCHMARK_MAIN();

--- a/be/src/bench/shuffle_chunk_bench.cpp
+++ b/be/src/bench/shuffle_chunk_bench.cpp
@@ -1,4 +1,16 @@
-// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <benchmark/benchmark.h>
 #include <testutil/assert.h>

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -85,7 +85,9 @@ public:
     size_t deserialize(const uint8_t* data);
     void merge(const SimdBlockFilter& bf);
     bool check_equal(const SimdBlockFilter& bf) const;
-    uint32_t directory_mask() const { return _directory_mask; }
+    uint32_t directory_mask() const {
+        return _directory_mask;
+    }
 
 private:
     // The number of bits to set in a tiny Bloom filter block
@@ -112,7 +114,9 @@ private:
     // log2(number of bytes in a bucket):
     static constexpr int LOG_BUCKET_BYTE_SIZE = 5;
 
-    size_t get_alloc_size() const { return 1ull << (_log_num_buckets + LOG_BUCKET_BYTE_SIZE); }
+    size_t get_alloc_size() const {
+        return 1ull << (_log_num_buckets + LOG_BUCKET_BYTE_SIZE);
+    }
 
     // Common:
     // log_num_buckets_ is the log (base 2) of the number of buckets in the directory:
@@ -499,6 +503,33 @@ public:
         return false;
     }
 
+    void compute_hash(const std::vector<Column*>& columns, RunningContext* ctx) const override {
+        if (columns.empty() || _join_mode == TRuntimeFilterBuildJoinMode::NONE) return;
+        size_t num_rows = columns[0]->size();
+
+        // initialize hash_values.
+        // reuse ctx's hash_values object.
+        std::vector<uint32_t>& _hash_values = ctx->hash_values;
+        switch (_join_mode) {
+        case TRuntimeFilterBuildJoinMode::LOCAL_HASH_BUCKET:
+        case TRuntimeFilterBuildJoinMode::COLOCATE:
+        case TRuntimeFilterBuildJoinMode::BORADCAST: {
+            _hash_values.assign(num_rows, 0);
+            break;
+        }
+        case TRuntimeFilterBuildJoinMode::PARTITIONED:
+        case TRuntimeFilterBuildJoinMode::SHUFFLE_HASH_BUCKET: {
+            _hash_values.assign(num_rows, HashUtil::FNV_SEED);
+            break;
+        }
+        default:
+            DCHECK(false) << "unexpected join mode: " << _join_mode;
+        }
+
+        // compute hash_values
+        _compute_hash_values_for_multi_part(ctx, _join_mode, columns, num_rows, _hash_values);
+    }
+
 private:
     void _init_min_max() {
         if constexpr (IsSlice<CppType>) {
@@ -649,33 +680,6 @@ private:
         const uint32_t bucket_idx = shuffle_hash;
         size_t hash = compute_hash(value);
         return _hash_partition_bf[bucket_idx].test_hash(hash);
-    }
-
-    void compute_hash(const std::vector<Column*>& columns, RunningContext* ctx) const override {
-        if (columns.empty() || _join_mode == TRuntimeFilterBuildJoinMode::NONE) return;
-        size_t num_rows = columns[0]->size();
-
-        // initialize hash_values.
-        // reuse ctx's hash_values object.
-        std::vector<uint32_t>& _hash_values = ctx->hash_values;
-        switch (_join_mode) {
-        case TRuntimeFilterBuildJoinMode::LOCAL_HASH_BUCKET:
-        case TRuntimeFilterBuildJoinMode::COLOCATE:
-        case TRuntimeFilterBuildJoinMode::BORADCAST: {
-            _hash_values.assign(num_rows, 0);
-            break;
-        }
-        case TRuntimeFilterBuildJoinMode::PARTITIONED:
-        case TRuntimeFilterBuildJoinMode::SHUFFLE_HASH_BUCKET: {
-            _hash_values.assign(num_rows, HashUtil::FNV_SEED);
-            break;
-        }
-        default:
-            DCHECK(false) << "unexpected join mode: " << _join_mode;
-        }
-
-        // compute hash_values
-        _compute_hash_values_for_multi_part(ctx, _join_mode, columns, num_rows, _hash_values);
     }
 
     using HashValues = std::vector<uint32_t>;

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -85,9 +85,7 @@ public:
     size_t deserialize(const uint8_t* data);
     void merge(const SimdBlockFilter& bf);
     bool check_equal(const SimdBlockFilter& bf) const;
-    uint32_t directory_mask() const {
-        return _directory_mask;
-    }
+    uint32_t directory_mask() const { return _directory_mask; }
 
 private:
     // The number of bits to set in a tiny Bloom filter block
@@ -114,9 +112,7 @@ private:
     // log2(number of bytes in a bucket):
     static constexpr int LOG_BUCKET_BYTE_SIZE = 5;
 
-    size_t get_alloc_size() const {
-        return 1ull << (_log_num_buckets + LOG_BUCKET_BYTE_SIZE);
-    }
+    size_t get_alloc_size() const { return 1ull << (_log_num_buckets + LOG_BUCKET_BYTE_SIZE); }
 
     // Common:
     // log_num_buckets_ is the log (base 2) of the number of buckets in the directory:


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add benchmark case for shuffle chunk on large cluster:

the test result:

```
Run on (104 X 3199.92 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x52)
  L1 Instruction 32 KiB (x52)
  L2 Unified 1024 KiB (x52)
  L3 Unified 36608 KiB (x2)
Load Average: 19.54, 8.61, 7.72
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
bench_func/400/400/140/4096/80  27877156137 ns   27874069320 ns            0
bench_func/400/400/70/4096/80   22137756737 ns   22135190899 ns            0
bench_func/400/400/20/4096/80   13752425194 ns   13750963797 ns            0
bench_func/400/400/10/4096/80   11105780918 ns   11104585967 ns            0
bench_func/400/400/3/4096/80    7534822018 ns   7534002194 ns            0
bench_func/800/200/140/4096/80  20488811788 ns   20486881907 ns            0
bench_func/1600/100/140/4096/80 18494220669 ns   18492415312 ns            0
bench_func/16000/10/140/4096/80 20047868394 ns   20047494894 ns            0
bench_func/200/400/140/8192/80  21289845759 ns   21287707860 ns            0
bench_func/100/400/140/16384/80 22993518613 ns   22982506039 ns            0
bench_func/50/400/140/32768/80  25111112763 ns   25108499526 ns            0
bench_func/25/400/140/65536/80  25299955247 ns   25297208085 ns            0
bench_func/400/400/140/4096/0   38779182714 ns   38775134584 ns            0
bench_func/400/400/70/4096/0    38341062936 ns   38336479559 ns            0
bench_func/400/400/20/4096/0    21923492598 ns   21918081115 ns            0
bench_func/400/400/10/4096/0    17226990666 ns   17225074034 ns            0
bench_func/400/400/3/4096/0     9980669197 ns   9979709738 ns            0

```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
