### PR TITLE
[Enhancement] add session variable default_table_compression

### DIFF
--- a/docs/reference/System_variable.md
+++ b/docs/reference/System_variable.md
@@ -106,7 +106,7 @@ SELECT /*+ SET_VAR(query_timeout = 1) */ sleep(3);
 
 * default_table_compression
 
-  Set the default compression algorithm for table storage, supported compression algorithms are: `snappy, lz4, lz4_frame, zlib, zstd`.
+  Set the default compression algorithm for table storage, supported compression algorithms are: `snappy, lz4, zlib, zstd`.
 
 * disable_colocate_join
 

--- a/docs/reference/System_variable.md
+++ b/docs/reference/System_variable.md
@@ -106,7 +106,7 @@ SELECT /*+ SET_VAR(query_timeout = 1) */ sleep(3);
 
 * default_table_compression
 
-  Set the default compression algorithm for table storage, supported compression algorithms are: `snappy, lz4, lz4_frame, zlib, zstd, gzip, deflate, bzip2, lzo, brotli`.
+  Set the default compression algorithm for table storage, supported compression algorithms are: `snappy, lz4, lz4_frame, zlib, zstd`.
 
 * disable_colocate_join
 

--- a/docs/reference/System_variable.md
+++ b/docs/reference/System_variable.md
@@ -104,6 +104,10 @@ SELECT /*+ SET_VAR(query_timeout = 1) */ sleep(3);
 
   Used to set the default storage format used by the storage engine of the computing node. The currently supported storage formats are `alpha` and `beta`.
 
+* default_table_compression
+
+  Set the default compression algorithm for table storage, supported compression algorithms are: `snappy, lz4, lz4_frame, zlib, zstd, gzip, deflate, bzip2, lzo, brotli`.
+
 * disable_colocate_join
 
   Used to control whether the Colocation Join is enabled. The default value is `false`, meaning the feature is enabled. When this feature is disabled, query planning will not attempt to execute Colocation Join.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/CompressionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/CompressionUtils.java
@@ -25,7 +25,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -58,14 +60,18 @@ public class CompressionUtils {
         if (compressionType == null) {
             return null;
         } else if (compressionType == TCompressionType.LZ4
-                   || compressionType == TCompressionType.LZ4_FRAME
-                   || compressionType == TCompressionType.ZLIB
-                   || compressionType == TCompressionType.ZSTD
-                   || compressionType == TCompressionType.SNAPPY) {
+                || compressionType == TCompressionType.LZ4_FRAME
+                || compressionType == TCompressionType.ZLIB
+                || compressionType == TCompressionType.ZSTD
+                || compressionType == TCompressionType.SNAPPY) {
             return compressionType;
         } else {
             return null;
         }
+    }
+
+    public static List<String> getSupportedCompressionNames() {
+        return new ArrayList<>(T_COMPRESSION_BY_NAME.keySet());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -280,6 +280,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
 
+    public static final String DEFAULT_TABLE_COMPRESSION = "default_table_compression";
+
     // In most cases, the partition statistics obtained from the hive metastore are empty.
     // Because we get partition statistics asynchronously for the first query of a table or partition,
     // if the gc of any service is caused, you can set the value to 100 for testing.
@@ -736,6 +738,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = HIVE_PARTITION_STATS_SAMPLE_SIZE)
     private int hivePartitionStatsSampleSize = 3000;
+
+    @VarAttr(name = DEFAULT_TABLE_COMPRESSION)
+    private String defaultTableCompressionAlgorithm = "lz4_frame";
 
     @VariableMgr.VarAttr(name = ENABLE_ADAPTIVE_SINK_DOP)
     private boolean enableAdaptiveSinkDop = false;
@@ -1646,6 +1651,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnablePruneComplexTypes(boolean enablePruneComplexTypes) {
         this.enablePruneComplexTypes = enablePruneComplexTypes;
+    }
+
+    public String getDefaultTableCompression() {
+        return defaultTableCompressionAlgorithm;
+    }
+
+    public void setDefaultTableCompression(String compression) {
+        this.defaultTableCompressionAlgorithm = compression;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -29,6 +29,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
+import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.mysql.MysqlPassword;
@@ -50,6 +51,7 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.system.HeartbeatFlags;
+import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TTabletInternalParallelMode;
 import com.starrocks.thrift.TWorkGroup;
 import org.apache.commons.lang3.StringUtils;
@@ -172,6 +174,15 @@ public class SetStmtAnalyzer {
 
         if (variable.equalsIgnoreCase(SessionVariable.TABLET_INTERNAL_PARALLEL_MODE)) {
             validateTabletInternalParallelModeValue(resolvedExpression.getStringValue());
+        }
+
+        if (variable.equalsIgnoreCase(SessionVariable.DEFAULT_TABLE_COMPRESSION)) {
+            String compressionName = resolvedExpression.getStringValue();
+            TCompressionType compressionType = CompressionUtils.getCompressTypeByName(compressionName);
+            if (compressionType == null) {
+                throw new SemanticException(String.format("Unsupported compression type: %s, supported list is %s",
+                        compressionName, StringUtils.join(CompressionUtils.getSupportedCompressionNames(), ",")));
+            }
         }
 
         var.setResolvedExpression(resolvedExpression);


### PR DESCRIPTION
Signed-off-by: Murphy <mofei@starrocks.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17642

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Add a session variable `default_table_compression` to choose default compression algorithm when creating table.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
