### PR TITLE
[Enhancement] add flag `hudi_mor_force_jni_reader`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -202,10 +202,6 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         THudiTable tHudiTable = new THudiTable();
         tHudiTable.setLocation(getTableLocation());
 
-        String loc = tHudiTable.getLocation();
-        loc = loc.replace("emr-header-1.cluster-49091:9000", "mycluster");
-        tHudiTable.setLocation(loc);
-
         // columns and partition columns
         Set<String> partitionColumnNames = Sets.newHashSet();
         List<TColumn> tPartitionColumns = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -202,6 +202,10 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         THudiTable tHudiTable = new THudiTable();
         tHudiTable.setLocation(getTableLocation());
 
+        String loc = tHudiTable.getLocation();
+        loc = loc.replace("emr-header-1.cluster-49091:9000", "mycluster");
+        tHudiTable.setLocation(loc);
+
         // columns and partition columns
         Set<String> partitionColumnNames = Sets.newHashSet();
         List<TColumn> tPartitionColumns = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1012,8 +1012,10 @@ public class CoordinatorPreprocessor {
                     scanNode instanceof FileTableScanNode) {
                 if (connectContext != null) {
                     queryOptions.setUse_scan_block_cache(connectContext.getSessionVariable().getUseScanBlockCache());
-                    queryOptions.setEnable_populate_block_cache(
+                    queryOptions.
+                            setEnable_populate_block_cache(
                             connectContext.getSessionVariable().getEnablePopulateBlockCache());
+                    queryOptions.setHudi_mor_force_jni_reader(connectContext.getSessionVariable().getHudiMORForceJNIReader());
                 }
                 HDFSBackendSelector selector =
                         new HDFSBackendSelector(scanNode, locations, assignment, addressToBackendID, usedBackendIDs,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -305,6 +305,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_SCAN_BLOCK_CACHE = "enable_scan_block_cache";
     public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
+    public static final String HUDI_MOR_FORCE_JNI_READER = "hudi_mor_force_jni_reader";
 
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
@@ -769,6 +770,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_POPULATE_BLOCK_CACHE)
     private boolean enablePopulateBlockCache = true;
 
+    @VariableMgr.VarAttr(name = HUDI_MOR_FORCE_JNI_READER)
+    private boolean hudiMORForceJNIReader = true;
+
     public boolean getUseScanBlockCache() {
         return useScanBlockCache;
     }
@@ -839,6 +843,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean getEnablePopulateBlockCache() {
         return enablePopulateBlockCache;
+    }
+
+    public boolean getHudiMORForceJNIReader() {
+        return hudiMORForceJNIReader;
     }
 
     public void setCboCTEMaxLimit(int cboCTEMaxLimit) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -771,7 +771,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enablePopulateBlockCache = true;
 
     @VariableMgr.VarAttr(name = HUDI_MOR_FORCE_JNI_READER)
-    private boolean hudiMORForceJNIReader = true;
+    private boolean hudiMORForceJNIReader = false;
 
     public boolean getUseScanBlockCache() {
         return useScanBlockCache;

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -214,6 +214,8 @@ struct TQueryOptions {
   69: optional bool enable_populate_block_cache;
 
   70: optional bool allow_throw_exception = 0;
+
+  71: optional bool hudi_mor_force_jni_reader;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Right now, HUDI MOR and COW have two different impls. MOR goes via JNI and COW goes via C++. And If MOR has no delta logs, it also goes via C++(not JNI), which is hard for us to test. Because sometimes QA does not know if there is delta logs or not.

So the purpose of this SV is to enfoce hudi mor reader goes via JNI, we can test it thoroughly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
