### PR TITLE
[Enhancement][branch-2.5] Optimize csv scanner and byte buffer (backport #16772)

### DIFF
--- a/be/src/exec/vectorized/csv_scanner.cpp
+++ b/be/src/exec/vectorized/csv_scanner.cpp
@@ -191,7 +191,6 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
     DCHECK_EQ(0, chunk->num_rows());
     Status status;
     CSVReader::Record record;
-    CSVReader::Fields fields;
 
     int num_columns = chunk->num_columns();
     _column_raw_ptrs.resize(num_columns);
@@ -255,6 +254,7 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
         }
         num_rows += !has_error;
     }
+    fields.clear();
     return chunk->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");
 }
 

--- a/be/src/exec/vectorized/csv_scanner.h
+++ b/be/src/exec/vectorized/csv_scanner.h
@@ -64,6 +64,7 @@ private:
     int _curr_file_index = -1;
     CSVReaderPtr _curr_reader;
     std::vector<ConverterPtr> _converters;
+    CSVReader::Fields fields;
 };
 
 } // namespace starrocks::vectorized

--- a/be/src/util/byte_buffer.h
+++ b/be/src/util/byte_buffer.h
@@ -26,6 +26,7 @@
 #include <memory>
 
 #include "common/logging.h"
+#include "gutil/strings/fastmem.h"
 
 namespace starrocks {
 
@@ -41,12 +42,12 @@ struct ByteBuffer {
     ~ByteBuffer() { delete[] ptr; }
 
     void put_bytes(const char* data, size_t size) {
-        memcpy(ptr + pos, data, size);
+        strings::memcpy_inlined(ptr + pos, data, size);
         pos += size;
     }
 
     void get_bytes(char* data, size_t size) {
-        memcpy(data, ptr + pos, size);
+        strings::memcpy_inlined(data, ptr + pos, size);
         pos += size;
         DCHECK(pos <= limit);
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16771

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Memcpy is used very frequently in bytebuffer,
the performance of strings::memcpy_inlined is better than memcpy,
we replace the old memcpy to new memcpy.
  
In my test, clickbench stream load improve from 8m55s to 8m31s. 

Besides, CSVReader::Fields fields, CSVRow row is frequently reused in csv scanner, 
we can maintain them in CSVScanner class. Thus reduce the cost to create a new vector and resize it if 
there are a lot of columns.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
- [ ] 2.5
- [ ] 2.4
- [ ] 2.3
- [ ] 2.2
