### PR TITLE
[Enhancement] avoid build slice cache in BinaryColumn

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -37,6 +37,17 @@ public:
 
     using Container = Buffer<Slice>;
 
+    struct BinaryDataProxyContainer {
+        BinaryDataProxyContainer(const BinaryColumnBase& column) : _column(column) {}
+
+        Slice operator[](size_t index) const { return _column.get_slice(index); }
+
+        size_t size() { return _column.size(); }
+
+    private:
+        const BinaryColumnBase& _column;
+    };
+
     // TODO(kks): when we create our own vector, we could let vector[-1] = 0,
     // and then we don't need explicitly emplace_back zero value
     BinaryColumnBase<T>() { _offsets.emplace_back(0); }
@@ -262,6 +273,8 @@ public:
         return _slices;
     }
 
+    const BinaryDataProxyContainer& get_proxy_data() const { return _immuable_container; }
+
     Bytes& get_bytes() { return _bytes; }
 
     const Bytes& get_bytes() const { return _bytes; }
@@ -332,6 +345,7 @@ private:
 
     mutable Container _slices;
     mutable bool _slices_cache = false;
+    BinaryDataProxyContainer _immuable_container = BinaryDataProxyContainer(*this);
 };
 
 using Offsets = BinaryColumnBase<uint32_t>::Offsets;

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -174,7 +174,7 @@ public:
 
     Status do_visit(BinaryColumn* column) {
         auto col = down_cast<BinaryColumn*>(_column);
-        auto& slices = col->get_data();
+        auto& slices = col->get_proxy_data();
         std::vector<Slice> datas(_sel_mask.size());
         size_t offsets = 0;
 

--- a/be/src/exec/sorting/merge_column.cpp
+++ b/be/src/exec/sorting/merge_column.cpp
@@ -171,9 +171,9 @@ public:
     template <typename SizeT>
     Status do_visit(const BinaryColumnBase<SizeT>& _) {
         using ColumnType = const BinaryColumnBase<SizeT>;
-        using Container = typename ColumnType::Container;
-        auto& left_data = down_cast<ColumnType*>(_left_col)->get_data();
-        auto& right_data = down_cast<ColumnType*>(_right_col)->get_data();
+        using Container = typename BinaryColumnBase<SizeT>::BinaryDataProxyContainer;
+        auto& left_data = down_cast<const ColumnType*>(_left_col)->get_proxy_data();
+        auto& right_data = down_cast<const ColumnType*>(_right_col)->get_proxy_data();
         return merge_ordinary_column<Container, Slice>(left_data, right_data);
     }
 

--- a/be/src/exec/sorting/sort_column.cpp
+++ b/be/src/exec/sorting/sort_column.cpp
@@ -101,7 +101,7 @@ public:
             return lhs.inline_value.compare(rhs.inline_value);
         };
 
-        auto inlined = create_inline_permutation<Slice>(_permutation, column.get_data());
+        auto inlined = create_inline_permutation<Slice>(_permutation, column.get_proxy_data());
         RETURN_IF_ERROR(
                 sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), inlined, _tie, cmp, _range, _build_tie));
         restore_inline_permutation(inlined, _permutation);

--- a/be/src/exec/sorting/sort_permute.cpp
+++ b/be/src/exec/sorting/sort_permute.cpp
@@ -187,10 +187,10 @@ public:
 
     template <typename T>
     Status do_visit(BinaryColumnBase<T>* dst) {
-        using Container = typename BinaryColumnBase<T>::Container;
+        using Container = typename BinaryColumnBase<T>::BinaryDataProxyContainer;
         std::vector<const Container*> srcs;
         for (auto& column : _columns) {
-            srcs.push_back(&(down_cast<const BinaryColumnBase<T>*>(column.get())->get_data()));
+            srcs.push_back(&(down_cast<const BinaryColumnBase<T>*>(column.get())->get_proxy_data()));
         }
 
         auto& offsets = dst->get_offset();

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -1465,7 +1465,7 @@ StatusOr<ColumnPtr> StringFunctions::append_trailing_char_if_absent(FunctionCont
 
         auto* const_tailing = ColumnHelper::as_raw_column<ConstColumn>(columns[1]);
         auto tailing_col = ColumnHelper::cast_to<TYPE_VARCHAR>(const_tailing->data_column());
-        const Slice& slice = tailing_col->get_data()[0];
+        const Slice& slice = tailing_col->get_slice(0);
         if (slice.size != 1) {
             return ColumnHelper::create_const_null_column(columns[0]->size());
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

BinaryColumn::get_data() will build slice cache. we don't have to build slice cache in most case

benchmark case:
baseline(665702d31378c71554f8da7b42f0c38b7d051183):
data prepare: SSB100G 1FE 1BE DOP=52  core=104
```
 CREATE TABLE `lineorder_varchar` (
  `lo_orderkey` varchar(50) NOT NULL COMMENT "",
  `lo_linenumber` varchar(50) NOT NULL COMMENT "",
  `lo_custkey` varchar(50) NOT NULL COMMENT "",
  `lo_partkey` varchar(50) NOT NULL COMMENT "",
  `lo_suppkey` varchar(50) NOT NULL COMMENT "",
  `lo_orderdate` varchar(50) NOT NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`lo_orderkey`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "DEFAULT",
"enable_persistent_index" = "false",
"replicated_storage" = "false",
"compression" = "LZ4"
);
insert into lineorder_varchar select  `lo_orderkey`, `lo_linenumber`, `lo_custkey`, `lo_partkey`, `lo_suppkey` `lo_orderdate` from lineorder;
```
TEST SQL:
```
select lo_orderkey,     lo_linenumber,     lo_custkey,     row_number()  over (partition by lo_partkey)  from lineorder_varchar limit 10
```

baseline:
```
  - Total: 31s213ms
     - Query Type: Query
     - Query State: EOF
     - StarRocks Version: UNKNOWN-cb89311ec7
     - User: root
     - Default Db: ssb
     - Sql Statement: select lo_orderkey,     lo_linenumber,     lo_custkey,     row_number()  over (partition by lo_partkey)  from lineorder_varchar limit 10
     - QueryCpuCost: 20m36s
     - QueryMemCost: 170.367GB

```
```
  - Total: 19s59ms
     - Query Type: Query
     - Query State: EOF
     - StarRocks Version: UNKNOWN-cb89311ec7
     - User: root
     - Default Db: ssb
     - Sql Statement: select lo_orderkey,     lo_linenumber,     lo_custkey,     row_number()  over (partition by lo_partkey)  from lineorder_varchar limit 10
     - QueryCpuCost: 13m
     - QueryMemCost: 81.884GB
```

Signed-off-by: stdpain <drfeng08@gmail.com>

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
