### PR TITLE
[BugFix] replace comment to a space when remove it

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -175,7 +175,10 @@ public class SqlParser {
                     inComment = false;
                     i++;
                 }
-
+                // We should replace the comment to a space when we remove it. If not, sql like
+                // "select * from-- comments
+                // t1" will transform to wrong sql like "select * fromt1"
+                sb.append(" ");
                 continue;
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -2,7 +2,6 @@
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.analysis.CompoundPredicate;
-import com.starrocks.common.Config;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SqlModeHelper;
@@ -569,5 +568,15 @@ public class AnalyzeSingleTest {
         String sql = "select * from test.t0 [_META_]";
         QueryStatement queryStatement = (QueryStatement) analyzeSuccess(sql);
         Assert.assertTrue(((TableRelation) ((SelectRelation) queryStatement.getQueryRelation()).getRelation()).isMetaQuery());
+    }
+
+    @Test
+    public void testRemoveComment() {
+        analyzeSuccess("select * from-- comment\n" + "test.t0");
+        analyzeSuccess("select * from/*comment*/test.t0");
+
+        analyzeFail("select * fro-- comment\nm test.t0");
+        analyzeFail("select * fro/*comment*/m test.t0");
+
     }
 }


### PR DESCRIPTION
Signed-off-by: packy <wangchao@starrocks.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We should replace the comment to a space when we remove it. If not, sql like
```
select * from-- comments
t1
```

will transform to wrong sql like 
```
select * fromt1
```

The 2.5 or latest version use new parser to process the comment and don't have this problem.
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
