### PR TITLE
[BugFix] Support concrete scalar types as return column types of polymorphic TVFs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -351,6 +351,7 @@ public class PolymorphicFunctionAnalyzer {
                     realTableFnRetTypes.add(typeElement);
                 } else {
                     assert !retType.isPseudoType();
+                    realTableFnRetTypes.add(t);
                 }
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.FunctionName;
 import org.junit.Assert;
 import org.junit.Before;
@@ -242,4 +243,29 @@ public class FunctionSetTest {
         Assert.assertEquals(Type.INT, fn.getReturnType());
         Assert.assertEquals(new ArrayType(Type.NULL), fn.getArgs()[0]);
     }
+
+    @Test
+    public void testPolymorphicTVF() {
+        // First two columns of the result are polymorphic (derived from argument type), but the last argument is of a
+        // "concrete" type BIGINT, which is retained in the resolved function.
+        TableFunction polymorphicTVF =
+                new TableFunction(new FunctionName("three_column_tvf"), Lists.newArrayList("a", "b", "c"),
+                        Lists.newArrayList(Type.ANY_ARRAY),
+                        Lists.newArrayList(Type.ANY_ELEMENT, Type.ANY_ELEMENT, Type.BIGINT));
+
+        functionSet.addBuiltin(polymorphicTVF);
+
+
+        Type[] argTypes = new Type[] {VARCHAR_ARRAY};
+        Function desc = new Function(new FunctionName("three_column_tvf"), argTypes, Type.INVALID, false);
+        Function fn = functionSet.getFunction(desc, Function.CompareMode.IS_IDENTICAL);
+        Assert.assertNotNull(fn);
+        Assert.assertTrue(fn instanceof TableFunction);
+        TableFunction tableFunction = (TableFunction) fn;
+        Assert.assertEquals(3, tableFunction.getTableFnReturnTypes().size());
+        Assert.assertEquals(Type.VARCHAR, tableFunction.getTableFnReturnTypes().get(0));
+        Assert.assertEquals(Type.VARCHAR, tableFunction.getTableFnReturnTypes().get(1));
+        Assert.assertEquals(Type.BIGINT, tableFunction.getTableFnReturnTypes().get(2));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
@@ -283,5 +283,4 @@ public class FunctionSetTest {
         Assert.assertEquals(Type.BIGINT, tableFunction.getTableFnReturnTypes().get(0));
         Assert.assertEquals(Type.VARCHAR, tableFunction.getTableFnReturnTypes().get(1));
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
@@ -255,7 +255,6 @@ public class FunctionSetTest {
 
         functionSet.addBuiltin(polymorphicTVF);
 
-
         Type[] argTypes = new Type[] {VARCHAR_ARRAY};
         Function desc = new Function(new FunctionName("three_column_tvf"), argTypes, Type.INVALID, false);
         Function fn = functionSet.getFunction(desc, Function.CompareMode.IS_IDENTICAL);
@@ -266,6 +265,23 @@ public class FunctionSetTest {
         Assert.assertEquals(Type.VARCHAR, tableFunction.getTableFnReturnTypes().get(0));
         Assert.assertEquals(Type.VARCHAR, tableFunction.getTableFnReturnTypes().get(1));
         Assert.assertEquals(Type.BIGINT, tableFunction.getTableFnReturnTypes().get(2));
+
+        // Same but for two column TVF.
+        TableFunction twoColumnTVF =
+                new TableFunction(new FunctionName("two_column_tvf"), Lists.newArrayList("a", "b"),
+                        Lists.newArrayList(Type.ANY_ARRAY),
+                        Lists.newArrayList(Type.BIGINT, Type.ANY_ELEMENT));
+        functionSet.addBuiltin(twoColumnTVF);
+
+        argTypes = new Type[] {VARCHAR_ARRAY};
+        desc = new Function(new FunctionName("two_column_tvf"), argTypes, Type.INVALID, false);
+        fn = functionSet.getFunction(desc, Function.CompareMode.IS_IDENTICAL);
+        Assert.assertNotNull(fn);
+        Assert.assertTrue(fn instanceof TableFunction);
+        tableFunction = (TableFunction) fn;
+        Assert.assertEquals(2, tableFunction.getTableFnReturnTypes().size());
+        Assert.assertEquals(Type.BIGINT, tableFunction.getTableFnReturnTypes().get(0));
+        Assert.assertEquals(Type.VARCHAR, tableFunction.getTableFnReturnTypes().get(1));
     }
 
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

IF the TVF is declared as returning both polymorphic column types and concrete types, the concrete types right now are dropped when resolving the type.
For example:

FUNC(ANY_ARRAY) -> <ANY_ELEMENT, BIGINT> is the template,

and the invocation is 
FUNC(ARRAY_VARCHAR).

During resolution, we correctly resolve ANY_ELEMENT as VARCHAR, but we also want to retain BIGINT as one of the return columns.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
