### PR TITLE
[Refactor] Construct queryPredicateSplit to avoid creating multi times for multi MVs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/LineageFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/LineageFactory.java
@@ -62,4 +62,10 @@ public class LineageFactory {
             return null;
         }
     }
+
+    public static Map<ColumnRefOperator, ScalarOperator> getLineage(OptExpression expression,
+                                                                    ColumnRefFactory refFactory) {
+        LineageFactory factory = new LineageFactory(expression, refFactory);
+        return factory.getLineage();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -23,20 +23,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.JoinOperator;
-import com.starrocks.analysis.SlotRef;
-import com.starrocks.catalog.Column;
-import com.starrocks.catalog.ExpressionRangePartitionInfo;
-import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.PartitionKey;
-import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
-import com.starrocks.sql.analyzer.RelationFields;
-import com.starrocks.sql.analyzer.RelationId;
-import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -60,8 +49,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
-import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
-import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import org.apache.commons.collections4.iterators.PermutationIterator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -151,7 +138,8 @@ public class MaterializedViewRewriter {
         }
     }
 
-    public List<OptExpression> rewrite() {
+    public List<OptExpression> rewrite(ReplaceColumnRefRewriter queryColumnRefRewriter,
+                                       PredicateSplit queryPredicateSplit) {
         OptExpression queryExpression = materializationContext.getQueryExpression();
         OptExpression mvExpression = materializationContext.getMvExpression();
         List<Table> queryTables = MvUtils.getAllTables(queryExpression);
@@ -162,32 +150,19 @@ public class MaterializedViewRewriter {
             return Lists.newArrayList();
         }
 
-        Map<ColumnRefOperator, ScalarOperator> queryLineage =
-                getLineage(queryExpression, materializationContext.getQueryRefFactory());
-
-        ReplaceColumnRefRewriter queryColumnRefRewriter = new ReplaceColumnRefRewriter(queryLineage, true);
-        List<ScalarOperator> queryConjuncts = MvUtils.getAllPredicates(queryExpression);
-        ScalarOperator queryPredicate = null;
-        if (!queryConjuncts.isEmpty()) {
-            queryPredicate = Utils.compoundAnd(queryConjuncts);
-            queryPredicate = queryColumnRefRewriter.rewrite(queryPredicate.clone());
-        }
-
-        // Compensate partition predicates and add them into query predicate.
-        ScalarOperator queryPartitionPredicate =
-                compensatePartitionPredicate(queryExpression, materializationContext.getQueryRefFactory());
-        if (queryPartitionPredicate == null) {
+        // for query: A1 join A2 join B, mv: A1 join A2 join B
+        // there may be two mapping:
+        //    1. A1 -> A1, A2 -> A2, B -> B
+        //    2. A1 -> A2, A2 -> A1, B -> B
+        List<BiMap<Integer, Integer>> relationIdMappings = generateRelationIdMap(materializationContext.getQueryRefFactory(),
+                        queryTables, queryExpression, materializationContext.getMvColumnRefFactory(), mvTables, mvExpression);
+        if (relationIdMappings.isEmpty()) {
             return Lists.newArrayList();
         }
-        if (!ConstantOperator.TRUE.equals(queryPartitionPredicate)) {
-            queryPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(queryPredicate, queryPartitionPredicate));
-        }
 
-        final PredicateSplit queryPredicateSplit = PredicateSplit.splitPredicate(queryPredicate);
-        EquivalenceClasses queryEc = createEquivalenceClasses(queryPredicateSplit.getEqualPredicates());
-
+        // Compute MV queryPredicateSplit
         Map<ColumnRefOperator, ScalarOperator> mvLineage =
-                getLineage(mvExpression, materializationContext.getMvColumnRefFactory());
+                LineageFactory.getLineage(mvExpression, materializationContext.getMvColumnRefFactory());
         ReplaceColumnRefRewriter mvColumnRefRewriter = new ReplaceColumnRefRewriter(mvLineage, true);
         List<ScalarOperator> mvConjuncts = MvUtils.getAllPredicates(mvExpression);
         ScalarOperator mvPredicate = null;
@@ -199,20 +174,8 @@ public class MaterializedViewRewriter {
 
         Map<Integer, List<ColumnRefOperator>> queryRelationIdToColumns =
                 getRelationIdToColumns(materializationContext.getQueryRefFactory());
-
         Map<Integer, List<ColumnRefOperator>> mvRelationIdToColumns =
                 getRelationIdToColumns(materializationContext.getMvColumnRefFactory());
-
-        // for query: A1 join A2 join B, mv: A1 join A2 join B
-        // there may be two mapping:
-        //    1. A1 -> A1, A2 -> A2, B -> B
-        //    2. A1 -> A2, A2 -> A1, B -> B
-        List<BiMap<Integer, Integer>> relationIdMappings = generateRelationIdMap(materializationContext.getQueryRefFactory(),
-                queryTables, queryExpression, materializationContext.getMvColumnRefFactory(), mvTables, mvExpression);
-        if (relationIdMappings.isEmpty()) {
-            return Lists.newArrayList();
-        }
-
         // used to judge whether query scalar ops can be rewritten
         List<ColumnRefOperator> scanMvOutputColumns =
                 ((LogicalOlapScanOperator) materializationContext.getScanMvOperator()).getOutputColumns();
@@ -220,11 +183,13 @@ public class MaterializedViewRewriter {
                 .stream().flatMap(List::stream)
                 .filter(columnRef -> !scanMvOutputColumns.contains(columnRef))
                 .collect(Collectors.toSet());
+        EquivalenceClasses queryEc = createEquivalenceClasses(queryPredicateSplit.getEqualPredicates());
         RewriteContext rewriteContext = new RewriteContext(queryExpression, queryPredicateSplit, queryEc,
                 queryRelationIdToColumns, materializationContext.getQueryRefFactory(),
                 queryColumnRefRewriter, mvExpression, mvPredicateSplit, mvRelationIdToColumns,
                 materializationContext.getMvColumnRefFactory(), mvColumnRefRewriter,
                 materializationContext.getOutputMapping(), queryColumnSet);
+
         List<OptExpression> results = Lists.newArrayList();
         for (BiMap<Integer, Integer> relationIdMapping : relationIdMappings) {
             rewriteContext.setQueryToMvRelationIdMapping(relationIdMapping);
@@ -279,14 +244,15 @@ public class MaterializedViewRewriter {
                     rewriteContext.getMvExpression(), rewriteContext.getMvRefFactory());
 
             if (!ConstantOperator.TRUE.equals(equalPredicates)) {
-                Multimap<ScalarOperator, ColumnRefOperator> normalizedMap =
-                        normalizeAndReverseProjection(viewExprMap, rewriteContext, true);
                 List<ScalarOperator> conjuncts = Utils.extractConjuncts(equalPredicates);
                 // swapped by query based view ec
                 List<ScalarOperator> swappedConjuncts = conjuncts.stream().map(conjunct -> {
                     ColumnRewriter rewriter = new ColumnRewriter(rewriteContext);
                     return rewriter.rewriteByViewEc(conjunct);
                 }).collect(Collectors.toList());
+
+                Multimap<ScalarOperator, ColumnRefOperator> normalizedMap =
+                        normalizeAndReverseProjection(viewExprMap, rewriteContext, true);
                 List<ScalarOperator> rewrittens = rewriteScalarOpToTarget(swappedConjuncts, normalizedMap,
                         rewriteContext.getOutputMapping(), new ColumnRefSet(rewriteContext.getQueryColumnSet()));
                 if (rewrittens == null || rewrittens.isEmpty()) {
@@ -505,29 +471,24 @@ public class MaterializedViewRewriter {
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : columnRefMap.entrySet()) {
             ScalarOperator rewritten = rewriteContext.getMvColumnRefRewriter().rewrite(entry.getValue());
             if (isQueryAgainstView) {
+                ScalarOperator rewriteScalarOp;
                 if (isViewBased) {
-                    ScalarOperator swapped = columnRewriter.rewriteViewToQueryWithViewEc(rewritten);
-                    reversedMap.put(swapped, entry.getKey());
+                    rewriteScalarOp = columnRewriter.rewriteViewToQueryWithViewEc(rewritten);
                 } else {
-                    ScalarOperator swapped = columnRewriter.rewriteViewToQueryWithQueryEc(rewritten);
-                    reversedMap.put(swapped, entry.getKey());
+                    rewriteScalarOp = columnRewriter.rewriteViewToQueryWithQueryEc(rewritten);
                 }
+                reversedMap.put(rewriteScalarOp, entry.getKey());
             } else {
+                ScalarOperator rewriteScalarOp;
                 if (isViewBased) {
-                    ScalarOperator swapped = columnRewriter.rewriteByViewEc(rewritten);
-                    reversedMap.put(swapped, entry.getKey());
+                    rewriteScalarOp = columnRewriter.rewriteByViewEc(rewritten);
                 } else {
-                    ScalarOperator swapped = columnRewriter.rewriteByQueryEc(rewritten);
-                    reversedMap.put(swapped, entry.getKey());
+                    rewriteScalarOp = columnRewriter.rewriteByQueryEc(rewritten);
                 }
+                reversedMap.put(rewriteScalarOp, entry.getKey());
             }
         }
         return reversedMap;
-    }
-
-    protected Map<ColumnRefOperator, ScalarOperator> getLineage(OptExpression expression, ColumnRefFactory refFactory) {
-        LineageFactory factory = new LineageFactory(expression, refFactory);
-        return factory.getLineage();
     }
 
     // equalPredicates eg: t1.a = t2.b and t1.c = t2.d
@@ -614,69 +575,6 @@ public class MaterializedViewRewriter {
         return targetExpr;
     }
 
-    private ScalarOperator compensatePartitionPredicate(OptExpression plan, ColumnRefFactory columnRefFactory) {
-        List<LogicalOlapScanOperator> olapScanOperators = MvUtils.getOlapScanNode(plan);
-        if (olapScanOperators.isEmpty()) {
-            return ConstantOperator.createBoolean(true);
-        }
-        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
-        for (LogicalOlapScanOperator olapScanOperator : olapScanOperators) {
-            Preconditions.checkState(olapScanOperator.getTable().isNativeTable());
-            OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
-            if (olapScanOperator.getSelectedPartitionId() != null
-                    && olapScanOperator.getSelectedPartitionId().size() == olapTable.getPartitions().size()) {
-                continue;
-            }
-
-            if (olapTable.getPartitionInfo() instanceof ExpressionRangePartitionInfo) {
-                ExpressionRangePartitionInfo partitionInfo = (ExpressionRangePartitionInfo) olapTable.getPartitionInfo();
-                Expr partitionExpr = partitionInfo.getPartitionExprs().get(0);
-                List<SlotRef> slotRefs = Lists.newArrayList();
-                partitionExpr.collect(SlotRef.class, slotRefs);
-                Preconditions.checkState(slotRefs.size() == 1);
-                Optional<ColumnRefOperator> partitionColumn = olapScanOperator.getColRefToColumnMetaMap().keySet().stream()
-                        .filter(columnRefOperator -> columnRefOperator.getName().equals(slotRefs.get(0).getColumnName()))
-                        .findFirst();
-                if (!partitionColumn.isPresent()) {
-                    return null;
-                }
-                ExpressionMapping mapping = new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()));
-                mapping.put(slotRefs.get(0), partitionColumn.get());
-                ScalarOperator partitionScalarOperator =
-                        SqlToScalarOperatorTranslator.translate(partitionExpr, mapping, columnRefFactory);
-                List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
-                for (long pid : olapScanOperator.getSelectedPartitionId()) {
-                    selectedRanges.add(partitionInfo.getRange(pid));
-                }
-                List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
-                List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionScalarOperator, mergedRanges);
-                ScalarOperator partitionPredicate = Utils.compoundOr(rangePredicates);
-                partitionPredicates.add(partitionPredicate);
-            } else if (olapTable.getPartitionInfo() instanceof RangePartitionInfo) {
-                RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
-                List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
-                if (partitionColumns.size() != 1) {
-                    // now do not support more than one partition columns
-                    return null;
-                }
-                List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
-                for (long pid : olapScanOperator.getSelectedPartitionId()) {
-                    selectedRanges.add(rangePartitionInfo.getRange(pid));
-                }
-                List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
-                ColumnRefOperator partitionColumnRef = olapScanOperator.getColumnReference(partitionColumns.get(0));
-                List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionColumnRef, mergedRanges);
-                ScalarOperator partitionPredicate = Utils.compoundOr(rangePredicates);
-                if (partitionPredicate != null) {
-                    partitionPredicates.add(partitionPredicate);
-                }
-            } else {
-                return null;
-            }
-        }
-        return partitionPredicates.isEmpty() ? ConstantOperator.createBoolean(true) : Utils.compoundAnd(partitionPredicates);
-    }
-
     protected List<ScalarOperator> rewriteScalarOpToTarget(List<ScalarOperator> exprsToRewrites,
                                                            Multimap<ScalarOperator, ColumnRefOperator> reversedViewProjection,
                                                            Map<ColumnRefOperator, ColumnRefOperator> outputMapping,
@@ -723,6 +621,9 @@ public class MaterializedViewRewriter {
         return true;
     }
 
+    // TODO: support rewrite query by using mv's binary predicate later:
+    // MV   : deptno + 1
+    // Query: deptno > 10
     protected ScalarOperator replaceExprWithTarget(ScalarOperator expr,
                                                  Multimap<ScalarOperator, ColumnRefOperator> exprMap,
                                                  Map<ColumnRefOperator, ColumnRefOperator> columnMapping) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -15,17 +15,43 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.LineageFactory;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVColumnPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
+import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public abstract class BaseMaterializedViewRewriteRule extends TransformationRule {
 
@@ -41,11 +67,37 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
     @Override
     public List<OptExpression> transform(OptExpression queryExpression, OptimizerContext context) {
         List<OptExpression> results = Lists.newArrayList();
+        ColumnRefFactory queryColumnRefFactory = context.getColumnRefFactory();
+
+        // Construct queryPredicateSplit to avoid creating multi times for multi MVs.
+
+        // Compute Query queryPredicateSplit
+        Map<ColumnRefOperator, ScalarOperator> queryLineage =
+                LineageFactory.getLineage(queryExpression, queryColumnRefFactory);
+        ReplaceColumnRefRewriter queryColumnRefRewriter = new ReplaceColumnRefRewriter(queryLineage, true);
+        List<ScalarOperator> queryConjuncts = MvUtils.getAllPredicates(queryExpression);
+        ScalarOperator queryPredicate = null;
+        if (!queryConjuncts.isEmpty()) {
+            queryPredicate = Utils.compoundAnd(queryConjuncts);
+            queryPredicate = queryColumnRefRewriter.rewrite(queryPredicate.clone());
+        }
+        // Compensate partition predicates and add them into query predicate.
+        ScalarOperator queryPartitionPredicate =
+                compensatePartitionPredicate(queryExpression, queryColumnRefFactory);
+        if (queryPartitionPredicate == null) {
+            return Lists.newArrayList();
+        }
+        if (!ConstantOperator.TRUE.equals(queryPartitionPredicate)) {
+            queryPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(queryPredicate, queryPartitionPredicate));
+        }
+        final PredicateSplit queryPredicateSplit = PredicateSplit.splitPredicate(queryPredicate);
+
         for (MaterializationContext mvContext : context.getCandidateMvs()) {
             mvContext.setQueryExpression(queryExpression);
             mvContext.setOptimizerContext(context);
             MaterializedViewRewriter rewriter = getMaterializedViewRewrite(mvContext);
-            List<OptExpression> rewrittens = rewriter.rewrite();
+            List<OptExpression> rewrittens = rewriter.rewrite(queryColumnRefRewriter,
+                    queryPredicateSplit);
             if (rewrittens != null && !rewrittens.isEmpty()) {
                 for (OptExpression rewritten : rewrittens) {
                     MVColumnPruner columnPruner = new MVColumnPruner();
@@ -62,5 +114,69 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
 
     public MaterializedViewRewriter getMaterializedViewRewrite(MaterializationContext mvContext) {
         return new MaterializedViewRewriter(mvContext);
+    }
+
+    private ScalarOperator compensatePartitionPredicate(OptExpression plan, ColumnRefFactory columnRefFactory) {
+        List<LogicalOlapScanOperator> olapScanOperators = MvUtils.getOlapScanNode(plan);
+        if (olapScanOperators.isEmpty()) {
+            return ConstantOperator.createBoolean(true);
+        }
+        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
+        for (LogicalOlapScanOperator olapScanOperator : olapScanOperators) {
+            Preconditions.checkState(olapScanOperator.getTable().isNativeTable());
+            OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
+            if (olapScanOperator.getSelectedPartitionId() != null
+                    && olapScanOperator.getSelectedPartitionId().size() == olapTable.getPartitions().size()) {
+                continue;
+            }
+
+            if (olapTable.getPartitionInfo() instanceof ExpressionRangePartitionInfo) {
+                ExpressionRangePartitionInfo partitionInfo = (ExpressionRangePartitionInfo) olapTable.getPartitionInfo();
+                Expr partitionExpr = partitionInfo.getPartitionExprs().get(0);
+                List<SlotRef> slotRefs = Lists.newArrayList();
+                partitionExpr.collect(SlotRef.class, slotRefs);
+                Preconditions.checkState(slotRefs.size() == 1);
+                Optional<ColumnRefOperator> partitionColumn = olapScanOperator.getColRefToColumnMetaMap().keySet().stream()
+                        .filter(columnRefOperator -> columnRefOperator.getName().equals(slotRefs.get(0).getColumnName()))
+                        .findFirst();
+                if (!partitionColumn.isPresent()) {
+                    return null;
+                }
+                ExpressionMapping mapping = new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()));
+                mapping.put(slotRefs.get(0), partitionColumn.get());
+                ScalarOperator partitionScalarOperator =
+                        SqlToScalarOperatorTranslator.translate(partitionExpr, mapping, columnRefFactory);
+                List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
+                for (long pid : olapScanOperator.getSelectedPartitionId()) {
+                    selectedRanges.add(partitionInfo.getRange(pid));
+                }
+                List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
+                List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionScalarOperator, mergedRanges);
+                ScalarOperator partitionPredicate = Utils.compoundOr(rangePredicates);
+                partitionPredicates.add(partitionPredicate);
+            } else if (olapTable.getPartitionInfo() instanceof RangePartitionInfo) {
+                RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
+                List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
+                if (partitionColumns.size() != 1) {
+                    // now do not support more than one partition columns
+                    return null;
+                }
+                List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
+                for (long pid : olapScanOperator.getSelectedPartitionId()) {
+                    selectedRanges.add(rangePartitionInfo.getRange(pid));
+                }
+                List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
+                ColumnRefOperator partitionColumnRef = olapScanOperator.getColumnReference(partitionColumns.get(0));
+                List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionColumnRef, mergedRanges);
+                ScalarOperator partitionPredicate = Utils.compoundOr(rangePredicates);
+                if (partitionPredicate != null) {
+                    partitionPredicates.add(partitionPredicate);
+                }
+            } else {
+                return null;
+            }
+        }
+        return partitionPredicates.isEmpty() ?
+                ConstantOperator.createBoolean(true) : Utils.compoundAnd(partitionPredicates);
     }
 }


### PR DESCRIPTION
Signed-off-by: Kevin Li <ming.moriarty@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
- Construct queryPredicateSplit in `BaseMaterializedViewRewriteRule ` to avoid creating multi times for multi MVs 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
