### PR TITLE
[Feature] Support external catlog -- add getUUID api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -300,6 +300,17 @@ public class Database extends MetaObject implements Writable {
         return id;
     }
 
+    /**
+     * Get the unique id of database in string format, since we already ensure
+     * the uniqueness of id for internal database, we just convert it to string
+     * and return, for external database it's up to the implementation of connector.
+     *
+     * @return unique id of database in string format
+     */
+    public String getUUID() {
+        return Long.toString(id);
+    }
+
     public String getOriginName() {
         return fullQualifiedName;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -179,6 +179,17 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         return id;
     }
 
+    /**
+     * Get the unique id of table in string format, since we already ensure
+     * the uniqueness of id for internal table, we just convert it to string
+     * and return, for external table it's up to the implementation of connector.
+     *
+     * @return unique id of table in string format
+     */
+    public String getUUID() {
+        return Long.toString(id);
+    }
+
     public void setId(long id) {
         this.id = id;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
@@ -23,13 +23,17 @@ import java.util.List;
 import java.util.Objects;
 
 public class DbPEntryObject implements PEntryObject {
-    public static final long ALL_DATABASE_ID = -2; // -2 represent all
+    public static final String ALL_DATABASES_UUID = "ALL_DATABASES_UUID"; // represent all databases
 
     @SerializedName(value = "i")
-    private long id;
+    private String uuid;
 
-    public long getId() {
-        return id;
+    public String getUUID() {
+        return uuid;
+    }
+
+    protected DbPEntryObject(String uuid) {
+        this.uuid = uuid;
     }
 
     public static DbPEntryObject generate(GlobalStateMgr mgr, List<String> tokens) throws PrivilegeException {
@@ -38,18 +42,23 @@ public class DbPEntryObject implements PEntryObject {
         }
 
         if (tokens.get(0).equals("*")) {
-            return new DbPEntryObject(ALL_DATABASE_ID);
+            return new DbPEntryObject(ALL_DATABASES_UUID);
         }
 
         Database database = mgr.getDb(tokens.get(0));
         if (database == null) {
             throw new PrivObjNotFoundException("cannot find db: " + tokens.get(0));
         }
-        return new DbPEntryObject(database.getId());
+        return new DbPEntryObject(database.getUUID());
     }
 
-    protected DbPEntryObject(long dbId) {
-        id = dbId;
+    public static DbPEntryObject generate(
+            List<String> allTypes, String restrictType, String restrictName) throws PrivilegeException {
+        // only support ON ALL DATABASE
+        if (allTypes.size() != 1 || restrictType != null || restrictName != null) {
+            throw new PrivilegeException("invalid ALL statement for databases! only support ON ALL DATABASES");
+        }
+        return new DbPEntryObject(ALL_DATABASES_UUID);
     }
 
     /**
@@ -65,25 +74,26 @@ public class DbPEntryObject implements PEntryObject {
             return false;
         }
         DbPEntryObject other = (DbPEntryObject) obj;
-        if (other.id == ALL_DATABASE_ID) {
+        if (Objects.equals(other.uuid, ALL_DATABASES_UUID)) {
             return true;
         }
-        return other.id == id;
+        return Objects.equals(other.uuid, uuid);
     }
 
     @Override
     public boolean isFuzzyMatching() {
-        return ALL_DATABASE_ID == id;
+        return ALL_DATABASES_UUID.equals(uuid);
     }
 
     @Override
     public boolean validate(GlobalStateMgr globalStateMgr) {
-        return globalStateMgr.getDbIncludeRecycleBin(this.id) != null;
+        // TODO(yiming): change validation method for external catalog
+        return globalStateMgr.getDbIncludeRecycleBin(Long.parseLong(this.uuid)) != null;
     }
 
     @Override
     public PEntryObject clone() {
-        return new DbPEntryObject(id);
+        return new DbPEntryObject(uuid);
     }
 
     @Override
@@ -92,7 +102,17 @@ public class DbPEntryObject implements PEntryObject {
             throw new ClassCastException("cannot cast " + obj.getClass().toString() + " to " + this.getClass());
         }
         DbPEntryObject o = (DbPEntryObject) obj;
-        return Long.compare(this.id, o.id);
+        // Always put the fuzzy matching object at the front of the privilege entry list
+        // when sorting in ascendant order.
+        if (Objects.equals(this.uuid, o.uuid)) {
+            return 0;
+        } else if (Objects.equals(this.uuid, ALL_DATABASES_UUID)) {
+            return -1;
+        } else if (Objects.equals(o.uuid, ALL_DATABASES_UUID)) {
+            return 1;
+        } else {
+            return this.uuid.compareTo(o.uuid);
+        }
     }
 
     @Override
@@ -104,11 +124,11 @@ public class DbPEntryObject implements PEntryObject {
             return false;
         }
         DbPEntryObject that = (DbPEntryObject) o;
-        return id == that.id;
+        return Objects.equals(uuid, that.uuid);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(uuid);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/MaterializedViewPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/MaterializedViewPEntryObject.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 public class MaterializedViewPEntryObject extends TablePEntryObject {
 
-    protected MaterializedViewPEntryObject(long databaseId, long tableId) {
-        super(databaseId, tableId);
+    protected MaterializedViewPEntryObject(String dbUUID, String tblUUID) {
+        super(dbUUID, tblUUID);
     }
 
     public static MaterializedViewPEntryObject generate(GlobalStateMgr mgr, List<String> tokens)
@@ -31,31 +31,31 @@ public class MaterializedViewPEntryObject extends TablePEntryObject {
         if (tokens.size() != 2) {
             throw new PrivilegeException("invalid object tokens, should have two: " + tokens);
         }
-        long dbId;
-        long tableId;
+        String dbUUID;
+        String tblUUID;
 
         if (tokens.get(0).equals("*")) {
-            dbId = ALL_DATABASE_ID;
-            tableId = ALL_TABLES_ID;
+            dbUUID = ALL_DATABASE_UUID;
+            tblUUID = ALL_TABLES_UUID;
         } else {
             Database database = mgr.getDb(tokens.get(0));
             if (database == null) {
                 throw new PrivObjNotFoundException("cannot find db: " + tokens.get(0));
             }
-            dbId = database.getId();
+            dbUUID = database.getUUID();
 
             if (tokens.get(1).equals("*")) {
-                tableId = ALL_TABLES_ID;
+                tblUUID = ALL_TABLES_UUID;
             } else {
                 Table table = database.getTable(tokens.get(1));
                 if (table == null || !table.getType().equals(Table.TableType.MATERIALIZED_VIEW)) {
                     throw new PrivObjNotFoundException(
                             "cannot find materialized view " + tokens.get(1) + " in db " + tokens.get(0));
                 }
-                tableId = table.getId();
+                tblUUID = table.getUUID();
             }
         }
 
-        return new MaterializedViewPEntryObject(dbId, tableId);
+        return new MaterializedViewPEntryObject(dbUUID, tblUUID);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeManager.java
@@ -200,8 +200,9 @@ public class PrivilegeManager {
             rolePrivilegeCollection = initBuiltinRoleUnlocked(PUBLIC_ROLE_ID, publicRoleName);
             // GRANT SELECT ON ALL TABLES IN information_schema
             List<PEntryObject> object = Collections.singletonList(new TablePEntryObject(
-                    SystemId.INFORMATION_SCHEMA_DB_ID, TablePEntryObject.ALL_TABLES_ID));
-            rolePrivilegeCollection.grant(ObjectType.TABLE, Collections.singletonList(PrivilegeType.SELECT), object, false);
+                    Long.toString(SystemId.INFORMATION_SCHEMA_DB_ID), TablePEntryObject.ALL_TABLES_UUID));
+            rolePrivilegeCollection.grant(ObjectType.TABLE, Collections.singletonList(PrivilegeType.SELECT), object,
+                    false);
 
             // 6. builtin user root
             UserPrivilegeCollection rootCollection = new UserPrivilegeCollection();

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ViewPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ViewPEntryObject.java
@@ -25,38 +25,38 @@ import java.util.List;
  * View is a subclass of table, only the table type is different
  */
 public class ViewPEntryObject extends TablePEntryObject {
-    protected ViewPEntryObject(long databaseId, long tableId) {
-        super(databaseId, tableId);
+    protected ViewPEntryObject(String dbUUID, String tblUUID) {
+        super(dbUUID, tblUUID);
     }
 
     public static ViewPEntryObject generate(GlobalStateMgr mgr, List<String> tokens) throws PrivilegeException {
         if (tokens.size() != 2) {
             throw new PrivilegeException("invalid object tokens, should have two: " + tokens);
         }
-        long dbId;
-        long tableId;
+        String dbUUID;
+        String tblUUID;
 
         if (tokens.get(0).equals("*")) {
-            dbId = ALL_DATABASE_ID;
-            tableId = ALL_TABLES_ID;
+            dbUUID = ALL_DATABASE_UUID;
+            tblUUID = ALL_TABLES_UUID;
         } else {
             Database database = mgr.getDb(tokens.get(0));
             if (database == null) {
                 throw new PrivObjNotFoundException("cannot find db: " + tokens.get(0));
             }
-            dbId = database.getId();
+            dbUUID = database.getUUID();
 
             if (tokens.get(1).equals("*")) {
-                tableId = ALL_TABLES_ID;
+                tblUUID = ALL_TABLES_UUID;
             } else {
                 Table table = database.getTable(tokens.get(1));
                 if (table == null || !table.getType().equals(Table.TableType.VIEW)) {
                     throw new PrivObjNotFoundException("cannot find view " + tokens.get(1) + " in db " + tokens.get(0));
                 }
-                tableId = table.getId();
+                tblUUID = table.getUUID();
             }
         }
 
-        return new ViewPEntryObject(dbId, tableId);
+        return new ViewPEntryObject(dbUUID, tblUUID);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -108,6 +108,7 @@ import com.starrocks.sql.ast.ViewRelation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -334,20 +335,23 @@ public class AstToStringBuilder {
                     case VIEW:
                     case MATERIALIZED_VIEW: {
                         TablePEntryObject tablePEntryObject = (TablePEntryObject) stmt.getObjectList().get(0);
-                        if (tablePEntryObject.getDatabaseId() == TablePEntryObject.ALL_DATABASE_ID) {
+                        if (Objects.equals(tablePEntryObject.getDatabaseUUID(), TablePEntryObject.ALL_DATABASE_UUID)) {
                             sb.append("ALL ").append(plural).append(" IN ALL DATABASES");
                         } else {
-                            Database database = GlobalStateMgr.getCurrentState().getDb(tablePEntryObject.getDatabaseId());
-                            if (tablePEntryObject.getTableId() == TablePEntryObject.ALL_TABLES_ID) {
+                            // TODO(yiming): change it for external catalog
+                            Database database = GlobalStateMgr.getCurrentState()
+                                    .getDb(Long.parseLong(tablePEntryObject.getDatabaseUUID()));
+                            if (Objects.equals(tablePEntryObject.getTableUUID(), TablePEntryObject.ALL_TABLES_UUID)) {
                                 sb.append("ALL TABLES ");
                                 sb.append("IN DATABASE ").append(database.getFullName());
                             } else {
                                 sb.append(stmt.getObjectType().name()).append(" ");
-
                                 List<String> objectString = new ArrayList<>();
                                 for (PEntryObject pEntryObject : stmt.getObjectList()) {
+
                                     TablePEntryObject tp = (TablePEntryObject) pEntryObject;
-                                    Table table = database.getTable(tp.getTableId());
+                                    // TODO(yiming): change it for external catalog
+                                    Table table = database.getTable(Long.parseLong(tp.getTableUUID()));
                                     objectString.add(database.getFullName() + "." + table.getName());
                                 }
                                 sb.append(Joiner.on(", ").join(objectString));
@@ -357,11 +361,13 @@ public class AstToStringBuilder {
                     }
                     case DATABASE: {
                         DbPEntryObject dbPEntryObject = (DbPEntryObject) stmt.getObjectList().get(0);
-                        if (dbPEntryObject.getId() == DbPEntryObject.ALL_DATABASE_ID) {
+                        if (Objects.equals(dbPEntryObject.getUUID(), DbPEntryObject.ALL_DATABASES_UUID)) {
                             sb.append("ALL DATABASES");
                         } else {
                             sb.append(stmt.getObjectType().name()).append(" ");
-                            Database database = GlobalStateMgr.getCurrentState().getDb(dbPEntryObject.getId());
+                            // TODO(yiming): change it for external catalog
+                            Database database =
+                                    GlobalStateMgr.getCurrentState().getDb(Long.parseLong(dbPEntryObject.getUUID()));
                             sb.append(database.getFullName());
                         }
                         break;

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
@@ -29,7 +29,7 @@ public class PrivilegeCollectionTest {
         PrivilegeType select = PrivilegeType.SELECT;
         PrivilegeType insert = PrivilegeType.INSERT;
         PrivilegeType delete = PrivilegeType.DELETE;
-        TablePEntryObject table1 = new TablePEntryObject(1, 2);
+        TablePEntryObject table1 = new TablePEntryObject("1", "2");
         ObjectType system = ObjectType.SYSTEM;
 
         Assert.assertFalse(collection.check(table, insert, table1));
@@ -90,7 +90,7 @@ public class PrivilegeCollectionTest {
         PrivilegeType select = PrivilegeType.SELECT;
         PrivilegeType insert = PrivilegeType.INSERT;
         PrivilegeType delete = PrivilegeType.DELETE;
-        TablePEntryObject table1 = new TablePEntryObject(1, 2);
+        TablePEntryObject table1 = new TablePEntryObject("1", "2");
 
         // grant select on table1 with grant option
         collection.grant(table, Arrays.asList(select), Arrays.asList(table1), true);
@@ -145,10 +145,10 @@ public class PrivilegeCollectionTest {
         ObjectType table = ObjectType.TABLE;
         PrivilegeType select = PrivilegeType.SELECT;
         PrivilegeType insert = PrivilegeType.INSERT;
-        TablePEntryObject table1 = new TablePEntryObject(1, 2);
-        TablePEntryObject allTablesInDb = new TablePEntryObject(1, TablePEntryObject.ALL_TABLES_ID);
+        TablePEntryObject table1 = new TablePEntryObject("1", "2");
+        TablePEntryObject allTablesInDb = new TablePEntryObject("1", TablePEntryObject.ALL_TABLES_UUID);
         TablePEntryObject allTablesInALLDb = new TablePEntryObject(
-                TablePEntryObject.ALL_DATABASE_ID, TablePEntryObject.ALL_TABLES_ID);
+                TablePEntryObject.ALL_DATABASE_UUID, TablePEntryObject.ALL_TABLES_UUID);
 
         // grant select,insert on db1.table1
         collection.grant(table, Arrays.asList(select, insert), Arrays.asList(table1), false);
@@ -192,10 +192,10 @@ public class PrivilegeCollectionTest {
         PrivilegeType select = PrivilegeType.SELECT;
         PrivilegeType insert = PrivilegeType.INSERT;
 
-        TablePEntryObject table1 = new TablePEntryObject(111, 222);
+        TablePEntryObject table1 = new TablePEntryObject("111", "222");
         ObjectType db = ObjectType.DATABASE;
         PrivilegeType drop = PrivilegeType.DROP;
-        DbPEntryObject db1 = new DbPEntryObject(333);
+        DbPEntryObject db1 = new DbPEntryObject("333");
 
         PrivilegeCollection collection = new PrivilegeCollection();
         PrivilegeCollection selectTable = new PrivilegeCollection();
@@ -245,7 +245,7 @@ public class PrivilegeCollectionTest {
         PrivilegeType select = PrivilegeType.SELECT;
         PrivilegeType insert = PrivilegeType.INSERT;
         PrivilegeType delete = PrivilegeType.DELETE;
-        TablePEntryObject table1 = new TablePEntryObject(111, 222);
+        TablePEntryObject table1 = new TablePEntryObject("111", "222");
         PrivilegeCollection.PrivilegeEntry entry = new PrivilegeCollection.PrivilegeEntry(
                 new ActionSet(Arrays.asList(select, insert)),
                 table1,

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeManagerTest.java
@@ -559,16 +559,16 @@ public class PrivilegeManagerTest {
         manager.grant(grantDbStmt);
         List<PEntryObject> objects = Arrays.asList(goodTableObject);
         // 3. add invalidate entry: select on invalidatedb.table
-        objects = Arrays.asList(new TablePEntryObject(-1, goodTableObject.tableId));
+        objects = Arrays.asList(new TablePEntryObject("-1", goodTableObject.tableUUID));
         manager.grantToUser(grantTableStmt.getObjectType(), grantTableStmt.getPrivilegeTypes(), objects, false, testUser);
         // 4. add invalidate entry: select on db.invalidatetable
-        objects = Arrays.asList(new TablePEntryObject(goodTableObject.databaseId, -1));
+        objects = Arrays.asList(new TablePEntryObject(goodTableObject.databaseUUID, "-1"));
         manager.grantToUser(grantTableStmt.getObjectType(), grantTableStmt.getPrivilegeTypes(), objects, false, testUser);
         // 5. add invalidate entry: create_table, drop on invalidatedb
-        objects = Arrays.asList(new DbPEntryObject(-1));
+        objects = Arrays.asList(new DbPEntryObject("-1"));
         manager.grantToUser(grantDbStmt.getObjectType(), grantDbStmt.getPrivilegeTypes(), objects, false, testUser);
         // 6. add valid entry: ALL databases
-        objects = Arrays.asList(new DbPEntryObject(DbPEntryObject.ALL_DATABASE_ID));
+        objects = Arrays.asList(new DbPEntryObject(DbPEntryObject.ALL_DATABASES_UUID));
         manager.grantToUser(grantDbStmt.getObjectType(), grantDbStmt.getPrivilegeTypes(), objects, false, testUser);
         // 7. add valid user
         sql = "grant impersonate on USER root to test_user";


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Change the id of DbPEntryObject and TablePEntryObject to uuid in
string format because for external catalog, the connector cannot
generate a unique integer id for its table or database. For internal
table or db, we just use the interger id directly, SR already ensure its
uniqueness, for external table or, it's up to implementation of connector.

Signed-off-by: Dejun Xia <xiadejun@starrocks.com>

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
