### PR TITLE
[BugFix] set _column_pool_memory_tracker be shared_ptr for gracefully exit BE

### DIFF
--- a/be/src/column/column_pool.h
+++ b/be/src/column/column_pool.h
@@ -195,8 +195,8 @@ class CACHELINE_ALIGNED ColumnPool {
     };
 
 public:
-    void set_mem_tracker(MemTracker* mem_tracker) { _mem_tracker = mem_tracker; }
-    MemTracker* mem_tracker() { return _mem_tracker; }
+    void set_mem_tracker(std::shared_ptr<MemTracker> mem_tracker) { _mem_tracker = std::move(mem_tracker); }
+    MemTracker* mem_tracker() { return _mem_tracker.get(); }
 
     static std::enable_if_t<std::is_default_constructible_v<T>, ColumnPool*> singleton() {
         static ColumnPool p;
@@ -369,7 +369,7 @@ private:
 
     ~ColumnPool() = default;
 
-    MemTracker* _mem_tracker = nullptr;
+    std::shared_ptr<MemTracker> _mem_tracker = nullptr;
 
     static __thread LocalPool* _local_pool; // NOLINT
     static std::atomic<long> _nlocal;       // NOLINT

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -345,7 +345,7 @@ void ExecEnv::add_rf_event(const RfTracePoint& pt) {
 
 class SetMemTrackerForColumnPool {
 public:
-    SetMemTrackerForColumnPool(MemTracker* mem_tracker) : _mem_tracker(mem_tracker) {}
+    SetMemTrackerForColumnPool(std::shared_ptr<MemTracker> mem_tracker) : _mem_tracker(std::move(mem_tracker)) {}
 
     template <typename Pool>
     void operator()() {
@@ -353,7 +353,7 @@ public:
     }
 
 private:
-    MemTracker* _mem_tracker = nullptr;
+    std::shared_ptr<MemTracker> _mem_tracker = nullptr;
 };
 
 Status ExecEnv::init_mem_tracker() {
@@ -417,7 +417,7 @@ Status ExecEnv::init_mem_tracker() {
 
     MemChunkAllocator::init_instance(_chunk_allocator_mem_tracker.get(), config::chunk_reserved_bytes_limit);
 
-    SetMemTrackerForColumnPool op(column_pool_mem_tracker());
+    SetMemTrackerForColumnPool op(_column_pool_mem_tracker);
     ForEach<ColumnPoolList>(op);
     _init_storage_page_cache();
     return Status::OK();


### PR DESCRIPTION
Signed-off-by: fzhedu <fzhedu@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/1852
before

```
==174521==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 475136 byte(s) in 29 object(s) allocated from:
    #0 0xef61817 in operator new(unsigned long) ../../../../libsanitizer/asan/asan_new_delete.cpp:99
    #1 0xf06f72c in __gnu_cxx::new_allocator<int>::allocate(unsigned long, void const*) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/ext/new_allocator.h:115
    #2 0xf0688a7 in std::allocator_traits<std::allocator<int> >::allocate(std::allocator<int>&, unsigned long) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/alloc_traits.h:460
    #3 0xf0f3f3f in std::_Vector_base<int, std::allocator<int> >::_M_allocate(unsigned long) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/stl_vector.h:346
    #4 0xf1657cf in std::vector<int, std::allocator<int> >::reserve(unsigned long) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/vector.tcc:78
    #5 0xf154bd0 in starrocks::FixedLengthColumnBase<int>::reserve(unsigned long) ../src/column/fixed_length_column_base.h:92
    #6 0xf4646cf in starrocks::NullableColumn::reserve(unsigned long) ../src/column/nullable_column.h:106
    #7 0x16029a40 in starrocks::ChunkHelper::new_chunk_pooled(starrocks::Schema const&, unsigned long, bool) ../src/storage/chunk_helper.cpp:277
    #8 0x10f66de7 in starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*) ../src/exec/pipeline/scan/olap_chunk_source.cpp:299
    #9 0x10ee9400 in starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*) ../src/exec/pipeline/scan/chunk_source.cpp:79
    #10 0x10f24c7e in operator() ../src/exec/pipeline/scan/scan_operator.cpp:367
    #11 0x10f2a21b in __invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::<lambda()>&> /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60
    #12 0x10f2a0c9 in __invoke_r<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::<lambda()>&> /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #13 0x10f29f3e in _M_invoke /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #14 0xf0ebfa3 in std::function<void ()>::operator()() const /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #15 0x11292c37 in starrocks::workgroup::ScanExecutor::worker_thread() ../src/exec/workgroup/scan_executor.cpp:61
    #16 0x11292481 in operator() ../src/exec/workgroup/scan_executor.cpp:32
    #17 0x11293e91 in __invoke_impl<void, starrocks::workgroup::ScanExecutor::initialize(int)::<lambda()>&> /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60
    #18 0x11293b59 in __invoke_r<void, starrocks::workgroup::ScanExecutor::initialize(int)::<lambda()>&> /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #19 0x112936ce in _M_invoke /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #20 0xf0ebfa3 in std::function<void ()>::operator()() const /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #21 0x16e9d3eb in starrocks::FunctionRunnable::run() ../src/util/threadpool.cpp:57
    #22 0x16e9a1ed in starrocks::ThreadPool::dispatch_thread() ../src/util/threadpool.cpp:552
    #23 0x16eb77b7 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:73
    #24 0x16eb7110 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:95
    #25 0x16eb6507 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:416
    #26 0x16eb4e69 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:499
    #27 0x16eb1ecd in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60
    #28 0x16eaf831 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #29 0x16eab468 in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291

Direct leak of 118784 byte(s) in 29 object(s) allocated from:
    #0 0xef61817 in operator new(unsigned long) ../../../../libsanitizer/asan/asan_new_delete.cpp:99
    #1 0xf0df77a in __gnu_cxx::new_allocator<unsigned char>::allocate(unsigned long, void const*) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/ext/new_allocator.h:115
    #2 0xf0df4d3 in std::allocator_traits<std::allocator<unsigned char> >::allocate(std::allocator<unsigned char>&, unsigned long) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/alloc_traits.h:460
    #3 0xf0de6e1 in std::_Vector_base<unsigned char, std::allocator<unsigned char> >::_M_allocate(unsigned long) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/stl_vector.h:346
    #4 0xf0ea9e7 in std::vector<unsigned char, std::allocator<unsigned char> >::reserve(unsigned long) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/vector.tcc:78
    #5 0xf0eb306 in starrocks::FixedLengthColumnBase<unsigned char>::reserve(unsigned long) ../src/column/fixed_length_column_base.h:92
    #6 0xf4646f1 in starrocks::NullableColumn::reserve(unsigned long) ../src/column/nullable_column.h:107
    #7 0x16029a40 in starrocks::ChunkHelper::new_chunk_pooled(starrocks::Schema const&, unsigned long, bool) ../src/storage/chunk_helper.cpp:277
    #8 0x10f66de7 in starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*) ../src/exec/pipeline/scan/olap_chunk_source.cpp:299
    #9 0x10ee9400 in starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*) ../src/exec/pipeline/scan/chunk_source.cpp:79
    #10 0x10f24c7e in operator() ../src/exec/pipeline/scan/scan_operator.cpp:367
    #11 0x10f2a21b in __invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::<lambda()>&> /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60
    #12 0x10f2a0c9 in __invoke_r<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::<lambda()>&> /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #13 0x10f29f3e in _M_invoke /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #14 0xf0ebfa3 in std::function<void ()>::operator()() const /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #15 0x11292c37 in starrocks::workgroup::ScanExecutor::worker_thread() ../src/exec/workgroup/scan_executor.cpp:61
    #16 0x11292481 in operator() ../src/exec/workgroup/scan_executor.cpp:32
    #17 0x11293e91 in __invoke_impl<void, starrocks::workgroup::ScanExecutor::initialize(int)::<lambda()>&> /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60
    #18 0x11293b59 in __invoke_r<void, starrocks::workgroup::ScanExecutor::initialize(int)::<lambda()>&> /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #19 0x112936ce in _M_invoke /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291
    #20 0xf0ebfa3 in std::function<void ()>::operator()() const /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
    #21 0x16e9d3eb in starrocks::FunctionRunnable::run() ../src/util/threadpool.cpp:57
    #22 0x16e9a1ed in starrocks::ThreadPool::dispatch_thread() ../src/util/threadpool.cpp:552
    #23 0x16eb77b7 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:73
    #24 0x16eb7110 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:95
    #25 0x16eb6507 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:416
    #26 0x16eb4e69 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/functional:499
    #27 0x16eb1ecd in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60
    #28 0x16eaf831 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110
    #29 0x16eab468 in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291

Direct leak of 432 byte(s) in 18 object(s) allocated from:
    #0 0xef6005f in __interceptor_malloc ../../../../libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x1606b7f7 in starrocks::ColumnPool<starrocks::FixedLengthColumn<int> >::_push_free_block(starrocks::ColumnPoolFreeBlock<starrocks::FixedLengthColumn<int>, 256ul> const&) ../src/column/column_pool.h:340
    #2 0x16063ca4 in starrocks::ColumnPool<starrocks::FixedLengthColumn<int> >::LocalPool::~LocalPool() ../src/column/column_pool.h:120
    #3 0x16063c12 in starrocks::ColumnPool<starrocks::FixedLengthColumn<int> >::LocalPool::delete_local_pool(void*) ../src/column/column_pool.h:194
    #4 0x1851eb22 in butil::detail::ThreadExitHelper::~ThreadExitHelper() ../src/butil/thread_local.cpp:41
    #5 0x1851eb22 in delete_thread_exit_helper ../src/butil/thread_local.cpp:77
    #6 0x1851eb22 in delete_thread_exit_helper ../src/butil/thread_local.cpp:76
    #7 0x7f98ccddaca1 in __nptl_deallocate_tsd (/lib64/libpthread.so.0+0x7ca1)

Direct leak of 264 byte(s) in 11 object(s) allocated from:
    #0 0xef6005f in __interceptor_malloc ../../../../libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x1605cd17 in starrocks::ColumnPool<starrocks::FixedLengthColumn<unsigned char> >::_push_free_block(starrocks::ColumnPoolFreeBlock<starrocks::FixedLengthColumn<unsigned char>, 256ul> const&) ../src/column/column_pool.h:340
    #2 0x1605909e in starrocks::ColumnPool<starrocks::FixedLengthColumn<unsigned char> >::LocalPool::~LocalPool() ../src/column/column_pool.h:120
    #3 0x1605900c in starrocks::ColumnPool<starrocks::FixedLengthColumn<unsigned char> >::LocalPool::delete_local_pool(void*) ../src/column/column_pool.h:194
    #4 0x1851eb22 in butil::detail::ThreadExitHelper::~ThreadExitHelper() ../src/butil/thread_local.cpp:41
    #5 0x1851eb22 in delete_thread_exit_helper ../src/butil/thread_local.cpp:77
    #6 0x1851eb22 in delete_thread_exit_helper ../src/butil/thread_local.cpp:76
    #7 0x7f98ccddaca1 in __nptl_deallocate_tsd (/lib64/libpthread.so.0+0x7ca1)

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0xef61ac7 in operator new(unsigned long, std::nothrow_t const&) ../../../../libsanitizer/asan/asan_new_delete.cpp:105
    #1 0x1a4a504d in __cxa_thread_atexit ../../../../libstdc++-v3/libsupc++/atexit_thread.cc:146

SUMMARY: AddressSanitizer: 594640 byte(s) leaked in 88 allocation(s).
```


**TODO: after this PR, there still is a leak.**

```
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0xef61ac7 in operator new(unsigned long, std::nothrow_t const&) ../../../../libsanitizer/asan/asan_new_delete.cpp:105
    #1 0x1a4a504d in __cxa_thread_atexit ../../../../libstdc++-v3/libsupc++/atexit_thread.cc:146
```
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


some data structures like `column_pool_memory_tracker` are allocated in the main threads and used in some sub threads from thread pools. These used data structures are deallocated when the main thread exit, but sub threads are still alive, maybe resulting in using freed memory.

this PR make `_column_pool_memory_tracker` be shared_ptr to avoid early deleted.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
