### PR TITLE
[BugFix] fix pk lake table partial update multi segment

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -124,6 +124,9 @@ public:
 
     Status build_schema_and_writer();
 
+    void TEST_set_partial_update(std::shared_ptr<const TabletSchema> tschema,
+                                 const std::vector<int32_t>& referenced_column_ids);
+
 private:
     Status reset_memtable();
 
@@ -151,6 +154,15 @@ private:
     std::shared_ptr<const TabletSchema> _partial_update_tablet_schema;
     std::vector<int32_t> _referenced_column_ids;
 };
+
+void DeltaWriterImpl::TEST_set_partial_update(std::shared_ptr<const TabletSchema> tschema,
+                                              const std::vector<int32_t>& referenced_column_ids) {
+    _partial_update_tablet_schema = tschema;
+    _referenced_column_ids = referenced_column_ids;
+    build_schema_and_writer();
+    // recover _tablet_schema with partial update schema
+    _tablet_schema = _partial_update_tablet_schema;
+}
 
 Status DeltaWriterImpl::build_schema_and_writer() {
     if (_mem_table_sink == nullptr) {
@@ -400,6 +412,11 @@ int64_t DeltaWriter::data_size() const {
 
 int64_t DeltaWriter::num_rows() const {
     return _impl->num_rows();
+}
+
+void DeltaWriter::TEST_set_partial_update(std::shared_ptr<const TabletSchema> tschema,
+                                          const std::vector<int32_t>& referenced_column_ids) {
+    _impl->TEST_set_partial_update(tschema, referenced_column_ids);
 }
 
 std::unique_ptr<DeltaWriter> DeltaWriter::create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id,

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -24,6 +24,7 @@ namespace starrocks {
 class MemTracker;
 class SlotDescriptor;
 class Chunk;
+class TabletSchema;
 } // namespace starrocks
 
 namespace starrocks::lake {
@@ -93,6 +94,9 @@ public:
     // The total number of rows have been written.
     // NOTE: Do NOT invoke this function after `close()`, otherwise may get unexpected result.
     int64_t num_rows() const;
+
+    void TEST_set_partial_update(std::shared_ptr<const TabletSchema> tschema,
+                                 const std::vector<int32_t>& referenced_column_ids);
 
 private:
     DeltaWriterImpl* _impl;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -183,6 +183,7 @@ set(EXEC_FILES
         ./storage/lake/horizontal_compaction_task_test.cpp
         ./storage/lake/schema_change_test.cpp
         ./storage/lake/tablet_manager_test.cpp
+        ./storage/lake/partial_update_test.cpp
         ./storage/lake/tablet_reader_test.cpp
         ./storage/lake/tablet_writer_test.cpp
         ./storage/lake/primary_key_compaction_task_test.cpp

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -1,0 +1,372 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/meta_file.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/rowset/segment.h"
+#include "storage/rowset/segment_iterator.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+using VSchema = starrocks::Schema;
+using VChunk = starrocks::Chunk;
+
+class TestLocationProvider : public LocationProvider {
+public:
+    explicit TestLocationProvider(std::string dir) : _dir(dir) {}
+
+    std::set<int64_t> owned_tablets() const override { return _owned_shards; }
+
+    std::string root_location(int64_t tablet_id) const override { return _dir; }
+
+    Status list_root_locations(std::set<std::string>* roots) const override {
+        roots->insert(_dir);
+        return Status::OK();
+    }
+
+    void set_failed(bool f) { _set_failed = f; }
+
+    std::set<int64_t> _owned_shards;
+    std::string _dir;
+    bool _set_failed = false;
+};
+
+class PartialUpdateTest : public testing::Test {
+public:
+    PartialUpdateTest() {
+        _location_provider = std::make_unique<TestLocationProvider>(kTestGroupPath);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
+
+        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_next_rowset_id(1);
+        _location_provider->_owned_shards.insert(_tablet_metadata->id());
+
+        _backup_location_provider = _tablet_manager->TEST_set_location_provider(_location_provider.get());
+
+        _parent_mem_tracker = std::make_unique<MemTracker>(-1);
+        _mem_tracker = std::make_unique<MemTracker>(-1, "", _parent_mem_tracker.get());
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+            c1->set_aggregation("REPLACE");
+        }
+        _referenced_column_ids.push_back(0);
+        _referenced_column_ids.push_back(1);
+        _partial_tablet_schema = TabletSchema::create(*schema);
+        _partial_schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(*_partial_tablet_schema));
+
+        auto c2 = schema->add_column();
+        {
+            c2->set_unique_id(next_id());
+            c2->set_name("c2");
+            c2->set_type("INT");
+            c2->set_is_key(false);
+            c2->set_is_nullable(false);
+            c2->set_aggregation("REPLACE");
+        }
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(*_tablet_schema));
+    }
+
+    void SetUp() override {
+        (void)fs::remove_all(kTestGroupPath);
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kTxnLogDirectoryName)));
+        CHECK_OK(_tablet_manager->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+        tablet.delete_txn_log(_txn_id);
+        _txn_id++;
+        (void)ExecEnv::GetInstance()->lake_tablet_manager()->TEST_set_location_provider(_backup_location_provider);
+        (void)fs::remove_all(kTestGroupPath);
+    }
+
+    VChunk generate_data(int64_t chunk_size, int shift, bool partial, int update_ratio) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        std::vector<int> v2(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i + shift * chunk_size;
+        }
+        auto rng = std::default_random_engine{};
+        std::shuffle(v0.begin(), v0.end(), rng);
+        for (int i = 0; i < chunk_size; i++) {
+            v1[i] = v0[i] * update_ratio;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+        if (!partial) {
+            for (int i = 0; i < chunk_size; i++) {
+                v2[i] = v0[i] * 4;
+            }
+            auto c2 = Int32Column::create();
+            c2->append_numbers(v2.data(), v2.size() * sizeof(int));
+            return VChunk({c0, c1, c2}, _schema);
+        } else {
+            return VChunk({c0, c1}, _partial_schema);
+        }
+    }
+
+    int64_t check(int64_t version, std::function<bool(int c0, int c1, int c2)> check_fn) {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        auto chunk = ChunkHelper::new_chunk(*_schema, 128);
+        int64_t ret = 0;
+        while (true) {
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            ret += chunk->num_rows();
+            auto cols = chunk->columns();
+            for (int i = 0; i < chunk->num_rows(); i++) {
+                EXPECT_TRUE(check_fn(cols[0]->get(i).get_int32(), cols[1]->get(i).get_int32(),
+                                     cols[2]->get(i).get_int32()));
+            }
+            chunk->reset();
+        }
+        return ret;
+    }
+
+protected:
+    constexpr static const char* const kTestGroupPath = "test_lake_partial_update";
+    constexpr static const int kChunkSize = 12;
+
+    std::unique_ptr<TestLocationProvider> _location_provider;
+    LocationProvider* _backup_location_provider;
+    std::unique_ptr<UpdateManager> _update_manager;
+    std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<TabletSchema> _partial_tablet_schema;
+    std::unique_ptr<MemTracker> _parent_mem_tracker;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<VSchema> _schema;
+    std::shared_ptr<VSchema> _partial_schema;
+    std::vector<int32_t> _referenced_column_ids;
+    int64_t _txn_id = 1231;
+    int64_t _partition_id = 4561;
+};
+
+TEST_F(PartialUpdateTest, test_write) {
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 3);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+
+    // partial update
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+}
+
+TEST_F(PartialUpdateTest, test_write_multi_segment) {
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 3);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+
+    // partial update, and make it generate two segment files in one rowset
+    const int64_t old_size = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    config::write_buffer_size = old_size;
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    // check segment size in last metadata
+    EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+}
+
+TEST_F(PartialUpdateTest, test_write_multi_segment_by_diff_val) {
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 5);
+    auto chunk2 = generate_data(kChunkSize, 0, true, 6);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+
+    // partial update, and make it generate two segment files in one rowset
+    const int64_t old_size = config::write_buffer_size;
+    config::write_buffer_size = 1;
+    for (int i = 0; i < 3; i++) {
+        _txn_id++;
+        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                _mem_tracker.get());
+        delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->write(chunk2, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+        version++;
+    }
+    config::write_buffer_size = old_size;
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 6 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    // check segment size in last metadata
+    EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17075

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In lake primary table (ENGINE=STARROCKS)，primary key table partial update multi segment in one rowset, will rewrite segment using wrong data.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
