### PR TITLE
[Enhancement] adjust default pipeline dop to the number of cores

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1010,6 +1010,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             if (pipelineDop > 0) {
                 return pipelineDop;
             }
+            if (maxPipelineDop <= 0) {
+                return BackendCoreStat.getDefaultDOP();
+            }
             return Math.min(maxPipelineDop, BackendCoreStat.getDefaultDOP());
         } else {
             return parallelExecInstanceNum;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -187,6 +187,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String TABLET_INTERNAL_PARALLEL_MODE = "tablet_internal_parallel_mode";
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
     public static final String PIPELINE_DOP = "pipeline_dop";
+    public static final String MAX_PIPELINE_DOP = "max_pipeline_dop";
 
     public static final String PROFILE_TIMEOUT = "profile_timeout";
     public static final String PROFILE_LIMIT_FOLD = "profile_limit_fold";
@@ -570,6 +571,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
+
+    /*
+     * The maximum pipeline dop limit which only takes effect when pipeline_dop=0.
+     * This limitation is to avoid the negative overhead caused by scheduling on super multi-core scenarios.
+     */
+    @VariableMgr.VarAttr(name = MAX_PIPELINE_DOP)
+    private int maxPipelineDop = 64;
 
     @VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE)
     private int profileTimeout = 2;
@@ -1002,7 +1010,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             if (pipelineDop > 0) {
                 return pipelineDop;
             }
-            return BackendCoreStat.getDefaultDOP();
+            return Math.min(maxPipelineDop, BackendCoreStat.getDefaultDOP());
         } else {
             return parallelExecInstanceNum;
         }
@@ -1258,6 +1266,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
+    }
+
+    public void setMaxPipelineDop(int maxPipelineDop) {
+        this.maxPipelineDop = maxPipelineDop;
+    }
+
+    public int getMaxPipelineDop() {
+        return this.maxPipelineDop;
     }
 
     public boolean isEnableSharedScan() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -83,7 +83,6 @@ public class BackendCoreStat {
     }
 
     public static int getDefaultDOP() {
-        int avgNumOfCores = BackendCoreStat.getAvgNumOfHardwareCoresOfBe();
-        return Math.max(1, avgNumOfCores / 2);
+        return Math.max(1, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -200,7 +200,7 @@ public class AggregateTest extends PlanTestBase {
         int originPipelineDop = connectContext.getSessionVariable().getPipelineDop();
         try {
             int cpuCores = 8;
-            int expectedTotalDop = cpuCores / 2;
+            int expectedTotalDop = cpuCores;
             {
                 BackendCoreStat.setDefaultCoresOfBe(cpuCores);
                 Pair<String, ExecPlan> plan = UtFrameUtils.getPlanAndFragment(connectContext, queryStr);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
@@ -70,7 +70,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         PlanFragment fragment0 = plan.getFragments().get(0);
         assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "SCAN SCHEMA");
         Assert.assertEquals(1, fragment0.getParallelExecNum());
-        Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
+        Assert.assertEquals(numHardwareCores, fragment0.getPipelineDop());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         PlanFragment fragment1 = plan.getFragments().get(1);
         assertContains(fragment1.getExplainString(TExplainLevel.NORMAL), "MetaScan");
         Assert.assertEquals(1, fragment1.getParallelExecNum());
-        Assert.assertEquals(numHardwareCores / 2, fragment1.getPipelineDop());
+        Assert.assertEquals(numHardwareCores, fragment1.getPipelineDop());
     }
 
     @Test
@@ -93,7 +93,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         PlanFragment fragment0 = plan.getFragments().get(0);
         assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "RESULT SINK");
         Assert.assertEquals(1, fragment0.getParallelExecNum());
-        Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
+        Assert.assertEquals(numHardwareCores, fragment0.getPipelineDop());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class PipelineParallelismTest extends PlanTestBase {
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // ParallelExecNum of fragment not 1. still can not use pipeline
             Assert.assertEquals(1, fragment0.getParallelExecNum());
-            Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
+            Assert.assertEquals(numHardwareCores, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }
@@ -165,7 +165,7 @@ public class PipelineParallelismTest extends PlanTestBase {
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
             Assert.assertEquals(1, fragment0.getParallelExecNum());
-            Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
+            Assert.assertEquals(numHardwareCores, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }
@@ -203,7 +203,7 @@ public class PipelineParallelismTest extends PlanTestBase {
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
             Assert.assertEquals(1, fragment0.getParallelExecNum());
-            Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
+            Assert.assertEquals(numHardwareCores, fragment0.getPipelineDop());
         } finally {
             Config.enable_pipeline_load = prevEnablePipelineLoad;
         }
@@ -216,7 +216,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         PlanFragment fragment1 = plan.getFragments().get(1);
         assertContains(fragment1.getExplainString(TExplainLevel.NORMAL), "TOP-N");
         Assert.assertEquals(1, fragment1.getParallelExecNum());
-        Assert.assertEquals(numHardwareCores / 2, fragment1.getPipelineDop());
+        Assert.assertEquals(numHardwareCores, fragment1.getPipelineDop());
     }
 
     private void testJoinHelper(int expectedParallelism) throws Exception {
@@ -265,7 +265,7 @@ public class PipelineParallelismTest extends PlanTestBase {
 
             connectContext.getSessionVariable().setPipelineDop(0);
             connectContext.getSessionVariable().setParallelExecInstanceNum(1);
-            testJoinHelper(numHardwareCores / 2);
+            testJoinHelper(numHardwareCores);
 
             connectContext.getSessionVariable().setPipelineDop(4);
             connectContext.getSessionVariable().setParallelExecInstanceNum(8);

--- a/fe/fe-core/src/test/java/com/starrocks/system/BackendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/BackendTest.java
@@ -32,10 +32,10 @@ public class BackendTest {
     public void cpuCoreUpdate() {
         BackendCoreStat.setNumOfHardwareCoresOfBe(1, 8);
         Assert.assertEquals(8, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
-        Assert.assertEquals(4, BackendCoreStat.getDefaultDOP());
+        Assert.assertEquals(8, BackendCoreStat.getDefaultDOP());
 
         BackendCoreStat.setNumOfHardwareCoresOfBe(1, 16);
         Assert.assertEquals(16, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
-        Assert.assertEquals(8, BackendCoreStat.getDefaultDOP());
+        Assert.assertEquals(16, BackendCoreStat.getDefaultDOP());
     }
 }


### PR DESCRIPTION
Signed-off-by: silverbullet233 <3675229+silverbullet233@users.noreply.github.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Adjust the default pipeline dop from half the number of cores to the number of cores, so that the query can make full use of CPU resources, and increase the maximum pipeline dop limit to reduce the extra overhead caused by scheduling in super multi-core scenarios.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
