### PR TITLE
[BugFix] Use plan's row_desc instead of empty row_desc

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -497,9 +497,8 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
         if (tsink.type == TDataSinkType::RESULT_SINK) {
             _query_ctx->set_result_sink(true);
         }
-        RowDescriptor row_desc;
         RETURN_IF_ERROR(DataSink::create_data_sink(runtime_state, tsink, fragment.output_exprs, params,
-                                                   request.sender_id(), row_desc, &datasink));
+                                                   request.sender_id(), plan->row_desc(), &datasink));
         RuntimeProfile* sink_profile = datasink->profile();
         if (sink_profile != nullptr) {
             runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);


### PR DESCRIPTION
Signed-off-by: Kevin Li <ming.moriarty@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
- `MemoryScratchSink` uses `_row_desc` to generate `_id_to_col_name`, if `_row_desc` is empty, the arrow filed converted by `convert_to_arrow_schema` will not contain col_name.
- `col_name` in arrow field is used in starrocks-flink-connector. 

```
void MemoryScratchSinkOperatorFactory::_prepare_id_to_col_name_map() {
    for (auto* tuple_desc : _row_desc.tuple_descriptors()) {
        auto& slots = tuple_desc->slots();
        int64_t tuple_id = tuple_desc->id();
        for (auto slot : slots) {
            int64_t slot_id = slot->id();
            int64_t id = tuple_id << 32 | slot_id;
            _id_to_col_name.emplace(id, slot->col_name());
        }
    }
}


Status convert_to_arrow_schema(const RowDescriptor& row_desc,
                               const std::unordered_map<int64_t, std::string>& id_to_col_name,
                               std::shared_ptr<arrow::Schema>* result,
                               const std::vector<ExprContext*>& output_expr_ctxs) {
    std::vector<std::shared_ptr<arrow::Field>> fields;
    for (const auto& expr_context : output_expr_ctxs) {
        Expr* expr = expr_context->root();
        std::shared_ptr<arrow::Field> field;
        string col_name;
        ColumnRef* col_ref = expr->get_column_ref();
        DCHECK(col_ref != nullptr);
        int64_t slot_id = col_ref->slot_id();
        int64_t tuple_id = col_ref->tuple_id();
        int64_t id = tuple_id << 32 | slot_id;
        auto it = id_to_col_name.find(id);
        if (it == id_to_col_name.end()) {
            LOG(WARNING) << "Can't find the RefSlot in the row_desc.";
        } else {
            col_name = it->second;
        }

        RETURN_IF_ERROR(convert_to_arrow_field(expr->type(), col_name, expr->is_nullable(), &field));
        fields.push_back(field);
    }
    *result = arrow::schema(std::move(fields));
    return Status::OK();
}
```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
