### PR TITLE
[BugFix] unify Operator hashCode method

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalProjectOperator.java
@@ -65,7 +65,7 @@ public final class LogicalProjectOperator extends LogicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(opType, columnRefMap);
+        return Objects.hash(super.hashCode(), opType, columnRefMap);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalRepeatOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalRepeatOperator.java
@@ -105,7 +105,8 @@ public class LogicalRepeatOperator extends LogicalOperator {
 
         LogicalRepeatOperator that = (LogicalRepeatOperator) o;
         return Objects.equals(outputGrouping, that.outputGrouping) &&
-                Objects.equals(repeatColumnRefList, that.repeatColumnRefList);
+                Objects.equals(repeatColumnRefList, that.repeatColumnRefList) &&
+                Objects.equals(groupingIds, that.groupingIds);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
@@ -173,9 +173,9 @@ public class LogicalTopNOperator extends LogicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), partitionByColumns, partitionLimit, orderByElements, offset,
-                sortPhase, topNType, isSplit);
+        return Objects.hash(super.hashCode(), orderByElements, offset, sortPhase, topNType, isSplit);
     }
+
 
     public static Builder builder() {
         return new Builder();
@@ -204,6 +204,8 @@ public class LogicalTopNOperator extends LogicalOperator {
             this.sortPhase = topNOperator.sortPhase;
             this.topNType = topNOperator.topNType;
             this.isSplit = topNOperator.isSplit;
+            this.partitionLimit = topNOperator.partitionLimit;
+            this.partitionByColumns = topNOperator.partitionByColumns;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java
@@ -94,7 +94,7 @@ public class LogicalValuesOperator extends LogicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(columnRefSet);
+        return Objects.hashCode(super.hashCode(), columnRefSet);
     }
 
     public static class Builder extends LogicalOperator.Builder<LogicalValuesOperator, LogicalValuesOperator.Builder> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalProjectOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalProjectOperator.java
@@ -65,7 +65,7 @@ public class PhysicalProjectOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(columnRefMap, commonSubOperatorMap);
+        return Objects.hashCode(super.hashCode(), columnRefMap, commonSubOperatorMap);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSetOperation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSetOperation.java
@@ -72,6 +72,6 @@ public class PhysicalSetOperation extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(outputColumnRefOp);
+        return Objects.hashCode(super.hashCode(), outputColumnRefOp);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTableFunctionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTableFunctionOperator.java
@@ -102,6 +102,6 @@ public class PhysicalTableFunctionOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(fn, fnResultColumnRefSet);
+        return Objects.hashCode(super.hashCode(), fn, fnResultColumnRefSet);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -95,7 +95,7 @@ public class PhysicalTopNOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(sortPhase, orderSpec);
+        return Objects.hash(super.hashCode(), orderSpec, offset, sortPhase, topNType, isSplit);
     }
 
     @Override
@@ -110,7 +110,10 @@ public class PhysicalTopNOperator extends PhysicalOperator {
 
         PhysicalTopNOperator that = (PhysicalTopNOperator) o;
 
-        return sortPhase.equals(that.sortPhase) && orderSpec.equals(that.orderSpec);
+        return partitionLimit == that.partitionLimit && offset == that.offset && isSplit == that.isSplit &&
+                Objects.equals(partitionByColumns, that.partitionByColumns) &&
+                Objects.equals(orderSpec, that.orderSpec) &&
+                sortPhase == that.sortPhase && topNType == that.topNType;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalValuesOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalValuesOperator.java
@@ -77,7 +77,7 @@ public class PhysicalValuesOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(columnRefSet);
+        return Objects.hashCode(super.hashCode(), columnRefSet);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalWindowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalWindowOperator.java
@@ -107,7 +107,7 @@ public class PhysicalWindowOperator extends PhysicalOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(analyticCall);
+        return Objects.hash(super.hashCode(), analyticCall);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/OperatorEqualsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/OperatorEqualsTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.operator;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OperatorEqualsTest {
+
+    @Test
+    public void testTopNOperator() {
+        LogicalTopNOperator logicalA = LogicalTopNOperator.builder()
+                .setProjection(new Projection(Maps.newHashMap())).build();
+        LogicalTopNOperator logicalB = LogicalTopNOperator.builder().build();
+        Assert.assertNotEquals(logicalA.hashCode(), logicalB.hashCode());
+        Assert.assertNotEquals(logicalA, logicalB);
+
+        PhysicalTopNOperator physicalA = new PhysicalTopNOperator(null, 10, 10, null,
+                0, null, null, true, true, null, null);
+        PhysicalTopNOperator physicalB = new PhysicalTopNOperator(null, 10, 10, null,
+                0, null, null, true, true,
+                null, new Projection(Maps.newHashMap()));
+        Assert.assertNotEquals(physicalA.hashCode(), physicalB.hashCode());
+        Assert.assertNotEquals(physicalA, physicalB);
+    }
+
+    @Test
+    public void testUnionOperator() {
+        LogicalUnionOperator logicalA = LogicalUnionOperator.builder()
+                .setProjection(new Projection(Maps.newHashMap())).build();
+        LogicalUnionOperator logicalB = LogicalUnionOperator.builder().build();
+        Assert.assertNotEquals(logicalA.hashCode(), logicalB.hashCode());
+        Assert.assertNotEquals(logicalA, logicalB);
+
+        PhysicalUnionOperator physicalA = new PhysicalUnionOperator(null, null, true,
+                10, new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ,
+                        Lists.newArrayList(
+                                ConstantOperator.createBoolean(true),
+                                ConstantOperator.createBoolean(false)
+                        )), null);
+
+        PhysicalUnionOperator physicalB = new PhysicalUnionOperator(null, null, true,
+                10, null, null);
+
+        Assert.assertNotEquals(physicalA.hashCode(), physicalB.hashCode());
+        Assert.assertNotEquals(physicalA, physicalB);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2736,4 +2736,16 @@ public class JoinTest extends PlanTestBase {
                 "subv0 on t0.v1 = subv0.k1;";
         getFragmentPlan(sql);
     }
+
+    @Test
+    public void testTopNGroupMerge() throws Exception {
+        String sql = "with tmp1 as (select * from t0 order by v1 asc), tmp2 as (select v4 from t1 group by v4)" +
+                "select count(*) from t0, tmp2, tmp1, t1 " +
+                "where 1 in (select v4 from t1);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "21:NESTLOOP JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  other join predicates: 19: v4 = 1");
+    }
 }


### PR DESCRIPTION
Signed-off-by: packy <wangchao@starrocks.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Like this pr #17166 , unify hashCode method helps reduce the time cost when get OptExpression from map.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
