### PR TITLE
[Feature] Read binlog to generate change events

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -889,7 +889,7 @@ CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache=1
 
 // limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
-CONF_mInt64(wait_apply_time, "6000")                                 // 6s
+CONF_mInt64(wait_apply_time, "6000");                                // 6s
 
 // Max size of a binlog file. The default is 512MB.
 CONF_Int64(binlog_file_max_size, "536870912");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -891,8 +891,8 @@ CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache=1
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
 CONF_mInt64(wait_apply_time, "6000")                                 // 6s
 
-        // Max size of a binlog file. The default is 512MB.
-        CONF_Int64(binlog_file_max_size, "536870912");
+// Max size of a binlog file. The default is 512MB.
+CONF_Int64(binlog_file_max_size, "536870912");
 
 // Max size of a binlog page. The default is 1MB.
 CONF_Int32(binlog_page_max_size, "1048576");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -893,7 +893,6 @@ CONF_mInt64(wait_apply_time, "6000")                                 // 6s
 
 // Max size of a binlog file. The default is 512MB.
 CONF_Int64(binlog_file_max_size, "536870912");
-
 // Max size of a binlog page. The default is 1MB.
 CONF_Int32(binlog_page_max_size, "1048576");
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -183,6 +183,7 @@ add_library(Storage STATIC
     binlog_file_reader.cpp
     binlog_builder.cpp
     binlog_manager.cpp
+    binlog_reader.cpp
     lake/update_compaction_state.cpp
     lake/txn_log_applier.cpp
 )

--- a/be/src/storage/binlog_file_reader.cpp
+++ b/be/src/storage/binlog_file_reader.cpp
@@ -89,7 +89,7 @@ Status BinlogFileReader::_seek_to_page(int64_t version, int64_t seq_id) {
             // generate a page with an EMPTY log entry, and only allow to seek with
             // <version, 0> to get the log entry
             if (end_seq_id == -1 || seq_id <= end_seq_id) {
-                CHECK((end_seq_id != -1) || (seq_id == 0));
+                DCHECK((end_seq_id != -1) || (seq_id == 0));
                 RETURN_IF_ERROR(
                         _read_page_content(_next_page_index, &page_header_pb, &(_current_page_context->page_content)));
                 break;

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -150,4 +150,41 @@ void BinlogManager::_apply_build_result(BinlogBuildResult* result) {
     _active_binlog_writer = result->active_writer;
 }
 
+StatusOr<int64_t> BinlogManager::register_reader(std::shared_ptr<BinlogReader> reader) {
+    std::unique_lock lock(_meta_lock);
+    int64_t reader_id = _next_reader_id++;
+    _binlog_readers.emplace(reader_id, reader);
+    VLOG(3) << "Register reader " << reader_id << " in binlog manager " << _path;
+    return reader_id;
+}
+
+void BinlogManager::unregister_reader(int64_t reader_id) {
+    std::unique_lock lock(_meta_lock);
+    VLOG(3) << "Unregister reader " << reader_id << " in binlog manager " << _path;
+    _binlog_readers.erase(reader_id);
+}
+
+StatusOr<BinlogFileMetaPBPtr> BinlogManager::find_binlog_meta(int64_t version, int64_t seq_id) {
+    std::shared_lock lock(_meta_lock);
+    int128_t lsn = BinlogUtil::get_lsn(version, seq_id);
+    // find the first file whose start lsn is greater than the target
+    auto upper = _binlog_file_metas.upper_bound(lsn);
+    if (upper == _binlog_file_metas.begin()) {
+        return Status::NotFound(fmt::format("Can't find file meta for version {}, seq_id {}", version, seq_id));
+    }
+
+    BinlogFileMetaPBPtr file_meta;
+    if (upper == _binlog_file_metas.end()) {
+        file_meta = _binlog_file_metas.rbegin()->second;
+    } else {
+        file_meta = (--upper)->second;
+    }
+
+    if (file_meta->end_version() < version) {
+        return Status::NotFound(fmt::format("Can't find file meta for version {}}, seq_id {}", version, seq_id));
+    }
+
+    return file_meta;
+}
+
 } // namespace starrocks

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -181,10 +181,17 @@ StatusOr<BinlogFileMetaPBPtr> BinlogManager::find_binlog_meta(int64_t version, i
     }
 
     if (file_meta->end_version() < version) {
-        return Status::NotFound(fmt::format("Can't find file meta for version {}}, seq_id {}", version, seq_id));
+        return Status::NotFound(fmt::format("Can't find file meta for version {}, seq_id {}", version, seq_id));
     }
 
     return file_meta;
+}
+
+void BinlogManager::close_active_writer() {
+    if (_active_binlog_writer != nullptr) {
+        _active_binlog_writer->close(true);
+        _active_binlog_writer.reset();
+    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -170,6 +170,8 @@ public:
 
     int64_t total_rowset_disk_size() { return _total_rowset_disk_size; }
 
+    void close_active_writer();
+
 private:
     void _apply_build_result(BinlogBuildResult* result);
 

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -207,7 +207,7 @@ private:
     int64_t _total_rowset_disk_size = 0;
 
     // Allocate an id for each binlog reader. Protected by _meta_lock
-    int64_t _next_reader_id;
+    int64_t _next_reader_id = 0;
     // Mapping from the reader id to the readers. Protected by _meta_lock
     std::unordered_map<int64_t, BinlogReaderSharedPtr> _binlog_readers;
 };

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -24,6 +24,7 @@
 #include "gen_cpp/binlog.pb.h"
 #include "storage/binlog_builder.h"
 #include "storage/binlog_file_writer.h"
+#include "storage/binlog_reader.h"
 
 namespace starrocks {
 
@@ -92,7 +93,7 @@ private:
 };
 
 // Manages the binlog metas and files, including generation, deletion and read.
-class BinlogManager : public std::enable_shared_from_this<BinlogManager> {
+class BinlogManager {
 public:
     BinlogManager(int64_t tablet_id, std::string path, int64_t max_file_size, int32_t max_page_size,
                   CompressionTypePB compression_type, std::shared_ptr<RowsetFetcher> rowset_fetcher);
@@ -139,6 +140,18 @@ public:
 
     // Commit the result of pre-commit, and it's visible for reading
     void commit_ingestion(int64_t version);
+
+    // Register the reader, and return a unique id allocated for this reader.
+    StatusOr<int64_t> register_reader(std::shared_ptr<BinlogReader> reader);
+
+    // Unregister the reader with the given id.
+    void unregister_reader(int64_t reader_id);
+
+    // Find the binlog file which may contain the change event with given <version, seq_id>.
+    // Return Status::NotFound if there is no such file.
+    StatusOr<BinlogFileMetaPBPtr> find_binlog_meta(int64_t version, int64_t seq_id);
+
+    std::string get_binlog_file_path(int64_t file_id) { return BinlogUtil::binlog_file_path(_path, file_id); }
 
     // For testing
     int64_t next_file_id() { return _next_file_id; }
@@ -192,6 +205,11 @@ private:
     // statistics for disk usage
     int64_t _total_binlog_file_disk_size = 0;
     int64_t _total_rowset_disk_size = 0;
+
+    // Allocate an id for each binlog reader. Protected by _meta_lock
+    int64_t _next_reader_id;
+    // Mapping from the reader id to the readers. Protected by _meta_lock
+    std::unordered_map<int64_t, BinlogReaderSharedPtr> _binlog_readers;
 };
 
 } // namespace starrocks

--- a/be/src/storage/binlog_reader.cpp
+++ b/be/src/storage/binlog_reader.cpp
@@ -20,6 +20,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/segment_options.h"
+#include "storage/tablet.h"
 
 namespace starrocks {
 

--- a/be/src/storage/binlog_reader.cpp
+++ b/be/src/storage/binlog_reader.cpp
@@ -96,6 +96,7 @@ Status BinlogReader::get_next(ChunkPtr* chunk, int64_t max_version_exclusive) {
     if (_log_entry_info != nullptr && _log_entry_info->log_entry->entry_type() == EMPTY_PB) {
         _next_version += 1;
         _next_seq_id = 0;
+        _log_entry_info = nullptr;
     }
     Status status;
     while (_log_entry_info == nullptr && _next_version < max_version_exclusive) {
@@ -121,7 +122,7 @@ Status BinlogReader::get_next(ChunkPtr* chunk, int64_t max_version_exclusive) {
         }
 
         // sanity check
-        if (_log_entry_info->version != _next_version || _log_entry_info->start_seq_id == _next_seq_id) {
+        if (_log_entry_info->version != _next_version || _log_entry_info->start_seq_id != _next_seq_id) {
             std::string err_msg = fmt::format(
                     "Unexpected entry version/seq_id, reader: {}, tablet: {}, "
                     "expect version/seq_id {}/{}, actual version/seq_id {}/{}",

--- a/be/src/storage/binlog_reader.cpp
+++ b/be/src/storage/binlog_reader.cpp
@@ -1,0 +1,322 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/binlog_reader.h"
+
+#include <utility>
+
+#include "column/datum.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowid_range_option.h"
+#include "storage/rowset/segment_options.h"
+
+namespace starrocks {
+
+std::unordered_set<std::string_view> BINLOG_META_SET{BINLOG_OP, BINLOG_VERSION, BINLOG_SEQ_ID, BINLOG_TIMESTAMP};
+
+BinlogReader::BinlogReader(TabletSharedPtr tablet, BinlogReaderParams reader_params)
+        : _tablet(std::move(tablet)), _reader_params(std::move(reader_params)) {}
+
+Status BinlogReader::init() {
+    _binlog_manager = _tablet->binlog_manager();
+    if (_binlog_manager == nullptr) {
+        return Status::InternalError(
+                fmt::format("Fail to initialize binlog reader because there is no binlog manager."
+                            " Tablet: {}, keys type: {}",
+                            _tablet->full_name(), KeysType_Name(_tablet->keys_type())));
+    }
+    StatusOr<int64_t> status_or = _binlog_manager->register_reader(shared_from_this());
+    if (!status_or.ok()) {
+        LOG(ERROR) << "Fail to initialize binlog reader for tablet " << _tablet->full_name() << ", "
+                   << status_or.status();
+        return status_or.status();
+    }
+    _reader_id = status_or.value();
+
+    Schema& schema = _reader_params.output_schema;
+    for (uint32_t i = 0; i < schema.num_fields(); i++) {
+        std::string_view cname = schema.field(i)->name();
+        if (BINLOG_META_SET.count(cname) == 0) {
+            _data_column_index.emplace_back(i);
+            continue;
+        }
+
+        if (cname == BINLOG_OP) {
+            _binlog_op_column_index = i;
+        } else if (cname == BINLOG_VERSION) {
+            _binlog_version_column_index = i;
+        } else if (cname == BINLOG_SEQ_ID) {
+            _binlog_seq_id_column_index = i;
+        } else if (cname == BINLOG_TIMESTAMP) {
+            _binlog_timestamp_column_index = i;
+        }
+    }
+    _data_schema = Schema(&_reader_params.output_schema, _data_column_index);
+    _data_chunk = ChunkHelper::new_chunk(_data_schema, 0);
+
+    _initialized = true;
+
+    VLOG(3) << "Initialize binlog reader " << _reader_id << " for tablet " << _tablet->full_name();
+    return Status::OK();
+}
+
+Status BinlogReader::seek(int64_t version, int64_t seq_id) {
+    if (_next_version == version && _next_seq_id == seq_id) {
+        return Status::OK();
+    }
+    _reset();
+    RETURN_IF_ERROR(_seek_binlog_file_reader(version, seq_id));
+    _log_entry_info = _binlog_file_reader->log_entry();
+    _next_version = version;
+    _next_seq_id = seq_id;
+    if (_log_entry_info->log_entry->entry_type() != EMPTY_PB) {
+        RETURN_IF_ERROR(_init_segment_iterator());
+    }
+    VLOG(3) << "Binlog reader " << _reader_id << " for tablet " << _tablet->full_name() << ", seek to version "
+            << version << ", seq_id " << seq_id;
+    return Status::OK();
+}
+
+Status BinlogReader::get_next(ChunkPtr* chunk, int64_t max_version_exclusive) {
+    // Invariant: if _log_entry_info is not nullptr, change event with
+    // <_next_version, _next_seq_id> must be in this log entry, otherwise
+    // need to find the log entry first
+    if (_log_entry_info != nullptr && _log_entry_info->log_entry->entry_type() == EMPTY_PB) {
+        _next_version += 1;
+        _next_seq_id = 0;
+    }
+    Status status;
+    while (_log_entry_info == nullptr && _next_version < max_version_exclusive) {
+        if (_binlog_file_reader != nullptr) {
+            status = _binlog_file_reader->next();
+            if (!status.ok() && !status.is_end_of_file()) {
+                return status;
+            }
+
+            if (status.is_end_of_file()) {
+                _binlog_file_reader.reset();
+            }
+        }
+        if (_binlog_file_reader == nullptr) {
+            RETURN_IF_ERROR(_seek_binlog_file_reader(_next_version, _next_seq_id));
+        }
+        _log_entry_info = _binlog_file_reader->log_entry();
+        // versions may be not continuous because binlog on a tablet replica
+        // does not clone missing version from other replicas
+        if (_log_entry_info->version > _next_version) {
+            return Status::NotFound(
+                    fmt::format("Can't find next version {}, next seq_id {}", _next_version, _next_seq_id));
+        }
+
+        // sanity check
+        if (_log_entry_info->version != _next_version || _log_entry_info->start_seq_id == _next_seq_id) {
+            std::string err_msg = fmt::format(
+                    "Unexpected entry version/seq_id, reader: {}, tablet: {}, "
+                    "expect version/seq_id {}/{}, actual version/seq_id {}/{}",
+                    _reader_id, _tablet->full_name(), _next_version, _next_seq_id, _log_entry_info->version,
+                    _log_entry_info->start_seq_id);
+            LOG(ERROR) << err_msg;
+            return Status::InternalError(err_msg);
+        }
+        if (_log_entry_info->log_entry->entry_type() != EMPTY_PB) {
+            RETURN_IF_ERROR(_init_segment_iterator());
+            break;
+        }
+        // continue to find a non-empty log entry
+        _next_version += 1;
+        _next_seq_id = 0;
+        _log_entry_info = nullptr;
+    }
+
+    if (_next_version >= max_version_exclusive) {
+        return Status::EndOfFile(fmt::format("End of max version {}", max_version_exclusive));
+    }
+
+    LogEntryInfo* log_entry_info = _log_entry_info;
+    _swap_output_and_data_chunk(chunk->get());
+    status = _segment_iterator->get_next(_data_chunk.get());
+    int32_t num_rows = _data_chunk->num_rows();
+    _swap_output_and_data_chunk(chunk->get());
+    // sanity check: should not meet the end of file
+    if (status.is_end_of_file()) {
+        std::string err_msg = fmt::format(
+                "Segment should not meet the end of file, reader {}, tablet {}, "
+                "next version/seq_id {}/{}, expect end seq_id {}, rowset {}, segment index {}",
+                _reader_id, _tablet->full_name(), _next_version, _next_seq_id, log_entry_info->end_seq_id,
+                _rowset->rowset_id().to_string(), _log_entry_info->file_id->segment_index());
+        LOG(ERROR) << err_msg;
+        return Status::InternalError(err_msg);
+    }
+    if (!status.ok()) {
+        return status;
+    }
+    _append_meta_column(chunk->get(), num_rows, log_entry_info->version, log_entry_info->timestamp_in_us, _next_seq_id);
+    _next_seq_id += num_rows;
+    // read all change events in this log entry
+    if (_next_seq_id > log_entry_info->end_seq_id) {
+        bool release_rowset = false;
+        // it's also the last log entry in this version, and
+        // should move to the next version
+        if (log_entry_info->end_of_version) {
+            _next_version += 1;
+            _next_seq_id = 0;
+            release_rowset = true;
+        }
+        // for duplicate key, the log entry and segment are one-to-one,
+        // and release the iterator as soon as possible
+        _release_segment_iterator(release_rowset);
+        _log_entry_info = nullptr;
+    }
+
+    return Status::OK();
+}
+
+void BinlogReader::_append_meta_column(Chunk* output_chunk, int32_t num_rows, int64_t version, int64_t timestamp,
+                                       int64_t start_seq_id) {
+    // for duplicate key table, a chunk only contains rows from a segment, and they have same versions,
+    // timestamps, and ops are INSERT
+    if (_binlog_op_column_index > -1) {
+        ColumnPtr& column = output_chunk->get_column_by_index(_binlog_op_column_index);
+        int8_t insert = 0;
+        column->append_value_multiple_times(&insert, num_rows);
+    }
+
+    if (_binlog_version_column_index > -1) {
+        ColumnPtr& column = output_chunk->get_column_by_index(_binlog_version_column_index);
+        column->append_value_multiple_times(&version, num_rows);
+    }
+
+    if (_binlog_seq_id_column_index > -1) {
+        ColumnPtr& column = output_chunk->get_column_by_index(_binlog_seq_id_column_index);
+        int64_t end_seq_id = start_seq_id + num_rows - 1;
+        for (int64_t seq_id = start_seq_id; seq_id <= end_seq_id; seq_id++) {
+            Datum datum(seq_id);
+            column->append_datum(datum);
+        }
+    }
+
+    if (_binlog_timestamp_column_index > -1) {
+        ColumnPtr& column = output_chunk->get_column_by_index(_binlog_timestamp_column_index);
+        column->append_value_multiple_times(&timestamp, num_rows);
+    }
+}
+
+void BinlogReader::_swap_output_and_data_chunk(Chunk* output_chunk) {
+    Columns& output_columns = output_chunk->columns();
+    for (size_t i = 0; i < _data_column_index.size(); i++) {
+        uint32_t index = _data_column_index[i];
+        _data_chunk->get_column_by_index(i).swap(output_columns[index]);
+    }
+    _data_chunk->reset();
+}
+
+Status BinlogReader::_seek_binlog_file_reader(int64_t version, int64_t seq_id) {
+    auto status_or = _binlog_manager->find_binlog_meta(version, seq_id);
+    if (!status_or.ok()) {
+        return status_or.status();
+    }
+    _file_meta = status_or.value();
+    std::string file_path = _binlog_manager->get_binlog_file_path(_file_meta->id());
+    _binlog_file_reader = std::make_shared<BinlogFileReader>(file_path, _file_meta);
+    RETURN_IF_ERROR(_binlog_file_reader->seek(version, seq_id));
+    return Status::OK();
+}
+
+Status BinlogReader::_init_segment_iterator() {
+    LogEntryInfo* log_entry_info = _log_entry_info;
+    int64_t rowset_id = _log_entry_info->file_id->rowset_id();
+    if (_rowset != nullptr && rowset_id != _rowset->start_version()) {
+        _rowset->release();
+        _rowset.reset();
+    }
+    if (_rowset == nullptr) {
+        {
+            std::shared_lock lock(_tablet->get_header_lock());
+            _rowset = _tablet->get_inc_rowset_by_version(Version(rowset_id, rowset_id));
+        }
+        _rowset->acquire();
+        RETURN_IF_ERROR(_rowset->load());
+        VLOG(3) << "Load rowset for reader: " << _reader_id << ", tablet: " << _tablet->full_name()
+                << ", rowset: " << _rowset->rowset_id() << ", version: " << _rowset->version();
+    }
+
+    int segment_index = _log_entry_info->file_id->segment_index();
+    SegmentSharedPtr seg_ptr = _rowset->segments()[segment_index];
+    SegmentReadOptions seg_options;
+    ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(_rowset->rowset_path()))
+    seg_options.chunk_size = _reader_params.chunk_size;
+    seg_options.stats = &_stats;
+    // set start row to read if next change event is not the first row in the segment
+    if (log_entry_info->start_seq_id < _next_seq_id) {
+        // for duplicate key, LogEntryInfo#start_row_id is 0
+        rowid_t start_row_id = _next_seq_id - log_entry_info->start_seq_id;
+        SparseRange range(start_row_id, seg_ptr->num_rows());
+        seg_options.rowid_range_option = std::make_shared<RowidRangeOption>(_rowset->rowset_id(), segment_index, range);
+    }
+    auto res = seg_ptr->new_iterator(_data_schema, seg_options);
+    if (!res.ok()) {
+        return res.status();
+    }
+    _segment_iterator = res.value();
+    VLOG(3) << "Create segment iterator for reader: " << _reader_id << ", tablet: " << _tablet->full_name()
+            << ", rowset: " << _rowset->rowset_id() << ", version: " << _rowset->version()
+            << ", segment index: " << segment_index;
+    return Status::OK();
+}
+
+void BinlogReader::_release_segment_iterator(bool release_rowset) {
+    if (_segment_iterator != nullptr) {
+        _segment_iterator->close();
+        _segment_iterator.reset();
+    }
+    if (release_rowset && _rowset != nullptr) {
+        _rowset->release();
+        _rowset.reset();
+    }
+}
+
+void BinlogReader::_reset() {
+    if (_segment_iterator != nullptr) {
+        _segment_iterator->close();
+        _segment_iterator.reset();
+    }
+
+    if (_rowset != nullptr) {
+        _rowset->release();
+        _rowset.reset();
+    }
+
+    if (_binlog_file_reader != nullptr) {
+        _binlog_file_reader.reset();
+    }
+
+    if (_file_meta != nullptr) {
+        _file_meta.reset();
+    }
+
+    _log_entry_info = nullptr;
+}
+
+void BinlogReader::close() {
+    if (_closed) {
+        return;
+    }
+    _closed = true;
+    if (_initialized) {
+        _reset();
+        _binlog_manager->unregister_reader(_reader_id);
+    }
+}
+
+} // namespace starrocks

--- a/be/src/storage/binlog_reader.h
+++ b/be/src/storage/binlog_reader.h
@@ -33,10 +33,10 @@ struct BinlogReaderParams {
 };
 
 // Column names for metas
-const std::string BINLOG_OP = "_binlog_op";
-const std::string BINLOG_VERSION = "_binlog_version";
-const std::string BINLOG_SEQ_ID = "_binlog_seq_id";
-const std::string BINLOG_TIMESTAMP = "_binlog_timestamp";
+constexpr const char* BINLOG_OP = "_binlog_op";
+constexpr const char* BINLOG_VERSION = "_binlog_version";
+constexpr const char* BINLOG_SEQ_ID = "_binlog_seq_id";
+constexpr const char* BINLOG_TIMESTAMP = "_binlog_timestamp";
 
 class Tablet;
 class BinlogManager;

--- a/be/src/storage/binlog_reader.h
+++ b/be/src/storage/binlog_reader.h
@@ -90,11 +90,10 @@ public:
     // Return Status::OK() if there is at least one change event in the chunk
     // Return Status::EndOfFile() if there is no more change events, or the
     // version of left change events are no less than *max_version_exclusive*.
-    // Return Status::NotFound if can't find the change event for the
-    // <_next_version, _seq_id> before calling get_next(). This may happen when
-    // the versions are not continuous in a tablet replica, and you may need
-    // to get the data from ather replicas.
-    // Return other status if error happens.
+    // Return Status::NotFound if there are missing change events less than
+    // *max_version_exclusive*. This may happen when the versions are not
+    // continuous in a tablet replica, and you may need to get the data from
+    // ather replicas. Return other status if error happens.
     Status get_next(ChunkPtr* chunk, int64_t max_version_exclusive);
 
     // The version of the next change event to read, and will update after seek/get_next is called.

--- a/be/src/storage/binlog_reader.h
+++ b/be/src/storage/binlog_reader.h
@@ -1,0 +1,151 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
+#include "fs/fs.h"
+#include "gen_cpp/PlanNodes_constants.h"
+#include "gen_cpp/binlog.pb.h"
+#include "storage/binlog_file_reader.h"
+#include "storage/binlog_manager.h"
+#include "storage/chunk_iterator.h"
+#include "storage/rowset/rowset.h"
+#include "storage/tablet.h"
+
+namespace starrocks {
+
+struct BinlogReaderParams {
+    // Chunk size to read from a segment at a time
+    int chunk_size;
+    // The schema of output from the reader
+    Schema output_schema;
+};
+
+// Column names for metas
+const std::string BINLOG_OP = "_binlog_op";
+const std::string BINLOG_VERSION = "_binlog_version";
+const std::string BINLOG_SEQ_ID = "_binlog_seq_id";
+const std::string BINLOG_TIMESTAMP = "_binlog_timestamp";
+
+// Read binlog in a tablet. Binlog can be treated as a table with schema. The schema includes the
+// data columns of base table and meta columns of binlog. The name and SQL data type of meta columns
+// are as following.
+//    +-------------------+---------------+----------------------------------------------------------------------+
+//    | Column Name       | SQL Data Type | Description                                                          |
+//    +===================+===============+======================================================================+
+//    | _binlog_op        | TINYINT       | Operation of the change event in the binlog                          |
+//    |                   |               | INSERT (0)                                                           |
+//    |                   |               | UPDATE_BEFORE (1)                                                    |
+//    |                   |               | UPDATE_AFTER (2)                                                     |
+//    |                   |               | DELETE (3)                                                           |
+//    +-------------------+---------------+----------------------------------------------------------------------+
+//    | _binlog_version   | BIGINT        | The version of ingestion to generate the change event                |
+//    +-------------------+---------------+----------------------------------------------------------------------+
+//    | _binlog_seq_id    | BIGINT        | The sequence number of the change event in the version               |
+//    +-------------------+---------------+----------------------------------------------------------------------+
+//    | _binlog_timestamp | BIGINT        | The timestamp to generate the change event. The unit is microsecond. |
+//    +-------------------+---------------+----------------------------------------------------------------------+
+// BinlogReader will read binlog in chunks, and you can define the schema of the chunk via constructor's
+// parameter *schema* which can contain both data columns and meta columns.
+//
+// How to use
+//  std::shared_ptr<BinlogReader> binlog_reader;
+//  // seek to the start position
+//  Status st = binlog_reader->seek(start_version, start_seq_id);
+//  while (st.ok()) {
+//     st = binlog_reader->get_next();
+//     // process chunk if there are rows in it
+//  }
+//  // get the next position <next_version, next_seq_id> of binlog
+//  // to read, and you can save it as the binlog offset
+//  binlog_reader->next_version()
+//  binlog_reader->next_seq_id()
+class BinlogReader : public std::enable_shared_from_this<BinlogReader> {
+public:
+    BinlogReader(TabletSharedPtr tablet, BinlogReaderParams reader_params);
+
+    Status init();
+
+    // Seek to the position at <version, seq_id>. The position is inclusive.
+    // Returns Status::OK() if find the change event, Status::NotFound() if
+    // there is no such event, and other status if error happens
+    Status seek(int64_t version, int64_t seq_id);
+
+    // Get a chunk of change events less than the *max_version_exclusive*.
+    // The schema of chunk should be the same with BinlogReaderParams#schema.
+    // Return Status::OK() if there is at least one change event in the chunk
+    // Return Status::EndOfFile() if there is no more change events, or the
+    // version of left change events are no less than *max_version_exclusive*.
+    // Return Status::NotFound if can't find the change event for the
+    // <_next_version, _seq_id> before calling get_next(). This may happen when
+    // the versions are not continuous in a tablet replica, and you may need
+    // to get the data from ather replicas.
+    // Return other status if error happens.
+    Status get_next(ChunkPtr* chunk, int64_t max_version_exclusive);
+
+    // The version of the next change event to read, and will update after seek/get_next is called.
+    int64_t next_version() { return _next_version; }
+
+    // The seq_id of next change event to read, and will update after seek/get_next is called.
+    int64_t next_seq_id() { return _next_seq_id; }
+
+    void close();
+
+private:
+    Status _seek_binlog_file_reader(int64_t version, int64_t seq_id);
+    Status _init_segment_iterator();
+    void _release_segment_iterator(bool release_rowset);
+    void _reset();
+    void _swap_output_and_data_chunk(Chunk* output_chunk);
+    void _append_meta_column(Chunk* output_chunk, int32_t num_rows, int64_t version, int64_t timestamp,
+                             int64_t start_seq_id);
+
+    TabletSharedPtr _tablet;
+    BinlogReaderParams _reader_params;
+    BinlogManager* _binlog_manager;
+    int64_t _reader_id;
+    // Schema for data columns, used to read data from segments
+    Schema _data_schema;
+    // Index of each _data_schema column in the _reader_params#output_schema
+    std::vector<uint32_t> _data_column_index;
+    // Index of each meta column in the _reader_params#output_schema.
+    // -1 if they are not in the output schema
+    int32_t _binlog_op_column_index = -1;
+    int32_t _binlog_version_column_index = -1;
+    int32_t _binlog_seq_id_column_index = -1;
+    int32_t _binlog_timestamp_column_index = -1;
+
+    // current binlog file to read
+    BinlogFileMetaPBPtr _file_meta;
+    std::shared_ptr<BinlogFileReader> _binlog_file_reader;
+    // owned by _binlog_file_reader
+    LogEntryInfo* _log_entry_info;
+    int64_t _next_version = -1;
+    int64_t _next_seq_id = -1;
+
+    OlapReaderStatistics _stats;
+    RowsetSharedPtr _rowset;
+    ChunkIteratorPtr _segment_iterator;
+    // the chunk delivered to the segment iterator for get_next()
+    ChunkPtr _data_chunk;
+
+    bool _initialized = false;
+    bool _closed = false;
+};
+
+using BinlogReaderSharedPtr = std::shared_ptr<BinlogReader>;
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -253,6 +253,7 @@ set(EXEC_FILES
         ./storage/binlog_file_test.cpp
         ./storage/binlog_builder_test.cpp
         ./storage/binlog_manager_test.cpp
+        ./storage/binlog_reader_test.cpp
         ./storage/tablet_binlog_test.cpp
         ./storage/publish_version_task_test.cpp
         ./runtime/buffer_control_block_test.cpp

--- a/be/test/storage/binlog_reader_test.cpp
+++ b/be/test/storage/binlog_reader_test.cpp
@@ -1,0 +1,338 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/binlog_reader.h"
+
+#include <gtest/gtest.h>
+
+#include "column/datum_tuple.h"
+#include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_schema_helper.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class RowsetInfo;
+class OutputVerifier;
+
+class BinlogReaderTest : public testing::Test {
+public:
+    void SetUp() override {
+        srand(GetCurrentTimeMicros());
+        _tablet = create_tablet(rand(), rand());
+        _schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+    }
+
+    void TearDown() override {
+        if (_tablet) {
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
+            _tablet.reset();
+        }
+    }
+
+protected:
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TBinlogConfig binlog_config;
+        binlog_config.version = 1;
+        binlog_config.binlog_enable = true;
+        binlog_config.binlog_ttl_second = 30 * 60;
+        binlog_config.binlog_max_size = INT64_MAX;
+        request.__set_binlog_config(binlog_config);
+
+        TColumn k1;
+        k1.column_name = "k1";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k1.column_name = "k2";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn v1;
+        v1.column_name = "v1";
+        v1.__set_is_key(false);
+        v1.column_type.type = TPrimitiveType::VARCHAR;
+        request.tablet_schema.columns.push_back(v1);
+
+        request.compression_type = TCompressionType::NO_COMPRESSION;
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    FieldPtr make_field(ColumnId cid, const std::string& cname, LogicalType type) {
+        return std::make_shared<Field>(cid, cname, get_type_info(type), false);
+    }
+
+    void create_rowset(int32_t* start_key, RowsetInfo& rowset_info, RowsetSharedPtr* rowset);
+
+    void ingestion_rowsets(std::vector<RowsetInfo>& rowset_infos);
+
+    void test_reader(Schema& output_schema, OutputVerifier& verifier);
+
+protected:
+    TabletSharedPtr _tablet;
+    Schema _schema;
+};
+
+struct RowsetInfo {
+    int64_t version;
+    int64_t create_time_in_us;
+    int64_t total_rows;
+    int64_t num_segments;
+};
+
+struct ExpectRowInfo {
+    int32_t key;
+    int8_t op;
+    int64_t version;
+    int64_t seq_id;
+    int64_t timestamp;
+};
+
+void BinlogReaderTest::create_rowset(int32_t* start_key, RowsetInfo& rowset_info, RowsetSharedPtr* rowset) {
+    RowsetWriterContext writer_context;
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.rowset_id = rowset_id;
+    writer_context.tablet_id = _tablet->tablet_id();
+    writer_context.tablet_schema_hash = _tablet->schema_hash();
+    writer_context.partition_id = 10;
+    writer_context.rowset_path_prefix = _tablet->schema_hash_path();
+    writer_context.rowset_state = COMMITTED;
+    writer_context.tablet_schema = &_tablet->tablet_schema();
+    writer_context.version.first = 0;
+    writer_context.version.second = 0;
+    writer_context.segments_overlap = NONOVERLAPPING;
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_OK(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer));
+    for (int64_t seg_index = 0; seg_index < rowset_info.num_segments; seg_index++) {
+        int64_t avg_rows = rowset_info.total_rows / rowset_info.num_segments;
+        int64_t extra_rows = seg_index < rowset_info.total_rows % rowset_info.num_segments;
+        int64_t num_rows = avg_rows + extra_rows;
+        std::vector<uint32_t> column_indexes{0, 1, 2};
+        auto chunk = ChunkHelper::new_chunk(_schema, num_rows);
+        for (int i = *start_key; i < num_rows + *start_key; i++) {
+            auto& cols = chunk->columns();
+            cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[2]->append_datum(Datum(std::to_string(i)));
+        }
+        ASSERT_OK(rowset_writer->flush_chunk(*chunk));
+        *start_key += num_rows;
+    }
+
+    auto status_or = rowset_writer->build();
+    ASSERT_OK(status_or.status());
+    *rowset = status_or.value();
+}
+
+void BinlogReaderTest::ingestion_rowsets(std::vector<RowsetInfo>& rowset_infos) {
+    int32_t start_key = 0;
+    for (auto& rowset_info : rowset_infos) {
+        RowsetSharedPtr rowset;
+        create_rowset(&start_key, rowset_info, &rowset);
+        rowset_info.create_time_in_us = rowset->creation_time() * 1000000;
+        ASSERT_OK(_tablet->add_inc_rowset(rowset, rowset_info.version));
+    }
+}
+
+class OutputVerifier {
+public:
+    virtual void verify(DatumTuple& actual_tuple, ExpectRowInfo& row_info) = 0;
+};
+
+void verify_binlog_reader(TabletSharedPtr tablet, std::vector<RowsetInfo>& rowset_infos, int32_t rowset_index,
+                          int64_t row_index, Schema& output_schema, OutputVerifier* verifier) {
+    int64_t next_key = 0;
+    for (int i = 0; i < rowset_index; rowset_index++) {
+        next_key += rowset_infos[rowset_index].total_rows;
+    }
+    next_key += row_index;
+    int64_t next_rowset_index = rowset_index;
+    int64_t next_row_index = row_index;
+    BinlogReaderParams params;
+    params.chunk_size = 100;
+    params.output_schema = output_schema;
+    BinlogReaderSharedPtr binlog_reader = std::make_shared<BinlogReader>(tablet, params);
+    ASSERT_OK(binlog_reader->init());
+    ASSERT_OK(binlog_reader->seek(rowset_infos[rowset_index].version, row_index));
+    ASSERT_EQ(rowset_infos[next_rowset_index].version, binlog_reader->next_version());
+    ASSERT_EQ(next_row_index, binlog_reader->next_seq_id());
+    ChunkPtr chunk = ChunkHelper::new_chunk(output_schema, 100);
+    Status st;
+    while (true) {
+        chunk->reset();
+        st = binlog_reader->get_next(&chunk, INT64_MAX);
+        if (!st.ok()) {
+            break;
+        }
+        ASSERT_EQ(output_schema.num_fields(), chunk->num_columns());
+        ExpectRowInfo row_info;
+        int32_t next_tuple = 0;
+        while (next_tuple < chunk->num_rows()) {
+            while (next_rowset_index < rowset_infos.size() &&
+                   rowset_infos[next_rowset_index].total_rows == next_row_index) {
+                next_rowset_index += 1;
+                next_row_index = 0;
+            }
+            ASSERT_TRUE(next_rowset_index < rowset_infos.size());
+            row_info.key = next_key;
+            row_info.op = 0;
+            row_info.version = rowset_infos[next_rowset_index].version;
+            row_info.seq_id = next_row_index;
+            row_info.timestamp = rowset_infos[next_rowset_index].create_time_in_us;
+            DatumTuple actual_row = chunk->get(next_tuple);
+            verifier->verify(actual_row, row_info);
+            next_tuple += 1;
+            next_key += 1;
+            next_row_index += 1;
+        }
+        ASSERT_EQ(chunk->num_rows(), next_tuple);
+        if (next_rowset_index < rowset_infos.size() && rowset_infos[next_rowset_index].total_rows == next_row_index) {
+            next_rowset_index += 1;
+            next_row_index = 0;
+        }
+        int64_t next_version = next_rowset_index == rowset_infos.size() ? rowset_infos.back().version + 1
+                                                                        : rowset_infos[next_rowset_index].version;
+        ASSERT_EQ(next_version, binlog_reader->next_version());
+        ASSERT_EQ(next_row_index, binlog_reader->next_seq_id());
+    }
+    ASSERT_TRUE(st.is_end_of_file());
+    ASSERT_EQ(rowset_infos.size(), next_rowset_index);
+    ASSERT_EQ(rowset_infos.back().version, binlog_reader->next_version());
+    ASSERT_EQ(rowset_infos.back().version, binlog_reader->next_seq_id());
+    binlog_reader->close();
+}
+
+void BinlogReaderTest::test_reader(Schema& output_schema, OutputVerifier& verifier) {
+    std::vector<RowsetInfo> rowset_infos;
+    for (int i = 2; i < 100; i++) {
+        RowsetInfo rowset_info;
+        rowset_info.version = i;
+        rowset_info.total_rows = std::rand() % 10000;
+        rowset_info.num_segments = std::min(rowset_info.total_rows, (int64_t)std::rand() % 10);
+        rowset_infos.push_back(rowset_info);
+    }
+    ingestion_rowsets(rowset_infos);
+
+    for (int32_t rowset_index = 0; rowset_index < rowset_infos.size(); rowset_index++) {
+        RowsetInfo& rowset_info = rowset_infos[rowset_index];
+        verify_binlog_reader(_tablet, rowset_infos, rowset_index, 0, output_schema, &verifier);
+        if (rowset_info.total_rows > 1) {
+            verify_binlog_reader(_tablet, rowset_infos, rowset_index, rowset_info.total_rows - 1, output_schema,
+                                 &verifier);
+            verify_binlog_reader(_tablet, rowset_infos, rowset_index, rowset_info.total_rows / 2, output_schema,
+                                 &verifier);
+        }
+    }
+
+    BinlogReaderParams params;
+    params.chunk_size = 100;
+    params.output_schema = output_schema;
+    BinlogReaderSharedPtr binlog_reader = std::make_shared<BinlogReader>(_tablet, params);
+    ASSERT_OK(binlog_reader->init());
+    ASSERT_TRUE(binlog_reader->seek(rowset_infos.back().version, 0).is_not_found());
+    binlog_reader->close();
+}
+
+// verifier for the output including both data and meta columns
+class FullColumnsVerifier : public OutputVerifier {
+public:
+    void verify(DatumTuple& actual_tuple, ExpectRowInfo& row_info) override {
+        ASSERT_EQ(row_info.key, actual_tuple[0].get_int32());
+        ASSERT_EQ(row_info.key, actual_tuple[1].get_int32());
+        ASSERT_EQ(std::to_string(row_info.key), actual_tuple[2].get_slice());
+        ASSERT_EQ(row_info.op, actual_tuple[3].get_int8());
+        ASSERT_EQ(row_info.version, actual_tuple[4].get_int64());
+        ASSERT_EQ(row_info.seq_id, actual_tuple[5].get_int64());
+        ASSERT_EQ(row_info.timestamp, actual_tuple[6].get_int64());
+    }
+};
+
+TEST_F(BinlogReaderTest, test_read_full_columns) {
+    Schema schema;
+    FieldPtr op = make_field(4, BINLOG_OP, TYPE_TINYINT);
+    FieldPtr version = make_field(5, BINLOG_VERSION, TYPE_BIGINT);
+    FieldPtr seq_id = make_field(6, BINLOG_SEQ_ID, TYPE_BIGINT);
+    FieldPtr timestamp = make_field(7, BINLOG_TIMESTAMP, TYPE_BIGINT);
+    schema.append(_schema.field(0));
+    schema.append(_schema.field(1));
+    schema.append(_schema.field(2));
+    schema.append(op);
+    schema.append(version);
+    schema.append(seq_id);
+    schema.append(timestamp);
+
+    FullColumnsVerifier verifier;
+    test_reader(schema, verifier);
+}
+
+// verifier for the output only including data columns
+class DataColumnsVerifier : public OutputVerifier {
+public:
+    void verify(DatumTuple& actual_tuple, ExpectRowInfo& row_info) override {
+        ASSERT_EQ(row_info.key, actual_tuple[0].get_int32());
+        ASSERT_EQ(row_info.key, actual_tuple[1].get_int32());
+        ASSERT_EQ(std::to_string(row_info.key), actual_tuple[2].get_slice());
+    }
+};
+
+TEST_F(BinlogReaderTest, test_read_data_columns) {
+    DataColumnsVerifier verifier;
+    test_reader(_schema, verifier);
+}
+
+// verify the result for BinlogReaderTest#_output_partial_schema
+class RandomColumnsVerifier : public OutputVerifier {
+public:
+    void verify(DatumTuple& actual_tuple, ExpectRowInfo& row_info) override {
+        ASSERT_EQ(row_info.op, actual_tuple[0].get_int8());
+        ASSERT_EQ(std::to_string(row_info.key), actual_tuple[1].get_slice());
+        ASSERT_EQ(row_info.key, actual_tuple[2].get_int32());
+    }
+};
+
+// verifier for the output including random columns
+TEST_F(BinlogReaderTest, test_read_random_columns) {
+    Schema schema;
+    FieldPtr op = make_field(4, BINLOG_OP, TYPE_TINYINT);
+    schema.append(op);
+    schema.append(_schema.field(2));
+    schema.append(_schema.field(0));
+
+    RandomColumnsVerifier verifier;
+    test_reader(schema, verifier);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The feature to support the storage of binlog has several PRs
* Support to write/read binlog file
* Generate binlog when the ingestion is published
* Cleanup the binlog when expired or oversize
* Load binlog when loading tablet
* Read binlog to generate change events

This is the third PR. Read binlog to generate change events.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
