### PR TITLE
[Enhancement] Compatible with only load once rowset avoid trigger compaction

### DIFF
--- a/be/src/storage/size_tiered_compaction_policy.cpp
+++ b/be/src/storage/size_tiered_compaction_policy.cpp
@@ -105,16 +105,16 @@ Status SizeTieredCompactionPolicy::_pick_rowsets_to_size_tiered_compact(bool for
 
     std::sort(candidate_rowsets.begin(), candidate_rowsets.end(), Rowset::comparator);
 
-    if (time(nullptr) - candidate_rowsets[0]->creation_time() >
-        config::base_compaction_interval_seconds_since_last_operation) {
-        force_base_compaction = true;
-    }
-
     if (!force_base_compaction && candidate_rowsets.size() == 2 && candidate_rowsets[0]->end_version() == 1 &&
         candidate_rowsets[1]->rowset_meta()->get_compaction_score() <= 1) {
         // the tablet is with rowset: [0-1], [2-y]
         // and [0-1] has no data. in this situation, no need to do base compaction.
         return Status::NotFound("compaction no suitable version error.");
+    }
+
+    if (time(nullptr) - candidate_rowsets[0]->creation_time() >
+        config::base_compaction_interval_seconds_since_last_operation) {
+        force_base_compaction = true;
     }
 
     struct SizeTieredLevel {


### PR DESCRIPTION
Signed-off-by: meegoo <hujie-dlut@qq.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
rowsets like [0-1][2-2] is generated by former version StarRocks when load only once. It will not trigger compaction, so we need compatible with avoid unnecessary compaction when upgrade to 2.5

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
