### PR TITLE
[BugFix] unify Operator equal method

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -186,12 +186,11 @@ public class LogicalAggregationOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalAggregationOperator that = (LogicalAggregationOperator) o;
         return type == that.type && Objects.equals(aggregations, that.aggregations) &&
                 Objects.equals(groupingKeys, that.groupingKeys);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEAnchorOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEAnchorOperator.java
@@ -79,12 +79,11 @@ public class LogicalCTEAnchorOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalCTEAnchorOperator that = (LogicalCTEAnchorOperator) o;
         return Objects.equals(cteId, that.cteId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEConsumeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEConsumeOperator.java
@@ -90,9 +90,7 @@ public class LogicalCTEConsumeOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEProduceOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEProduceOperator.java
@@ -70,9 +70,7 @@ public class LogicalCTEProduceOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
@@ -207,9 +207,6 @@ public class LogicalJoinOperator extends LogicalOperator {
             return true;
         }
 
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
         if (!super.equals(o)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -142,12 +142,11 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalOlapScanOperator that = (LogicalOlapScanOperator) o;
         return selectedIndexId == that.selectedIndexId &&
                 Objects.equals(hashDistributionSpec, that.hashDistributionSpec) &&
@@ -159,8 +158,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), hashDistributionSpec, selectedIndexId, selectedPartitionId,
-                partitionNames,
+        return Objects.hash(super.hashCode(), selectedIndexId, selectedPartitionId,
                 selectedTabletId, hintsTabletIds);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
@@ -69,16 +69,18 @@ public final class LogicalProjectOperator extends LogicalOperator {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof LogicalProjectOperator)) {
-            return false;
-        }
-        LogicalProjectOperator rhs = (LogicalProjectOperator) obj;
-        if (this == rhs) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
 
-        return columnRefMap.keySet().equals(rhs.columnRefMap.keySet());
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        LogicalProjectOperator that = (LogicalProjectOperator) o;
+
+        return columnRefMap.keySet().equals(that.columnRefMap.keySet());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalRepeatOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalRepeatOperator.java
@@ -98,12 +98,11 @@ public class LogicalRepeatOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalRepeatOperator that = (LogicalRepeatOperator) o;
         return Objects.equals(outputGrouping, that.outputGrouping) &&
                 Objects.equals(repeatColumnRefList, that.repeatColumnRefList);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
@@ -145,12 +145,11 @@ public abstract class LogicalScanOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalScanOperator that = (LogicalScanOperator) o;
         return Objects.equals(table.getId(), that.table.getId()) &&
                 Objects.equals(colRefToColumnMetaMap.keySet(), that.getColRefToColumnMetaMap().keySet());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalSetOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalSetOperator.java
@@ -70,14 +70,13 @@ public abstract class LogicalSetOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalSetOperator that = (LogicalSetOperator) o;
-        return Objects.equals(outputColumnRefOp, that.outputColumnRefOp) && opType == that.opType;
+        return Objects.equals(outputColumnRefOp, that.outputColumnRefOp);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTableFunctionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTableFunctionOperator.java
@@ -113,12 +113,11 @@ public class LogicalTableFunctionOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalTableFunctionOperator that = (LogicalTableFunctionOperator) o;
         return Objects.equals(fn, that.fn) && Objects.equals(fnResultColumnRefSet, that.fnResultColumnRefSet)
                 && Objects.equals(outerColumnRefSet, that.outerColumnRefSet)
@@ -127,7 +126,7 @@ public class LogicalTableFunctionOperator extends LogicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), fn, fnResultColumnRefSet, outerColumnRefSet, fnParamColumnProject);
+        return Objects.hash(super.hashCode(), fn, fnResultColumnRefSet);
     }
 
     public static class Builder

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
@@ -159,12 +159,11 @@ public class LogicalTopNOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalTopNOperator that = (LogicalTopNOperator) o;
         return partitionLimit == that.partitionLimit && offset == that.offset && isSplit == that.isSplit &&
                 Objects.equals(partitionByColumns, that.partitionByColumns) &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalUnionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalUnionOperator.java
@@ -44,6 +44,25 @@ public class LogicalUnionOperator extends LogicalSetOperator {
     }
 
     @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        LogicalUnionOperator that = (LogicalUnionOperator) o;
+        return isUnionAll == that.isUnionAll;
+    }
+
+    @Override
     public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
         return visitor.visitLogicalUnion(this, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalWindowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalWindowOperator.java
@@ -115,12 +115,11 @@ public class LogicalWindowOperator extends LogicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         LogicalWindowOperator that = (LogicalWindowOperator) o;
         return Objects.equals(windowCall, that.windowCall)
                 && Objects.equals(partitionExpressions, that.partitionExpressions)
@@ -130,7 +129,7 @@ public class LogicalWindowOperator extends LogicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), windowCall, partitionExpressions, orderByElements, analyticWindow);
+        return Objects.hash(super.hashCode(), windowCall);
     }
 
     public static class Builder extends LogicalOperator.Builder<LogicalWindowOperator, LogicalWindowOperator.Builder> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEAnchorOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEAnchorOperator.java
@@ -57,12 +57,11 @@ public class PhysicalCTEAnchorOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalCTEAnchorOperator that = (PhysicalCTEAnchorOperator) o;
         return Objects.equals(cteId, that.cteId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEConsumeOperator.java
@@ -64,12 +64,11 @@ public class PhysicalCTEConsumeOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalCTEConsumeOperator that = (PhysicalCTEConsumeOperator) o;
         return Objects.equals(cteId, that.cteId) &&
                 Objects.equals(cteOutputColumnRefMap, that.cteOutputColumnRefMap);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEProduceOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEProduceOperator.java
@@ -49,12 +49,11 @@ public class PhysicalCTEProduceOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalCTEProduceOperator that = (PhysicalCTEProduceOperator) o;
         return Objects.equals(cteId, that.cteId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalDeltaLakeScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalDeltaLakeScanOperator.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
-import com.google.common.base.Objects;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -60,28 +59,6 @@ public class PhysicalDeltaLakeScanOperator extends PhysicalScanOperator {
     @Override
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalDeltaLakeScan(optExpression, context);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-
-        PhysicalDeltaLakeScanOperator that = (PhysicalDeltaLakeScanOperator) o;
-        ScanOperatorPredicates targetPredicts = ((PhysicalDeltaLakeScanOperator) o).getScanOperatorPredicates();
-        return Objects.equal(table, that.table) && predicates.equals(targetPredicts);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(super.hashCode(), table, predicates);
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalEsScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalEsScanOperator.java
@@ -28,7 +28,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class PhysicalEsScanOperator extends PhysicalScanOperator {
     private final List<EsShardPartitions> selectedIndex;
@@ -55,25 +54,5 @@ public class PhysicalEsScanOperator extends PhysicalScanOperator {
     @Override
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalEsScan(optExpression, context);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        PhysicalEsScanOperator that = (PhysicalEsScanOperator) o;
-        return Objects.equals(selectedIndex, that.selectedIndex);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), selectedIndex);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalFileScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalFileScanOperator.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
-import com.google.common.base.Objects;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -61,28 +60,6 @@ public class PhysicalFileScanOperator extends PhysicalScanOperator {
     @Override
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalFileScan(optExpression, context);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-
-        PhysicalFileScanOperator that = (PhysicalFileScanOperator) o;
-        ScanOperatorPredicates targetPredicts = ((PhysicalFileScanOperator) o).getScanOperatorPredicates();
-        return Objects.equal(table, that.table) && predicates.equals(targetPredicts);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(super.hashCode(), table, predicates);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -149,12 +149,11 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalHashAggregateOperator that = (PhysicalHashAggregateOperator) o;
         return type == that.type && Objects.equals(aggregations, that.aggregations) &&
                 Objects.equals(groupBys, that.groupBys);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
@@ -66,12 +66,11 @@ public class PhysicalHashJoinOperator extends PhysicalJoinOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalHashJoinOperator that = (PhysicalHashJoinOperator) o;
         return joinType == that.joinType && Objects.equals(onPredicate, that.onPredicate);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHiveScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHiveScanOperator.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
-import com.google.common.base.Objects;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -61,28 +60,6 @@ public class PhysicalHiveScanOperator extends PhysicalScanOperator {
     @Override
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalHiveScan(optExpression, context);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-
-        PhysicalHiveScanOperator that = (PhysicalHiveScanOperator) o;
-        ScanOperatorPredicates targetPredicts = ((PhysicalHiveScanOperator) o).getScanOperatorPredicates();
-        return Objects.equal(table, that.table) && predicates.equals(targetPredicts);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(super.hashCode(), table, predicates);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHudiScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHudiScanOperator.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
-import com.google.common.base.Objects;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -63,27 +62,6 @@ public class PhysicalHudiScanOperator extends PhysicalScanOperator {
         return visitor.visitPhysicalHudiScan(optExpression, context);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-
-        PhysicalHudiScanOperator that = (PhysicalHudiScanOperator) o;
-        ScanOperatorPredicates targetPredicts = ((PhysicalHudiScanOperator) o).getScanOperatorPredicates();
-        return Objects.equal(table, that.table) && predicates.equals(targetPredicts);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(super.hashCode(), table, predicates);
-    }
 
     @Override
     public ColumnRefSet getUsedColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergScanOperator.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
-import com.google.common.base.Objects;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -61,28 +60,6 @@ public class PhysicalIcebergScanOperator extends PhysicalScanOperator {
     @Override
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalIcebergScan(optExpression, context);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-
-        PhysicalIcebergScanOperator that = (PhysicalIcebergScanOperator) o;
-        ScanOperatorPredicates targetPredicts = ((PhysicalIcebergScanOperator) o).getScanOperatorPredicates();
-        return Objects.equal(table, that.table) && predicates.equals(targetPredicts);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(super.hashCode(), table, predicates);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
@@ -76,12 +76,11 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalJoinOperator that = (PhysicalJoinOperator) o;
         return joinType == that.joinType && Objects.equals(onPredicate, that.onPredicate);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMergeJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMergeJoinOperator.java
@@ -67,12 +67,11 @@ public class PhysicalMergeJoinOperator extends PhysicalJoinOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalMergeJoinOperator that = (PhysicalMergeJoinOperator) o;
         return joinType == that.joinType && Objects.equals(onPredicate, that.onPredicate);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
@@ -61,12 +61,11 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalMetaScanOperator that = (PhysicalMetaScanOperator) o;
         return Objects.equals(aggColumnIdToNames, that.aggColumnIdToNames);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.optimizer.statistics.ColumnDict;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class PhysicalOlapScanOperator extends PhysicalScanOperator {
@@ -160,6 +161,30 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
     @Override
     public <R, C> R accept(OptExpressionVisitor<R, C> visitor, OptExpression optExpression, C context) {
         return visitor.visitPhysicalOlapScan(optExpression, context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), selectedIndexId, selectedPartitionId,
+                selectedTabletId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        PhysicalOlapScanOperator that = (PhysicalOlapScanOperator) o;
+        return selectedIndexId == that.selectedIndexId &&
+                Objects.equals(hashDistributionSpec, that.hashDistributionSpec) &&
+                Objects.equals(selectedPartitionId, that.selectedPartitionId) &&
+                Objects.equals(selectedTabletId, that.selectedTabletId);
     }
 
     public HashDistributionSpec getDistributionSpec() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalProjectOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalProjectOperator.java
@@ -53,9 +53,11 @@ public class PhysicalProjectOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+
+        if (!super.equals(o)) {
             return false;
         }
+
         PhysicalProjectOperator that = (PhysicalProjectOperator) o;
         return Objects.equal(columnRefMap, that.columnRefMap) &&
                 Objects.equal(commonSubOperatorMap, that.commonSubOperatorMap);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalRepeatOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalRepeatOperator.java
@@ -78,7 +78,8 @@ public class PhysicalRepeatOperator extends PhysicalOperator {
 
         PhysicalRepeatOperator that = (PhysicalRepeatOperator) o;
         return Objects.equals(outputGrouping, that.outputGrouping) &&
-                Objects.equals(repeatColumnRef, that.repeatColumnRef);
+                Objects.equals(repeatColumnRef, that.repeatColumnRef) &&
+                Objects.equals(groupingIds, that.groupingIds);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalRepeatOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalRepeatOperator.java
@@ -71,9 +71,11 @@ public class PhysicalRepeatOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+
+        if (!super.equals(o)) {
             return false;
         }
+
         PhysicalRepeatOperator that = (PhysicalRepeatOperator) o;
         return Objects.equals(outputGrouping, that.outputGrouping) &&
                 Objects.equals(repeatColumnRef, that.repeatColumnRef);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
@@ -112,12 +112,11 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+
         if (!super.equals(o)) {
             return false;
         }
+
         PhysicalScanOperator that = (PhysicalScanOperator) o;
         return Objects.equals(table.getId(), that.table.getId()) &&
                 Objects.equals(colRefToColumnMetaMap, that.getColRefToColumnMetaMap());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSetOperation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSetOperation.java
@@ -60,9 +60,11 @@ public class PhysicalSetOperation extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+
+        if (!super.equals(o)) {
             return false;
         }
+
         PhysicalSetOperation that = (PhysicalSetOperation) o;
         return Objects.equal(outputColumnRefOp, that.outputColumnRefOp) &&
                 Objects.equal(childOutputColumns, that.childOutputColumns);
@@ -70,6 +72,6 @@ public class PhysicalSetOperation extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(outputColumnRefOp, childOutputColumns);
+        return Objects.hashCode(outputColumnRefOp);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTableFunctionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTableFunctionOperator.java
@@ -89,9 +89,11 @@ public class PhysicalTableFunctionOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+
+        if (!super.equals(o)) {
             return false;
         }
+
         PhysicalTableFunctionOperator that = (PhysicalTableFunctionOperator) o;
         return Objects.equal(fn, that.fn) && Objects.equal(fnResultColumnRefSet, that.fnResultColumnRefSet) &&
                 Objects.equal(outerColumnRefSet, that.outerColumnRefSet) &&
@@ -100,6 +102,6 @@ public class PhysicalTableFunctionOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(fn, fnResultColumnRefSet, outerColumnRefSet, fnParamColumnRef);
+        return Objects.hashCode(fn, fnResultColumnRefSet);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -99,18 +99,18 @@ public class PhysicalTopNOperator extends PhysicalOperator {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof PhysicalTopNOperator)) {
-            return false;
-        }
-
-        PhysicalTopNOperator rhs = (PhysicalTopNOperator) obj;
-        if (this == rhs) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
 
-        return sortPhase.equals(rhs.sortPhase) &&
-                orderSpec.equals(rhs.orderSpec);
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PhysicalTopNOperator that = (PhysicalTopNOperator) o;
+
+        return sortPhase.equals(that.sortPhase) && orderSpec.equals(that.orderSpec);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalUnionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalUnionOperator.java
@@ -41,6 +41,25 @@ public class PhysicalUnionOperator extends PhysicalSetOperation {
     }
 
     @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PhysicalUnionOperator that = (PhysicalUnionOperator) o;
+        return isUnionAll == that.isUnionAll;
+    }
+
+    @Override
     public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
         return visitor.visitPhysicalUnion(this, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalWindowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalWindowOperator.java
@@ -93,9 +93,11 @@ public class PhysicalWindowOperator extends PhysicalOperator {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+
+        if (!super.equals(o)) {
             return false;
         }
+
         PhysicalWindowOperator that = (PhysicalWindowOperator) o;
         return Objects.equals(analyticCall, that.analyticCall) &&
                 Objects.equals(partitionExpressions, that.partitionExpressions) &&
@@ -105,7 +107,7 @@ public class PhysicalWindowOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(analyticCall, partitionExpressions, orderByElements, analyticWindow);
+        return Objects.hash(analyticCall);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: packy <wangchao@starrocks.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16908

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`equals()` method in `PhysicalTopNOperator` doesn't compare predicate and projection. This may lead  two different group be merged.

By the way, I checked all operators' `hashCode()` and `equals` method to ensure the `equals()` method be right and remove some redundant code as below:
- remove `o == null || getClass() != o.getClass()` which has exist  in `super.equals()`
- remove `equals()` and `hashCode()` method in external table because these private field can't be setted. So no need to implement these method in child class.
- remove some unnecessary part when calculating  hashcode

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
