### PR TITLE
[BugFix] Fix memo phase still has logical project operator bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -308,7 +308,10 @@ public class Optimizer {
 
         ruleRewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());
         ruleRewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+
+        // After this rule, we shouldn't generate logical project operator
         ruleRewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
+
         ruleRewriteOnlyOnce(tree, rootTaskContext, new GroupByCountDistinctRewriteRule());
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.INTERSECT_REWRITE);
         ruleRewriteIterative(tree, rootTaskContext, new RemoveAggregationFromAggTable());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.operator.logical;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -22,6 +23,7 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
@@ -110,6 +112,12 @@ public final class LogicalProjectOperator extends LogicalOperator {
 
         public Builder setColumnRefMap(Map<ColumnRefOperator, ScalarOperator> columnRefMap) {
             this.columnRefMap = columnRefMap;
+            return this;
+        }
+
+        @Override
+        public Builder setProjection(Projection projection) {
+            Preconditions.checkState(false, "Shouldn't set projection to Project Operator");
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
@@ -28,9 +28,9 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -124,8 +124,8 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
                 return false;
             }
         }
-        List<String> groupKeyColumns = aggregationOperator.getGroupingKeys().stream()
-                .map(columnRefOperator -> columnRefOperator.getName().toLowerCase()).collect(Collectors.toList());
+        Set<String> groupKeyColumns = aggregationOperator.getGroupingKeys().stream()
+                .map(columnRefOperator -> columnRefOperator.getName().toLowerCase()).collect(Collectors.toSet());
         return groupKeyColumns.containsAll(keyColumnNames)
                 && groupKeyColumns.containsAll(partitionColumnNames)
                 && groupKeyColumns.containsAll(distributionColumnNames);
@@ -172,7 +172,7 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
             newProjectMap = projectMap;
         }
 
-        LogicalProjectOperator projectOperator = new LogicalProjectOperator(newProjectMap);
-        return Lists.newArrayList(OptExpression.create(projectOperator, newChildOpt));
+        newChildOpt.getOp().setProjection(new Projection(newProjectMap));
+        return Lists.newArrayList(newChildOpt);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2726,4 +2726,14 @@ public class JoinTest extends PlanTestBase {
                 "  13:AGGREGATE (merge finalize)\n" +
                 "  |  group by: 16: v4, 14: v2, 15: v3");
     }
+
+    @Test // shouldn't have exception
+    public void testRemoveAggregationFromAggTableRuluWithJoinAssociateRule() throws Exception {
+        String sql = "select t0.v1 from t0 inner join (select a.k1, a.k2 from " +
+                "(select k1, k2, k3 from test_agg group by k1, k2, k3) as a " +
+                "where EXISTS (select a.k2 from " +
+                "(select k1, k2, k3 from test_agg group by k1, k2, k3) as a )) " +
+                "subv0 on t0.v1 = subv0.k1;";
+        getFragmentPlan(sql);
+    }
 }


### PR DESCRIPTION
Signed-off-by: kangkaisen <kangkaisen@apache.org>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/StarRocks/starrocks/issues/16984

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2

for https://github.com/StarRocks/starrocks/issues/16984

The directly cause is when JoinAssociateBaseRule, we set projection to a logical project operator, and the projection lost.
```
        if (CollectionUtils.isNotEmpty(splitter.getBotJoinChildCols())) {
            RowOutputInfo mergedRow = newBotJoinLeftChild.getRowOutputInfo().addColsToRow(
                    splitter.getBotJoinChildCols(),
                    newBotJoinLeftChild.getOp().getProjection() != null);
            Operator.Builder builder = OperatorBuilderFactory.build(newBotJoinLeftChild.getOp());

            Operator newBotJoinLeftChildOp = builder.withOperator(newBotJoinLeftChild.getOp())
                    .setProjection(new Projection(mergedRow.getColumnRefMap())).build();
```
```
        @Override
        public LogicalProjectOperator build() {
            return new LogicalProjectOperator(columnRefMap, this.limit);
        }
```

The root cause is after MergeProjectWithChildRule, we shouldn't have LogicalProjectOperator. but `RemoveAggregationFromAggTable` generate LogicalProjectOperator.
