### PR TITLE
[BugFix] fix refresh hive metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
@@ -148,7 +148,8 @@ public class CacheUpdateProcessor {
             List<RemotePathKey> presentPathKey = remoteFileIO.get().getPresentPathKeyInCache(tableLocation, isRecursive);
             List<Future<?>> futures = Lists.newArrayList();
             presentPathKey.forEach(pathKey -> {
-                if (operator == Operator.UPDATE && existPaths.contains(pathKey.getPath())) {
+                String pathWithSlash = pathKey.getPath().endsWith("/") ? pathKey.getPath() : pathKey.getPath() + "/";
+                if (operator == Operator.UPDATE && existPaths.contains(pathWithSlash)) {
                     futures.add(executor.submit(() -> remoteFileIO.get().updateRemoteFiles(pathKey)));
                 } else {
                     futures.add(executor.submit(() -> remoteFileIO.get().invalidatePartition(pathKey)));


### PR DESCRIPTION
Signed-off-by: stephen <stephen5217@163.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
This currently results contents of cache will be clears, which is equivalent to invalidate cache. So we need to add "/" at path of PathKey to check if this partition path need to refresh.  

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
