### PR TITLE
[Enhancement] Refine mem tracker mechanism to support operator level tracing

### DIFF
--- a/be/src/exec/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/aggregate/aggregate_base_node.cpp
@@ -43,7 +43,7 @@ Status AggregateBaseNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
     auto params = convert_to_aggregator_params(_tnode);
     _aggregator = std::make_shared<Aggregator>(std::move(params));
-    return _aggregator->prepare(state, _pool, runtime_profile(), _mem_tracker.get());
+    return _aggregator->prepare(state, _pool, runtime_profile());
 }
 
 Status AggregateBaseNode::close(RuntimeState* state) {
@@ -51,6 +51,7 @@ Status AggregateBaseNode::close(RuntimeState* state) {
         return Status::OK();
     }
     if (_aggregator != nullptr) {
+        _mem_tracker->set(std::max(_aggregator->hash_map_memory_usage(), _aggregator->hash_set_memory_usage()));
         _num_rows_returned = _aggregator->num_rows_returned();
         _aggregator->close(state);
         _aggregator.reset();

--- a/be/src/exec/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/aggregate/aggregate_base_node.cpp
@@ -51,7 +51,11 @@ Status AggregateBaseNode::close(RuntimeState* state) {
         return Status::OK();
     }
     if (_aggregator != nullptr) {
-        _mem_tracker->set(std::max(_aggregator->hash_map_memory_usage(), _aggregator->hash_set_memory_usage()));
+        if (_aggregator->is_hash_set()) {
+            _mem_tracker->set(_aggregator->hash_set_memory_usage());
+        } else {
+            _mem_tracker->set(_aggregator->hash_map_memory_usage());
+        }
         _num_rows_returned = _aggregator->num_rows_returned();
         _aggregator->close(state);
         _aggregator.reset();

--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -81,7 +81,6 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
             if (!_aggregator->is_none_group_by_exprs()) {
                 TRY_CATCH_ALLOC_SCOPE_START()
                 _aggregator->build_hash_map(chunk_size, agg_group_by_with_limit);
-                _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
 
                 _aggregator->try_convert_to_two_level_map();
                 TRY_CATCH_ALLOC_SCOPE_END()

--- a/be/src/exec/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/aggregate/aggregate_streaming_node.cpp
@@ -90,7 +90,6 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
                     RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(input_chunk.get(), input_chunk_size));
                 }
 
-                _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
                 TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
 
                 COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
@@ -125,7 +124,6 @@ Status AggregateStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, bo
                         RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(input_chunk.get(), input_chunk_size));
                     }
 
-                    _mem_tracker->set(_aggregator->hash_map_variant().reserved_memory_usage(_aggregator->mem_pool()));
                     TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
                     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
                     continue;

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -67,7 +67,6 @@ Status DistinctBlockingNode::open(RuntimeState* state) {
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
             TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_set(chunk->num_rows()));
-            _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
             TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
             _aggregator->update_num_input_rows(chunk->num_rows());

--- a/be/src/exec/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/aggregate/distinct_streaming_node.cpp
@@ -84,7 +84,6 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
 
                 COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
-                _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
                 _aggregator->try_convert_to_two_level_set();
 
                 TRY_CATCH_ALLOC_SCOPE_END()
@@ -107,7 +106,6 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
                     _aggregator->build_hash_set(input_chunk_size);
 
                     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
-                    _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
 
                     _aggregator->try_convert_to_two_level_set();
                     TRY_CATCH_ALLOC_SCOPE_END()

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -165,13 +165,11 @@ Status Aggregator::open(RuntimeState* state) {
     return Status::OK();
 }
 
-Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile,
-                           MemTracker* mem_tracker) {
+Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile) {
     _state = state;
 
     _pool = pool;
     _runtime_profile = runtime_profile;
-    _mem_tracker = mem_tracker;
 
     _limit = _params->limit;
     _needs_finalize = _params->needs_finalize;
@@ -759,13 +757,15 @@ Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, 
 }
 
 void Aggregator::try_convert_to_two_level_map() {
-    if (_mem_tracker->consumption() > two_level_memory_threshold) {
+    auto current_size = _hash_map_variant.reserved_memory_usage(mem_pool());
+    if (current_size > two_level_memory_threshold) {
         _hash_map_variant.convert_to_two_level(_state);
     }
 }
 
 void Aggregator::try_convert_to_two_level_set() {
-    if (_mem_tracker->consumption() > two_level_memory_threshold) {
+    auto current_size = _hash_set_variant.reserved_memory_usage(mem_pool());
+    if (current_size > two_level_memory_threshold) {
         _hash_set_variant.convert_to_two_level(_state);
     }
 }

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -238,6 +238,7 @@ public:
     void set_aggr_phase(AggrPhase aggr_phase) { _aggr_phase = aggr_phase; }
     AggrPhase get_aggr_phase() { return _aggr_phase; }
 
+    bool is_hash_set() { return _is_only_group_by_columns; }
     const int64_t hash_map_memory_usage() const { return _hash_map_variant.reserved_memory_usage(mem_pool()); }
     const int64_t hash_set_memory_usage() const { return _hash_set_variant.reserved_memory_usage(mem_pool()); }
 

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -216,8 +216,7 @@ public:
     }
 
     Status open(RuntimeState* state);
-    virtual Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile,
-                           MemTracker* mem_tracker);
+    virtual Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile);
     void close(RuntimeState* state) override;
 
     const MemPool* mem_pool() const { return _mem_pool.get(); }
@@ -238,6 +237,9 @@ public:
     int64_t num_pass_through_rows() { return _num_pass_through_rows; }
     void set_aggr_phase(AggrPhase aggr_phase) { _aggr_phase = aggr_phase; }
     AggrPhase get_aggr_phase() { return _aggr_phase; }
+
+    const int64_t hash_map_memory_usage() const { return _hash_map_variant.reserved_memory_usage(mem_pool()); }
+    const int64_t hash_set_memory_usage() const { return _hash_set_variant.reserved_memory_usage(mem_pool()); }
 
     TStreamingPreaggregationMode::type streaming_preaggregation_mode() { return _streaming_preaggregation_mode; }
     const AggHashMapVariant& hash_map_variant() { return _hash_map_variant; }
@@ -316,8 +318,6 @@ protected:
 
     bool _is_closed = false;
     RuntimeState* _state = nullptr;
-
-    MemTracker* _mem_tracker = nullptr;
 
     ObjectPool* _pool;
     std::unique_ptr<MemPool> _mem_pool;

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -216,7 +216,7 @@ Status ExecNode::prepare(RuntimeState* state) {
                 return RuntimeProfile::units_per_second(capture0, capture1);
             },
             "");
-    _mem_tracker.reset(new MemTracker(_runtime_profile.get(), -1, _runtime_profile->name(), nullptr));
+    _mem_tracker.reset(new MemTracker(_runtime_profile.get(), "", -1, _runtime_profile->name(), nullptr));
     RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state));
     RETURN_IF_ERROR(_runtime_filter_collector.prepare(state, row_desc(), _runtime_profile.get()));
 

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -216,7 +216,8 @@ Status ExecNode::prepare(RuntimeState* state) {
                 return RuntimeProfile::units_per_second(capture0, capture1);
             },
             "");
-    _mem_tracker.reset(new MemTracker(_runtime_profile.get(), "", -1, _runtime_profile->name(), nullptr));
+    _mem_tracker.reset(new MemTracker(_runtime_profile.get(), std::make_tuple(true, false, false), "", -1,
+                                      _runtime_profile->name(), nullptr));
     RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state));
     RETURN_IF_ERROR(_runtime_filter_collector.prepare(state, row_desc(), _runtime_profile.get()));
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -22,11 +22,13 @@ namespace starrocks::pipeline {
 
 Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get(), _mem_tracker.get()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get()));
     return _aggregator->open(state);
 }
 
 void AggregateDistinctStreamingSinkOperator::close(RuntimeState* state) {
+    auto* counter = ADD_COUNTER(_unique_metrics, "HashTableMemoryUsage", TUnit::BYTES);
+    counter->set(_aggregator->hash_set_memory_usage());
     _aggregator->unref(state);
     Operator::close(state);
 }
@@ -78,7 +80,6 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_preaggregati
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
-    _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
     TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
     return Status::OK();
@@ -98,7 +99,6 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const ChunkPt
         TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_set(chunk_size));
         COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 
-        _mem_tracker->set(_aggregator->hash_set_variant().reserved_memory_usage(_aggregator->mem_pool()));
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
     } else {
         {

--- a/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
@@ -28,7 +28,7 @@ SortedAggregateStreamingSinkOperator::SortedAggregateStreamingSinkOperator(
 
 Status SortedAggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get(), _mem_tracker.get()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get()));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -61,7 +61,8 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
 }
 
 Status Operator::prepare(RuntimeState* state) {
-    _mem_tracker = std::make_shared<MemTracker>(_common_metrics.get(), -1, _name, nullptr);
+    _mem_tracker =
+            std::make_shared<MemTracker>(_common_metrics.get(), "Operator", -1, _name, state->instance_mem_tracker());
     _total_timer = ADD_TIMER(_common_metrics, "OperatorTotalTime");
     _push_timer = ADD_TIMER(_common_metrics, "PushTotalTime");
     _pull_timer = ADD_TIMER(_common_metrics, "PullTotalTime");

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -61,8 +61,8 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
 }
 
 Status Operator::prepare(RuntimeState* state) {
-    _mem_tracker =
-            std::make_shared<MemTracker>(_common_metrics.get(), "Operator", -1, _name, state->instance_mem_tracker());
+    _mem_tracker = std::make_shared<MemTracker>(_common_metrics.get(), std::make_tuple(false, true, true), "Operator",
+                                                -1, _name, state->instance_mem_tracker());
     _total_timer = ADD_TIMER(_common_metrics, "OperatorTotalTime");
     _push_timer = ADD_TIMER(_common_metrics, "PushTotalTime");
     _pull_timer = ADD_TIMER(_common_metrics, "PullTotalTime");

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -134,6 +134,8 @@ public:
 
     int32_t get_plan_node_id() const { return _plan_node_id; }
 
+    MemTracker* mem_tracker() const { return _mem_tracker.get(); }
+
     RuntimeProfile* get_runtime_profile() const { return _runtime_profile.get(); }
 
     virtual std::string get_name() const {
@@ -233,11 +235,6 @@ protected:
     std::shared_ptr<RuntimeProfile> _common_metrics;
     std::shared_ptr<RuntimeProfile> _unique_metrics;
 
-    // All the memory usage will be automatically added to the instance level MemTracker by memory allocate hook
-    // But for some special operators, we hope to see the memory usage of some special data structures,
-    // such as hash table of aggregate operators.
-    // So the following indenpendent MemTracker is introduced to record these memory usage
-    std::shared_ptr<MemTracker> _mem_tracker = nullptr;
     bool _conjuncts_and_in_filters_is_cached = false;
     std::vector<ExprContext*> _cached_conjuncts_and_in_filters;
 
@@ -269,6 +266,10 @@ protected:
 private:
     void _init_rf_counters(bool init_bloom);
     void _init_conjuct_counters();
+
+    // All the memory usage will be automatically added to this MemTracker by memory allocate hook
+    // Do not use this MemTracker manually
+    std::shared_ptr<MemTracker> _mem_tracker = nullptr;
 };
 
 class OperatorFactory {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -52,7 +52,8 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
 
     _schedule_timer = ADD_TIMER(_runtime_profile, "ScheduleTime");
     _schedule_counter = ADD_COUNTER(_runtime_profile, "ScheduleCount", TUnit::UNIT);
-    _yield_by_time_limit_counter = ADD_COUNTER(_runtime_profile, "YieldByTimeLimit", TUnit::UNIT);
+    _yield_by_time_limit_counter =
+            ADD_COUNTER_SKIP_MERGE(_runtime_profile, "YieldByTimeLimit", TUnit::UNIT, TCounterMergeType::SKIP_ALL);
     _yield_by_preempt_counter = ADD_COUNTER(_runtime_profile, "YieldByPreempt", TUnit::UNIT);
     _block_by_precondition_counter = ADD_COUNTER(_runtime_profile, "BlockByPrecondition", TUnit::UNIT);
     _block_by_output_full_counter = ADD_COUNTER(_runtime_profile, "BlockByOutputFull", TUnit::UNIT);
@@ -245,6 +246,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 // operator
                 StatusOr<ChunkPtr> maybe_chunk;
                 {
+                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(curr_op->mem_tracker());
                     SCOPED_TIMER(curr_op->_pull_timer);
                     QUERY_TRACE_SCOPED(curr_op->get_name(), "pull_chunk");
                     maybe_chunk = curr_op->pull_chunk(runtime_state);
@@ -266,6 +268,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                         size_t row_num = maybe_chunk.value()->num_rows();
                         total_rows_moved += row_num;
                         {
+                            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(next_op->mem_tracker());
                             SCOPED_TIMER(next_op->_push_timer);
                             QUERY_TRACE_SCOPED(next_op->get_name(), "push_chunk");
                             return_status = next_op->push_chunk(runtime_state, maybe_chunk.value());
@@ -517,6 +520,7 @@ Status PipelineDriver::_mark_operator_finishing(OperatorPtr& op, RuntimeState* s
     VLOG_ROW << strings::Substitute("[Driver] finishing operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(op->mem_tracker());
         SCOPED_TIMER(op->_finishing_timer);
         op_state = OperatorStage::FINISHING;
         QUERY_TRACE_SCOPED(op->get_name(), "set_finishing");
@@ -534,6 +538,7 @@ Status PipelineDriver::_mark_operator_finished(OperatorPtr& op, RuntimeState* st
     VLOG_ROW << strings::Substitute("[Driver] finished operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(op->mem_tracker());
         SCOPED_TIMER(op->_finished_timer);
         op_state = OperatorStage::FINISHED;
         QUERY_TRACE_SCOPED(op->get_name(), "set_finished");
@@ -555,8 +560,11 @@ Status PipelineDriver::_mark_operator_cancelled(OperatorPtr& op, RuntimeState* s
 
     VLOG_ROW << strings::Substitute("[Driver] cancelled operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
-    op_state = OperatorStage::CANCELLED;
-    return op->set_cancelled(state);
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(op->mem_tracker());
+        op_state = OperatorStage::CANCELLED;
+        return op->set_cancelled(state);
+    }
 }
 
 Status PipelineDriver::_mark_operator_closed(OperatorPtr& op, RuntimeState* state) {
@@ -574,6 +582,7 @@ Status PipelineDriver::_mark_operator_closed(OperatorPtr& op, RuntimeState* stat
     VLOG_ROW << strings::Substitute("[Driver] close operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(op->mem_tracker());
         SCOPED_TIMER(op->_close_timer);
         op_state = OperatorStage::CLOSED;
         QUERY_TRACE_SCOPED(op->get_name(), "close");

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -347,7 +347,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             // set driver_id/query_id/fragment_instance_id to thread local
             // driver_id will be used in some Expr such as regex_replace
             SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker());
 
             auto& chunk_source = _chunk_sources[chunk_source_index];
             [[maybe_unused]] std::string category;

--- a/be/src/exec/pipeline/stream_pipeline_driver.cpp
+++ b/be/src/exec/pipeline/stream_pipeline_driver.cpp
@@ -84,6 +84,7 @@ StatusOr<DriverState> StreamPipelineDriver::process(RuntimeState* runtime_state,
                 // operator
                 StatusOr<ChunkPtr> maybe_chunk;
                 {
+                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(curr_op->mem_tracker());
                     SCOPED_TIMER(curr_op->_pull_timer);
                     QUERY_TRACE_SCOPED(curr_op->get_name(), "pull_chunk");
                     maybe_chunk = curr_op->pull_chunk(runtime_state);
@@ -104,6 +105,7 @@ StatusOr<DriverState> StreamPipelineDriver::process(RuntimeState* runtime_state,
                         size_t row_num = chunk_value->num_rows();
                         total_rows_moved += row_num;
                         {
+                            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(next_op->mem_tracker());
                             SCOPED_TIMER(next_op->_push_timer);
                             QUERY_TRACE_SCOPED(next_op->get_name(), "push_chunk");
                             return_status = next_op->push_chunk(runtime_state, chunk_value);
@@ -223,6 +225,7 @@ StatusOr<DriverState> StreamPipelineDriver::_handle_finish_operators(RuntimeStat
             // operator
             StatusOr<ChunkPtr> maybe_chunk;
             {
+                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(curr_op->mem_tracker());
                 SCOPED_TIMER(curr_op->_pull_timer);
                 QUERY_TRACE_SCOPED(curr_op->get_name(), "pull_chunk");
                 maybe_chunk = curr_op->pull_chunk(runtime_state);
@@ -243,6 +246,7 @@ StatusOr<DriverState> StreamPipelineDriver::_handle_finish_operators(RuntimeStat
                     size_t row_num = chunk_value->num_rows();
                     total_rows_moved += row_num;
                     {
+                        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(next_op->mem_tracker());
                         SCOPED_TIMER(next_op->_push_timer);
                         QUERY_TRACE_SCOPED(next_op->get_name(), "push_chunk");
                         return_status = next_op->push_chunk(runtime_state, chunk_value);

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -269,9 +269,8 @@ SortedStreamingAggregator::~SortedStreamingAggregator() {
     }
 }
 
-Status SortedStreamingAggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile,
-                                          MemTracker* mem_tracker) {
-    RETURN_IF_ERROR(Aggregator::prepare(state, pool, runtime_profile, mem_tracker));
+Status SortedStreamingAggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile) {
+    RETURN_IF_ERROR(Aggregator::prepare(state, pool, runtime_profile));
     _streaming_state_allocator =
             std::make_shared<StateAllocator>(_mem_pool.get(), _state->chunk_size(), _agg_states_total_size);
     return Status::OK();

--- a/be/src/exec/sorted_streaming_aggregator.h
+++ b/be/src/exec/sorted_streaming_aggregator.h
@@ -27,8 +27,7 @@ public:
     SortedStreamingAggregator(AggregatorParamsPtr&& params);
     ~SortedStreamingAggregator() override;
 
-    Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile,
-                   MemTracker* mem_tracker) override;
+    Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile) override;
     Status streaming_compute_agg_state(size_t chunk_size);
 
     StatusOr<ChunkPtr> pull_eos_chunk();

--- a/be/src/exec/stream/aggregate/stream_aggregate_operator.cpp
+++ b/be/src/exec/stream/aggregate/stream_aggregate_operator.cpp
@@ -65,7 +65,7 @@ Status StreamAggregateOperator::reset_epoch(RuntimeState* state) {
 
 Status StreamAggregateOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get(), _mem_tracker.get()));
+    RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get()));
     return _aggregator->open(state);
 }
 

--- a/be/src/exec/stream/aggregate/stream_aggregator.h
+++ b/be/src/exec/stream/aggregate/stream_aggregator.h
@@ -65,9 +65,8 @@ public:
 
     Status open(RuntimeState* state) { return Aggregator::open(state); }
 
-    Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile,
-                   MemTracker* mem_tracker) override {
-        RETURN_IF_ERROR(Aggregator::prepare(state, pool, runtime_profile, mem_tracker));
+    Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile) override {
+        RETURN_IF_ERROR(Aggregator::prepare(state, pool, runtime_profile));
         RETURN_IF_ERROR(_prepare_state_tables(state));
         return Status::OK();
     }

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -55,15 +55,18 @@ public:
 
     void commit() {
         MemTracker* cur_tracker = mem_tracker();
-        if (_cache_size != 0 && cur_tracker != nullptr) {
+        if (cur_tracker != nullptr) {
             cur_tracker->consume(_cache_size);
-            cur_tracker->offset_allocation(_allocated_cache_size - _cache_size);
+            if (_cache_size > 0) {
+                _allocated_cache_size -= _cache_size;
+            } else {
+                _deallocated_cache_size += _cache_size;
+            }
+            cur_tracker->update_allocation(_allocated_cache_size);
+            cur_tracker->update_deallocation(_deallocated_cache_size);
             _cache_size = 0;
             _allocated_cache_size = 0;
-        }
-        if (_allocated_cache_size != 0 && cur_tracker != nullptr) {
-            cur_tracker->offset_allocation(_allocated_cache_size);
-            _allocated_cache_size = 0;
+            _deallocated_cache_size = 0;
         }
     }
 
@@ -108,15 +111,11 @@ public:
     bool is_catched() const { return _is_catched; }
 
     void mem_consume(int64_t size) {
-        MemTracker* cur_tracker = mem_tracker();
         _cache_size += size;
         _allocated_cache_size += size;
         _total_consumed_bytes += size;
-        if (cur_tracker != nullptr && _cache_size >= BATCH_SIZE) {
-            cur_tracker->consume(_cache_size);
-            cur_tracker->offset_allocation(_allocated_cache_size - _cache_size);
-            _cache_size = 0;
-            _allocated_cache_size = 0;
+        if (_cache_size >= BATCH_SIZE) {
+            commit();
         }
     }
 
@@ -128,9 +127,16 @@ public:
         if (cur_tracker != nullptr && _cache_size >= BATCH_SIZE) {
             MemTracker* limit_tracker = cur_tracker->try_consume(_cache_size);
             if (LIKELY(limit_tracker == nullptr)) {
-                cur_tracker->offset_allocation(_allocated_cache_size - _cache_size);
+                if (_cache_size > 0) {
+                    _allocated_cache_size -= _cache_size;
+                } else {
+                    _deallocated_cache_size += _cache_size;
+                }
+                cur_tracker->update_allocation(_allocated_cache_size);
+                cur_tracker->update_deallocation(_deallocated_cache_size);
                 _cache_size = 0;
                 _allocated_cache_size = 0;
+                _deallocated_cache_size = 0;
                 return true;
             } else {
                 _cache_size -= size;
@@ -164,11 +170,10 @@ public:
     }
 
     void mem_release(int64_t size) {
-        MemTracker* cur_tracker = mem_tracker();
         _cache_size -= size;
-        if (cur_tracker != nullptr && _cache_size <= -BATCH_SIZE) {
-            cur_tracker->release(-_cache_size);
-            _cache_size = 0;
+        _deallocated_cache_size += size;
+        if (_cache_size <= -BATCH_SIZE) {
+            commit();
         }
     }
 
@@ -194,6 +199,8 @@ private:
     int64_t _cache_size = 0;
     // Allocated but not committed memory bytes, always positive
     int64_t _allocated_cache_size = 0;
+    // Deallocated but not committed memory bytes, always positive
+    int64_t _deallocated_cache_size = 0;
     int64_t _total_consumed_bytes = 0; // Totally consumed memory bytes
     int64_t _try_consume_mem_size = 0; // Last time tried to consumed bytes
     // Store in TLS for diagnose coredump easier

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -48,6 +48,7 @@ namespace starrocks {
 
 const std::string MemTracker::PEAK_MEMORY_USAGE = "PeakMemoryUsage";
 const std::string MemTracker::ALLOCATED_MEMORY_USAGE = "AllocatedMemoryUsage";
+const std::string MemTracker::DEALLOCATED_MEMORY_USAGE = "DeallocatedMemoryUsage";
 
 MemTracker::MemTracker(int64_t byte_limit, std::string label, MemTracker* parent)
         : _limit(byte_limit),
@@ -57,7 +58,9 @@ MemTracker::MemTracker(int64_t byte_limit, std::string label, MemTracker* parent
           _local_consumption_counter(TUnit::BYTES,
                                      RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG)),
           _allocation(&_local_allocation_counter),
-          _local_allocation_counter(TUnit::BYTES) {
+          _local_allocation_counter(TUnit::BYTES),
+          _deallocation(&_local_deallocation_counter),
+          _local_deallocation_counter(TUnit::BYTES) {
     if (parent != nullptr) _parent->add_child_tracker(this);
     Init();
 }
@@ -71,24 +74,36 @@ MemTracker::MemTracker(Type type, int64_t byte_limit, std::string label, MemTrac
           _local_consumption_counter(TUnit::BYTES,
                                      RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG)),
           _allocation(&_local_allocation_counter),
-          _local_allocation_counter(TUnit::BYTES) {
+          _local_allocation_counter(TUnit::BYTES),
+          _deallocation(&_local_deallocation_counter),
+          _local_deallocation_counter(TUnit::BYTES) {
     if (parent != nullptr) _parent->add_child_tracker(this);
     Init();
 }
 
-MemTracker::MemTracker(RuntimeProfile* profile, const std::string& counter_name_prefix, int64_t byte_limit,
-                       std::string label, MemTracker* parent)
+MemTracker::MemTracker(RuntimeProfile* profile, std::tuple<bool, bool, bool> attaching_info,
+                       const std::string& counter_name_prefix, int64_t byte_limit, std::string label,
+                       MemTracker* parent)
         : _limit(byte_limit),
           _label(std::move(label)),
           _parent(parent),
-          _consumption(profile->AddHighWaterMarkCounter(
-                  counter_name_prefix + PEAK_MEMORY_USAGE, TUnit::BYTES,
-                  RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG))),
+          _consumption(std::get<0>(attaching_info)
+                               ? profile->AddHighWaterMarkCounter(
+                                         counter_name_prefix + PEAK_MEMORY_USAGE, TUnit::BYTES,
+                                         RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG))
+                               : &_local_consumption_counter),
           _local_consumption_counter(TUnit::BYTES,
                                      RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG)),
-          _allocation(profile->add_counter(counter_name_prefix + ALLOCATED_MEMORY_USAGE, TUnit::BYTES,
-                                           RuntimeProfile::Counter::create_strategy(TUnit::BYTES))),
-          _local_allocation_counter(TUnit::BYTES) {
+          _allocation(std::get<1>(attaching_info)
+                              ? profile->add_counter(counter_name_prefix + ALLOCATED_MEMORY_USAGE, TUnit::BYTES,
+                                                     RuntimeProfile::Counter::create_strategy(TUnit::BYTES))
+                              : &_local_allocation_counter),
+          _local_allocation_counter(TUnit::BYTES),
+          _deallocation(std::get<2>(attaching_info)
+                                ? profile->add_counter(counter_name_prefix + DEALLOCATED_MEMORY_USAGE, TUnit::BYTES,
+                                                       RuntimeProfile::Counter::create_strategy(TUnit::BYTES))
+                                : &_local_deallocation_counter),
+          _local_deallocation_counter(TUnit::BYTES) {
     if (parent != nullptr) _parent->add_child_tracker(this);
     Init();
 }

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -46,14 +46,18 @@
 
 namespace starrocks {
 
-const std::string MemTracker::COUNTER_NAME = "PeakMemoryUsage";
+const std::string MemTracker::PEAK_MEMORY_USAGE = "PeakMemoryUsage";
+const std::string MemTracker::ALLOCATED_MEMORY_USAGE = "AllocatedMemoryUsage";
 
 MemTracker::MemTracker(int64_t byte_limit, std::string label, MemTracker* parent)
         : _limit(byte_limit),
           _label(std::move(label)),
           _parent(parent),
-          _consumption(&_local_counter),
-          _local_counter(TUnit::BYTES) {
+          _consumption(&_local_consumption_counter),
+          _local_consumption_counter(TUnit::BYTES,
+                                     RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG)),
+          _allocation(&_local_allocation_counter),
+          _local_allocation_counter(TUnit::BYTES) {
     if (parent != nullptr) _parent->add_child_tracker(this);
     Init();
 }
@@ -63,19 +67,28 @@ MemTracker::MemTracker(Type type, int64_t byte_limit, std::string label, MemTrac
           _limit(byte_limit),
           _label(std::move(label)),
           _parent(parent),
-          _consumption(&_local_counter),
-          _local_counter(TUnit::BYTES) {
+          _consumption(&_local_consumption_counter),
+          _local_consumption_counter(TUnit::BYTES,
+                                     RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG)),
+          _allocation(&_local_allocation_counter),
+          _local_allocation_counter(TUnit::BYTES) {
     if (parent != nullptr) _parent->add_child_tracker(this);
     Init();
 }
 
-MemTracker::MemTracker(RuntimeProfile* profile, int64_t byte_limit, std::string label, MemTracker* parent)
+MemTracker::MemTracker(RuntimeProfile* profile, const std::string& counter_name_prefix, int64_t byte_limit,
+                       std::string label, MemTracker* parent)
         : _limit(byte_limit),
           _label(std::move(label)),
           _parent(parent),
-          _consumption(profile->AddHighWaterMarkCounter(COUNTER_NAME, TUnit::BYTES,
-                                                        RuntimeProfile::Counter::create_strategy(TUnit::BYTES))),
-          _local_counter(TUnit::BYTES) {
+          _consumption(profile->AddHighWaterMarkCounter(
+                  counter_name_prefix + PEAK_MEMORY_USAGE, TUnit::BYTES,
+                  RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG))),
+          _local_consumption_counter(TUnit::BYTES,
+                                     RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG)),
+          _allocation(profile->add_counter(counter_name_prefix + ALLOCATED_MEMORY_USAGE, TUnit::BYTES,
+                                           RuntimeProfile::Counter::create_strategy(TUnit::BYTES))),
+          _local_allocation_counter(TUnit::BYTES) {
     if (parent != nullptr) _parent->add_child_tracker(this);
     Init();
 }

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -105,8 +105,8 @@ public:
 
     /// C'tor for tracker for which consumption counter is created as part of a profile.
     /// The counter is created with name COUNTER_NAME.
-    MemTracker(RuntimeProfile* profile, int64_t byte_limit, std::string label = std::string(),
-               MemTracker* parent = nullptr);
+    explicit MemTracker(RuntimeProfile* profile, const std::string& counter_name_prefix = std::string(),
+                        int64_t byte_limit = -1, std::string label = std::string(), MemTracker* parent = nullptr);
 
     ~MemTracker();
 
@@ -119,7 +119,17 @@ public:
     }
 
     // used for single mem_tracker
-    void set(int64_t bytes) { _consumption->set(bytes); }
+    void set(int64_t bytes) {
+        _consumption->set(bytes);
+        _allocation->set(bytes);
+    }
+
+    void offset_allocation(int64_t offset_bytes) {
+        if (offset_bytes <= 0) return;
+        for (auto* tracker : _all_trackers) {
+            tracker->_allocation->update(offset_bytes);
+        }
+    }
 
     void consume(int64_t bytes) {
         if (bytes <= 0) {
@@ -128,6 +138,7 @@ public:
         }
         for (auto* tracker : _all_trackers) {
             tracker->_consumption->add(bytes);
+            tracker->_allocation->update(bytes);
         }
     }
 
@@ -166,7 +177,7 @@ public:
     /// Increases consumption of this tracker and its ancestors by 'bytes' only if
     /// they can all consume 'bytes'. If this brings any of them over, none of them
     /// are updated.
-    /// Returns true if the try succeeded.
+    /// Returns nullptr if the try succeeded, otherwise return the tracker that failed.
     WARN_UNUSED_RESULT
     MemTracker* try_consume(int64_t bytes) {
         if (UNLIKELY(bytes <= 0)) return nullptr;
@@ -177,13 +188,16 @@ public:
             const int64_t limit = tracker->limit();
             if (limit < 0) {
                 tracker->_consumption->add(bytes); // No limit at this tracker.
+                tracker->_allocation->update(bytes);
             } else {
                 if (LIKELY(tracker->_consumption->try_add(bytes, limit))) {
+                    tracker->_allocation->update(bytes);
                     continue;
                 } else {
                     // Failed for this mem tracker. Roll back the ones that succeeded.
                     for (int64_t j = _all_trackers.size() - 1; j > i; --j) {
                         _all_trackers[j]->_consumption->add(-bytes);
+                        _all_trackers[j]->_allocation->update(-bytes);
                     }
                     return tracker;
                 }
@@ -262,6 +276,7 @@ public:
     int64_t consumption() const { return _consumption->current_value(); }
 
     int64_t peak_consumption() const { return _consumption->value(); }
+    int64_t allocation() const { return _allocation->value(); }
 
     MemTracker* parent() const { return _parent; }
 
@@ -269,12 +284,14 @@ public:
 
     std::string err_msg(const std::string& msg) const;
 
-    static const std::string COUNTER_NAME;
+    static const std::string PEAK_MEMORY_USAGE;
+    static const std::string ALLOCATED_MEMORY_USAGE;
 
     std::string debug_string() {
         std::stringstream msg;
         msg << "limit: " << _limit << "; "
             << "consumption: " << _consumption->current_value() << "; "
+            << "allocation: " << _allocation->value() << "; "
             << "label: " << _label << "; "
             << "all tracker size: " << _all_trackers.size() << "; "
             << "limit trackers size: " << _limit_trackers.size() << "; "
@@ -311,7 +328,13 @@ private:
     RuntimeProfile::HighWaterMarkCounter* _consumption;
 
     /// holds _consumption counter if not tied to a profile
-    RuntimeProfile::HighWaterMarkCounter _local_counter;
+    RuntimeProfile::HighWaterMarkCounter _local_consumption_counter;
+
+    /// in bytes; not owned. Only record allocation but ignore deallocation
+    RuntimeProfile::Counter* _allocation;
+
+    /// holds _cumulative_consumption counter if not tied to a profile
+    RuntimeProfile::Counter _local_allocation_counter;
 
     std::vector<MemTracker*> _all_trackers;   // this tracker plus all of its ancestors
     std::vector<MemTracker*> _limit_trackers; // _all_trackers with valid limits

--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -67,20 +67,20 @@ void QueryStatistics::add_scan_stats(int64_t scan_rows, int64_t scan_bytes) {
 
 void QueryStatistics::merge(int sender_id, QueryStatistics& other) {
     // Make the exchange action atomic
-    int64_t rows = other.scan_rows.load();
-    scan_rows += rows;
-    other.scan_rows -= rows;
+    int64_t scan_rows = other.scan_rows.load();
+    this->scan_rows += scan_rows;
+    other.scan_rows -= scan_rows;
 
-    int64_t bytes = other.scan_bytes.load();
-    scan_bytes += bytes;
-    other.scan_bytes -= bytes;
+    int64_t scan_bytes = other.scan_bytes.load();
+    this->scan_bytes += scan_bytes;
+    other.scan_bytes -= scan_bytes;
 
     int64_t cpu_ns = other.cpu_ns.load();
-    cpu_ns += cpu_ns;
+    this->cpu_ns += cpu_ns;
     other.cpu_ns -= cpu_ns;
 
-    int64_t mem_bytes = other.mem_cost_bytes.load();
-    mem_cost_bytes = std::max<int64_t>(mem_cost_bytes, mem_bytes);
+    int64_t mem_cost_bytes = other.mem_cost_bytes.load();
+    this->mem_cost_bytes = std::max<int64_t>(this->mem_cost_bytes, mem_cost_bytes);
 
     _stats_items.insert(_stats_items.end(), other._stats_items.begin(), other._stats_items.end());
 }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -180,8 +180,8 @@ void RuntimeState::init_mem_trackers(const TUniqueId& query_id, MemTracker* pare
 
     _query_mem_tracker =
             std::make_shared<MemTracker>(MemTracker::QUERY, bytes_limit, runtime_profile()->name(), parent);
-    _instance_mem_tracker = std::make_shared<MemTracker>(_profile.get(), "Instance", -1, runtime_profile()->name(),
-                                                         _query_mem_tracker.get());
+    _instance_mem_tracker = std::make_shared<MemTracker>(_profile.get(), std::make_tuple(true, true, true), "Instance",
+                                                         -1, runtime_profile()->name(), _query_mem_tracker.get());
     _instance_mem_pool = std::make_unique<MemPool>();
 }
 
@@ -194,8 +194,8 @@ void RuntimeState::init_mem_trackers(const std::shared_ptr<MemTracker>& query_me
 
     // all fragment instances in a BE shared a common query_mem_tracker.
     _query_mem_tracker = query_mem_tracker;
-    _instance_mem_tracker = std::make_shared<MemTracker>(_profile.get(), "Instance", -1, runtime_profile()->name(),
-                                                         _query_mem_tracker.get());
+    _instance_mem_tracker = std::make_shared<MemTracker>(_profile.get(), std::make_tuple(true, true, true), "Instance",
+                                                         -1, runtime_profile()->name(), _query_mem_tracker.get());
     _instance_mem_pool = std::make_unique<MemPool>();
 }
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -180,21 +180,22 @@ void RuntimeState::init_mem_trackers(const TUniqueId& query_id, MemTracker* pare
 
     _query_mem_tracker =
             std::make_shared<MemTracker>(MemTracker::QUERY, bytes_limit, runtime_profile()->name(), parent);
-    _instance_mem_tracker =
-            std::make_shared<MemTracker>(_profile.get(), -1, runtime_profile()->name(), _query_mem_tracker.get());
+    _instance_mem_tracker = std::make_shared<MemTracker>(_profile.get(), "Instance", -1, runtime_profile()->name(),
+                                                         _query_mem_tracker.get());
     _instance_mem_pool = std::make_unique<MemPool>();
 }
 
 void RuntimeState::init_mem_trackers(const std::shared_ptr<MemTracker>& query_mem_tracker) {
     DCHECK(query_mem_tracker != nullptr);
 
-    auto* mem_tracker_counter = ADD_COUNTER(_profile.get(), "QueryMemoryLimit", TUnit::BYTES);
+    auto* mem_tracker_counter =
+            ADD_COUNTER_SKIP_MERGE(_profile.get(), "QueryMemoryLimit", TUnit::BYTES, TCounterMergeType::SKIP_ALL);
     mem_tracker_counter->set(query_mem_tracker->limit());
 
     // all fragment instances in a BE shared a common query_mem_tracker.
     _query_mem_tracker = query_mem_tracker;
-    _instance_mem_tracker =
-            std::make_shared<MemTracker>(_profile.get(), -1L, runtime_profile()->name(), _query_mem_tracker.get());
+    _instance_mem_tracker = std::make_shared<MemTracker>(_profile.get(), "Instance", -1, runtime_profile()->name(),
+                                                         _query_mem_tracker.get());
     _instance_mem_pool = std::make_unique<MemPool>();
 }
 

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -118,14 +118,21 @@ class RuntimeProfile {
 public:
     class Counter {
     public:
-        static TCounterStrategy create_strategy(TUnit::type type,
+        static TCounterStrategy create_strategy(TCounterAggregateType::type aggregate_type,
                                                 TCounterMergeType::type merge_type = TCounterMergeType::MERGE_ALL,
                                                 int64_t display_threshold = 0) {
             TCounterStrategy strategy;
-            strategy.aggregate_type = is_time_type(type) ? TCounterAggregateType::AVG : TCounterAggregateType::SUM;
+            strategy.aggregate_type = aggregate_type;
             strategy.merge_type = merge_type;
             strategy.display_threshold = display_threshold;
             return strategy;
+        }
+
+        static TCounterStrategy create_strategy(TUnit::type type,
+                                                TCounterMergeType::type merge_type = TCounterMergeType::MERGE_ALL,
+                                                int64_t display_threshold = 0) {
+            auto aggregate_type = is_time_type(type) ? TCounterAggregateType::AVG : TCounterAggregateType::SUM;
+            return create_strategy(aggregate_type, merge_type, display_threshold);
         }
 
         explicit Counter(TUnit::type type, int64_t value = 0)

--- a/be/test/exec/stream/stream_aggregator_test.cpp
+++ b/be/test/exec/stream/stream_aggregator_test.cpp
@@ -32,7 +32,7 @@ public:
     };
 
     StreamAggregateTestBase(bool is_generate_retract) : _is_generate_retract(is_generate_retract) {}
-    ~StreamAggregateTestBase() = default;
+    ~StreamAggregateTestBase() override = default;
 
     std::vector<LogicalType> get_slot_types(std::vector<SlotTypeInfo> slot_infos) {
         std::vector<LogicalType> types;
@@ -160,7 +160,7 @@ public:
 };
 
 TEST_F(CountStreamAggregateTest, TestNoRetracts_NoGenerateRetracts) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     // 0: StreamRowOp::INSERT,
@@ -181,7 +181,7 @@ TEST_F(CountStreamAggregateTest, TestNoRetracts_NoGenerateRetracts) {
 }
 
 TEST_F(CountStreamAggregateTest, TestWithRetracts_NoGenerateRetracts) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     // 0: StreamRowOp::INSERT,
@@ -204,7 +204,7 @@ TEST_F(CountStreamAggregateTest, TestWithRetracts_NoGenerateRetracts) {
 }
 
 TEST_F(CountStreamAggregateTest, TestNoRetracts_MultiRuns) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     // 0: StreamRowOp::INSERT,
@@ -268,7 +268,7 @@ TEST_F(CountStreamAggregateTest, TestNoRetracts_MultiRuns) {
 }
 
 TEST_F(CountStreamAggregateTestWithGenerateRetracts, TestWithRetracts_GenerateRetracts) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     // 0: StreamRowOp::INSERT,
@@ -290,7 +290,7 @@ TEST_F(CountStreamAggregateTestWithGenerateRetracts, TestWithRetracts_GenerateRe
 }
 
 TEST_F(CountStreamAggregateTestWithGenerateRetracts, TestWithRetracts_MultiRuns) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     // 0: StreamRowOp::INSERT,
@@ -400,7 +400,7 @@ public:
 };
 
 TEST_F(SumAvgStreamAggregateTestWithoutRetract, TestNoRetracts_OneRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     auto result_chunk_ptr = std::make_shared<StreamChunk>();
@@ -428,7 +428,7 @@ TEST_F(SumAvgStreamAggregateTestWithoutRetract, TestNoRetracts_OneRun) {
 }
 
 TEST_F(SumAvgStreamAggregateTestWithoutRetract, TestNoRetracts_MultiRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
     // Run 1
     auto result_chunk_ptr = std::make_shared<StreamChunk>();
@@ -536,7 +536,7 @@ public:
 };
 
 TEST_F(MinMaxCountStreamAggregateTestWithoutRetract, TestNoRetracts_OneRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     RunBatchAndCheck(1, StreamRowData<int64_t>{{{1, 2, 1}, {1, 2, 2}}, {0, 0, 0}},
@@ -545,7 +545,7 @@ TEST_F(MinMaxCountStreamAggregateTestWithoutRetract, TestNoRetracts_OneRun) {
 }
 
 TEST_F(MinMaxCountStreamAggregateTestWithoutRetract, TestNoRetracts_MultiRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
     // Run 1
     RunBatchAndCheck(1, StreamRowData<int64_t>{{{1, 2, 1}, {1, 2, 2}}, {0, 0, 0}},
@@ -565,7 +565,7 @@ public:
 };
 
 TEST_F(MinMaxCountStreamAggregateTestWithRetract, TestWihRetracts_OneRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     RunBatchAndCheck(1, StreamRowData<int64_t>{{{1, 2, 1}, {1, 2, 1}}, {0, 0, 1}},
@@ -574,7 +574,7 @@ TEST_F(MinMaxCountStreamAggregateTestWithRetract, TestWihRetracts_OneRun) {
 }
 
 TEST_F(MinMaxCountStreamAggregateTestWithRetract, TestWihRetracts_MultiRun1) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
     // Run 1
     // Input:
@@ -618,7 +618,7 @@ TEST_F(MinMaxCountStreamAggregateTestWithRetract, TestWihRetracts_MultiRun1) {
 }
 
 TEST_F(MinMaxCountStreamAggregateTestWithRetract, TestWihRetracts_MultiRun2) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     // key <-> min <-> max <-> count
@@ -717,7 +717,7 @@ public:
 };
 
 TEST_F(AllStreamAggregateFunctionsTestWithoutRetract, TestNoRetracts_OneRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     auto result_chunk_ptr = std::make_shared<StreamChunk>();
@@ -748,7 +748,7 @@ TEST_F(AllStreamAggregateFunctionsTestWithoutRetract, TestNoRetracts_OneRun) {
 }
 
 TEST_F(AllStreamAggregateFunctionsTestWithoutRetract, TestNoRetracts_MultiRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
     auto result_chunk_ptr = std::make_shared<StreamChunk>();
     auto intermediate_chunk_ptr = std::make_shared<Chunk>();
@@ -876,7 +876,7 @@ public:
 };
 
 TEST_F(AllStreamAggregateFunctionsTestWithoutRetractWithString, TestNoRetracts_OneRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     auto result_chunk_ptr = std::make_shared<StreamChunk>();
@@ -902,7 +902,7 @@ TEST_F(AllStreamAggregateFunctionsTestWithoutRetractWithString, TestNoRetracts_O
 }
 
 TEST_F(AllStreamAggregateFunctionsTestWithoutRetractWithString, TestNoRetracts_MultiRun) {
-    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile, _mem_tracker.get()));
+    DCHECK_IF_ERROR(_stream_aggregator->prepare(_runtime_state, &_obj_pool, _runtime_profile));
     DCHECK_IF_ERROR(_stream_aggregator->open(_runtime_state));
 
     // NOTE: binary/slice is not copied into datum, need this vector to track all chunk of state' life .

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -87,7 +87,7 @@ public class Counter {
 
     public Counter(TUnit type, TCounterStrategy strategy, long value) {
         this.type = type.getValue();
-        if (strategy == null) {
+        if (strategy == null || strategy.aggregate_type == null || strategy.merge_type == null) {
             this.strategy = Counter.createStrategy(type);
         } else {
             this.strategy = strategy;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -75,8 +75,6 @@ public class ProfileManager {
     public static final String SQL_STATEMENT = "Sql Statement";
     public static final String USER = "User";
     public static final String DEFAULT_DB = "Default Db";
-    public static final String QUERY_CPU_COST = "QueryCpuCost";
-    public static final String QUERY_MEM_COST = "QueryMemCost";
     public static final String VARIABLES = "Variables";
     public static final String PROFILE_TIME = "Collect Profile Time";
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -231,7 +231,7 @@ public class LoadLoadingTask extends LoadTask {
                 curCoordinator.getQueryProfile().getCounterTotalTime()
                         .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
                 curCoordinator.endProfile();
-                curCoordinator.mergeIsomorphicProfiles();
+                curCoordinator.mergeIsomorphicProfiles(null);
                 profile.addChild(curCoordinator.getQueryProfile());
 
                 StringBuilder builder = new StringBuilder();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1596,6 +1596,7 @@ public class Coordinator {
         }
 
         long queryAllocatedMemoryUsage = 0;
+        long queryDeallocatedMemoryUsage = 0;
         // Calculate ExecutionTotalTime, which comprising all operator's sync time and async time
         // We can get Operator's sync time from OperatorTotalTime, and for async time, only ScanOperator and
         // ExchangeOperator have async operations, we can get async time from ScanTime(for ScanOperator) and
@@ -1606,6 +1607,10 @@ public class Coordinator {
             Counter instanceAllocatedMemoryUsage = fragmentProfile.getCounter("InstanceAllocatedMemoryUsage");
             if (instanceAllocatedMemoryUsage != null) {
                 queryAllocatedMemoryUsage += instanceAllocatedMemoryUsage.getValue();
+            }
+            Counter instanceDeallocatedMemoryUsage = fragmentProfile.getCounter("InstanceDeallocatedMemoryUsage");
+            if (instanceDeallocatedMemoryUsage != null) {
+                queryDeallocatedMemoryUsage += instanceDeallocatedMemoryUsage.getValue();
             }
 
             for (Pair<RuntimeProfile, Boolean> pipelineProfilePair : fragmentProfile.getChildList()) {
@@ -1644,6 +1649,9 @@ public class Coordinator {
         Counter queryAllocatedMemoryUsageCounter =
                 queryProfile.addCounter("QueryAllocatedMemoryUsage", TUnit.BYTES, null);
         queryAllocatedMemoryUsageCounter.setValue(queryAllocatedMemoryUsage);
+        Counter queryDeallocatedMemoryUsageCounter =
+                queryProfile.addCounter("QueryDeallocatedMemoryUsage", TUnit.BYTES, null);
+        queryDeallocatedMemoryUsageCounter.setValue(queryDeallocatedMemoryUsage);
         Counter queryCumulativeOperatorTimer =
                 queryProfile.addCounter("QueryCumulativeOperatorTime", TUnit.TIME_NS, null);
         queryCumulativeOperatorTimer.setValue(queryCumulativeOperatorTime);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -61,6 +61,7 @@ import com.starrocks.planner.ScanNode;
 import com.starrocks.proto.PExecBatchPlanFragmentsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.qe.QueryStatisticsItem.FragmentInstanceInfo;
 import com.starrocks.rpc.BackendServiceClient;
@@ -1509,7 +1510,7 @@ public class Coordinator {
         return false;
     }
 
-    public void mergeIsomorphicProfiles() {
+    public void mergeIsomorphicProfiles(PQueryStatistics statistics) {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
 
         if (!sessionVariable.isEnableProfile()) {
@@ -1594,13 +1595,19 @@ public class Coordinator {
             backendNum.setValue(networkAddresses.size());
         }
 
+        long queryAllocatedMemoryUsage = 0;
         // Calculate ExecutionTotalTime, which comprising all operator's sync time and async time
         // We can get Operator's sync time from OperatorTotalTime, and for async time, only ScanOperator and
         // ExchangeOperator have async operations, we can get async time from ScanTime(for ScanOperator) and
         // NetworkTime(for ExchangeOperator)
-        long operatorCumulativeTime = 0;
+        long queryCumulativeOperatorTime = 0;
         boolean foundResultSink = false;
         for (RuntimeProfile fragmentProfile : fragmentProfiles) {
+            Counter instanceAllocatedMemoryUsage = fragmentProfile.getCounter("InstanceAllocatedMemoryUsage");
+            if (instanceAllocatedMemoryUsage != null) {
+                queryAllocatedMemoryUsage += instanceAllocatedMemoryUsage.getValue();
+            }
+
             for (Pair<RuntimeProfile, Boolean> pipelineProfilePair : fragmentProfile.getChildList()) {
                 RuntimeProfile pipelineProfile = pipelineProfilePair.first;
                 for (Pair<RuntimeProfile, Boolean> operatorProfilePair : pipelineProfile.getChildList()) {
@@ -1620,23 +1627,32 @@ public class Coordinator {
                     }
                     Counter operatorTotalTime = commonMetrics.getMaxCounter("OperatorTotalTime");
                     Preconditions.checkNotNull(operatorTotalTime);
-                    operatorCumulativeTime += operatorTotalTime.getValue();
+                    queryCumulativeOperatorTime += operatorTotalTime.getValue();
 
                     Counter scanTime = uniqueMetrics.getMaxCounter("ScanTime");
                     if (scanTime != null) {
-                        operatorCumulativeTime += scanTime.getValue();
+                        queryCumulativeOperatorTime += scanTime.getValue();
                     }
 
                     Counter networkTime = uniqueMetrics.getMaxCounter("NetworkTime");
                     if (networkTime != null) {
-                        operatorCumulativeTime += networkTime.getValue();
+                        queryCumulativeOperatorTime += networkTime.getValue();
                     }
                 }
             }
         }
-        Counter operatorCumulativeTimer = queryProfile.addCounter("OperatorCumulativeTime", TUnit.TIME_NS, null);
-        operatorCumulativeTimer.setValue(operatorCumulativeTime);
+        Counter queryAllocatedMemoryUsageCounter =
+                queryProfile.addCounter("QueryAllocatedMemoryUsage", TUnit.BYTES, null);
+        queryAllocatedMemoryUsageCounter.setValue(queryAllocatedMemoryUsage);
+        Counter queryCumulativeOperatorTimer =
+                queryProfile.addCounter("QueryCumulativeOperatorTime", TUnit.TIME_NS, null);
+        queryCumulativeOperatorTimer.setValue(queryCumulativeOperatorTime);
         queryProfile.getCounterTotalTime().setValue(0);
+
+        long memCostBytes = statistics == null || statistics.memCostBytes == null ? 0 : statistics.memCostBytes;
+        long cpuCostNs = statistics == null || statistics.cpuCostNs == null ? 0 : statistics.cpuCostNs;
+        queryProfile.addInfoString("QueryCumulativeCpuTime", DebugUtil.getPrettyStringNs(cpuCostNs));
+        queryProfile.addInfoString("MachinePeakMemoryUsage", DebugUtil.getPrettyStringBytes(memCostBytes));
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -243,12 +243,6 @@ public class StmtExecutor {
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
         summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
 
-        PQueryStatistics statistics = getQueryStatisticsForAuditLog();
-        long memCostBytes = statistics == null || statistics.memCostBytes == null ? 0 : statistics.memCostBytes;
-        long cpuCostNs = statistics == null || statistics.cpuCostNs == null ? 0 : statistics.cpuCostNs;
-        summaryProfile.addInfoString(ProfileManager.QUERY_CPU_COST, DebugUtil.getPrettyStringNs(cpuCostNs));
-        summaryProfile.addInfoString(ProfileManager.QUERY_MEM_COST, DebugUtil.getPrettyStringBytes(memCostBytes));
-
         // Add some import variables in profile
         SessionVariable variables = context.getSessionVariable();
         if (variables != null) {
@@ -277,7 +271,7 @@ public class StmtExecutor {
             if (coord.getQueryProfile() != null) {
                 coord.getQueryProfile().getCounterTotalTime().setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
                 coord.endProfile();
-                coord.mergeIsomorphicProfiles();
+                coord.mergeIsomorphicProfiles(getQueryStatisticsForAuditLog());
                 profile.addChild(coord.getQueryProfile());
             }
             coord = null;
@@ -928,7 +922,6 @@ public class StmtExecutor {
                 .dropHistogramStatsMetaAndData(StatisticUtils.buildConnectContext(), Sets.newHashSet(table.getId()));
         GlobalStateMgr.getCurrentStatisticStorage().expireHistogramStatistics(table.getId(), columns);
     }
-
 
     private void handleKillAnalyzeStmt() {
         KillAnalyzeStmt killAnalyzeStmt = (KillAnalyzeStmt) parsedStmt;


### PR DESCRIPTION
Signed-off-by: liuyehcf <1559500551@qq.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Support operator level memory tracing

Currently, we only support instance level memory tracing. And we can further support operator level memory tracing by 

1. Attach Operator's MemTracker, as child, to FragmentInstance's MemTracker
2. Set thread local mem_tracker when calling `push_chunk`、`pull_chunk`、`set_finishing`、`set_finished`、`set_cancelled` and `close`. Memory consumption information will be recorded both in Operator's MemTracker and FragmentInstance's MemTracker.

## Improve MemTracker mechanism

For now, we only record the peak memory usage of a given query, and it is not enough when it comes to the requirements of the memory test framework, which demands a query should have stable memory usage.

So we need to record another two metrics called `MemTracker::_allocation` and `MemTracker::_deallocation`, which respectively record allocation and deallocation.

### Be compatible with CurrentThread

For sake of performance, not every memory allocation and deallocation will be passed to MemTracker for updation. CurrentThread will first cache it, when exceed the threshold `CurrentThread::BATCH_SIZE`, then update MemTracker. This cache processing will violate the correctness of the `MemTracker::_allocation` and `MemTracker::_deallocation`. 

So we  need to improve the cache mechanism as well by adding two field `CurrentThread::_allocated_cache_size`  and `CurrentThread::_deallocated_cache_size` 

## Metrics renames

Rename:

1. QueryCpuTime -> QueryCumulativeCpuTime
2. QueryMemUsage -> MachinePeakMemoryUsage
3. OperatorCumulativeTime -> QueryCumulativeOperatorTime

## Example

After this pr
* every Operator's level has `OperatorAllocatedMemoryUsage/OperatorDeallocatedMemoryUsage`
    * We hide `OperatorPeakMemoryUsage`, because in some workflow, suppose A and B are two adjcent operators, memory only allocated in A and only deallocated in B, the peak memory usage for A and B is meaningless.
* every Instance's level has `InstanceAllocatedMemoryUsage/InstanceDeallocatedMemoryUsage/InstancePeakMemoryUsage`
* every Query's level has `QueryAllocatedMemoryUsage/QueryDeallocatedMemoryUsage/MachinePeakMemoryUsage`

```
...
  Execution Profile 666250bb-a39f-11ed-9724-00163e1f2aee:
     - QueryCumulativeCpuTime: 2m47s
     - MachinePeakMemoryUsage: 12.722GB
     - ExecutionWallTime: 8s82ms
     - QueryAllocatedMemoryUsage: 220.89 GB
     - QueryCumulativeOperatorTime: 10s753ms
 ...
    Fragment 2:
       - InstanceAllocatedMemoryUsage: 63.31 GB
         - __MAX_OF_InstanceAllocatedMemoryUsage: 21.35 GB
         - __MIN_OF_InstanceAllocatedMemoryUsage: 20.63 GB
       - InstancePeakMemoryUsage: 203.69 MB
         - __MAX_OF_InstancePeakMemoryUsage: 203.98 MB
         - __MIN_OF_InstancePeakMemoryUsage: 203.44 MB
       - QueryMemoryLimit: 38.07 GB
 ...
        EXCHANGE_SINK (plan_node_id=1):
          CommonMetrics:
             - CloseTime: 3.8us
               - __MAX_OF_CloseTime: 19.366us
               - __MIN_OF_CloseTime: 447ns
             - OperatorAllocatedMemoryUsage: 19.00 KB
               - __MAX_OF_OperatorAllocatedMemoryUsage: 4.31 KB
               - __MIN_OF_OperatorAllocatedMemoryUsage: 640.00 B
             - OperatorDeallocatedMemoryUsage: 6.02 KB
               - __MAX_OF_OperatorDeallocatedMemoryUsage: 1.55 KB
               - __MIN_OF_OperatorDeallocatedMemoryUsage: 64.00 B
...
```

## Performance test

operator level memory tracing may introduce some overhead from 2 aspects:

1. thread_local obj `tls_mem_tracker` will be switched
2. every time recording memory allocation/dellocation, before this pr, two mem_tracker will be updated(Query level and Instance level), and after this pr, there will be one more Operator mem_tracker

So I have conduct a experiment to find out whether this overhead can lead to significant performance deduction. And the results show that the overhead is negligible

TPCH-100g, 16c/64g * 3

| Query | Before | After |
|:--|:--|:--|
| Q1 | 1.978 | 1.98 |
| Q2 | 0.156 | 0.135 |
| Q3 | 0.78 | 0.758 |
| Q4 | 0.446 | 0.445 |
| Q5 | 1.308 | 1.309 |
| Q6 | 0.06 | 0.063 |
| Q7 | 1.083 | 1.105 |
| Q8 | 0.594 | 0.606 |
| Q9 | 2.032 | 2.067 |
| Q10 | 0.528 | 0.523 |
| Q11 | 0.191 | 0.184 |
| Q12 | 0.192 | 0.192 |
| Q13 | 1.892 | 1.891 |
| Q14 | 0.168 | 0.17 |
| Q15 | 0.31 | 0.273 |
| Q16 | 0.199 | 0.201 |
| Q17 | 0.376 | 0.379 |
| Q18 | 4.163 | 4.149 |
| Q19 | 0.473 | 0.479 |
| Q20 | 0.269 | 0.267 |
| Q21 | 0.082 | 0.096 |
| Q22 | 0.394 | 0.374 |

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
