### PR TITLE
[BugFix] Don't need to close _conjunct_ctxs explicitly in ESDataSource

### DIFF
--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -153,7 +153,6 @@ Status ESDataSource::_normalize_conjuncts() {
 
     for (int i = _predicate_idx.size() - 1; i >= 0; i--) {
         int conjunct_index = _predicate_idx[i];
-        _conjunct_ctxs[conjunct_index]->close(_runtime_state);
         _conjunct_ctxs.erase(_conjunct_ctxs.begin() + conjunct_index);
     }
     return Status::OK();


### PR DESCRIPTION
Signed-off-by: Smith Cruise <chendingchao1@126.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

`ESDataSource`'s `_conjunct_ctxs` comes from `ScanNode`. All io tasks in one driver shared the same ExprContext from `ScanNode`, so we do not need to close ExprContext explicitly, because it will be closed automatically by `ScanNode::close()`.

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
  - [x] 2.2
