### PR TITLE
[Enhancement] refactor default flush_thread_num_per_store value

### DIFF
--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -104,6 +104,8 @@ public:
     bool load(const char* filename);
     template <typename T>
     bool get(const char* key, const char* defstr, T& retval) const;
+    bool contain(const char* key) const;
+    void set(const char* key, const char* value);
 
 private:
     std::map<std::string, std::string> file_conf_map;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

default flush_thread_num_per_store value is 2, it is too small if
Be only have one disk, in this pr, we refactor the default
flush_thread_num_per_store value if user hasn't set it.

Its value equals to num_cores / 2 / disk_store_num, also,
the flush_thread_num_per_store has a upper bound 8 and lower bound 2.

clickbench load time     before optimize     after optimize
c6a.4xlarge 500 gb gp2     400s                  400s
c6a.4xmetal 500 gb gp2     402s                      332s

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
