### PR TITLE
[BugFix] Fix expression reuse error of nested array lambda functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -96,6 +96,10 @@ public final class ColumnRefOperator extends ScalarOperator {
         return new ColumnRefSet(id);
     }
 
+    public boolean isVirtualColumnRef() {
+        return this.opType.equals(OperatorType.LAMBDA_ARGUMENT);
+    }
+
     @Override
     public String toString() {
         return id + ": " + name;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
@@ -78,8 +78,6 @@ public class ScalarOperatorsReuseRule implements TreeRewriteRule {
             for (Map.Entry<ColumnRefOperator, ScalarOperator> kv : operatorMap.entrySet()) {
                 kv.getValue().accept(rewriter, null);
             }
-
-            return;
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: kangkaisen <kangkaisen@apache.org>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fix https://github.com/StarRocks/starrocks/issues/17644

## Problem Summary(Required) ：
The simplified sql:

```
WITH `CASE_006` AS
  (SELECT array_map((arg_001) -> (arg_001), `c1`) AS `argument_003`,
          array_map((arg_002) -> (CAST(1 AS BIGINT)), `c1`) AS `argument_004`
   FROM `TEST1`.`CASE`)

select argument_004, ARRAY_FILTER((x, y) -> y IS NOT NULL, `argument_003`, `argument_004`) AS `source_target_005` from CASE_006;
```

The error plan

```
|   |  <slot 32> : 37: array_map                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
|   |  <slot 35> : array_filter(29: PU_9_ARRAY_AGG_8_activity_activityname, array_map((<slot 33>, <slot 34>) -> <slot 34> IS NOT NULL, 29: PU_9_ARRAY_AGG_8_activity_activityname, 37: array_map))                                                                                                                                                                                                                                                                                                                                                                                        |
|   |  common expressions:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|   |  <slot 36> : <slot 16> -> 1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|   |  <slot 37> : array_map(36: expr, 29: PU_9_ARRAY_AGG_8_activity_activityname)
```

**The direct reason is  the lambda function  <slot 16> -> 1    shouldn't be common expressions.**

The root reason is when reuseLambda is false, ignoreLambdaArg is true when first, but for nested lambda functions, after second time, the ignoreLambdaArg will false again.

**In fact, we only use reuseLambda is enough**:
1. when first round try to reuse all exprs in projection, the reuseLambda is false, we need to handle `a + b` reuse in `select a+b, array_map(x-> 2*x+2*x > a+b, [1])`
2. when second  round to reuse all exprs in only lambda function，the reuseLambda is true,  we need to handle `2*x` reuse in `select a+b, array_map(x-> 2*x+2*x > a+b, [1])`

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
