### PR TITLE
[Enhancement]  Support select star and expr without alias in CreateMaterializedViewStatement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -676,7 +676,7 @@ public class Alter {
                         || properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {
                     ((SchemaChangeHandler) schemaChangeHandler).updateTableConstraint(db, olapTable.getName(), properties);
                 } else {
-                    throw new DdlException("Invalid alter opertion: " + alterClause.getOpType());
+                    throw new DdlException("Invalid alter operation: " + alterClause.getOpType());
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -574,7 +574,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             }
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
 
-            Set<String> modifiedColumns = getModifiedColumns(tbl);
+            // Before schema change, collect modified columns for related mvs.
+            Set<String> modifiedColumns = collectModifiedColumnsForRelatedMVs(tbl);
 
             for (long partitionId : partitionIndexMap.rowKeySet()) {
                 Partition partition = tbl.getPartition(partitionId);
@@ -634,7 +635,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         this.span.end();
     }
 
-    private Set<String> getModifiedColumns(OlapTable tbl) {
+    private Set<String> collectModifiedColumnsForRelatedMVs(OlapTable tbl) {
         if (tbl.getRelatedMaterializedViews().isEmpty()) {
             return Sets.newHashSet();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -662,7 +662,10 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             }
             for (Column mvColumn : mv.getColumns()) {
                 if (modifiedColumns.contains(mvColumn.getName())) {
+                    LOG.warn("Set materialized view {} inactive because the base table's scheme has changed",
+                            mv.getName());
                     mv.setActive(false);
+                    return;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -68,6 +68,8 @@ public class Util {
 
     private static final long DEFAULT_EXEC_CMD_TIMEOUT_MS = 600000L;
 
+    public static final String AUTO_GENERATED_EXPR_ALIAS_PREFIX = "EXPR$";
+
     private static final String[] ORDINAL_SUFFIX =
             new String[] {"th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"};
 
@@ -441,5 +443,8 @@ public class Util {
             }
         }
     }
-}
 
+    public static String deriveAliasFromOrdinal(int ordinal) {
+        return AUTO_GENERATED_EXPR_ALIAS_PREFIX + ordinal;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -206,7 +206,7 @@ public class MaterializedViewAnalyzer {
             // for select star, use `analyze` to deduce its child's output and validate select list then.
             for (SelectRelation selectRelation : selectRelations) {
                 // check alias except * and SlotRef
-                validateSelectItem(selectRelation.getSelectList());
+                validateSelectItem(selectRelation);
             }
 
             // convert queryStatement to sql and set
@@ -283,19 +283,13 @@ public class MaterializedViewAnalyzer {
             }
         }
 
-        private void validateSelectItem(SelectList selectList) {
-            List<SelectListItem> selectListItems = selectList.getItems();
-            for (SelectListItem selectListItem : selectListItems) {
+        private void validateSelectItem(SelectRelation selectRelation) {
+            for (SelectListItem selectListItem : selectRelation.getSelectList().getItems()) {
                 Preconditions.checkState((selectListItem.getExpr() instanceof SlotRef)
                         || selectListItem.getAlias() != null);
-                if (selectListItem.isStar() && selectListItem.getStarExpandedExprs() != null) {
-                    for (Expr expandExpr : selectListItem.getStarExpandedExprs()) {
-                        checkNondeterministicFunction(expandExpr);
-                    }
-                } else if (selectListItem.getExpr() != null) {
-                    // check select item has nondeterministic function
-                    checkNondeterministicFunction(selectListItem.getExpr());
-                }
+            }
+            for (Expr expr : selectRelation.getOutputExpr()) {
+                checkNondeterministicFunction(expr);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -50,6 +50,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.Util;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
@@ -96,6 +97,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -191,13 +193,21 @@ public class MaterializedViewAnalyzer {
             if (CollectionUtils.isEmpty(selectRelations)) {
                 throw new SemanticException("Materialized view query statement must contain at least one select");
             }
+
+            // derive alias
+            final HashSet<String> aliases = Sets.newHashSet();
             for (SelectRelation selectRelation : selectRelations) {
-                // check alias except * and SlotRef
-                validateSelectItem(selectRelation.getSelectList());
+                deriveSelectAlias(selectRelation.getSelectList(), aliases);
             }
 
             // analyze query statement, can check whether tables and columns exist in catalog
             Analyzer.analyze(queryStatement, context);
+
+            // for select star, use `analyze` to deduce its child's output and validate select list then.
+            for (SelectRelation selectRelation : selectRelations) {
+                // check alias except * and SlotRef
+                validateSelectItem(selectRelation.getSelectList());
+            }
 
             // convert queryStatement to sql and set
             statement.setInlineViewDef(AstToSQLBuilder.toSQL(queryStatement));
@@ -262,20 +272,28 @@ public class MaterializedViewAnalyzer {
             return null;
         }
 
+        private void deriveSelectAlias(SelectList selectList, HashSet<String> aliases) {
+            for (SelectListItem selectListItem : selectList.getItems()) {
+                if (!(selectListItem.getExpr() instanceof SlotRef)
+                        && selectListItem.getAlias() == null) {
+                    String alias = Util.deriveAliasFromOrdinal(aliases.size());
+                    selectListItem.setAlias(alias);
+                    aliases.add(alias);
+                }
+            }
+        }
+
         private void validateSelectItem(SelectList selectList) {
             List<SelectListItem> selectListItems = selectList.getItems();
             for (SelectListItem selectListItem : selectListItems) {
-                if (!FeConstants.runningUnitTest) {
-                    if (selectListItem.isStar()) {
-                        throw new SemanticException("Select * is not supported in materialized view");
-                    } else if (!(selectListItem.getExpr() instanceof SlotRef)
-                            && selectListItem.getAlias() == null) {
-                        throw new SemanticException("Materialized view query statement select item " +
-                                selectListItem.getExpr().toSql() + " must has an alias");
+                Preconditions.checkState((selectListItem.getExpr() instanceof SlotRef)
+                        || selectListItem.getAlias() != null);
+                if (selectListItem.isStar() && selectListItem.getStarExpandedExprs() != null) {
+                    for (Expr expandExpr : selectListItem.getStarExpandedExprs()) {
+                        checkNondeterministicFunction(expandExpr);
                     }
-                }
-                // check select item has nondeterministic function
-                if (selectListItem.getExpr() != null) {
+                } else if (selectListItem.getExpr() != null) {
+                    // check select item has nondeterministic function
                     checkNondeterministicFunction(selectListItem.getExpr());
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -240,9 +240,6 @@ public class SelectAnalyzer {
                     outputExpressionBuilder.add(fieldReference);
                 }
                 outputFields.addAll(fields);
-
-                item.setStarExpandedExprs(
-                        fields.stream().map(field -> field.getOriginExpression()).collect(Collectors.toList()));
             } else {
                 String name;
                 if (item.getExpr() instanceof SlotRef) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -240,6 +240,7 @@ public class SelectAnalyzer {
                     outputExpressionBuilder.add(fieldReference);
                 }
                 outputFields.addAll(fields);
+                
             } else {
                 String name;
                 if (item.getExpr() instanceof SlotRef) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -241,6 +241,8 @@ public class SelectAnalyzer {
                 }
                 outputFields.addAll(fields);
 
+                item.setStarExpandedExprs(
+                        fields.stream().map(field -> field.getOriginExpression()).collect(Collectors.toList()));
             } else {
                 String name;
                 if (item.getExpr() instanceof SlotRef) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
@@ -87,11 +87,4 @@ public class SelectListItem implements ParseNode {
         this.alias = alias;
     }
 
-    public List<Expr> getStarExpandedExprs() {
-        return starExpandedExprs;
-    }
-
-    public void setStarExpandedExprs(List<Expr> starExpandedExprs) {
-        this.starExpandedExprs = starExpandedExprs;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
@@ -20,16 +20,12 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.TableName;
 
-import java.util.List;
-
 public class SelectListItem implements ParseNode {
     private Expr expr;
     // for "[name.]*"
     private final TableName tblName;
     private final boolean isStar;
     private String alias;
-
-    private List<Expr> starExpandedExprs;
 
     public SelectListItem(Expr expr, String alias) {
         super();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
@@ -20,12 +20,16 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.TableName;
 
+import java.util.List;
+
 public class SelectListItem implements ParseNode {
     private Expr expr;
     // for "[name.]*"
     private final TableName tblName;
     private final boolean isStar;
     private String alias;
+
+    private List<Expr> starExpandedExprs;
 
     public SelectListItem(Expr expr, String alias) {
         super();
@@ -81,5 +85,13 @@ public class SelectListItem implements ParseNode {
 
     public void setAlias(String alias) {
         this.alias = alias;
+    }
+
+    public List<Expr> getStarExpandedExprs() {
+        return starExpandedExprs;
+    }
+
+    public void setStarExpandedExprs(List<Expr> starExpandedExprs) {
+        this.starExpandedExprs = starExpandedExprs;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -270,8 +270,7 @@ public class AlterJobV2Test {
             waitForSchemaChangeAlterJobFinish();
             MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState()
                     .getDb("test").getTable("mv5");
-            // TODO: should be inactive.
-            Assert.assertTrue(mv.isActive());
+            Assert.assertTrue(!mv.isActive());
         } catch (Exception e) {
             Assert.fail();
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1549,6 +1549,48 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
+    public void testAsHasStarWithSameColumns() throws Exception {
+        String sql = "create materialized view testAsHasStar " +
+                "partition by ss " +
+                "distributed by hash(ss) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select a.k1 ss, a.*, b.* from tbl1 as a join tbl1 as b on a.k1=b.k1;";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Duplicate column name 'k1'"));
+        } finally {
+            dropMv("testAsHasStar");
+        }
+    }
+
+    @Test
+    public void testMVWithSameColumns() throws Exception {
+        String sql = "create materialized view testAsHasStar " +
+                "partition by ss " +
+                "distributed by hash(ss) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select a.k1 ss, a.k2, b.k2 from tbl1 as a join tbl1 as b on a.k1=b.k1;";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Duplicate column name 'k2'"));
+        } finally {
+            dropMv("testAsHasStar");
+        }
+    }
+
+    @Test
     public void testAsHasStarWithNondeterministicFunction() {
         String sql = "create materialized view mv1 " +
                 "distributed by hash(ss) buckets 10 " +

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -46,6 +46,7 @@ import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.RefreshSchemeDesc;
 import com.starrocks.sql.ast.StatementBase;
@@ -1515,8 +1516,8 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testAsHasStar() {
-        String sql = "create materialized view mv1 " +
+    public void testAsHasStar() throws Exception {
+        String sql = "create materialized view testAsHasStar " +
                 "partition by ss " +
                 "distributed by hash(ss) buckets 10 " +
                 "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
@@ -1525,15 +1526,48 @@ public class CreateMaterializedViewTest {
                 ") " +
                 "as select k1 ss, *  from tbl1;";
         try {
-            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+            MaterializedView mv = ((MaterializedView) testDb.getTable("testAsHasStar"));
+            mv.setActive(false);
+            List<Column> mvColumns = mv.getFullSchema();
+
+            Table baseTable = testDb.getTable("tbl1");
+            List<Column> baseColumns = baseTable.getFullSchema();
+
+            Assert.assertEquals(mvColumns.size(), baseColumns.size() + 1);
+            Assert.assertEquals("ss", mvColumns.get(0).getName());
+            for (int i = 1; i < mvColumns.size(); i++) {
+                Assert.assertEquals(mvColumns.get(i).getName(),
+                        baseColumns.get(i - 1).getName());
+            }
         } catch (Exception e) {
-            Assert.assertEquals("Select * is not supported in materialized view", e.getMessage());
+            Assert.fail("Select * should be supported in materialized view");
+        } finally {
+            dropMv("testAsHasStar");
         }
     }
 
     @Test
-    public void testAsSelectItemNoAlias() {
+    public void testAsHasStarWithNondeterministicFunction() {
         String sql = "create materialized view mv1 " +
+                "distributed by hash(ss) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select k1 ss, *  from (select *, rand(), current_date() from tbl1) as t;";
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
+            Assert.assertEquals("Materialized view query statement select item rand() " +
+                    "not supported nondeterministic function", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testAsSelectItemAlias1() throws Exception {
+        String sql = "create materialized view testAsSelectItemAlias1 " +
                 "partition by k1 " +
                 "distributed by hash(k2) buckets 10 " +
                 "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
@@ -1542,10 +1576,115 @@ public class CreateMaterializedViewTest {
                 ")" +
                 "as select date_trunc('month',tbl1.k1), k1, k2 from tbl1;";
         try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+            MaterializedView mv = ((MaterializedView) testDb.getTable("testAsSelectItemAlias1"));
+            mv.setActive(false);
+            List<Column> mvColumns = mv.getFullSchema();
+
+            Assert.assertEquals("EXPR$0", mvColumns.get(0).getName());
+            Assert.assertEquals("k1", mvColumns.get(1).getName());
+            Assert.assertEquals("k2", mvColumns.get(2).getName());
+
+        } catch (Exception e) {
+            Assert.fail("Materialized view query statement select item " +
+                    "date_trunc('month', `tbl1`.`k1`) should be supported");
+        } finally {
+            dropMv("testAsSelectItemAlias1");
+        }
+    }
+
+    @Test
+    public void testAsSelectItemAlias2() throws Exception {
+        String sql = "create materialized view testAsSelectItemAlias2 " +
+                "partition by k1 " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")" +
+                "as " +
+                "select date_trunc('month',tbl1.k1), k1, k2 from tbl1 union all " +
+                "select date_trunc('month',tbl1.k1), k1, k2 from tbl1;";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+            MaterializedView mv = ((MaterializedView) testDb.getTable("testAsSelectItemAlias2"));
+            mv.setActive(false);
+            List<Column> mvColumns = mv.getFullSchema();
+
+            Assert.assertEquals("EXPR$0", mvColumns.get(0).getName());
+            Assert.assertEquals("k1", mvColumns.get(1).getName());
+            Assert.assertEquals("k2", mvColumns.get(2).getName());
+
+        } catch (Exception e) {
+            Assert.fail("Materialized view query statement select item " +
+                    "date_trunc('month', `tbl1`.`k1`) should be supported");
+        } finally {
+            dropMv("testAsSelectItemAlias2");
+        }
+    }
+
+    @Test
+    // partition by expr is still not supported.
+    public void testAsSelectItemAlias3() throws Exception {
+        String sql = "create materialized view testAsSelectItemAlias3 " +
+                "partition by date_trunc('month',tbl1.k1) " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")" +
+                "as select date_trunc('month',tbl1.k1), k1, k2 from tbl1;";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Materialized view partition exp: " +
+                    "`tbl1`.`k1` must related to column"));
+        } finally {
+            dropMv("testAsSelectItemAlias3");
+        }
+    }
+
+    @Test
+    // distribution by expr is still not supported.
+    public void testAsSelectItemAlias4() throws Exception {
+        String sql = "create materialized view testAsSelectItemAlias1 " +
+                "partition by k1 " +
+                "distributed by hash(date_trunc('month',tbl1.k1)) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")" +
+                "as select date_trunc('month',tbl1.k1), k1, k2 from tbl1;";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("You have an error in your SQL syntax; check the manual that " +
+                    "corresponds to your MySQL server version for the right syntax to use near '(' at line 1"));
+        } finally {
+            dropMv("testAsSelectItemAlias1");
+        }
+    }
+
+    @Test
+    public void testAsSelectItemNoAliasWithNondeterministicFunction1() {
+        String sql = "create materialized view mv1 " +
+                "partition by k1 " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")" +
+                "as select rand(), date_trunc('month',tbl1.k1), k1, k2 from tbl1;";
+        try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
-            Assert.assertEquals("Materialized view query statement select item " +
-                    "date_trunc('month', `tbl1`.`k1`) must has an alias", e.getMessage());
+            Assert.assertEquals("Materialized view query statement select item rand() not " +
+                    "supported nondeterministic function",
+                    e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -178,23 +178,23 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     @Test
     public void testSwapOuterJoin() {
         for (String joinType : outerJoinTypes) {
-            String mv = "select count(*) from " +
+            String mv = "select count(*) as col1 from " +
                     "emps " + joinType + " join locations on emps.locationid = locations.locationid";
             testRewriteOK(mv, "select count(*)  + 1 from " +
                     "emps " + joinType + " join locations on emps.locationid = locations.locationid");
 
             // outer join cannot swap join orders
-            testRewriteFail(mv, "select count(*) from " +
+            testRewriteFail(mv, "select count(*) as col1 from " +
                     "locations " + joinType + " join emps on emps.locationid = locations.locationid");
-            testRewriteFail(mv, "select count(*) + 1 from " +
+            testRewriteFail(mv, "select count(*) + 1 as col1 from " +
                     "locations " + joinType + " join emps on emps.locationid = locations.locationid");
 
             // outer join cannot change join type
             if (joinType.equalsIgnoreCase("right")) {
-                testRewriteFail(mv, "select count(*) from " +
+                testRewriteFail(mv, "select count(*)  as col1 from " +
                         "emps left join locations on emps.locationid = locations.locationid");
             } else {
-                testRewriteFail(mv, "select count(*) from " +
+                testRewriteFail(mv, "select count(*) as col1 from " +
                         "emps right join locations on emps.locationid = locations.locationid");
             }
         }
@@ -314,7 +314,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
 
     @Test
     public void testAggregate9() {
-        testRewriteOK("select sum(salary), count(salary) + 1 from emps",
+        testRewriteOK("select sum(salary) as col1, count(salary) + 1 from emps",
                 "select sum(salary), count(salary) + 1 from emps");
         testRewriteFail("select empid, deptno," +
                         " sum(salary) as total, count(salary) + 1 as cnt" +

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -161,7 +161,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         final String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
         if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv, "test");
+            Task task = TaskBuilder.buildMvTask(mv, dbName);
             TaskBuilder.updateTaskInfo(task, mv);
             taskManager.createTask(task, false);
         }


### PR DESCRIPTION
Signed-off-by: Kevin Li <ming.moriarty@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：

Fixes #

- Support select star and expr without alias in CreateMaterializedViewStatement, like other Database system:
  - https://docs.snowflake.com/en/user-guide/views-materialized.html#label-limitations-on-creating-materialized-views
  - https://www.postgresql.org/docs/current/sql-creatematerializedview.html

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
