### PR TITLE
[BugFix] Clear olap scan bucket exprs correctly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -218,6 +218,10 @@ public class OlapScanNode extends ScanNode {
         this.bucketColumns = bucketColumns;
     }
 
+    public List<Expr> getBucketExprs() {
+        return bucketExprs;
+    }
+
     public void setBucketExprs(List<Expr> bucketExprs) {
         this.bucketExprs = bucketExprs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1398,12 +1398,13 @@ public class PlanFragmentBuilder {
                 }
             }
 
+            clearOlapScanNodePartitions(sourceFragment.getPlanRoot());
+
             return sourceFragment;
         }
 
         /**
-         * Clear partitionExprs of OlapScanNode (the bucket keys to pass to BE), if they don't satisfy
-         * the required hash property of blocking aggregation.
+         * Clear partitionExprs of OlapScanNode (the bucket keys to pass to BE).
          * <p>
          * When partitionExprs of OlapScanNode are passed to BE, the post operators will use them as
          * local shuffle partition exprs.
@@ -1416,35 +1417,23 @@ public class PlanFragmentBuilder {
          * partitionExprs of OlapScanNode must be cleared to make BE use group by keys not bucket keys as
          * local shuffle partition exprs.
          *
-         * @param fragment The fragment which need to check whether to clear bucket keys of OlapScanNode.
-         * @param aggOp    The aggregate which need to check whether OlapScanNode satisfies its reuiqred hash property.
+         * @param root The root node of the fragment which need to check whether to clear bucket keys of OlapScanNode.
          */
-        private void clearOlapScanNodePartitionsIfNotSatisfy(PlanFragment fragment,
-                                                             PhysicalHashAggregateOperator aggOp) {
-            // Only check ScanNode->BlockingAgg, which must be one-phase agg or
-            // the first phase in three/four-phase agg whose second phase is pruned.
-            if (!aggOp.isOnePhaseAgg() && !aggOp.isMergedLocalAgg()) {
+        private void clearOlapScanNodePartitions(PlanNode root) {
+            if (root instanceof OlapScanNode) {
+                OlapScanNode scanNode = (OlapScanNode) root;
+                scanNode.setBucketExprs(Lists.newArrayList());
+                scanNode.setBucketColumns(Lists.newArrayList());
                 return;
             }
 
-            if (aggOp.getPartitionByColumns().isEmpty()) {
+            if (root instanceof ExchangeNode) {
                 return;
             }
 
-            PlanNode leafNode = fragment.getLeftMostLeafNode();
-            if (!(leafNode instanceof OlapScanNode)) {
-                return;
+            for (PlanNode child : root.getChildren()) {
+                clearOlapScanNodePartitions(child);
             }
-
-            OlapScanNode olapScanNode = (OlapScanNode) leafNode;
-            Set<ColumnRefOperator> requiredPartColumns = new HashSet<>(aggOp.getPartitionByColumns());
-            boolean satisfy = requiredPartColumns.containsAll(olapScanNode.getBucketColumns());
-            if (satisfy) {
-                return;
-            }
-
-            olapScanNode.setBucketExprs(Lists.newArrayList());
-            olapScanNode.setBucketColumns(Lists.newArrayList());
         }
 
         private static class AggregateExprInfo {
@@ -1679,7 +1668,9 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
             if (node.isOnePhaseAgg() || node.isMergedLocalAgg() || node.getType().isDistinctGlobal()) {
-                clearOlapScanNodePartitionsIfNotSatisfy(inputFragment, node);
+                if (optExpr.getLogicalProperty().isExecuteInOneTablet()) {
+                    clearOlapScanNodePartitions(aggregationNode);
+                }
                 // For ScanNode->LocalShuffle->AggNode, we needn't assign scan ranges per driver sequence.
                 inputFragment.setAssignScanRangesPerDriverSeq(!withLocalShuffle);
                 aggregationNode.setWithLocalShuffle(withLocalShuffle);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.planner.AggregationNode;
+import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
@@ -1079,7 +1080,6 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "  |  group by: 1: C_CUSTKEY, 2: C_NAME");
     }
 
-
     @Test
     public void testAggNodeAndBucketDistribution() throws Exception {
         // For the local one-phase aggregation, enable AssignScanRangesPerDriverSeq and disable SharedScan.
@@ -1402,5 +1402,49 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "  |  output columns:\n" +
                 "  |  1 <-> [1: LO_ORDERKEY, INT, false]\n" +
                 "  |  cardinality: 9223372036854775807");
+    }
+
+    @Test
+    public void testAggExecuteInOneTablet() throws Exception {
+        String sql;
+        String plan;
+        ExecPlan execPlan;
+        OlapScanNode olapScanNode;
+
+        // dates_n only contains one tablet.
+        sql = "select count(d_datekey), d_date from dates_n group by d_date";
+        execPlan = getExecPlan(sql);
+        olapScanNode = (OlapScanNode) execPlan.getScanNodes().get(0);
+        Assert.assertEquals(0, olapScanNode.getBucketExprs().size());
+        plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(1: d_datekey)\n" +
+                "  |  group by: 2: d_date\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+
+        // dates_n only contains one tablet.
+        sql = "select count(d_date), d_datekey from dates_n group by d_datekey";
+        execPlan = getExecPlan(sql);
+        olapScanNode = (OlapScanNode) execPlan.getScanNodes().get(0);
+        Assert.assertEquals(0, olapScanNode.getBucketExprs().size());
+        plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(2: d_date)\n" +
+                "  |  group by: 1: d_datekey\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+
+        // lineorder_new_l contains more than one tablet.
+        sql = "select count(P_TYPE), LO_ORDERKEY from lineorder_new_l group by LO_ORDERKEY";
+        execPlan = getExecPlan(sql);
+        olapScanNode = (OlapScanNode) execPlan.getScanNodes().get(0);
+        Assert.assertEquals(1, olapScanNode.getBucketExprs().size());
+        plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(36: P_TYPE)\n" +
+                "  |  group by: 1: LO_ORDERKEY\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -34,6 +35,11 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
     public static void beforeClass() throws Exception {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
+    }
+
+    @After
+    public void after() {
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 
     //  agg


### PR DESCRIPTION
Signed-off-by: ZiheLiu <ziheliu1024@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17673

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When `OlapScanNode.bucketExprs` is passed to BE, the post operators will use them as  local shuffle partition exprs.

The bucket keys can satisfy the required hash property of blocking aggregation except two scenarios:
- OlapScanNode only has one tablet after pruned.
- It is executed on the single BE.
Therefore, we should clear `OlapScanNode.bucketExprs` for these two scenarios.

However, there are two problems in the current logic:
1. We check whether grouping keys contain all the bucket keys of the left most scan node of this fragment. 
    However, grouping key may use the right join key. 
```
 BlockingAgg(t2.a)
       |
 ColocateJoin(t1.a=t2.a, t1.b=t2.b)
  /         \
Scan(t1)    Scan(t2)
```

2. We only clear `bucketExprs` of the left most scan node, not all the scan nodes (`Scan(t2)`), which results in that `HashJoinProbe` uses `t1.a, t1.b` as local shuffle key (not from `bucketExprs`) and `HashJoinBuild` uses `t2.a` as local shuffle key (from `bucketExprs`).

## Modification
1. Only clear `bucketExprs` when it is exactly OlapScanNode only has one tablet  or executed on the single BE.
2. Clear `bucketExprs` of all the OlapScanNode in this fragment.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
