### PR TITLE
[BugFix] Fix parquet DictDecoder<Slice> array out of bounds access

### DIFF
--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -214,6 +214,7 @@ public:
     }
 
     Status next_batch(size_t count, ColumnContentType content_type, Column* dst) override {
+        _indexes.reserve(count);
         _index_batch_decoder.GetBatch(&_indexes[0], count);
 
         switch (content_type) {


### PR DESCRIPTION
Signed-off-by: Smith Cruise <chendingchao1@126.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We resize _indexes with a chunk size(4096) in `set_dict()`.
If the user has a col `ARRAY<INT>`, it has more than 4096 elements in one row, in `next_batch()` function, the `count` value is larger than 4096. So to be safe, we need to `reserve()` vector before writing to `_indexes`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
