### PR TITLE
[Enhancement] Support hash-based analytic

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -212,6 +212,9 @@ set(EXEC_FILES
     pipeline/set/intersect_build_sink_operator.cpp
     pipeline/set/intersect_probe_sink_operator.cpp
     pipeline/set/intersect_output_source_operator.cpp
+    pipeline/hash_partition_context.cpp
+    pipeline/hash_partition_sink_operator.cpp
+    pipeline/hash_partition_source_operator.cpp
     pipeline/adaptive/collect_stats_sink_operator.cpp
     pipeline/adaptive/collect_stats_source_operator.cpp
     pipeline/adaptive/collect_stats_context.cpp

--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -326,7 +326,7 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
         ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink);
     } else if (_tnode.analytic_node.order_by_exprs.empty() && _tnode.analytic_node.__isset.use_hash_based_partition &&
                _tnode.analytic_node.use_hash_based_partition) {
-        // analytic has only partition by but withouth order by
+        // analytic has only partition by columns but no order by columns
         auto pseudo_plan_node_id = context->next_pseudo_plan_node_id();
         HashPartitionContextFactoryPtr hash_partition_ctx_factory =
                 std::make_shared<HashPartitionContextFactory>(_tnode.analytic_node.partition_exprs);

--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -324,17 +324,19 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
     if (_tnode.analytic_node.partition_exprs.empty()) {
         // analytic's dop must be 1 if with no partition clause
         ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink);
-    } else if (_tnode.analytic_node.order_by_exprs.empty()) {
+    } else if (_tnode.analytic_node.order_by_exprs.empty() && _tnode.analytic_node.__isset.use_hash_based_partition &&
+               _tnode.analytic_node.use_hash_based_partition) {
         // analytic has only partition by but withouth order by
+        auto pseudo_plan_node_id = context->next_pseudo_plan_node_id();
         HashPartitionContextFactoryPtr hash_partition_ctx_factory =
                 std::make_shared<HashPartitionContextFactory>(_tnode.analytic_node.partition_exprs);
-        ops_with_sink.emplace_back(std::make_shared<HashPartitionSinkOperatorFactory>(context->next_operator_id(), id(),
-                                                                                      hash_partition_ctx_factory));
+        ops_with_sink.emplace_back(std::make_shared<HashPartitionSinkOperatorFactory>(
+                context->next_operator_id(), pseudo_plan_node_id, hash_partition_ctx_factory));
         context->add_pipeline(ops_with_sink);
 
         ops_with_sink.clear();
         auto hash_partition_source_op = std::make_shared<HashPartitionSourceOperatorFactory>(
-                context->next_operator_id(), id(), hash_partition_ctx_factory);
+                context->next_operator_id(), pseudo_plan_node_id, hash_partition_ctx_factory);
         context->inherit_upstream_source_properties(hash_partition_source_op.get(), upstream_source_op);
         ops_with_sink.push_back(std::move(hash_partition_source_op));
     }

--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -21,6 +21,9 @@
 #include "column/chunk.h"
 #include "exec/pipeline/analysis/analytic_sink_operator.h"
 #include "exec/pipeline/analysis/analytic_source_operator.h"
+#include "exec/pipeline/hash_partition_context.h"
+#include "exec/pipeline/hash_partition_sink_operator.h"
+#include "exec/pipeline/hash_partition_source_operator.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_builder.h"
@@ -316,12 +319,27 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
     using namespace pipeline;
 
     OpFactories ops_with_sink = _children[0]->decompose_to_pipeline(context);
-
-    // analytic's dop must be 1 if with no partition clause
-    if (_tnode.analytic_node.partition_exprs.empty()) {
-        ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink);
-    }
     auto* upstream_source_op = context->source_operator(ops_with_sink);
+
+    if (_tnode.analytic_node.partition_exprs.empty()) {
+        // analytic's dop must be 1 if with no partition clause
+        ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink);
+    } else if (_tnode.analytic_node.order_by_exprs.empty()) {
+        // analytic has only partition by but withouth order by
+        HashPartitionContextFactoryPtr hash_partition_ctx_factory =
+                std::make_shared<HashPartitionContextFactory>(_tnode.analytic_node.partition_exprs);
+        ops_with_sink.emplace_back(std::make_shared<HashPartitionSinkOperatorFactory>(context->next_operator_id(), id(),
+                                                                                      hash_partition_ctx_factory));
+        context->add_pipeline(ops_with_sink);
+
+        ops_with_sink.clear();
+        auto hash_partition_source_op = std::make_shared<HashPartitionSourceOperatorFactory>(
+                context->next_operator_id(), id(), hash_partition_ctx_factory);
+        context->inherit_upstream_source_properties(hash_partition_source_op.get(), upstream_source_op);
+        ops_with_sink.push_back(std::move(hash_partition_source_op));
+    }
+
+    upstream_source_op = context->source_operator(ops_with_sink);
     auto degree_of_parallelism = upstream_source_op->degree_of_parallelism();
 
     AnalytorFactoryPtr analytor_factory =

--- a/be/src/exec/partition/chunks_partitioner.cpp
+++ b/be/src/exec/partition/chunks_partitioner.cpp
@@ -39,15 +39,15 @@ Status ChunksPartitioner::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-ChunkPtr ChunksPartitioner::consume_from_downgrade_buffer() {
+ChunkPtr ChunksPartitioner::consume_from_passthrough_buffer() {
     ChunkPtr chunk = nullptr;
-    if (_downgrade_buffer.empty()) {
+    if (_passthrough_buffer.empty()) {
         return chunk;
     }
     {
         std::lock_guard<std::mutex> l(_buffer_lock);
-        chunk = _downgrade_buffer.front();
-        _downgrade_buffer.pop();
+        chunk = _passthrough_buffer.front();
+        _passthrough_buffer.pop();
     }
     return chunk;
 }

--- a/be/src/exec/partition/chunks_partitioner.cpp
+++ b/be/src/exec/partition/chunks_partitioner.cpp
@@ -34,7 +34,7 @@ ChunksPartitioner::ChunksPartitioner(const bool has_nullable_partition_column,
 Status ChunksPartitioner::prepare(RuntimeState* state) {
     _state = state;
     _mem_pool = std::make_unique<MemPool>();
-    _obj_pool = state->obj_pool();
+    _obj_pool = std::make_unique<ObjectPool>();
     _init_hash_map_variant();
     return Status::OK();
 }
@@ -50,10 +50,6 @@ ChunkPtr ChunksPartitioner::consume_from_downgrade_buffer() {
         _downgrade_buffer.pop();
     }
     return chunk;
-}
-
-int32_t ChunksPartitioner::num_partitions() {
-    return _hash_map_variant.size();
 }
 
 bool ChunksPartitioner::_is_partition_columns_fixed_size(const std::vector<ExprContext*>& partition_expr_ctxs,

--- a/be/src/exec/partition/chunks_partitioner.h
+++ b/be/src/exec/partition/chunks_partitioner.h
@@ -72,7 +72,7 @@ public:
     }
 
     // Number of partitions
-    int32_t num_partitions() { return _hash_map_variant.size(); }
+    int32_t num_partitions() const { return _hash_map_variant.size(); }
 
     bool is_passthrough() const { return _is_passthrough; }
 

--- a/be/src/exec/partition/chunks_partitioner.h
+++ b/be/src/exec/partition/chunks_partitioner.h
@@ -125,10 +125,12 @@ private:
     void _split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk,
                                    NewPartitionCallback&& new_partition_cb,
                                    PartitionChunkConsumer&& partition_chunk_consumer) {
-        _is_downgrade = hash_map_with_key.template append_chunk<EnableDowngrade>(
-                chunk, _partition_columns, _mem_pool.get(), _obj_pool.get(),
-                std::forward<NewPartitionCallback>(new_partition_cb),
-                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+        if (!_is_downgrade) {
+            _is_downgrade = hash_map_with_key.template append_chunk<EnableDowngrade>(
+                    chunk, _partition_columns, _mem_pool.get(), _obj_pool.get(),
+                    std::forward<NewPartitionCallback>(new_partition_cb),
+                    std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+        }
         if (_is_downgrade) {
             std::lock_guard<std::mutex> l(_buffer_lock);
             _downgrade_buffer.push(chunk);

--- a/be/src/exec/partition/chunks_partitioner.h
+++ b/be/src/exec/partition/chunks_partitioner.h
@@ -51,7 +51,7 @@ public:
     //      called when coming a new key not in the hash map.
     // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
     //      called for each partition with enough num rows after adding chunk to the hash map.
-    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
     Status offer(const ChunkPtr& chunk, NewPartitionCallback&& new_partition_cb,
                  PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!_partition_it.has_value());
@@ -63,35 +63,50 @@ public:
         }
 
         TRY_CATCH_BAD_ALLOC(_hash_map_variant.visit([&](auto& hash_map_with_key) {
-            _split_chunk_by_partition(*hash_map_with_key, chunk, std::forward<NewPartitionCallback>(new_partition_cb),
-                                      std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+            _split_chunk_by_partition<EnableDowngrade>(*hash_map_with_key, chunk,
+                                                       std::forward<NewPartitionCallback>(new_partition_cb),
+                                                       std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         }));
 
         return Status::OK();
     }
 
     // Number of partitions
-    int32_t num_partitions();
+    int32_t num_partitions() { return _hash_map_variant.size(); }
 
     bool is_downgrade() const { return _is_downgrade; }
 
     bool is_downgrade_buffer_empty() const { return _downgrade_buffer.empty(); }
 
+    bool is_hash_map_eos() const { return _hash_map_eos && (!_hash_map_variant.is_nullable() || _null_key_eos); }
+
     // Consumers consume from the hash map
-    // method signature is: bool consumer(int32_t partition_idx, const ChunkPtr& chunk)
-    // The return value of the consumer denote whether to continue or not
+    // @Params:
+    // @consumer: bool consumer(int32_t partition_idx, const ChunkPtr& chunk)
+    //      The return value of the consumer denote whether to continue or not
     template <typename Consumer>
     Status consume_from_hash_map(Consumer&& consumer) {
-        // First, fetch chunks from hash map
-        TRY_CATCH_BAD_ALLOC(_hash_map_variant.visit(
-                [&](auto& hash_map_with_key) { _fetch_chunks_from_hash_map(*hash_map_with_key, consumer); }));
+        if (is_hash_map_eos()) {
+            return Status::OK();
+        }
 
-        // Second, fetch chunks from null_key_value if any
         TRY_CATCH_BAD_ALLOC(_hash_map_variant.visit([&](auto& hash_map_with_key) {
-            if constexpr (std::decay_t<decltype(*hash_map_with_key)>::is_nullable) {
-                fetch_chunks_from_null_key_value(*hash_map_with_key, consumer);
+            // First, fetch chunks from hash map
+            bool continue_consume;
+            _fetch_chunks_from_hash_map(*hash_map_with_key, consumer, continue_consume);
+            if (continue_consume && _hash_map_eos) {
+                // Second, fetch chunks from null_key_value if any
+                if constexpr (std::decay_t<decltype(*hash_map_with_key)>::is_nullable) {
+                    _fetch_chunks_from_null_key_value(*hash_map_with_key, consumer);
+                }
             }
         }));
+
+        if (is_hash_map_eos()) {
+            _hash_map_variant.reset();
+            _mem_pool.reset();
+            _obj_pool.reset();
+        }
 
         return Status::OK();
     }
@@ -105,13 +120,15 @@ private:
                                           bool* has_null);
     void _init_hash_map_variant();
 
-    template <typename HashMapWithKey, typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename HashMapWithKey, typename NewPartitionCallback,
+              typename PartitionChunkConsumer>
     void _split_chunk_by_partition(HashMapWithKey& hash_map_with_key, const ChunkPtr& chunk,
                                    NewPartitionCallback&& new_partition_cb,
                                    PartitionChunkConsumer&& partition_chunk_consumer) {
-        _is_downgrade = hash_map_with_key.append_chunk(chunk, _partition_columns, _mem_pool.get(), _obj_pool,
-                                                       std::forward<NewPartitionCallback>(new_partition_cb),
-                                                       std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+        _is_downgrade = hash_map_with_key.template append_chunk<EnableDowngrade>(
+                chunk, _partition_columns, _mem_pool.get(), _obj_pool.get(),
+                std::forward<NewPartitionCallback>(new_partition_cb),
+                std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
         if (_is_downgrade) {
             std::lock_guard<std::mutex> l(_buffer_lock);
             _downgrade_buffer.push(chunk);
@@ -120,9 +137,10 @@ private:
 
     // Fetch chunks from hash map, return true if reaches eos
     template <typename HashMapWithKey, typename Consumer>
-    bool _fetch_chunks_from_hash_map(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
+    void _fetch_chunks_from_hash_map(HashMapWithKey& hash_map_with_key, Consumer&& consumer, bool& continue_consume) {
+        continue_consume = true;
         if (_hash_map_eos) {
-            return true;
+            return;
         }
         if (!_partition_it.has_value()) {
             _partition_it = hash_map_with_key.hash_map.begin();
@@ -157,23 +175,24 @@ private:
 
             while (chunk_it != chunk_end) {
                 if (!consumer(partition_idx, *chunk_it++)) {
-                    return false;
+                    // Fetch suspend, and it may proceed the next call.
+                    continue_consume = false;
+                    return;
                 }
             }
 
             // Move to next partition
+            partition_it->second->reset();
             ++partition_it;
             _chunk_it.reset();
         }
-
-        return true;
     }
 
     // Fetch chunks from HashMapWithKey.null_key_value, return true if reaches eos
     template <typename HashMapWithKey, typename Consumer>
-    bool fetch_chunks_from_null_key_value(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
+    void _fetch_chunks_from_null_key_value(HashMapWithKey& hash_map_with_key, Consumer&& consumer) {
         if (_null_key_eos) {
-            return true;
+            return;
         }
 
         std::vector<ChunkPtr>& chunks = hash_map_with_key.null_key_value.chunks;
@@ -188,6 +207,7 @@ private:
 
         DeferOp defer([&]() {
             if (chunk_it == chunk_end) {
+                hash_map_with_key.null_key_value.reset();
                 _null_key_eos = true;
                 _chunk_it.reset();
             } else {
@@ -196,13 +216,11 @@ private:
         });
 
         while (chunk_it != chunk_end) {
-            // Because we first fetch chunks from hash_map, so the _partition_idx here
-            // is already set to hash_map.size()
             if (!consumer(hash_map_with_key.kNullKeyPartitionIdx, *chunk_it++)) {
-                return false;
+                // Fetch suspend, and it may proceed the next call.
+                return;
             }
         }
-        return true;
     }
 
     const bool _has_nullable_partition_column;
@@ -211,7 +229,7 @@ private:
 
     RuntimeState* _state = nullptr;
     std::unique_ptr<MemPool> _mem_pool = nullptr;
-    ObjectPool* _obj_pool = nullptr;
+    std::unique_ptr<ObjectPool> _obj_pool = nullptr;
 
     Columns _partition_columns;
     // Hash map which holds chunks of different partitions
@@ -226,6 +244,7 @@ private:
     std::any _partition_it;
     // Iterator of chunks of current partition
     std::any _chunk_it;
+
     bool _hash_map_eos = false;
     bool _null_key_eos = false;
 };

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -87,7 +87,7 @@ struct PartitionHashMapBase {
     static constexpr bool is_fixed_length_slice = IsFixedLengthSlice;
 
     const int32_t chunk_size;
-    bool is_downgrade = false;
+    bool is_passthrough = false;
 
     int64_t total_num_rows = 0;
 
@@ -128,7 +128,7 @@ protected:
             partition_chunk_consumer(value.partition_idx, std::move(value.chunks[i]));
         }
 
-        if (value.remain_size == 0 || is_downgrade) {
+        if (value.remain_size == 0 || is_passthrough) {
             // The last chunk is also full.
             partition_chunk_consumer(value.partition_idx, std::move(value.chunks[num_chunks - 1]));
             value.chunks.clear();
@@ -139,17 +139,17 @@ protected:
         }
     }
 
-    template <bool EnableDowngrade, typename HashMap>
-    void check_downgrade(HashMap& hash_map) {
-        if constexpr (!EnableDowngrade) {
+    template <bool EnablePassthrough, typename HashMap>
+    void check_passthrough(HashMap& hash_map) {
+        if constexpr (!EnablePassthrough) {
             return;
         }
-        if (is_downgrade) {
+        if (is_passthrough) {
             return;
         }
         auto partition_num = hash_map.size();
         if (partition_num > 512 && total_num_rows < 10000 * partition_num) {
-            is_downgrade = true;
+            is_passthrough = true;
         }
     }
 
@@ -164,13 +164,13 @@ protected:
     //      called when coming a new key not in the hash map.
     // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
     //      called for each partition with enough num rows after adding chunk to the hash map.
-    template <bool EnableDowngrade, typename HashMap, typename KeyLoader, typename KeyAllocator,
+    template <bool EnablePassthrough, typename HashMap, typename KeyLoader, typename KeyAllocator,
               typename NewPartitionCallback, typename PartitionChunkConsumer>
     void append_chunk_for_one_key(HashMap& hash_map, ChunkPtr chunk, KeyLoader&& key_loader,
                                   KeyAllocator&& key_allocator, ObjectPool* obj_pool,
                                   NewPartitionCallback&& new_partition_cb,
                                   PartitionChunkConsumer&& partition_chunk_consumer) {
-        if (is_downgrade) {
+        if (is_passthrough) {
             return;
         }
 
@@ -181,7 +181,7 @@ protected:
         auto next_partition_idx = hash_map.size();
         uint32_t i = 0;
 
-        for (; !is_downgrade && i < size; i++) {
+        for (; !is_passthrough && i < size; i++) {
             const auto& key = key_loader(i);
             visited_keys.insert(key);
 
@@ -192,7 +192,7 @@ protected:
                 return ctor(key_allocator(key), part_chunks);
             });
             if (is_new_partition) {
-                check_downgrade<EnableDowngrade>(hash_map);
+                check_passthrough<EnablePassthrough>(hash_map);
                 if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(new_partition_cb)>>) {
                     new_partition_cb(next_partition_idx);
                 }
@@ -224,7 +224,7 @@ protected:
         }
 
         // The first i rows has been pushed into hash_map
-        if (is_downgrade && i > 0) {
+        if (is_passthrough && i > 0) {
             for (auto& column : chunk->columns()) {
                 column->remove_first_n_values(i);
             }
@@ -243,14 +243,14 @@ protected:
     //      called when coming a new key not in the hash map.
     // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
     //      called for each partition with enough num rows after adding chunk to the hash map.
-    template <bool EnableDowngrade, typename HashMap, typename KeyLoader, typename KeyAllocator,
+    template <bool EnablePassthrough, typename HashMap, typename KeyLoader, typename KeyAllocator,
               typename NewPartitionCallback, typename PartitionChunkConsumer>
     void append_chunk_for_one_nullable_key(HashMap& hash_map, PartitionChunks& null_key_value, ChunkPtr chunk,
                                            const NullableColumn* nullable_key_column, KeyLoader&& key_loader,
                                            KeyAllocator&& key_allocator, ObjectPool* obj_pool,
                                            NewPartitionCallback&& new_partition_cb,
                                            PartitionChunkConsumer&& partition_chunk_consumer) {
-        if (is_downgrade) {
+        if (is_passthrough) {
             return;
         }
 
@@ -298,7 +298,7 @@ protected:
             auto next_partition_idx = hash_map.size() + 1;
 
             uint32_t i = 0;
-            for (; !is_downgrade && i < size; i++) {
+            for (; !is_passthrough && i < size; i++) {
                 PartitionChunks* value_ptr = nullptr;
                 if (null_flag_data[i] == 1) {
                     value_ptr = &null_key_value;
@@ -311,7 +311,7 @@ protected:
                         return ctor(key_allocator(key), obj_pool->add(new PartitionChunks(next_partition_idx)));
                     });
                     if (is_new_partition) {
-                        check_downgrade<EnableDowngrade>(hash_map);
+                        check_passthrough<EnablePassthrough>(hash_map);
                         if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(new_partition_cb)>>) {
                             new_partition_cb(next_partition_idx);
                         }
@@ -348,7 +348,7 @@ protected:
             }
 
             // The first i rows has been pushed into hash_map
-            if (is_downgrade && i > 0) {
+            if (is_passthrough && i > 0) {
                 for (auto& column : chunk->columns()) {
                     column->remove_first_n_values(i);
                 }
@@ -366,18 +366,18 @@ struct PartitionHashMapWithOneNumberKey : public PartitionHashMapBase<false, fal
 
     PartitionHashMapWithOneNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<ColumnType*>(key_columns[0].get());
         const auto& key_column_data = key_column->get_data();
-        append_chunk_for_one_key<EnableDowngrade>(
+        append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk, [&](uint32_t offset) { return key_column_data[offset]; },
                 [](const FieldType& key) { return key; }, obj_pool,
                 std::forward<NewPartitionCallback>(new_partition_cb),
                 std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
-        return is_downgrade;
+        return is_passthrough;
     }
 };
 
@@ -391,18 +391,18 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase<tr
 
     PartitionHashMapWithOneNullableNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto& key_column_data = down_cast<ColumnType*>(nullable_key_column->data_column().get())->get_data();
-        append_chunk_for_one_nullable_key<EnableDowngrade>(
+        append_chunk_for_one_nullable_key<EnablePassthrough>(
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column_data[offset]; }, [](const FieldType& key) { return key; },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
                 std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
-        return is_downgrade;
+        return is_passthrough;
     }
 };
 
@@ -413,12 +413,12 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase<false, fal
 
     PartitionHashMapWithOneStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<BinaryColumn*>(key_columns[0].get());
-        append_chunk_for_one_key<EnableDowngrade>(
+        append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk, [&](uint32_t offset) { return key_column->get_slice(offset); },
                 [&](const Slice& key) {
                     uint8_t* pos = mem_pool->allocate(key.size);
@@ -427,7 +427,7 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase<false, fal
                 },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
                 std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
-        return is_downgrade;
+        return is_passthrough;
     }
 };
 
@@ -439,13 +439,13 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase<tr
 
     PartitionHashMapWithOneNullableStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto* key_column = down_cast<BinaryColumn*>(nullable_key_column->data_column().get());
-        append_chunk_for_one_nullable_key<EnableDowngrade>(
+        append_chunk_for_one_nullable_key<EnablePassthrough>(
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column->get_slice(offset); },
                 [&](const Slice& key) {
@@ -455,7 +455,7 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase<tr
                 },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
                 std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
-        return is_downgrade;
+        return is_passthrough;
     }
 };
 
@@ -477,11 +477,11 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
               inner_mem_pool(std::make_unique<MemPool>()),
               buffer(inner_mem_pool->allocate(max_one_row_size * chunk_size)) {}
 
-    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
-        if (is_downgrade) {
-            return is_downgrade;
+        if (is_passthrough) {
+            return is_passthrough;
         }
 
         size_t num_rows = chunk->num_rows();
@@ -500,7 +500,7 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
             key_column->serialize_batch(buffer, slice_sizes, num_rows, max_one_row_size);
         }
 
-        append_chunk_for_one_key<EnableDowngrade>(
+        append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk,
                 [&](uint32_t offset) {
                     return Slice{buffer + offset * max_one_row_size, slice_sizes[offset]};
@@ -513,7 +513,7 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
                 std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
 
-        return is_downgrade;
+        return is_passthrough;
     }
 
     uint32_t get_max_serialize_size(const Columns& key_columns) {
@@ -545,13 +545,13 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
         memset(buf, 0x0, max_fixed_size * chunk_size);
     }
 
-    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnablePassthrough, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(fixed_byte_size != -1);
 
-        if (is_downgrade) {
-            return is_downgrade;
+        if (is_passthrough) {
+            return is_passthrough;
         }
 
         size_t num_rows = chunk->num_rows();
@@ -572,13 +572,13 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
             }
         }
 
-        append_chunk_for_one_key<EnableDowngrade>(
+        append_chunk_for_one_key<EnablePassthrough>(
                 hash_map, chunk, [&](uint32_t offset) { return keys[offset]; },
                 [&](const FixedSizeSliceKey& key) { return key; }, obj_pool,
                 std::forward<NewPartitionCallback>(new_partition_cb),
                 std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
 
-        return is_downgrade;
+        return is_passthrough;
     }
 };
 

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -41,6 +41,11 @@ struct PartitionChunks {
     int32_t remain_size = 0;
 
     const size_t partition_idx;
+
+    void reset() {
+        chunks.clear();
+        select_indexes.clear();
+    }
 };
 
 // =====================
@@ -134,8 +139,11 @@ protected:
         }
     }
 
-    template <typename HashMap>
+    template <bool EnableDowngrade, typename HashMap>
     void check_downgrade(HashMap& hash_map) {
+        if constexpr (!EnableDowngrade) {
+            return;
+        }
         if (is_downgrade) {
             return;
         }
@@ -156,8 +164,8 @@ protected:
     //      called when coming a new key not in the hash map.
     // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
     //      called for each partition with enough num rows after adding chunk to the hash map.
-    template <typename HashMap, typename KeyLoader, typename KeyAllocator, typename NewPartitionCallback,
-              typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename HashMap, typename KeyLoader, typename KeyAllocator,
+              typename NewPartitionCallback, typename PartitionChunkConsumer>
     void append_chunk_for_one_key(HashMap& hash_map, ChunkPtr chunk, KeyLoader&& key_loader,
                                   KeyAllocator&& key_allocator, ObjectPool* obj_pool,
                                   NewPartitionCallback&& new_partition_cb,
@@ -184,8 +192,11 @@ protected:
                 return ctor(key_allocator(key), part_chunks);
             });
             if (is_new_partition) {
-                check_downgrade(hash_map);
-                new_partition_cb(next_partition_idx++);
+                check_downgrade<EnableDowngrade>(hash_map);
+                if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(new_partition_cb)>>) {
+                    new_partition_cb(next_partition_idx);
+                }
+                next_partition_idx++;
             }
 
             auto& value = *(iter->second);
@@ -206,8 +217,10 @@ protected:
             flush(*(hash_map[key]), chunk);
         }
 
-        for (const auto& key : visited_keys) {
-            consume_full_chunks(*(hash_map[key]), std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+        if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(partition_chunk_consumer)>>) {
+            for (const auto& key : visited_keys) {
+                consume_full_chunks(*(hash_map[key]), std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+            }
         }
 
         // The first i rows has been pushed into hash_map
@@ -230,8 +243,8 @@ protected:
     //      called when coming a new key not in the hash map.
     // @partition_chunk_consumer: void(size_t partition_idx, const ChunkPtr& chunk)
     //      called for each partition with enough num rows after adding chunk to the hash map.
-    template <typename HashMap, typename KeyLoader, typename KeyAllocator, typename NewPartitionCallback,
-              typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename HashMap, typename KeyLoader, typename KeyAllocator,
+              typename NewPartitionCallback, typename PartitionChunkConsumer>
     void append_chunk_for_one_nullable_key(HashMap& hash_map, PartitionChunks& null_key_value, ChunkPtr chunk,
                                            const NullableColumn* nullable_key_column, KeyLoader&& key_loader,
                                            KeyAllocator&& key_allocator, ObjectPool* obj_pool,
@@ -243,7 +256,9 @@ protected:
 
         if (!init_null_key_partition) {
             init_null_key_partition = true;
-            new_partition_cb(kNullKeyPartitionIdx);
+            if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(new_partition_cb)>>) {
+                new_partition_cb(kNullKeyPartitionIdx);
+            }
         }
 
         if (nullable_key_column->only_null()) {
@@ -269,7 +284,9 @@ protected:
             null_key_value.remain_size = chunk_size - null_key_value.chunks.back()->num_rows();
             total_num_rows += size;
 
-            consume_full_chunks(null_key_value, std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+            if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(partition_chunk_consumer)>>) {
+                consume_full_chunks(null_key_value, std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+            }
         } else {
             phmap::flat_hash_set<typename HashMap::key_type, typename HashMap::hasher, typename HashMap::key_equal,
                                  typename HashMap::allocator_type>
@@ -294,8 +311,11 @@ protected:
                         return ctor(key_allocator(key), obj_pool->add(new PartitionChunks(next_partition_idx)));
                     });
                     if (is_new_partition) {
-                        check_downgrade(hash_map);
-                        new_partition_cb(next_partition_idx++);
+                        check_downgrade<EnableDowngrade>(hash_map);
+                        if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(new_partition_cb)>>) {
+                            new_partition_cb(next_partition_idx);
+                        }
+                        next_partition_idx++;
                     }
                     value_ptr = iter->second;
                 }
@@ -319,10 +339,13 @@ protected:
             }
             flush(null_key_value, chunk);
 
-            for (const auto& key : visited_keys) {
-                consume_full_chunks(*(hash_map[key]), std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+            if constexpr (!std::is_same_v<std::nullptr_t, std::decay_t<decltype(partition_chunk_consumer)>>) {
+                for (const auto& key : visited_keys) {
+                    consume_full_chunks(*(hash_map[key]),
+                                        std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
+                }
+                consume_full_chunks(null_key_value, std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
             }
-            consume_full_chunks(null_key_value, std::forward<PartitionChunkConsumer>(partition_chunk_consumer));
 
             // The first i rows has been pushed into hash_map
             if (is_downgrade && i > 0) {
@@ -343,13 +366,13 @@ struct PartitionHashMapWithOneNumberKey : public PartitionHashMapBase<false, fal
 
     PartitionHashMapWithOneNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<ColumnType*>(key_columns[0].get());
         const auto& key_column_data = key_column->get_data();
-        append_chunk_for_one_key(
+        append_chunk_for_one_key<EnableDowngrade>(
                 hash_map, chunk, [&](uint32_t offset) { return key_column_data[offset]; },
                 [](const FieldType& key) { return key; }, obj_pool,
                 std::forward<NewPartitionCallback>(new_partition_cb),
@@ -368,13 +391,13 @@ struct PartitionHashMapWithOneNullableNumberKey : public PartitionHashMapBase<tr
 
     PartitionHashMapWithOneNullableNumberKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto& key_column_data = down_cast<ColumnType*>(nullable_key_column->data_column().get())->get_data();
-        append_chunk_for_one_nullable_key(
+        append_chunk_for_one_nullable_key<EnableDowngrade>(
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column_data[offset]; }, [](const FieldType& key) { return key; },
                 obj_pool, std::forward<NewPartitionCallback>(new_partition_cb),
@@ -390,12 +413,12 @@ struct PartitionHashMapWithOneStringKey : public PartitionHashMapBase<false, fal
 
     PartitionHashMapWithOneStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(!key_columns[0]->is_nullable());
         const auto* key_column = down_cast<BinaryColumn*>(key_columns[0].get());
-        append_chunk_for_one_key(
+        append_chunk_for_one_key<EnableDowngrade>(
                 hash_map, chunk, [&](uint32_t offset) { return key_column->get_slice(offset); },
                 [&](const Slice& key) {
                     uint8_t* pos = mem_pool->allocate(key.size);
@@ -416,13 +439,13 @@ struct PartitionHashMapWithOneNullableStringKey : public PartitionHashMapBase<tr
 
     PartitionHashMapWithOneNullableStringKey(int32_t chunk_size) : PartitionHashMapBase(chunk_size) {}
 
-    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(key_columns[0]->is_nullable());
         const auto* nullable_key_column = ColumnHelper::as_raw_column<NullableColumn>(key_columns[0].get());
         const auto* key_column = down_cast<BinaryColumn*>(nullable_key_column->data_column().get());
-        append_chunk_for_one_nullable_key(
+        append_chunk_for_one_nullable_key<EnableDowngrade>(
                 hash_map, null_key_value, chunk, nullable_key_column,
                 [&](uint32_t offset) { return key_column->get_slice(offset); },
                 [&](const Slice& key) {
@@ -454,7 +477,7 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
               inner_mem_pool(std::make_unique<MemPool>()),
               buffer(inner_mem_pool->allocate(max_one_row_size * chunk_size)) {}
 
-    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         if (is_downgrade) {
@@ -477,7 +500,7 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
             key_column->serialize_batch(buffer, slice_sizes, num_rows, max_one_row_size);
         }
 
-        append_chunk_for_one_key(
+        append_chunk_for_one_key<EnableDowngrade>(
                 hash_map, chunk,
                 [&](uint32_t offset) {
                     return Slice{buffer + offset * max_one_row_size, slice_sizes[offset]};
@@ -522,7 +545,7 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
         memset(buf, 0x0, max_fixed_size * chunk_size);
     }
 
-    template <typename NewPartitionCallback, typename PartitionChunkConsumer>
+    template <bool EnableDowngrade, typename NewPartitionCallback, typename PartitionChunkConsumer>
     bool append_chunk(ChunkPtr chunk, const Columns& key_columns, MemPool* mem_pool, ObjectPool* obj_pool,
                       NewPartitionCallback&& new_partition_cb, PartitionChunkConsumer&& partition_chunk_consumer) {
         DCHECK(fixed_byte_size != -1);
@@ -549,7 +572,7 @@ struct PartitionHashMapWithSerializedKeyFixedSize : public PartitionHashMapBase<
             }
         }
 
-        append_chunk_for_one_key(
+        append_chunk_for_one_key<EnableDowngrade>(
                 hash_map, chunk, [&](uint32_t offset) { return keys[offset]; },
                 [&](const FixedSizeSliceKey& key) { return key; }, obj_pool,
                 std::forward<NewPartitionCallback>(new_partition_cb),

--- a/be/src/exec/partition/partition_hash_variant.cpp
+++ b/be/src/exec/partition/partition_hash_variant.cpp
@@ -126,6 +126,11 @@ void PartitionHashMapVariant::init(RuntimeState* state, Type type_) {
     }
 }
 
+void PartitionHashMapVariant::reset() {
+    detail::PartitionHashMapWithKeyPtr ptr;
+    hash_map_with_key = std::move(ptr);
+}
+
 size_t PartitionHashMapVariant::capacity() const {
     return visit([](const auto& hash_map_with_key) { return hash_map_with_key->hash_map.capacity(); });
 }
@@ -142,5 +147,9 @@ size_t PartitionHashMapVariant::size() const {
 
 size_t PartitionHashMapVariant::memory_usage() const {
     return visit([](const auto& hash_map_with_key) { return hash_map_with_key->hash_map.dump_bound(); });
+}
+
+bool PartitionHashMapVariant::is_nullable() const {
+    return visit([](const auto& hash_map_with_key) { return std::decay_t<decltype(*hash_map_with_key)>::is_nullable; });
 }
 } // namespace starrocks

--- a/be/src/exec/partition/partition_hash_variant.h
+++ b/be/src/exec/partition/partition_hash_variant.h
@@ -191,10 +191,14 @@ struct PartitionHashMapVariant {
 
     void init(RuntimeState* state, Type type_);
 
+    void reset();
+
     size_t capacity() const;
 
     size_t size() const;
 
     size_t memory_usage() const;
+
+    bool is_nullable() const;
 };
 } // namespace starrocks

--- a/be/src/exec/pipeline/hash_partition_context.cpp
+++ b/be/src/exec/pipeline/hash_partition_context.cpp
@@ -1,0 +1,101 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/hash_partition_context.h"
+
+#include "exprs/expr.h"
+
+namespace starrocks::pipeline {
+
+Status HashPartitionContext::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_partition_exprs, &_partition_exprs, state));
+    RETURN_IF_ERROR(Expr::prepare(_partition_exprs, state));
+    RETURN_IF_ERROR(Expr::open(_partition_exprs, state));
+    for (auto& expr : _partition_exprs) {
+        auto& type_desc = expr->root()->type();
+        if (!type_desc.support_groupby()) {
+            return Status::NotSupported(fmt::format("partition by type {} is not supported", type_desc.debug_string()));
+        }
+    }
+    auto partition_size = _t_partition_exprs.size();
+    _partition_types.resize(partition_size);
+    for (auto i = 0; i < partition_size; ++i) {
+        TExprNode expr = _t_partition_exprs[i].nodes[0];
+        _partition_types[i].result_type = TypeDescriptor::from_thrift(expr.type);
+        _partition_types[i].is_nullable = expr.is_nullable;
+        _has_nullable_key = _has_nullable_key || _partition_types[i].is_nullable;
+    }
+
+    _chunks_partitioner = std::make_unique<ChunksPartitioner>(_has_nullable_key, _partition_exprs, _partition_types);
+    return _chunks_partitioner->prepare(state);
+}
+
+Status HashPartitionContext::push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk) {
+    return _chunks_partitioner->offer<false>(chunk, nullptr, nullptr);
+}
+
+void HashPartitionContext::sink_complete() {
+    _is_sink_complete = true;
+}
+
+bool HashPartitionContext::has_output() {
+    return _is_sink_complete && (!_chunks_partitioner->is_hash_map_eos() || _chunk != nullptr);
+}
+
+bool HashPartitionContext::is_finished() {
+    if (!_is_sink_complete) {
+        return false;
+    }
+    return !has_output();
+}
+
+StatusOr<ChunkPtr> HashPartitionContext::pull_one_chunk(RuntimeState* state) {
+    ChunkPtr output = nullptr;
+    if (!_chunks_partitioner->is_hash_map_eos()) {
+        _chunks_partitioner->consume_from_hash_map([&](int32_t partition_idx, ChunkPtr& chunk) {
+            if (_chunk == nullptr) {
+                if (chunk->num_rows() < state->chunk_size()) {
+                    _chunk = std::move(chunk);
+                    return true;
+                } else {
+                    output = std::move(chunk);
+                    return false;
+                }
+            } else if (_chunk->num_rows() + chunk->num_rows() <= state->chunk_size()) {
+                _chunk->append(*chunk);
+                chunk = nullptr;
+                return true;
+            } else {
+                output = std::move(_chunk);
+                _chunk = std::move(chunk);
+                return false;
+            }
+        });
+    } else if (_chunk != nullptr) {
+        output = std::move(_chunk);
+    }
+    return output;
+}
+
+HashPartitionContext* HashPartitionContextFactory::create(int32_t driver_sequence) {
+    if (auto it = _ctxs.find(driver_sequence); it != _ctxs.end()) {
+        return it->second.get();
+    }
+
+    auto ctx = std::make_shared<HashPartitionContext>(_t_partition_exprs);
+    auto* ctx_raw_ptr = ctx.get();
+    _ctxs.emplace(driver_sequence, std::move(ctx));
+    return ctx_raw_ptr;
+}
+}; // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hash_partition_context.h
+++ b/be/src/exec/pipeline/hash_partition_context.h
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/partition/chunks_partitioner.h"
+
+namespace starrocks::pipeline {
+
+class HashPartitionContext;
+class HashPartitionContextFactory;
+
+using HashPartitionContextPtr = std::shared_ptr<HashPartitionContext>;
+using HashPartitionContextFactoryPtr = std::shared_ptr<HashPartitionContextFactory>;
+
+class HashPartitionContext {
+public:
+    HashPartitionContext(const std::vector<TExpr>& t_partition_exprs) : _t_partition_exprs(t_partition_exprs) {}
+
+    Status prepare(RuntimeState* state);
+
+    // Add one chunk to partitioner
+    Status push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk);
+
+    // Pull one chunk from sorters or downgrade_buffer
+    StatusOr<ChunkPtr> pull_one_chunk(RuntimeState* state);
+
+    // Notify that there is no further input for partitiner
+    void sink_complete();
+
+    // Return true if at least one of the sorters has remaining data
+    bool has_output();
+
+    // Return true if sink completed and all the data in the chunks_sorters has been pulled out
+    bool is_finished();
+
+private:
+    const std::vector<TExpr>& _t_partition_exprs;
+    std::vector<ExprContext*> _partition_exprs;
+    std::vector<PartitionColumnType> _partition_types;
+
+    bool _has_nullable_key = false;
+    // No more input chunks if after _is_sink_complete is set to true
+    bool _is_sink_complete = false;
+
+    ChunksPartitionerPtr _chunks_partitioner;
+
+    ChunkPtr _chunk = nullptr;
+};
+
+class HashPartitionContextFactory {
+public:
+    HashPartitionContextFactory(const std::vector<TExpr>& t_partition_exprs) : _t_partition_exprs(t_partition_exprs) {}
+
+    HashPartitionContext* create(int32_t driver_sequence);
+
+private:
+    std::unordered_map<int32_t, HashPartitionContextPtr> _ctxs;
+
+    const std::vector<TExpr>& _t_partition_exprs;
+};
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hash_partition_context.h
+++ b/be/src/exec/pipeline/hash_partition_context.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "exec/partition/chunks_partitioner.h"
+#include "storage/chunk_helper.h"
 
 namespace starrocks::pipeline {
 
@@ -56,7 +57,7 @@ private:
 
     ChunksPartitionerPtr _chunks_partitioner;
 
-    ChunkPtr _chunk = nullptr;
+    ChunkPipelineAccumulator _acc;
 };
 
 class HashPartitionContextFactory {

--- a/be/src/exec/pipeline/hash_partition_context.h
+++ b/be/src/exec/pipeline/hash_partition_context.h
@@ -33,7 +33,7 @@ public:
     // Add one chunk to partitioner
     Status push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk);
 
-    // Pull one chunk from sorters or downgrade_buffer
+    // Pull one chunk from sorters or passthrough_buffer
     StatusOr<ChunkPtr> pull_one_chunk(RuntimeState* state);
 
     // Notify that there is no further input for partitiner

--- a/be/src/exec/pipeline/hash_partition_sink_operator.cpp
+++ b/be/src/exec/pipeline/hash_partition_sink_operator.cpp
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hash_partition_sink_operator.h"
+
+namespace starrocks::pipeline {
+
+Status HashPartitionSinkOperator::prepare(RuntimeState* state) {
+    Operator::prepare(state);
+    return _hash_partition_ctx->prepare(state);
+}
+
+StatusOr<ChunkPtr> HashPartitionSinkOperator::pull_chunk(RuntimeState* state) {
+    return Status::InternalError("Shouldn't call pull_chunk from hash partition sink operator.");
+}
+
+Status HashPartitionSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    return _hash_partition_ctx->push_one_chunk_to_partitioner(state, chunk);
+}
+
+Status HashPartitionSinkOperator::set_finishing(RuntimeState* state) {
+    _hash_partition_ctx->sink_complete();
+    _is_finished = true;
+    return Status::OK();
+}
+
+HashPartitionSinkOperatorFactory::HashPartitionSinkOperatorFactory(
+        int32_t id, int32_t plan_node_id, HashPartitionContextFactoryPtr hash_partition_ctx_factory)
+        : OperatorFactory(id, "hash_partition_sink", plan_node_id),
+          _hash_partition_ctx_factory(std::move(hash_partition_ctx_factory)) {}
+
+OperatorPtr HashPartitionSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    return std::make_shared<HashPartitionSinkOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                       _hash_partition_ctx_factory->create(driver_sequence));
+}
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hash_partition_sink_operator.h
+++ b/be/src/exec/pipeline/hash_partition_sink_operator.h
@@ -19,8 +19,26 @@
 #include "exec/pipeline/operator.h"
 
 /**
- * TODO 
- * 1. disable downgrade
+ * HashPartition{Sink/Source}Operator pair is used to reorder the input sequence by
+ * grouping rows into different partitions, and each partition is defined by (partition by columns). 
+ * And for rows in the same partition, the order between them is arbitrary.
+ *
+ * Here is an example:
+ *  pc1: partition by column 1
+ *  pc2: partition by column 2
+ *
+ * pc1 pc2 c3 c4
+ * 1   2   9  8
+ * 1   3   4  6
+ * 1   2   5  8
+ * 1   3   2  6
+ *
+ * one possible output can be:
+ * pc1 pc2 c3 c4
+ * 1   2   9  8
+ * 1   2   5  8
+ * 1   3   4  5
+ * 1   3   2  6
  */
 namespace starrocks::pipeline {
 class HashPartitionSinkOperator final : public Operator {

--- a/be/src/exec/pipeline/hash_partition_sink_operator.h
+++ b/be/src/exec/pipeline/hash_partition_sink_operator.h
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/partition/chunks_partitioner.h"
+#include "exec/pipeline/hash_partition_context.h"
+#include "exec/pipeline/operator.h"
+
+/**
+ * TODO 
+ * 1. disable downgrade
+ */
+namespace starrocks::pipeline {
+class HashPartitionSinkOperator final : public Operator {
+public:
+    HashPartitionSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                              HashPartitionContext* hash_partition_ctx)
+            : Operator(factory, id, "hash_partition_sink", plan_node_id, driver_sequence),
+              _hash_partition_ctx(hash_partition_ctx) {}
+
+    Status prepare(RuntimeState* state) override;
+
+    bool has_output() const override { return false; }
+
+    bool need_input() const override { return true; }
+
+    bool is_finished() const override { return _is_finished; }
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+    Status set_finishing(RuntimeState* state) override;
+
+private:
+    bool _is_finished = false;
+    HashPartitionContext* _hash_partition_ctx;
+};
+
+class HashPartitionSinkOperatorFactory final : public OperatorFactory {
+public:
+    HashPartitionSinkOperatorFactory(int32_t id, int32_t plan_node_id,
+                                     HashPartitionContextFactoryPtr hash_partition_ctx_factory);
+
+    ~HashPartitionSinkOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+private:
+    HashPartitionContextFactoryPtr _hash_partition_ctx_factory;
+};
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hash_partition_source_operator.cpp
+++ b/be/src/exec/pipeline/hash_partition_source_operator.cpp
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hash_partition_source_operator.h"
+
+namespace starrocks::pipeline {
+
+bool HashPartitionSourceOperator::has_output() const {
+    return _hash_partition_ctx->has_output();
+}
+
+bool HashPartitionSourceOperator::is_finished() const {
+    return _hash_partition_ctx->is_finished();
+}
+
+StatusOr<ChunkPtr> HashPartitionSourceOperator::pull_chunk(RuntimeState* state) {
+    return _hash_partition_ctx->pull_one_chunk(state);
+}
+
+HashPartitionSourceOperatorFactory::HashPartitionSourceOperatorFactory(
+        int32_t id, int32_t plan_node_id, HashPartitionContextFactoryPtr hash_partition_ctx_factory)
+        : SourceOperatorFactory(id, "hash_partition_source", plan_node_id),
+          _hash_partition_ctx_factory(std::move(hash_partition_ctx_factory)) {}
+
+OperatorPtr HashPartitionSourceOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    return std::make_shared<HashPartitionSourceOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                         _hash_partition_ctx_factory->create(driver_sequence));
+}
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hash_partition_source_operator.h
+++ b/be/src/exec/pipeline/hash_partition_source_operator.h
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/partition/chunks_partitioner.h"
+#include "exec/pipeline/hash_partition_context.h"
+#include "exec/pipeline/source_operator.h"
+
+namespace starrocks::pipeline {
+class HashPartitionSourceOperator final : public SourceOperator {
+public:
+    HashPartitionSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                                HashPartitionContext* hash_partition_ctx)
+            : SourceOperator(factory, id, "hash_partition_source", plan_node_id, driver_sequence),
+              _hash_partition_ctx(hash_partition_ctx) {}
+
+    ~HashPartitionSourceOperator() override = default;
+
+    bool has_output() const override;
+
+    bool is_finished() const override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+private:
+    HashPartitionContext* _hash_partition_ctx;
+};
+
+class HashPartitionSourceOperatorFactory final : public SourceOperatorFactory {
+public:
+    HashPartitionSourceOperatorFactory(int32_t id, int32_t plan_node_id,
+                                       HashPartitionContextFactoryPtr hash_partition_ctx_factory);
+
+    ~HashPartitionSourceOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+private:
+    HashPartitionContextFactoryPtr _hash_partition_ctx_factory;
+};
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -70,7 +70,7 @@ Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(RuntimeState* st
             [this, state](size_t partition_idx, const ChunkPtr& chunk) {
                 _chunks_sorters[partition_idx]->update(state, chunk);
             });
-    if (_chunks_partitioner->is_downgrade()) {
+    if (_chunks_partitioner->is_passthrough()) {
         transfer_all_chunks_from_partitioner_to_sorters(state);
     }
     return st;
@@ -100,8 +100,8 @@ Status LocalPartitionTopnContext::transfer_all_chunks_from_partitioner_to_sorter
 }
 
 bool LocalPartitionTopnContext::has_output() {
-    if (_chunks_partitioner->is_downgrade() && _is_transfered) {
-        return _sorter_index < _chunks_sorters.size() || !_chunks_partitioner->is_downgrade_buffer_empty();
+    if (_chunks_partitioner->is_passthrough() && _is_transfered) {
+        return _sorter_index < _chunks_sorters.size() || !_chunks_partitioner->is_passthrough_buffer_empty();
     }
     return _is_sink_complete && _sorter_index < _chunks_sorters.size();
 }
@@ -121,7 +121,7 @@ StatusOr<ChunkPtr> LocalPartitionTopnContext::pull_one_chunk() {
             return chunk;
         }
     }
-    chunk = _chunks_partitioner->consume_from_downgrade_buffer();
+    chunk = _chunks_partitioner->consume_from_passthrough_buffer();
     return chunk;
 }
 

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -60,7 +60,7 @@ Status LocalPartitionTopnContext::prepare(RuntimeState* state) {
 }
 
 Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(RuntimeState* state, const ChunkPtr& chunk) {
-    auto st = _chunks_partitioner->offer(
+    auto st = _chunks_partitioner->offer<true>(
             chunk,
             [this, state](size_t partition_idx) {
                 _chunks_sorters.emplace_back(std::make_shared<ChunksSorterTopn>(

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -61,7 +61,7 @@ public:
     // Return true if sink completed and all the data in the chunks_sorters has been pulled out
     bool is_finished();
 
-    // Pull one chunk from sorters or downgrade_buffer
+    // Pull one chunk from sorters or passthrough_buffer
     StatusOr<ChunkPtr> pull_one_chunk();
 
 private:

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
@@ -80,8 +80,14 @@ public class AnalyticExpr extends Expr {
     // in SQL, and hence, will fail analysis().
     private boolean resetWindow = false;
 
+    private final String partitionHint;
+    private final boolean useHashBasedPartition;
+
     // SQL string of this AnalyticExpr before standardization. Returned in toSqlImpl().
     private String sqlString;
+
+    private static final String HINT_SORT = "sort";
+    private static final String HINT_HASH = "hash";
 
     public static String LEAD = "LEAD";
     public static String LAG = "LAG";
@@ -100,7 +106,7 @@ public class AnalyticExpr extends Expr {
     public static String HLL_UNION_AGG = "HLL_UNION_AGG";
 
     public AnalyticExpr(FunctionCallExpr fnCall, List<Expr> partitionExprs,
-                        List<OrderByElement> orderByElements, AnalyticWindow window) {
+                        List<OrderByElement> orderByElements, AnalyticWindow window, String partitionHint) {
         Preconditions.checkNotNull(fnCall);
         this.fnCall = fnCall;
         this.partitionExprs = partitionExprs != null ? partitionExprs : new ArrayList<Expr>();
@@ -110,6 +116,22 @@ public class AnalyticExpr extends Expr {
         }
 
         this.window = window;
+
+        if (partitionHint == null || !this.orderByElements.isEmpty()) {
+            this.partitionHint = null;
+            this.useHashBasedPartition = false;
+        } else if (HINT_SORT.equalsIgnoreCase(partitionHint)) {
+            this.partitionHint = HINT_SORT;
+            this.useHashBasedPartition = false;
+        } else if (HINT_HASH.equalsIgnoreCase(partitionHint)) {
+            this.partitionHint = HINT_HASH;
+            this.useHashBasedPartition = true;
+        } else {
+            this.partitionHint = null;
+            this.useHashBasedPartition = false;
+            Preconditions.checkState(false, "partition by hint can only be 'sort' or 'hash'");
+        }
+
         setChildren();
     }
 
@@ -127,6 +149,8 @@ public class AnalyticExpr extends Expr {
         partitionExprs = Expr.cloneList(other.partitionExprs);
         window = (other.window != null ? other.window.clone() : null);
         resetWindow = other.resetWindow;
+        partitionHint = other.partitionHint;
+        useHashBasedPartition = other.useHashBasedPartition;
         sqlString = other.sqlString;
         setChildren();
     }
@@ -147,6 +171,14 @@ public class AnalyticExpr extends Expr {
         return window;
     }
 
+    public String getPartitionHint() {
+        return partitionHint;
+    }
+
+    public boolean isUseHashBasedPartition() {
+        return useHashBasedPartition;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (!super.equals(obj)) {
@@ -155,21 +187,12 @@ public class AnalyticExpr extends Expr {
 
         AnalyticExpr o = (AnalyticExpr) obj;
 
-        if (!fnCall.equals(o.getFnCall())) {
-            return false;
-        }
-
-        if ((window == null) != (o.window == null)) {
-            return false;
-        }
-
-        if (window != null) {
-            if (!window.equals(o.window)) {
-                return false;
-            }
-        }
-
-        return orderByElements.equals(o.orderByElements);
+        return Objects.equals(fnCall, o.fnCall) &&
+                Objects.equals(partitionExprs, o.partitionExprs) &&
+                Objects.equals(orderByElements, o.orderByElements) &&
+                Objects.equals(window, o.window) &&
+                Objects.equals(partitionHint, o.partitionHint) &&
+                Objects.equals(useHashBasedPartition, o.useHashBasedPartition);
     }
 
     /**
@@ -411,6 +434,7 @@ public class AnalyticExpr extends Expr {
         // all children information is contained in the group of fnCall, partitionExprs, orderByElements and window,
         // so need to calculate super's hashCode.
         // field window is correlated with field resetWindow, so no need to add resetWindow when calculating hashCode.
-        return Objects.hash(type, opcode, fnCall, partitionExprs, orderByElements, window);
+        return Objects.hash(type, opcode, fnCall, partitionExprs, orderByElements, window, partitionHint,
+                useHashBasedPartition);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -627,7 +627,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         List<Expr> partitionExprs = visit(node.getPartitionBy(), context, Expr.class);
 
         return new AnalyticExpr(functionCallExpr, partitionExprs, orderByElements,
-                (AnalyticWindow) processOptional(node.getFrame(), context));
+                (AnalyticWindow) processOptional(node.getFrame(), context), null);
     }
 
     private ParseNode visitWindow(FunctionCallExpr functionCallExpr, Window windowSpec, ParseTreeContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
@@ -57,8 +57,6 @@ import com.starrocks.thrift.TPlanNodeType;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.stream.Collectors;
 
 public class AnalyticEvalNode extends PlanNode {
     private List<Expr> analyticFnCalls;
@@ -71,6 +69,8 @@ public class AnalyticEvalNode extends PlanNode {
     private List<OrderByElement> orderByElements;
 
     private final AnalyticWindow analyticWindow;
+
+    private final boolean useHashBasedPartition;
 
     // Physical tuples used/produced by this analytic node.
     private final TupleDescriptor intermediateTupleDesc;
@@ -85,7 +85,9 @@ public class AnalyticEvalNode extends PlanNode {
     public AnalyticEvalNode(
             PlanNodeId id, PlanNode input, List<Expr> analyticFnCalls,
             List<Expr> partitionExprs, List<OrderByElement> orderByElements,
-            AnalyticWindow analyticWindow, TupleDescriptor intermediateTupleDesc,
+            AnalyticWindow analyticWindow,
+            boolean useHashBasedPartition,
+            TupleDescriptor intermediateTupleDesc,
             TupleDescriptor outputTupleDesc,
             Expr partitionByEq, Expr orderByEq, TupleDescriptor bufferedTupleDesc) {
         super(id, input.getTupleIds(), "ANALYTIC");
@@ -96,6 +98,7 @@ public class AnalyticEvalNode extends PlanNode {
         this.partitionExprs = partitionExprs;
         this.orderByElements = orderByElements;
         this.analyticWindow = analyticWindow;
+        this.useHashBasedPartition = useHashBasedPartition;
         this.intermediateTupleDesc = intermediateTupleDesc;
         this.outputTupleDesc = outputTupleDesc;
         this.partitionByEq = partitionByEq;
@@ -135,6 +138,7 @@ public class AnalyticEvalNode extends PlanNode {
                 .add("subtitutedPartitionExprs", Expr.debugString(substitutedPartitionExprs))
                 .add("orderByElements", Joiner.on(", ").join(orderByElementStrs))
                 .add("window", analyticWindow)
+                .add("useHashBasedPartition", useHashBasedPartition)
                 .add("intermediateTid", intermediateTupleDesc.getId())
                 .add("intermediateTid", outputTupleDesc.getId())
                 .add("outputTid", outputTupleDesc.getId())
@@ -200,6 +204,10 @@ public class AnalyticEvalNode extends PlanNode {
             msg.analytic_node.setOrder_by_eq(orderByEq.treeToThrift());
         }
 
+        if (useHashBasedPartition) {
+            msg.analytic_node.setUse_hash_based_partition(useHashBasedPartition);
+        }
+
         if (bufferedTupleDesc != null) {
             msg.analytic_node.setBuffered_tuple_id(bufferedTupleDesc.getId().asInt());
         }
@@ -262,6 +270,10 @@ public class AnalyticEvalNode extends PlanNode {
             output.append("\n");
         }
 
+        if (useHashBasedPartition) {
+            output.append(prefix).append("useHashBasedPartition").append("\n");
+        }
+
         return output.toString();
     }
 
@@ -289,7 +301,8 @@ public class AnalyticEvalNode extends PlanNode {
     }
 
     @Override
-    public boolean pushDownRuntimeFilters(DescriptorTable descTbl, RuntimeFilterDescription description, Expr probeExpr, List<Expr> partitionByExprs) {
+    public boolean pushDownRuntimeFilters(DescriptorTable descTbl, RuntimeFilterDescription description, Expr probeExpr,
+                                          List<Expr> partitionByExprs) {
         if (!canPushDownRuntimeFilter()) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -309,6 +309,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_SORT_AGGREGATE = "enable_sort_aggregate";
 
+    public static final String WINDOW_PARTITION_MODE = "window_partition_mode";
+
     public static final String ENABLE_SCAN_BLOCK_CACHE = "enable_scan_block_cache";
     public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
     public static final String HUDI_MOR_FORCE_JNI_READER = "hudi_mor_force_jni_reader";
@@ -779,11 +781,19 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_SORT_AGGREGATE)
     private boolean enableSortAggregate = false;
 
+    // 1: sort based, 2: hash based
+    @VarAttr(name = WINDOW_PARTITION_MODE, flag = VariableMgr.INVISIBLE)
+    private int windowPartitionMode = 1;
+
     @VarAttr(name = ENABLE_REWRITE_SUM_BY_ASSOCIATIVE_RULE)
     private boolean enableRewriteSumByAssociativeRule = true;
 
     public boolean isEnableSortAggregate() {
         return enableSortAggregate;
+    }
+
+    public int getWindowPartitionMode() {
+        return windowPartitionMode;
     }
 
     public void setEnableSortAggregate(boolean enableSortAggregate) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalWindowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalWindowOperator.java
@@ -47,6 +47,12 @@ public class LogicalWindowOperator extends LogicalOperator {
      */
     private final ImmutableList<Ordering> enforceSortColumns;
 
+    /**
+     * For window functions with only partition by column but without order by column,
+     * we can perform hash-based partition according to hint.
+     */
+    private final boolean useHashBasedPartition;
+
     private LogicalWindowOperator(Builder builder) {
         super(OperatorType.LOGICAL_WINDOW, builder.getLimit(), builder.getPredicate(), builder.getProjection());
         this.windowCall = ImmutableMap.copyOf(builder.windowCall);
@@ -54,6 +60,7 @@ public class LogicalWindowOperator extends LogicalOperator {
         this.orderByElements = ImmutableList.copyOf(builder.orderByElements);
         this.analyticWindow = builder.analyticWindow;
         this.enforceSortColumns = ImmutableList.copyOf(builder.enforceSortColumns);
+        this.useHashBasedPartition = builder.useHashBasedPartition;
     }
 
     public Map<ColumnRefOperator, CallOperator> getWindowCall() {
@@ -74,6 +81,10 @@ public class LogicalWindowOperator extends LogicalOperator {
 
     public List<Ordering> getEnforceSortColumns() {
         return enforceSortColumns;
+    }
+
+    public boolean isUseHashBasedPartition() {
+        return useHashBasedPartition;
     }
 
     @Override
@@ -124,12 +135,14 @@ public class LogicalWindowOperator extends LogicalOperator {
         return Objects.equals(windowCall, that.windowCall)
                 && Objects.equals(partitionExpressions, that.partitionExpressions)
                 && Objects.equals(orderByElements, that.orderByElements)
-                && Objects.equals(analyticWindow, that.analyticWindow);
+                && Objects.equals(analyticWindow, that.analyticWindow)
+                && Objects.equals(useHashBasedPartition, that.useHashBasedPartition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), windowCall);
+        return Objects.hash(super.hashCode(), windowCall, partitionExpressions, orderByElements, analyticWindow,
+                useHashBasedPartition);
     }
 
     public static class Builder extends LogicalOperator.Builder<LogicalWindowOperator, LogicalWindowOperator.Builder> {
@@ -138,6 +151,7 @@ public class LogicalWindowOperator extends LogicalOperator {
         private List<Ordering> orderByElements = Lists.newArrayList();
         private AnalyticWindow analyticWindow;
         private List<Ordering> enforceSortColumns = Lists.newArrayList();
+        private boolean useHashBasedPartition = false;
 
         @Override
         public LogicalWindowOperator build() {
@@ -153,6 +167,7 @@ public class LogicalWindowOperator extends LogicalOperator {
             this.orderByElements = windowOperator.orderByElements;
             this.analyticWindow = windowOperator.analyticWindow;
             this.enforceSortColumns = windowOperator.enforceSortColumns;
+            this.useHashBasedPartition = windowOperator.useHashBasedPartition;
             return this;
         }
 
@@ -179,6 +194,11 @@ public class LogicalWindowOperator extends LogicalOperator {
 
         public Builder setEnforceSortColumns(List<Ordering> enforceSortColumns) {
             this.enforceSortColumns = enforceSortColumns;
+            return this;
+        }
+
+        public Builder setUseHashBasedPartition(boolean useHashBasedPartition) {
+            this.useHashBasedPartition = useHashBasedPartition;
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalWindowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalWindowOperator.java
@@ -37,12 +37,14 @@ public class PhysicalWindowOperator extends PhysicalOperator {
     private final List<Ordering> orderByElements;
     private final AnalyticWindow analyticWindow;
     private final List<Ordering> enforceOrderBy;
+    private final boolean useHashBasedPartition;
 
     public PhysicalWindowOperator(Map<ColumnRefOperator, CallOperator> analyticCall,
                                   List<ScalarOperator> partitionExpressions,
                                   List<Ordering> orderByElements,
                                   AnalyticWindow analyticWindow,
                                   List<Ordering> enforceOrderBy,
+                                  boolean useHashBasedPartition,
                                   long limit,
                                   ScalarOperator predicate,
                                   Projection projection) {
@@ -52,7 +54,7 @@ public class PhysicalWindowOperator extends PhysicalOperator {
         this.orderByElements = orderByElements;
         this.analyticWindow = analyticWindow;
         this.enforceOrderBy = enforceOrderBy;
-
+        this.useHashBasedPartition = useHashBasedPartition;
         this.limit = limit;
         this.predicate = predicate;
         this.projection = projection;
@@ -76,6 +78,10 @@ public class PhysicalWindowOperator extends PhysicalOperator {
 
     public List<Ordering> getEnforceOrderBy() {
         return enforceOrderBy;
+    }
+
+    public boolean isUseHashBasedPartition() {
+        return useHashBasedPartition;
     }
 
     @Override
@@ -102,12 +108,14 @@ public class PhysicalWindowOperator extends PhysicalOperator {
         return Objects.equals(analyticCall, that.analyticCall) &&
                 Objects.equals(partitionExpressions, that.partitionExpressions) &&
                 Objects.equals(orderByElements, that.orderByElements) &&
-                Objects.equals(analyticWindow, that.analyticWindow);
+                Objects.equals(analyticWindow, that.analyticWindow) &&
+                Objects.equals(useHashBasedPartition, that.useHashBasedPartition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), analyticCall);
+        return Objects.hash(super.hashCode(), analyticCall, partitionExpressions, orderByElements, analyticWindow,
+                useHashBasedPartition);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/WindowImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/WindowImplementationRule.java
@@ -41,6 +41,7 @@ public class WindowImplementationRule extends ImplementationRule {
                 logical.getOrderByElements(),
                 logical.getAnalyticWindow(),
                 logical.getEnforceSortColumns(),
+                logical.isUseHashBasedPartition(),
                 logical.getLimit(),
                 logical.getPredicate(),
                 logical.getProjection());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -327,17 +327,10 @@ class QueryTransformer {
             }
         }
 
-        List<WindowTransformer.PartitionGroup> partitionGroups =
+        List<LogicalWindowOperator> logicalWindowOperators =
                 WindowTransformer.reorderWindowOperator(windowOperators, columnRefFactory, subOpt);
-        for (WindowTransformer.PartitionGroup partitionGroup : partitionGroups) {
-            for (WindowTransformer.SortGroup sortGroup : partitionGroup.getSortGroups()) {
-                for (LogicalWindowOperator logicalWindowOperator : sortGroup.getWindowOperators()) {
-                    LogicalWindowOperator newLogicalWindowOperator =
-                            new LogicalWindowOperator.Builder().withOperator(logicalWindowOperator)
-                                    .setEnforceSortColumns(sortGroup.getEnforceSortColumns()).build();
-                    subOpt = subOpt.withNewRoot(newLogicalWindowOperator);
-                }
-            }
+        for (LogicalWindowOperator logicalWindowOperator : logicalWindowOperators) {
+            subOpt = subOpt.withNewRoot(logicalWindowOperator);
         }
 
         return subOpt;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -29,6 +29,7 @@ import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.OrderByElement;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.Ordering;
@@ -283,9 +284,13 @@ public class WindowTransformer {
             // Each LogicalWindowOperator will belong to a SortGroup,
             // so we need to record sortProperty to ensure that only one SortNode is enforced
             List<Ordering> sortEnforceProperty = new ArrayList<>();
-            partitions.forEach(p -> sortEnforceProperty.add(new Ordering((ColumnRefOperator) p, true, true)));
+            ConnectContext session = ConnectContext.get();
+            if (!session.getSessionVariable().isEnablePipelineEngine() || !orderings.isEmpty()) {
+                partitions.forEach(p -> sortEnforceProperty.add(new Ordering((ColumnRefOperator) p, true, true)));
+            }
             for (Ordering ordering : orderings) {
-                if (sortEnforceProperty.stream().noneMatch(sp -> sp.getColumnRef().equals(ordering.getColumnRef()))) {
+                if (sortEnforceProperty.stream()
+                        .noneMatch(sp -> sp.getColumnRef().equals(ordering.getColumnRef()))) {
                     sortEnforceProperty.add(ordering);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -30,6 +30,7 @@ import com.starrocks.analysis.OrderByElement;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.Ordering;
@@ -240,15 +241,14 @@ public class WindowTransformer {
      * SortGroup represent the window functions that can be calculated in one SortNode
      * to reduce the generation of SortNode
      */
-    public static List<WindowTransformer.PartitionGroup> reorderWindowOperator(
+    public static List<LogicalWindowOperator> reorderWindowOperator(
             List<WindowOperator> windowOperators, ColumnRefFactory columnRefFactory, OptExprBuilder subOpt) {
         /*
-         * Step 1.
          * Generate a LogicalAnalyticOperator for each group of
          * window function with the same window frame, partition and order by
          */
         List<LogicalWindowOperator> logicalWindowOperators = new ArrayList<>();
-        for (WindowTransformer.WindowOperator windowOperator : windowOperators) {
+        for (WindowOperator windowOperator : windowOperators) {
             Map<ColumnRefOperator, CallOperator> analyticCall = new HashMap<>();
 
             for (AnalyticExpr analyticExpr : windowOperator.getWindowFunctions()) {
@@ -284,8 +284,7 @@ public class WindowTransformer {
             // Each LogicalWindowOperator will belong to a SortGroup,
             // so we need to record sortProperty to ensure that only one SortNode is enforced
             List<Ordering> sortEnforceProperty = new ArrayList<>();
-            ConnectContext session = ConnectContext.get();
-            if (!session.getSessionVariable().isEnablePipelineEngine() || !orderings.isEmpty()) {
+            if (!windowOperator.useHashBasedPartition) {
                 partitions.forEach(p -> sortEnforceProperty.add(new Ordering((ColumnRefOperator) p, true, true)));
             }
             for (Ordering ordering : orderings) {
@@ -301,18 +300,71 @@ public class WindowTransformer {
                     .setOrderByElements(orderings)
                     .setAnalyticWindow(windowOperator.getWindow())
                     .setEnforceSortColumns(sortEnforceProperty.stream().distinct().collect(Collectors.toList()))
+                    .setUseHashBasedPartition(windowOperator.useHashBasedPartition)
                     .build());
         }
 
+        List<LogicalWindowOperator> hashBasedWindowOperators = logicalWindowOperators.stream()
+                .filter(LogicalWindowOperator::isUseHashBasedPartition)
+                .collect(Collectors.toList());
+        List<LogicalWindowOperator> sortBasedWindowOperators = logicalWindowOperators.stream()
+                .filter(op -> !op.isUseHashBasedPartition())
+                .collect(Collectors.toList());
+
+        List<PartitionGroup<?>> partitionGroups = new ArrayList<>();
+
+        partitionGroups.addAll(reorderHashBasedWindowOperator(hashBasedWindowOperators));
+        partitionGroups.addAll(reorderSortedBasedWindowOperator(sortBasedWindowOperators));
+
+        partitionGroups.sort(Comparator.comparingInt(p -> p.partitionExpressions.size() * -1));
+
+        List<LogicalWindowOperator> reorderedWindowOperators = new ArrayList<>();
+        for (PartitionGroup<?> partitionGroup : partitionGroups) {
+            for (Object item : partitionGroup.getItems()) {
+                if (item instanceof SortGroup) {
+                    SortGroup sortGroup = (SortGroup) item;
+                    for (LogicalWindowOperator windowOperator : sortGroup.getWindowOperators()) {
+                        reorderedWindowOperators.add(new LogicalWindowOperator.Builder()
+                                .withOperator(windowOperator)
+                                .setEnforceSortColumns(sortGroup.getEnforceSortColumns())
+                                .build());
+                    }
+                } else if (item instanceof LogicalWindowOperator) {
+                    reorderedWindowOperators.add((LogicalWindowOperator) item);
+                }
+            }
+        }
+
+        return reorderedWindowOperators;
+    }
+
+    private static List<PartitionGroup<LogicalWindowOperator>> reorderHashBasedWindowOperator(
+            List<LogicalWindowOperator> hashBasedWindowOperators) {
+
+        List<PartitionGroup<LogicalWindowOperator>> partitionGroups = new ArrayList<>();
+
+        for (LogicalWindowOperator windowOperator : hashBasedWindowOperators) {
+            PartitionGroup<LogicalWindowOperator> partitionGroup = new PartitionGroup<>();
+            partitionGroup.setPartitionExpressions(windowOperator.getPartitionExpressions());
+            partitionGroup.addItem(windowOperator);
+            partitionGroups.add(partitionGroup);
+        }
+
+        return partitionGroups;
+    }
+
+    private static List<PartitionGroup<SortGroup>> reorderSortedBasedWindowOperator(
+            List<LogicalWindowOperator> sortBasedWindowOperators) {
+
         /*
-         * Step 2.
+         * Step 1.
          * SortGroup represent the window functions that can be calculated in one SortNode
          * to reduce the generation of SortNode
          */
-        List<WindowTransformer.SortGroup> sortedGroups = new ArrayList<>();
-        for (LogicalWindowOperator windowOperator : logicalWindowOperators) {
+        List<SortGroup> sortedGroups = new ArrayList<>();
+        for (LogicalWindowOperator windowOperator : sortBasedWindowOperators) {
             boolean find = false;
-            for (WindowTransformer.SortGroup windowInSorted : sortedGroups) {
+            for (SortGroup windowInSorted : sortedGroups) {
                 if (!isPrefixHyperPartitionSet(windowOperator.getPartitionExpressions(),
                         windowInSorted.getPartitionExprs())
                         && !isPrefixHyperPartitionSet(windowInSorted.getPartitionExprs(),
@@ -337,7 +389,7 @@ public class WindowTransformer {
             }
 
             if (!find) {
-                WindowTransformer.SortGroup sortGroup = new WindowTransformer.SortGroup(
+                SortGroup sortGroup = new SortGroup(
                         windowOperator.getEnforceSortColumns(), windowOperator.getPartitionExpressions());
                 sortGroup.addWindowOperator(windowOperator);
                 sortedGroups.add(sortGroup);
@@ -345,7 +397,7 @@ public class WindowTransformer {
         }
 
         /*
-         * Step 3.
+         * Step 2.
          * Put the nodes with more partition columns at the top of the query plan
          * to ensure that the Enforce operation can meet the conditions, and only one ExchangeNode will be generated
          */
@@ -353,35 +405,34 @@ public class WindowTransformer {
                 .sort(Comparator.comparingInt(w -> w.getPartitionExpressions().size())));
 
         /*
-         * Step4.
+         * Step 3.
          * The nodes with the same partition group are placed together to reduce the generation of Exchange nodes.
          */
-        List<PartitionGroup> partitionGroups = new ArrayList<>();
+        List<PartitionGroup<SortGroup>> partitionGroups = new ArrayList<>();
         for (SortGroup sortGroup : sortedGroups) {
             boolean find = false;
-            for (PartitionGroup partitionGroup : partitionGroups) {
+            for (PartitionGroup<SortGroup> partitionGroup : partitionGroups) {
                 if (isPrefixHyperPartitionSet(sortGroup.partitionExpressions, partitionGroup.partitionExpressions)) {
-                    partitionGroup.addSortGroup(sortGroup);
+                    partitionGroup.addItem(sortGroup);
                     find = true;
                     break;
                 } else if (isPrefixHyperPartitionSet(partitionGroup.partitionExpressions,
                         sortGroup.partitionExpressions)) {
                     partitionGroup.setPartitionExpressions(sortGroup.partitionExpressions);
-                    partitionGroup.addSortGroup(sortGroup);
+                    partitionGroup.addItem(sortGroup);
                     find = true;
                     break;
                 }
             }
             if (!find) {
-                PartitionGroup partitionGroup = new PartitionGroup();
+                PartitionGroup<SortGroup> partitionGroup = new PartitionGroup<>();
                 partitionGroup.setPartitionExpressions(sortGroup.partitionExpressions);
-                partitionGroup.addSortGroup(sortGroup);
+                partitionGroup.addItem(sortGroup);
                 partitionGroups.add(partitionGroup);
             }
         }
-        partitionGroups.forEach(partitionGroup -> partitionGroup.sortGroups.sort(
+        partitionGroups.forEach(partitionGroup -> partitionGroup.items.sort(
                 Comparator.comparingInt(s -> s.getPartitionExprs().size())));
-        partitionGroups.sort(Comparator.comparingInt(p -> p.partitionExpressions.size() * -1));
 
         return partitionGroups;
     }
@@ -445,20 +496,20 @@ public class WindowTransformer {
         }
     }
 
-    public static class PartitionGroup {
-        private final List<SortGroup> sortGroups;
+    public static class PartitionGroup<T> {
+        private final List<T> items;
         private List<ScalarOperator> partitionExpressions;
 
         public PartitionGroup() {
-            sortGroups = new ArrayList<>();
+            items = new ArrayList<>();
         }
 
-        public void addSortGroup(SortGroup sortGroup) {
-            sortGroups.add(sortGroup);
+        public void addItem(T item) {
+            items.add(item);
         }
 
-        public List<SortGroup> getSortGroups() {
-            return sortGroups;
+        public List<T> getItems() {
+            return items;
         }
 
         public void setPartitionExpressions(
@@ -472,6 +523,7 @@ public class WindowTransformer {
         private final List<Expr> partitionExprs;
         private List<OrderByElement> orderByElements;
         private final AnalyticWindow window;
+        private final boolean useHashBasedPartition;
 
         public WindowOperator(AnalyticExpr analyticExpr, List<Expr> partitionExprs,
                               List<OrderByElement> orderByElements, AnalyticWindow window) {
@@ -479,6 +531,22 @@ public class WindowTransformer {
             this.partitionExprs = partitionExprs;
             this.orderByElements = orderByElements;
             this.window = window;
+            SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
+            if (!partitionExprs.isEmpty() && orderByElements.isEmpty()) {
+                if (!sessionVariable.isEnablePipelineEngine()) {
+                    this.useHashBasedPartition = false;
+                } else {
+                    if (analyticExpr.getPartitionHint() == null) {
+                        // Respect session variable if there is no hint
+                        this.useHashBasedPartition = sessionVariable.getWindowPartitionMode() == 2;
+                    } else {
+                        // Respect hint if it exists
+                        this.useHashBasedPartition = analyticExpr.isUseHashBasedPartition();
+                    }
+                }
+            } else {
+                this.useHashBasedPartition = false;
+            }
         }
 
         public void addFunction(AnalyticExpr analyticExpr) {
@@ -517,12 +585,14 @@ public class WindowTransformer {
             }
             WindowOperator that = (WindowOperator) o;
             return Objects.equals(partitionExprs, that.partitionExprs) &&
-                    Objects.equals(orderByElements, that.orderByElements) && Objects.equals(window, that.window);
+                    Objects.equals(orderByElements, that.orderByElements) &&
+                    Objects.equals(window, that.window) &&
+                    Objects.equals(useHashBasedPartition, that.useHashBasedPartition);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(partitionExprs, orderByElements, window);
+            return Objects.hash(partitionExprs, orderByElements, window, useHashBasedPartition);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4781,7 +4781,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         List<Expr> partitionExprs = visit(context.partition, Expr.class);
 
         return new AnalyticExpr(functionCallExpr, partitionExprs, orderByElements,
-                (AnalyticWindow) visitIfPresent(context.windowFrame()));
+                (AnalyticWindow) visitIfPresent(context.windowFrame()),
+                context.bracketHint() == null ? null : context.bracketHint().identifier(0).getText());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1858,7 +1858,7 @@ whenClause
 
 over
     : OVER '('
-        (PARTITION BY partition+=expression (',' partition+=expression)*)?
+        (bracketHint? PARTITION BY partition+=expression (',' partition+=expression)*)?
         (ORDER BY sortItem (',' sortItem)*)?
         windowFrame?
       ')'

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -327,7 +327,8 @@ public class PlanFragmentBuilder {
                 FragmentNormalizer normalizer = new FragmentNormalizer(execPlan, fragment);
                 normalizer.normalize();
             }
-        } else if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().isEnableRuntimeAdaptiveDop()) {
+        } else if (ConnectContext.get() != null &&
+                ConnectContext.get().getSessionVariable().isEnableRuntimeAdaptiveDop()) {
             for (PlanFragment fragment : fragments) {
                 if (fragment.canUseRuntimeAdaptiveDop()) {
                     fragment.enableAdaptiveDop();
@@ -2297,6 +2298,7 @@ public class PlanFragmentBuilder {
                     partitionExprs,
                     orderByElements,
                     node.getAnalyticWindow(),
+                    node.isUseHashBasedPartition(),
                     null, outputTupleDesc, null, null,
                     context.getDescTbl().createTupleDescriptor());
             analyticEvalNode.setSubstitutedPartitionExprs(partitionExprs);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
@@ -59,7 +59,7 @@ class ExprHashCodeTest {
                 predicate, predicate);
         ArithmeticExpr arithmeticExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, intLiteral, largeIntLiteral);
         AnalyticExpr analyticExpr = new AnalyticExpr(functionCallExpr, ImmutableList.of(stringLiteral),
-                null, AnalyticWindow.DEFAULT_WINDOW);
+                null, AnalyticWindow.DEFAULT_WINDOW, null);
         List<Expr> exprList = Lists.newArrayList(floatLiteral, intLiteral, largeIntLiteral, stringLiteral, dateLiteral,
                 decimalLiteral, functionCallExpr, likePredicate, existsPredicate, predicate, compoundPredicate,
                 arithmeticExpr, analyticExpr);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
@@ -691,5 +690,46 @@ public class WindowTest extends PlanTestBase {
                 "  |  cardinality: 1\n" +
                 "  |  probe runtime filters:\n" +
                 "  |  - filter_id = 0, probe_expr = (1: v1)");
+    }
+
+    @Test
+    public void testHashBasedWindowTest() throws Exception {
+        {
+            String sql = "select sum(v1) over ([hash] partition by v1,v2 )," +
+                    "sum(v1/v3) over ([hash] partition by v1,v2 ) " +
+                    "from t0";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, sum(1: v1), ], [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  useHashBasedPartition");
+        }
+        {
+            String sql = "select sum(v1) over ( partition by v1,v2 )," +
+                    "sum(v1/v3) over ([hash] partition by v1,v2 ) " +
+                    "from t0";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  4:ANALYTIC\n" +
+                    "  |  functions: [, sum(1: v1), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2");
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  useHashBasedPartition");
+        }
+        {
+            String sql = "select sum(v1) over ([hash] partition by v1 )," +
+                    "sum(v1/v3) over ([hash] partition by v1,v2 ) " +
+                    "from t0";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  4:ANALYTIC\n" +
+                    "  |  functions: [, sum(1: v1), ]\n" +
+                    "  |  partition by: 1: v1\n" +
+                    "  |  useHashBasedPartition");
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  useHashBasedPartition");
+        }
     }
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -807,6 +807,7 @@ struct TAnalyticNode {
   11: optional string sql_aggregate_functions
 
   20: optional bool has_outer_join_child
+  21: optional bool use_hash_based_partition
 }
 
 struct TMergeNode {


### PR DESCRIPTION
Signed-off-by: liuyehcf <1559500551@qq.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17955

## Enhancement

As stated in https://github.com/StarRocks/starrocks/issues/17955. Hash-based window function may provide significant boost in performance for some cases.

Think about the query `select sum(v1) over(partition by v2,v3,...) from t0`, the evaluation doesn't rely on orderliness, and all it is needed is the rows with same value of partition by columns are putting together. So we can perform either sort or hash partition ahead of window function.

But here comes the problem: how to choose sort-based or hash-based? The deciding factor is **cardinality**.
* For low cardinality, hash-based is more efficient than sort-based
* For high cardinality, hash-based requires much more memory and performance could be very bad

## Changelist

1. Add `HashPartition{Sink/Source}Operator` pair to support hash partitioner.
2. Add session variable `window_partition_mode` to modify the default implementation of partition by
    * 1(default)：sort
    * 2：hash
3. Add partition hint, `[hash] partition by v1` or `[sort] partition by v2`. And `window_partition_mode` will be ignored if `hint` exists.

## Experiment

Env：1fe/3be, 16c/64 for each

Cardinality of each column in the table `t0`(100M rows)：
* `par_int_low`：200
* `par_int_high`：10w
* `par_str_low`：200
* `par_str_high`：10w

Cardinality of each column in table `lineitem`(tpch-100g)：
* `l_linestatus`：2
* `l_returnflag`：3
* `l_shipinstruct`：4
* `l_shipmode`：7
* `l_linenumber`：7
* `l_tax`：9
* `l_discount`：11
* `l_quantity`：50
* `l_commitdate`：2466
* `l_shipdate`：2526
* `l_receiptdate`：2555
* `l_suppkey`：1000000
* `l_extendedprice`：3786026
* `l_partkey`：20000000
* `l_comment`：142510152
* `l_orderkey`：150000000

```sql
-- Q1
select sum(wv) from (
    select sum(fn_int) over(partition by par_int_low) as wv from t0
) a

-- Q2
select sum(wv) from (
    select sum(fn_int) over(partition by par_int_high) as wv from t0
) a

-- Q3
select sum(wv) from (
    select sum(fn_int) over(partition by par_str_low) as wv from t0
) a

-- Q4
select sum(wv) from (
    select sum(fn_int) over(partition by par_str_high) as wv from t0
) a

-- Q5
select sum(wv) from (
    select sum(fn_int) over(partition by par_int_low, par_str_low) as wv from t0
) a

-- Q6
select sum(wv) from (
    select sum(fn_int) over(partition by par_int_high, par_str_high) as wv from t0
) a

-- Q7
-- partition cardinality=112
select sum(wv) from (
    select sum(L_ORDERKEY) over(partition by l_linestatus, l_returnflag, l_shipinstruct, l_shipmode) as wv
    from lineitem
)a

-- Q8
-- partition cardinality=784
select sum(wv) from (
    select sum(L_ORDERKEY) over(partition by l_linestatus, l_returnflag, l_shipinstruct, l_shipmode, l_linenumber) as wv
    from lineitem
)a

-- Q9
-- partition cardinality=7056
select sum(wv) from (
    select sum(L_ORDERKEY) over(partition by l_linestatus, l_returnflag, l_shipinstruct, l_shipmode, l_linenumber, l_tax) as wv
    from lineitem
)a

-- Q10
-- partition cardinality=77616
select sum(wv) from (
    select sum(L_ORDERKEY) over(partition by l_linestatus, l_returnflag, l_shipinstruct, l_shipmode, l_linenumber, l_tax,l_discount) as wv
    from lineitem
)a

-- Q11
-- partition cardinality=3798995
select sum(wv) from (
    select sum(L_ORDERKEY) over(partition by l_linestatus, l_returnflag, l_shipinstruct, l_shipmode, l_linenumber, l_tax,l_discount,l_quantity) as wv
    from lineitem
)a
```

| Query | Sort-based | Hash-based |
|:--|:--|:--|
| Q1 | 0.736s-917.14 MB | 0.340s-1.04 GB |
| Q2 | 0.977s-959.83 MB | 1.499s-1.15 GB |
| Q3 | 4.688s-1.77 GB | 0.951s-2.90 GB |
| Q4 | 3.441s-2.87 GB | 3.062s-3.04 GB |
| Q5 | 6.985s-2.32 GB | 2.387s-3.77 GB |
| Q6 | 3.307s-3.77 GB | OOM |
| Q7 | 91.266s-11.76 GB | 13.218s-19.43 GB |
| Q8 | 91.652s-11.11 GB | 8.752s-16.63 GB |
| Q9 | 103.085s-13.63 GB | 10.623s-19.24 GB |
| Q10 | 124.747s-15.46 GB | 18.823s-22.50 GB |
| Q11 | 144.973s-17.71 GB | 68.111s-26.64 GB |

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
