### PR TITLE
[BugFix][cherry-pick] Fix partition prune null predicate error (#17269)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
@@ -197,6 +197,10 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
         return this instanceof NullLiteral;
     }
 
+    public boolean isConstantNull() {
+        return this instanceof NullLiteral;
+    }
+
     @Override
     public int compareTo(LiteralExpr o) {
         return compareLiteral(o);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPredicatePrune.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPredicatePrune.java
@@ -103,8 +103,9 @@ public class PartitionPredicatePrune extends TransformationRule {
                 continue;
             }
 
-            // None bound predicate can't prune
-            if (null == pcf.lowerBound && null == pcf.upperBound) {
+            // None/Null bound predicate can't prune
+            if ((null == pcf.lowerBound || pcf.lowerBound.isConstantNull()) &&
+                    (null == pcf.upperBound || pcf.upperBound.isConstantNull())) {
                 continue;
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1767,4 +1767,25 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "     rollup: lineitem_partition\n" +
                 "     tabletRatio=1");
     }
+
+    @Test
+    public void testPruneInvalidPredicate() throws Exception {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable table2 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem_partition");
+        setTableStatistics(table2, 10);
+
+        new MockUp<LocalTablet>() {
+            @Mock
+            public long getRowCount(long version) {
+                return 10;
+            }
+        };
+
+        String sql = "select * from lineitem_partition where L_SHIPDATE > cast(true as date)";
+        String plan = getFragmentPlan(sql);
+
+        assertContains(plan, "TABLE: lineitem_partition\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 11: L_SHIPDATE > CAST(TRUE AS DATE)");
+    }
 }


### PR DESCRIPTION
Signed-off-by: Seaven <seaven_7@qq.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
