### PR TITLE
[BugFix] fix block cache key beause of undefined behaviour

### DIFF
--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -26,8 +26,8 @@
 
 namespace starrocks::io {
 
-CacheInputStream::CacheInputStream(std::string filename, std::shared_ptr<SeekableInputStream> stream)
-        : _filename(std::move(filename)), _stream(std::move(stream)), _offset(0) {
+CacheInputStream::CacheInputStream(const std::string& filename, std::shared_ptr<SeekableInputStream> stream)
+        : _filename(filename), _stream(std::move(stream)), _offset(0) {
     _size = _stream->get_size().value();
 #ifdef WITH_BLOCK_CACHE
     // _cache_key = _filename;

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -33,7 +33,7 @@ public:
     };
 
     static constexpr int64_t BLOCK_SIZE = 1 * 1024 * 1024;
-    explicit CacheInputStream(std::string filename, std::shared_ptr<SeekableInputStream> stream);
+    explicit CacheInputStream(const std::string& filename, std::shared_ptr<SeekableInputStream> stream);
 
     ~CacheInputStream() override = default;
 


### PR DESCRIPTION
Signed-off-by: yanz <dirtysalt1987@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17516

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The old code is like below. The problem is, when we `std::move(filename)`, filename has undefined behaviour data. So `hash_value` is also undefined.  And on my machine, filename is clear and hash value is 0.

```
CacheInputStream::CacheInputStream(std::string filename, std::shared_ptr<SeekableInputStream> stream)
        : _filename(std::move(filename)), _stream(std::move(stream)), _offset(0) {
    _size = _stream->get_size().value();
#ifdef WITH_BLOCK_CACHE
    // _cache_key = _filename;
    // use hash(filename) as cache key.
    _cache_key.resize(16);
    char* data = _cache_key.data();
    uint64_t hash_value = HashUtil::hash64(filename.data(), filename.size(), 0);
    memcpy(data, &hash_value, sizeof(hash_value));
    int64_t file_size = _size;
    memcpy(data + 8, &file_size, sizeof(file_size));
    _buffer.reserve(BlockCache::instance()->block_size());
#endif
}
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
