### PR TITLE
[Enhancement] Fix build warnings with clang14

### DIFF
--- a/be/src/column/CMakeLists.txt
+++ b/be/src/column/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/column")
 add_library(Column STATIC
         array_column.cpp
         chunk.cpp
+        chunk_extra_data.cpp
         column.cpp
         column_helper.cpp
         column_viewer.cpp

--- a/be/src/column/chunk_extra_data.cpp
+++ b/be/src/column/chunk_extra_data.cpp
@@ -1,0 +1,104 @@
+
+
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/chunk_extra_data.h"
+
+namespace starrocks {
+void ChunkExtraColumnsData::filter(const Buffer<uint8_t>& selection) const {
+    for (auto& col : _columns) {
+        col->filter(selection);
+    }
+}
+
+void ChunkExtraColumnsData::filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) const {
+    for (auto& col : _columns) {
+        col->filter_range(selection, from, to);
+    }
+}
+
+ChunkExtraColumnsDataPtr ChunkExtraColumnsData::clone_empty(size_t size) const {
+    Columns columns(_columns.size());
+    for (size_t i = 0; i < _columns.size(); i++) {
+        columns[i] = _columns[i]->clone_empty();
+        columns[i]->reserve(size);
+    }
+    auto extra_data_metas = _data_metas;
+    return std::make_shared<ChunkExtraColumnsData>(extra_data_metas, columns);
+}
+
+void ChunkExtraColumnsData::append(const ChunkExtraColumnsData& src, size_t offset, size_t count) {
+    auto src_columns = src.columns();
+    DCHECK_EQ(src_columns.size(), _columns.size());
+    for (size_t i = 0; i < _columns.size(); ++i) {
+        _columns[i]->append(*src_columns[i], offset, count);
+    }
+}
+
+void ChunkExtraColumnsData::append_selective(const ChunkExtraColumnsData& src, const uint32_t* indexes, uint32_t from,
+                                             uint32_t size) {
+    auto src_columns = src.columns();
+    DCHECK_EQ(src_columns.size(), _columns.size());
+    for (size_t i = 0; i < _columns.size(); ++i) {
+        _columns[i]->append_selective(*src_columns[i], indexes, from, size);
+    }
+}
+
+size_t ChunkExtraColumnsData::memory_usage() const {
+    size_t memory_usage = 0;
+    for (const auto& column : _columns) {
+        memory_usage += column->memory_usage();
+    }
+    return memory_usage;
+}
+
+size_t ChunkExtraColumnsData::bytes_usage(size_t from, size_t size) const {
+    size_t bytes_usage = 0;
+    for (const auto& column : _columns) {
+        bytes_usage += column->byte_size(from, size);
+    }
+    return bytes_usage;
+}
+
+int64_t ChunkExtraColumnsData::max_serialized_size(const int encode_level) {
+    DCHECK_EQ(encode_level, 0);
+    int64_t serialized_size = 0;
+    for (auto i = 0; i < _columns.size(); ++i) {
+        serialized_size += serde::ColumnArraySerde::max_serialized_size(*_columns[i], 0);
+    }
+    return serialized_size;
+}
+
+uint8_t* ChunkExtraColumnsData::serialize(uint8_t* buff, bool sorted, const int encode_level) {
+    DCHECK_EQ(encode_level, 0);
+    for (auto i = 0; i < _columns.size(); ++i) {
+        buff = serde::ColumnArraySerde::serialize(*_columns[i], buff, sorted, encode_level);
+    }
+    return buff;
+}
+
+const uint8_t* ChunkExtraColumnsData::deserialize(const uint8_t* buff, bool sorted, const int encode_level) {
+    DCHECK_EQ(encode_level, 0);
+    for (auto i = 0; i < _columns.size(); ++i) {
+        buff = serde::ColumnArraySerde::deserialize(buff, _columns[i].get(), sorted, encode_level);
+    }
+    return buff;
+}
+
+ChunkExtraColumnsData* ChunkExtraColumnsData::as_raw(const ChunkExtraDataPtr& extra_data) {
+    return extra_data ? down_cast<ChunkExtraColumnsData*>(extra_data.get()) : nullptr;
+}
+
+} // namespace starrocks

--- a/be/src/column/chunk_extra_data.h
+++ b/be/src/column/chunk_extra_data.h
@@ -18,7 +18,6 @@
 #include "serde/column_array_serde.h"
 
 namespace starrocks {
-
 class ChunkExtraColumnsData;
 using ChunkExtraColumnsDataPtr = std::shared_ptr<ChunkExtraColumnsData>;
 
@@ -28,7 +27,7 @@ struct ChunkExtraColumnsMeta {
     bool is_const;
 };
 
-/**
+/*
  * `ChunkExtraColumnsData` is a specific implementation which includes extra 
  * columns besides the schema, and it supports common methods like Chunk. eg, 
  * In Stream MV scenes, the hidden `_op_` column can be added in the ChunkExtraData.
@@ -44,84 +43,22 @@ public:
     Columns columns() const { return _columns; }
     size_t num_rows() const { return _columns.empty() ? 0 : _columns[0]->size(); }
 
-    void filter(const Buffer<uint8_t>& selection) const {
-        for (auto& col : _columns) {
-            col->filter(selection);
-        }
-    }
+    void filter(const Buffer<uint8_t>& selection) const;
+    void filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) const;
 
-    void filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) const {
-        for (auto& col : _columns) {
-            col->filter_range(selection, from, to);
-        }
-    }
+    ChunkExtraColumnsDataPtr clone_empty(size_t size) const;
 
-    ChunkExtraColumnsDataPtr clone_empty(size_t size) const {
-        Columns columns(_columns.size());
-        for (size_t i = 0; i < _columns.size(); i++) {
-            columns[i] = _columns[i]->clone_empty();
-            columns[i]->reserve(size);
-        }
-        auto extra_data_metas = _data_metas;
-        return std::make_shared<ChunkExtraColumnsData>(extra_data_metas, columns);
-    }
+    void append(const ChunkExtraColumnsData& src, size_t offset, size_t count);
+    void append_selective(const ChunkExtraColumnsData& src, const uint32_t* indexes, uint32_t from, uint32_t size);
 
-    void append(const ChunkExtraColumnsData& src, size_t offset, size_t count) {
-        auto src_columns = src.columns();
-        DCHECK_EQ(src_columns.size(), _columns.size());
-        for (size_t i = 0; i < _columns.size(); ++i) {
-            _columns[i]->append(*src_columns[i], offset, count);
-        }
-    }
+    size_t memory_usage() const;
+    size_t bytes_usage(size_t from, size_t size) const;
 
-    void append_selective(const ChunkExtraColumnsData& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
-        auto src_columns = src.columns();
-        DCHECK_EQ(src_columns.size(), _columns.size());
-        for (size_t i = 0; i < _columns.size(); ++i) {
-            _columns[i]->append_selective(*src_columns[i], indexes, from, size);
-        }
-    }
+    int64_t max_serialized_size(const int encode_level = 0);
+    uint8_t* serialize(uint8_t* buff, bool sorted = false, const int encode_level = 0);
+    const uint8_t* deserialize(const uint8_t* buff, bool sorted = false, const int encode_level = 0);
 
-    size_t memory_usage() const {
-        size_t memory_usage = 0;
-        for (const auto& column : _columns) {
-            memory_usage += column->memory_usage();
-        }
-        return memory_usage;
-    }
-
-    size_t bytes_usage(size_t from, size_t size) const {
-        size_t bytes_usage = 0;
-        for (const auto& column : _columns) {
-            bytes_usage += column->byte_size(from, size);
-        }
-        return bytes_usage;
-    }
-
-    int64_t max_serialized_size(const int encode_level = 0) {
-        DCHECK_EQ(encode_level, 0);
-        int64_t serialized_size = 0;
-        for (auto i = 0; i < _columns.size(); ++i) {
-            serialized_size += serde::ColumnArraySerde::max_serialized_size(*_columns[i], 0);
-        }
-        return serialized_size;
-    }
-
-    uint8_t* serialize(uint8_t* buff, bool sorted = false, const int encode_level = 0) {
-        DCHECK_EQ(encode_level, 0);
-        for (auto i = 0; i < _columns.size(); ++i) {
-            buff = serde::ColumnArraySerde::serialize(*_columns[i], buff, sorted, encode_level);
-        }
-        return buff;
-    }
-
-    const uint8_t* deserialize(const uint8_t* buff, bool sorted = false, const int encode_level = 0) {
-        DCHECK_EQ(encode_level, 0);
-        for (auto i = 0; i < _columns.size(); ++i) {
-            buff = serde::ColumnArraySerde::deserialize(buff, _columns[i].get(), sorted, encode_level);
-        }
-        return buff;
-    }
+    static ChunkExtraColumnsData* as_raw(const ChunkExtraDataPtr& extra_data);
 
 private:
     std::vector<ChunkExtraColumnsMeta> _data_metas;

--- a/be/src/column/stream_chunk.cpp
+++ b/be/src/column/stream_chunk.cpp
@@ -40,4 +40,91 @@ EpochInfo EpochInfo::from_start_epoch_task(const TMVStartEpochTask& start_epoch)
     return res;
 }
 
+std::string EpochInfo::debug_string() const {
+    std::stringstream ss;
+    ss << "epoch_id=" << epoch_id << ", txn_id=" << txn_id << ", max_exec_millis=" << max_exec_millis
+       << ", max_scan_rows=" << max_scan_rows << ", trigger_mode=" << (int)(trigger_mode);
+    return ss.str();
+}
+
+StreamChunkPtr StreamChunkConverter::make_stream_chunk(ChunkPtr chunk, Int8ColumnPtr ops) {
+    std::vector<ChunkExtraColumnsMeta> stream_extra_data_meta = {
+            ChunkExtraColumnsMeta{.type = TypeDescriptor(TYPE_TINYINT), .is_null = false, .is_const = false}};
+    std::vector<ColumnPtr> stream_extra_data = {ops};
+    auto extra_data =
+            std::make_shared<ChunkExtraColumnsData>(std::move(stream_extra_data_meta), std::move(stream_extra_data));
+    chunk->set_extra_data(std::move(extra_data));
+    return chunk;
+}
+
+bool StreamChunkConverter::has_ops_column(const StreamChunk& chunk) {
+    if (chunk.has_extra_data() && down_cast<ChunkExtraColumnsData*>(chunk.get_extra_data().get())) {
+        return true;
+    }
+    return false;
+}
+
+bool StreamChunkConverter::has_ops_column(const StreamChunkPtr& chunk_ptr) {
+    if (!chunk_ptr) {
+        return false;
+    }
+    return has_ops_column(*chunk_ptr);
+}
+
+bool StreamChunkConverter::has_ops_column(const StreamChunk* chunk_ptr) {
+    if (!chunk_ptr) {
+        return false;
+    }
+    return has_ops_column(*chunk_ptr);
+}
+
+Int8Column* StreamChunkConverter::ops_col(const StreamChunk& stream_chunk) {
+    DCHECK(has_ops_column(stream_chunk));
+    auto extra_column_data = down_cast<ChunkExtraColumnsData*>(stream_chunk.get_extra_data().get());
+    DCHECK(extra_column_data);
+    DCHECK_EQ(extra_column_data->columns().size(), 1);
+    auto* op_col = ColumnHelper::as_raw_column<Int8Column>(extra_column_data->columns()[0]);
+    DCHECK(op_col);
+    DCHECK_EQ(stream_chunk.num_rows(), op_col->size());
+    return op_col;
+}
+
+Int8Column* StreamChunkConverter::ops_col(const StreamChunkPtr& stream_chunk_ptr) {
+    DCHECK(stream_chunk_ptr);
+    return ops_col(*stream_chunk_ptr);
+}
+
+Int8Column* StreamChunkConverter::ops_col(const StreamChunk* stream_chunk_ptr) {
+    DCHECK(stream_chunk_ptr);
+    return ops_col(*stream_chunk_ptr);
+}
+
+const StreamRowOp* StreamChunkConverter::ops(const StreamChunk& stream_chunk) {
+    auto* op_col = ops_col(stream_chunk);
+    return (StreamRowOp*)(op_col->get_data().data());
+}
+
+const StreamRowOp* StreamChunkConverter::ops(const StreamChunk* stream_chunk) {
+    auto* op_col = ops_col(stream_chunk);
+    return (StreamRowOp*)(op_col->get_data().data());
+}
+
+const StreamRowOp* StreamChunkConverter::ops(const StreamChunkPtr& stream_chunk) {
+    auto* op_col = ops_col(stream_chunk);
+    return (StreamRowOp*)(op_col->get_data().data());
+}
+
+ChunkPtr StreamChunkConverter::to_chunk(const StreamChunkPtr& stream_chunk) {
+    if (has_ops_column(stream_chunk)) {
+        auto extra_column_data = down_cast<ChunkExtraColumnsData*>(stream_chunk->get_extra_data().get());
+        DCHECK(extra_column_data);
+        auto mock_slot_id = stream_chunk->num_columns();
+        for (auto& extra_column : extra_column_data->columns()) {
+            stream_chunk->append_column(extra_column, mock_slot_id++);
+        }
+        stream_chunk->set_extra_data(nullptr);
+    }
+    return stream_chunk;
+}
+
 } // namespace starrocks

--- a/be/src/column/stream_chunk.h
+++ b/be/src/column/stream_chunk.h
@@ -84,6 +84,8 @@ struct MVMaintenanceTaskInfo {
 struct EpochInfo {
     // transaction id
     int64_t txn_id;
+    // load_id
+    TUniqueId load_id;
     // epoch marker id
     int64_t epoch_id;
     // max binlog duration which this epoch will run
@@ -95,12 +97,7 @@ struct EpochInfo {
 
     static EpochInfo from_start_epoch_task(const TMVStartEpochTask& start_epoch);
 
-    std::string debug_string() const {
-        std::stringstream ss;
-        ss << "epoch_id=" << epoch_id << ", max_exec_millis=" << max_exec_millis << ", max_scan_rows=" << max_scan_rows
-           << ", trigger_mode=" << (int)(trigger_mode);
-        return ss.str();
-    }
+    std::string debug_string() const;
 };
 
 /**
@@ -111,72 +108,21 @@ struct EpochInfo {
  */
 class StreamChunkConverter {
 public:
-    static StreamChunkPtr make_stream_chunk(ChunkPtr chunk, Int8ColumnPtr ops) {
-        static std::vector<ChunkExtraColumnsMeta> stream_extra_data_meta = {
-                ChunkExtraColumnsMeta{.type = TypeDescriptor(TYPE_TINYINT), .is_null = false, .is_const = false}};
-        std::vector<ColumnPtr> stream_extra_data = {ops};
-        auto extra_data = std::make_shared<ChunkExtraColumnsData>(std::move(stream_extra_data_meta),
-                                                                  std::move(stream_extra_data));
-        chunk->set_extra_data(std::move(extra_data));
-        return chunk;
-    }
+    static StreamChunkPtr make_stream_chunk(ChunkPtr chunk, Int8ColumnPtr ops);
 
-    static bool has_ops_column(const StreamChunk& chunk) {
-        if (chunk.has_extra_data() && typeid(*chunk.get_extra_data()) == typeid(ChunkExtraColumnsData)) {
-            return true;
-        }
-        return false;
-    }
+    static bool has_ops_column(const StreamChunk& chunk);
+    static bool has_ops_column(const StreamChunkPtr& chunk_ptr);
+    static bool has_ops_column(const StreamChunk* chunk_ptr);
 
-    static bool has_ops_column(const StreamChunkPtr& chunk_ptr) {
-        if (!chunk_ptr) {
-            return false;
-        }
-        return has_ops_column(*chunk_ptr);
-    }
+    static Int8Column* ops_col(const StreamChunk& stream_chunk);
+    static Int8Column* ops_col(const StreamChunkPtr& stream_chunk_ptr);
+    static Int8Column* ops_col(const StreamChunk* stream_chunk_ptr);
 
-    static bool has_ops_column(StreamChunk* chunk_ptr) {
-        if (!chunk_ptr) {
-            return false;
-        }
-        return has_ops_column(*chunk_ptr);
-    }
+    static const StreamRowOp* ops(const StreamChunk& stream_chunk);
+    static const StreamRowOp* ops(const StreamChunk* stream_chunk);
+    static const StreamRowOp* ops(const StreamChunkPtr& stream_chunk);
 
-    static Int8Column* ops_col(const StreamChunk& stream_chunk) {
-        DCHECK(has_ops_column(stream_chunk));
-        auto extra_column_data = down_cast<ChunkExtraColumnsData*>(stream_chunk.get_extra_data().get());
-        DCHECK(extra_column_data);
-        DCHECK_EQ(extra_column_data->columns().size(), 1);
-        auto* op_col = ColumnHelper::as_raw_column<Int8Column>(extra_column_data->columns()[0]);
-        DCHECK(op_col);
-        DCHECK_EQ(stream_chunk.num_rows(), op_col->size());
-        return op_col;
-    }
-
-    static Int8Column* ops_col(const StreamChunkPtr& stream_chunk_ptr) {
-        DCHECK(stream_chunk_ptr);
-        return ops_col(*stream_chunk_ptr);
-    }
-
-    static Int8Column* ops_col(StreamChunk* stream_chunk_ptr) {
-        DCHECK(stream_chunk_ptr);
-        return ops_col(*stream_chunk_ptr);
-    }
-
-    static const StreamRowOp* ops(const StreamChunk& stream_chunk) {
-        auto* op_col = ops_col(stream_chunk);
-        return (StreamRowOp*)(op_col->get_data().data());
-    }
-
-    static const StreamRowOp* ops(StreamChunk* stream_chunk) {
-        auto* op_col = ops_col(stream_chunk);
-        return (StreamRowOp*)(op_col->get_data().data());
-    }
-
-    static const StreamRowOp* ops(const StreamChunkPtr& stream_chunk) {
-        auto* op_col = ops_col(stream_chunk);
-        return (StreamRowOp*)(op_col->get_data().data());
-    }
+    static ChunkPtr to_chunk(const StreamChunkPtr& stream_chunk);
 };
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -94,7 +94,7 @@ public:
             std::string sort_keys, int64_t offset, int64_t limit, const TTopNType::type topn_type,
             const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
             const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc,
-            std::vector<ExprContext*> analytic_partition_exprs, RuntimeFilterHub* hub)
+            std::vector<ExprContext*> analytic_partition_exprs)
             : OperatorFactory(id, "local_sort_sink", plan_node_id),
               _sort_context_factory(std::move(std::move(sort_context_factory))),
               _sort_exec_exprs(sort_exec_exprs),
@@ -108,8 +108,7 @@ public:
               _materialized_tuple_desc(materialized_tuple_desc),
               _parent_node_row_desc(parent_node_row_desc),
               _parent_node_child_row_desc(parent_node_child_row_desc),
-              _analytic_partition_exprs(std::move(analytic_partition_exprs)),
-              _hub(hub) {}
+              _analytic_partition_exprs(std::move(analytic_partition_exprs)) {}
 
     ~PartitionSortSinkOperatorFactory() override = default;
 
@@ -137,7 +136,6 @@ private:
     const RowDescriptor& _parent_node_row_desc;
     const RowDescriptor& _parent_node_child_row_desc;
     std::vector<ExprContext*> _analytic_partition_exprs;
-    RuntimeFilterHub* _hub;
 };
 
 } // namespace pipeline

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -243,7 +243,6 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
                 _sort_exec_exprs.lhs_ordering_expr_ctxs(), _is_asc_order, _is_null_first, _build_runtime_filters);
     }
 
-    auto rf_hub = context->fragment_context()->runtime_filter_hub();
     // Create a shared RefCountedRuntimeFilterCollector
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
     OperatorFactoryPtr sink_operator;
@@ -257,7 +256,7 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
         sink_operator = std::make_shared<PartitionSortSinkOperatorFactory>(
                 context->next_operator_id(), id(), sort_context_factory, _sort_exec_exprs, _is_asc_order,
                 _is_null_first, _sort_keys, _offset, _limit, _tnode.sort_node.topn_type, _order_by_types,
-                _materialized_tuple_desc, child(0)->row_desc(), _row_descriptor, _analytic_partition_exprs, rf_hub);
+                _materialized_tuple_desc, child(0)->row_desc(), _row_descriptor, _analytic_partition_exprs);
     }
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(sink_operator.get(), context, rc_rf_probe_collector);

--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -103,8 +103,7 @@ Status DataStreamRecvr::create_merger_for_pipeline(RuntimeState* state, const So
                                                    const std::vector<bool>* is_null_first) {
     DCHECK(_is_merging);
     _chunks_merger = nullptr;
-    // TODO: set profile
-    _cascade_merger = std::make_unique<CascadeChunkMerger>(state, state->runtime_profile());
+    _cascade_merger = std::make_unique<CascadeChunkMerger>(state);
 
     std::vector<ChunkProvider> providers;
     for (SenderQueue* q : _sender_queues) {

--- a/be/src/runtime/sorted_chunks_merger.cpp
+++ b/be/src/runtime/sorted_chunks_merger.cpp
@@ -301,8 +301,7 @@ void SortedChunksMerger::collect_merged_chunks(ChunkPtr* chunk) {
     _row_number = 0;
 }
 
-CascadeChunkMerger::CascadeChunkMerger(RuntimeState* state, RuntimeProfile* profile)
-        : _state(state), _profile(profile), _sort_exprs(nullptr) {}
+CascadeChunkMerger::CascadeChunkMerger(RuntimeState* state) : _state(state), _sort_exprs(nullptr) {}
 
 Status CascadeChunkMerger::init(const std::vector<ChunkProvider>& providers,
                                 const std::vector<ExprContext*>* sort_exprs, const std::vector<bool>* sort_orders,

--- a/be/src/runtime/sorted_chunks_merger.h
+++ b/be/src/runtime/sorted_chunks_merger.h
@@ -96,7 +96,7 @@ private:
 // Merge sorted chunks in cascade style
 class CascadeChunkMerger {
 public:
-    CascadeChunkMerger(RuntimeState* state, RuntimeProfile* profile);
+    CascadeChunkMerger(RuntimeState* state);
     ~CascadeChunkMerger() = default;
 
     Status init(const std::vector<ChunkProvider>& has_suppliers, const std::vector<ExprContext*>* sort_exprs,
@@ -107,7 +107,6 @@ public:
 
 private:
     RuntimeState* _state;
-    RuntimeProfile* _profile;
 
     const std::vector<ExprContext*>* _sort_exprs;
     SortDescs _sort_desc;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -87,7 +87,6 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     size_t ndelvec = new_deletes.size();
     vector<std::pair<uint32_t, DelVectorPtr>> new_del_vecs(ndelvec);
     size_t idx = 0;
-    size_t old_total_del = 0;
     size_t new_del = 0;
     size_t total_del = 0;
     for (auto& new_delete : new_deletes) {
@@ -118,7 +117,6 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                         "v:$6",
                         tablet->id(), rssid, cur_old, cur_add, cur_new, old_del_vec->version(), metadata.version());
             }
-            old_total_del += cur_old;
             new_del += cur_add;
             total_del += cur_new;
         }


### PR DESCRIPTION
Signed-off-by: Kevin Li <ming.moriarty@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Fix build warnings with clang14
```
-- Build files have been written to: /home/disk1/lishuming/work/sr_dev/be/build_Release
[283/1000] Building CXX object src/exec/CMakeFiles/Exec.dir/pipeline/sort/partition_sort_sink_operator.cpp.o
In file included from ../src/exec/pipeline/sort/partition_sort_sink_operator.cpp:15:
../src/exec/pipeline/sort/partition_sort_sink_operator.h:140:23: warning: private field '_hub' is not used [-Wunused-private-field]
    RuntimeFilterHub* _hub;
                      ^
1 warning generated.
[658/1000] Building CXX object src/storage/CMakeFiles/Storage.dir/lake/update_manager.cpp.o
../src/storage/lake/update_manager.cpp:90:12: warning: variable 'old_total_del' set but not used [-Wunused-but-set-variable]
    size_t old_total_del = 0;
           ^
1 warning generated.
[723/1000] Building CXX object src/runtime/CMakeFiles/Runtime.dir/sorted_chunks_merger.cpp.o
In file included from ../src/runtime/sorted_chunks_merger.cpp:15:
../src/runtime/sorted_chunks_merger.h:110:21: warning: private field '_profile' is not used [-Wunused-private-field]
    RuntimeProfile* _profile;
                    ^
1 warning generated.
[1000/1000] Linking CXX executable ../output/lib/starrocks_be
```


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
