### PR TITLE
[Enhancement] Disable operator's mem_tracker if profile is disable

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -33,6 +33,9 @@
 
 namespace starrocks::pipeline {
 
+#define SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op) \
+    _is_profile_enabled ? op->mem_tracker() : _runtime_state->instance_mem_tracker()
+
 PipelineDriver::~PipelineDriver() noexcept {
     if (_workgroup != nullptr) {
         _workgroup->decr_num_running_drivers();
@@ -41,6 +44,7 @@ PipelineDriver::~PipelineDriver() noexcept {
 
 Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _runtime_state = runtime_state;
+    _is_profile_enabled = _runtime_state->query_ctx()->is_report_profile();
 
     auto* prepare_timer = ADD_TIMER(_runtime_profile, "DriverPrepareTime");
     SCOPED_TIMER(prepare_timer);
@@ -246,7 +250,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 // operator
                 StatusOr<ChunkPtr> maybe_chunk;
                 {
-                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(curr_op->mem_tracker());
+                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(curr_op);
                     SCOPED_TIMER(curr_op->_pull_timer);
                     QUERY_TRACE_SCOPED(curr_op->get_name(), "pull_chunk");
                     maybe_chunk = curr_op->pull_chunk(runtime_state);
@@ -268,7 +272,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                         size_t row_num = maybe_chunk.value()->num_rows();
                         total_rows_moved += row_num;
                         {
-                            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(next_op->mem_tracker());
+                            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(next_op);
                             SCOPED_TIMER(next_op->_push_timer);
                             QUERY_TRACE_SCOPED(next_op->get_name(), "push_chunk");
                             return_status = next_op->push_chunk(runtime_state, maybe_chunk.value());
@@ -522,7 +526,7 @@ Status PipelineDriver::_mark_operator_finishing(OperatorPtr& op, RuntimeState* s
     VLOG_ROW << strings::Substitute("[Driver] finishing operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(op->mem_tracker());
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op);
         SCOPED_TIMER(op->_finishing_timer);
         op_state = OperatorStage::FINISHING;
         QUERY_TRACE_SCOPED(op->get_name(), "set_finishing");
@@ -540,7 +544,7 @@ Status PipelineDriver::_mark_operator_finished(OperatorPtr& op, RuntimeState* st
     VLOG_ROW << strings::Substitute("[Driver] finished operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(op->mem_tracker());
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op);
         SCOPED_TIMER(op->_finished_timer);
         op_state = OperatorStage::FINISHED;
         QUERY_TRACE_SCOPED(op->get_name(), "set_finished");
@@ -563,7 +567,7 @@ Status PipelineDriver::_mark_operator_cancelled(OperatorPtr& op, RuntimeState* s
     VLOG_ROW << strings::Substitute("[Driver] cancelled operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(op->mem_tracker());
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op);
         op_state = OperatorStage::CANCELLED;
         return op->set_cancelled(state);
     }
@@ -584,7 +588,7 @@ Status PipelineDriver::_mark_operator_closed(OperatorPtr& op, RuntimeState* stat
     VLOG_ROW << strings::Substitute("[Driver] close operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(op->mem_tracker());
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op);
         SCOPED_TIMER(op->_close_timer);
         op_state = OperatorStage::CLOSED;
         QUERY_TRACE_SCOPED(op->get_name(), "close");

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -33,8 +33,9 @@
 
 namespace starrocks::pipeline {
 
-#define SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op) \
-    _is_profile_enabled ? op->mem_tracker() : _runtime_state->instance_mem_tracker()
+#define SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op)                          \
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_is_profile_enabled ? op->mem_tracker() \
+                                                               : _runtime_state->instance_mem_tracker())
 
 PipelineDriver::~PipelineDriver() noexcept {
     if (_workgroup != nullptr) {

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -473,6 +473,8 @@ protected:
     size_t _driver_queue_level = 0;
     std::atomic<bool> _in_ready_queue{false};
 
+    bool _is_profile_enabled = false;
+
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;
     RuntimeProfile::Counter* _active_timer = nullptr;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -347,7 +347,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             // set driver_id/query_id/fragment_instance_id to thread local
             // driver_id will be used in some Expr such as regex_replace
             SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker());
+            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(
+                    state->query_ctx()->is_report_profile() ? mem_tracker() : state->instance_mem_tracker());
 
             auto& chunk_source = _chunk_sources[chunk_source_index];
             [[maybe_unused]] std::string category;

--- a/be/src/exec/pipeline/stream_pipeline_driver.cpp
+++ b/be/src/exec/pipeline/stream_pipeline_driver.cpp
@@ -84,7 +84,6 @@ StatusOr<DriverState> StreamPipelineDriver::process(RuntimeState* runtime_state,
                 // operator
                 StatusOr<ChunkPtr> maybe_chunk;
                 {
-                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(curr_op->mem_tracker());
                     SCOPED_TIMER(curr_op->_pull_timer);
                     QUERY_TRACE_SCOPED(curr_op->get_name(), "pull_chunk");
                     maybe_chunk = curr_op->pull_chunk(runtime_state);
@@ -105,7 +104,6 @@ StatusOr<DriverState> StreamPipelineDriver::process(RuntimeState* runtime_state,
                         size_t row_num = chunk_value->num_rows();
                         total_rows_moved += row_num;
                         {
-                            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(next_op->mem_tracker());
                             SCOPED_TIMER(next_op->_push_timer);
                             QUERY_TRACE_SCOPED(next_op->get_name(), "push_chunk");
                             return_status = next_op->push_chunk(runtime_state, chunk_value);
@@ -225,7 +223,6 @@ StatusOr<DriverState> StreamPipelineDriver::_handle_finish_operators(RuntimeStat
             // operator
             StatusOr<ChunkPtr> maybe_chunk;
             {
-                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(curr_op->mem_tracker());
                 SCOPED_TIMER(curr_op->_pull_timer);
                 QUERY_TRACE_SCOPED(curr_op->get_name(), "pull_chunk");
                 maybe_chunk = curr_op->pull_chunk(runtime_state);
@@ -246,7 +243,6 @@ StatusOr<DriverState> StreamPipelineDriver::_handle_finish_operators(RuntimeStat
                     size_t row_num = chunk_value->num_rows();
                     total_rows_moved += row_num;
                     {
-                        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(next_op->mem_tracker());
                         SCOPED_TIMER(next_op->_push_timer);
                         QUERY_TRACE_SCOPED(next_op->get_name(), "push_chunk");
                         return_status = next_op->push_chunk(runtime_state, chunk_value);

--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -25,7 +25,7 @@ CurrentThread::~CurrentThread() {
         tls_is_thread_status_init = false;
         return;
     }
-    commit();
+    commit(true);
     tls_is_thread_status_init = false;
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1623,7 +1623,8 @@ public class Coordinator {
                     RuntimeProfile operatorProfile = operatorProfilePair.first;
                     if (!foundResultSink & operatorProfile.getName().contains("RESULT_SINK")) {
                         long executionWallTime = pipelineProfile.getCounter("DriverTotalTime").getValue();
-                        Counter executionTotalTime = queryProfile.addCounter("ExecutionWallTime", TUnit.TIME_NS, null);
+                        Counter executionTotalTime =
+                                queryProfile.addCounter("QueryExecutionWallTime", TUnit.TIME_NS, null);
                         queryProfile.getCounterTotalTime().setValue(0);
                         executionTotalTime.setValue(executionWallTime);
                         foundResultSink = true;
@@ -1661,10 +1662,11 @@ public class Coordinator {
         queryCumulativeOperatorTimer.setValue(queryCumulativeOperatorTime);
         queryProfile.getCounterTotalTime().setValue(0);
 
-        long memCostBytes = statistics == null || statistics.memCostBytes == null ? 0 : statistics.memCostBytes;
-        long cpuCostNs = statistics == null || statistics.cpuCostNs == null ? 0 : statistics.cpuCostNs;
-        queryProfile.addInfoString("QueryCumulativeCpuTime", DebugUtil.getPrettyStringNs(cpuCostNs));
-        queryProfile.addInfoString("MachinePeakMemoryUsage", DebugUtil.getPrettyStringBytes(memCostBytes));
+        Counter queryCumulativeCpuTime = queryProfile.addCounter("QueryCumulativeCpuTime", TUnit.TIME_NS, null);
+        queryCumulativeCpuTime.setValue(statistics == null || statistics.cpuCostNs == null ? 0 : statistics.cpuCostNs);
+        Counter queryPeakMemoryUsage = queryProfile.addCounter("QueryPeakMemoryUsage", TUnit.BYTES, null);
+        queryPeakMemoryUsage.setValue(
+                statistics == null || statistics.memCostBytes == null ? 0 : statistics.memCostBytes);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: liuyehcf <1559500551@qq.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

#17023 bring performance deduction, the reason comes from two aspects:
1. 3 atomic rather than 1 atomic are updated each time for MemTracker updation.
2. there have been more context switch. when calling `push_chunk` and `pull_chunk`, the thread_local will change to operator's mem_tracker, in memory intensive cases, the total amount of context switch will be tremendous, which will finally lead to MemTrack's updation.

## Experiment

benchmark_04(1fe, 3be, 16c/64G)

```sql
select count(*) from ssb_200g.lineorder_flat where LO_ORDERDATE != '1994-04-12';
```

|  | 1 concurrency | 10 concurrency |
|:--|:--|:--|
| before #17023(disable profile) | 177ms | 0.716s |
| before #17023(enable profile) | 183ms | 0.7.66s |
| #17023(disable profile) | 417ms | 1.596s |
| #17023(enable profile) | 435ms | 1.596s |
| this pr(disable profile) | 176ms | 0.699s |
| this pr(enable profile) | 390ms | 1.317s |

So we can draw the conclusion that this pr's performance is same as before #17023 if profile is disabled. But there still has substantial deduction in performance if profile is enabled for memory intensive situations.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
