### PR TITLE
[BugFix] Fix the bug that the primary key table supports mixed upserts and deletes causing BE crash

### DIFF
--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -283,6 +283,7 @@ Status RowsetWriter::flush_segment(const SegmentPB& segment_pb, butil::IOBuf& da
         }
         RETURN_IF_ERROR(wfile->close());
 
+        _delfile_idxes.emplace_back(_num_segment + _num_delfile);
         _num_delfile++;
         _num_rows_del += segment_pb.delete_num_rows();
 


### PR DESCRIPTION
Signed-off-by: zhangqiang <qiangzh95@gmail.com>

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1890

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This bug was introduced by the pr(https://github.com/StarRocks/starrocks/pull/17264) which add support  for mix upsert and delete for primary key table.

The pr introduced the `_delfile_idxes` to save the delete file idxes but ignore the replicated storage engine.  It only update the `_num_delfile` but not update `_delfile_idxes`. So BE will crash in the following check `DCHECK(_delfile_idxes.size() == _num_delfile);`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
