### PR TITLE
[Enhancement] add PeakMemoryUsage for LocalExchangeSinkOperator

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -80,6 +80,8 @@ public:
 
     int32_t incr_epoch_finished_sinker() { return ++_epoch_finished_sinker; }
 
+    size_t get_memory_usage() const { return _memory_manager->get_memory_usage(); }
+
 protected:
     const std::string _name;
     std::shared_ptr<LocalExchangeMemoryManager> _memory_manager;

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -38,6 +38,8 @@ public:
 
     size_t get_memory_limit_per_driver() const { return _max_memory_usage_per_driver; }
 
+    size_t get_memory_usage() const { return _memory_usage; }
+
     bool is_full() const { return _memory_usage >= _max_memory_usage; }
 
 private:

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -24,6 +24,8 @@ Status LocalExchangeSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     _exchanger->incr_sinker();
     _unique_metrics->add_info_string("ShuffleNum", std::to_string(_exchanger->source_dop()));
+    _peak_memory_usage_counter = _common_metrics->AddHighWaterMarkCounter(
+            "PeakMemoryUsage", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
     return Status::OK();
 }
 
@@ -42,7 +44,9 @@ Status LocalExchangeSinkOperator::set_finishing(RuntimeState* state) {
 }
 
 Status LocalExchangeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-    return _exchanger->accept(chunk, _driver_sequence);
+    auto res = _exchanger->accept(chunk, _driver_sequence);
+    _peak_memory_usage_counter->set(_exchanger->get_memory_usage());
+    return res;
 }
 
 /// LocalExchangeSinkOperatorFactory.

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -24,8 +24,8 @@ Status LocalExchangeSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     _exchanger->incr_sinker();
     _unique_metrics->add_info_string("ShuffleNum", std::to_string(_exchanger->source_dop()));
-    _peak_memory_usage_counter = _common_metrics->AddHighWaterMarkCounter(
-            "PeakMemoryUsage", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
+    _peak_memory_usage_counter = _unique_metrics->AddHighWaterMarkCounter(
+            "LocalExchangePeakMemoryUsage", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
@@ -65,7 +65,7 @@ public:
 private:
     bool _is_finished = false;
     const std::shared_ptr<LocalExchanger>& _exchanger;
-
+    RuntimeProfile::HighWaterMarkCounter* _peak_memory_usage_counter = nullptr;
     // STREAM MV
     bool _is_epoch_finished = false;
 };


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # 
add PeakMemoryUsage for LocalExchangeSinkOperator


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

add PeakMemoryUsage for LocalExchangeSinkOperator

local_exchange_buffer_mem_limit_per_driver = 128MB

![image](https://user-images.githubusercontent.com/6490813/216547569-bb9bcda0-97dd-43b8-a1a8-8d157c35d4ce.png)

local_exchange_buffer_mem_limit_per_driver = 1KB
![image](https://user-images.githubusercontent.com/6490813/216549703-7b5b06f9-9455-4961-8e51-df99a531a313.png)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
