### PR TITLE
[Feature] lake primary table support compact delvec to avoid small files

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -805,6 +805,7 @@ CONF_Int64(lake_gc_metadata_check_interval, /*30 minutes=*/"1800");
 CONF_Int64(lake_gc_segment_check_interval, /*60 minutes=*/"3600");
 // This value should be much larger than the maximum timeout of loading/compaction/schema change jobs.
 CONF_Int64(lake_gc_segment_expire_seconds, /*3 days=*/"259200");
+CONF_Int64(lake_delvec_compact_threshold, /*10 files=*/"10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -49,6 +49,8 @@ public:
 
 private:
     Status _finalize_delvec(int64_t version);
+    // compact multi delvec files to one file
+    Status _compact_delvec();
 
 private:
     Tablet _tablet;

--- a/docs/administration/Configuration.md
+++ b/docs/administration/Configuration.md
@@ -528,6 +528,7 @@ BE static parameters are as follows.
 | lake_gc_segment_check_interval | 3600 | N/A | |
 | lake_gc_segment_expire_seconds | 259200 | N/A | |
 | lake_metadata_cache_limit | 2147483648 | N/A | |
+| lake_delvec_compact_threshold | 10 | N/A | |
 | late_materialization_ratio | 10 | N/A | |
 | local_library_dir |  | N/A | |
 | loop_count_wait_fragments_finish | 0 | N/A | |


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14853

## Problem Summary(Required) ：
In lake primary table, each time transaction publish, it could generate delvec file (end with `.delvec`) which used for record segment files's rows exist or not. The delvec file could be small because it store bitmap format data, and there will be too much delvec files on cloud. 
So we add delvec files compaction policy to merge many small delvec files to one big delvec file. We add config `lake_delvec_compact_threshold`, when delvec files in one tablet is more than `lake_delvec_compact_threshold`, delvec file compaction will be triggered.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
