### PR TITLE
[BugFix] fix parquet load crash for array

### DIFF
--- a/be/src/exec/vectorized/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/vectorized/arrow_to_starrocks_converter.cpp
@@ -857,7 +857,7 @@ struct ArrowListConverter {
                                Column::Filter* column_filter, ArrowConvertContext* ctx,
                                const TypeDescriptor* type_desc) {
         auto* col_array = down_cast<ArrayColumn*>(column);
-        UInt32Column* col_offsets = col_array->offsets_column().get() + column_start_idx;
+        UInt32Column* col_offsets = col_array->offsets_column().get();
 
         auto type_id = array->type_id();
         if (is_list(type_id)) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17693

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If the parquet file more than one row group, and one of the row group's size is less than 4096, than column_start_idx will be more than 0, in this case, col_offsets will be an pointer pointing to an unknown space. We fix this bug in this pr.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
