### PR TITLE
[Enhancement] Disable adaptive dop for TopN with RF

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -87,6 +87,7 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
     public List<Expr> resolvedTupleExprs;
 
     private final List<RuntimeFilterDescription> buildRuntimeFilters = Lists.newArrayList();
+    private boolean withRuntimeFilters = false;
 
     public void setAnalyticPartitionExprs(List<Expr> exprs) {
         this.analyticPartitionExprs = exprs;
@@ -161,6 +162,7 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
                 this.buildRuntimeFilters.add(rf);
             }
         }
+        withRuntimeFilters = !buildRuntimeFilters.isEmpty();
     }
 
     @Override
@@ -333,7 +335,7 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
 
     @Override
     public boolean canUsePipeLine() {
-        return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
+        return !withRuntimeFilters && getChildren().stream().allMatch(PlanNode::canUsePipeLine);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -335,12 +335,12 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
 
     @Override
     public boolean canUsePipeLine() {
-        return !withRuntimeFilters && getChildren().stream().allMatch(PlanNode::canUsePipeLine);
+        return getChildren().stream().allMatch(PlanNode::canUsePipeLine);
     }
 
     @Override
     public boolean canUseRuntimeAdaptiveDop() {
-        return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
+        return !withRuntimeFilters && getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: ZiheLiu <ziheliu1024@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When enabling adaptive dop, `OlapScan->TopN` will be modified to `OlapScan->CsSink.  CsSource->TopN`, which will delay TopN getting data and building runtime filters.
Therefore, disable adaptive dop when TopN with runtime filters.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
