### PR TITLE
[BugFix] Remove the hiveclient from client pool when occuring error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ClassUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ClassUtils.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class ClassUtils {
+    private static final HashMap WRAPPER_TO_PRIMITIVE = new HashMap();
+    static {
+        WRAPPER_TO_PRIMITIVE.put(Boolean.class, Boolean.TYPE);
+        WRAPPER_TO_PRIMITIVE.put(Character.class, Character.TYPE);
+        WRAPPER_TO_PRIMITIVE.put(Byte.class, Byte.TYPE);
+        WRAPPER_TO_PRIMITIVE.put(Short.class, Short.TYPE);
+        WRAPPER_TO_PRIMITIVE.put(Integer.class, Integer.TYPE);
+        WRAPPER_TO_PRIMITIVE.put(Float.class, Float.TYPE);
+        WRAPPER_TO_PRIMITIVE.put(Long.class, Long.TYPE);
+        WRAPPER_TO_PRIMITIVE.put(Double.class, Double.TYPE);
+        WRAPPER_TO_PRIMITIVE.put(ArrayList.class, List.class);
+        WRAPPER_TO_PRIMITIVE.put(String.class, String.class);
+    }
+
+    public static Class<?>[] getCompatibleParamClasses(Object[] args) {
+        Class<?>[] argTypes = new Class[args.length];
+        for (int i = 0; i < args.length; i++) {
+            argTypes[i] = toPrimitiveClass(args[i].getClass());
+        }
+        return argTypes;
+    }
+
+    // return wrapped type if its type is primitive.
+    public static Class<?> toPrimitiveClass(Class<?> parameterType) {
+        if (!parameterType.isPrimitive() || parameterType.getName().equals("java.util.ArrayList")) {
+            Class<?> wrapperType = getWrapperType(parameterType);
+
+            assert wrapperType != null;
+            return wrapperType;
+        } else {
+            return parameterType;
+        }
+    }
+
+    public static Class<?> getWrapperType(Class<?> primitiveType) {
+        return (Class) WRAPPER_TO_PRIMITIVE.get(primitiveType);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaStoreThriftClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaStoreThriftClient.java
@@ -362,10 +362,6 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
         return localMetaStore;
     }
 
-    public boolean isConnected() {
-        return isConnected;
-    }
-
     @Override
     public boolean isCompatibleWith(Configuration conf) {
         // Make a copy of currentMetaVars, there is a race condition that
@@ -402,11 +398,10 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
                     " at the client level.");
         } else {
             close();
-
-            if (uriResolverHook != null) {
-                //for dynamic uris, re-lookup if there are new metastore locations
-                resolveUris();
-            }
+            // If the user passes in an address of 'hive.metastore.uris' similar to nginx, fe may only resolve to one url.
+            // If the user's ip changes, thrift client can't use other url to access. Therefore, we need to resolve uris
+            // for each reconnect. After all, reconnect is a rare behavior.
+            resolveUris();
 
             if (MetastoreConf.getVar(conf, ConfVars.THRIFT_URI_SELECTION).equalsIgnoreCase("RANDOM")) {
                 // Swap the first element of the metastoreUris[] with a random element from the rest

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -15,10 +15,6 @@
 
 package com.starrocks.connector.hive;
 
-import com.starrocks.connector.hive.HiveMetaClient;
-import com.starrocks.connector.hive.HiveMetaStoreThriftClient;
-import com.starrocks.connector.hive.HiveMetastoreApiConverter;
-import com.starrocks.connector.hive.TextFileFormatDesc;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -32,6 +28,7 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,10 +46,6 @@ public class HiveMetaClientTest {
             {
                 metaStoreClient.getTable(anyString, anyString);
                 result = new Table();
-                minTimes = 0;
-
-                metaStoreClient.isConnected();
-                result = true;
                 minTimes = 0;
             }
         };
@@ -92,10 +85,67 @@ public class HiveMetaClientTest {
             es.shutdown();
             es.awaitTermination(1, TimeUnit.HOURS);
         }
-
         System.out.println("called times is " + clientNum[0]);
 
-        Assert.assertTrue(clientNum[0] >= 1 && clientNum[0] <= poolSize);
+        Assert.assertTrue(
+                clientNum[0] >= 1 && clientNum[0] <= poolSize);
+    }
+
+    @Test
+    public void testGetHiveClient() {
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:9030");
+        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        try {
+            client.getAllDatabaseNames();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Unable to instantiate"));
+        }
+    }
+
+    @Test
+    public void testRecyclableClient(@Mocked HiveMetaStoreThriftClient metaStoreClient) throws TException {
+        new Expectations() {
+            {
+                metaStoreClient.getTable(anyString, anyString);
+                result = new Exception("get table failed");
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<RetryingMetaStoreClient>() {
+            @Mock
+            public IMetaStoreClient getProxy(Configuration hiveConf, HiveMetaHookLoader hookLoader,
+                                             ConcurrentHashMap<String, Long> metaCallTimeMap, String mscClassName,
+                                             boolean allowEmbedded) throws MetaException {
+                return metaStoreClient;
+            }
+        };
+
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:9030");
+        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        try {
+            client.getTable("db", "tbl");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Failed to get table"));
+            Assert.assertEquals(0, client.getClientSize());
+        }
+
+        new Expectations() {
+            {
+                metaStoreClient.getTable(anyString, anyString);
+                result = new Table();
+                minTimes = 0;
+            }
+        };
+
+        client.getTable("db", "tbl");
+        Assert.assertEquals(1, client.getClientSize());
+
+        client.getTable("db", "tbl");
+        Assert.assertEquals(1, client.getClientSize());
+
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
The major change in this pr is remove the hiveclient from client pool when there is an error in accessing the hive metastore.
The connection which accessing hive metastore is a long connection. If anything goes wrong on the server that causes a exception throw, we'll retry and put the connection back in the pool. There are a lot of reasons why accessing hive metastore with this long connection causes an error. we use the user case for example.
The `hive.metastore.uris` of catalog properties be passed a nginx like [waggle-dance ](https://github.com/ExpediaGroup/waggle-dance) hostname.  If there is an exception by ip changed of user hive metastore, we will use the all uris in `hive.metastore.uris` to reconnect service. But at this point, we will only use the old ip resolved when the client was initialized. By default, hive metastore expects all available ip addresses to be passed as arguments `hive.metastore.uris`. So we resolve uris for each reconnect.  For all other exceptions, we added the behavior to remove the hive client from the pool, ensuring that we don't reuse the wrong connection for every accessing.
The only limitation of each resove url is that InetAddress may reuse ip according to the hostname, but the ip cache ttl of jvm defaults to 30 seconds, which can be ignored in corner case.






## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
