### PR TITLE
[BugFix] Fix auth upgrade failure when replaying old auth journal

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationManager.java
@@ -509,8 +509,8 @@ public class AuthenticationManager {
         return isLoaded;
     }
 
-    public void setLoaded() {
-        isLoaded = true;
+    public void setLoaded(boolean loaded) {
+        isLoaded = loaded;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -171,6 +171,7 @@ public class ResourceGroupMgr implements Writable {
                 }
             } catch (PrivilegeException e) {
                 LOG.info("getUnqualifiedRole failed for resource group, error message: " + e.getMessage());
+                return null;
             }
         }
         String qualifiedRoleName = GlobalStateMgr.getCurrentState().getAuth()

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/AuthUpgrader.java
@@ -87,8 +87,8 @@ public class AuthUpgrader {
         LOG.info("start to replay upgrade journal.");
         upgradeUser();
         upgradeRole(roleNameToId);
-        authenticationManager.setLoaded();
-        privilegeManager.setLoaded();
+        authenticationManager.setLoaded(true);
+        privilegeManager.setLoaded(true);
         LOG.info("replayed upgrade journal successfully.");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -1921,8 +1921,8 @@ public class PrivilegeManager {
         return isLoaded;
     }
 
-    public void setLoaded() {
-        isLoaded = true;
+    public void setLoaded(boolean loaded) {
+        isLoaded = loaded;
     }
 
     /**


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17451 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For follower/observer, defer setting auth to null when we have replayed all the journal,
because we may encounter old auth journal when replaying log in which case we still
need the auth object. This problem can happend in the following senario:
1. start 3fe cluster with old auth version
2. create some users
3. upgrade to new privilege framework
4. rollback to old auth version
5. create some user
6. upgrade again

Signed-off-by: Dejun Xia <xiadejun@starrocks.com>

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
