### PR TITLE
[Refactor] optimize jindosdk decompress procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ fe/fe-core/gen
 fe/fe-common/.classpath
 fs_brokers/apache_hdfs_broker/src/main/resources/
 fs_brokers/apache_hdfs_broker/src/main/thrift/
+fs_brokers/apache_hdfs_broker/jindosdk-4.6.2
 dependency-reduced-pom.xml
 tags
 .tags

--- a/fs_brokers/apache_hdfs_broker/build.sh
+++ b/fs_brokers/apache_hdfs_broker/build.sh
@@ -52,13 +52,15 @@ mv broker_thirdparty_jars/*.jar ${BROKER_OUTPUT}/lib/
 rm -r broker_thirdparty_jars broker_thirdparty_jars.tar.gz
 
 # jindosdk-4.6.2.tar.gz is very large, about 931M, so we cache it in local disk
-if [[ ! -f ./jindosdk-4.6.2.tar.gz ]]; then
+if [ ! -d ${BROKER_HOME}/jindosdk-4.6.2 ]; then
     echo "download aliyun jindo..."
     wget https://jindodata-binary.oss-cn-shanghai.aliyuncs.com/release/4.6.2/jindosdk-4.6.2.tar.gz
+    tar xvf jindosdk-4.6.2.tar.gz
 fi
-tar xvf jindosdk-4.6.2.tar.gz
 cp -r jindosdk-4.6.2/lib/*.jar ${BROKER_OUTPUT}/lib/
-rm -r jindosdk-4.6.2
+if [ -f ${BROKER_HOME}/jindosdk-4.6.2.tar.gz ]; then
+    rm -r ${BROKER_HOME}/jindosdk-4.6.2.tar.gz
+fi
 
 
 cp -r -p ${BROKER_HOME}/bin/*.sh ${BROKER_OUTPUT}/bin/
@@ -68,8 +70,6 @@ cp -r -p ${BROKER_HOME}/conf/log4j.properties ${BROKER_OUTPUT}/conf/
 cp -r -p ${BROKER_HOME}/target/lib/* ${BROKER_OUTPUT}/lib/
 cp -r -p ${BROKER_HOME}/target/apache_hdfs_broker.jar ${BROKER_OUTPUT}/lib/
 
-echo ""
-echo ""
 echo ""
 echo "***************************************"
 echo "**Successfully build StarRocks Broker**"


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, we will decompress jindosdk-4.6.2.tar.gz when building broker, this is very time consuming.
In this pr, we optimize this procedure, jindosdk-4.6.2.tar.gz will only be decompressed in the first time it downloads.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
