### PR TITLE
[Enhancement] Rank window function optimization supports multi partition columns

### DIFF
--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -362,6 +362,10 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase {
               buffer(inner_mem_pool->allocate(max_one_row_size * chunk_size)) {}
 
     bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+        if (is_downgrade) {
+            return is_downgrade;
+        }
+
         size_t num_rows = chunk->num_rows();
         slice_sizes.assign(num_rows, 0);
 
@@ -424,6 +428,10 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase 
 
     bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
         DCHECK(fixed_byte_size != -1);
+
+        if (is_downgrade) {
+            return is_downgrade;
+        }
 
         size_t num_rows = chunk->num_rows();
         slice_sizes.assign(num_rows, 0);

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -343,29 +343,111 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
     }
 };
 
-// TODO(hcf) to be implemented
 template <typename HashMap>
-struct PartitionHashMapWithSerializedKey {
+struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase {
     using Iterator = typename HashMap::iterator;
+    using KeyType = typename HashMap::key_type;
+
     HashMap hash_map;
 
-    PartitionHashMapWithSerializedKey(int32_t chunk_size) {}
+    Buffer<uint32_t> slice_sizes;
+    uint32_t max_one_row_size = 8;
+
+    std::unique_ptr<MemPool> inner_mem_pool;
+    uint8_t* buffer;
+
+    PartitionHashMapWithSerializedKey(int32_t chunk_size)
+            : PartitionHashMapBase(chunk_size),
+              inner_mem_pool(std::make_unique<MemPool>()),
+              buffer(inner_mem_pool->allocate(max_one_row_size * chunk_size)) {}
+
     bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
-        return false;
+        size_t num_rows = chunk->num_rows();
+        slice_sizes.assign(num_rows, 0);
+
+        uint32_t cur_max_one_row_size = get_max_serialize_size(key_columns);
+        if (UNLIKELY(cur_max_one_row_size > max_one_row_size)) {
+            max_one_row_size = cur_max_one_row_size;
+            inner_mem_pool->clear();
+            // reserved extra SLICE_MEMEQUAL_OVERFLOW_PADDING bytes to prevent SIMD instructions
+            // from accessing out-of-bound memory.
+            buffer = inner_mem_pool->allocate(max_one_row_size * chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+        }
+
+        for (const auto& key_column : key_columns) {
+            key_column->serialize_batch(buffer, slice_sizes, num_rows, max_one_row_size);
+        }
+
+        append_chunk_for_one_key(
+                hash_map, chunk,
+                [&](uint32_t offset) {
+                    return Slice{buffer + offset * max_one_row_size, slice_sizes[offset]};
+                },
+                [&](const KeyType& key) {
+                    uint8_t* pos = mem_pool->allocate(key.size);
+                    strings::memcpy_inlined(pos, key.data, key.size);
+                    return Slice{pos, key.size};
+                },
+                obj_pool);
+
+        return is_downgrade;
+    }
+
+    uint32_t get_max_serialize_size(const Columns& key_columns) {
+        uint32_t max_size = 0;
+        for (const auto& key_column : key_columns) {
+            max_size += key_column->max_one_element_serialize_size();
+        }
+        return max_size;
     }
 };
 
-// TODO(hcf) to be implemented
 template <typename HashMap>
-struct PartitionHashMapWithSerializedKeyFixedSize {
+struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase {
     using Iterator = typename HashMap::iterator;
+    using FixedSizeSliceKey = typename HashMap::key_type;
+
+    static constexpr size_t max_fixed_size = sizeof(FixedSizeSliceKey);
+
     HashMap hash_map;
     bool has_null_column = false;
     int fixed_byte_size = -1; // unset state
 
-    PartitionHashMapWithSerializedKeyFixedSize(int32_t chunk_size) {}
+    Buffer<uint32_t> slice_sizes;
+    std::vector<FixedSizeSliceKey> buffer;
+
+    PartitionHashMapWithSerializedKeyFixedSize(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {
+        buffer.reserve(chunk_size);
+        auto* buf = reinterpret_cast<uint8_t*>(buffer.data());
+        memset(buf, 0x0, max_fixed_size * chunk_size);
+    }
+
     bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
-        return false;
+        DCHECK(fixed_byte_size != -1);
+
+        size_t num_rows = chunk->num_rows();
+        slice_sizes.assign(num_rows, 0);
+
+        auto* buf = reinterpret_cast<uint8_t*>(buffer.data());
+        if (has_null_column) {
+            memset(buf, 0x0, max_fixed_size * num_rows);
+        }
+        for (const auto& key_column : key_columns) {
+            key_column->serialize_batch(buf, slice_sizes, num_rows, max_fixed_size);
+        }
+
+        auto* keys = reinterpret_cast<FixedSizeSliceKey*>(buffer.data());
+        if (has_null_column) {
+            for (size_t i = 0; i < num_rows; ++i) {
+                keys[i].u.size = slice_sizes[i];
+            }
+        }
+
+        append_chunk_for_one_key(
+                hash_map, chunk, [&](uint32_t offset) { return keys[offset]; },
+                [&](const FixedSizeSliceKey& key) { return key; }, obj_pool);
+
+        return is_downgrade;
     }
 };
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownLimitRankingWindowRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownLimitRankingWindowRule.java
@@ -128,11 +128,6 @@ public class PushDownLimitRankingWindowRule extends TransformationRule {
                 .map(ScalarOperator::<ColumnRefOperator>cast)
                 .collect(Collectors.toList());
 
-        // TODO(hcf) we will support multi-partition later
-        if (partitionByColumns.size() > 1) {
-            return Collections.emptyList();
-        }
-
         Ordering firstOrdering = topNOperator.getOrderByElements().get(0);
         if (!firstOrdering.isAscending()) {
             return Collections.emptyList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateRankingWindowRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateRankingWindowRule.java
@@ -135,11 +135,6 @@ public class PushDownPredicateRankingWindowRule extends TransformationRule {
                 .map(ScalarOperator::<ColumnRefOperator>cast)
                 .collect(Collectors.toList());
 
-        // TODO(hcf) we will support multi-partition later
-        if (partitionByColumns.size() > 1) {
-            return Collections.emptyList();
-        }
-
         TopNType topNType = TopNType.parse(callOperator.getFnName());
 
         // If partition by columns is not empty, then we cannot derive sort property from the SortNode


### PR DESCRIPTION
Signed-off-by: ZiheLiu <ziheliu1024@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #17553.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Test
### Environment
3 BE (16vCPUs, 64GB RAM)
ssb 100g

### Queries
```sql
-- Q1 low cardinal (63), HashMapWithSerializedKeyFixedSize
with w1 as (select lo_tax, lo_linenumber, row_number() over(partition by lo_tax, lo_linenumber order by lo_orderkey) as rn from lineorder_flat) 
select 
    ifnull(sum(murmur_hash3_32(lo_tax)), 0)
    + ifnull(sum(murmur_hash3_32(lo_linenumber)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1


-- Q2 low cardinal (225), HashMapWithSerializedKey
with w1 as (select lo_tax, s_nation, row_number() over(partition by lo_tax, s_nation order by lo_orderkey) as rn from lineorder_flat) 
select /*+ SET_VAR(cbo_enable_low_cardinality_optimize=false) */ 
    ifnull(sum(murmur_hash3_32(lo_tax)), 0)
    + ifnull(sum(murmur_hash3_32(s_nation)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0)
from w1 where rn = 1

-- Q3 high cardinal (13998451), HashMapWithSerializedKeyFixedSize
with w1 as (select lo_custkey, lo_linenumber, row_number() over(partition by lo_custkey, lo_linenumber order by lo_orderkey) as rn from lineorder_flat) 
select 
    ifnull(sum(murmur_hash3_32(lo_custkey)), 0)
    + ifnull(sum(murmur_hash3_32(lo_linenumber)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1

-- Q4 high cardinal (49984917), HashMapWithSerializedKey
with w1 as (select c_name, s_nation, row_number() over(partition by c_name, s_nation order by lo_orderkey) as rn from lineorder_flat) 
select /*+ SET_VAR(cbo_enable_low_cardinality_optimize=false) */ 
    ifnull(sum(murmur_hash3_32(c_name)), 0)
    + ifnull(sum(murmur_hash3_32(s_nation)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1


-- Q5 very high cardinal (600037902), HashMapWithSerializedKeyFixedSize
with w1 as (select lo_orderkey, lo_linenumber, row_number() over(partition by lo_orderkey, lo_linenumber order by lo_orderkey) as rn from lineorder_flat) 
select
    ifnull(sum(murmur_hash3_32(lo_orderkey)), 0)
    + ifnull(sum(murmur_hash3_32(lo_linenumber)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1


-- Q6 very high  cardinal (150000000), HashMapWithSerializedKey
with w1 as (select lo_orderkey, c_name,  row_number() over(partition by lo_orderkey, c_name order by lo_orderkey) as rn from lineorder_flat) 
select /*+ SET_VAR(cbo_enable_low_cardinality_optimize=false) */ 
    ifnull(sum(murmur_hash3_32(lo_orderkey)), 0)
    + ifnull(sum(murmur_hash3_32(c_name)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1

```

### Test Result
As for the low cardinal, this PR can gain higher performance, but doesn't reduce  too much memory usage.

| Name | Time (s)  | Peak Memory (GB) | Time (s) | Peak Memory (GB) |
| ---- | --------- | ---------------- | -------- | ---------------- |
|      | Before PR |                  | After PR |                  |
| Q1   | 16.00     | 34.59            | 1.23     | 29.27            |
| Q2   | 20.82     | 42.40            | 4.47     | 35.42            |
| Q3   | 11.24     | 37.10            | 11.33    | 38.09            |
| Q4   | OOM       | 59.44            | OOM      | 58.64            |
| Q5   | 8.15      | 33.93            | 8.13     | 34.89            |
| Q6   | 12.08     | 52.64            | 12.25    | 56.87            |

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
