### PR TITLE
[BugFix]Fix heap-use-after-free in ASAN mode

### DIFF
--- a/be/src/column/column_pool.h
+++ b/be/src/column/column_pool.h
@@ -246,7 +246,12 @@ public:
             _release_free_block(blk);
         }
 
-        _mem_tracker->release(freed_bytes);
+        // _mem_tracker maybe nullptr in graceful exit because the main thread don't wait until all
+        // source in children threads are recycled, so the mem_tracker maybe release before we call
+        // ~LocalPool()
+        if (_mem_tracker) {
+            _mem_tracker->release(freed_bytes);
+        }
         tls_thread_status.mem_consume(freed_bytes);
 
         return freed_bytes;


### PR DESCRIPTION
Signed-off-by: zhangqiang <qiangzh95@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1822

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When we try graceful exit BE, we will deallocate all threads in all `_thread_pool` and deconstruct the `_mem_tracker`. However, when we deallocate `_thread_pool`, we don't wait until children thread deconstuct and we will call function `delete_local_pool` in `LocalPool` and maybe access the `_mem_tracker` which maybe nullptr. And that is why we will get a  heap-use-after-free error in ASAN mode.

And this bug only occurs when we exit BE process gracefully.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
