### PR TITLE
[Refactor] Wait for apply finish when exec primary key publish version

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -48,6 +48,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "gutil/strings/substitute.h"
+#include "gutil/sysinfo.h"
 #include "runtime/exec_env.h"
 #include "storage/snapshot_manager.h"
 #include "util/phmap/phmap.h"
@@ -216,7 +217,7 @@ void AgentServer::Impl::init_or_die() {
 #define CREATE_AND_START_POOL(pool_name, CLASS_NAME, worker_num)
 #endif // BE_TEST
 
-    CREATE_AND_START_POOL(_publish_version_workers, PublishVersionTaskWorkerPool, 1)
+    CREATE_AND_START_POOL(_publish_version_workers, PublishVersionTaskWorkerPool, base::NumCPUs())
     // Both PUSH and REALTIME_PUSH type use _push_workers
     CREATE_AND_START_POOL(_push_workers, PushTaskWorkerPool,
                           config::push_worker_count_high_priority + config::push_worker_count_normal_priority)

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -50,7 +50,8 @@ struct TabletPublishVersionTask {
 };
 
 void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionRequest& publish_version_req,
-                              TFinishTaskRequest& finish_task, std::unordered_set<DataDir*>& affected_dirs) {
+                              TFinishTaskRequest& finish_task, std::unordered_set<DataDir*>& affected_dirs,
+                              uint32_t wait_time) {
     int64_t start_ts = MonotonicMillis();
     int64_t transaction_id = publish_version_req.transaction_id;
 
@@ -112,7 +113,7 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                     affected_dirs.insert(tablet->data_dir());
                 }
                 task.st = StorageEngine::instance()->txn_manager()->publish_txn(task.partition_id, tablet, task.txn_id,
-                                                                                task.version, task.rowset);
+                                                                                task.version, task.rowset, wait_time);
                 if (!task.st.ok()) {
                     LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id() << " version:" << task.version
                                  << " partition:" << task.partition_id << " txn_id: " << task.txn_id

--- a/be/src/agent/publish_version.h
+++ b/be/src/agent/publish_version.h
@@ -27,6 +27,7 @@ class ThreadPoolToken;
 class DataDir;
 
 void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionRequest& publish_version_task,
-                              TFinishTaskRequest& finish_task, std::unordered_set<DataDir*>& affected_dirs);
+                              TFinishTaskRequest& finish_task, std::unordered_set<DataDir*>& affected_dirs,
+                              uint32_t wait_time);
 
 } // namespace starrocks

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -114,6 +114,7 @@ protected:
     std::deque<AgentTaskRequestPtr> _tasks;
 
     uint32_t _worker_count = 0;
+    uint32_t _sleeping_count = 0;
     CALLBACK_FUNCTION _callback_function = nullptr;
 
     std::atomic<bool> _stopped{false};

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -915,5 +915,6 @@ CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache=1
 
 // limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
+CONF_mInt64(wait_apply_time, "6000")                                 // 6s
 
 } // namespace starrocks::config

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -843,7 +843,7 @@ Status PInternalServiceImplBase<T>::_mv_commit_epoch(const pipeline::QueryContex
     publish_version_req.partition_version_infos = commit_epoch_task.partition_version_infos;
     publish_version_req.transaction_id = commit_epoch_task.transaction_id;
 
-    run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs);
+    run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs, 0);
     StorageEngine::instance()->txn_manager()->flush_dirs(affected_dirs);
     return Status::OK();
 }

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1125,9 +1125,9 @@ void Tablet::generate_tablet_meta_copy_unlocked(const TabletMetaSharedPtr& new_t
     new_tablet_meta->init_from_pb(&tablet_meta_pb);
 }
 
-Status Tablet::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
+Status Tablet::rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time) {
     CHECK(_updates) << "updates should exists";
-    return _updates->rowset_commit(version, rowset);
+    return _updates->rowset_commit(version, rowset, wait_time);
 }
 
 void Tablet::on_shutdown() {

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -235,7 +235,7 @@ public:
 
     // updatable tablet specific operations
     TabletUpdates* updates() { return _updates.get(); }
-    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset);
+    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time = 0);
 
     // if there is _compaction_task running
     // do not do compaction

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -533,7 +533,9 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
                       << " #pending:" << _pending_commits.size();
             _try_commit_pendings_unlocked();
             _check_for_apply();
-            st = _wait_for_version(EditVersion(version, 0), wait_time, ul);
+            if (wait_time > 0) {
+                st = _wait_for_version(EditVersion(version, 0), wait_time, ul);
+            }
         }
     }
     if (!st.ok() && !st.is_time_out()) {
@@ -1098,9 +1100,6 @@ Status TabletUpdates::_wait_for_version(const EditVersion& version, int64_t time
         return Status::InternalError(msg);
     }
     if (!(_edit_version_infos[_apply_version_idx]->version < version)) {
-        return Status::OK();
-    }
-    if (timeout_ms == 0) {
         return Status::OK();
     }
     int64_t wait_start = MonotonicMillis();

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -96,7 +96,7 @@ public:
 
     Status get_rowsets_total_stats(const std::vector<uint32_t>& rowsets, size_t* total_rows, size_t* total_dels);
 
-    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset);
+    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time);
 
     Status save_meta();
 

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -231,10 +231,10 @@ Status TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTransac
 }
 
 Status TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                               int64_t version, const RowsetSharedPtr& rowset) {
+                               int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time) {
     if (tablet->updates() != nullptr) {
         StarRocksMetrics::instance()->update_rowset_commit_request_total.increment(1);
-        auto st = tablet->rowset_commit(version, rowset);
+        auto st = tablet->rowset_commit(version, rowset, wait_time);
         if (!st.ok()) {
             StarRocksMetrics::instance()->update_rowset_commit_request_failed.increment(1);
             return st;

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -91,7 +91,7 @@ public:
                       const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery);
 
     Status publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                       int64_t version, const RowsetSharedPtr& rowset);
+                       int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time = 0);
 
     // persist_tablet_related_txns persists the tablets' meta and make it crash-safe.
     Status persist_tablet_related_txns(const std::vector<TabletSharedPtr>& tablets);

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -402,7 +402,7 @@ PARALLEL_TEST(JsonColumnTest, test_serialize) {
 class JsonConvertTestFixture : public ::testing::TestWithParam<std::tuple<std::string>> {
 public:
 };
-/*
+
 TEST_P(JsonConvertTestFixture, convert_from_simdjson) {
     using namespace simdjson;
     std::string param_0 = std::get<0>(GetParam());
@@ -414,7 +414,6 @@ TEST_P(JsonConvertTestFixture, convert_from_simdjson) {
     ASSERT_TRUE(maybe_json.ok());
     ASSERT_EQ(json_str.data(), maybe_json.value().to_string_uncheck());
 }
-*/
 
 INSTANTIATE_TEST_SUITE_P(JsonConvertTest, JsonConvertTestFixture,
                          ::testing::Values(

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -402,7 +402,7 @@ PARALLEL_TEST(JsonColumnTest, test_serialize) {
 class JsonConvertTestFixture : public ::testing::TestWithParam<std::tuple<std::string>> {
 public:
 };
-
+/*
 TEST_P(JsonConvertTestFixture, convert_from_simdjson) {
     using namespace simdjson;
     std::string param_0 = std::get<0>(GetParam());
@@ -414,6 +414,7 @@ TEST_P(JsonConvertTestFixture, convert_from_simdjson) {
     ASSERT_TRUE(maybe_json.ok());
     ASSERT_EQ(json_str.data(), maybe_json.value().to_string_uncheck());
 }
+*/
 
 INSTANTIATE_TEST_SUITE_P(JsonConvertTest, JsonConvertTestFixture,
                          ::testing::Values(

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1209,7 +1209,7 @@ void build_persistent_index_from_tablet(size_t N) {
     RowsetSharedPtr rowset = create_rowset(tablet, keys);
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
     auto version = 2;
-    auto st = tablet->rowset_commit(version, rowset);
+    auto st = tablet->rowset_commit(version, rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     // Ensure that there is at most one thread doing the version apply job.
     ASSERT_LE(pool->num_threads(), 1);

--- a/be/test/storage/publish_version_task_test.cpp
+++ b/be/test/storage/publish_version_task_test.cpp
@@ -272,7 +272,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version) {
     pvinfo.version = 3;
     publish_version_req.partition_version_infos.push_back(pvinfo);
     // run publish version
-    run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs);
+    run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs, 0);
     // check finish_task_request
     ASSERT_EQ(1, finish_task_request.tablet_versions.size());
     ASSERT_EQ(3, finish_task_request.tablet_versions[0].version);
@@ -338,7 +338,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version2) {
         pvinfo.version = 3;
         publish_version_req.partition_version_infos.push_back(pvinfo);
         // run publish version
-        run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs);
+        run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs, 0);
         // check finish_task_request
         ASSERT_EQ(1, finish_task_request.tablet_versions.size());
         ASSERT_EQ(3, finish_task_request.tablet_versions[0].version);
@@ -360,7 +360,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version2) {
         pvinfo.version = 3;
         publish_version_req.partition_version_infos.push_back(pvinfo);
         // run publish version
-        run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs);
+        run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs, 0);
         // check finish_task_request
         ASSERT_EQ(1, finish_task_request.tablet_versions.size());
         ASSERT_EQ(3, finish_task_request.tablet_versions[0].version);

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -372,7 +372,7 @@ void RowsetTest::test_final_merge(bool has_merge_condition = false) {
 
     ASSERT_EQ(1, tablet->updates()->version_history_count());
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
-    auto st = tablet->rowset_commit(2, rowset);
+    auto st = tablet->rowset_commit(2, rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_LE(pool->num_threads(), 1);
     ASSERT_EQ(2, tablet->updates()->max_version());
@@ -532,7 +532,7 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
 
     ASSERT_EQ(1, tablet->updates()->version_history_count());
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
-    auto st = tablet->rowset_commit(2, rowset);
+    auto st = tablet->rowset_commit(2, rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_LE(pool->num_threads(), 1);
     ASSERT_EQ(2, tablet->updates()->max_version());
@@ -686,7 +686,7 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
     ASSERT_EQ(3, rowset->rowset_meta()->num_segments());
     ASSERT_EQ(rows_per_segment * 3, rowset->rowset_meta()->num_rows());
 
-    ASSERT_TRUE(tablet->rowset_commit(2, rowset).ok());
+    ASSERT_TRUE(tablet->rowset_commit(2, rowset, 0).ok());
     EXPECT_EQ(rows_per_segment * 2, read_tablet_and_compare(tablet, partial_schema, 2, rows_per_segment * 2));
     ASSERT_OK(starrocks::StorageEngine::instance()->update_manager()->on_rowset_finished(tablet.get(), rowset.get()));
 }

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -225,7 +225,7 @@ TEST_F(RowsetUpdateStateTest, prepare_partial_update_states) {
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
     for (int i = 0; i < rowsets.size(); i++) {
         auto version = i + 2;
-        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        auto st = _tablet->rowset_commit(version, rowsets[i], 0);
         ASSERT_TRUE(st.ok()) << st.to_string();
         // Ensure that there is at most one thread doing the version apply job.
         ASSERT_LE(pool->num_threads(), 1);
@@ -261,7 +261,7 @@ TEST_F(RowsetUpdateStateTest, check_conflict) {
     RowsetSharedPtr rowset = create_rowset(_tablet, keys);
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
     auto version = 2;
-    auto st = _tablet->rowset_commit(version, rowset);
+    auto st = _tablet->rowset_commit(version, rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_LE(pool->num_threads(), 1);
     ASSERT_EQ(version, _tablet->updates()->max_version());
@@ -308,7 +308,7 @@ TEST_F(RowsetUpdateStateTest, check_conflict) {
     CHECK_OK(writer->flush_chunk(*chunk));
     RowsetSharedPtr new_rowset = *writer->build();
     version = 3;
-    st = _tablet->rowset_commit(version, new_rowset);
+    st = _tablet->rowset_commit(version, new_rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_LE(pool->num_threads(), 1);
     ASSERT_EQ(version, _tablet->updates()->max_version());

--- a/be/test/storage/table_reader_test.cpp
+++ b/be/test/storage/table_reader_test.cpp
@@ -82,7 +82,7 @@ public:
         }
         CHECK_OK(writer->flush_chunk(*chunk));
         auto row_set = *writer->build();
-        ASSERT_TRUE(tablet->rowset_commit(version, row_set).ok());
+        ASSERT_TRUE(tablet->rowset_commit(version, row_set, 0).ok());
         ASSERT_EQ(version, tablet->updates()->max_version());
     }
 


### PR DESCRIPTION
Signed-off-by: zhangqiang <qiangzh95@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

PrimaryKey table only submit apply task to thread pool and return success directly when we do publish version right now. If we query immediately after publish success, we may need to wait for version apply finish which cause unstable query time.
So we try to wait for apply finished when we exec publish version.

It is important to note that this solution is a temporary one and does not completely solve the problem of unstable query time, i will reconsider the primary key publish version mechanism and solve the problem in the future pr.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
