### PR TITLE
[BugFix] Remove the closed hiveclient from client pool

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -100,7 +100,8 @@ public class HiveMetaClient {
         @Override
         public void close() {
             synchronized (clientPoolLock) {
-                if (clientPool.size() >= MAX_HMS_CONNECTION_POOL_SIZE) {
+                if (clientPool.size() >= MAX_HMS_CONNECTION_POOL_SIZE || (hiveClient instanceof HiveMetaStoreThriftClient &&
+                        !((HiveMetaStoreThriftClient) hiveClient).isConnected())) {
                     hiveClient.close();
                 } else {
                     clientPool.offer(this);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaStoreThriftClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaStoreThriftClient.java
@@ -362,6 +362,10 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
         return localMetaStore;
     }
 
+    public boolean isConnected() {
+        return isConnected;
+    }
+
     @Override
     public boolean isCompatibleWith(Configuration conf) {
         // Make a copy of currentMetaVars, there is a race condition that

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -50,6 +50,10 @@ public class HiveMetaClientTest {
                 metaStoreClient.getTable(anyString, anyString);
                 result = new Table();
                 minTimes = 0;
+
+                metaStoreClient.isConnected();
+                result = true;
+                minTimes = 0;
             }
         };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Currently, if a hive meta client that could access hive metastore need to be put into the client pool and reused. But if the connection has been closed, it will be also put back in the client pool. If user's hive metastore service ip keep changing, reconnecting the client using the original ip will cause time out. So we need to remove the closed hiveclient from client pool.
![RxDd3JN4Zj](https://user-images.githubusercontent.com/91597003/217449821-0baabeb8-675f-49ee-a6de-ab059357b634.jpg)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
