### PR TITLE
[BugFix] Fix auth upgrade failure on follower when replaying log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1252,7 +1252,7 @@ public class GlobalStateMgr {
         if (feType == FrontendNodeType.OBSERVER || feType == FrontendNodeType.FOLLOWER) {
             Preconditions.checkState(newType == FrontendNodeType.UNKNOWN);
             LOG.warn("{} to UNKNOWN, still offer read service", feType.name());
-            // not set canRead here, leave canRead as what is was.
+            // not set canRead here, leave canRead as what it was.
             // if meta out of date, canRead will be set to false in replayer thread.
             metaReplayState.setTransferToUnknown();
             feType = newType;
@@ -3537,12 +3537,14 @@ public class GlobalStateMgr {
     }
 
     public void replayAuthUpgrade(AuthUpgradeInfo info) throws AuthUpgrader.AuthUpgradeUnrecoverableException {
-        AuthUpgrader upgrader = new AuthUpgrader(auth, authenticationManager, privilegeManager, this);
-        upgrader.replayUpgrade(info.getRoleNameToId());
-        usingNewPrivilege.set(true);
-        domainResolver.setAuthenticationManager(authenticationManager);
-        if (!isCheckpointThread()) {
-            this.auth = null;
+        if (GlobalStateMgr.getCurrentState().needUpgradedToNewPrivilege()) {
+            AuthUpgrader upgrader = new AuthUpgrader(auth, authenticationManager, privilegeManager, this);
+            upgrader.replayUpgrade(info.getRoleNameToId());
+            usingNewPrivilege.set(true);
+            domainResolver.setAuthenticationManager(authenticationManager);
+            if (!isCheckpointThread()) {
+                this.auth = null;
+            }
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17300 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
FE may generate multiple auth upgrade logs in the upgrade process,
we only need to handle the upgrade log once.

Signed-off-by: Dejun Xia <xiadejun@starrocks.com>

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
