### PR TITLE
[BugFix] use synchronized way to allocate table id

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableId.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector;
 
 import com.starrocks.common.Id;
@@ -26,12 +25,12 @@ public class ConnectorTableId extends Id<ConnectorTableId> {
     public static IdGenerator<ConnectorTableId> createGenerator() {
         return new IdGenerator<ConnectorTableId>() {
             @Override
-            public ConnectorTableId getNextId() {
+            public synchronized ConnectorTableId getNextId() {
                 return new ConnectorTableId(nextId++);
             }
 
             @Override
-            public ConnectorTableId getMaxId() {
+            public synchronized ConnectorTableId getMaxId() {
                 return new ConnectorTableId(nextId - 1);
             }
         };


### PR DESCRIPTION
Signed-off-by: yanz <dirtysalt1987@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17446

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The root cause is, tuples are referring `item` and `store_sales` tables, but two table share a table id(20), which is not expected.

<img width="1174" alt="starrocks-fe - DescriptorTable java  fe-core" src="https://user-images.githubusercontent.com/1081215/216975919-bac25241-0f6b-4e51-a192-6e61d9b7b611.png">

I guess it only happens when
- during query planning stage, two tables are cached before, but both need to be refreshed
- google guava load two tables from hive in background threads.
- and when create and cache two tables, since `nextId` is not atomic, both are allocated the same table id. (And here is data race)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
