### PR TITLE
[BugFix] update args type when rewrite the input of agg funcs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -163,6 +163,17 @@ public class AggregateFunction extends Function {
         returnsNonNullOnEmpty = false;
     }
 
+    public AggregateFunction(AggregateFunction other) {
+        super(other);
+        intermediateType = other.intermediateType;
+        ignoresDistinct = other.ignoresDistinct;
+        isAnalyticFn = other.isAnalyticFn;
+        isAggregateFn = other.isAggregateFn;
+        returnsNonNullOnEmpty = other.returnsNonNullOnEmpty;
+        symbolName = other.symbolName;
+
+    }
+
     public String getSymbolName() {
         return symbolName == null ? Strings.EMPTY : symbolName;
     }
@@ -347,6 +358,11 @@ public class AggregateFunction extends Function {
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName == null ? "" : symbolName);
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
         return new Gson().toJson(properties);
+    }
+
+    @Override
+    public Function copy() {
+        return new AggregateFunction(this);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -784,7 +784,6 @@ public class Function implements Writable {
         }
 
         return this;
-
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -44,6 +44,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.thrift.TFunction;
 import com.starrocks.thrift.TFunctionBinaryType;
+import org.apache.commons.lang.ArrayUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -165,6 +166,22 @@ public class Function implements Writable {
         }
         this.retType = retType;
         this.isPolymorphic = Arrays.stream(this.argTypes).anyMatch(Type::isPseudoType);
+    }
+
+    // copy constructor
+    public Function(Function other) {
+        id = other.id;
+        name = other.name;
+        retType = other.retType;
+        argTypes = other.argTypes;
+        userVisible = other.userVisible;
+        location = other.location;
+        binaryType = other.binaryType;
+        checksum = other.checksum;
+        functionId = other.functionId;
+        isPolymorphic = other.isPolymorphic;
+        couldApplyDictOptimize = other.couldApplyDictOptimize;
+        isNullable = other.isNullable;
     }
 
     public FunctionName getFunctionName() {
@@ -751,6 +768,23 @@ public class Function implements Writable {
             return true;
         }
         return obj != null && obj.getClass() == this.getClass() && isIdentical((Function) obj);
+    }
+
+
+    // just shallow copy
+    public Function copy() {
+        return new Function(this);
+    }
+
+    public Function updateArgType(Type[] newTypes) {
+        if (!ArrayUtils.isEquals(argTypes, newTypes)) {
+            Function newFunc = copy();
+            newFunc.setArgsType(newTypes);
+            return newFunc;
+        }
+
+        return this;
+
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -92,6 +92,13 @@ public class ScalarFunction extends Function {
         super(fid, name, argTypes, retType, hasVarArgs);
     }
 
+    public ScalarFunction(ScalarFunction other) {
+        super(other);
+        symbolName = other.symbolName;
+        prepareFnSymbol = other.prepareFnSymbol;
+        closeFnSymbol = other.closeFnSymbol;
+    }
+
     public static ScalarFunction createVectorizedBuiltin(long fid,
                                                          String name, List<Type> argTypes,
                                                          boolean hasVarArgs, Type retType) {
@@ -227,5 +234,10 @@ public class ScalarFunction extends Function {
         properties.put(CreateFunctionStmt.SYMBOL_KEY, getSymbolName());
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
         return new Gson().toJson(properties);
+    }
+
+    @Override
+    public Function copy() {
+        return new ScalarFunction(this);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -65,6 +65,14 @@ public class TableFunction extends Function {
         setBinaryType(TFunctionBinaryType.BUILTIN);
     }
 
+    public TableFunction(TableFunction other) {
+        super(other);
+        defaultColumnNames = other.defaultColumnNames;
+        tableFnReturnTypes = other.tableFnReturnTypes;
+        symbolName = other.symbolName;
+
+    }
+
     public static void initBuiltins(FunctionSet functionSet) {
         TableFunction unnestFunction = new TableFunction(new FunctionName("unnest"), Lists.newArrayList("unnest"),
                 Lists.newArrayList(Type.ANY_ARRAY), Lists.newArrayList(Type.ANY_ELEMENT), true);
@@ -125,5 +133,10 @@ public class TableFunction extends Function {
         properties.put(CreateFunctionStmt.SYMBOL_KEY, symbolName);
         properties.put(CreateFunctionStmt.TYPE_KEY, getBinaryType().name());
         return new Gson().toJson(properties);
+    }
+
+    @Override
+    public Function copy() {
+        return new TableFunction(this);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
@@ -35,7 +35,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
-import org.jetbrains.annotations.NotNull;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Collection;
 import java.util.List;
@@ -73,7 +73,6 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
                     .put(FunctionSet.MIN, Pair.create(FunctionSet.MIN, FunctionSet.MIN))
                     .put(FunctionSet.SUM, Pair.create(FunctionSet.SUM, FunctionSet.SUM))
                     .put(FunctionSet.HLL_UNION, Pair.create(FunctionSet.HLL_UNION, FunctionSet.HLL_UNION))
-                    .put(FunctionSet.NDV, Pair.create(FunctionSet.HLL_UNION, FunctionSet.NDV))
                     .put(FunctionSet.BITMAP_UNION, Pair.create(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION))
                     .put(FunctionSet.BITMAP_UNION_COUNT,
                             Pair.create(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION_COUNT))
@@ -169,24 +168,16 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
 
         ColumnRefFactory factory = context.getColumnRefFactory();
         otherMap.forEach((k, v) -> {
-            Function origin = v.getFunction();
-            String firstFn = OTHER_FUNCTION_TRANS.get(origin.getFunctionName().getFunction()).first;
-            String secondFn = OTHER_FUNCTION_TRANS.get(origin.getFunctionName().getFunction()).second;
-
-            CallOperator firstAgg = genAggregation(firstFn, origin.getArgs(), v.getChildren(), v);
+            CallOperator firstAgg = transformOtherAgg(v, v.getArguments(), true);
             ColumnRefOperator firstOutput = factory.create(firstAgg, firstAgg.getType(), firstAgg.isNullable());
-
             firstAggregations.put(firstOutput, firstAgg);
 
-            CallOperator secondAgg =
-                    genAggregation(secondFn, new Type[] {firstAgg.getType()}, Lists.newArrayList(firstOutput), v);
+            CallOperator secondAgg = transformOtherAgg(v, Lists.newArrayList(firstOutput), false);
             secondAggregations.put(k, secondAgg);
         });
 
         distinctMap.forEach((k, v) -> {
-            Function origin = v.getFunction();
-            String secondFn = DISTINCT_FUNCTION_TRANS.get(origin.getFunctionName().getFunction());
-            CallOperator secondAgg = genAggregation(secondFn, origin.getArgs(), v.getChildren(), v);
+            CallOperator secondAgg = transformDistinctAgg(v);
             secondAggregations.put(k, secondAgg);
         });
 
@@ -198,19 +189,41 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
                 OptExpression.create(second.build(), OptExpression.create(first, input.getInputs())));
     }
 
-    @NotNull
-    private CallOperator genAggregation(String name, Type[] argTypes, List<ScalarOperator> args, CallOperator origin) {
-        if (FunctionSet.SUM.equals(name) || FunctionSet.MAX.equals(name) || FunctionSet.MIN.equals(name)) {
-            // for decimal
-            return new CallOperator(name, origin.getType(), args, origin.getFunction());
+    private CallOperator transformOtherAgg(CallOperator origin, List<ScalarOperator> args, boolean isFirst) {
+        String originFuncName = origin.getFunction().functionName();
+        if (isFirst) {
+            String firstFuncName = OTHER_FUNCTION_TRANS.get(originFuncName).first;
+            if (StringUtils.equals(originFuncName, firstFuncName)) {
+                return origin;
+            } else {
+                Function newFunc = Expr.getBuiltinFunction(firstFuncName, origin.getFunction().getArgs(),
+                        Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                return new CallOperator(firstFuncName, newFunc.getReturnType(), args, newFunc);
+            }
+        } else {
+            String secondFuncName = OTHER_FUNCTION_TRANS.get(originFuncName).second;
+            Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
+            Function newFunc = origin.getFunction().updateArgType(argTypes);
+            return new CallOperator(secondFuncName, newFunc.getReturnType(), args, newFunc);
         }
-        Function fn = Expr.getBuiltinFunction(name, argTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-        return new CallOperator(name, fn.getReturnType(), args, fn);
+    }
+
+
+    private CallOperator transformDistinctAgg(CallOperator origin) {
+        String originFuncName = origin.getFunction().functionName();
+        String newFuncName = DISTINCT_FUNCTION_TRANS.get(originFuncName);
+        if (StringUtils.equals(originFuncName, newFuncName)) {
+            return new CallOperator(originFuncName, origin.getType(), origin.getChildren(), origin.getFunction());
+        } else {
+            Function newFunc = Expr.getBuiltinFunction(newFuncName, origin.getFunction().getArgs(),
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            return new CallOperator(newFuncName, newFunc.getReturnType(), origin.getChildren(), newFunc);
+        }
     }
 
     private boolean isDistinct(CallOperator call) {
         return call.isDistinct() ||
-                FunctionSet.MULTI_DISTINCT_SUM.equals(call.getFunction().getFunctionName().getFunction()) ||
-                FunctionSet.MULTI_DISTINCT_COUNT.equals(call.getFunction().getFunctionName().getFunction());
+                FunctionSet.MULTI_DISTINCT_SUM.equals(call.getFunction().functionName()) ||
+                FunctionSet.MULTI_DISTINCT_COUNT.equals(call.getFunction().functionName());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
@@ -74,8 +74,6 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
                     .put(FunctionSet.SUM, Pair.create(FunctionSet.SUM, FunctionSet.SUM))
                     .put(FunctionSet.HLL_UNION, Pair.create(FunctionSet.HLL_UNION, FunctionSet.HLL_UNION))
                     .put(FunctionSet.BITMAP_UNION, Pair.create(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION))
-                    .put(FunctionSet.BITMAP_UNION_COUNT,
-                            Pair.create(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION_COUNT))
                     .put(FunctionSet.PERCENTILE_UNION,
                             Pair.create(FunctionSet.PERCENTILE_UNION, FunctionSet.PERCENTILE_UNION))
                     .build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -48,6 +48,7 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -66,6 +67,13 @@ public class SplitAggregateRule extends TransformationRule {
 
     private static final SplitAggregateRule INSTANCE = new SplitAggregateRule();
 
+    private static final int AUTO_MODE = 0;
+
+    private static final int ONE_STAGE = 1;
+
+    private static final int TWO_STAGE = 2;
+
+
     public static SplitAggregateRule getInstance() {
         return INSTANCE;
     }
@@ -78,16 +86,6 @@ public class SplitAggregateRule extends TransformationRule {
         LogicalAggregationOperator agg = (LogicalAggregationOperator) input.getOp();
         // Only apply this rule if the aggregate type is global and not split
         return agg.getType().isGlobal() && !agg.isSplit();
-    }
-
-    private boolean canGenerateMultiStageAggregate(OptExpression input) {
-        // Must do one stage aggregate If the child contains limit,
-        // the aggregation must be a single node to ensure correctness.
-        // eg. select count(*) from (select * table limit 2) t
-        if (input.inputAt(0).getOp().hasLimit()) {
-            return false;
-        }
-        return true;
     }
 
     private boolean mustGenerateMultiStageAggregate(OptExpression input, List<CallOperator> distinctAggCallOperator) {
@@ -118,8 +116,10 @@ public class SplitAggregateRule extends TransformationRule {
 
     // Note: This method logic must consistent with CostEstimator::needGenerateOneStageAggNode
     private boolean needGenerateMultiStageAggregate(OptExpression input, List<CallOperator> distinctAggCallOperator) {
-        // 1. check if can generate multi stage aggregate.
-        if (!canGenerateMultiStageAggregate(input)) {
+        // 1. Must do one stage aggregate If the child contains limit,
+        //    the aggregation must be a single node to ensure correctness.
+        //    eg. select count(*) from (select * table limit 2) t
+        if (input.inputAt(0).getOp().hasLimit()) {
             return false;
         }
         // 2. check if must generate multi stage aggregate.
@@ -128,42 +128,30 @@ public class SplitAggregateRule extends TransformationRule {
         }
         // 3. Respect user hint
         int aggStage = ConnectContext.get().getSessionVariable().getNewPlannerAggStage();
-        if (aggStage == 1) {
+        if (aggStage == ONE_STAGE) {
             return false;
         }
         // 4. If scan tablet sum leas than 1, do one phase aggregate is enough
-        if (aggStage == 0 && input.getLogicalProperty().isExecuteInOneTablet()) {
+        if (aggStage == AUTO_MODE && input.getLogicalProperty().isExecuteInOneTablet()) {
             return false;
         }
         // Default, we could generate two stage aggregate
         return true;
     }
 
-    // check if has multi distinct function and each has same multi columns
-    private boolean hasMultiDistinctCallWithSameMultiColumns(List<CallOperator> distinctAggCallOperator) {
-        if (distinctAggCallOperator.size() <= 1) {
-            return false;
-        }
-        boolean hasSameMultiColumn = false;
+    // check if multi distinct functions used the same columns.
+    private void checkDistinctAgg(List<CallOperator> distinctAggCallOperator) {
         List<ScalarOperator> distinctChild0 = distinctAggCallOperator.get(0).getChildren();
         for (int i = 1; i < distinctAggCallOperator.size(); ++i) {
             List<ScalarOperator> distinctChildI = distinctAggCallOperator.get(i).getChildren();
             if (!distinctChild0.equals(distinctChildI)) {
-                if (distinctChild0.size() > 1 || distinctChildI.size() > 1) {
-                    // such as : select count(distinct a,b), count(distinct b, c) from table is not valid
-                    throw new StarRocksPlannerException("The query contains multi count distinct or " +
-                            "sum distinct, each can't have multi columns.", ErrorType.USER_ERROR);
-                }
-            } else {
-                if (distinctChild0.size() > 1) {
-                    hasSameMultiColumn = true;
-                }
+                throw new StarRocksPlannerException("The query contains multi count distinct or " +
+                        "sum distinct, each can't have multi columns.", ErrorType.USER_ERROR);
             }
         }
-        return hasSameMultiColumn;
     }
 
-    private boolean hasAggregateEffect(OptExpression input, List<ColumnRefOperator> distinctColumns) {
+    private boolean hasAggregateEffect(OptExpression input) {
         Statistics statistics = input.getGroupExpression().getGroup().getStatistics();
         Statistics inputStatistics = input.getGroupExpression().getInputs().get(0).getStatistics();
         Collection<ColumnStatistic> inputsColumnStatistics = inputStatistics.getColumnStatistics().values();
@@ -182,82 +170,58 @@ public class SplitAggregateRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
-        List<OptExpression> newExpressions = new ArrayList<>();
         LogicalAggregationOperator operator = (LogicalAggregationOperator) input.getOp();
 
         List<CallOperator> distinctAggCallOperator = operator.getAggregations().values().stream()
                 .filter(CallOperator::isDistinct)
-                // Don't need do three stage or four stage aggregate for const column
+                // Don't need to do three stage or four stage aggregate for const column
                 .filter(c -> !c.getUsedColumns().isEmpty())
                 .collect(Collectors.toList());
-        long distinctCount = distinctAggCallOperator.size();
 
+        // no need to do multiple stage agg
         if (!needGenerateMultiStageAggregate(input, distinctAggCallOperator)) {
             return Lists.newArrayList();
         }
 
-        boolean hasMultiDistinctCallWithMultiColumns = false;
-        // only has multi column distinct function needs to check
-        if (distinctCount > 1) {
-            hasMultiDistinctCallWithMultiColumns = hasMultiDistinctCallWithSameMultiColumns(distinctAggCallOperator);
+        // do two stage agg if without distinct agg
+        if (distinctAggCallOperator.size() == 0) {
+            return implementTwoStageAgg(input, operator);
         }
 
-        if (distinctCount == 1 || (distinctCount > 1 && hasMultiDistinctCallWithMultiColumns)) {
-            // Get distinct columns and position in all aggregate functions
-            List<ColumnRefOperator> distinctColumns = Lists.newArrayList();
-            int singleDistinctFunctionPos = -1;
-            for (Map.Entry<ColumnRefOperator, CallOperator> kv : operator.getAggregations().entrySet()) {
-                singleDistinctFunctionPos++;
-                if (kv.getValue().isDistinct()) {
-                    distinctColumns = kv.getValue().getUsedColumns().getStream().
-                            map(id -> context.getColumnRefFactory().getColumnRef(id)).collect(Collectors.toList());
-                    break;
-                }
-            }
+        // now the distinctAggCallOperator must contain at least one multiple column agg
+        // we need ensure all the distinctAggCall contains same columns
+        checkDistinctAgg(distinctAggCallOperator);
 
-            if (!operator.getGroupingKeys().isEmpty()) {
-                if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 0) {
-                    if (isGroupByAllConstant(input, operator)) {
-                        return implementOneDistinctWithConstantGroupByAgg(context.getColumnRefFactory(),
-                                input, operator, distinctColumns, singleDistinctFunctionPos,
-                                operator.getGroupingKeys());
-                        // If agg node has limit or has a very good aggregation effect which could reduce the shuffle data,
-                        // we prefer to choose 2 phase aggregate
-                    } else if (canGenerateTwoStageAggregate(operator, distinctColumns) &&
-                            (operator.hasLimit() || hasAggregateEffect(input, distinctColumns))) {
-                        return implementTwoStageAgg(input, operator);
-                    } else {
-                        return implementOneDistinctWithGroupByAgg(context.getColumnRefFactory(), input, operator,
-                                singleDistinctFunctionPos);
-                    }
-                } else if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 2 &&
-                        canGenerateTwoStageAggregate(operator, distinctColumns)) {
-                    return implementTwoStageAgg(input, operator);
-                } else {
-                    if (isGroupByAllConstant(input, operator)) {
-                        return implementOneDistinctWithConstantGroupByAgg(context.getColumnRefFactory(),
-                                input, operator, distinctColumns, singleDistinctFunctionPos,
-                                operator.getGroupingKeys());
-                    } else {
-                        return implementOneDistinctWithGroupByAgg(context.getColumnRefFactory(), input, operator,
-                                singleDistinctFunctionPos);
-                    }
-                }
+        // Get distinct columns and position in all aggregate functions
+        List<ColumnRefOperator> distinctColumns = Lists.newArrayList();
+        int singleDistinctFunctionPos = -1;
+        for (Map.Entry<ColumnRefOperator, CallOperator> kv : operator.getAggregations().entrySet()) {
+            singleDistinctFunctionPos++;
+            if (kv.getValue().isDistinct()) {
+                distinctColumns = kv.getValue().getUsedColumns().getStream().
+                        map(id -> context.getColumnRefFactory().getColumnRef(id)).collect(Collectors.toList());
+                break;
+            }
+        }
+
+        // if two stage agg is suitable, transform it to two stage agg
+        if (isSuitableForTwoStage(input, operator, distinctColumns)) {
+            return implementTwoStageAgg(input, operator);
+        }
+
+        if (!operator.getGroupingKeys().isEmpty()) {
+            if (isGroupByAllConstant(input, operator)) {
+                return implementOneDistinctWithConstantGroupByAgg(context.getColumnRefFactory(),
+                        input, operator, distinctColumns, singleDistinctFunctionPos,
+                        operator.getGroupingKeys());
             } else {
-                if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 0) {
-                    return implementOneDistinctWithOutGroupByAgg(context.getColumnRefFactory(),
-                            input, operator, distinctColumns, singleDistinctFunctionPos);
-                } else if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 2 &&
-                        canGenerateTwoStageAggregate(operator, distinctColumns)) {
-                    return implementTwoStageAgg(input, operator);
-                } else {
-                    return implementOneDistinctWithOutGroupByAgg(context.getColumnRefFactory(),
-                            input, operator, distinctColumns, singleDistinctFunctionPos);
-                }
+                return implementOneDistinctWithGroupByAgg(context.getColumnRefFactory(), input, operator,
+                        singleDistinctFunctionPos);
             }
+        } else {
+            return implementOneDistinctWithoutGroupByAgg(context.getColumnRefFactory(),
+                    input, operator, distinctColumns, singleDistinctFunctionPos);
         }
-
-        return implementTwoStageAgg(input, operator);
     }
 
     private boolean isGroupByAllConstant(OptExpression input, LogicalAggregationOperator operator) {
@@ -271,6 +235,23 @@ public class SplitAggregateRule extends TransformationRule {
         List<ScalarOperator> groupingKeys = operator.getGroupingKeys().stream().map(rewriter::rewrite).
                 collect(Collectors.toList());
         return groupingKeys.stream().allMatch(ScalarOperator::isConstant);
+    }
+
+    private boolean isSuitableForTwoStage(OptExpression input, LogicalAggregationOperator operator,
+                                          List<ColumnRefOperator> distinctColumns) {
+        int aggMode = ConnectContext.get().getSessionVariable().getNewPlannerAggStage();
+        boolean canTwoStage = canGenerateTwoStageAggregate(operator, distinctColumns);
+
+        if (!canTwoStage) {
+            return false;
+        }
+
+        if (aggMode == TWO_STAGE) {
+            return true;
+        }
+
+        return CollectionUtils.isNotEmpty(operator.getGroupingKeys())
+                && aggMode == AUTO_MODE && hasAggregateEffect(input);
     }
 
     private boolean canGenerateTwoStageAggregate(LogicalAggregationOperator operator,
@@ -446,7 +427,7 @@ public class SplitAggregateRule extends TransformationRule {
 
     // For SQL: select count(distinct id_bigint), sum(id_int)from test_basic ;
     // Local Agg -> Distinct global Agg -> Distinct local Agg -> Global Agg
-    private List<OptExpression> implementOneDistinctWithOutGroupByAgg(
+    private List<OptExpression> implementOneDistinctWithoutGroupByAgg(
             ColumnRefFactory columnRefFactory,
             OptExpression input,
             LogicalAggregationOperator oldAgg,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -184,7 +184,7 @@ public class SplitAggregateRule extends TransformationRule {
         }
 
         // do two stage agg if without distinct agg
-        if (distinctAggCallOperator.size() == 0) {
+        if (CollectionUtils.isEmpty(distinctAggCallOperator)) {
             return implementTwoStageAgg(input, operator);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2137,17 +2137,10 @@ public class AggregateTest extends PlanTestBase {
         assertContains(plan, "bitmap_union[([15: bitmap_union, BITMAP, true]); args: BITMAP; result: BITMAP; " +
                 "args nullable: true;");
 
-        sql = "select count(distinct v1), bitmap_union_count(BITMAP_HASH(v3)) from test_object group by v2, v3";
-        plan = getVerboseExplain(sql);
-        assertContains(plan, "bitmap_union_count[([16: bitmap_union, BITMAP, true]); args: BITMAP; " +
-                "result: BITMAP; args nullable: true;");
-
         sql = "select count(distinct t1a), PERCENTILE_UNION(PERCENTILE_HASH(t1f)) from test_all_type group by t1c";
         plan = getVerboseExplain(sql);
         assertContains(plan, "percentile_union[([14: percentile_union, PERCENTILE, true]); args: PERCENTILE; " +
                 "result: PERCENTILE; args nullable: true;");
         FeConstants.runningUnitTest = false;
-
-
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -781,7 +781,9 @@ public class AggregateTest extends PlanTestBase {
     @Test
     public void testDistinctPushDown() throws Exception {
         String sql = "select distinct k1 from (select distinct k1 from test.pushdown_test) t where k1 > 1";
-        starRocksAssert.query(sql).explainContains("  RESULT SINK\n" +
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "RESULT SINK\n" +
                 "\n" +
                 "  1:AGGREGATE (update finalize)\n" +
                 "  |  group by: 1: k1\n" +
@@ -1102,7 +1104,7 @@ public class AggregateTest extends PlanTestBase {
         connectContext.getSessionVariable().setSqlMode(0);
         String sql = "select v1, v2 from t0 group by v1";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("PLAN FRAGMENT 0\n" +
+        Assert.assertTrue(plan, plan.contains("PLAN FRAGMENT 0\n" +
                 " OUTPUT EXPRS:1: v1 | 4: any_value\n" +
                 "  PARTITION: RANDOM\n" +
                 "\n" +
@@ -2113,5 +2115,39 @@ public class AggregateTest extends PlanTestBase {
                 "  |  <slot 14> : 'b'");
         assertContains(plan, "  2:EXCHANGE\n" +
                 "     limit: 1");
+    }
+
+    @Test
+    public void testDistinctRewrite() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "select count(distinct t1a), sum(t1c) from test_all_type group by t1b";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "sum[([13: sum, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true;");
+
+        sql = "select multi_distinct_count(t1a), max(t1c) from test_all_type group by t1b, t1c";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "max[([13: max, INT, true]); args: INT;");
+
+        sql = "select sum(distinct v1), hll_union(hll_hash(v3)) from test_object group by v2";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "hll_union[([16: hll_union, HLL, true]); args: HLL; result: HLL; args nullable: true;");
+
+        sql = "select count(distinct v1), BITMAP_UNION(b1) from test_object group by v2, v3";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "bitmap_union[([15: bitmap_union, BITMAP, true]); args: BITMAP; result: BITMAP; " +
+                "args nullable: true;");
+
+        sql = "select count(distinct v1), bitmap_union_count(BITMAP_HASH(v3)) from test_object group by v2, v3";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "bitmap_union_count[([16: bitmap_union, BITMAP, true]); args: BITMAP; " +
+                "result: BITMAP; args nullable: true;");
+
+        sql = "select count(distinct t1a), PERCENTILE_UNION(PERCENTILE_HASH(t1f)) from test_all_type group by t1c";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "percentile_union[([14: percentile_union, PERCENTILE, true]); args: PERCENTILE; " +
+                "result: PERCENTILE; args nullable: true;");
+        FeConstants.runningUnitTest = false;
+
+
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In `GroupByCountDistinctRewriteRule` we do things as below:
```
v1 is the distribution key
# before
select count(distinct v1), sum(v2) from t1 group by v3;

# after
select count(v1), sum(sum1) from 
     (select v1, sum(v2) sum1 from t1 group by v1, v3) group by v3;
```
After this transformation, we actually have two different agg operators. The top agg use the output from bottom agg as its input. Hence, we need update the type of argument in callOperator `sum(sum1)`.

Other changes:
We have only four implementation to transform a one stage agg to multiple stage agg. But we have more than ten branches to these implmentations. So I simplifies the code based on the old logic. Now the steps to choose a implementation are as follows:
1. check if it need multiple stage agg. If not, return empty.
2. check the number of distinct agg function. If it's zero, choose two stage agg.
3. check if these distinct agg function are supported. If not, throw exception.
4. check if it is suitable for two stage agg(the check logic is in `isSuitableForTwoStage()` method). If true, choose two stage agg.
5. check if it contains group by keys. 
    If ture: 
    - if all group by keys are constant, choose `implementOneDistinctWithConstantGroupByAgg`
    - if not, choose `implementOneDistinctWithGroupByAgg`
    
    else, choose `implementOneDistinctWithoutGroupByAgg`.



## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
