### PR TITLE
[BugFix] Fix invalid compaction when tablet not in running state 

### DIFF
--- a/be/src/storage/default_compaction_policy.cpp
+++ b/be/src/storage/default_compaction_policy.cpp
@@ -24,6 +24,10 @@
 namespace starrocks {
 
 bool DefaultCumulativeBaseCompactionPolicy::need_compaction(double* score, CompactionType* type) {
+    if (_tablet->tablet_state() != TABLET_RUNNING) {
+        return false;
+    }
+
     _tablet->calculate_cumulative_point();
     auto cumu_st = _pick_rowsets_to_cumulative_compact(&_cumulative_rowsets, &_cumulative_score);
     auto base_st = _pick_rowsets_to_base_compact(&_base_rowsets, &_base_score);

--- a/be/src/storage/size_tiered_compaction_policy.cpp
+++ b/be/src/storage/size_tiered_compaction_policy.cpp
@@ -29,6 +29,10 @@ SizeTieredCompactionPolicy::SizeTieredCompactionPolicy(Tablet* tablet) : _tablet
 }
 
 bool SizeTieredCompactionPolicy::need_compaction(double* score, CompactionType* type) {
+    if (_tablet->tablet_state() != TABLET_RUNNING) {
+        return false;
+    }
+
     bool force_base_compaction = false;
     if (type && *type == BASE_COMPACTION) {
         force_base_compaction = true;

--- a/be/test/storage/default_compaction_policy_test.cpp
+++ b/be/test/storage/default_compaction_policy_test.cpp
@@ -354,6 +354,42 @@ TEST_F(DefaultCompactionPolicyTest, test_max_cumulative_compaction) {
     ASSERT_EQ(5, versions[1].second);
 }
 
+TEST_F(DefaultCompactionPolicyTest, test_tablet_not_running) {
+    LOG(INFO) << "test_tablet_not_running";
+    create_tablet_schema(UNIQUE_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    for (int i = 0; i < 6; ++i) {
+        write_new_version(tablet_meta);
+    }
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    tablet->set_tablet_state(TABLET_NOTREADY);
+    init_compaction_context(tablet);
+
+    auto res = compact(tablet);
+    ASSERT_FALSE(res.ok());
+
+    tablet->set_tablet_state(TABLET_RUNNING);
+
+    res = compact(tablet);
+    ASSERT_TRUE(res.ok());
+
+    ASSERT_EQ(2, tablet->version_count());
+    ASSERT_EQ(5, tablet->cumulative_layer_point());
+    std::vector<Version> versions;
+    tablet->list_versions(&versions);
+    ASSERT_EQ(2, versions.size());
+    ASSERT_EQ(0, versions[0].first);
+    ASSERT_EQ(4, versions[0].second);
+    ASSERT_EQ(5, versions[1].first);
+    ASSERT_EQ(5, versions[1].second);
+}
+
 TEST_F(DefaultCompactionPolicyTest, test_missed_first_version) {
     LOG(INFO) << "test_missed_first_version";
     create_tablet_schema(UNIQUE_KEYS);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17280

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The new compaction framework splits compaction into two phases: strategy selection and execution. Currently, only the execution phase judges the tablet status, while the selection phase does not.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
