### PR TITLE
[BugFix] Fix partition prune null predicate error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
@@ -215,6 +215,10 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
         return this instanceof NullLiteral;
     }
 
+    public boolean isConstantNull() {
+        return this instanceof NullLiteral;
+    }
+
     @Override
     public int compareTo(LiteralExpr o) {
         return compareLiteral(o);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPredicatePrune.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPredicatePrune.java
@@ -116,8 +116,9 @@ public class PartitionPredicatePrune extends TransformationRule {
                 continue;
             }
 
-            // None bound predicate can't prune
-            if (null == pcf.lowerBound && null == pcf.upperBound) {
+            // None/Null bound predicate can't prune
+            if ((null == pcf.lowerBound || pcf.lowerBound.isConstantNull()) &&
+                    (null == pcf.upperBound || pcf.upperBound.isConstantNull())) {
                 continue;
             }
 


### PR DESCRIPTION
Signed-off-by: Seaven <seaven_7@qq.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/17204

![image](https://user-images.githubusercontent.com/5609319/216340921-6b8f4264-19ae-4de8-be16-15bff3480b86.png)

invaild predicate can't pruned

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
