### PR TITLE
[Enhancement] add column prune after mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -365,7 +365,9 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         if (newAggregations == null) {
             return null;
         }
-        return createNewAggregate(queryAgg, newAggregations, aggregateMapping, unionExpr);
+        OptExpression result = createNewAggregate(queryAgg, newAggregations, aggregateMapping, unionExpr);
+        deriveLogicalProperty(result);
+        return result;
     }
 
     private OptExpression createNewAggregate(LogicalAggregationOperator queryAgg,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnPruner.java
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.sql.common.UnsupportedException;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ColumnPruner {
+    private ColumnRefSet requiredOutputColumns;
+
+    public OptExpression pruneColumns(OptExpression queryExpression) {
+        Projection projection = queryExpression.getOp().getProjection();
+        // OptExpression after mv rewrite must have projection
+        // if not, skip this rewrite result
+        if (projection == null) {
+            return null;
+        }
+        requiredOutputColumns = new ColumnRefSet(projection.getOutputColumns());
+        return queryExpression.getOp().accept(new ColumnPruneVisitor(), queryExpression, null);
+    }
+
+    // prune columns by top-down
+    // now only SPJG/union operators are suppported
+    private class ColumnPruneVisitor extends OptExpressionVisitor<OptExpression, Void> {
+        public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
+            LogicalScanOperator scanOperator = optExpression.getOp().cast();
+
+            Projection projection = scanOperator.getProjection();
+            if (projection != null) {
+                projection.getColumnRefMap().values().forEach(s -> requiredOutputColumns.union(s.getUsedColumns()));
+            }
+
+            Set<ColumnRefOperator> outputColumns =
+                    scanOperator.getColRefToColumnMetaMap().keySet().stream().filter(requiredOutputColumns::contains)
+                            .collect(Collectors.toSet());
+            outputColumns.addAll(Utils.extractColumnRef(scanOperator.getPredicate()));
+            if (outputColumns.size() == 0) {
+                outputColumns.add(Utils.findSmallestColumnRef(
+                        new ArrayList<>(scanOperator.getColRefToColumnMetaMap().keySet())));
+            }
+
+            ImmutableMap.Builder<ColumnRefOperator, Column> columnRefColumnMapBuilder = new ImmutableMap.Builder<>();
+            scanOperator.getColRefToColumnMetaMap().keySet().stream()
+                    .filter(key -> outputColumns.contains(key))
+                    .forEach(key -> columnRefColumnMapBuilder.put(key, scanOperator.getColRefToColumnMetaMap().get(key)));
+            ImmutableMap<ColumnRefOperator, Column> newColumnRefMap = columnRefColumnMapBuilder.build();
+            if (newColumnRefMap.size() != scanOperator.getColRefToColumnMetaMap().size()) {
+                Operator.Builder builder = OperatorBuilderFactory.build(scanOperator);
+                builder.withOperator(scanOperator);
+                LogicalScanOperator.Builder scanBuilder = (LogicalScanOperator.Builder) builder;
+                scanBuilder.setColRefToColumnMetaMap(newColumnRefMap);
+                Operator newQueryOp = builder.build();
+                return OptExpression.create(newQueryOp);
+            } else {
+                return optExpression;
+            }
+        }
+
+        public OptExpression visitLogicalAggregate(OptExpression optExpression, Void context) {
+            LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) optExpression.getOp();
+            if (aggregationOperator.getProjection() != null) {
+                Projection projection = aggregationOperator.getProjection();
+                projection.getColumnRefMap().values().forEach(s -> requiredOutputColumns.union(s.getUsedColumns()));
+            }
+            if (aggregationOperator.getPredicate() != null) {
+                requiredOutputColumns.union(Utils.extractColumnRef(aggregationOperator.getPredicate()));
+            }
+            requiredOutputColumns.union(aggregationOperator.getGroupingKeys());
+            for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregationOperator.getAggregations().entrySet()) {
+                requiredOutputColumns.union(entry.getKey());
+                requiredOutputColumns.union(Utils.extractColumnRef(entry.getValue()));
+            }
+            List<OptExpression> children = visitChildren(optExpression);
+            return OptExpression.create(aggregationOperator, children);
+        }
+
+        public OptExpression visitLogicalUnion(OptExpression optExpression, Void context) {
+            for (int childIdx = 0; childIdx < optExpression.arity(); ++childIdx) {
+                requiredOutputColumns.union(optExpression.getChildOutputColumns(childIdx));
+            }
+            List<OptExpression> children = visitChildren(optExpression);
+            return OptExpression.create(optExpression.getOp(), children);
+        }
+
+        // now filter and join operator will not be kept in plan after mv rewrite
+        // keep these two functions for extendibility
+        public OptExpression visitLogicalFilter(OptExpression optExpression, Void context) {
+            LogicalFilterOperator filterOperator = (LogicalFilterOperator) optExpression.getOp();
+            ColumnRefSet requiredInputColumns = filterOperator.getRequiredChildInputColumns();
+            requiredOutputColumns.union(requiredInputColumns);
+            List<OptExpression> children = visitChildren(optExpression);
+            return OptExpression.create(filterOperator, children);
+        }
+
+        public OptExpression visitLogicalJoin(OptExpression optExpression, Void context) {
+            LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();
+            requiredOutputColumns.union(joinOperator.getRequiredChildInputColumns());
+            List<OptExpression> children = visitChildren(optExpression);
+            return OptExpression.create(joinOperator, children);
+        }
+
+        public OptExpression visit(OptExpression optExpression, Void context) {
+            throw UnsupportedException.unsupportedException(String.format("ColumnPrunner does not support:%s", optExpression));
+        }
+
+        private List<OptExpression> visitChildren(OptExpression optExpression) {
+            List<OptExpression> children = Lists.newArrayList();
+            for (OptExpression child : optExpression.getInputs()) {
+                children.add(child.getOp().accept(this, child, null));
+            }
+            return children;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ColumnPruner {
+public class MVColumnPruner {
     private ColumnRefSet requiredOutputColumns;
 
     public OptExpression pruneColumns(OptExpression queryExpression) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -319,7 +319,7 @@ public class MaterializedViewRewriter {
         // the predicate empid:1 < 10 can not be rewritten
         mvRefSets.except(scanOutputColumns);
         if (!ConstantOperator.TRUE.equals(equalPredicates)) {
-            equalPredicates = rewriteScalarOperatorToTarget(otherPredicates, queryExprMap, rewriteContext, mvRefSets, true);
+            equalPredicates = rewriteScalarOperatorToTarget(equalPredicates, queryExprMap, rewriteContext, mvRefSets, true);
         }
         if (!ConstantOperator.TRUE.equals(otherPredicates)) {
             otherPredicates = rewriteScalarOperatorToTarget(otherPredicates, queryExprMap, rewriteContext, mvRefSets, false);
@@ -439,7 +439,9 @@ public class MaterializedViewRewriter {
                 .setProjection(projection)
                 .isUnionAll(true)
                 .build();
-        return OptExpression.create(unionOperator, newQueryInput, viewInput);
+        OptExpression result = OptExpression.create(unionOperator, newQueryInput, viewInput);
+        deriveLogicalProperty(result);
+        return result;
     }
 
     protected Multimap<ScalarOperator, ColumnRefOperator> normalizeAndReverseProjection(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -22,7 +22,7 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.ColumnPruner;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVColumnPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 
 import java.util.List;
@@ -48,7 +48,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             List<OptExpression> rewrittens = rewriter.rewrite();
             if (rewrittens != null && !rewrittens.isEmpty()) {
                 for (OptExpression rewritten : rewrittens) {
-                    ColumnPruner columnPruner = new ColumnPruner();
+                    MVColumnPruner columnPruner = new MVColumnPruner();
                     OptExpression exprAfterPrune = columnPruner.pruneColumns(rewritten);
                     if (exprAfterPrune != null) {
                         results.add(exprAfterPrune);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17051

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
add column pruner to prune columns of plan after mv rewrite. pruner collect used columns by top-down and prune the mv scan operator.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
