### PR TITLE
[Enhancement] disable Dynamic Partition in replay dump test

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
@@ -134,6 +134,10 @@ public class DynamicPartitionProperty {
         return enable;
     }
 
+    public void disable() {
+        this.enable = false;
+    }
+
     public StartOfDate getStartOfWeek() {
         return startOfWeek;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -561,6 +561,12 @@ public class UtFrameUtils {
             String dbName = entry.getKey().split("\\.")[0];
             OlapTable replayTable = (OlapTable) connectContext.getGlobalStateMgr().getDb("" + dbName)
                     .getTable(entry.getKey().split("\\.")[1]);
+
+            // Should disable Dynamic Partition in replay dump test
+            if (replayTable.getTableProperty() != null) {
+                replayTable.getTableProperty().getDynamicPartitionProperty().disable();
+            }
+
             for (Map.Entry<String, Long> partitionEntry : entry.getValue().entrySet()) {
                 setPartitionStatistics(replayTable, partitionEntry.getKey(), partitionEntry.getValue());
             }


### PR DESCRIPTION
Signed-off-by: kangkaisen <kangkaisen@apache.org>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

For http://39.101.206.100:8090/job/starrocks_fe_unittest/46895/testReport/junit/com.starrocks.sql.plan/ReplayFromDumpTest/testMultiCountDistinct/

```
java.util.ConcurrentModificationException
	at com.google.common.collect.Lists.newArrayList(Lists.java:129)
	at com.starrocks.catalog.OlapTable.getAllPartitions(OlapTable.java:963)
	at com.starrocks.sql.plan.PlanTestBase.setPartitionStatistics(PlanTestBase.java:1125)
	at com.starrocks.utframe.UtFrameUtils.initMockEnv(UtFrameUtils.java:565)
	at com.starrocks.utframe.UtFrameUtils.getNewPlanAndFragmentFromDump(UtFrameUtils.java:632)
	at com.starrocks.sql.plan.ReplayFromDumpTest.getPlanFragment(ReplayFromDumpTest.java:167)
	at com.starrocks.sql.plan.ReplayFromDumpTest.testMultiCountDistinct(ReplayFromDumpTest.java:476)
```

If the olap table enable Dynamic Partition, the idToPartition will be read and modified at the same time, so the ConcurrentModificationException will be throwed.


## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
