### PR TITLE
[BugFix] Fix unused DCHECK in DictMappingExpr

### DIFF
--- a/be/src/exprs/dictmapping_expr.cpp
+++ b/be/src/exprs/dictmapping_expr.cpp
@@ -18,6 +18,7 @@ namespace starrocks {
 DictMappingExpr::DictMappingExpr(const TExprNode& node) : Expr(node, false) {}
 
 StatusOr<ColumnPtr> DictMappingExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
+    // TODO: record rewrite info in ExprContext
     // If dict_func_expr is nullptr, then it means that this DictExpr has not been rewritten.
     // But in some cases we need to evaluate the original expression directly
     // (usually column_expr_predicate).

--- a/be/src/exprs/dictmapping_expr.h
+++ b/be/src/exprs/dictmapping_expr.h
@@ -56,15 +56,11 @@ public:
     }
 
     SlotId slot_id() {
-        DCHECK(dict_func_expr == nullptr);
         DCHECK_EQ(children().size(), 2);
         return down_cast<const ColumnRef*>(get_child(0))->slot_id();
     }
 
-    int get_slot_ids(std::vector<SlotId>* slot_ids) const override {
-        DCHECK(dict_func_expr == nullptr);
-        return get_child(1)->get_slot_ids(slot_ids);
-    }
+    int get_slot_ids(std::vector<SlotId>* slot_ids) const override { return get_child(1)->get_slot_ids(slot_ids); }
 
 private:
     std::shared_ptr<std::once_flag> _rewrite_once_flag = std::make_shared<std::once_flag>();

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -302,7 +302,7 @@ StatusOr<bool> ColumnPredicateRewriter::_rewrite_expr_predicate(ObjectPool* pool
     size_t value_size = raw_dict_column->size();
     std::vector<uint8_t> selection(value_size);
     const auto* pred = down_cast<const ColumnExprPredicate*>(raw_pred);
-    pred->evaluate(raw_dict_column.get(), selection.data(), 0, value_size);
+    RETURN_IF_ERROR(pred->evaluate(raw_dict_column.get(), selection.data(), 0, value_size));
 
     size_t code_size = raw_code_column->size();
     const auto& code_column = ColumnHelper::cast_to<TYPE_INT>(raw_code_column);

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1271,7 +1271,7 @@ Status SegmentIterator::_rewrite_predicates() {
     //
     ColumnPredicateRewriter rewriter(_column_iterators, _opts.predicates, _schema, _predicate_need_rewrite,
                                      _predicate_columns, _scan_range);
-    rewriter.rewrite_predicate(&_obj_pool);
+    RETURN_IF_ERROR(rewriter.rewrite_predicate(&_obj_pool));
 
     // for each delete predicate,
     // If the global dictionary optimization is enabled for the column,
@@ -1286,7 +1286,7 @@ Status SegmentIterator::_rewrite_predicates() {
 
     for (auto& conjunct_predicate : _opts.delete_predicates.predicate_list()) {
         ConjunctivePredicatesRewriter crewriter(conjunct_predicate, *_opts.global_dictmaps, &disable_dict_rewrites);
-        crewriter.rewrite_predicate(&_obj_pool);
+        RETURN_IF_ERROR(crewriter.rewrite_predicate(&_obj_pool));
     }
 
     return Status::OK();


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1833

## Problem Summary(Required) ：
when we enable tablet inner parallel scan. olap-scan-prepare-operator may execute multi times. and they share the same conjunct_ctxs 
```
    _conjunct_ctxs = _scan_node->conjunct_ctxs();
    ...
    // Parse conjuncts via _conjuncts_manager.
    RETURN_IF_ERROR(cm.parse_conjuncts(true, max_scan_key_num, enable_column_expr_predicate));

    // Get key_ranges and not_push_down_conjuncts from _conjuncts_manager.
    RETURN_IF_ERROR(_conjuncts_manager.get_key_ranges(&_key_ranges));
    _conjuncts_manager.get_not_push_down_conjuncts(&_not_push_down_conjuncts);

    _dict_optimize_parser.set_mutable_dict_maps(state, state->mutable_query_global_dict_map());
    RETURN_IF_ERROR(_dict_optimize_parser.rewrite_conjuncts(&_not_push_down_conjuncts, state));
```
when we rewrite the conjuncts. if we call slot_id in next time, DCHECK will failed.

but it's safe to call parse_conjuncts when we rewrite the conjuncts. so we could remove it

Signed-off-by: stdpain <drfeng08@gmail.com>

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
  - [ ] 2.2
