### PR TITLE
[BugFix] Fix local shuffle

### DIFF
--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -177,9 +177,8 @@ pipeline::OpFactories AggregateBlockingNode::_decompose_to_pipeline(pipeline::Op
     auto aggregator_factory = std::make_shared<AggFactory>(_tnode);
 
     auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
-    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
-    auto partition_type = context->source_operator(ops_with_sink)->partition_type();
-    auto operators_generator = [this, should_cache, could_local_shuffle, partition_type, context](bool post_cache) {
+    auto* upstream_source_op = context->source_operator(ops_with_sink);
+    auto operators_generator = [this, should_cache, upstream_source_op, context](bool post_cache) {
         // shared by sink operator and source operator
         auto aggregator_factory = std::make_shared<AggFactory>(_tnode);
         AggrMode aggr_mode = should_cache ? (post_cache ? AM_BLOCKING_POST_CACHE : AM_BLOCKING_PRE_CACHE) : AM_DEFAULT;
@@ -187,8 +186,7 @@ pipeline::OpFactories AggregateBlockingNode::_decompose_to_pipeline(pipeline::Op
         auto sink_operator = std::make_shared<SinkFactory>(context->next_operator_id(), id(), aggregator_factory);
         auto source_operator = std::make_shared<SourceFactory>(context->next_operator_id(), id(), aggregator_factory);
 
-        source_operator->set_could_local_shuffle(could_local_shuffle);
-        source_operator->set_partition_type(partition_type);
+        context->inherit_upstream_source_properties(source_operator.get(), upstream_source_op);
         return std::tuple<OpFactoryPtr, SourceOperatorFactoryPtr>(sink_operator, source_operator);
     };
 
@@ -202,10 +200,6 @@ pipeline::OpFactories AggregateBlockingNode::_decompose_to_pipeline(pipeline::Op
     OpFactories ops_with_source;
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(agg_source_op.get(), context, rc_rf_probe_collector);
-    // Aggregator must be used by a pair of sink and source operators,
-    // so ops_with_source's degree of parallelism must be equal with operators_with_sink's
-    auto* upstream_source_op = context->source_operator(ops_with_sink);
-    agg_source_op->set_degree_of_parallelism(upstream_source_op->degree_of_parallelism());
     ops_with_source.push_back(std::move(agg_source_op));
 
     if (should_cache) {

--- a/be/src/exec/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/aggregate/aggregate_streaming_node.cpp
@@ -215,15 +215,14 @@ pipeline::OpFactories AggregateStreamingNode::decompose_to_pipeline(pipeline::Pi
     size_t degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
 
     auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
-    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
-    auto partition_type = context->source_operator(ops_with_sink)->partition_type();
     if (!should_cache && _tnode.agg_node.__isset.interpolate_passthrough && _tnode.agg_node.interpolate_passthrough &&
-        could_local_shuffle) {
+        context->could_local_shuffle(ops_with_sink)) {
         ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink,
                                                                               degree_of_parallelism, true);
     }
 
-    auto operators_generator = [this, should_cache, could_local_shuffle, partition_type, context](bool post_cache) {
+    auto* upstream_source_op = context->source_operator(ops_with_sink);
+    auto operators_generator = [this, should_cache, upstream_source_op, context](bool post_cache) {
         // shared by sink operator factory and source operator factory
         AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
         auto aggr_mode = should_cache ? (post_cache ? AM_STREAMING_POST_CACHE : AM_STREAMING_PRE_CACHE) : AM_DEFAULT;
@@ -232,8 +231,7 @@ pipeline::OpFactories AggregateStreamingNode::decompose_to_pipeline(pipeline::Pi
                                                                                      aggregator_factory);
         auto source_operator = std::make_shared<AggregateStreamingSourceOperatorFactory>(context->next_operator_id(),
                                                                                          id(), aggregator_factory);
-        source_operator->set_could_local_shuffle(could_local_shuffle);
-        source_operator->set_partition_type(partition_type);
+        context->inherit_upstream_source_properties(source_operator.get(), upstream_source_op);
         return std::tuple<OpFactoryPtr, SourceOperatorFactoryPtr>{sink_operator, source_operator};
     };
 
@@ -247,10 +245,6 @@ pipeline::OpFactories AggregateStreamingNode::decompose_to_pipeline(pipeline::Pi
     OpFactories ops_with_source;
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(agg_source_op.get(), context, rc_rf_probe_collector);
-
-    // Aggregator must be used by a pair of sink and source operators,
-    // so operators_with_source's degree of parallelism must be equal with operators_with_sink's
-    agg_source_op->set_degree_of_parallelism(degree_of_parallelism);
     ops_with_source.push_back(std::move(agg_source_op));
 
     if (should_cache) {

--- a/be/src/exec/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/aggregate/distinct_streaming_node.cpp
@@ -179,12 +179,9 @@ pipeline::OpFactories DistinctStreamingNode::decompose_to_pipeline(pipeline::Pip
 
     OpFactories ops_with_sink = _children[0]->decompose_to_pipeline(context);
 
-    size_t degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
     auto should_cache = context->should_interpolate_cache_operator(ops_with_sink[0], id());
-    bool could_local_shuffle = context->could_local_shuffle(ops_with_sink);
-    auto partition_type = context->source_operator(ops_with_sink)->partition_type();
-
-    auto operators_generator = [this, should_cache, could_local_shuffle, partition_type, context](bool post_cache) {
+    auto* upstream_source_op = context->source_operator(ops_with_sink);
+    auto operators_generator = [this, should_cache, upstream_source_op, context](bool post_cache) {
         // shared by sink operator factory and source operator factory
         AggregatorFactoryPtr aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
         AggrMode aggr_mode =
@@ -194,8 +191,7 @@ pipeline::OpFactories DistinctStreamingNode::decompose_to_pipeline(pipeline::Pip
                 context->next_operator_id(), id(), aggregator_factory);
         auto source_operator = std::make_shared<AggregateDistinctStreamingSourceOperatorFactory>(
                 context->next_operator_id(), id(), aggregator_factory);
-        source_operator->set_could_local_shuffle(could_local_shuffle);
-        source_operator->set_partition_type(partition_type);
+        context->inherit_upstream_source_properties(source_operator.get(), upstream_source_op);
         return std::tuple<OpFactoryPtr, SourceOperatorFactoryPtr>(sink_operator, source_operator);
     };
     auto [agg_sink_op, agg_source_op] = operators_generator(true);
@@ -209,9 +205,6 @@ pipeline::OpFactories DistinctStreamingNode::decompose_to_pipeline(pipeline::Pip
     OpFactories ops_with_source;
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(agg_source_op.get(), context, rc_rf_probe_collector);
-    // Aggregator must be used by a pair of sink and source operators,
-    // so ops_with_source's degree of parallelism must be equal with ops_with_sink's
-    agg_source_op->set_degree_of_parallelism(degree_of_parallelism);
     ops_with_source.push_back(std::move(agg_source_op));
 
     if (should_cache) {

--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -264,7 +264,8 @@ pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilde
             context->next_operator_id(), id(), except_partition_ctx_factory, _children.size() - 1);
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(except_output_source.get(), context, rc_rf_probe_collector);
-    except_output_source->set_degree_of_parallelism(context->degree_of_parallelism());
+    context->inherit_upstream_source_properties(except_output_source.get(),
+                                                context->source_operator(ops_with_except_build_sink));
     ops_with_except_output_source.emplace_back(std::move(except_output_source));
     if (limit() != -1) {
         ops_with_except_output_source.emplace_back(

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -110,6 +110,8 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
             DCHECK(match_exactly_once);
         }
     } else {
+        // partition_exprs is only avaiable for the bucket shuffle join,
+        // so local shuffle use _probe_expr_ctxs and _build_expr_ctxs for the other joins.
         _probe_equivalence_partition_expr_ctxs = _probe_expr_ctxs;
         _build_equivalence_partition_expr_ctxs = _build_expr_ctxs;
     }

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -109,6 +109,9 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
             }
             DCHECK(match_exactly_once);
         }
+    } else {
+        _probe_equivalence_partition_expr_ctxs = _probe_expr_ctxs;
+        _build_equivalence_partition_expr_ctxs = _build_expr_ctxs;
     }
 
     RETURN_IF_ERROR(Expr::create_expr_trees(_pool, tnode.hash_join_node.other_join_conjuncts,
@@ -447,21 +450,13 @@ pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuil
             // 2. Otherwise, add LocalExchangeOperator
             // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into HashJoin{Build, Probe}Operator.
             auto* rhs_source_op = context->source_operator(rhs_operators);
-            TPartitionType::type part_type = rhs_source_op->partition_type();
-
-            const auto& rhs_partition_exprs = part_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED
-                                                      ? _build_equivalence_partition_expr_ctxs
-                                                      : _build_expr_ctxs;
             rhs_operators = context->maybe_interpolate_local_shuffle_exchange(runtime_state(), rhs_operators,
-                                                                              rhs_partition_exprs);
+                                                                              _build_equivalence_partition_expr_ctxs);
 
             auto* lhs_source_op = context->source_operator(lhs_operators);
-            DCHECK_EQ(part_type, lhs_source_op->partition_type());
-            const auto& lhs_partition_exprs = part_type == TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED
-                                                      ? _probe_equivalence_partition_expr_ctxs
-                                                      : _probe_expr_ctxs;
+            DCHECK_EQ(rhs_source_op->partition_type(), lhs_source_op->partition_type());
             lhs_operators = context->maybe_interpolate_local_shuffle_exchange(runtime_state(), lhs_operators,
-                                                                              lhs_partition_exprs);
+                                                                              _probe_equivalence_partition_expr_ctxs);
         }
     }
 

--- a/be/src/exec/intersect_node.cpp
+++ b/be/src/exec/intersect_node.cpp
@@ -278,7 +278,8 @@ pipeline::OpFactories IntersectNode::decompose_to_pipeline(pipeline::PipelineBui
             context->next_operator_id(), id(), intersect_partition_ctx_factory, _children.size() - 1);
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(intersect_output_source.get(), context, rc_rf_probe_collector);
-    intersect_output_source->set_degree_of_parallelism(context->degree_of_parallelism());
+    context->inherit_upstream_source_properties(intersect_output_source.get(),
+                                                context->source_operator(ops_with_intersect_build_sink));
     operators_with_intersect_output_source.emplace_back(std::move(intersect_output_source));
     if (limit() != -1) {
         operators_with_intersect_output_source.emplace_back(

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -98,6 +98,9 @@ public:
 
     static int localExchangeBufferChunks() { return kLocalExchangeBufferChunks; }
 
+    void inherit_upstream_source_properties(SourceOperatorFactory* downstream_source,
+                                            SourceOperatorFactory* upstream_source);
+
 private:
     OpFactories _do_maybe_interpolate_local_shuffle_exchange(
             RuntimeState* state, OpFactories& pred_operators, const std::vector<ExprContext*>& partition_expr_ctxs,

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -56,16 +56,16 @@ public:
     virtual bool could_local_shuffle() const { return _could_local_shuffle; }
     void set_could_local_shuffle(bool could_local_shuffle) { _could_local_shuffle = could_local_shuffle; }
     virtual TPartitionType::type partition_type() const { return _partition_type; }
-    void set_partition_type(TPartitionType::type partition_type) { _partition_type = partition_type; };
-    virtual const std::vector<ExprContext*>& partition_exprs() const { return _empty_partition_exprs; }
+    void set_partition_type(TPartitionType::type partition_type) { _partition_type = partition_type; }
+    virtual const std::vector<ExprContext*>& partition_exprs() const { return _partition_exprs; }
+    void set_partition_exprs(const std::vector<ExprContext*>& partition_exprs) { _partition_exprs = partition_exprs; }
 
 protected:
     size_t _degree_of_parallelism = 1;
     bool _could_local_shuffle = true;
     TPartitionType::type _partition_type = TPartitionType::type::HASH_PARTITIONED;
     MorselQueueFactory* _morsel_queue_factory = nullptr;
-    // Because partition_exprs() returns const reference, we need a non-temporal empty vector here.
-    const std::vector<ExprContext*> _empty_partition_exprs;
+    std::vector<ExprContext*> _partition_exprs;
 };
 
 class SourceOperator : public Operator {

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -231,9 +231,6 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
     // define a runtime filter holder
     context->fragment_context()->runtime_filter_hub()->add_holder(_id);
 
-    auto degree_of_parallelism = context->source_operator(ops_sink_with_sort)->degree_of_parallelism();
-    auto could_local_shuffle = context->source_operator(ops_sink_with_sort)->could_local_shuffle();
-    auto partition_type = context->source_operator(ops_sink_with_sort)->partition_type();
     std::any context_factory;
     if (is_partition) {
         context_factory = std::make_shared<LocalPartitionTopnContextFactory>(
@@ -282,22 +279,13 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
 
     ops_sink_with_sort.emplace_back(std::move(sink_operator));
     context->add_pipeline(ops_sink_with_sort);
-    if (is_merging) {
-        if (is_partition) {
-            source_operator->set_degree_of_parallelism(degree_of_parallelism);
-            source_operator->set_could_local_shuffle(could_local_shuffle);
-            source_operator->set_partition_type(partition_type);
-        } else {
-            // source_operator's instance count must be 1
-            source_operator->set_degree_of_parallelism(1);
-            source_operator->set_could_local_shuffle(true);
-            source_operator->set_partition_type(partition_type);
-        }
-    } else {
-        // Each PartitionSortSinkOperator has an independent LocalMergeSortSinkOperator respectively
-        source_operator->set_degree_of_parallelism(degree_of_parallelism);
-        source_operator->set_could_local_shuffle(could_local_shuffle);
-        source_operator->set_partition_type(partition_type);
+
+    auto* upstream_source_op = context->source_operator(ops_sink_with_sort);
+    context->inherit_upstream_source_properties(source_operator.get(), upstream_source_op);
+    if (is_merging && !is_partition) {
+        // source_operator's instance count must be 1
+        source_operator->set_degree_of_parallelism(1);
+        source_operator->set_could_local_shuffle(true);
     }
     operators_source_with_sort.emplace_back(std::move(source_operator));
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17137.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
### Problem for The Query 1
- `partition_exprs` are not passed to `upstream_source`, such as ScanNode⇨LocalPassthroughSink, LocalPassthroughSource⇨BroadcastJoinProbe⇨[LocalShuffle]⇨ColocateJoin.
- The `_probe_equivalence_partition_expr_ctxs` used by the `LocalShuffle` of `JoinNode` for is only available for Local Bucket Shuffle, but we always set `part_type` to `BUCKET_SHUFFLE_HASH_PARTITIONED`.


### Problem for The Query 2
- `select distinct(k1) from t0` where `k1` is the bucketing key, and when `agg_stage` is forces to 4, `ColcoateBackendSelector` is not used (because `ColcoateBackendSelector` is only used for the local one-stage aggregation and the second-stage of four-stage aggregation is pruned)



## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
