### PR TITLE
[BugFix] Fix stream cascade merge may get wrong result

### DIFF
--- a/be/src/exec/sorting/merge.h
+++ b/be/src/exec/sorting/merge.h
@@ -133,8 +133,10 @@ private:
     std::unique_ptr<SimpleChunkSortCursor> _right_cursor;
     ChunkProvider _chunk_provider;
 
+#ifndef NDEBUG
     bool _left_is_empty = false;
     bool _right_is_empty = false;
+#endif
 };
 
 // Merge multiple cursors in cascade way

--- a/be/src/exec/sorting/merge.h
+++ b/be/src/exec/sorting/merge.h
@@ -132,6 +132,9 @@ private:
     std::unique_ptr<SimpleChunkSortCursor> _left_cursor;
     std::unique_ptr<SimpleChunkSortCursor> _right_cursor;
     ChunkProvider _chunk_provider;
+
+    bool _left_is_empty = false;
+    bool _right_is_empty = false;
 };
 
 // Merge multiple cursors in cascade way

--- a/be/src/exec/sorting/merge_cascade.cpp
+++ b/be/src/exec/sorting/merge_cascade.cpp
@@ -153,14 +153,14 @@ StatusOr<ChunkUniquePtr> MergeTwoCursor::merge_sorted_cursor_two_way() {
     const SortDescs& sort_desc = _sort_desc;
     ChunkUniquePtr result;
 
-    {
-        // debug scope
-        DCHECK(!(_left_is_empty && !_left_run.empty()));
-        DCHECK(!(_right_is_empty && !_right_run.empty()));
+#ifndef NDEBUG
+    // debug scope
+    DCHECK(!(_left_is_empty && !_left_run.empty()));
+    DCHECK(!(_right_is_empty && !_right_run.empty()));
 
-        _left_is_empty |= _left_run.empty();
-        _right_is_empty |= _right_run.empty();
-    }
+    _left_is_empty |= _left_run.empty();
+    _right_is_empty |= _right_run.empty();
+#endif
 
     int intersect = _left_run.intersect(sort_desc, _right_run);
     if (intersect < 0) {

--- a/be/src/exec/sorting/merge_cascade.cpp
+++ b/be/src/exec/sorting/merge_cascade.cpp
@@ -122,15 +122,17 @@ bool MergeTwoCursor::move_cursor() {
         auto chunk = _left_cursor->try_get_next();
         if (chunk.first) {
             _left_run = SortedRun(ChunkPtr(chunk.first.release()), chunk.second);
-            eos = false;
         }
     }
     if (_right_run.empty() && !_right_cursor->is_eos()) {
         auto chunk = _right_cursor->try_get_next();
         if (chunk.first) {
             _right_run = SortedRun(ChunkPtr(chunk.first.release()), chunk.second);
-            eos = false;
         }
+    }
+
+    if (!_left_run.empty() && !_right_run.empty()) {
+        eos = false;
     }
 
     // one is eos but the other has data stream
@@ -150,6 +152,15 @@ StatusOr<ChunkUniquePtr> MergeTwoCursor::merge_sorted_cursor_two_way() {
     DCHECK(!(_left_run.empty() && _right_run.empty()));
     const SortDescs& sort_desc = _sort_desc;
     ChunkUniquePtr result;
+
+    {
+        // debug scope
+        DCHECK(!(_left_is_empty && !_left_run.empty()));
+        DCHECK(!(_right_is_empty && !_right_run.empty()));
+
+        _left_is_empty |= _left_run.empty();
+        _right_is_empty |= _right_run.empty();
+    }
 
     int intersect = _left_run.intersect(sort_desc, _right_run);
     if (intersect < 0) {

--- a/be/test/runtime/merge_cascade_test.cpp
+++ b/be/test/runtime/merge_cascade_test.cpp
@@ -40,12 +40,6 @@ TEST(MergeCascadeTest, merge_cursor_test) {
     ASSERT_OK(sort_exprs.prepare(&dummy_rt_st, {}, {}));
     ASSERT_OK(sort_exprs.open(&dummy_rt_st));
 
-    std::queue<ChunkUniquePtr> l_chunk_channel;
-    std::queue<ChunkUniquePtr> r_chunk_channel;
-
-    bool l_shutdown = false;
-    bool r_shutdown = false;
-
     struct ChannelChunkProvider {
         ChannelChunkProvider(std::queue<ChunkUniquePtr>& channel_, bool* shutdown_)
                 : channel(channel_), _shutdown(shutdown_) {}
@@ -70,41 +64,102 @@ TEST(MergeCascadeTest, merge_cursor_test) {
         bool* _shutdown;
     };
 
-    ChunkProvider l_provider = ChannelChunkProvider(l_chunk_channel, &l_shutdown);
-    ChunkProvider r_provider = ChannelChunkProvider(r_chunk_channel, &r_shutdown);
+    // merge two stream
+    // one is not ready
+    {
+        std::queue<ChunkUniquePtr> l_chunk_channel;
+        std::queue<ChunkUniquePtr> r_chunk_channel;
 
-    auto l_cursor = std::make_unique<SimpleChunkSortCursor>(l_provider, &sort_exprs.lhs_ordering_expr_ctxs());
-    auto r_cursor = std::make_unique<SimpleChunkSortCursor>(r_provider, &sort_exprs.lhs_ordering_expr_ctxs());
+        bool l_shutdown = false;
+        bool r_shutdown = false;
 
-    size_t chunk_size = 4096;
-    auto l = chunk->clone_unique();
-    l->columns()[0]->append_datum(Datum(1));
-    l->columns()[0]->assign(chunk_size, 0);
+        ChunkProvider l_provider = ChannelChunkProvider(l_chunk_channel, &l_shutdown);
+        ChunkProvider r_provider = ChannelChunkProvider(r_chunk_channel, &r_shutdown);
 
-    auto r = chunk->clone_unique();
-    r->columns()[0]->append_datum(Datum(9999));
-    r->columns()[0]->assign(chunk_size, 0);
+        auto l_cursor = std::make_unique<SimpleChunkSortCursor>(l_provider, &sort_exprs.lhs_ordering_expr_ctxs());
+        auto r_cursor = std::make_unique<SimpleChunkSortCursor>(r_provider, &sort_exprs.lhs_ordering_expr_ctxs());
 
-    l_chunk_channel.emplace(l->clone_unique());
-    r_chunk_channel.emplace(r->clone_unique());
+        size_t chunk_size = 4096;
+        auto l = chunk->clone_unique();
+        l->columns()[0]->append_datum(Datum(1));
+        l->columns()[0]->assign(chunk_size, 0);
 
-    auto desc = SortDescs::asc_null_first(1);
-    MergeTwoCursor cursor(desc, std::move(l_cursor), std::move(r_cursor));
+        auto r = chunk->clone_unique();
+        r->columns()[0]->append_datum(Datum(9999));
+        r->columns()[0]->assign(chunk_size, 0);
 
-    auto out_cursor = cursor.as_chunk_cursor();
-    ASSERT_TRUE(out_cursor->is_data_ready());
+        l_chunk_channel.emplace(l->clone_unique());
+        r_chunk_channel.emplace(r->clone_unique());
 
-    // call get next 1
-    auto merge_res = out_cursor->try_get_next();
-    // call get next 2
-    merge_res = out_cursor->try_get_next();
+        auto desc = SortDescs::asc_null_first(1);
+        MergeTwoCursor cursor(desc, std::move(l_cursor), std::move(r_cursor));
 
-    // left channel is is not eos
-    ASSERT_TRUE(merge_res.first == nullptr);
+        auto out_cursor = cursor.as_chunk_cursor();
+        ASSERT_TRUE(out_cursor->is_data_ready());
 
-    l_shutdown = true;
-    merge_res = out_cursor->try_get_next();
+        // call get next 1
+        auto merge_res = out_cursor->try_get_next();
+        // call get next 2
+        merge_res = out_cursor->try_get_next();
 
-    ASSERT_FALSE(merge_res.first->is_empty());
+        // left channel is is not eos
+        ASSERT_TRUE(merge_res.first == nullptr);
+
+        l_shutdown = true;
+        merge_res = out_cursor->try_get_next();
+
+        ASSERT_FALSE(merge_res.first->is_empty());
+    }
+
+    // merge two stream
+    // all of data return in one batch
+    // one is not ready the other is ready
+    {
+        std::queue<ChunkUniquePtr> l_chunk_channel;
+        std::queue<ChunkUniquePtr> r_chunk_channel;
+
+        bool l_shutdown = false;
+        bool r_shutdown = false;
+
+        ChunkProvider l_provider = ChannelChunkProvider(l_chunk_channel, &l_shutdown);
+        ChunkProvider r_provider = ChannelChunkProvider(r_chunk_channel, &r_shutdown);
+
+        auto l_cursor = std::make_unique<SimpleChunkSortCursor>(l_provider, &sort_exprs.lhs_ordering_expr_ctxs());
+        auto r_cursor = std::make_unique<SimpleChunkSortCursor>(r_provider, &sort_exprs.lhs_ordering_expr_ctxs());
+
+        size_t chunk_size = 4096;
+        auto l = chunk->clone_unique();
+        l->columns()[0]->append_datum(Datum(1));
+        l->columns()[0]->assign(chunk_size, 0);
+
+        auto r = chunk->clone_unique();
+        r->columns()[0]->append_datum(Datum(1));
+        r->columns()[0]->assign(chunk_size, 0);
+
+        l_chunk_channel.emplace(l->clone_unique());
+        r_chunk_channel.emplace(r->clone_unique());
+
+        auto desc = SortDescs::asc_null_first(1);
+        MergeTwoCursor cursor(desc, std::move(l_cursor), std::move(r_cursor));
+
+        auto out_cursor = cursor.as_chunk_cursor();
+        ASSERT_TRUE(out_cursor->is_data_ready());
+
+        // call get next 1
+        auto merge_res = out_cursor->try_get_next();
+        ASSERT_TRUE(!merge_res.first->is_empty());
+
+        // call get next 2
+        merge_res = out_cursor->try_get_next();
+
+        ASSERT_TRUE(l_chunk_channel.empty() && r_chunk_channel.empty());
+        // both chunk has no chunk
+        ASSERT_TRUE(merge_res.first == nullptr);
+
+        // notify one channel, but the other channel is not ready
+        l_chunk_channel.emplace(l->clone_unique());
+        merge_res = out_cursor->try_get_next();
+        ASSERT_TRUE(merge_res.first == nullptr);
+    }
 }
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1842

## Problem Summary(Required) ：
detail see in UT
```
merge two stream
all of data return in one batch
one is not ready the other is ready
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
