### PR TITLE
[Feature]DLA async table writer used for iceberg table sink

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -80,6 +80,7 @@ set(EXEC_FILES
     arrow_to_json_converter.cpp
     parquet_scanner.cpp
     parquet_reader.cpp
+    parquet_writer.cpp
     parquet_builder.cpp
     file_scan_node.cpp
     assert_num_rows_node.cpp

--- a/be/src/exec/parquet_builder.cpp
+++ b/be/src/exec/parquet_builder.cpp
@@ -30,314 +30,53 @@
 
 namespace starrocks {
 
-ParquetOutputStream::ParquetOutputStream(std::unique_ptr<WritableFile> writable_file)
-        : _writable_file(std::move(writable_file)) {
-    set_mode(arrow::io::FileMode::WRITE);
-}
-
-ParquetOutputStream::~ParquetOutputStream() {
-    arrow::Status st = ParquetOutputStream::Close();
-    if (!st.ok()) {
-        LOG(WARNING) << "close parquet output stream failed, err msg: " << st.ToString();
-    }
-}
-
-arrow::Status ParquetOutputStream::Write(const std::shared_ptr<arrow::Buffer>& data) {
-    arrow::Status st = Write(data->data(), data->size());
-    if (!st.ok()) {
-        LOG(WARNING) << "Failed to write data to output stream, err msg: " << st.message();
-    }
-    return st;
-}
-
-arrow::Status ParquetOutputStream::Write(const void* data, int64_t nbytes) {
-    if (_is_closed) {
-        return arrow::Status::IOError("The output stream is closed but there are still inputs");
-    }
-
-    const char* ch = reinterpret_cast<const char*>(data);
-
-    Slice slice(ch, nbytes);
-    Status st = _writable_file->append(slice);
-    if (!st.ok()) {
-        return arrow::Status::IOError(st.to_string());
-    }
-
-    return arrow::Status::OK();
-}
-
-arrow::Result<int64_t> ParquetOutputStream::Tell() const {
-    return _writable_file->size();
-}
-
-arrow::Status ParquetOutputStream::Close() {
-    if (_is_closed) {
-        return arrow::Status::OK();
-    }
-    Status st = _writable_file->close();
-    if (!st.ok()) {
-        LOG(WARNING) << "close parquet output stream failed, err msg: " << st;
-        return arrow::Status::IOError(st.to_string());
-    }
-    _is_closed = true;
-    return arrow::Status::OK();
-}
-
 ParquetBuilder::ParquetBuilder(std::unique_ptr<WritableFile> writable_file,
-                               const std::vector<ExprContext*>& output_expr_ctxs, const ParquetBuilderOptions& options,
-                               const std::vector<std::string>& file_column_names)
-        : _writable_file(std::move(writable_file)),
-          _output_expr_ctxs(output_expr_ctxs),
-          _row_group_max_size(options.row_group_max_size) {
-    _init(options, file_column_names);
+                               std::shared_ptr<::parquet::WriterProperties> properties,
+                               std::shared_ptr<::parquet::schema::GroupNode> schema,
+                               const std::vector<ExprContext*>& output_expr_ctxs, int64_t row_group_max_size) {
+    _writer = std::make_unique<starrocks::parquet::SyncFileWriter>(std::move(writable_file), std::move(properties),
+                                                                   std::move(schema), output_expr_ctxs);
+    _writer->set_max_row_group_size(row_group_max_size);
+    _writer->init();
 }
 
-Status ParquetBuilder::_init(const ParquetBuilderOptions& options, const std::vector<std::string>& file_column_names) {
-    _init_properties(options);
-    Status st = _init_schema(file_column_names);
-    if (!st.ok()) {
-        LOG(WARNING) << "Failed to init parquet schema: " << st;
-    }
-
-    _output_stream = std::make_shared<ParquetOutputStream>(std::move(_writable_file));
-    _buffered_values_estimate.reserve(_schema->field_count());
-    _file_writer = ::parquet::ParquetFileWriter::Open(_output_stream, _schema, _properties);
-    return Status::OK();
-}
-
-void ParquetBuilder::_init_properties(const ParquetBuilderOptions& options) {
+std::shared_ptr<::parquet::WriterProperties> ParquetBuilder::get_properties(const ParquetBuilderOptions& options) {
     ::parquet::WriterProperties::Builder builder;
     builder.version(::parquet::ParquetVersion::PARQUET_2_0);
     options.use_dict ? builder.enable_dictionary() : builder.disable_dictionary();
-    ParquetBuildHelper::build_compression_type(builder, options.compression_type);
-    _properties = builder.build();
+    starrocks::parquet::ParquetBuildHelper::build_compression_type(builder, options.compression_type);
+    return builder.build();
 }
 
-Status ParquetBuilder::_init_schema(const std::vector<std::string>& file_column_names) {
+std::shared_ptr<::parquet::schema::GroupNode> ParquetBuilder::get_schema(
+        const std::vector<std::string>& file_column_names, const std::vector<ExprContext*>& output_expr_ctxs) {
     ::parquet::schema::NodeVector fields;
-    for (int i = 0; i < _output_expr_ctxs.size(); i++) {
+    for (int i = 0; i < output_expr_ctxs.size(); i++) {
         ::parquet::Repetition::type parquet_repetition_type;
         ::parquet::Type::type parquet_data_type;
-        auto column_expr = _output_expr_ctxs[i]->root();
-        ParquetBuildHelper::build_file_data_type(parquet_data_type, column_expr->type().type);
-        ParquetBuildHelper::build_parquet_repetition_type(parquet_repetition_type, column_expr->is_nullable());
+        auto column_expr = output_expr_ctxs[i]->root();
+        starrocks::parquet::ParquetBuildHelper::build_file_data_type(parquet_data_type, column_expr->type().type);
+        starrocks::parquet::ParquetBuildHelper::build_parquet_repetition_type(parquet_repetition_type,
+                                                                              column_expr->is_nullable());
         ::parquet::schema::NodePtr nodePtr = ::parquet::schema::PrimitiveNode::Make(
                 file_column_names[i], parquet_repetition_type, parquet_data_type);
         fields.push_back(nodePtr);
     }
 
-    _schema = std::static_pointer_cast<::parquet::schema::GroupNode>(
+    return std::static_pointer_cast<::parquet::schema::GroupNode>(
             ::parquet::schema::GroupNode::Make("schema", ::parquet::Repetition::REQUIRED, fields));
-    return Status::OK();
 }
-
-void ParquetBuildHelper::build_file_data_type(parquet::Type::type& parquet_data_type,
-                                              const LogicalType& column_data_type) {
-    switch (column_data_type) {
-    case TYPE_BOOLEAN: {
-        parquet_data_type = parquet::Type::BOOLEAN;
-        break;
-    }
-    case TYPE_TINYINT:
-    case TYPE_SMALLINT:
-    case TYPE_INT: {
-        parquet_data_type = parquet::Type::INT32;
-        break;
-    }
-    case TYPE_BIGINT:
-    case TYPE_DATE:
-    case TYPE_DATETIME: {
-        parquet_data_type = parquet::Type::INT64;
-        break;
-    }
-    case TYPE_LARGEINT: {
-        parquet_data_type = parquet::Type::INT96;
-        break;
-    }
-    case TYPE_FLOAT: {
-        parquet_data_type = parquet::Type::FLOAT;
-        break;
-    }
-    case TYPE_DOUBLE: {
-        parquet_data_type = parquet::Type::DOUBLE;
-        break;
-    }
-    case TYPE_CHAR:
-    case TYPE_VARCHAR:
-    case TYPE_DECIMAL:
-    case TYPE_DECIMAL32:
-    case TYPE_DECIMAL64:
-    case TYPE_DECIMALV2: {
-        parquet_data_type = parquet::Type::BYTE_ARRAY;
-        break;
-    }
-    default:
-        parquet_data_type = parquet::Type::UNDEFINED;
-    }
-}
-
-void ParquetBuildHelper::build_parquet_repetition_type(parquet::Repetition::type& parquet_repetition_type,
-                                                       const bool is_nullable) {
-    parquet_repetition_type = is_nullable ? parquet::Repetition::OPTIONAL : parquet::Repetition::REQUIRED;
-}
-
-void ParquetBuildHelper::build_compression_type(parquet::WriterProperties::Builder& builder,
-                                                const TCompressionType::type& compression_type) {
-    switch (compression_type) {
-    case TCompressionType::SNAPPY: {
-        builder.compression(parquet::Compression::SNAPPY);
-        break;
-    }
-    case TCompressionType::GZIP: {
-        builder.compression(parquet::Compression::GZIP);
-        break;
-    }
-    case TCompressionType::BROTLI: {
-        builder.compression(parquet::Compression::BROTLI);
-        break;
-    }
-    case TCompressionType::ZSTD: {
-        builder.compression(parquet::Compression::ZSTD);
-        break;
-    }
-    case TCompressionType::LZ4: {
-        builder.compression(parquet::Compression::LZ4);
-        break;
-    }
-    case TCompressionType::LZO: {
-        builder.compression(parquet::Compression::LZO);
-        break;
-    }
-    case TCompressionType::BZIP2: {
-        builder.compression(parquet::Compression::BZ2);
-        break;
-    }
-    default:
-        builder.compression(parquet::Compression::UNCOMPRESSED);
-    }
-}
-
-void ParquetBuilder::_generate_rg_writer() {
-    if (_rg_writer == nullptr) {
-        _rg_writer = _file_writer->AppendBufferedRowGroup();
-    }
-}
-
-#define DISPATCH_PARQUET_NUMERIC_WRITER(WRITER, COLUMN_TYPE, NATIVE_TYPE)                                         \
-    ParquetBuilder::_generate_rg_writer();                                                                        \
-    parquet::WRITER* col_writer = static_cast<parquet::WRITER*>(_rg_writer->column(i));                           \
-    col_writer->WriteBatch(                                                                                       \
-            num_rows, nullable ? def_level.data() : nullptr, nullptr,                                             \
-            reinterpret_cast<const NATIVE_TYPE*>(down_cast<const COLUMN_TYPE*>(data_column)->get_data().data())); \
-    _buffered_values_estimate[i] = col_writer->EstimatedBufferedValueBytes();
 
 Status ParquetBuilder::add_chunk(Chunk* chunk) {
-    if (!chunk->has_rows()) {
-        return Status::OK();
-    }
-
-    size_t num_rows = chunk->num_rows();
-    for (size_t i = 0; i < chunk->num_columns(); i++) {
-        const auto& col = chunk->get_column_by_index(i);
-        bool nullable = col->is_nullable();
-        auto null_column = nullable && down_cast<NullableColumn*>(col.get())->has_null()
-                                   ? down_cast<NullableColumn*>(col.get())->null_column()
-                                   : nullptr;
-        const auto data_column = ColumnHelper::get_data_column(col.get());
-
-        std::vector<int16_t> def_level(num_rows, 1);
-        if (null_column != nullptr) {
-            auto nulls = null_column->get_data();
-            for (size_t j = 0; j < num_rows; j++) {
-                def_level[j] = nulls[j] == 0;
-            }
-        }
-
-        const auto type = _output_expr_ctxs[i]->root()->type().type;
-        switch (type) {
-        case TYPE_BOOLEAN: {
-            DISPATCH_PARQUET_NUMERIC_WRITER(BoolWriter, BooleanColumn, bool)
-            break;
-        }
-        case TYPE_INT: {
-            DISPATCH_PARQUET_NUMERIC_WRITER(Int32Writer, Int32Column, int32_t)
-            break;
-        }
-        case TYPE_BIGINT: {
-            DISPATCH_PARQUET_NUMERIC_WRITER(Int64Writer, Int64Column, int64_t)
-            break;
-        }
-        case TYPE_FLOAT: {
-            DISPATCH_PARQUET_NUMERIC_WRITER(FloatWriter, FloatColumn, float)
-            break;
-        }
-        case TYPE_DOUBLE: {
-            DISPATCH_PARQUET_NUMERIC_WRITER(DoubleWriter, DoubleColumn, double)
-            break;
-        }
-        default: {
-            return Status::InvalidArgument("Unsupported type");
-        }
-        }
-    }
-
-    _check_size();
-    return Status::OK();
-}
-
-// The current row group written bytes = total_bytes_written + total_compressed_bytes + estimated_bytes.
-// total_bytes_written: total bytes written by the page writer
-// total_compressed_types: total bytes still compressed but not written
-// estimated_bytes: estimated size of all column chunk uncompressed values that are not written to a page yet. it
-// mainly includes value buffer size and repetition buffer size and definition buffer value for each column.
-size_t ParquetBuilder::_get_rg_written_bytes() {
-    if (_rg_writer == nullptr) {
-        return 0;
-    }
-    auto estimated_bytes = std::accumulate(_buffered_values_estimate.begin(), _buffered_values_estimate.end(), 0);
-    return _rg_writer->total_bytes_written() + _rg_writer->total_compressed_bytes() + estimated_bytes;
-}
-
-// TODO(stephen): we should use the average of each row bytes to calculate the remaining writable size.
-void ParquetBuilder::_check_size() {
-    if (ParquetBuilder::_get_rg_written_bytes() > _row_group_max_size) {
-        _flush_row_group();
-    }
-}
-
-void ParquetBuilder::_flush_row_group() {
-    _rg_writer->Close();
-    _total_row_group_writen_bytes = _output_stream->Tell().MoveValueUnsafe();
-    _rg_writer = nullptr;
-    std::fill(_buffered_values_estimate.begin(), _buffered_values_estimate.end(), 0);
-}
-
-std::size_t ParquetBuilder::file_size() {
-    DCHECK(_output_stream != nullptr);
-    if (_rg_writer == nullptr) {
-        return 0;
-    }
-
-    return _total_row_group_writen_bytes + _get_rg_written_bytes();
+    return _writer->write(chunk);
 }
 
 Status ParquetBuilder::finish() {
-    if (_closed) {
-        return Status::OK();
-    }
+    return _writer->close();
+}
 
-    if (_rg_writer != nullptr) {
-        _flush_row_group();
-    }
-
-    _file_writer->Close();
-    auto st = _output_stream->Close();
-    if (st != ::arrow::Status::OK()) {
-        return Status::InternalError("Close file failed!");
-    }
-
-    _closed = true;
-    return Status::OK();
+std::size_t ParquetBuilder::file_size() {
+    return _writer->file_size();
 }
 
 } // namespace starrocks

--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -1,0 +1,197 @@
+
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/parquet_writer.h"
+
+#include <fmt/format.h>
+
+#include "runtime/exec_env.h"
+#include "util/priority_thread_pool.hpp"
+#include "util/uid_util.h"
+
+namespace starrocks {
+
+ParquetWriterWrap::ParquetWriterWrap(const TableInfo& tableInfo, const PartitionInfo& partitionInfo,
+                                     const std::vector<ExprContext*>& output_expr_ctxs, RuntimeProfile* parent_profile)
+        : _output_expr_ctxs(output_expr_ctxs), _parent_profile(parent_profile) {
+    init_parquet_writer(tableInfo, partitionInfo);
+}
+
+Status ParquetWriterWrap::init_parquet_writer(const TableInfo& tableInfo, const PartitionInfo& partitionInfo) {
+    ASSIGN_OR_RETURN(_fs, FileSystem::CreateSharedFromString(tableInfo._table_location));
+    _schema = tableInfo._schema;
+    ::parquet::WriterProperties::Builder builder;
+    if (tableInfo._enable_dictionary) {
+        builder.enable_dictionary();
+    } else {
+        builder.disable_dictionary();
+    }
+    builder.version(::parquet::ParquetVersion::PARQUET_2_0);
+    starrocks::parquet::ParquetBuildHelper::build_compression_type(builder, tableInfo._compress_type);
+    _properties = builder.build();
+    if (partitionInfo._column_names.size() != partitionInfo._column_values.size()) {
+        return Status::InvalidArgument("columns and values are not matched in partitionInfo");
+    }
+    std::stringstream ss;
+    ss << tableInfo._table_location;
+    ss << "/data/";
+    ss << partitionInfo.partition_dir();
+    _partition_dir = ss.str();
+    return Status::OK();
+}
+
+std::string ParquetWriterWrap::get_new_file_name() {
+    _cnt += 1;
+    _location = _partition_dir + fmt::format("{}_{}.parquet", _cnt, generate_uuid_string());
+    return _location;
+}
+
+Status ParquetWriterWrap::new_file_writer() {
+    std::string file_name = get_new_file_name();
+    WritableFileOptions options{.sync_on_close = false, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    ASSIGN_OR_RETURN(auto writable_file, _fs->new_writable_file(options, file_name));
+    _writer = std::make_shared<starrocks::parquet::AsyncFileWriter>(std::move(writable_file), file_name, _partition_dir,
+                                                                    _properties, _schema, _output_expr_ctxs,
+                                                                    _parent_profile);
+    auto st = _writer->init();
+    return st;
+}
+
+Status ParquetWriterWrap::append_chunk(Chunk* chunk, RuntimeState* state) {
+    if (_writer == nullptr) {
+        auto status = new_file_writer();
+        if (!status.ok()) {
+            return status;
+        }
+    }
+    // exceed file size
+    if (_writer->file_size() > _max_file_size) {
+        auto st = close_current_writer(state);
+        if (st.ok()) {
+            new_file_writer();
+        }
+    }
+    auto st = _writer->write(chunk);
+    return st;
+}
+
+Status ParquetWriterWrap::close_current_writer(RuntimeState* state) {
+    Status st = _writer->close(state, ParquetWriterWrap::add_iceberg_commit_info);
+    if (st.ok()) {
+        _pending_commits.emplace_back(_writer);
+        return Status::OK();
+    } else {
+        LOG(WARNING) << "close file error: " << _location;
+        return Status::IOError("close file error!");
+    }
+}
+
+Status ParquetWriterWrap::close(RuntimeState* state) {
+    if (_writer != nullptr) {
+        auto st = close_current_writer(state);
+        if (!st.ok()) {
+            return st;
+        }
+    }
+    return Status::OK();
+}
+
+bool ParquetWriterWrap::closed() {
+    for (auto& writer : _pending_commits) {
+        if (writer != nullptr && writer->closed()) {
+            writer = nullptr;
+        }
+        if (writer != nullptr && (!writer->closed())) {
+            return false;
+        }
+    }
+
+    if (_writer != nullptr) {
+        return _writer->closed();
+    }
+
+    return true;
+}
+
+void ParquetWriterWrap::add_iceberg_commit_info(starrocks::parquet::AsyncFileWriter* writer, RuntimeState* state) {
+    TIcebergDataFile dataFile;
+    dataFile.partition_path = writer->file_dir();
+    dataFile.path = writer->file_name();
+    dataFile.format = "parquet";
+    dataFile.record_count = writer->metadata()->num_rows();
+    dataFile.file_size_in_bytes = writer->file_size();
+    std::vector<int64_t> split_offsets;
+    writer->split_offsets(split_offsets);
+    dataFile.split_offsets = split_offsets;
+
+    std::unordered_map<int32_t, int64_t> column_sizes;
+    std::unordered_map<int32_t, int64_t> value_counts;
+    std::unordered_map<int32_t, int64_t> null_value_counts;
+    std::unordered_map<int32_t, std::string> min_values;
+    std::unordered_map<int32_t, std::string> max_values;
+
+    const auto& metadata = writer->metadata();
+
+    for (int i = 0; i < metadata->num_row_groups(); ++i) {
+        auto block = metadata->RowGroup(i);
+        for (int j = 0; j < block->num_columns(); j++) {
+            auto column_meta = block->ColumnChunk(j);
+            int field_id = j + 1;
+            if (null_value_counts.find(field_id) == null_value_counts.end()) {
+                null_value_counts.insert({field_id, column_meta->statistics()->null_count()});
+            } else {
+                null_value_counts[field_id] += column_meta->statistics()->null_count();
+            }
+
+            if (column_sizes.find(field_id) == column_sizes.end()) {
+                column_sizes.insert({field_id, column_meta->total_compressed_size()});
+            } else {
+                column_sizes[field_id] += column_meta->total_compressed_size();
+            }
+
+            if (value_counts.find(field_id) == value_counts.end()) {
+                value_counts.insert({field_id, column_meta->num_values()});
+            } else {
+                value_counts[field_id] += column_meta->num_values();
+            }
+
+            min_values[field_id] = column_meta->statistics()->EncodeMin();
+            max_values[field_id] = column_meta->statistics()->EncodeMax();
+        }
+    }
+
+    TIcebergColumnStats stats;
+    for (auto& i : column_sizes) {
+        stats.columnSizes.insert({i.first, i.second});
+    }
+    for (auto& i : value_counts) {
+        stats.valueCounts.insert({i.first, i.second});
+    }
+    for (auto& i : null_value_counts) {
+        stats.nullValueCounts.insert({i.first, i.second});
+    }
+    for (auto& i : min_values) {
+        stats.lowerBounds.insert({i.first, i.second});
+    }
+    for (auto& i : max_values) {
+        stats.upperBounds.insert({i.first, i.second});
+    }
+
+    dataFile.column_stats = stats;
+
+    state->add_iceberg_data_file(dataFile);
+}
+
+} // namespace starrocks

--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -1,0 +1,100 @@
+
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/api.h>
+#include <arrow/buffer.h>
+#include <arrow/io/api.h>
+#include <arrow/io/file.h>
+#include <arrow/io/interfaces.h>
+#include <parquet/api/reader.h>
+#include <parquet/api/writer.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/arrow/writer.h>
+#include <parquet/exception.h>
+
+#include "common/logging.h"
+#include "exec/pipeline/fragment_context.h"
+#include "formats/parquet/file_writer.h"
+#include "fs/fs.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+struct TableInfo;
+struct PartitionInfo;
+
+struct TableInfo {
+    std::string _table_location;
+    std::string _file_format;
+    TCompressionType::type _compress_type = TCompressionType::SNAPPY;
+    bool _enable_dictionary = true;
+
+    std::shared_ptr<::parquet::schema::GroupNode> _schema;
+    ;
+};
+
+struct PartitionInfo {
+    std::vector<std::string> _column_names;
+    std::vector<std::string> _column_values;
+
+    std::string partition_dir() const {
+        std::stringstream ss;
+        for (size_t i = 0; i < _column_names.size(); i++) {
+            ss << _column_names[i];
+            ss << "=";
+            ss << _column_values[i];
+            ss << "/";
+        }
+        return ss.str();
+    }
+};
+
+class ParquetWriterWrap {
+public:
+    ParquetWriterWrap(const TableInfo& tableInfo, const PartitionInfo& partitionInfo,
+                      const std::vector<ExprContext*>& output_expr_ctxs, RuntimeProfile* parent_profile);
+    ~ParquetWriterWrap() = default;
+
+    Status append_chunk(Chunk* chunk, RuntimeState* state); //check if we need a new file, file_writer->write
+    // init filesystem, init writeproperties, schema
+    Status init_parquet_writer(const TableInfo& tableInfo, const PartitionInfo& partitionInfo);
+    Status close(RuntimeState* state);
+    bool writable() const { return _writer == nullptr || _writer->writable(); }
+    bool closed();
+
+    static void add_iceberg_commit_info(starrocks::parquet::AsyncFileWriter* writer, RuntimeState* state);
+
+private:
+    std::string get_new_file_name();
+    Status new_file_writer();
+    Status close_current_writer(RuntimeState* state);
+
+    std::shared_ptr<FileSystem> _fs;
+    std::shared_ptr<starrocks::parquet::AsyncFileWriter> _writer = nullptr;
+    std::shared_ptr<::parquet::WriterProperties> _properties;
+    std::shared_ptr<::parquet::schema::GroupNode> _schema;
+    std::string _partition_dir;
+    int32_t _cnt = 0;
+    std::string _location;
+    std::vector<std::shared_ptr<starrocks::parquet::AsyncFileWriter>> _pending_commits;
+    int64_t _max_file_size = 512 * 1024 * 1024;
+    std::vector<ExprContext*> _output_expr_ctxs;
+    RuntimeProfile* _parent_profile;
+};
+
+} // namespace starrocks

--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -64,15 +64,15 @@ struct PartitionInfo {
     }
 };
 
-class ParquetWriterWrap {
+class RollingAsyncParquetWriter {
 public:
-    ParquetWriterWrap(const TableInfo& tableInfo, const PartitionInfo& partitionInfo,
-                      const std::vector<ExprContext*>& output_expr_ctxs, RuntimeProfile* parent_profile);
-    ~ParquetWriterWrap() = default;
+    RollingAsyncParquetWriter(const TableInfo& tableInfo, const PartitionInfo& partitionInfo,
+                              const std::vector<ExprContext*>& output_expr_ctxs, RuntimeProfile* parent_profile);
+    ~RollingAsyncParquetWriter() = default;
 
     Status append_chunk(Chunk* chunk, RuntimeState* state); //check if we need a new file, file_writer->write
     // init filesystem, init writeproperties, schema
-    Status init_parquet_writer(const TableInfo& tableInfo, const PartitionInfo& partitionInfo);
+    Status init_rolling_writer(const TableInfo& tableInfo, const PartitionInfo& partitionInfo);
     Status close(RuntimeState* state);
     bool writable() const { return _writer == nullptr || _writer->writable(); }
     bool closed();
@@ -85,7 +85,7 @@ private:
     Status close_current_writer(RuntimeState* state);
 
     std::shared_ptr<FileSystem> _fs;
-    std::shared_ptr<starrocks::parquet::AsyncFileWriter> _writer = nullptr;
+    std::shared_ptr<starrocks::parquet::AsyncFileWriter> _writer;
     std::shared_ptr<::parquet::WriterProperties> _properties;
     std::shared_ptr<::parquet::schema::GroupNode> _schema;
     std::string _partition_dir;

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(Formats STATIC
         parquet/meta_helper.cpp
         parquet/group_reader.cpp
         parquet/file_reader.cpp
+        parquet/file_writer.cpp
         )
 
 add_subdirectory(orc/apache-orc)

--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -1,0 +1,435 @@
+
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/file_writer.h"
+
+#include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "exprs/expr.h"
+#include "runtime/exec_env.h"
+#include "util/priority_thread_pool.hpp"
+#include "util/runtime_profile.h"
+#include "util/slice.h"
+
+namespace starrocks::parquet {
+
+ParquetOutputStream::ParquetOutputStream(std::unique_ptr<starrocks::WritableFile> wfile) : _wfile(std::move(wfile)) {
+    set_mode(arrow::io::FileMode::WRITE);
+}
+
+ParquetOutputStream::~ParquetOutputStream() {
+    arrow::Status st = ParquetOutputStream::Close();
+    if (!st.ok()) {
+        LOG(WARNING) << "close parquet output stream failed: " << st;
+    }
+}
+
+arrow::Status ParquetOutputStream::Write(const std::shared_ptr<arrow::Buffer>& data) {
+    arrow::Status st = Write(data->data(), data->size());
+    if (!st.ok()) {
+        LOG(WARNING) << "Failed to write data to output stream, err msg: " << st.message();
+    }
+    return st;
+}
+
+arrow::Status ParquetOutputStream::Write(const void* data, int64_t nbytes) {
+    if (_is_closed) {
+        return arrow::Status::IOError("The output stream is closed but there are still inputs");
+    }
+
+    const char* ch = reinterpret_cast<const char*>(data);
+
+    if (_header_state == INITED) {
+        _header_state = CACHED;
+    } else {
+        if (_header_state == CACHED) {
+            _header_state = WRITEN;
+            Status st = _wfile->append(Slice("PAR1"));
+            if (!st.ok()) {
+                return arrow::Status::IOError(st.to_string());
+            }
+        }
+        Status st = _wfile->append(Slice(ch, nbytes));
+        if (!st.ok()) {
+            return arrow::Status::IOError(st.to_string());
+        }
+    }
+
+    return arrow::Status::OK();
+}
+
+arrow::Result<int64_t> ParquetOutputStream::Tell() const {
+    if (_header_state == CACHED) {
+        return 4;
+    } else {
+        return _wfile->size();
+    }
+}
+
+arrow::Status ParquetOutputStream::Close() {
+    if (_is_closed) {
+        return arrow::Status::OK();
+    }
+    Status st = _wfile->close();
+    if (!st.ok()) {
+        LOG(WARNING) << "close parquet output stream failed: " << st;
+        return arrow::Status::IOError(st.to_string());
+    }
+    _is_closed = true;
+    return arrow::Status::OK();
+}
+
+void ParquetBuildHelper::build_file_data_type(::parquet::Type::type& parquet_data_type,
+                                              const LogicalType& column_data_type) {
+    switch (column_data_type) {
+    case TYPE_BOOLEAN: {
+        parquet_data_type = ::parquet::Type::BOOLEAN;
+        break;
+    }
+    case TYPE_TINYINT:
+    case TYPE_SMALLINT:
+    case TYPE_INT: {
+        parquet_data_type = ::parquet::Type::INT32;
+        break;
+    }
+    case TYPE_BIGINT:
+    case TYPE_DATE:
+    case TYPE_DATETIME: {
+        parquet_data_type = ::parquet::Type::INT64;
+        break;
+    }
+    case TYPE_LARGEINT: {
+        parquet_data_type = ::parquet::Type::INT96;
+        break;
+    }
+    case TYPE_FLOAT: {
+        parquet_data_type = ::parquet::Type::FLOAT;
+        break;
+    }
+    case TYPE_DOUBLE: {
+        parquet_data_type = ::parquet::Type::DOUBLE;
+        break;
+    }
+    case TYPE_CHAR:
+    case TYPE_VARCHAR:
+    case TYPE_DECIMAL:
+    case TYPE_DECIMAL32:
+    case TYPE_DECIMAL64:
+    case TYPE_DECIMALV2: {
+        parquet_data_type = ::parquet::Type::BYTE_ARRAY;
+        break;
+    }
+    default:
+        parquet_data_type = ::parquet::Type::UNDEFINED;
+    }
+}
+
+void ParquetBuildHelper::build_parquet_repetition_type(::parquet::Repetition::type& parquet_repetition_type,
+                                                       const bool is_nullable) {
+    parquet_repetition_type = is_nullable ? ::parquet::Repetition::OPTIONAL : ::parquet::Repetition::REQUIRED;
+}
+
+void ParquetBuildHelper::build_compression_type(::parquet::WriterProperties::Builder& builder,
+                                                const TCompressionType::type& compression_type) {
+    switch (compression_type) {
+    case TCompressionType::SNAPPY: {
+        builder.compression(::parquet::Compression::SNAPPY);
+        break;
+    }
+    case TCompressionType::GZIP: {
+        builder.compression(::parquet::Compression::GZIP);
+        break;
+    }
+    case TCompressionType::BROTLI: {
+        builder.compression(::parquet::Compression::BROTLI);
+        break;
+    }
+    case TCompressionType::ZSTD: {
+        builder.compression(::parquet::Compression::ZSTD);
+        break;
+    }
+    case TCompressionType::LZ4: {
+        builder.compression(::parquet::Compression::LZ4);
+        break;
+    }
+    case TCompressionType::LZO: {
+        builder.compression(::parquet::Compression::LZO);
+        break;
+    }
+    case TCompressionType::BZIP2: {
+        builder.compression(::parquet::Compression::BZ2);
+        break;
+    }
+    default:
+        builder.compression(::parquet::Compression::UNCOMPRESSED);
+    }
+}
+
+FileWriterBase::FileWriterBase(std::unique_ptr<WritableFile> writable_file,
+                               std::shared_ptr<::parquet::WriterProperties> properties,
+                               std::shared_ptr<::parquet::schema::GroupNode> schema,
+                               const std::vector<ExprContext*>& output_expr_ctxs)
+        : _properties(std::move(properties)), _schema(std::move(schema)), _output_expr_ctxs(output_expr_ctxs) {
+    _outstream = std::make_shared<ParquetOutputStream>(std::move(writable_file));
+    _buffered_values_estimate.reserve(_schema->field_count());
+}
+
+Status FileWriterBase::init() {
+    _writer = ::parquet::ParquetFileWriter::Open(_outstream, _schema, _properties);
+    if (_writer == nullptr) {
+        return Status::InternalError("Failed to create file writer");
+    }
+    return Status::OK();
+}
+
+::parquet::RowGroupWriter* FileWriterBase::_get_rg_writer() {
+    if (_rg_writer == nullptr) {
+        _rg_writer = _writer->AppendBufferedRowGroup();
+    }
+    return _rg_writer;
+}
+
+#define DISPATCH_PARQUET_NUMERIC_WRITER(WRITER, COLUMN_TYPE, NATIVE_TYPE)                                         \
+    ::parquet::RowGroupWriter* rg_writer = _get_rg_writer();                                                      \
+    ::parquet::WRITER* col_writer = static_cast<::parquet::WRITER*>(rg_writer->column(i));                        \
+    col_writer->WriteBatch(                                                                                       \
+            num_rows, nullable ? def_level.data() : nullptr, nullptr,                                             \
+            reinterpret_cast<const NATIVE_TYPE*>(down_cast<const COLUMN_TYPE*>(data_column)->get_data().data())); \
+    _buffered_values_estimate[i] = col_writer->EstimatedBufferedValueBytes();
+
+#define DISPATCH_PARQUET_STRING_WRITER()                                                                     \
+    ::parquet::RowGroupWriter* rg_writer = _get_rg_writer();                                                 \
+    ::parquet::ByteArrayWriter* col_writer = static_cast<::parquet::ByteArrayWriter*>(rg_writer->column(i)); \
+    if (nullable) {                                                                                          \
+        LOG(WARNING) << "nullable string writer";                                                            \
+        ::parquet::ByteArray value;                                                                          \
+        const BinaryColumn* binary_col = down_cast<const BinaryColumn*>(data_column);                        \
+        for (size_t i = 0; i < num_rows; i++) {                                                              \
+            value.ptr = reinterpret_cast<const uint8_t*>(binary_col->get_slice(i).get_data());               \
+            value.len = binary_col->get_slice(i).get_size();                                                 \
+            col_writer->WriteBatch(1, &def_level[i], nullptr, &value);                                       \
+        }                                                                                                    \
+    } else {                                                                                                 \
+        ::parquet::ByteArray value;                                                                          \
+        const BinaryColumn* binary_col = down_cast<const BinaryColumn*>(data_column);                        \
+        for (size_t i = 0; i < num_rows; i++) {                                                              \
+            value.ptr = reinterpret_cast<const uint8_t*>(binary_col->get_slice(i).get_data());               \
+            value.len = binary_col->get_slice(i).get_size();                                                 \
+            col_writer->WriteBatch(1, nullptr, nullptr, &value);                                             \
+        }                                                                                                    \
+    }                                                                                                        \
+    _buffered_values_estimate[i] = col_writer->EstimatedBufferedValueBytes();
+
+Status FileWriterBase::write(Chunk* chunk) {
+    if (!chunk->has_rows()) {
+        return Status::OK();
+    }
+
+    Columns result_columns;
+    // Step 1: compute expr
+    int num_columns = _output_expr_ctxs.size();
+    result_columns.reserve(num_columns);
+
+    for (int i = 0; i < num_columns; ++i) {
+        ASSIGN_OR_RETURN(ColumnPtr column, _output_expr_ctxs[i]->evaluate(chunk));
+        //column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
+        //         ? vectorized::ColumnHelper::convert_time_column_from_double_to_str(column)
+        //         : column;
+        result_columns.emplace_back(std::move(column));
+    }
+
+    size_t num_rows = chunk->num_rows();
+    for (size_t i = 0; i < result_columns.size(); i++) {
+        // auto &col = chunk->get_column_by_index(i);
+        auto& col = result_columns[i];
+        bool nullable = col->is_nullable();
+        auto null_column = nullable && down_cast<starrocks::NullableColumn*>(col.get())->has_null()
+                                   ? down_cast<starrocks::NullableColumn*>(col.get())->null_column()
+                                   : nullptr;
+        const auto data_column = ColumnHelper::get_data_column(col.get());
+
+        std::vector<int16_t> def_level(num_rows);
+        std::fill(def_level.begin(), def_level.end(), 1);
+        if (null_column != nullptr) {
+            auto nulls = null_column->get_data();
+            for (size_t j = 0; j < num_rows; j++) {
+                def_level[j] = nulls[j] == 0;
+            }
+        }
+
+        const auto type = _output_expr_ctxs[i]->root()->type().type;
+        switch (type) {
+        case TYPE_BOOLEAN: {
+            DISPATCH_PARQUET_NUMERIC_WRITER(BoolWriter, starrocks::BooleanColumn, bool)
+            break;
+        }
+        case TYPE_INT: {
+            DISPATCH_PARQUET_NUMERIC_WRITER(Int32Writer, starrocks::Int32Column, int32_t)
+            break;
+        }
+        case TYPE_BIGINT: {
+            DISPATCH_PARQUET_NUMERIC_WRITER(Int64Writer, starrocks::Int64Column, int64_t)
+            break;
+        }
+        case TYPE_FLOAT: {
+            DISPATCH_PARQUET_NUMERIC_WRITER(FloatWriter, starrocks::FloatColumn, float)
+            break;
+        }
+        case TYPE_DOUBLE: {
+            DISPATCH_PARQUET_NUMERIC_WRITER(DoubleWriter, starrocks::DoubleColumn, double)
+            break;
+        }
+        case TYPE_CHAR:
+        case TYPE_VARCHAR: {
+            DISPATCH_PARQUET_STRING_WRITER()
+            break;
+        }
+        default: {
+            //TODO: support other types
+            return Status::InvalidArgument("Unsupported type");
+        }
+        }
+    }
+
+    if (_get_current_rg_written_bytes() > _max_row_group_size) {
+        _flush_row_group();
+    }
+
+    return Status::OK();
+}
+
+// The current row group written bytes = total_bytes_written + total_compressed_bytes + estimated_bytes.
+// total_bytes_written: total bytes written by the page writer
+// total_compressed_types: total bytes still compressed but not written
+// estimated_bytes: estimated size of all column chunk uncompressed values that are not written to a page yet. it
+// mainly includes value buffer size and repetition buffer size and definition buffer value for each column.
+std::size_t FileWriterBase::_get_current_rg_written_bytes() const {
+    if (_rg_writer == nullptr) {
+        return 0;
+    }
+
+    auto estimated_bytes = std::accumulate(_buffered_values_estimate.begin(), _buffered_values_estimate.end(), 0);
+
+    return _rg_writer->total_bytes_written() + _rg_writer->total_compressed_bytes() + estimated_bytes;
+}
+
+std::size_t FileWriterBase::file_size() const {
+    DCHECK(_outstream != nullptr);
+    return _outstream->Tell().MoveValueUnsafe() + _get_current_rg_written_bytes();
+}
+
+Status FileWriterBase::split_offsets(std::vector<int64_t>& splitOffsets) const {
+    if (_file_metadata == nullptr) {
+        LOG(WARNING) << "file metadata null";
+        return Status::InternalError("Get split offsets while the file metadata is null");
+    }
+    for (int i = 0; i < _file_metadata->num_row_groups(); i++) {
+        auto first_column_meta = _file_metadata->RowGroup(i)->ColumnChunk(0);
+        int64_t dict_page_offset = first_column_meta->dictionary_page_offset();
+        int64_t first_data_page_offset = first_column_meta->data_page_offset();
+        int64_t split_offset = dict_page_offset > 0 && dict_page_offset < first_data_page_offset
+                                       ? dict_page_offset
+                                       : first_data_page_offset;
+        splitOffsets.emplace_back(split_offset);
+    }
+    return Status::OK();
+}
+
+void SyncFileWriter::_flush_row_group() {
+    _rg_writer->Close();
+    _rg_writer = nullptr;
+    std::fill(_buffered_values_estimate.begin(), _buffered_values_estimate.end(), 0);
+}
+
+Status SyncFileWriter::close() {
+    if (_closed) {
+        return Status::OK();
+    }
+
+    _writer->Close();
+    _rg_writer = nullptr;
+    auto st = _outstream->Close();
+    if (st != ::arrow::Status::OK()) {
+        return Status::InternalError("Close file failed!");
+    }
+
+    _closed = true;
+    return Status::OK();
+}
+
+AsyncFileWriter::AsyncFileWriter(std::unique_ptr<WritableFile> writable_file, std::string file_name,
+                                 std::string& file_dir, std::shared_ptr<::parquet::WriterProperties> properties,
+                                 std::shared_ptr<::parquet::schema::GroupNode> schema,
+                                 const std::vector<ExprContext*>& output_expr_ctxs, RuntimeProfile* parent_profile)
+        : FileWriterBase(std::move(writable_file), std::move(properties), std::move(schema), output_expr_ctxs),
+          _file_name(file_name),
+          _file_dir(file_dir),
+          _parent_profile(parent_profile) {
+    _io_timer = ADD_TIMER(_parent_profile, "FileWriterIoTimer");
+}
+
+void AsyncFileWriter::_flush_row_group() {
+    {
+        auto lock = std::unique_lock(_m);
+        _rg_writer_closing = true;
+    }
+    bool ret = ExecEnv::GetInstance()->pipeline_sink_io_pool()->try_offer([&]() {
+        SCOPED_TIMER(_io_timer);
+        _rg_writer->Close();
+        _rg_writer = nullptr;
+        std::fill(_buffered_values_estimate.begin(), _buffered_values_estimate.end(), 0);
+        {
+            auto lock = std::unique_lock(_m);
+            _rg_writer_closing = false;
+            lock.unlock();
+            _cv.notify_one();
+        }
+    });
+    if (!ret) {
+        {
+            auto lock = std::unique_lock(_m);
+            _rg_writer_closing = false;
+            lock.unlock();
+            _cv.notify_one();
+        }
+    }
+}
+
+Status AsyncFileWriter::close(RuntimeState* state,
+                              std::function<void(starrocks::parquet::AsyncFileWriter*, RuntimeState*)> cb) {
+    bool ret = ExecEnv::GetInstance()->pipeline_sink_io_pool()->try_offer([&, state, cb]() {
+        SCOPED_TIMER(_io_timer);
+        {
+            auto lock = std::unique_lock(_m);
+            _cv.wait(lock, [&] { return !_rg_writer_closing; });
+        }
+        _writer->Close();
+        _rg_writer = nullptr;
+        _file_metadata = _writer->metadata();
+        auto st = _outstream->Close();
+        if (cb != nullptr) {
+            cb(this, state);
+        }
+        _closed.store(true);
+    });
+    if (ret) {
+        return Status::OK();
+    } else {
+        return Status::InternalError("Submit close file error");
+    }
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/file_writer.h
+++ b/be/src/formats/parquet/file_writer.h
@@ -1,0 +1,159 @@
+
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/api.h>
+#include <arrow/buffer.h>
+#include <arrow/io/api.h>
+#include <arrow/io/file.h>
+#include <arrow/io/interfaces.h>
+#include <gen_cpp/DataSinks_types.h>
+#include <parquet/api/reader.h>
+#include <parquet/api/writer.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/arrow/writer.h>
+#include <parquet/exception.h>
+
+#include "column/chunk.h"
+#include "fs/fs.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::parquet {
+
+class ParquetOutputStream : public arrow::io::OutputStream {
+public:
+    ParquetOutputStream(std::unique_ptr<starrocks::WritableFile> wfile);
+    ~ParquetOutputStream() override;
+
+    arrow::Status Write(const void* data, int64_t nbytes) override;
+    arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override;
+    arrow::Status Close() override;
+    arrow::Result<int64_t> Tell() const override;
+
+    bool closed() const override { return _is_closed; };
+
+private:
+    std::unique_ptr<starrocks::WritableFile> _wfile;
+    bool _is_closed = false;
+
+    enum HEADER_STATE {
+        INITED = 1,
+        CACHED = 2,
+        WRITEN = 3,
+    };
+    HEADER_STATE _header_state = INITED;
+};
+
+class ParquetBuildHelper {
+public:
+    static void build_file_data_type(::parquet::Type::type& parquet_data_type, const LogicalType& column_data_type);
+
+    static void build_parquet_repetition_type(::parquet::Repetition::type& parquet_repetition_type,
+                                              const bool is_nullable);
+
+    static void build_compression_type(::parquet::WriterProperties::Builder& builder,
+                                       const TCompressionType::type& compression_type);
+};
+
+class FileWriterBase {
+public:
+    FileWriterBase(std::unique_ptr<WritableFile> writable_file, std::shared_ptr<::parquet::WriterProperties> properties,
+                   std::shared_ptr<::parquet::schema::GroupNode> schema,
+                   const std::vector<ExprContext*>& output_expr_ctxs);
+    virtual ~FileWriterBase() = default;
+
+    Status init();
+    Status write(Chunk* chunk);
+    std::size_t file_size() const;
+    void set_max_row_group_size(int64_t rg_size) { _max_row_group_size = rg_size; }
+    std::shared_ptr<::parquet::FileMetaData> metadata() const { return _file_metadata; }
+    Status split_offsets(std::vector<int64_t>& splitOffsets) const;
+    virtual bool closed() const = 0;
+
+protected:
+    virtual void _flush_row_group() = 0;
+
+private:
+    ::parquet::RowGroupWriter* _get_rg_writer();
+    std::size_t _get_current_rg_written_bytes() const;
+
+protected:
+    std::shared_ptr<ParquetOutputStream> _outstream;
+    std::shared_ptr<::parquet::WriterProperties> _properties;
+    std::shared_ptr<::parquet::schema::GroupNode> _schema;
+    std::unique_ptr<::parquet::ParquetFileWriter> _writer;
+    ::parquet::RowGroupWriter* _rg_writer = nullptr;
+    std::vector<ExprContext*> _output_expr_ctxs;
+    std::shared_ptr<::parquet::FileMetaData> _file_metadata;
+
+    int64_t _max_row_group_size = 128 * 1024 * 1024; // 128 * 1024 * 1024;
+    std::vector<int64_t> _buffered_values_estimate;
+};
+
+class SyncFileWriter : public FileWriterBase {
+public:
+    SyncFileWriter(std::unique_ptr<WritableFile> writable_file, std::shared_ptr<::parquet::WriterProperties> properties,
+                   std::shared_ptr<::parquet::schema::GroupNode> schema,
+                   const std::vector<ExprContext*>& output_expr_ctxs)
+            : FileWriterBase(std::move(writable_file), std::move(properties), std::move(schema), output_expr_ctxs) {}
+    ~SyncFileWriter() override = default;
+
+    Status close();
+    bool closed() const override { return _closed; }
+
+private:
+    void _flush_row_group() override;
+    bool _closed = false;
+};
+
+class AsyncFileWriter : public FileWriterBase {
+public:
+    AsyncFileWriter(std::unique_ptr<WritableFile> writable_file, std::string file_name, std::string& file_dir,
+                    std::shared_ptr<::parquet::WriterProperties> properties,
+                    std::shared_ptr<::parquet::schema::GroupNode> schema,
+                    const std::vector<ExprContext*>& output_expr_ctxs, RuntimeProfile* parent_profile);
+
+    ~AsyncFileWriter() override = default;
+
+    Status close(RuntimeState* state,
+                 std::function<void(starrocks::parquet::AsyncFileWriter*, RuntimeState*)> cb = nullptr);
+
+    bool writable() {
+        auto lock = std::unique_lock(_m);
+        return !_rg_writer_closing;
+    }
+    bool closed() const override { return _closed.load(); }
+
+    std::string file_name() const { return _file_name; }
+
+    std::string file_dir() const { return _file_dir; }
+
+private:
+    void _flush_row_group() override;
+
+    std::string _file_name;
+    std::string _file_dir;
+
+    std::atomic<bool> _closed = false;
+    RuntimeProfile* _parent_profile;
+    RuntimeProfile::Counter* _io_timer = nullptr;
+
+    std::condition_variable _cv;
+    bool _rg_writer_closing = false;
+    std::mutex _m;
+};
+
+} // namespace starrocks::parquet

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -317,6 +317,16 @@ public:
         _tablet_fail_infos.emplace_back(std::move(fail_info));
     }
 
+    std::vector<TIcebergDataFile>& iceberg_commit_infos() {
+        std::lock_guard<std::mutex> l(_iceberg_info_lock);
+        return _iceberg_sink_commit_infos;
+    }
+
+    void add_iceberg_data_file(const TIcebergDataFile& file) {
+        std::lock_guard<std::mutex> l(_iceberg_info_lock);
+        _iceberg_sink_commit_infos.emplace_back(std::move(file));
+    }
+
     // get mem limit for load channel
     // if load mem limit is not set, or is zero, using query mem limit instead.
     int64_t get_load_mem_limit() const;
@@ -447,6 +457,9 @@ private:
     std::mutex _tablet_infos_lock;
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
     std::vector<TTabletFailInfo> _tablet_fail_infos;
+
+    std::mutex _iceberg_info_lock;
+    std::vector<TIcebergDataFile> _iceberg_sink_commit_infos;
 
     // prohibit copies
     RuntimeState(const RuntimeState&) = delete;

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -214,3 +214,22 @@ struct TDataSink {
   9: optional TMultiCastDataStreamSink multi_cast_stream_sink
   10: optional TSchemaTableSink schema_table_sink
 }
+
+struct TIcebergColumnStats {
+    1: optional map<i32, i64> columnSizes
+    2: optional map<i32, i64> valueCounts
+    3: optional map<i32, i64> nullValueCounts
+    4: optional map<i32, i64> nanValueCounts
+    5: optional map<i32, binary> lowerBounds;
+    6: optional map<i32, binary> upperBounds;
+}
+
+struct TIcebergDataFile {
+    1: optional string path
+    2: optional string format
+    3: optional i64 record_count
+    4: optional i64 file_size_in_bytes
+    5: optional string partition_path;
+    6: optional list<i64> split_offsets;
+    7: optional TIcebergColumnStats column_stats;
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

parquet_builder wrapped Parquet::SyncFileWriter used for select * outfiles
parquet_writer wrapped Parquet::AsyncFileWriter used for table sink operator.
In TableSinkOperator one parquet_writer work on one partition, so it need to 
deal with rolling files.
The different between SyncFileWriter and AsyncFileWriter is that 
weather io is sync or async.
Up to now, our writer if based on arrow, For parquet file writer, RowGroup is 
the unit that flush to persistent storage, so we cached rowgroup in memory.
and when the rowgroup size is suitable, we need an io thread to flush, 
so that the operator thread (pipeline) can go on other work. 
And during rowgroup flushing, the file is not writable and the operator don't 
need input.
we also need io thread to deal with file closing, we need file metadata for table
sink, so there need a cb function to commit metadata to RuntimeState.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
