### PR TITLE
[BugFix] Restore logging for cluster load statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1085,7 +1085,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
      * eg:
      *    A tablet has been scheduled for 5 times and all were failed. its priority will be downgraded. And if it is
      *    scheduled for 5 times and all are failed again, it will be downgraded again, until to the LOW.
-     *    And than, because of LOW, this tablet can not be scheduled for a long time, and it will be upgraded
+     *    And then, because of LOW, this tablet can not be scheduled for a long time, and it will be upgraded
      *    to NORMAL, if still not being scheduled, it will be upgraded up to VERY_HIGH.
      *
      * return true if dynamic priority changed

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -148,6 +148,7 @@ public class TabletScheduler extends LeaderDaemon {
     private Map<Long, PathSlot> backendsWorkingSlots = Maps.newConcurrentMap();
     private ClusterLoadStatistic loadStatistic;
     private long lastStatUpdateTime = 0;
+    private long lastClusterLoadLoggingTime = 0;
 
     private long lastSlotAdjustTime = 0;
 
@@ -389,8 +390,9 @@ public class TabletScheduler extends LeaderDaemon {
     private void updateClusterLoadStatistic() {
         ClusterLoadStatistic clusterLoadStatistic = new ClusterLoadStatistic(infoService, invertedIndex);
         clusterLoadStatistic.init();
-        if (System.currentTimeMillis() - lastStatUpdateTime > CLUSTER_LOAD_STATISTICS_LOGGING_INTERVAL_MS) {
+        if (System.currentTimeMillis() - lastClusterLoadLoggingTime > CLUSTER_LOAD_STATISTICS_LOGGING_INTERVAL_MS) {
             LOG.info("update cluster load statistic:\n{}", clusterLoadStatistic.getBrief());
+            lastClusterLoadLoggingTime = System.currentTimeMillis();
         }
         this.loadStatistic = clusterLoadStatistic;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The logging for cluster load statistics is mistakenly removed by previous pr.

Signed-off-by: Dejun Xia <xiadejun@starrocks.com>

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
