### PR TITLE
[Enhancement] Add ConnectorTblMetaInfoMgr to manage metadata which can not get from hms

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -40,6 +40,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.connector.ConnectorTableInfo;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -573,6 +574,15 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
                 }
                 MvId mvId = new MvId(db.getId(), id);
                 table.addRelatedMaterializedView(mvId);
+
+                if (!table.isLocalTable()) {
+                    GlobalStateMgr.getCurrentState().getConnectorTblMetaInfoMgr().addConnectorTableInfo(
+                            baseTableInfo.getCatalogName(), baseTableInfo.getDbName(),
+                            baseTableInfo.getTableIdentifier(),
+                            ConnectorTableInfo.builder().setRelatedMaterializedViews(
+                                    Sets.newHashSet(mvId)).build()
+                    );
+                }
             }
         }
         analyzePartitionInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableInfo.java
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.Table;
+
+import java.util.Set;
+
+public class ConnectorTableInfo {
+    // There is no need to persist relatedMaterializedViews, we can add this info from mv when it load image and
+    // replay create mv journal.
+    private Set<MvId> relatedMaterializedViews;
+
+    private ConnectorTableInfo(Set<MvId> relatedMaterializedViews) {
+        this.relatedMaterializedViews = relatedMaterializedViews;
+    }
+
+    public void addConnectorTableInfo(ConnectorTableInfo tableInfo) {
+        if (relatedMaterializedViews == null) {
+            relatedMaterializedViews = Sets.newHashSet(tableInfo.relatedMaterializedViews);
+        } else {
+            relatedMaterializedViews.addAll(tableInfo.relatedMaterializedViews);
+        }
+    }
+
+    public void removeConnectorTableInfo(ConnectorTableInfo tableInfo) {
+        if (relatedMaterializedViews != null && tableInfo.relatedMaterializedViews != null) {
+            relatedMaterializedViews.removeAll(tableInfo.relatedMaterializedViews);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectorTableInfo {" +
+                "relatedMaterializedViews=" + relatedMaterializedViews +
+                "}";
+    }
+
+    public void seTableInfoForConnectorTable(Table table) {
+        if (relatedMaterializedViews != null) {
+            for (MvId relatedMaterializedView : relatedMaterializedViews) {
+                table.addRelatedMaterializedView(relatedMaterializedView);
+            }
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Set<MvId> relatedMaterializedViews = Sets.newHashSet();
+
+        public Builder setRelatedMaterializedViews(Set<MvId> relatedMaterializedViews) {
+            this.relatedMaterializedViews = relatedMaterializedViews;
+            return this;
+        }
+
+        public ConnectorTableInfo build() {
+            return new ConnectorTableInfo(relatedMaterializedViews);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableInfo.java
@@ -29,7 +29,7 @@ public class ConnectorTableInfo {
         this.relatedMaterializedViews = relatedMaterializedViews;
     }
 
-    public void addConnectorTableInfo(ConnectorTableInfo tableInfo) {
+    public void updateMetaInfo(ConnectorTableInfo tableInfo) {
         if (relatedMaterializedViews == null) {
             relatedMaterializedViews = Sets.newHashSet(tableInfo.relatedMaterializedViews);
         } else {
@@ -37,7 +37,7 @@ public class ConnectorTableInfo {
         }
     }
 
-    public void removeConnectorTableInfo(ConnectorTableInfo tableInfo) {
+    public void removeMetaInfo(ConnectorTableInfo tableInfo) {
         if (relatedMaterializedViews != null && tableInfo.relatedMaterializedViews != null) {
             relatedMaterializedViews.removeAll(tableInfo.relatedMaterializedViews);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTblMetaInfoMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTblMetaInfoMgr.java
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class ConnectorTblMetaInfoMgr {
+    private static final Logger LOG = LogManager.getLogger(ConnectorTblMetaInfoMgr.class);
+
+    // catalogName -> dbName -> tableIdentifier -> ConnectorTableInfo
+    private Table<String, String, Map<String, ConnectorTableInfo>> persistTableInfos;
+
+    private ReentrantReadWriteLock lock;
+
+    public ConnectorTblMetaInfoMgr() {
+        persistTableInfos = HashBasedTable.create();
+        lock = new ReentrantReadWriteLock();
+    }
+
+    public ConnectorTableInfo getConnectorTableInfo(String catalog, String db, String tableIdentifier) {
+        readLock();
+        try {
+            Map<String, ConnectorTableInfo> tableInfoMap = persistTableInfos.get(catalog, db);
+            return tableInfoMap == null ? null : tableInfoMap.get(tableIdentifier);
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public void addConnectorTableInfo(String catalog, String db, String tableIdentifier,
+                                      ConnectorTableInfo connectorTableInfo) {
+        writeLock();
+        try {
+            Map<String, ConnectorTableInfo> tableInfoMap = persistTableInfos.get(catalog, db);
+            if (tableInfoMap == null) {
+                tableInfoMap = Maps.newHashMap();
+            }
+
+            ConnectorTableInfo tableInfo = tableInfoMap.get(tableIdentifier);
+            if (tableInfo == null) {
+                tableInfo = ConnectorTableInfo.builder().build();
+            }
+            tableInfo.addConnectorTableInfo(connectorTableInfo);
+
+            tableInfoMap.put(tableIdentifier, tableInfo);
+            persistTableInfos.put(catalog, db, tableInfoMap);
+            LOG.info("{}.{}.{} add persistent connector table info : {}", catalog, db, tableIdentifier,
+                    connectorTableInfo);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public boolean removeConnectorTableInfo(String catalog, String db, String tableIdentifier,
+                                            ConnectorTableInfo connectorTableInfo) {
+        writeLock();
+        try {
+            Map<String, ConnectorTableInfo> tableInfoMap = persistTableInfos.get(catalog, db);
+            if (tableInfoMap == null) {
+                return false;
+            }
+
+            ConnectorTableInfo tableInfo = tableInfoMap.get(tableIdentifier);
+            if (tableInfo == null) {
+                return false;
+            }
+            tableInfo.removeConnectorTableInfo(connectorTableInfo);
+            LOG.info("{}.{}.{} remove persistent connector table info : {}", catalog, db, tableIdentifier,
+                    connectorTableInfo);
+            return true;
+        } finally {
+            writeUnlock();
+        }
+    }
+
+
+    public void setTableInfoForConnectorTable(String catalog, String db,
+                                              com.starrocks.catalog.Table table) {
+        Preconditions.checkState(table != null);
+        String tableIdentifier = table.getTableIdentifier();
+        ConnectorTableInfo tableInfo = getConnectorTableInfo(catalog, db, tableIdentifier);
+        if (tableInfo != null) {
+            tableInfo.seTableInfoForConnectorTable(table);
+        }
+    }
+
+    private void writeLock() {
+        lock.writeLock().lock();
+    }
+
+    private void writeUnlock() {
+        lock.writeLock().unlock();
+    }
+
+    private void readLock() {
+        lock.readLock().lock();
+    }
+
+    private void readUnlock() {
+        lock.readLock().unlock();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -653,9 +653,10 @@ public class GlobalStateMgr {
         this.localMetastore = new LocalMetastore(this, recycleBin, colocateTableIndex, nodeMgr.getClusterInfo());
         this.warehouseMgr = new WarehouseManager();
         this.connectorMgr = new ConnectorMgr();
-        this.metadataMgr = new MetadataMgr(localMetastore, connectorMgr);
-        this.catalogMgr = new CatalogMgr(connectorMgr);
         this.connectorTblMetaInfoMgr = new ConnectorTblMetaInfoMgr();
+        this.metadataMgr = new MetadataMgr(localMetastore, connectorMgr, connectorTblMetaInfoMgr);
+        this.catalogMgr = new CatalogMgr(connectorMgr);
+
 
         this.taskManager = new TaskManager();
         this.insertOverwriteJobManager = new InsertOverwriteJobManager();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -117,6 +117,7 @@ import com.starrocks.common.util.RangeUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.Util;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorTableInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
@@ -3591,6 +3592,15 @@ public class LocalMetastore implements ConnectorMetadata {
                     Table baseTable = baseTableInfo.getTable();
                     if (baseTable != null) {
                         baseTable.removeRelatedMaterializedView(mvId);
+                        if (!baseTable.isLocalTable()) {
+                            // remove relatedMaterializedViews for connector table
+                            GlobalStateMgr.getCurrentState().getConnectorTblMetaInfoMgr().
+                                    removeConnectorTableInfo(baseTableInfo.getCatalogName(),
+                                            baseTableInfo.getDbName(),
+                                            baseTableInfo.getTableIdentifier(),
+                                            ConnectorTableInfo.builder().setRelatedMaterializedViews(
+                                                    Sets.newHashSet(mvId)).build());
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -139,7 +139,13 @@ public class MetadataMgr {
 
     public Table getTable(String catalogName, String dbName, String tblName) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
-        return connectorMetadata.map(metadata -> metadata.getTable(dbName, tblName)).orElse(null);
+        Table connectorTable = connectorMetadata.map(metadata -> metadata.getTable(dbName, tblName)).orElse(null);
+        if (connectorTable != null) {
+            // Load meta information from ConnectorTblMetaInfoMgr for each external table.
+            GlobalStateMgr.getCurrentState().getConnectorTblMetaInfoMgr().setTableInfoForConnectorTable(catalogName,
+                    dbName, connectorTable);
+        }
+        return connectorTable;
     }
 
     public Statistics getTableStatistics(OptimizerContext session,

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -26,6 +26,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
+import com.starrocks.connector.ConnectorTblMetaInfoMgr;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.ConnectContext;
@@ -47,12 +48,15 @@ public class MetadataMgr {
 
     private final LocalMetastore localMetastore;
     private final ConnectorMgr connectorMgr;
+    private final ConnectorTblMetaInfoMgr connectorTblMetaInfoMgr;
     private final Map<String, QueryMetadatas> metadataByQueryId = new ConcurrentHashMap<>();
 
-    public MetadataMgr(LocalMetastore localMetastore, ConnectorMgr connectorMgr) {
+    public MetadataMgr(LocalMetastore localMetastore, ConnectorMgr connectorMgr,
+                       ConnectorTblMetaInfoMgr connectorTblMetaInfoMgr) {
         Preconditions.checkNotNull(localMetastore, "localMetastore is null");
         this.localMetastore = localMetastore;
         this.connectorMgr = connectorMgr;
+        this.connectorTblMetaInfoMgr = connectorTblMetaInfoMgr;
     }
 
     protected Optional<ConnectorMetadata> getOptionalMetadata(String catalogName) {
@@ -142,8 +146,7 @@ public class MetadataMgr {
         Table connectorTable = connectorMetadata.map(metadata -> metadata.getTable(dbName, tblName)).orElse(null);
         if (connectorTable != null) {
             // Load meta information from ConnectorTblMetaInfoMgr for each external table.
-            GlobalStateMgr.getCurrentState().getConnectorTblMetaInfoMgr().setTableInfoForConnectorTable(catalogName,
-                    dbName, connectorTable);
+            connectorTblMetaInfoMgr.setTableInfoForConnectorTable(catalogName, dbName, connectorTable);
         }
         return connectorTable;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/MockedMetadataMgr.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/MockedMetadataMgr.java
@@ -28,7 +28,7 @@ public class MockedMetadataMgr extends MetadataMgr {
     private final LocalMetastore localMetastore;
 
     public MockedMetadataMgr(LocalMetastore localMetastore, ConnectorMgr connectorMgr) {
-        super(localMetastore, connectorMgr);
+        super(localMetastore, connectorMgr, new ConnectorTblMetaInfoMgr());
         this.localMetastore = localMetastore;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/ReplayMetadataMgr.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/ReplayMetadataMgr.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.ConnectorMgr;
+import com.starrocks.connector.ConnectorTblMetaInfoMgr;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.LocalMetastore;
@@ -53,7 +54,7 @@ public class ReplayMetadataMgr extends MetadataMgr {
                              ConnectorMgr connectorMgr,
                              Map<String, Map<String, Map<String, HiveMetaStoreTableDumpInfo>>> externalTableInfoMap,
                              Map<String, Map<String, ColumnStatistic>> identifyToColumnStats) {
-        super(localMetastore, connectorMgr);
+        super(localMetastore, connectorMgr, new ConnectorTblMetaInfoMgr());
         init(externalTableInfoMap, identifyToColumnStats);
     }
 


### PR DESCRIPTION
Signed-off-by: Youngwb <yangwenbo_mailbox@163.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#17453 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For external table, it do not persist it's meta info, it will generate a new table from hms after refresh external table stmt, but sometimes the exteral table need some meta info which can not get from hms (such like related mv on this table), so we add ConnectorTblMetaInfoMgr to manage these meta info.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
