### PR TITLE
[BugFix] Fix auth upgrade failure when object not found

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/FunctionPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/FunctionPEntryObject.java
@@ -61,7 +61,7 @@ public class FunctionPEntryObject implements PEntryObject {
 
             Database database = mgr.getDb(restrictName);
             if (database == null) {
-                throw new PrivilegeException("cannot find db: " + restrictName);
+                throw new PrivObjNotFoundException("cannot find db: " + restrictName);
             }
             return new FunctionPEntryObject(database.getId(), ALL_FUNCTIONS_SIG);
         } else if (allTypes.size() == 2) {

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/MaterializedViewPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/MaterializedViewPEntryObject.java
@@ -56,7 +56,7 @@ public class MaterializedViewPEntryObject extends TablePEntryObject {
 
             Database database = mgr.getDb(restrictName);
             if (database == null) {
-                throw new PrivilegeException("cannot find db: " + restrictName);
+                throw new PrivObjNotFoundException("cannot find db: " + restrictName);
             }
             return new MaterializedViewPEntryObject(database.getId(), ALL_TABLES_ID);
         } else if (allTypes.size() == 2) {

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
@@ -60,7 +60,7 @@ public class TablePEntryObject implements PEntryObject {
 
             Database database = mgr.getDb(restrictName);
             if (database == null) {
-                throw new PrivilegeException("cannot find db: " + restrictName);
+                throw new PrivObjNotFoundException("cannot find db: " + restrictName);
             }
             return new TablePEntryObject(database.getId(), ALL_TABLES_ID);
         } else if (allTypes.size() == 2) {

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/UserPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/UserPEntryObject.java
@@ -31,7 +31,7 @@ public class UserPEntryObject implements PEntryObject {
 
     public static UserPEntryObject generate(GlobalStateMgr mgr, UserIdentity user) throws PrivilegeException {
         if (!mgr.getAuthenticationManager().doesUserExist(user)) {
-            throw new PrivilegeException("cannot find user " + user);
+            throw new PrivObjNotFoundException("cannot find user " + user);
         }
         return new UserPEntryObject(user);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ViewPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ViewPEntryObject.java
@@ -57,7 +57,7 @@ public class ViewPEntryObject extends TablePEntryObject {
 
             Database database = mgr.getDb(restrictName);
             if (database == null) {
-                throw new PrivilegeException("cannot find db: " + restrictName);
+                throw new PrivObjNotFoundException("cannot find db: " + restrictName);
             }
             return new ViewPEntryObject(database.getId(), ALL_TABLES_ID);
         } else if (allTypes.size() == 2) {

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthUpgraderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/AuthUpgraderTest.java
@@ -26,6 +26,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.PrivilegeCheckerV2;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.After;
@@ -45,6 +46,8 @@ import java.util.Set;
 public class AuthUpgraderTest {
     private ConnectContext ctx;
     private long roleUserId = 0;
+
+    private StarRocksAssert starRocksAssert;
 
     private UtFrameUtils.PseudoImage executeAndUpgrade(boolean onlyUpgradeJournal, String... sqls) throws Exception {
         GlobalStateMgr.getCurrentState().initAuth(false);
@@ -135,7 +138,7 @@ public class AuthUpgraderTest {
         UtFrameUtils.setUpForPersistTest();
         UtFrameUtils.addMockBackend(10002);
         UtFrameUtils.addMockBackend(10003);
-        StarRocksAssert starRocksAssert = new StarRocksAssert();
+        starRocksAssert = new StarRocksAssert();
         starRocksAssert.withDatabase("db0");
         starRocksAssert.withDatabase("db1");
         String createResourceStmt = "create external resource 'hive0' PROPERTIES(" +
@@ -160,6 +163,68 @@ public class AuthUpgraderTest {
     @After
     public void cleanUp() {
         UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testUpgradeAfterDbDropped() throws Exception {
+        starRocksAssert.withDatabase("db2");
+        UtFrameUtils.PseudoImage image = executeAndUpgrade(
+                true,
+                "create user testusefordrop",
+                "GRANT select_priv on db2.* TO testusefordrop",
+                "GRANT select_priv on db1.* TO testusefordrop",
+                "drop database db2 force");
+        // check twice, the second time is as follower
+        for (int i = 0; i != 2; ++i) {
+            if (i == 1) {
+                replayUpgrade(image);
+            }
+            checkPrivilegeAsUser(
+                    UserIdentity.createAnalyzedUserIdentWithIp("testusefordrop", "%"),
+                    "select * from db1.tbl1");
+            starRocksAssert.withDatabase("db2");
+            String createTblStmtStr = "create table db2.tbl0 "
+                    + "(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
+                    + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1)"
+                    + " buckets 3 properties('replication_num' = '1');";
+            starRocksAssert.withTable(createTblStmtStr);
+            try {
+                checkPrivilegeAsUser(
+                        UserIdentity.createAnalyzedUserIdentWithIp("testusefordrop", "%"),
+                        "select * from db2.tbl0");
+            } catch (SemanticException e) {
+                Assert.assertTrue(e.getMessage().contains("SELECT command denied to user 'testusefordrop'"));
+            }
+        }
+    }
+
+    @Test
+    public void testUpgradeAfterTableDropped() throws Exception {
+        starRocksAssert.withDatabase("db2");
+        String createTblStmtStr = "create table db2.tbl0 "
+                + "(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
+                + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1)"
+                + " buckets 3 properties('replication_num' = '1');";
+        starRocksAssert.withTable(createTblStmtStr);
+        UtFrameUtils.PseudoImage image = executeAndUpgrade(
+                true,
+                "create user testusefordrop2",
+                "GRANT select_priv on db2.tbl0 TO testusefordrop2",
+                "GRANT select_priv on db1.* TO testusefordrop2",
+                "drop table db2.tbl0 force");
+
+        checkPrivilegeAsUser(
+                UserIdentity.createAnalyzedUserIdentWithIp("testusefordrop2", "%"),
+                "select * from db1.tbl1");
+
+        starRocksAssert.withTable(createTblStmtStr);
+        try {
+            checkPrivilegeAsUser(
+                    UserIdentity.createAnalyzedUserIdentWithIp("testusefordrop2", "%"),
+                    "select * from db2.tbl0");
+        } catch (SemanticException e) {
+            Assert.assertTrue(e.getMessage().contains("SELECT command denied to user 'testusefordrop2'"));
+        }
     }
 
     @Test
@@ -280,6 +345,26 @@ public class AuthUpgraderTest {
             ctx.setCurrentUserIdentity(user);
             ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(
                     ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory", "%"));
+        }
+    }
+
+    @Test
+    public void testImpersonateAfterUserDropped() throws Exception {
+        UtFrameUtils.PseudoImage image = executeAndUpgrade(
+                true,
+                "create user testafteruserdropped",
+                "create user gregory1",
+                "GRANT impersonate on gregory1 TO testafteruserdropped",
+                "drop user gregory1");
+
+        // check twice, the second time is as follower
+        for (int i = 0; i != 2; ++i) {
+            if (i == 1) {
+                replayUpgrade(image);
+            }
+            ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("testafteruserdropped", "%"));
+            Assert.assertFalse(ctx.getGlobalStateMgr().getPrivilegeManager().canExecuteAs(
+                    ctx, UserIdentity.createAnalyzedUserIdentWithIp("gregory1", "%")));
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17091 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In old {@link Auth} module, privilege entry is not removed after corresponding object(db, table etc.)
is dropped, so in the upgrade process we should always ignore the exception because of non-existed
object, for those privilege entries, we don't need to transform them to privilege entry in new RBAC
based privilege framework.

Signed-off-by: Dejun Xia <xiadejun@starrocks.com>

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
