### PR TITLE
[BugFix] Fix the problem of slow show frontends when the Kubernetes pod restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -23,7 +23,6 @@ package com.starrocks.ha;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.sleepycat.bind.tuple.TupleBinding;
 import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseEntry;
@@ -70,11 +69,6 @@ public class BDBHA implements HAProtocol {
     public BDBHA(BDBEnvironment env, String nodeName) {
         this.environment = env;
         this.nodeName = nodeName;
-    }
-
-    @Override
-    public long getEpochNumber() {
-        return 0;
     }
 
     @Override
@@ -127,6 +121,15 @@ public class BDBHA implements HAProtocol {
     }
 
     @Override
+    public InetSocketAddress getLeader() {
+        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
+        String leaderName = replicationGroupAdmin.getMasterNodeName();
+        ReplicationGroup rg = replicationGroupAdmin.getGroup();
+        ReplicationNode rn = rg.getMember(leaderName);
+        return rn.getSocketAddress();
+    }
+
+    @Override
     public List<InetSocketAddress> getObserverNodes() {
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
         if (replicationGroupAdmin == null) {
@@ -171,46 +174,6 @@ public class BDBHA implements HAProtocol {
     }
 
     @Override
-    public InetSocketAddress getLeader() {
-        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
-        String leaderName = replicationGroupAdmin.getMasterNodeName();
-        ReplicationGroup rg = replicationGroupAdmin.getGroup();
-        ReplicationNode rn = rg.getMember(leaderName);
-        return rn.getSocketAddress();
-    }
-
-    @Override
-    public List<InetSocketAddress> getNoneLeaderNodes() {
-        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
-        if (replicationGroupAdmin == null) {
-            return null;
-        }
-        List<InetSocketAddress> ret = new ArrayList<InetSocketAddress>();
-        try {
-            ReplicationGroup replicationGroup = replicationGroupAdmin.getGroup();
-            for (ReplicationNode replicationNode : replicationGroup.getSecondaryNodes()) {
-                ret.add(replicationNode.getSocketAddress());
-            }
-            for (ReplicationNode replicationNode : replicationGroup.getElectableNodes()) {
-                if (!replicationNode.getName().equals(replicationGroupAdmin.getMasterNodeName())) {
-                    ret.add(replicationNode.getSocketAddress());
-                }
-            }
-        } catch (UnknownMasterException e) {
-            LOG.warn("Catch UnknownMasterException when calling getNoneLeaderNodes.", e);
-            return null;
-        }
-        return ret;
-    }
-
-    @Override
-    public boolean isLeader() {
-        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
-        String leaderName = replicationGroupAdmin.getMasterNodeName();
-        return leaderName.equals(nodeName);
-    }
-
-    @Override
     public boolean removeElectableNode(String nodeName) {
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
         if (replicationGroupAdmin == null) {
@@ -226,35 +189,6 @@ public class BDBHA implements HAProtocol {
             return false;
         }
         return true;
-    }
-
-    // When new Follower FE is added to the cluster, it should also be added to the helper sockets in
-    // ReplicationGroupAdmin, in order to fix the following case:
-    // 1. A Observer starts with helper of master FE.
-    // 2. Master FE is dead, new Master is elected.
-    // 3. Observer's helper sockets only contains the info of the dead master FE.
-    //    So when you try to get frontends' info from this Observer, it will throw the Exception:
-    //    "Could not determine master from helpers at:[/dead master FE host:port]"
-    public void addHelperSocket(String ip, Integer port) {
-        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
-        Set<InetSocketAddress> helperSockets = Sets.newHashSet(replicationGroupAdmin.getHelperSockets());
-        InetSocketAddress newHelperSocket = new InetSocketAddress(ip, port);
-        if (!helperSockets.contains(newHelperSocket)) {
-            helperSockets.add(newHelperSocket);
-            environment.setNewReplicationGroupAdmin(helperSockets);
-            LOG.info("add {}:{} to helper sockets", ip, port);
-        }
-    }
-
-    public void removeHelperSocket(String ip, Integer port) {
-        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
-        Set<InetSocketAddress> helperSockets = Sets.newHashSet(replicationGroupAdmin.getHelperSockets());
-        InetSocketAddress targetAddress = new InetSocketAddress(ip, port);
-        if (helperSockets.contains(targetAddress)) {
-            helperSockets.remove(targetAddress);
-            environment.setNewReplicationGroupAdmin(helperSockets);
-            LOG.info("remove helper socket {}:{} from replicationGroupAdmin", ip, port);
-        }
     }
 
     public void removeNodeIfExist(String host, int port, String excludeNodeName) {

--- a/fe/fe-core/src/main/java/com/starrocks/ha/HAProtocol.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/HAProtocol.java
@@ -21,27 +21,17 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 public interface HAProtocol {
-    // get current epoch number
-    public long getEpochNumber();
-
     // increase epoch number by one
-    public boolean fencing();
+    boolean fencing();
+
+    InetSocketAddress getLeader();
 
     // get observer nodes in the current group
-    public List<InetSocketAddress> getObserverNodes();
+    List<InetSocketAddress> getObserverNodes();
 
     // get replica nodes in the current group
-    public List<InetSocketAddress> getElectableNodes(boolean leaderIncluded);
-
-    // get the leader of current group
-    public InetSocketAddress getLeader();
-
-    // get all the nodes except leader in the current group
-    public List<InetSocketAddress> getNoneLeaderNodes();
-
-    // check if the current node is leader
-    public boolean isLeader();
+    List<InetSocketAddress> getElectableNodes(boolean leaderIncluded);
 
     // remove a node from the group
-    public boolean removeElectableNode(String nodeName);
+    boolean removeElectableNode(String nodeName);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -53,6 +53,7 @@ import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.HAProtocol;
 import com.starrocks.journal.JournalException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Frontend;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -62,11 +63,11 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 /* this class contains the reference to bdb environment.
  * including all the opened databases and the replicationGroupAdmin.
@@ -89,7 +90,6 @@ public class BDBEnvironment {
     private DatabaseConfig dbConfig;
     private TransactionConfig txnConfig;
     private CloseSafeDatabase epochDB = null;  // used for fencing
-    private ReplicationGroupAdmin replicationGroupAdmin = null;
 
     // mark whether environment is closing, if true, all calling to environment will fail
     private volatile boolean closing = false;
@@ -254,25 +254,6 @@ public class BDBEnvironment {
             try {
                 LOG.info("start to setup bdb environment for {} times", i + 1);
                 replicatedEnvironment = new ReplicatedEnvironment(envHome, replicationConfig, environmentConfig);
-
-                // get replicationGroupAdmin object.
-                Set<InetSocketAddress> adminNodes = new HashSet<InetSocketAddress>();
-                // 1. add helper node
-                HostAndPort helperAddress = HostAndPort.fromString(helperHostPort);
-                InetSocketAddress helper = new InetSocketAddress(helperAddress.getHost(),
-                        helperAddress.getPort());
-                adminNodes.add(helper);
-                LOG.info("add helper[{}] as ReplicationGroupAdmin", helperHostPort);
-                // 2. add self if is electable
-                if (!selfNodeHostPort.equals(helperHostPort) && isElectable) {
-                    HostAndPort selfNodeAddress = HostAndPort.fromString(selfNodeHostPort);
-                    InetSocketAddress self = new InetSocketAddress(selfNodeAddress.getHost(),
-                            selfNodeAddress.getPort());
-                    adminNodes.add(self);
-                    LOG.info("add self[{}] as ReplicationGroupAdmin", selfNodeHostPort);
-                }
-
-                replicationGroupAdmin = new ReplicationGroupAdmin(STARROCKS_JOURNAL_GROUP, adminNodes);
 
                 // get a BDBHA object and pass the reference to GlobalStateMgr
                 HAProtocol protocol = new BDBHA(this, selfNodeName);
@@ -442,11 +423,13 @@ public class BDBEnvironment {
     }
 
     public ReplicationGroupAdmin getReplicationGroupAdmin() {
-        return this.replicationGroupAdmin;
-    }
-
-    public void setNewReplicationGroupAdmin(Set<InetSocketAddress> newHelperNodes) {
-        this.replicationGroupAdmin = new ReplicationGroupAdmin(STARROCKS_JOURNAL_GROUP, newHelperNodes);
+        Set<InetSocketAddress> addrs = GlobalStateMgr.getCurrentState()
+                .getFrontends(FrontendNodeType.FOLLOWER)
+                .stream()
+                .filter(Frontend::isAlive)
+                .map(fe -> new InetSocketAddress(fe.getHost(), fe.getEditLogPort()))
+                .collect(Collectors.toSet());
+        return new ReplicationGroupAdmin(STARROCKS_JOURNAL_GROUP, addrs);
     }
 
     // Return a handle to the epochDB

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -147,7 +147,6 @@ import com.starrocks.external.hive.HiveRepository;
 import com.starrocks.external.hive.events.MetastoreEventsProcessor;
 import com.starrocks.external.iceberg.IcebergRepository;
 import com.starrocks.external.starrocks.StarRocksRepository;
-import com.starrocks.ha.BDBHA;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.HAProtocol;
 import com.starrocks.ha.LeaderInfo;
@@ -1103,17 +1102,6 @@ public class GlobalStateMgr {
         }
 
         // transfer from INIT/UNKNOWN to OBSERVER/FOLLOWER
-
-        // add helper sockets
-        if (Config.edit_log_type.equalsIgnoreCase("BDB")) {
-            for (Frontend fe : nodeMgr.getFrontends().values()) {
-                if (fe.getRole() == FrontendNodeType.FOLLOWER) {
-                    if (getHaProtocol() instanceof BDBHA) {
-                        ((BDBHA) getHaProtocol()).addHelperSocket(fe.getHost(), fe.getEditLogPort());
-                    }
-                }
-            }
-        }
 
         if (replayer == null) {
             createReplayer();

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -687,7 +687,6 @@ public class NodeMgr {
             if (stateMgr.getHaProtocol() instanceof BDBHA) {
                 BDBHA bdbha = (BDBHA) stateMgr.getHaProtocol();
                 if (role == FrontendNodeType.FOLLOWER) {
-                    bdbha.addHelperSocket(host, editLogPort);
                     bdbha.addUnstableNode(host, getFollowerCnt());
                 }
 
@@ -770,7 +769,6 @@ public class NodeMgr {
 
                 BDBHA ha = (BDBHA) stateMgr.getHaProtocol();
                 ha.removeUnstableNode(host, getFollowerCnt());
-                ha.removeHelperSocket(host, port);
             }
             stateMgr.getEditLog().logRemoveFrontend(fe);
         } finally {
@@ -802,10 +800,6 @@ public class NodeMgr {
             frontends.put(fe.getNodeName(), fe);
             if (fe.getRole() == FrontendNodeType.FOLLOWER) {
                 helperNodes.add(Pair.create(fe.getHost(), fe.getEditLogPort()));
-                if (!GlobalStateMgr.isCheckpointThread()) {
-                    BDBHA ha = (BDBHA) stateMgr.getHaProtocol();
-                    ha.addHelperSocket(fe.getHost(), fe.getEditLogPort());
-                }
             }
         } finally {
             unlock();
@@ -838,10 +832,6 @@ public class NodeMgr {
             }
             if (removedFe.getRole() == FrontendNodeType.FOLLOWER) {
                 helperNodes.remove(Pair.create(removedFe.getHost(), removedFe.getEditLogPort()));
-                if (!GlobalStateMgr.isCheckpointThread()) {
-                    BDBHA ha = (BDBHA) stateMgr.getHaProtocol();
-                    ha.removeHelperSocket(removedFe.getHost(), removedFe.getEditLogPort());
-                }
             }
 
             removedFrontends.add(removedFe.getNodeName());

--- a/fe/fe-core/src/test/java/com/starrocks/ha/BDBHATest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/ha/BDBHATest.java
@@ -1,9 +1,5 @@
 package com.starrocks.ha;
 
-import java.net.InetSocketAddress;
-import java.util.Set;
-
-import com.google.common.collect.Sets;
 import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.server.GlobalStateMgr;
@@ -57,11 +53,6 @@ public class BDBHATest {
         Assert.assertEquals(1,
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());
 
-        Set<InetSocketAddress> helperSocketsBefore = Sets.newHashSet(environment.getReplicationGroupAdmin().getHelperSockets());
-        InetSocketAddress targetAddress = new InetSocketAddress("host1", 9010);
-        Assert.assertTrue(helperSocketsBefore.contains(targetAddress));        
-
-
         // one joined successfully
         new Frontend(FrontendNodeType.FOLLOWER, "node1", "host2", 9010)
                 .handleHbResponse(new FrontendHbResponse("n1", 8030, 9050,
@@ -72,9 +63,6 @@ public class BDBHATest {
 
         // the other one is dropped
         GlobalStateMgr.getCurrentState().dropFrontend(FrontendNodeType.FOLLOWER, "host1", 9010);
-
-        Set<InetSocketAddress> helperSocketsAfter = Sets.newHashSet(environment.getReplicationGroupAdmin().getHelperSockets());
-        Assert.assertTrue(!helperSocketsAfter.contains(targetAddress));
 
         Assert.assertEquals(0,
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
@@ -142,11 +142,6 @@ public class MockJournal implements Journal {
     public static class MockProtocol implements HAProtocol {
 
         @Override
-        public long getEpochNumber() {
-            return 0;
-        }
-
-        @Override
         public boolean fencing() {
             return true;
         }
@@ -164,16 +159,6 @@ public class MockJournal implements Journal {
         @Override
         public InetSocketAddress getLeader() {
             return null;
-        }
-
-        @Override
-        public List<InetSocketAddress> getNoneLeaderNodes() {
-            return Lists.newArrayList();
-        }
-
-        @Override
-        public boolean isLeader() {
-            return true;
         }
 
         @Override


### PR DESCRIPTION
Signed-off-by: gengjun-git gengjun@starrocks.com

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17339
The bdb rpc client ReplicationGroupAdmin converts the FQDN to ip after creation, but the ip of the pod changes after restart in Kubernetes, so the rpc call gets stuck because the old ip is unreachable.
To solve this problem, do not cache ReplicationGroupAdmin. The usage of ReplicationGroupAdmin is not frequent, so the overhead of build connection can be ignored.

Signed-off-by: gengjun-git gengjun@starrocks.com

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
