### PR TITLE
[BugFix] Fix ConcurrentModification when olap table deepCopy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -73,9 +73,9 @@ public class RangePartitionInfo extends PartitionInfo {
     @SerializedName(value = "partitionColumns")
     private List<Column> partitionColumns = Lists.newArrayList();
     // formal partition id -> partition range
-    private Map<Long, Range<PartitionKey>> idToRange = Maps.newHashMap();
+    private Map<Long, Range<PartitionKey>> idToRange = Maps.newConcurrentMap();
     // temp partition id -> partition range
-    private Map<Long, Range<PartitionKey>> idToTempRange = Maps.newHashMap();
+    private Map<Long, Range<PartitionKey>> idToTempRange = Maps.newConcurrentMap();
 
     // partitionId -> serialized Range<PartitionKey>
     // because Range<PartitionKey> and PartitionKey can not be serialized by gson
@@ -391,13 +391,13 @@ public class RangePartitionInfo extends PartitionInfo {
 
     @Override
     public void gsonPreProcess() throws IOException {
-        serializedIdToRange = Maps.newHashMap();
+        serializedIdToRange = Maps.newConcurrentMap();
         for (Map.Entry<Long, Range<PartitionKey>> entry : idToRange.entrySet()) {
             byte[] serializedRange = serializeRange(entry.getValue());
             serializedIdToRange.put(entry.getKey(), serializedRange);
         }
 
-        serializedIdToTempRange = Maps.newHashMap();
+        serializedIdToTempRange = Maps.newConcurrentMap();
         for (Map.Entry<Long, Range<PartitionKey>> entry : idToTempRange.entrySet()) {
             byte[] serializedRange = serializeRange(entry.getValue());
             serializedIdToTempRange.put(entry.getKey(), serializedRange);
@@ -406,14 +406,14 @@ public class RangePartitionInfo extends PartitionInfo {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        idToRange = Maps.newHashMap();
+        idToRange = Maps.newConcurrentMap();
         if (serializedIdToRange != null && !serializedIdToRange.isEmpty()) {
             for (Map.Entry<Long, byte[]> entry : serializedIdToRange.entrySet()) {
                 idToRange.put(entry.getKey(), deserializeRange(entry.getValue()));
             }
             serializedIdToRange = null;
         }
-        idToTempRange = Maps.newHashMap();
+        idToTempRange = Maps.newConcurrentMap();
         if (serializedIdToTempRange != null && !serializedIdToTempRange.isEmpty()) {
             for (Map.Entry<Long, byte[]> entry : serializedIdToTempRange.entrySet()) {
                 idToTempRange.put(entry.getKey(), deserializeRange(entry.getValue()));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SetExecutor.java
@@ -147,7 +147,7 @@ public class SetExecutor {
     private void deriveExpressionResult(UserVariable userVariable) {
         QueryStatement queryStatement = ((Subquery) userVariable.getExpression()).getQueryStatement();
         ExecPlan execPlan = StatementPlanner.plan(queryStatement,
-                ConnectContext.get(), true, TResultSinkType.VARIABLE);
+                ConnectContext.get(), TResultSinkType.VARIABLE);
         StmtExecutor executor = new StmtExecutor(ctx, queryStatement);
         Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(ctx, execPlan);
         if (!sqlResult.second.ok()) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -161,7 +161,7 @@ public class StatisticExecutor {
         context.setThreadLocalInfo();
         StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
 
-        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, false, TResultSinkType.STATISTIC);
+        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
         StmtExecutor executor = new StmtExecutor(context, parsedStmt);
         Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(context, execPlan);
         if (!sqlResult.second.ok()) {
@@ -264,7 +264,7 @@ public class StatisticExecutor {
 
     private List<TStatisticData> executeDQL(ConnectContext context, String sql) {
         StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
-        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, true, TResultSinkType.STATISTIC);
+        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
         StmtExecutor executor = new StmtExecutor(context, parsedStmt);
         Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(context, execPlan);
         if (!sqlResult.second.ok()) {


### PR DESCRIPTION
Signed-off-by: kangkaisen <kangkaisen@apache.org>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

for https://github.com/StarRocks/StarRocksBenchmark/issues/325

**The directly cause of this bug is in RangePartitionInfo's gsonPreProcess method, serializedIdToRange will be modified.**

**when I resolve this issue, I also find a potential bug，when analyze the olap table, we must hold the db lock.**


## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
