### PR TITLE
[BugFix] fix min-readable-version lost during replay

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -193,6 +193,13 @@ public class Replica implements Writable {
     public Replica(long replicaId, long backendId, long version, int schemaHash,
                    long dataSize, long rowCount, ReplicaState state,
                    long lastFailedVersion, long lastSuccessVersion) {
+        this(replicaId, backendId, version, schemaHash, dataSize, rowCount, state,
+                lastFailedVersion, lastSuccessVersion, 0);
+    }
+
+    public Replica(long replicaId, long backendId, long version, int schemaHash,
+                   long dataSize, long rowCount, ReplicaState state,
+                   long lastFailedVersion, long lastSuccessVersion, long minReadableVersion) {
         this.id = replicaId;
         this.backendId = backendId;
         this.version = version;
@@ -213,6 +220,7 @@ public class Replica implements Writable {
         } else {
             this.lastSuccessVersion = lastSuccessVersion;
         }
+        this.minReadableVersion = minReadableVersion;
     }
 
     public void setLastWriteFail(boolean lastWriteFail) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ReplicaPersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ReplicaPersistInfo.java
@@ -304,6 +304,10 @@ public class ReplicaPersistInfo implements Writable {
         return lastSuccessVersion;
     }
 
+    public long getMinReadableVersion() {
+        return minReadableVersion;
+    }
+
     public static ReplicaPersistInfo read(DataInput in) throws IOException {
         ReplicaPersistInfo replicaInfo = new ReplicaPersistInfo();
         replicaInfo.readFields(in);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2936,7 +2936,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 schemaHash, info.getDataSize(), info.getRowCount(),
                 Replica.ReplicaState.NORMAL,
                 info.getLastFailedVersion(),
-                info.getLastSuccessVersion());
+                info.getLastSuccessVersion(),
+                info.getMinReadableVersion());
         tablet.addReplica(replica);
     }
 
@@ -2949,7 +2950,7 @@ public class LocalMetastore implements ConnectorMetadata {
         LocalTablet tablet = (LocalTablet) materializedIndex.getTablet(info.getTabletId());
         Replica replica = tablet.getReplicaByBackendId(info.getBackendId());
         Preconditions.checkNotNull(replica, info);
-        replica.updateRowCount(info.getVersion(), info.getDataSize(), info.getRowCount());
+        replica.updateRowCount(info.getVersion(), info.getMinReadableVersion(), info.getDataSize(), info.getRowCount());
         replica.setBad(false);
     }
 


### PR DESCRIPTION
Signed-off-by: Binglin Chang <decstery@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17191
Relates to #10694

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When replay ReplicaPersistInfo, minReadableVersion is omitted, this PR fixes this.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
