### PR TITLE
[Doc] Update group_concat default sep to `, `

### DIFF
--- a/docs/sql-reference/sql-functions/string-functions/group_concat.md
+++ b/docs/sql-reference/sql-functions/string-functions/group_concat.md
@@ -15,7 +15,7 @@ VARCHAR group_concat(VARCHAR str[, VARCHAR sep])
 ## Parameters
 
 - `str`: the values to concatenate. It must evaluate to VARCHAR.
-- `sep`: the separator, optional. If it is not specified, `, ` is used by default.
+- `sep`: the separator, optional. If it is not specified, `, ` (a comma and a space) is used by default.
 
 ## Return value
 

--- a/docs/sql-reference/sql-functions/string-functions/group_concat.md
+++ b/docs/sql-reference/sql-functions/string-functions/group_concat.md
@@ -15,7 +15,7 @@ VARCHAR group_concat(VARCHAR str[, VARCHAR sep])
 ## Parameters
 
 - `str`: the values to concatenate. It must evaluate to VARCHAR.
-- `sep`: the separator, optional. If it is not specified, comma `,` is used by default.
+- `sep`: the separator, optional. If it is not specified, `, ` is used by default.
 
 ## Return value
 


### PR DESCRIPTION
change group_concat default seperator to `, ` 
according to the 
[code](https://github.com/StarRocks/starrocks/blob/main/be/src/exprs/agg/group_concat.h#L105), the default sep is `, ` , not comma `,`.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [ ] 2.2
