### PR TITLE
[BugFix] Avoid calling GetReadStatistics function when accessing juicefs to avoid be crash

### DIFF
--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -38,6 +38,8 @@ public:
     void set_size(int64_t size) override;
 
 private:
+    bool _is_jfs_file() const;
+
     hdfsFS _fs;
     hdfsFile _file;
     std::string _file_name;
@@ -97,7 +99,17 @@ void HdfsInputStream::set_size(int64_t value) {
     _file_size = value;
 }
 
+bool HdfsInputStream::_is_jfs_file() const {
+    static const char* kFileSysPrefixJuicefs = "jfs://";
+    return strncmp(_file_name.c_str(), kFileSysPrefixJuicefs, strlen(kFileSysPrefixJuicefs)) == 0;
+}
+
 StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_statistics() {
+    // `GetReadStatistics` is not supported in juicefs hadoop sdk, and will cause the be crash
+    if (_is_jfs_file()) {
+        return nullptr;
+    }
+
     auto statistics = std::make_unique<io::NumericStatistics>();
     io::NumericStatistics* stats = statistics.get();
     auto ret = call_hdfs_scan_function_in_pthread([this, stats] {


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
As the `GetReadStatistics` is not supported in juicefs hadoop sdk, which will cause the be crash when visiting juicefs. So we avoid to call this function for juicefs.

(cherry-picked from #16969 )

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
