### PR TITLE
[BugFix] Broker load fail for GCP GCS's if bucket_name contains '_'

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -527,13 +527,13 @@ public class HdfsFsManager {
         CloudConfiguration cloudConfiguration =
                 CloudConfigurationFactory.tryBuildForStorage(loadProperties);
         if (cloudConfiguration != null) {
-            String host = S3A_SCHEME + "://" + pathUri.getUri().getHost();
+            String host = S3A_SCHEME + "://" + pathUri.getUriHost();
             fileSystemIdentity = new HdfsFsIdentity(host, cloudConfiguration.toString());
         } else {
-            // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+            // endpoint is the server host, pathUri.getUriHost() is the bucket
             // we should use these two params as the host identity, because FileSystem will
             // cache both.
-            String host = S3A_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+            String host = S3A_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
             String s3aUgi = accessKey + "," + secretKey;
             fileSystemIdentity = new HdfsFsIdentity(host, s3aUgi);
         }
@@ -619,10 +619,10 @@ public class HdfsFsManager {
         String endpoint = loadProperties.getOrDefault(FS_KS3_ENDPOINT, "");
         String disableCache = loadProperties.getOrDefault(FS_KS3_IMPL_DISABLE_CACHE, "true");
         String connectionSSLEnabled = loadProperties.getOrDefault(FS_KS3_CONNECTION_SSL_ENABLED, "false");
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will
         // cache both.
-        String host = KS3_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = KS3_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String ks3aUgi = accessKey + "," + secretKey;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, ks3aUgi);
         HdfsFs fileSystem = null;
@@ -696,10 +696,10 @@ public class HdfsFsManager {
         String endpoint = loadProperties.getOrDefault(FS_OBS_ENDPOINT, "");
         String disableCache = loadProperties.getOrDefault(FS_OBS_IMPL_DISABLE_CACHE, "true");
         String connectionSSLEnabled = loadProperties.getOrDefault(FS_OBS_CONNECTION_SSL_ENABLED, "false");
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will
         // cache both.
-        String host = OBS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = OBS_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String obsUgi = accessKey + "," + secretKey;
 
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, obsUgi);
@@ -857,10 +857,10 @@ public class HdfsFsManager {
         String endpoint = loadProperties.getOrDefault(FS_OSS_ENDPOINT, "");
         String disableCache = loadProperties.getOrDefault(FS_OSS_IMPL_DISABLE_CACHE, "true");
         String connectionSSLEnabled = loadProperties.getOrDefault(FS_OSS_CONNECTION_SSL_ENABLED, "false");
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will
         // cache both.
-        String host = OSS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = OSS_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String ossUgi = accessKey + "," + secretKey;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, ossUgi);
         HdfsFs fileSystem = null;
@@ -930,10 +930,10 @@ public class HdfsFsManager {
         String endpoint = loadProperties.getOrDefault(FS_COS_ENDPOINT, "");
         String disableCache = loadProperties.getOrDefault(FS_COS_IMPL_DISABLE_CACHE, "true");
         String connectionSSLEnabled = loadProperties.getOrDefault(FS_COS_CONNECTION_SSL_ENABLED, "false");
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will
         // cache both.
-        String host = COS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = COS_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String cosUgi = accessKey + "," + secretKey;
         HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, cosUgi);
         HdfsFs fileSystem = null;

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/WildcardURI.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/WildcardURI.java
@@ -63,6 +63,15 @@ public class WildcardURI {
         return uri;
     }
 
+    public String getUriHost() {
+        String host = uri.getHost();
+        if (host != null) {
+            return host;
+        } else {
+            return "";
+        }
+    }
+
     public String getAuthority() {
         return uri.getAuthority();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/fs/WildcardURITest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/WildcardURITest.java
@@ -55,4 +55,18 @@ public class WildcardURITest {
         }
     }
 
+    @Test
+    public void test_get_host() {
+        try {
+            String path = "s3a://buckettest/test.csv";
+            WildcardURI wildcardURI = new WildcardURI(path);
+            Assert.assertEquals("buckettest", wildcardURI.getUriHost());
+
+            path = "s3a://bucket_test/test.csv";
+            wildcardURI = new WildcardURI(path);
+            Assert.assertEquals("", wildcardURI.getUriHost());
+        } catch (UserException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
 }

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -470,9 +470,9 @@ public class FileSystemManager {
         String disableCache = properties.getOrDefault(FS_S3A_IMPL_DISABLE_CACHE, "true");
         String connectionSSLEnabled = properties.getOrDefault(FS_S3A_CONNECTION_SSL_ENABLED, "true");
         String awsCredProvider = properties.getOrDefault(FS_S3A_AWS_CRED_PROVIDER, null);
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will cache both.
-        String host = S3A_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = S3A_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String s3aUgi = accessKey + "," + secretKey;
         FileSystemIdentity fileSystemIdentity = new FileSystemIdentity(host, s3aUgi);
         BrokerFileSystem fileSystem = null;
@@ -531,9 +531,9 @@ public class FileSystemManager {
         String secretKey = properties.getOrDefault(FS_KS3_SECRET_KEY, "");
         String endpoint = properties.getOrDefault(FS_KS3_ENDPOINT, "");
         String disableCache = properties.getOrDefault(FS_KS3_IMPL_DISABLE_CACHE, "true");
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will cache both.
-        String host = KS3_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = KS3_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String ks3aUgi = accessKey + "," + secretKey;
         FileSystemIdentity fileSystemIdentity = new FileSystemIdentity(host, ks3aUgi);
         BrokerFileSystem fileSystem = null;
@@ -589,9 +589,9 @@ public class FileSystemManager {
         String endpoint = properties.getOrDefault(FS_OBS_ENDPOINT, "");
         String disableCache = properties.getOrDefault(FS_OBS_IMPL_DISABLE_CACHE, "true");
 
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will cache both.
-        String host = OBS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = OBS_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String obsUgi = accessKey + "," + secretKey;
 
         FileSystemIdentity fileSystemIdentity = new FileSystemIdentity(host, obsUgi);
@@ -709,9 +709,9 @@ public class FileSystemManager {
         String secretKey = properties.getOrDefault(FS_OSS_SECRET_KEY, "");
         String endpoint = properties.getOrDefault(FS_OSS_ENDPOINT, "");
         String disableCache = properties.getOrDefault(FS_OSS_IMPL_DISABLE_CACHE, "true");
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will cache both.
-        String host = OSS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = OSS_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String ossUgi = accessKey + "," + secretKey;
         FileSystemIdentity fileSystemIdentity = new FileSystemIdentity(host, ossUgi);
         BrokerFileSystem fileSystem = null;
@@ -759,9 +759,9 @@ public class FileSystemManager {
         String secretKey = properties.getOrDefault(FS_COS_SECRET_KEY, "");
         String endpoint = properties.getOrDefault(FS_COS_ENDPOINT, "");
         String disableCache = properties.getOrDefault(FS_COS_IMPL_DISABLE_CACHE, "true");
-        // endpoint is the server host, pathUri.getUri().getHost() is the bucket
+        // endpoint is the server host, pathUri.getUriHost() is the bucket
         // we should use these two params as the host identity, because FileSystem will cache both.
-        String host = COS_SCHEME + "://" + endpoint + "/" + pathUri.getUri().getHost();
+        String host = COS_SCHEME + "://" + endpoint + "/" + pathUri.getUriHost();
         String cosUgi = accessKey + "," + secretKey;
         FileSystemIdentity fileSystemIdentity = new FileSystemIdentity(host, cosUgi);
         BrokerFileSystem fileSystem = null;

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/WildcardURI.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/common/WildcardURI.java
@@ -67,6 +67,15 @@ public class WildcardURI {
         return uri;
     }
 
+    public String getUriHost() {
+        String host = uri.getHost();
+        if (host != null) {
+            return host;
+        } else {
+            return "";
+        }
+    }
+
     public String getAuthority() {
         return uri.getAuthority();
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For GCP GCS, its bucket name may contain '_' in the middle, for example, "s3a://broker_test/test.csv", at that time uri.getHost() will return nullptr. In this pr, we fix this bug.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
