### PR TITLE
[Enhancement] Make local partition topn streaming

### DIFF
--- a/be/src/exec/partition/chunks_partitioner.cpp
+++ b/be/src/exec/partition/chunks_partitioner.cpp
@@ -39,28 +39,6 @@ Status ChunksPartitioner::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status ChunksPartitioner::offer(const ChunkPtr& chunk) {
-    DCHECK(!_partition_it.has_value());
-
-    if (!_is_downgrade) {
-        for (size_t i = 0; i < _partition_exprs.size(); i++) {
-            ASSIGN_OR_RETURN(_partition_columns[i], _partition_exprs[i]->evaluate(chunk.get()));
-        }
-    }
-
-    if (false) {
-    }
-#define HASH_MAP_METHOD(NAME)                                                                          \
-    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                          \
-        TRY_CATCH_BAD_ALLOC(_split_chunk_by_partition<decltype(_hash_map_variant.NAME)::element_type>( \
-                *_hash_map_variant.NAME, chunk));                                                      \
-    }
-    APPLY_FOR_PARTITION_VARIANT_ALL(HASH_MAP_METHOD)
-#undef HASH_MAP_METHOD
-
-    return Status::OK();
-}
-
 ChunkPtr ChunksPartitioner::consume_from_downgrade_buffer() {
     ChunkPtr chunk = nullptr;
     if (_downgrade_buffer.empty()) {

--- a/be/src/exec/partition/chunks_partitioner.h
+++ b/be/src/exec/partition/chunks_partitioner.h
@@ -43,8 +43,38 @@ public:
     Status prepare(RuntimeState* state);
 
     // Chunk is divided into multiple parts by partition columns,
-    // and each partition corresponds to a key-value pair in the hash map
-    Status offer(const ChunkPtr& chunk);
+    // and each partition corresponds to a key-value pair in the hash map.
+    // Params:
+    // @chunk:
+    //      The chunk added to the hash map.
+    // @new_partition_cb: void(size_t partition_idx)
+    //      called when coming a new key not in the hash map.
+    // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
+    //      called for each partition with enough num rows after adding chunk to the hash map.
+    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    Status offer(const ChunkPtr& chunk, NewPartitionCallback&& new_partition_cb,
+                 PartitionChunkConsumer&& partition_chunk_consumer) {
+        DCHECK(!_partition_it.has_value());
+
+        if (!_is_downgrade) {
+            for (size_t i = 0; i < _partition_exprs.size(); i++) {
+                ASSIGN_OR_RETURN(_partition_columns[i], _partition_exprs[i]->evaluate(chunk.get()));
+            }
+        }
+
+        if (false) {
+        }
+#define HASH_MAP_METHOD(NAME)                                                                                   \
+    else if (_hash_map_variant.type == PartitionHashMapVariant::Type::NAME) {                                   \
+        TRY_CATCH_BAD_ALLOC(_split_chunk_by_partition<typename decltype(_hash_map_variant.NAME)::element_type>( \
+                *_hash_map_variant.NAME, chunk, std::forward<NewPartitionCallback>(new_partition_cb),           \
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer)));                               \
+    }
+        APPLY_FOR_PARTITION_VARIANT_ALL(HASH_MAP_METHOD)
+#undef HASH_MAP_METHOD
+
+        return Status::OK();
+    }
 
     // Number of partitions
     int32_t num_partitions();
@@ -92,9 +122,13 @@ private:
                                           bool* has_null);
     void _init_hash_map_variant();
 
-    template <typename HashMapWithKey>
-    void _split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk) {
-        _is_downgrade = hash_map_with_key.append_chunk(chunk, _partition_columns, _mem_pool.get(), _obj_pool);
+    template <typename HashMapWithKey, typename NewPartitionCallback, typename PartitionChunkConsumer>
+    void _split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk,
+                                   NewPartitionCallback&& new_partition_cb,
+                                   PartitionChunkConsumer&& partition_chunk_consumer) {
+        _is_downgrade = hash_map_with_key.append_chunk(chunk, _partition_columns, _mem_pool.get(), _obj_pool,
+                                                       std::forward<NewPartitionCallback>(new_partition_cb),
+                                                       std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         if (_is_downgrade) {
             std::lock_guard<std::mutex> l(_buffer_lock);
             _downgrade_buffer.push(chunk);
@@ -109,7 +143,6 @@ private:
         }
         if (!_partition_it.has_value()) {
             _partition_it = hash_map_with_key.hash_map.begin();
-            _partition_idx = 0;
         }
 
         using PartitionIterator = typename HashMapWithKey::Iterator;
@@ -131,6 +164,7 @@ private:
 
         while (partition_it != partition_end) {
             std::vector<ChunkPtr>& chunks = partition_it->second->chunks;
+            const auto partition_idx = partition_it->second->partition_idx;
             if (!_chunk_it.has_value()) {
                 _chunk_it = chunks.begin();
             }
@@ -139,14 +173,13 @@ private:
             auto chunk_end = chunks.end();
 
             while (chunk_it != chunk_end) {
-                if (!consumer(_partition_idx, *chunk_it++)) {
+                if (!consumer(partition_idx, *chunk_it++)) {
                     return false;
                 }
             }
 
             // Move to next partition
             ++partition_it;
-            ++_partition_idx;
             _chunk_it.reset();
         }
 
@@ -182,7 +215,7 @@ private:
         while (chunk_it != chunk_end) {
             // Because we first fetch chunks from hash_map, so the _partition_idx here
             // is already set to hash_map.size()
-            if (!consumer(_partition_idx, *chunk_it++)) {
+            if (!consumer(kNullKeyPartitionIdx, *chunk_it++)) {
                 return false;
             }
         }
@@ -192,6 +225,7 @@ private:
     const bool _has_nullable_partition_column;
     const std::vector<ExprContext*> _partition_exprs;
     const std::vector<PartitionColumnType> _partition_types;
+    static constexpr size_t kNullKeyPartitionIdx = 0;
 
     RuntimeState* _state = nullptr;
     std::unique_ptr<MemPool> _mem_pool = nullptr;
@@ -210,8 +244,6 @@ private:
     std::any _partition_it;
     // Iterator of chunks of current partition
     std::any _chunk_it;
-    // Offset of current consuming partition
-    int32_t _partition_idx = -1;
     bool _hash_map_eos = false;
     bool _null_key_eos = false;
 };

--- a/be/src/exec/partition/chunks_partitioner.h
+++ b/be/src/exec/partition/chunks_partitioner.h
@@ -215,7 +215,7 @@ private:
         while (chunk_it != chunk_end) {
             // Because we first fetch chunks from hash_map, so the _partition_idx here
             // is already set to hash_map.size()
-            if (!consumer(kNullKeyPartitionIdx, *chunk_it++)) {
+            if (!consumer(hash_map_with_key.kNullKeyPartitionIdx, *chunk_it++)) {
                 return false;
             }
         }
@@ -225,7 +225,6 @@ private:
     const bool _has_nullable_partition_column;
     const std::vector<ExprContext*> _partition_exprs;
     const std::vector<PartitionColumnType> _partition_types;
-    static constexpr size_t kNullKeyPartitionIdx = 0;
 
     RuntimeState* _state = nullptr;
     std::unique_ptr<MemPool> _mem_pool = nullptr;

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -82,6 +82,7 @@ struct PartitionHashMapBase {
     int64_t total_num_rows = 0;
 
     bool init_null_key_partition = false;
+    static constexpr size_t kNullKeyPartitionIdx = 0;
 
     PartitionHashMapBase(int32_t chunk_size) : chunk_size(chunk_size) {}
 
@@ -237,7 +238,7 @@ protected:
 
         if (!init_null_key_partition) {
             init_null_key_partition = true;
-            new_partition_cb(0);
+            new_partition_cb(kNullKeyPartitionIdx);
         }
 
         if (nullable_key_column->only_null()) {
@@ -358,7 +359,7 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase {
     using ColumnType = RunTimeColumnType<primitive_type>;
     using FieldType = RunTimeCppType<primitive_type>;
     HashMap hash_map;
-    PartitionChunks null_key_value{0};
+    PartitionChunks null_key_value{kNullKeyPartitionIdx};
 
     PartitionHashMapWithOneNullableNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
@@ -406,7 +407,7 @@ template <typename HashMap>
 struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
     using Iterator = typename HashMap::iterator;
     HashMap hash_map;
-    PartitionChunks null_key_value{0};
+    PartitionChunks null_key_value{kNullKeyPartitionIdx};
 
     PartitionHashMapWithOneNullableStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -27,6 +27,9 @@
 namespace starrocks {
 
 struct PartitionChunks {
+    explicit PartitionChunks(size_t partition_idx) : partition_idx(partition_idx) {}
+    DISALLOW_COPY_AND_ASSIGN(PartitionChunks);
+
     Chunks chunks;
 
     // Used to save the indexes of chunk of this partition, to avoid calling Chunk::append_selective many times
@@ -36,6 +39,8 @@ struct PartitionChunks {
     // Used to save the remain size of last chunk in chunks
     // Avoid virtual function call `chunks->back()->num_rows()`
     int32_t remain_size = 0;
+
+    const size_t partition_idx;
 };
 
 // =====================
@@ -76,6 +81,8 @@ struct PartitionHashMapBase {
 
     int64_t total_num_rows = 0;
 
+    bool init_null_key_partition = false;
+
     PartitionHashMapBase(int32_t chunk_size) : chunk_size(chunk_size) {}
 
 protected:
@@ -99,6 +106,28 @@ protected:
         }
     }
 
+    template <typename PartitionChunkConsumer>
+    void consume_full_chunks(PartitionChunks& value, PartitionChunkConsumer&& partition_chunk_consumer) {
+        if (value.chunks.empty()) {
+            return;
+        }
+
+        size_t num_chunks = value.chunks.size();
+        for (int i = 0; i < num_chunks - 1; ++i) {
+            partition_chunk_consumer(value.partition_idx, std::move(value.chunks[i]));
+        }
+
+        if (value.remain_size == 0 || is_downgrade) {
+            // The last chunk is also full.
+            partition_chunk_consumer(value.partition_idx, std::move(value.chunks[num_chunks - 1]));
+            value.chunks.clear();
+        } else if (num_chunks > 1) {
+            // Shrink chunks to only contain the last non-full chunk.
+            value.chunks[0] = std::move(value.chunks[num_chunks - 1]);
+            value.chunks.resize(1);
+        }
+    }
+
     template <typename HashMap>
     void check_downgrade(HashMap& hash_map) {
         if (is_downgrade) {
@@ -114,32 +143,48 @@ protected:
     // Each key mapped to a PartitionChunks which holds an array of chunks
     // chunk will be divided into multiply parts by partition key, and each parts will be append to the
     // last chunk of PartitionChunks.chunks. New chunk will be allocated if the last chunk reaches its capacity
-    // @key_loader used to load key for number type or slice type
-    template <typename HashMap, typename KeyLoader, typename KeyAllocator>
+    // Params:
+    // @key_loader
+    //      used to load key for number type or slice type.
+    // @new_partition_cb: void(size_t partition_idx)
+    //      called when coming a new key not in the hash map.
+    // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
+    //      called for each partition with enough num rows after adding chunk to the hash map.
+    template <typename HashMap, typename KeyLoader, typename KeyAllocator, typename NewPartitionCallback,
+              typename PartitionChunkConsumer>
     void append_chunk_for_one_key(HashMap& hash_map, ChunkPtr chunk, KeyLoader&& key_loader,
-                                  KeyAllocator&& key_allocator, ObjectPool* obj_pool) {
+                                  KeyAllocator&& key_allocator, ObjectPool* obj_pool,
+                                  NewPartitionCallback&& new_partition_cb,
+                                  PartitionChunkConsumer&& partition_chunk_consumer) {
         if (is_downgrade) {
             return;
         }
+
         phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
                              typename HashMap::allocator_type>
                 visited_keys(chunk->num_rows());
         const auto size = chunk->num_rows();
+        auto next_partition_idx = hash_map.size();
         uint32_t i = 0;
+
         for (; !is_downgrade && i < size; i++) {
             const auto& key = key_loader(i);
             visited_keys.insert(key);
+
             bool is_new_partition = false;
             auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
                 is_new_partition = true;
-                return ctor(key_allocator(key), obj_pool->add(new PartitionChunks()));
+                auto* part_chunks = obj_pool->add(new PartitionChunks(next_partition_idx));
+                return ctor(key_allocator(key), part_chunks);
             });
             if (is_new_partition) {
                 check_downgrade(hash_map);
+                new_partition_cb(next_partition_idx++);
             }
+
             auto& value = *(iter->second);
             if (value.chunks.empty() || value.remain_size <= 0) {
-                if (!value.chunks.empty()) {
+                if (!value.chunks.empty() && !value.select_indexes.empty()) {
                     value.chunks.back()->append_selective(*chunk, value.select_indexes.data(), 0,
                                                           value.select_indexes.size());
                 }
@@ -155,6 +200,10 @@ protected:
             flush(*(hash_map[key]), chunk);
         }
 
+        for (const auto& key : visited_keys) {
+            consume_full_chunks(*(hash_map[key]), std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+        }
+
         // The first i rows has been pushed into hash_map
         if (is_downgrade && i > 0) {
             for (auto& column : chunk->columns()) {
@@ -168,18 +217,33 @@ protected:
     // Each key mapped to a PartitionChunks which holds an array of chunks
     // chunk will be divided into multiply parts by partition key, and each parts will be append to the
     // last chunk of PartitionChunks.chunks. New chunk will be allocated if the last chunk reaches its capacity
-    // @key_loader used to load key for number type or slice type
-    template <typename HashMap, typename KeyLoader, typename KeyAllocator>
+    // Params:
+    // @key_loader
+    //      used to load key for number type or slice type.
+    // @new_partition_cb: void(size_t partition_idx)
+    //      called when coming a new key not in the hash map.
+    // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
+    //      called for each partition with enough num rows after adding chunk to the hash map.
+    template <typename HashMap, typename KeyLoader, typename KeyAllocator, typename NewPartitionCallback,
+              typename PartitionChunkConsumer>
     void append_chunk_for_one_nullable_key(HashMap& hash_map, PartitionChunks& null_key_value, ChunkPtr chunk,
                                            const NullableColumn* nullable_key_column, KeyLoader&& key_loader,
-                                           KeyAllocator&& key_allocator, ObjectPool* obj_pool) {
+                                           KeyAllocator&& key_allocator, ObjectPool* obj_pool,
+                                           NewPartitionCallback&& new_partition_cb,
+                                           PartitionChunkConsumer&& partition_chunk_consumer) {
         if (is_downgrade) {
             return;
         }
+
+        if (!init_null_key_partition) {
+            init_null_key_partition = true;
+            new_partition_cb(0);
+        }
+
         if (nullable_key_column->only_null()) {
             const auto size = chunk->num_rows();
             if (null_key_value.chunks.empty() || null_key_value.remain_size <= 0) {
-                if (!null_key_value.chunks.empty()) {
+                if (!null_key_value.chunks.empty() && !null_key_value.select_indexes.empty()) {
                     null_key_value.chunks.back()->append_selective(*chunk, null_key_value.select_indexes.data(), 0,
                                                                    null_key_value.select_indexes.size());
                 }
@@ -198,6 +262,8 @@ protected:
             null_key_value.chunks.back()->append(*chunk, offset, cur_remain_size);
             null_key_value.remain_size = chunk_size - null_key_value.chunks.back()->num_rows();
             total_num_rows += size;
+
+            consume_full_chunks(null_key_value, std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         } else {
             phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
                                  typename HashMap::allocator_type>
@@ -205,6 +271,8 @@ protected:
 
             const auto& null_flag_data = nullable_key_column->null_column()->get_data();
             const auto size = chunk->num_rows();
+            // partition_idx=0 is reserved by null key.
+            auto next_partition_idx = hash_map.size() + 1;
 
             uint32_t i = 0;
             for (; !is_downgrade && i < size; i++) {
@@ -217,17 +285,18 @@ protected:
                     bool is_new_partition = false;
                     auto iter = hash_map.lazy_emplace(key, [&](const auto& ctor) {
                         is_new_partition = true;
-                        return ctor(key_allocator(key), obj_pool->add(new PartitionChunks()));
+                        return ctor(key_allocator(key), obj_pool->add(new PartitionChunks(next_partition_idx)));
                     });
                     if (is_new_partition) {
                         check_downgrade(hash_map);
+                        new_partition_cb(next_partition_idx++);
                     }
                     value_ptr = iter->second;
                 }
 
                 auto& value = *value_ptr;
                 if (value.chunks.empty() || value.remain_size <= 0) {
-                    if (!value.chunks.empty()) {
+                    if (!value.chunks.empty() && !value.select_indexes.empty()) {
                         value.chunks.back()->append_selective(*chunk, value.select_indexes.data(), 0,
                                                               value.select_indexes.size());
                     }
@@ -243,6 +312,11 @@ protected:
                 flush(*(hash_map[key]), chunk);
             }
             flush(null_key_value, chunk);
+
+            for (const auto& key : visited_keys) {
+                consume_full_chunks(*(hash_map[key]), std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+            }
+            consume_full_chunks(null_key_value, std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
 
             // The first i rows has been pushed into hash_map
             if (is_downgrade && i > 0) {
@@ -263,13 +337,17 @@ struct PartitionHashMapWithOneNumberKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<ColumnType*>(key_columns[0].get());
         const auto& key_column_data = key_column->get_data();
         append_chunk_for_one_key(
                 hash_map, chunk, [&](uint32_t offset) { return key_column_data[offset]; },
-                [](const FieldType& key) { return key; }, obj_pool);
+                [](const FieldType& key) { return key; }, obj_pool,
+                std::forward<NewPartitionCallback>(new_partition_cb),
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         return is_downgrade;
     }
 };
@@ -280,18 +358,21 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase {
     using ColumnType = RunTimeColumnType<primitive_type>;
     using FieldType = RunTimeCppType<primitive_type>;
     HashMap hash_map;
-    PartitionChunks null_key_value;
+    PartitionChunks null_key_value{0};
 
     PartitionHashMapWithOneNullableNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto& key_column_data = down_cast<ColumnType*>(nullable_key_column->data_column().get())->get_data();
         append_chunk_for_one_nullable_key(
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column_data[offset]; }, [](const FieldType& key) { return key; },
-                obj_pool);
+                obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         return is_downgrade;
     }
 };
@@ -303,7 +384,9 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase {
 
     PartitionHashMapWithOneStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<BinaryColumn*>(key_columns[0].get());
         append_chunk_for_one_key(
@@ -313,7 +396,8 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase {
                     strings::memcpy_inlined(pos, key.data, key.size);
                     return Slice{pos, key.size};
                 },
-                obj_pool);
+                obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         return is_downgrade;
     }
 };
@@ -322,11 +406,13 @@ template <typename HashMap>
 struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
     using Iterator = typename HashMap::iterator;
     HashMap hash_map;
-    PartitionChunks null_key_value;
+    PartitionChunks null_key_value{0};
 
     PartitionHashMapWithOneNullableStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto* key_column = down_cast<BinaryColumn*>(nullable_key_column->data_column().get());
@@ -338,7 +424,8 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase {
                     strings::memcpy_inlined(pos, key.data, key.size);
                     return Slice{pos, key.size};
                 },
-                obj_pool);
+                obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         return is_downgrade;
     }
 };
@@ -361,7 +448,9 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase {
               inner_mem_pool(std::make_unique<MemPool>()),
               buffer(inner_mem_pool->allocate(max_one_row_size * chunk_size)) {}
 
-    bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         if (is_downgrade) {
             return is_downgrade;
         }
@@ -392,7 +481,8 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase {
                     strings::memcpy_inlined(pos, key.data, key.size);
                     return Slice{pos, key.size};
                 },
-                obj_pool);
+                obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
 
         return is_downgrade;
     }
@@ -426,7 +516,9 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase 
         memset(buf, 0x0, max_fixed_size * chunk_size);
     }
 
-    bool append_chunk(const ChunkPtr& chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool) {
+    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
+                      NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(fixed_byte_size != -1);
 
         if (is_downgrade) {
@@ -453,7 +545,9 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase 
 
         append_chunk_for_one_key(
                 hash_map, chunk, [&](uint32_t offset) { return keys[offset]; },
-                [&](const FixedSizeSliceKey& key) { return key; }, obj_pool);
+                [&](const FixedSizeSliceKey& key) { return key; }, obj_pool,
+                std::forward<NewPartitionCallback>(new_partition_cb),
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
 
         return is_downgrade;
     }

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -60,7 +60,16 @@ Status LocalPartitionTopnContext::prepare(RuntimeState* state) {
 }
 
 Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk) {
-    auto st = _chunks_partitioner->offer(chunk);
+    auto st = _chunks_partitioner->offer(
+            chunk,
+            [this, state](size_t partition_idx) {
+                _chunks_sorters.emplace_back(std::make_shared<ChunksSorterTopn>(
+                        state, &_sort_exprs, &_is_asc_order, &_is_null_first, _sort_keys, _offset, _partition_limit,
+                        _topn_type, ChunksSorterTopn::tunning_buffered_chunks(_partition_limit)));
+            },
+            [this, state](size_t partition_idx, const ChunkPtr& chunk) {
+                _chunks_sorters[partition_idx]->update(state, chunk);
+            });
     if (_chunks_partitioner->is_downgrade()) {
         transfer_all_chunks_from_partitioner_to_sorters(state);
     }
@@ -75,13 +84,7 @@ Status LocalPartitionTopnContext::transfer_all_chunks_from_partitioner_to_sorter
     if (_is_transfered) {
         return Status::OK();
     }
-    const auto num_partitions = _chunks_partitioner->num_partitions();
-    _chunks_sorters.resize(num_partitions);
-    for (int i = 0; i < num_partitions; ++i) {
-        _chunks_sorters[i] = std::make_shared<ChunksSorterTopn>(
-                state, &_sort_exprs, &_is_asc_order, &_is_null_first, _sort_keys, _offset, _partition_limit, _topn_type,
-                ChunksSorterTopn::tunning_buffered_chunks(_partition_limit));
-    }
+
     RETURN_IF_ERROR(
             _chunks_partitioner->consume_from_hash_map([this, state](int32_t partition_idx, const ChunkPtr& chunk) {
                 _chunks_sorters[partition_idx]->update(state, chunk);


### PR DESCRIPTION
Signed-off-by: ZiheLiu <ziheliu1024@gmail.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #17553.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Before this PR, the logic of local partition top n is as follows:
1. Add all the chunks to `PartitionHashMap`, where key is partition columns and value is chunks in each partition.
2. Sort each partition chunks.

After this PR, we sort partition chunks when the partition has received enough num rows (4096).

## Modification
Add two arguments to  `PartitionHashMap::append_chunk`:
- `new_partition_cb`: `void(size_t partition_idx)`
    called when coming a new key not in the hash map.
- `partition_chunk_consumer`: `void(size_t partition_idx, const ChunkPtr& chunk)`
    called for each partition with enough num rows (4096) after adding chunk to the hash map.



## Test
### Environment
3 BE (16vCPUs, 64GB RAM)
ssb 100g

### Queries
```sql
-- Q1 low cardinal (63), HashMapWithSerializedKeyFixedSize
with w1 as (select lo_tax, lo_linenumber, row_number() over(partition by lo_tax, lo_linenumber order by lo_orderkey) as rn from lineorder_flat) 
select 
    ifnull(sum(murmur_hash3_32(lo_tax)), 0)
    + ifnull(sum(murmur_hash3_32(lo_linenumber)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1


-- Q2 low cardinal (225), HashMapWithSerializedKey
with w1 as (select lo_tax, s_nation, row_number() over(partition by lo_tax, s_nation order by lo_orderkey) as rn from lineorder_flat) 
select /*+ SET_VAR(cbo_enable_low_cardinality_optimize=false) */ 
    ifnull(sum(murmur_hash3_32(lo_tax)), 0)
    + ifnull(sum(murmur_hash3_32(s_nation)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0)
from w1 where rn = 1

-- Q3 high cardinal (13998451), HashMapWithSerializedKeyFixedSize
with w1 as (select lo_custkey, lo_linenumber, row_number() over(partition by lo_custkey, lo_linenumber order by lo_orderkey) as rn from lineorder_flat) 
select 
    ifnull(sum(murmur_hash3_32(lo_custkey)), 0)
    + ifnull(sum(murmur_hash3_32(lo_linenumber)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1

-- Q4 high cardinal (49984917), HashMapWithSerializedKey
with w1 as (select c_name, s_nation, row_number() over(partition by c_name, s_nation order by lo_orderkey) as rn from lineorder_flat) 
select /*+ SET_VAR(cbo_enable_low_cardinality_optimize=false) */ 
    ifnull(sum(murmur_hash3_32(c_name)), 0)
    + ifnull(sum(murmur_hash3_32(s_nation)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1


-- Q5 very high cardinal (600037902), HashMapWithSerializedKeyFixedSize
with w1 as (select lo_orderkey, lo_linenumber, row_number() over(partition by lo_orderkey, lo_linenumber order by lo_orderkey) as rn from lineorder_flat) 
select
    ifnull(sum(murmur_hash3_32(lo_orderkey)), 0)
    + ifnull(sum(murmur_hash3_32(lo_linenumber)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1


-- Q6 very high  cardinal (150000000), HashMapWithSerializedKey
with w1 as (select lo_orderkey, c_name,  row_number() over(partition by lo_orderkey, c_name order by lo_orderkey) as rn from lineorder_flat) 
select /*+ SET_VAR(cbo_enable_low_cardinality_optimize=false) */ 
    ifnull(sum(murmur_hash3_32(lo_orderkey)), 0)
    + ifnull(sum(murmur_hash3_32(c_name)), 0)
    + ifnull(sum(murmur_hash3_32(rn)), 0) 
from w1 where rn = 1

```


### Result
| Name | Time (s)       | Peak Memory (GB) | Time (s)                 | Peak Memory (GB) |
| ---- | -------------- | ---------------- | ------------------------ | ---------------- |
|      | MultiPartition |                  | MultiPartition-Streaming |                  |
| Q1   | 1.24           | 1.84             | 1.07                     | **0.03**             |
| Q2   | 4.49           | 7.65             | 3.81                     | **0.20**             |
| Q3   | 11.11          | 9.13             | 11.50                    | 9.43             |
| Q4   | OOM            | -                | OOM                      | -                |
| Q5   | 7.96           | 5.09             | 8.04                     | 4.99             |
| Q6   |12.39          | 23.78            | 12.09                    | 23.85            |

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
