### PR TITLE
[BugFix] Fix rollback to 2.5 failure because of newer log type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -869,49 +869,70 @@ public class EditLog {
                     break;
                 }
                 case OperationType.OP_CREATE_USER_V2: {
-                    CreateUserInfo info = (CreateUserInfo) journal.getData();
-                    globalStateMgr.getAuthenticationManager().replayCreateUser(
-                            info.getUserIdentity(),
-                            info.getAuthenticationInfo(),
-                            info.getUserProperty(),
-                            info.getUserPrivilegeCollection(),
-                            info.getPluginId(),
-                            info.getPluginVersion());
+                    // For backward compatibility, we shouldn't replay log type from newer version
+                    if (GlobalStateMgr.USING_NEW_PRIVILEGE) {
+                        CreateUserInfo info = (CreateUserInfo) journal.getData();
+                        globalStateMgr.getAuthenticationManager().replayCreateUser(
+                                info.getUserIdentity(),
+                                info.getAuthenticationInfo(),
+                                info.getUserProperty(),
+                                info.getUserPrivilegeCollection(),
+                                info.getPluginId(),
+                                info.getPluginVersion());
+                    }
                     break;
                 }
                 case OperationType.OP_UPDATE_USER_PRIVILEGE_V2: {
-                    UserPrivilegeCollectionInfo info = (UserPrivilegeCollectionInfo) journal.getData();
-                    globalStateMgr.getPrivilegeManager().replayUpdateUserPrivilegeCollection(
-                            info.getUserIdentity(),
-                            info.getPrivilegeCollection(),
-                            info.getPluginId(),
-                            info.getPluginVersion());
+                    // For backward compatibility, we shouldn't replay log type from newer version
+                    if (GlobalStateMgr.USING_NEW_PRIVILEGE) {
+                        UserPrivilegeCollectionInfo info = (UserPrivilegeCollectionInfo) journal.getData();
+                        globalStateMgr.getPrivilegeManager().replayUpdateUserPrivilegeCollection(
+                                info.getUserIdentity(),
+                                info.getPrivilegeCollection(),
+                                info.getPluginId(),
+                                info.getPluginVersion());
+                    }
                     break;
                 }
                 case OperationType.OP_ALTER_USER_V2: {
-                    AlterUserInfo info = (AlterUserInfo) journal.getData();
-                    globalStateMgr.getAuthenticationManager().replayAlterUser(
-                            info.getUserIdentity(), info.getAuthenticationInfo());
+                    // For backward compatibility, we shouldn't replay log type from newer version
+                    if (GlobalStateMgr.USING_NEW_PRIVILEGE) {
+                        AlterUserInfo info = (AlterUserInfo) journal.getData();
+                        globalStateMgr.getAuthenticationManager().replayAlterUser(
+                                info.getUserIdentity(), info.getAuthenticationInfo());
+                    }
                     break;
                 }
                 case OperationType.OP_DROP_USER_V2: {
-                    UserIdentity userIdentity = (UserIdentity) journal.getData();
-                    globalStateMgr.getAuthenticationManager().replayDropUser(userIdentity);
+                    // For backward compatibility, we shouldn't replay log type from newer version
+                    if (GlobalStateMgr.USING_NEW_PRIVILEGE) {
+                        UserIdentity userIdentity = (UserIdentity) journal.getData();
+                        globalStateMgr.getAuthenticationManager().replayDropUser(userIdentity);
+                    }
                     break;
                 }
                 case OperationType.OP_UPDATE_ROLE_PRIVILEGE_V2: {
-                    RolePrivilegeCollectionInfo info = (RolePrivilegeCollectionInfo) journal.getData();
-                    globalStateMgr.getPrivilegeManager().replayUpdateRolePrivilegeCollection(info);
+                    // For backward compatibility, we shouldn't replay log type from newer version
+                    if (GlobalStateMgr.USING_NEW_PRIVILEGE) {
+                        RolePrivilegeCollectionInfo info = (RolePrivilegeCollectionInfo) journal.getData();
+                        globalStateMgr.getPrivilegeManager().replayUpdateRolePrivilegeCollection(info);
+                    }
                     break;
                 }
                 case OperationType.OP_DROP_ROLE_V2: {
-                    RolePrivilegeCollectionInfo info = (RolePrivilegeCollectionInfo) journal.getData();
-                    globalStateMgr.getPrivilegeManager().replayDropRole(info);
+                    // For backward compatibility, we shouldn't replay log type from newer version
+                    if (GlobalStateMgr.USING_NEW_PRIVILEGE) {
+                        RolePrivilegeCollectionInfo info = (RolePrivilegeCollectionInfo) journal.getData();
+                        globalStateMgr.getPrivilegeManager().replayDropRole(info);
+                    }
                     break;
                 }
                 case OperationType.OP_AUTH_UPGRDE_V2: {
-                    AuthUpgradeInfo info = (AuthUpgradeInfo) journal.getData();
-                    globalStateMgr.replayAuthUpgrade(info);
+                    // For backward compatibility, we shouldn't replay log type from newer version
+                    if (GlobalStateMgr.USING_NEW_PRIVILEGE) {
+                        AuthUpgradeInfo info = (AuthUpgradeInfo) journal.getData();
+                        globalStateMgr.replayAuthUpgrade(info);
+                    }
                     break;
                 }
                 default: {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17114 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For backward compatibility, we shouldn't replay log type from newer version.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
