### PR TITLE
[Enhancement] OutputProperty of PartitionTopN returns children property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -345,11 +345,9 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
         } else if (topN.getPartitionByColumns() == null) {
             outputProperty = PhysicalPropertySet.EMPTY;
         } else {
-            List<Integer> partitionColumnRefSet = new ArrayList<>();
-            topN.getPartitionByColumns().forEach(c ->
-                    partitionColumnRefSet.addAll(
-                            Arrays.stream(c.getUsedColumns().getColumnIds()).boxed().collect(Collectors.toList()))
-            );
+            List<Integer> partitionColumnRefSet = topN.getPartitionByColumns().stream()
+                    .flatMap(c -> Arrays.stream(c.getUsedColumns().getColumnIds()).boxed())
+                    .collect(Collectors.toList());
             if (partitionColumnRefSet.isEmpty()) {
                 outputProperty = PhysicalPropertySet.EMPTY;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -342,8 +342,19 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
             } else {
                 outputProperty = new PhysicalPropertySet(new SortProperty(topN.getOrderSpec()));
             }
-        } else {
+        } else if (topN.getPartitionByColumns() == null) {
             outputProperty = PhysicalPropertySet.EMPTY;
+        } else {
+            List<Integer> partitionColumnRefSet = new ArrayList<>();
+            topN.getPartitionByColumns().forEach(c ->
+                    partitionColumnRefSet.addAll(
+                            Arrays.stream(c.getUsedColumns().getColumnIds()).boxed().collect(Collectors.toList()))
+            );
+            if (partitionColumnRefSet.isEmpty()) {
+                outputProperty = PhysicalPropertySet.EMPTY;
+            } else {
+                outputProperty = new PhysicalPropertySet(childrenOutputProperties.get(0).getDistributionProperty());
+            }
         }
         return mergeCTEProperty(outputProperty);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1991,4 +1991,221 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 11: L_SHIPDATE > CAST(TRUE AS DATE)");
     }
+
+    @Test
+    public void testRankWindowOptimization() throws Exception {
+        String sql;
+        String plan;
+
+        // Partition columns include aggregation grouping columns, so need exchange between PartitionTopN and Analytic.
+        {
+            sql = "with " +
+                    "w1 as (select v2, max(v1) as max_v1 from t0 group by v2), " +
+                    "w2 as (select v2, max_v1, row_number() over(partition by v2, max_v1 order by max_v1) as rn from w1) " +
+                    "select * from w2 where rn = 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  6:ANALYTIC\n" +
+                    "  |  functions: [, row_number(), ]\n" +
+                    "  |  partition by: 11: v2, 13: max\n" +
+                    "  |  order by: 13: max ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  5:SORT\n" +
+                    "  |  order by: <slot 11> 11: v2 ASC, <slot 13> 13: max ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  4:PARTITION-TOP-N\n" +
+                    "  |  partition by: 11: v2 , 13: max \n" +
+                    "  |  partition limit: 2\n" +
+                    "  |  order by: <slot 11> 11: v2 ASC, <slot 13> 13: max ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  3:AGGREGATE (merge finalize)\n" +
+                    "  |  output: max(13: max)\n" +
+                    "  |  group by: 11: v2\n" +
+                    "  |  \n" +
+                    "  2:EXCHANGE");
+
+            sql = "with " +
+                    "w1 as (select v2, max(v1) as max_v1 from t0 group by v2), " +
+                    "w2 as (select v2, max_v1, row_number() over(partition by v2, max_v1 order by max_v1) as rn from w1) " +
+                    "select * from w2 order by rn, v2 limit 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "6:ANALYTIC\n" +
+                    "  |  functions: [, row_number(), ]\n" +
+                    "  |  partition by: 11: v2, 13: max\n" +
+                    "  |  order by: 13: max ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  5:SORT\n" +
+                    "  |  order by: <slot 11> 11: v2 ASC, <slot 13> 13: max ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  4:PARTITION-TOP-N\n" +
+                    "  |  partition by: 11: v2 , 13: max \n" +
+                    "  |  partition limit: 2\n" +
+                    "  |  order by: <slot 11> 11: v2 ASC, <slot 13> 13: max ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  3:AGGREGATE (merge finalize)\n" +
+                    "  |  output: max(13: max)\n" +
+                    "  |  group by: 11: v2\n" +
+                    "  |  \n" +
+                    "  2:EXCHANGE");
+        }
+
+        // Partition columns don't include aggregation grouping columns, so need exchange between PartitionTopN and Analytic.
+        {
+            sql = "with " +
+                    "w1 as (select v2, max(v1) as max_v1 from t0 group by v2), " +
+                    "w2 as (select v2, max_v1, row_number() over(partition by max_v1 order by v2) as rn from w1) " +
+                    "select * from w2 where rn = 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  7:ANALYTIC\n" +
+                    "  |  functions: [, row_number(), ]\n" +
+                    "  |  partition by: 13: max\n" +
+                    "  |  order by: 11: v2 ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  6:SORT\n" +
+                    "  |  order by: <slot 13> 13: max ASC, <slot 11> 11: v2 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  5:EXCHANGE");
+            assertContains(plan, "  4:PARTITION-TOP-N\n" +
+                    "  |  partition by: 13: max \n" +
+                    "  |  partition limit: 2\n" +
+                    "  |  order by: <slot 13> 13: max ASC, <slot 11> 11: v2 ASC\n" +
+                    "  |  offset: 0");
+
+            sql = "with " +
+                    "w1 as (select v2, max(v1) as max_v1 from t0 group by v2), " +
+                    "w2 as (select v2, max_v1, row_number() over(partition by max_v1 order by v2) as rn from w1) " +
+                    "select * from w2 order by rn, v2 limit 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  7:ANALYTIC\n" +
+                    "  |  functions: [, row_number(), ]\n" +
+                    "  |  partition by: 13: max\n" +
+                    "  |  order by: 11: v2 ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  6:SORT\n" +
+                    "  |  order by: <slot 13> 13: max ASC, <slot 11> 11: v2 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  5:EXCHANGE");
+            assertContains("  4:PARTITION-TOP-N\n" +
+                    "  |  partition by: 13: max \n" +
+                    "  |  partition limit: 2\n" +
+                    "  |  order by: <slot 13> 13: max ASC, <slot 11> 11: v2 ASC\n" +
+                    "  |  offset: 0");
+        }
+
+        // Partition columns include table bucket columns, so needn't exchange between PartitionTopN and Analytic.
+        {
+            sql = "with w1 as (select v1, v2, v3, row_number() over(partition by v1, v2 order by v3) as rn from t0) " +
+                    "select * from w1 where rn = 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  4:SELECT\n" +
+                    "  |  predicates: 8: row_number() = 2\n" +
+                    "  |  \n" +
+                    "  3:ANALYTIC\n" +
+                    "  |  functions: [, row_number(), ]\n" +
+                    "  |  partition by: 5: v1, 6: v2\n" +
+                    "  |  order by: 7: v3 ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  2:SORT\n" +
+                    "  |  order by: <slot 5> 5: v1 ASC, <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  1:PARTITION-TOP-N\n" +
+                    "  |  partition by: 5: v1 , 6: v2 \n" +
+                    "  |  partition limit: 2\n" +
+                    "  |  order by: <slot 5> 5: v1 ASC, <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+
+            sql = "with w1 as (select v1, v2, v3, row_number() over(partition by v1, v2 order by v3) as rn from t0) " +
+                    "select * from w1 order by rn, v1 limit 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  4:TOP-N\n" +
+                    "  |  order by: <slot 8> 8: row_number() ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  limit: 2\n" +
+                    "  |  \n" +
+                    "  3:ANALYTIC\n" +
+                    "  |  functions: [, row_number(), ]\n" +
+                    "  |  partition by: 5: v1, 6: v2\n" +
+                    "  |  order by: 7: v3 ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  2:SORT\n" +
+                    "  |  order by: <slot 5> 5: v1 ASC, <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  1:PARTITION-TOP-N\n" +
+                    "  |  partition by: 5: v1 , 6: v2 \n" +
+                    "  |  partition limit: 2\n" +
+                    "  |  order by: <slot 5> 5: v1 ASC, <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+        }
+
+        // Partition columns don't include table bucket columns, so need exchange between PartitionTopN and Analytic.
+        {
+            sql = "with w1 as (select v1, v2, v3, row_number() over(partition by v2, v3 order by v1) as rn from t0) " +
+                    "select * from w1 where rn = 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  5:SELECT\n" +
+                    "  |  predicates: 8: row_number() = 2\n" +
+                    "  |  \n" +
+                    "  4:ANALYTIC\n" +
+                    "  |  functions: [, row_number(), ]\n" +
+                    "  |  partition by: 6: v2, 7: v3\n" +
+                    "  |  order by: 5: v1 ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  3:SORT\n" +
+                    "  |  order by: <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  2:EXCHANGE\n");
+            assertContains(plan, "  1:PARTITION-TOP-N\n" +
+                    "  |  partition by: 6: v2 , 7: v3 \n" +
+                    "  |  partition limit: 2\n" +
+                    "  |  order by: <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+
+            sql = "with w1 as (select v1, v2, v3, row_number() over(partition by v2, v3 order by v1) as rn from t0) " +
+                    "select * from w1 order by rn, v1 limit 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  5:TOP-N\n" +
+                    "  |  order by: <slot 8> 8: row_number() ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  limit: 2\n" +
+                    "  |  \n" +
+                    "  4:ANALYTIC\n" +
+                    "  |  functions: [, row_number(), ]\n" +
+                    "  |  partition by: 6: v2, 7: v3\n" +
+                    "  |  order by: 5: v1 ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  3:SORT\n" +
+                    "  |  order by: <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n");
+            assertContains(plan, "  1:PARTITION-TOP-N\n" +
+                    "  |  partition by: 6: v2 , 7: v3 \n" +
+                    "  |  partition limit: 2\n" +
+                    "  |  order by: <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1997,7 +1997,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String sql;
         String plan;
 
-        // Partition columns include aggregation grouping columns, so need exchange between PartitionTopN and Analytic.
+        // Partition columns include aggregation grouping columns, so needdn't exchange between PartitionTopN and Analytic.
         {
             sql = "with " +
                     "w1 as (select v2, max(v1) as max_v1 from t0 group by v2), " +

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/window.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/window.sql
@@ -400,9 +400,8 @@ select * from (select * from (select v1, row_number() over(partition by v1) as `
 PREDICATE 4: row_number() = 1
     ANALYTIC ({4: row_number()=row_number()} [1: v1] [] ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
         TOP-N (order by [[1: v1 ASC NULLS FIRST]])
-            EXCHANGE SHUFFLE[1]
-                TOP-N (order by [[1: v1 ASC NULLS FIRST]])
-                    SCAN (columns[1: v1] predicate[1: v1 = 1])
+            TOP-N (order by [[1: v1 ASC NULLS FIRST]])
+                SCAN (columns[1: v1] predicate[1: v1 = 1])
 [end]
 
 [sql]


### PR DESCRIPTION
Signed-off-by: ZiheLiu <ziheliu1024@gmail.com>


## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #17553.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When hitting rank window partition optimization, there is a `PartitionTopN` before `Sort->Window`.
However, `PartitionTopN` doesn't inherent output property from children, which results in unuseless ExchangeSinkNode.

For exmaple, `OlapScanNode->Sort->Window` will be changed to `OlapScanNode->PartitionTopN->Exchange  --> Sort->Window`


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
