### PR TITLE
[Enhancement] Throw compile error when _GLIBCXX_USE_CXX11_ABI=0

### DIFF
--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -68,6 +68,10 @@
 #include "util/thrift_server.h"
 #include "util/uid_util.h"
 
+#if !_GLIBCXX_USE_CXX11_ABI
+#error _GLIBCXX_USE_CXX11_ABI must be non-zero
+#endif
+
 DECLARE_bool(s2debug);
 
 static void help(const char*);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
 Modifying `SinkBuffer::buffer `is protected by mutex, but getting size of buffer isn't protected to gain better performance. `std::list::size` before gcc5 traverses the whole list, which is not thread-safe.




## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
