### PR TITLE
[BugFix] cannot reorder when bottom join is full outer join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderProperty.java
@@ -75,13 +75,13 @@ public class JoinReorderProperty {
          *  ----- ---- ---- ---- ---- ---- ---- ---- ---- ---- -----
          *   ⟕     1    1    1    1    0    0    0    2    0    0
          *   ⋉     0    1    1    1    0    0    0    0    0    0
-         *   ▷     0    1    1    1    0    0    0    2    0    0
-         *   ⟗    1    2    0    0    0    0    0    2    0    0
+         *   ▷     0    1    1    1    0    0    0    0   0    0
+         *   ⟗    0    2    0    0    0    0    0    2    0    0
          */
         LEFT_ASSCOM_PROPERTY[JoinOperator.LEFT_OUTER_JOIN.ordinal()] = new int[] {1, 1, 1, 1, 0, 0, 0, 2, 0, 0};
         LEFT_ASSCOM_PROPERTY[JoinOperator.LEFT_SEMI_JOIN.ordinal()] = new int[] {0, 1, 1, 1, 0, 0, 0, 0, 0, 0};
         LEFT_ASSCOM_PROPERTY[JoinOperator.LEFT_ANTI_JOIN.ordinal()] = new int[] {0, 1, 1, 1, 0, 0, 0, 0, 0, 0};
-        LEFT_ASSCOM_PROPERTY[JoinOperator.FULL_OUTER_JOIN.ordinal()] = new int[] {1, 2, 0, 0, 0, 0, 0, 2, 0, 0};
+        LEFT_ASSCOM_PROPERTY[JoinOperator.FULL_OUTER_JOIN.ordinal()] = new int[] {0, 2, 0, 0, 0, 0, 0, 2, 0, 0};
     }
 
     public static int getAssociativityProperty(JoinOperator bottomJoinType, JoinOperator topJoinType, boolean isInnerMode) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EnumeratePlanTest.java
@@ -148,4 +148,14 @@ public class EnumeratePlanTest extends DistributedEnvPlanTestBase {
     public void testTPCHQ22EnumPlan() {
         runFileUnitTest("enumerate-plan/tpch-q22");
     }
+
+    @Test
+    public void testFullOuterJoinPlan_1() {
+        runFileUnitTest("enumerate-plan/full-outer-join-1");
+    }
+
+    @Test
+    public void testFullOuterJoinPlan_2() {
+        runFileUnitTest("enumerate-plan/full-outer-join-2");
+    }
 }

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/full-outer-join-1.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/full-outer-join-1.sql
@@ -2,28 +2,8 @@
 select * from (select * from region) t0 full join (select * from nation) t1 on t0.r_name = t1.n_name
 join (select * from supplier limit 10) t2 on 1 = 1;
 [planCount]
-4
+1
 [plan-1]
-CROSS JOIN (join-predicate [null] post-join-predicate [null])
-    SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null])
-    EXCHANGE BROADCAST
-        FULL OUTER JOIN (join-predicate [2: R_NAME = 6: N_NAME] post-join-predicate [null])
-            EXCHANGE SHUFFLE[2]
-                SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
-            EXCHANGE SHUFFLE[6]
-                SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
-[end]
-[plan-2]
-CROSS JOIN (join-predicate [null] post-join-predicate [null])
-    SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null])
-    EXCHANGE BROADCAST
-        FULL OUTER JOIN (join-predicate [6: N_NAME = 2: R_NAME] post-join-predicate [null])
-            EXCHANGE SHUFFLE[6]
-                SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
-            EXCHANGE SHUFFLE[2]
-                SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
-[end]
-[plan-3]
 CROSS JOIN (join-predicate [null] post-join-predicate [null])
     FULL OUTER JOIN (join-predicate [2: R_NAME = 6: N_NAME] post-join-predicate [null])
         EXCHANGE SHUFFLE[2]
@@ -31,15 +11,6 @@ CROSS JOIN (join-predicate [null] post-join-predicate [null])
         EXCHANGE SHUFFLE[6]
             SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
     EXCHANGE BROADCAST
-        SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null])
-[end]
-[plan-4]
-CROSS JOIN (join-predicate [null] post-join-predicate [null])
-    FULL OUTER JOIN (join-predicate [6: N_NAME = 2: R_NAME] post-join-predicate [null])
-        EXCHANGE SHUFFLE[6]
-            SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
-        EXCHANGE SHUFFLE[2]
-            SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
-    EXCHANGE BROADCAST
-        SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null])
-[end]
+        PREDICATE true
+            EXCHANGE GATHER
+                SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null]) Limit 10

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/full-outer-join-1.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/full-outer-join-1.sql
@@ -1,0 +1,45 @@
+[sql]
+select * from (select * from region) t0 full join (select * from nation) t1 on t0.r_name = t1.n_name
+join (select * from supplier limit 10) t2 on 1 = 1;
+[planCount]
+4
+[plan-1]
+CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null])
+    EXCHANGE BROADCAST
+        FULL OUTER JOIN (join-predicate [2: R_NAME = 6: N_NAME] post-join-predicate [null])
+            EXCHANGE SHUFFLE[2]
+                SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
+            EXCHANGE SHUFFLE[6]
+                SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
+[end]
+[plan-2]
+CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null])
+    EXCHANGE BROADCAST
+        FULL OUTER JOIN (join-predicate [6: N_NAME = 2: R_NAME] post-join-predicate [null])
+            EXCHANGE SHUFFLE[6]
+                SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
+            EXCHANGE SHUFFLE[2]
+                SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
+[end]
+[plan-3]
+CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    FULL OUTER JOIN (join-predicate [2: R_NAME = 6: N_NAME] post-join-predicate [null])
+        EXCHANGE SHUFFLE[2]
+            SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
+        EXCHANGE SHUFFLE[6]
+            SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
+    EXCHANGE BROADCAST
+        SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null])
+[end]
+[plan-4]
+CROSS JOIN (join-predicate [null] post-join-predicate [null])
+    FULL OUTER JOIN (join-predicate [6: N_NAME = 2: R_NAME] post-join-predicate [null])
+        EXCHANGE SHUFFLE[6]
+            SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
+        EXCHANGE SHUFFLE[2]
+            SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
+    EXCHANGE BROADCAST
+        SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null])
+[end]

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/full-outer-join-2.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/full-outer-join-2.sql
@@ -1,0 +1,42 @@
+[sql]
+select * from (select * from region) t0 full join (select * from nation) t1 on t0.r_name = t1.n_name
+join (select * from supplier limit 10) t2 on if(r_name is null, 1, r_name) = t2.S_ADDRESS;
+[planCount]
+3
+[plan-1]
+INNER JOIN (join-predicate [18: if = 12: S_ADDRESS] post-join-predicate [null])
+    FULL OUTER JOIN (join-predicate [2: R_NAME = 6: N_NAME] post-join-predicate [if(2: R_NAME IS NULL, 1, 2: R_NAME) IS NOT NULL])
+        EXCHANGE SHUFFLE[2]
+            SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
+        EXCHANGE SHUFFLE[6]
+            SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
+    EXCHANGE BROADCAST
+        PREDICATE 12: S_ADDRESS IS NOT NULL
+            EXCHANGE GATHER
+                SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null]) Limit 10
+[end]
+[plan-2]
+INNER JOIN (join-predicate [18: if = 12: S_ADDRESS] post-join-predicate [null])
+    FULL OUTER JOIN (join-predicate [6: N_NAME = 2: R_NAME] post-join-predicate [if(2: R_NAME IS NULL, 1, 2: R_NAME) IS NOT NULL])
+        EXCHANGE SHUFFLE[6]
+            SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
+        EXCHANGE SHUFFLE[2]
+            SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
+    EXCHANGE BROADCAST
+        PREDICATE 12: S_ADDRESS IS NOT NULL
+            EXCHANGE GATHER
+                SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null]) Limit 10
+[end]
+[plan-3]
+INNER JOIN (join-predicate [18: if = 12: S_ADDRESS] post-join-predicate [null])
+    EXCHANGE SHUFFLE[18]
+        FULL OUTER JOIN (join-predicate [2: R_NAME = 6: N_NAME] post-join-predicate [if(2: R_NAME IS NULL, 1, 2: R_NAME) IS NOT NULL])
+            EXCHANGE SHUFFLE[2]
+                SCAN (columns[1: R_REGIONKEY, 2: R_NAME, 3: R_COMMENT, 4: PAD] predicate[null])
+            EXCHANGE SHUFFLE[6]
+                SCAN (columns[5: N_NATIONKEY, 6: N_NAME, 7: N_REGIONKEY, 8: N_COMMENT, 9: PAD] predicate[null])
+    EXCHANGE SHUFFLE[12]
+        PREDICATE 12: S_ADDRESS IS NOT NULL
+            EXCHANGE GATHER
+                SCAN (columns[10: S_SUPPKEY, 11: S_NAME, 12: S_ADDRESS, 13: S_NATIONKEY, 14: S_PHONE, 15: S_ACCTBAL, 16: S_COMMENT, 17: PAD] predicate[null]) Limit 10
+[end]


### PR DESCRIPTION
Signed-off-by: packy <wangchao@starrocks.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
cannot reorder when bottom join is full outer join.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
