### PR TITLE
[Enhancement] Full sort late materialization

### DIFF
--- a/be/src/exec/chunks_sorter.cpp
+++ b/be/src/exec/chunks_sorter.cpp
@@ -153,7 +153,7 @@ ChunksSorter::ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>*
 
 ChunksSorter::~ChunksSorter() = default;
 
-void ChunksSorter::setup_runtime(RuntimeProfile* profile) {
+void ChunksSorter::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
     _build_timer = ADD_TIMER(profile, "BuildingTime");
     _sort_timer = ADD_TIMER(profile, "SortingTime");
     _merge_timer = ADD_TIMER(profile, "MergingTime");

--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -105,7 +105,7 @@ public:
                                                             const SortExecExprs& sort_exec_exprs,
                                                             const std::vector<OrderByType>& order_by_types);
 
-    virtual void setup_runtime(RuntimeProfile* profile);
+    virtual void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker);
 
     // Append a Chunk for sort.
     virtual Status update(RuntimeState* state, const ChunkPtr& chunk) = 0;

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -17,7 +17,10 @@
 #include "exec/sorting/merge.h"
 #include "exec/sorting/sort_permute.h"
 #include "exec/sorting/sorting.h"
+#include "exprs/column_ref.h"
 #include "exprs/expr.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 #include "util/stopwatch.hpp"
 
@@ -25,11 +28,24 @@ namespace starrocks {
 
 ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                            const std::vector<bool>* is_asc_order,
-                                           const std::vector<bool>* is_null_first, const std::string& sort_keys)
-        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false) {}
+                                           const std::vector<bool>* is_null_first, const std::string& sort_keys,
+                                           int64_t max_buffered_rows, int64_t max_buffered_bytes,
+                                           const std::vector<SlotId>& eager_materialized_slots)
+        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false),
+          max_buffered_rows(static_cast<size_t>(max_buffered_rows)),
+          max_buffered_bytes(max_buffered_bytes),
+          _eager_materialized_slots(eager_materialized_slots.begin(), eager_materialized_slots.end()) {}
 
 ChunksSorterFullSort::~ChunksSorterFullSort() = default;
-
+void ChunksSorterFullSort::setup_runtime(starrocks::RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
+    _runtime_profile = profile;
+    _parent_mem_tracker = parent_mem_tracker;
+    _object_pool = std::make_unique<ObjectPool>();
+    _runtime_profile->add_info_string("MaxBufferedRows", strings::Substitute("$0", max_buffered_rows));
+    _runtime_profile->add_info_string("MaxBufferedBytes", strings::Substitute("$0", max_buffered_bytes));
+    _profiler = _object_pool->add(new ChunksSorterFullSortProfiler(profile, parent_mem_tracker));
+}
 Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) {
     _merge_unsorted(state, chunk);
     _partial_sort(state, false);
@@ -40,29 +56,54 @@ Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) 
 // Accumulate unsorted input chunks into a larger chunk
 Status ChunksSorterFullSort::_merge_unsorted(RuntimeState* state, const ChunkPtr& chunk) {
     SCOPED_TIMER(_build_timer);
-
-    if (_unsorted_chunk == nullptr) {
-        // TODO: optimize the copy
-        _unsorted_chunk.reset(chunk->clone_unique().release());
-    } else {
-        _unsorted_chunk->append(*chunk);
-    }
-
+    _staging_unsorted_chunks.push_back(std::move(chunk));
+    _staging_unsorted_rows += chunk->num_rows();
+    _staging_unsorted_bytes += chunk->bytes_usage();
     return Status::OK();
 }
 
+template <typename BinaryColumnType>
+static void reserve_memory(Column* dst_col, const std::vector<ChunkPtr>& src_chunks, size_t col_idx) {
+    auto* binary_dst_col = down_cast<BinaryColumnType*>(dst_col);
+    size_t total_num_bytes = 0;
+    for (const auto& src_chk : src_chunks) {
+        const auto* src_data_col = ColumnHelper::get_data_column(src_chk->get_column_by_index(col_idx).get());
+        const auto* src_binary_col = down_cast<const BinaryColumnType*>(src_data_col);
+        total_num_bytes += src_binary_col->get_bytes().size();
+    }
+    binary_dst_col->get_bytes().reserve(total_num_bytes);
+}
+
+static void concat_chunks(ChunkPtr& dst_chunk, const std::vector<ChunkPtr>& src_chunks, size_t num_rows) {
+    DCHECK(!src_chunks.empty());
+    dst_chunk = src_chunks.front()->clone_empty(num_rows);
+    const auto num_columns = dst_chunk->num_columns();
+    for (auto i = 0; i < num_columns; ++i) {
+        auto dst_col = dst_chunk->get_column_by_index(i);
+        auto* dst_data_col = ColumnHelper::get_data_column(dst_col.get());
+        if (dst_data_col->is_binary()) {
+            reserve_memory<BinaryColumn>(dst_data_col, src_chunks, i);
+        } else if (dst_col->is_large_binary()) {
+            reserve_memory<LargeBinaryColumn>(dst_data_col, src_chunks, i);
+        }
+    }
+    for (const auto& src_chk : src_chunks) {
+        dst_chunk->append(*src_chk);
+    }
+}
 // Sort the large chunk
 Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
-    if (!_unsorted_chunk) {
+    if (!_staging_unsorted_rows) {
         return Status::OK();
     }
-    bool reach_limit = _unsorted_chunk->num_rows() >= kMaxBufferedChunkSize ||
-                       _unsorted_chunk->bytes_usage() >= kMaxBufferedChunkBytes;
+    bool reach_limit = _staging_unsorted_rows >= max_buffered_rows || _staging_unsorted_bytes >= max_buffered_bytes;
     if (done || reach_limit) {
-        SCOPED_TIMER(_sort_timer);
-
+        _max_num_rows = std::max<int>(_max_num_rows, _staging_unsorted_rows);
+        _profiler->input_required_memory->update(_staging_unsorted_bytes);
+        concat_chunks(_unsorted_chunk, _staging_unsorted_chunks, _staging_unsorted_rows);
         RETURN_IF_ERROR(_unsorted_chunk->upgrade_if_overflow());
 
+        SCOPED_TIMER(_sort_timer);
         DataSegment segment(_sort_exprs, _unsorted_chunk);
         _sort_permutation.resize(0);
         RETURN_IF_ERROR(
@@ -73,7 +114,10 @@ Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
 
         _sorted_chunks.emplace_back(std::move(sorted_chunk));
         _total_rows += _unsorted_chunk->num_rows();
-        _unsorted_chunk.reset();
+        _unsorted_chunk->reset();
+        _staging_unsorted_rows = 0;
+        _staging_unsorted_bytes = 0;
+        _staging_unsorted_chunks.clear();
     }
 
     return Status::OK();
@@ -81,15 +125,128 @@ Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
 
 Status ChunksSorterFullSort::_merge_sorted(RuntimeState* state) {
     SCOPED_TIMER(_merge_timer);
-
-    RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _sorted_chunks, &_merged_runs));
+    _profiler->num_sorted_runs->set((int64_t)_sorted_chunks.size());
+    if (_eager_materialized_slots.empty() || _sorted_chunks.size() < 3) {
+        _runtime_profile->add_info_string("LazyMaterialization", "false");
+        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _sorted_chunks, &_merged_runs));
+    } else {
+        _runtime_profile->add_info_string("LazyMaterialization", "true");
+        _split_lazy_and_eager_chunks();
+        _assign_ordinals();
+        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _eager_materialized_chunks, &_merged_runs));
+    }
 
     return Status::OK();
 }
 
+void ChunksSorterFullSort::_assign_ordinals() {
+    _chunk_idx_bits = (int)std::ceil(std::log2(_eager_materialized_chunks.size()));
+    _chunk_idx_bits = std::max(1, _chunk_idx_bits);
+    _offset_in_chunk_bits = (int)std::ceil(std::log2(_max_num_rows));
+    _offset_in_chunk_bits = std::max(1, _offset_in_chunk_bits);
+    auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
+    _runtime_profile->add_info_string("LazyMaterializationUse64BitOrdinal",
+                                      strings::Substitute("$0", use_64bit_ordinal));
+    if (use_64bit_ordinal) {
+        _assign_ordinals_tmpl<uint64_t>();
+    } else {
+        _assign_ordinals_tmpl<uint32_t>();
+    }
+}
+TYPE_GUARD(OrdinalGuard, type_is_ordinal, uint32_t, uint64_t);
+
+template <typename T, typename = OrdinalGuard<T>>
+using OrdinalColumn = FixedLengthColumn<T>;
+
+template <typename T>
+void ChunksSorterFullSort::_assign_ordinals_tmpl() {
+    static_assert(type_is_ordinal<T>, "T must be uint32_t or uint64_t");
+    size_t chunk_idx = 0;
+    for (auto& partial_sort_chunk : _eager_materialized_chunks) {
+        if (partial_sort_chunk->is_empty()) {
+            ++chunk_idx;
+            continue;
+        }
+        size_t num_rows = partial_sort_chunk->num_rows();
+        auto ordinal_column = OrdinalColumn<T>::create();
+        auto& ordinal_data = down_cast<OrdinalColumn<T>*>(ordinal_column.get())->get_data();
+        raw::make_room(&ordinal_data, num_rows);
+        for (T off = 0; off < num_rows; ++off) {
+            ordinal_data[off] = static_cast<T>((chunk_idx << _offset_in_chunk_bits) | off);
+        }
+        partial_sort_chunk->append_column(ordinal_column, ORDINAL_COLUMN_SLOT_ID);
+        ++chunk_idx;
+    }
+}
+
+void ChunksSorterFullSort::_split_lazy_and_eager_chunks() {
+    _eager_materialized_chunks.reserve(_sorted_chunks.size());
+    _lazy_materialized_chunks.reserve(_sorted_chunks.size());
+    auto& slot_id_to_column_id = _sorted_chunks[0]->get_slot_id_to_index_map();
+    _column_id_to_slot_id.resize(slot_id_to_column_id.size());
+    for (auto it : _sorted_chunks[0]->get_slot_id_to_index_map()) {
+        _column_id_to_slot_id[it.second] = it.first;
+    }
+    for (auto& chunk : _sorted_chunks) {
+        auto eager_chunk = std::make_unique<Chunk>();
+        auto lazy_chunk = std::make_unique<Chunk>();
+        for (auto column_id = 0; column_id < chunk->num_columns(); ++column_id) {
+            auto slot_id = _column_id_to_slot_id[column_id];
+            auto column = chunk->columns()[column_id];
+            if (_eager_materialized_slots.count(slot_id)) {
+                eager_chunk->append_column(column, slot_id);
+            } else {
+                lazy_chunk->append_column(column, slot_id);
+            }
+        }
+        _eager_materialized_chunks.push_back(std::move(eager_chunk));
+        _lazy_materialized_chunks.push_back(std::move(lazy_chunk));
+    }
+    _sorted_chunks.clear();
+}
+
+ChunkPtr ChunksSorterFullSort::_lazy_materialize(const starrocks::ChunkPtr& chunk) {
+    auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
+    if (use_64bit_ordinal) {
+        return _lazy_materialize_tmpl<uint64_t>(chunk);
+    } else {
+        return _lazy_materialize_tmpl<uint32_t>(chunk);
+    }
+}
+
+template <typename T>
+starrocks::ChunkPtr ChunksSorterFullSort::_lazy_materialize_tmpl(const starrocks::ChunkPtr& sorted_eager_chunk) {
+    static_assert(type_is_ordinal<T>, "T must be uint32_t or uint64_t");
+    const auto num_rows = sorted_eager_chunk->num_rows();
+    auto sorted_lazy_chunk = _lazy_materialized_chunks[0]->clone_empty(num_rows);
+    auto ordinal_column = sorted_eager_chunk->get_column_by_slot_id(ORDINAL_COLUMN_SLOT_ID);
+    auto& ordinal_data = down_cast<OrdinalColumn<T>*>(ordinal_column.get())->get_data();
+    T _offset_in_chunk_mask = static_cast<T>((1L << _offset_in_chunk_bits) - 1);
+    for (auto i = 0; i < num_rows; ++i) {
+        T ordinal = ordinal_data[i];
+        T chunk_idx = ordinal >> _offset_in_chunk_bits;
+        T off_in_chunk = ordinal & _offset_in_chunk_mask;
+        sorted_lazy_chunk->append(*_lazy_materialized_chunks[chunk_idx], off_in_chunk, 1);
+    }
+    auto final_chunk = std::make_shared<Chunk>();
+    for (auto slot_id : _column_id_to_slot_id) {
+        if (_eager_materialized_slots.count(slot_id)) {
+            final_chunk->append_column(sorted_eager_chunk->get_column_by_slot_id(slot_id), slot_id);
+        } else {
+            final_chunk->append_column(sorted_lazy_chunk->get_column_by_slot_id(slot_id), slot_id);
+        }
+    }
+    return final_chunk;
+}
 Status ChunksSorterFullSort::done(RuntimeState* state) {
     RETURN_IF_ERROR(_partial_sort(state, true));
-    RETURN_IF_ERROR(_merge_sorted(state));
+    {
+        typeof(_sort_permutation) tmp;
+        tmp.swap(_sort_permutation);
+        _unsorted_chunk.reset();
+    }
+    { RETURN_IF_ERROR(_merge_sorted(state)); }
+
     return Status::OK();
 }
 
@@ -104,6 +261,9 @@ Status ChunksSorterFullSort::get_next(ChunkPtr* chunk, bool* eos) {
     SortedRun& run = _merged_runs.front();
     *chunk = run.steal_chunk(chunk_size);
     if (*chunk != nullptr) {
+        if (!_eager_materialized_slots.empty()) {
+            *chunk = _lazy_materialize(*chunk);
+        }
         RETURN_IF_ERROR((*chunk)->downgrade());
     }
     if (run.empty()) {

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -133,10 +133,10 @@ Status ChunksSorterFullSort::_merge_sorted(RuntimeState* state) {
     // in at most one pass. there is no need to enable lazy materialization which eliminates non-order-by output
     // columns's permutation in multiple passes.
     if (_early_materialized_slots.empty() || _sorted_chunks.size() < 3) {
-        _runtime_profile->add_info_string("LazyMaterialization", "false");
+        _runtime_profile->add_info_string("LateMaterialization", "false");
         RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _sorted_chunks, &_merged_runs));
     } else {
-        _runtime_profile->add_info_string("LazyMaterialization", "true");
+        _runtime_profile->add_info_string("LateMaterialization", "true");
         _split_lazy_and_eager_chunks();
         _assign_ordinals();
         RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _early_materialized_chunks, &_merged_runs));
@@ -154,7 +154,7 @@ void ChunksSorterFullSort::_assign_ordinals() {
     // 4 billion rows, it may happen in product environment extremely rarely, if it really happens,
     // 64 bit ordinal is adopted.
     auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
-    _runtime_profile->add_info_string("LazyMaterializationUse64BitOrdinal",
+    _runtime_profile->add_info_string("LateMaterializationUse64BitOrdinal",
                                       strings::Substitute("$0", use_64bit_ordinal));
 
     if (use_64bit_ordinal) {

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -66,14 +66,14 @@ private:
     Status _merge_unsorted(RuntimeState* state, const ChunkPtr& chunk);
     Status _partial_sort(RuntimeState* state, bool done);
     Status _merge_sorted(RuntimeState* state);
-    void _split_lazy_and_eager_chunks();
+    void _split_late_and_early_chunks();
     static constexpr SlotId ORDINAL_COLUMN_SLOT_ID = -2;
     void _assign_ordinals();
     template <typename T>
     void _assign_ordinals_tmpl();
     ChunkPtr _late_materialize(const ChunkPtr& chunk);
     template <typename T>
-    ChunkPtr _late_materiallize_tmpl(const ChunkPtr& chunk);
+    ChunkPtr _late_materialize_tmpl(const ChunkPtr& chunk);
 
     size_t _total_rows = 0;        // Total rows of sorting data
     Permutation _sort_permutation; // Temp permutation for sorting

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -24,39 +24,12 @@ class ExprContext;
 struct ChunksSorterFullSortProfiler {
     ChunksSorterFullSortProfiler(RuntimeProfile* runtime_profile, MemTracker* parent_mem_tracker)
             : profile(runtime_profile) {
-        merge_unsorted_mem_tracker = std::make_shared<MemTracker>(
-                profile, std::make_tuple(true, true, true), "MergeUnsorted", -1, "local_sort_sink", parent_mem_tracker);
-
-        partial_sort_mem_tracker = std::make_shared<MemTracker>(
-                profile, std::make_tuple(true, true, true), "SortPartial", -1, "local_sort_sink", parent_mem_tracker);
-
-        merge_sorted_mem_tracker = std::make_shared<MemTracker>(
-                profile, std::make_tuple(true, true, true), "MergeSorted", -1, "local_sort_sink", parent_mem_tracker);
-        partial_sort_retention_memory = ADD_COUNTER(profile, "PartialSortRetentionMemory", TUnit::BYTES);
-        final_retention_memory = ADD_COUNTER(profile, "FinalRetentionMemory", TUnit::BYTES);
-        input_alloc_memory = ADD_COUNTER(profile, "InputAllocMemory", TUnit::BYTES);
         input_required_memory = ADD_COUNTER(profile, "InputRequiredMemory", TUnit::BYTES);
-        input_max_alloc_extra_memory = ADD_COUNTER(profile, "InputMaxAllocExtraMemory", TUnit::BYTES);
-        permutation_used_memory = ADD_COUNTER(profile, "PermutationUsedMemory", TUnit::BYTES);
-
-        unsorted_alloc_memory = ADD_COUNTER(profile, "UnsortedAllocMemory", TUnit::BYTES);
-        unsorted_required_memory = ADD_COUNTER(profile, "UnSortedRequiredMemory", TUnit::BYTES);
         num_sorted_runs = ADD_COUNTER(profile, "NumSortedRuns", TUnit::UNIT);
     }
 
     RuntimeProfile* profile{};
-    std::shared_ptr<MemTracker> merge_unsorted_mem_tracker{};
-    std::shared_ptr<MemTracker> partial_sort_mem_tracker{};
-    std::shared_ptr<MemTracker> merge_sorted_mem_tracker{};
-    RuntimeProfile::Counter* partial_sort_retention_memory = nullptr;
-    RuntimeProfile::Counter* final_retention_memory = nullptr;
-    RuntimeProfile::Counter* input_alloc_memory = nullptr;
     RuntimeProfile::Counter* input_required_memory = nullptr;
-    RuntimeProfile::Counter* input_max_alloc_extra_memory = nullptr;
-    RuntimeProfile::Counter* permutation_used_memory = nullptr;
-
-    RuntimeProfile::Counter* unsorted_alloc_memory = nullptr;
-    RuntimeProfile::Counter* unsorted_required_memory = nullptr;
     RuntimeProfile::Counter* num_sorted_runs = nullptr;
 };
 class ChunksSorterFullSort : public ChunksSorter {

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -21,7 +21,44 @@
 
 namespace starrocks {
 class ExprContext;
+struct ChunksSorterFullSortProfiler {
+    ChunksSorterFullSortProfiler(RuntimeProfile* runtime_profile, MemTracker* parent_mem_tracker)
+            : profile(runtime_profile) {
+        merge_unsorted_mem_tracker = std::make_shared<MemTracker>(
+                profile, std::make_tuple(true, true, true), "MergeUnsorted", -1, "local_sort_sink", parent_mem_tracker);
 
+        partial_sort_mem_tracker = std::make_shared<MemTracker>(
+                profile, std::make_tuple(true, true, true), "SortPartial", -1, "local_sort_sink", parent_mem_tracker);
+
+        merge_sorted_mem_tracker = std::make_shared<MemTracker>(
+                profile, std::make_tuple(true, true, true), "MergeSorted", -1, "local_sort_sink", parent_mem_tracker);
+        partial_sort_retention_memory = ADD_COUNTER(profile, "PartialSortRetentionMemory", TUnit::BYTES);
+        final_retention_memory = ADD_COUNTER(profile, "FinalRetentionMemory", TUnit::BYTES);
+        input_alloc_memory = ADD_COUNTER(profile, "InputAllocMemory", TUnit::BYTES);
+        input_required_memory = ADD_COUNTER(profile, "InputRequiredMemory", TUnit::BYTES);
+        input_max_alloc_extra_memory = ADD_COUNTER(profile, "InputMaxAllocExtraMemory", TUnit::BYTES);
+        permutation_used_memory = ADD_COUNTER(profile, "PermutationUsedMemory", TUnit::BYTES);
+
+        unsorted_alloc_memory = ADD_COUNTER(profile, "UnsortedAllocMemory", TUnit::BYTES);
+        unsorted_required_memory = ADD_COUNTER(profile, "UnSortedRequiredMemory", TUnit::BYTES);
+        num_sorted_runs = ADD_COUNTER(profile, "NumSortedRuns", TUnit::UNIT);
+    }
+
+    RuntimeProfile* profile{};
+    std::shared_ptr<MemTracker> merge_unsorted_mem_tracker{};
+    std::shared_ptr<MemTracker> partial_sort_mem_tracker{};
+    std::shared_ptr<MemTracker> merge_sorted_mem_tracker{};
+    RuntimeProfile::Counter* partial_sort_retention_memory = nullptr;
+    RuntimeProfile::Counter* final_retention_memory = nullptr;
+    RuntimeProfile::Counter* input_alloc_memory = nullptr;
+    RuntimeProfile::Counter* input_required_memory = nullptr;
+    RuntimeProfile::Counter* input_max_alloc_extra_memory = nullptr;
+    RuntimeProfile::Counter* permutation_used_memory = nullptr;
+
+    RuntimeProfile::Counter* unsorted_alloc_memory = nullptr;
+    RuntimeProfile::Counter* unsorted_required_memory = nullptr;
+    RuntimeProfile::Counter* num_sorted_runs = nullptr;
+};
 class ChunksSorterFullSort : public ChunksSorter {
 public:
     /**
@@ -33,7 +70,8 @@ public:
      */
     ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                          const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
-                         const std::string& sort_keys);
+                         const std::string& sort_keys, int64_t max_buffered_rows, int64_t max_buffered_bytes,
+                         const std::vector<SlotId>& eager_materialized_slots);
     ~ChunksSorterFullSort() override;
 
     // Append a Chunk for sort.
@@ -45,6 +83,8 @@ public:
 
     int64_t mem_usage() const override;
 
+    void setup_runtime(starrocks::RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
+
 private:
     // Three stages of sorting procedure:
     // 1. Accumulate input chunks into a big chunk(but not exceed the kMaxBufferedChunkSize), to reduce the memory copy during merge
@@ -53,16 +93,42 @@ private:
     Status _merge_unsorted(RuntimeState* state, const ChunkPtr& chunk);
     Status _partial_sort(RuntimeState* state, bool done);
     Status _merge_sorted(RuntimeState* state);
+    void _split_lazy_and_eager_chunks();
+    static constexpr SlotId ORDINAL_COLUMN_SLOT_ID = -2;
+    void _assign_ordinals();
+    template <typename T>
+    void _assign_ordinals_tmpl();
+    ChunkPtr _lazy_materialize(const ChunkPtr& chunk);
+    template <typename T>
+    ChunkPtr _lazy_materialize_tmpl(const ChunkPtr& chunk);
 
-    size_t _total_rows = 0;                     // Total rows of sorting data
-    Permutation _sort_permutation;              // Temp permutation for sorting
+    size_t _total_rows = 0;        // Total rows of sorting data
+    Permutation _sort_permutation; // Temp permutation for sorting
+    size_t _staging_unsorted_rows = 0;
+    size_t _staging_unsorted_bytes = 0;
+    std::vector<ChunkPtr> _staging_unsorted_chunks;
     ChunkPtr _unsorted_chunk;                   // Unsorted chunk, accumulate it to a larger chunk
     std::vector<ChunkUniquePtr> _sorted_chunks; // Partial sorted, but not merged
     SortedRuns _merged_runs;                    // After merge
+    RuntimeProfile* _runtime_profile = nullptr;
+    MemTracker* _parent_mem_tracker = nullptr;
+    std::unique_ptr<ObjectPool> _object_pool = nullptr;
+    ChunksSorterFullSortProfiler* _profiler = nullptr;
 
     // TODO: further tunning the buffer parameter
-    static constexpr size_t kMaxBufferedChunkSize = 1024000;   // Max buffer 1024000 rows
-    static constexpr size_t kMaxBufferedChunkBytes = 16 << 20; // Max buffer 16MB bytes
+    const size_t max_buffered_rows;  // Max buffer 1024000 rows
+    const size_t max_buffered_bytes; // Max buffer 16MB bytes
+
+    // only when order-by columns(_sort_exprs) are all ColumnRefs and the cost of eager-materialization of
+    // other columns is large than ordinal column, then we materialize order-by columns and ordinal columns eagerly,
+    // and other columns are lazy-materialized.
+    std::unordered_set<SlotId> _eager_materialized_slots;
+    int _max_num_rows = 0;
+    int _offset_in_chunk_bits = 0;
+    int _chunk_idx_bits = 0;
+    std::vector<SlotId> _column_id_to_slot_id;
+    std::vector<ChunkUniquePtr> _eager_materialized_chunks;
+    std::vector<ChunkUniquePtr> _lazy_materialized_chunks;
 };
 
 } // namespace starrocks

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -44,7 +44,7 @@ public:
     ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                          const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
                          const std::string& sort_keys, int64_t max_buffered_rows, int64_t max_buffered_bytes,
-                         const std::vector<SlotId>& eager_materialized_slots);
+                         const std::vector<SlotId>& early_materialized_slots);
     ~ChunksSorterFullSort() override;
 
     // Append a Chunk for sort.
@@ -71,9 +71,9 @@ private:
     void _assign_ordinals();
     template <typename T>
     void _assign_ordinals_tmpl();
-    ChunkPtr _lazy_materialize(const ChunkPtr& chunk);
+    ChunkPtr _late_materialize(const ChunkPtr& chunk);
     template <typename T>
-    ChunkPtr _lazy_materialize_tmpl(const ChunkPtr& chunk);
+    ChunkPtr _late_materiallize_tmpl(const ChunkPtr& chunk);
 
     size_t _total_rows = 0;        // Total rows of sorting data
     Permutation _sort_permutation; // Temp permutation for sorting
@@ -95,13 +95,13 @@ private:
     // only when order-by columns(_sort_exprs) are all ColumnRefs and the cost of eager-materialization of
     // other columns is large than ordinal column, then we materialize order-by columns and ordinal columns eagerly,
     // and other columns are lazy-materialized.
-    std::unordered_set<SlotId> _eager_materialized_slots;
+    std::unordered_set<SlotId> _early_materialized_slots;
     int _max_num_rows = 0;
     int _offset_in_chunk_bits = 0;
     int _chunk_idx_bits = 0;
     std::vector<SlotId> _column_id_to_slot_id;
-    std::vector<ChunkUniquePtr> _eager_materialized_chunks;
-    std::vector<ChunkUniquePtr> _lazy_materialized_chunks;
+    std::vector<ChunkUniquePtr> _early_materialized_chunks;
+    std::vector<ChunkUniquePtr> _late_materialized_chunks;
 };
 
 } // namespace starrocks

--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -290,8 +290,8 @@ int ChunksSorterHeapSort::_filter_data(detail::ChunkHolder* chunk_holder, int ro
     return chunk_holder->value()->chunk->filter(filter);
 }
 
-void ChunksSorterHeapSort::setup_runtime(RuntimeProfile* profile) {
-    ChunksSorter::setup_runtime(profile);
+void ChunksSorterHeapSort::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
     _sort_filter_costs = ADD_TIMER(profile, "SortFilterCost");
     _sort_filter_rows = ADD_COUNTER(profile, "SortFilterRows", TUnit::UNIT);
 }

--- a/be/src/exec/chunks_sorter_heap_sort.h
+++ b/be/src/exec/chunks_sorter_heap_sort.h
@@ -249,7 +249,7 @@ public:
 
     size_t get_output_rows() const override;
 
-    void setup_runtime(RuntimeProfile* profile) override;
+    void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
 
 private:
     size_t _number_of_rows_to_sort() const { return _offset + _limit; }

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -46,8 +46,8 @@ ChunksSorterTopn::ChunksSorterTopn(RuntimeState* state, const std::vector<ExprCo
 
 ChunksSorterTopn::~ChunksSorterTopn() = default;
 
-void ChunksSorterTopn::setup_runtime(RuntimeProfile* profile) {
-    ChunksSorter::setup_runtime(profile);
+void ChunksSorterTopn::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
     _sort_filter_timer = ADD_TIMER(profile, "SortFilterTime");
     _sort_filter_rows = ADD_COUNTER(profile, "SortFilterRows", TUnit::UNIT);
 }

--- a/be/src/exec/chunks_sorter_topn.h
+++ b/be/src/exec/chunks_sorter_topn.h
@@ -76,7 +76,7 @@ public:
 
     int64_t mem_usage() const override { return _raw_chunks.mem_usage() + _merged_segment.mem_usage(); }
 
-    void setup_runtime(RuntimeProfile* profile) override;
+    void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
 
     std::vector<JoinRuntimeFilter*>* runtime_filters(ObjectPool* pool) override;
 

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -61,7 +61,7 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
 }
 
 Status Operator::prepare(RuntimeState* state) {
-    _mem_tracker = std::make_shared<MemTracker>(_common_metrics.get(), std::make_tuple(false, true, true), "Operator",
+    _mem_tracker = std::make_shared<MemTracker>(_common_metrics.get(), std::make_tuple(true, true, true), "Operator",
                                                 -1, _name, state->instance_mem_tracker());
     _total_timer = ADD_TIMER(_common_metrics, "OperatorTotalTime");
     _push_timer = ADD_TIMER(_common_metrics, "PushTotalTime");

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -37,7 +37,7 @@ Status PartitionSortSinkOperator::prepare(RuntimeState* state) {
 
     _sort_context->ref();
     _sort_context->incr_sinker();
-    _chunks_sorter->setup_runtime(_unique_metrics.get());
+    _chunks_sorter->setup_runtime(_unique_metrics.get(), this->mem_tracker());
 
     return Status::OK();
 }
@@ -120,9 +120,9 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
                     _sort_keys, 0, _limit + _offset, _topn_type, max_buffered_chunks);
         }
     } else {
-        chunks_sorter =
-                std::make_unique<ChunksSorterFullSort>(runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                       &_is_asc_order, &_is_null_first, _sort_keys);
+        chunks_sorter = std::make_unique<ChunksSorterFullSort>(
+                runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                _sort_keys, _max_buffered_rows, _max_buffered_bytes, _eager_materialized_slots);
     }
     auto sort_context = _sort_context_factory->create(driver_sequence);
     sort_context->add_partition_chunks_sorter(chunks_sorter);

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -122,7 +122,7 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
     } else {
         chunks_sorter = std::make_unique<ChunksSorterFullSort>(
                 runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                _sort_keys, _max_buffered_rows, _max_buffered_bytes, _eager_materialized_slots);
+                _sort_keys, _max_buffered_rows, _max_buffered_bytes, _early_materialized_slots);
     }
     auto sort_context = _sort_context_factory->create(driver_sequence);
     sort_context->add_partition_chunks_sorter(chunks_sorter);

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -29,7 +29,6 @@ class ExprContext;
 class ResultWriter;
 class ExecNode;
 class ChunksSorter;
-
 namespace pipeline {
 
 /*
@@ -91,10 +90,11 @@ public:
     PartitionSortSinkOperatorFactory(
             int32_t id, int32_t plan_node_id, std::shared_ptr<SortContextFactory> sort_context_factory,
             SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
-            std::string sort_keys, int64_t offset, int64_t limit, const TTopNType::type topn_type,
-            const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
-            const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc,
-            std::vector<ExprContext*> analytic_partition_exprs)
+            std::string sort_keys, int64_t offset, int64_t limit, int64_t max_buffered_rows, int64_t max_buffered_bytes,
+            const TTopNType::type topn_type, const std::vector<OrderByType>& order_by_types,
+            TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
+            const RowDescriptor& parent_node_child_row_desc, std::vector<ExprContext*> analytic_partition_exprs,
+            const std::vector<SlotId>& eager_materialized_slots)
             : OperatorFactory(id, "local_sort_sink", plan_node_id),
               _sort_context_factory(std::move(std::move(sort_context_factory))),
               _sort_exec_exprs(sort_exec_exprs),
@@ -103,12 +103,15 @@ public:
               _sort_keys(std::move(sort_keys)),
               _offset(offset),
               _limit(limit),
+              _max_buffered_rows(max_buffered_rows),
+              _max_buffered_bytes(max_buffered_bytes),
               _topn_type(topn_type),
               _order_by_types(order_by_types),
               _materialized_tuple_desc(materialized_tuple_desc),
               _parent_node_row_desc(parent_node_row_desc),
               _parent_node_child_row_desc(parent_node_child_row_desc),
-              _analytic_partition_exprs(std::move(analytic_partition_exprs)) {}
+              _analytic_partition_exprs(std::move(analytic_partition_exprs)),
+              _eager_materialized_slots(eager_materialized_slots) {}
 
     ~PartitionSortSinkOperatorFactory() override = default;
 
@@ -126,6 +129,8 @@ private:
     const std::string _sort_keys;
     int64_t _offset;
     int64_t _limit;
+    int64_t _max_buffered_rows;
+    int64_t _max_buffered_bytes;
     const TTopNType::type _topn_type;
     const std::vector<OrderByType>& _order_by_types;
 
@@ -136,6 +141,7 @@ private:
     const RowDescriptor& _parent_node_row_desc;
     const RowDescriptor& _parent_node_child_row_desc;
     std::vector<ExprContext*> _analytic_partition_exprs;
+    std::vector<SlotId> _eager_materialized_slots;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -94,7 +94,7 @@ public:
             const TTopNType::type topn_type, const std::vector<OrderByType>& order_by_types,
             TupleDescriptor* materialized_tuple_desc, const RowDescriptor& parent_node_row_desc,
             const RowDescriptor& parent_node_child_row_desc, std::vector<ExprContext*> analytic_partition_exprs,
-            const std::vector<SlotId>& eager_materialized_slots)
+            const std::vector<SlotId>& early_materialized_slots)
             : OperatorFactory(id, "local_sort_sink", plan_node_id),
               _sort_context_factory(std::move(std::move(sort_context_factory))),
               _sort_exec_exprs(sort_exec_exprs),
@@ -111,7 +111,7 @@ public:
               _parent_node_row_desc(parent_node_row_desc),
               _parent_node_child_row_desc(parent_node_child_row_desc),
               _analytic_partition_exprs(std::move(analytic_partition_exprs)),
-              _eager_materialized_slots(eager_materialized_slots) {}
+              _early_materialized_slots(early_materialized_slots) {}
 
     ~PartitionSortSinkOperatorFactory() override = default;
 
@@ -141,7 +141,7 @@ private:
     const RowDescriptor& _parent_node_row_desc;
     const RowDescriptor& _parent_node_child_row_desc;
     std::vector<ExprContext*> _analytic_partition_exprs;
-    std::vector<SlotId> _eager_materialized_slots;
+    std::vector<SlotId> _early_materialized_slots;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -110,7 +110,6 @@ private:
     const int64_t _limit;
     const std::vector<ExprContext*> _sort_exprs;
     const SortDescs _sort_descs;
-    std::optional<std::unordered_set<SlotId>> _eager_materialized_slots;
     const std::vector<RuntimeFilterBuildDescriptor*>& _build_runtime_filters;
 };
 

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -110,6 +110,7 @@ private:
     const int64_t _limit;
     const std::vector<ExprContext*> _sort_exprs;
     const SortDescs _sort_descs;
+    std::optional<std::unordered_set<SlotId>> _eager_materialized_slots;
     const std::vector<RuntimeFilterBuildDescriptor*>& _build_runtime_filters;
 };
 

--- a/be/src/exec/sorting/merge.h
+++ b/be/src/exec/sorting/merge.h
@@ -26,7 +26,6 @@
 #include "runtime/chunk_cursor.h"
 
 namespace starrocks {
-
 // SortedRun represents part of sorted chunk, specified by the range
 // The chunk is sorted based on `orderby` columns
 struct SortedRun {

--- a/be/src/exec/sorting/sorting.h
+++ b/be/src/exec/sorting/sorting.h
@@ -82,7 +82,6 @@ struct SortDesc {
     bool is_null_first() const { return (null_first * sort_order) == -1; }
     bool asc_order() const { return sort_order == 1; }
 };
-
 struct SortDescs {
     std::vector<SortDesc> descs;
 

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -91,6 +91,36 @@ Status TopNNode::init(const TPlanNode& tnode, RuntimeState* state) {
     _materialized_tuple_desc = _row_descriptor.tuple_descriptors()[0];
     DCHECK(_materialized_tuple_desc != nullptr);
 
+    bool all_slot_ref = true;
+    std::unordered_set<SlotId> eager_materialized_slots;
+    for (ExprContext* expr_ctx : _sort_exec_exprs.lhs_ordering_expr_ctxs()) {
+        auto* expr = expr_ctx->root();
+        if (expr->is_slotref()) {
+            eager_materialized_slots.insert(down_cast<ColumnRef*>(expr)->slot_id());
+        } else {
+            all_slot_ref = false;
+        }
+    }
+
+    int materialized_cost = 0;
+    for (auto* slot : _materialized_tuple_desc->slots()) {
+        if (eager_materialized_slots.count(slot->id())) {
+            continue;
+        }
+        materialized_cost += slot->is_nullable();
+        if (slot->type().is_string_type()) {
+            materialized_cost += 16;
+        } else {
+            materialized_cost += std::max<int>(1, slot->type().get_slot_size());
+        }
+    }
+    static constexpr auto ORDINAL_SORT_COST = 4;
+    auto lazy_materialization = _tnode.sort_node.__isset.lazy_materialization && _tnode.sort_node.lazy_materialization;
+    if (lazy_materialization && all_slot_ref && materialized_cost > ORDINAL_SORT_COST) {
+        _eager_materialized_slots.insert(_eager_materialized_slots.begin(), eager_materialized_slots.begin(),
+                                         eager_materialized_slots.end());
+    }
+
     _runtime_profile->add_info_string("SortKeys", _sort_keys);
     _runtime_profile->add_info_string("SortType", tnode.sort_node.use_top_n ? "TopN" : "All");
     return Status::OK();
@@ -184,11 +214,12 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
 
     } else {
         _chunks_sorter = std::make_unique<ChunksSorterFullSort>(state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                &_is_asc_order, &_is_null_first, _sort_keys);
+                                                                &_is_asc_order, &_is_null_first, _sort_keys, 1024000,
+                                                                16 * 1024 * 1024, _eager_materialized_slots);
     }
 
     bool eos = false;
-    _chunks_sorter->setup_runtime(runtime_profile());
+    _chunks_sorter->setup_runtime(runtime_profile(), runtime_state()->instance_mem_tracker());
     do {
         RETURN_IF_CANCELLED(state);
         ChunkPtr chunk;
@@ -212,7 +243,6 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
 
 pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
-
     OpFactories ops_sink_with_sort = _children[0]->decompose_to_pipeline(context);
     bool is_partition = _tnode.sort_node.__isset.partition_exprs && !_tnode.sort_node.partition_exprs.empty();
     bool is_rank_topn_type = _tnode.sort_node.__isset.topn_type && _tnode.sort_node.topn_type != TTopNType::ROW_NUMBER;
@@ -252,11 +282,18 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
         sink_operator = std::make_shared<LocalPartitionTopnSinkOperatorFactory>(context->next_operator_id(), id(),
                                                                                 local_partition_topn_context_factory);
     } else {
+        int64_t max_buffered_rows = 1024000;
+        int64_t max_buffered_bytes = 16 * 1024 * 1024;
+        if (_tnode.sort_node.__isset.max_buffered_bytes) {
+            max_buffered_rows = _tnode.sort_node.max_buffered_rows;
+            max_buffered_bytes = _tnode.sort_node.max_buffered_bytes;
+        }
         const auto& sort_context_factory = std::any_cast<std::shared_ptr<SortContextFactory>>(context_factory);
         sink_operator = std::make_shared<PartitionSortSinkOperatorFactory>(
                 context->next_operator_id(), id(), sort_context_factory, _sort_exec_exprs, _is_asc_order,
-                _is_null_first, _sort_keys, _offset, _limit, _tnode.sort_node.topn_type, _order_by_types,
-                _materialized_tuple_desc, child(0)->row_desc(), _row_descriptor, _analytic_partition_exprs);
+                _is_null_first, _sort_keys, _offset, _limit, max_buffered_rows, max_buffered_bytes,
+                _tnode.sort_node.topn_type, _order_by_types, _materialized_tuple_desc, child(0)->row_desc(),
+                _row_descriptor, _analytic_partition_exprs, _eager_materialized_slots);
     }
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(sink_operator.get(), context, rc_rf_probe_collector);

--- a/be/src/exec/topn_node.h
+++ b/be/src/exec/topn_node.h
@@ -51,6 +51,7 @@ private:
 
     // _sort_exec_exprs contains the ordering expressions
     SortExecExprs _sort_exec_exprs;
+    std::vector<SlotId> _eager_materialized_slots{};
     std::vector<bool> _is_asc_order;
     std::vector<bool> _is_null_first;
     std::vector<OrderByType> _order_by_types;

--- a/be/src/exec/topn_node.h
+++ b/be/src/exec/topn_node.h
@@ -51,7 +51,7 @@ private:
 
     // _sort_exec_exprs contains the ordering expressions
     SortExecExprs _sort_exec_exprs;
-    std::vector<SlotId> _eager_materialized_slots{};
+    std::vector<SlotId> _early_materialized_slots{};
     std::vector<bool> _is_asc_order;
     std::vector<bool> _is_null_first;
     std::vector<OrderByType> _order_by_types;

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -366,6 +366,7 @@ int TypeDescriptor::get_slot_size() const {
     case TYPE_DATETIME_V1:
     case TYPE_NONE:
     case TYPE_MAX_VALUE:
+        DCHECK(false);
         break;
     }
     // For llvm complain

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -366,7 +366,6 @@ int TypeDescriptor::get_slot_size() const {
     case TYPE_DATETIME_V1:
     case TYPE_NONE:
     case TYPE_MAX_VALUE:
-        DCHECK(false);
         break;
     }
     // For llvm complain

--- a/be/test/exec/chunks_sorter_heap_sort_test.cpp
+++ b/be/test/exec/chunks_sorter_heap_sort_test.cpp
@@ -178,7 +178,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.done(nullptr);
 
@@ -198,7 +199,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.done(nullptr);
@@ -221,7 +223,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.done(nullptr);
@@ -256,7 +259,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 5;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 
@@ -281,7 +285,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 10;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 
@@ -307,7 +312,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 5;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 

--- a/be/test/exec/chunks_sorter_test.cpp
+++ b/be/test/exec/chunks_sorter_test.cpp
@@ -310,8 +310,11 @@ TEST_F(ChunksSorterTest, full_sort_incremental) {
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
-
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -516,7 +519,11 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -551,7 +558,11 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -589,7 +600,11 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -630,7 +645,11 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -193,6 +193,10 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
 
         msg.sort_node = new TSortNode(sortInfo, useTopN);
         msg.sort_node.setOffset(offset);
+        SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
+        msg.sort_node.setMax_buffered_rows(sessionVariable.getFullSortMaxBufferedRows());
+        msg.sort_node.setMax_buffered_bytes(sessionVariable.getFullSortMaxBufferedBytes());
+        msg.sort_node.setLazy_materialization(sessionVariable.isFullSortLazyMaterialization());
 
         if (info.getPartitionExprs() != null) {
             msg.sort_node.setPartition_exprs(Expr.treesToThrift(info.getPartitionExprs()));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -196,7 +196,7 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
         SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
         msg.sort_node.setMax_buffered_rows(sessionVariable.getFullSortMaxBufferedRows());
         msg.sort_node.setMax_buffered_bytes(sessionVariable.getFullSortMaxBufferedBytes());
-        msg.sort_node.setLazy_materialization(sessionVariable.isFullSortLazyMaterialization());
+        msg.sort_node.setLate_materialization(sessionVariable.isFullSortLateMaterialization());
 
         if (info.getPartitionExprs() != null) {
             msg.sort_node.setPartition_exprs(Expr.treesToThrift(info.getPartitionExprs()));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -358,7 +358,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // Used by full sort inorder to permute only order-by columns in cascading merging phase, after
     // that, non-order-by output columns are permuted according to the ordinal column.
-    public static final String FULL_SORT_LAZY_MATERIALIZATION = "full_sort_lazy_materialization";
+    public static final String FULL_SORT_LAZY_MATERIALIZATION = "full_sort_late_materialization";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -890,8 +890,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_BYTES, flag = VariableMgr.INVISIBLE)
     private long fullSortMaxBufferedBytes = 16 * 1024 * 1024;
 
-    @VariableMgr.VarAttr(name = FULL_SORT_LAZY_MATERIALIZATION)
-    private boolean fullSortLazyMaterialization = false;
+    @VariableMgr.VarAttr(name = FULL_SORT_LATE_MATERIALIZATION)
+    private boolean fullSortLateMaterialization = false;
 
     public void setFullSortMaxBufferedRows(long v) {
         fullSortMaxBufferedRows = v;
@@ -909,12 +909,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return fullSortMaxBufferedBytes;
     }
 
-    public void setFullSortLazyMaterialization(boolean v) {
-        fullSortLazyMaterialization = v;
+    public void setFullSortLateMaterialization(boolean v) {
+        fullSortLateMaterialization = v;
     }
 
-    public boolean isFullSortLazyMaterialization() {
-        return fullSortLazyMaterialization;
+    public boolean isFullSortLateMaterialization() {
+        return fullSortLateMaterialization;
     }
 
     public boolean isActivateAllRolesOnLogin() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -358,7 +358,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // Used by full sort inorder to permute only order-by columns in cascading merging phase, after
     // that, non-order-by output columns are permuted according to the ordinal column.
-    public static final String FULL_SORT_LAZY_MATERIALIZATION = "full_sort_late_materialization";
+    public static final String FULL_SORT_LATE_MATERIALIZATION = "full_sort_late_materialization";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -162,7 +162,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_PIPELINE = "enable_pipeline";
 
     public static final String ENABLE_RUNTIME_ADAPTIVE_DOP = "enable_runtime_adaptive_dop";
-    public static final String ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ = "runtime_adaptive_dop_max_block_rows_per_driver_seq";
+    public static final String ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ =
+            "runtime_adaptive_dop_max_block_rows_per_driver_seq";
 
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
     public static final String ENABLE_PIPELINE_QUERY_STATISTIC = "enable_pipeline_query_statistic";
@@ -348,6 +349,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN = "activate_all_roles_on_login";
 
     public static final String GROUP_CONCAT_MAX_LEN = "group_concat_max_len";
+
+    // full_sort_max_buffered_{rows,bytes} are thresholds that limits input size of partial_sort
+    // in full sort.
+    public static final String FULL_SORT_MAX_BUFFERED_ROWS = "full_sort_max_buffered_rows";
+
+    public static final String FULL_SORT_MAX_BUFFERED_BYTES = "full_sort_max_buffered_bytes";
+
+    // Used by full sort inorder to permute only order-by columns in cascading merging phase, after
+    // that, non-order-by output columns are permuted according to the ordinal column.
+    public static final String FULL_SORT_LAZY_MATERIALIZATION = "full_sort_lazy_materialization";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -872,6 +883,39 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = GROUP_CONCAT_MAX_LEN)
     private long groupConcatMaxLen = 65535;
+
+    @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_ROWS, flag = VariableMgr.INVISIBLE)
+    private long fullSortMaxBufferedRows = 1024000;
+
+    @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_BYTES, flag = VariableMgr.INVISIBLE)
+    private long fullSortMaxBufferedBytes = 16 * 1024 * 1024;
+
+    @VariableMgr.VarAttr(name = FULL_SORT_LAZY_MATERIALIZATION)
+    private boolean fullSortLazyMaterialization = false;
+
+    public void setFullSortMaxBufferedRows(long v) {
+        fullSortMaxBufferedRows = v;
+    }
+
+    public void setFullSortMaxBufferedBytes(long v) {
+        fullSortMaxBufferedBytes = v;
+    }
+
+    public long getFullSortMaxBufferedRows() {
+        return fullSortMaxBufferedRows;
+    }
+
+    public long getFullSortMaxBufferedBytes() {
+        return fullSortMaxBufferedBytes;
+    }
+
+    public void setFullSortLazyMaterialization(boolean v) {
+        fullSortLazyMaterialization = v;
+    }
+
+    public boolean isFullSortLazyMaterialization() {
+        return fullSortLazyMaterialization;
+    }
 
     public boolean isActivateAllRolesOnLogin() {
         if (activateAllRolesOnLogin.equals("ON")) {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -715,7 +715,7 @@ struct TSortNode {
   26: optional list<RuntimeFilter.TRuntimeFilterDescription> build_runtime_filters;
   27: optional i64 max_buffered_rows;
   28: optional i64 max_buffered_bytes;
-  29: optional bool lazy_materialization;
+  29: optional bool late_materialization;
 }
 
 enum TAnalyticWindowType {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -713,6 +713,9 @@ struct TSortNode {
   24: optional i64 partition_limit
   25: optional TTopNType topn_type;
   26: optional list<RuntimeFilter.TRuntimeFilterDescription> build_runtime_filters;
+  27: optional i64 max_buffered_rows;
+  28: optional i64 max_buffered_bytes;
+  29: optional bool lazy_materialization;
 }
 
 enum TAnalyticWindowType {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
### Description
Cascading merging phase in full sort is time-consuming, especially, when encoutering data skew.  so after parial sortting, each chunk in sorted runs are split into two group vertically, the first group contains order-by columns(eager materialized chunks), the other group contains non-order-by output columns(lazy materialized chunks). an ordinal column is added to the first group(eager materialized chunks), so in the cascading merging, the first group of columns are permuted instead of all of the output columns, when then cascading merger output ordered chunks on command, then permute the non-order-by output columns according to ordinal column in thes sorted eager chunks.  

The higher the cascading merging tree, the more time spent to permute non-order-by columns in order version, the permutation times is height(cascading merging tree) - 1, so in the lazy materialization, the non-order-by columns is permuted only once.

Because an ordinal column is added to the eager materialized chunks, cascading take extra time to permutation it along with order by columns, so in some corner cases, lazy materialization version would lag order version. for examples:
1. there are only  a few non-group-by columns, the cost of permuting these columns in cascading merging is less than permuting an ordinal column.
2. the cascading merging tree is short, there are sorted runs the number of whom is less than 3.

so, in these two scenarios, lazy materialization is turned off in BE.

Lazy materialization version outperform order version for 1.25 X ~ 2X, especially, in cases of many non-order by output columns  is present in full sort and the data skew is very drastic.

Because the rows in lazy materialized chunks are selected and append to output chunks of cascading merger in a streaming way, so all of the lazy materialized chunks are kept in memory until the entire results are fetched by downstream operator. So when lazy materialized is enabled, full sort will use 1.5X~ 2X memory of input data.


### Test

Tests conducted on dataset that has 13.95GB and 100000000 rows and very skew.

Queries
```
Q0: skew=6%
select c1,c2,sum(c8) over (partition by c1,c2) as c8_sum from data_skew;
Q1: skew=6%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c1,c2) as c8_sum from data_skew;
Q2: skew=12%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c2,c3) as c8_sum from data_skew;
Q3: skew=20%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c3,c4) as c8_sum from data_skew;
Q4: skew=30%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c4,c5) as c8_sum from data_skew;
Q5: skew=42%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c5,c6) as c8_sum from data_skew;
Q6: skew=56%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c6,c7) as c8_sum from data_skew;
```

#### Respond Time:  lazy_materialization/no_lazy_materialization = 1.30X ~ 1.93X

```
+=======+==========+==============+=================+
| Query | DataSkew | RT(lazy_mat) | RT(no_lazy_mat) |
+=======+==========+==============+=================+
| Q0    | 6%       | 10s156ms     | 9s13ms          |
| Q1    | 6%       | 20s250ms     | 26s253ms        |
| Q2    | 12%      | 26s76ms      | 40s826ms        |
| Q3    | 20%      | 37s115ms     | 59s440ms        |
| Q4    | 30%      | 49s795ms     | 1m33s           |
| Q5    | 42%      | 1m1s         | 2m7s            |
| Q6    | 56%      | 1m22s        | 2m50s           |
+-------+----------+--------------+-----------------+
```

#### InstancePeakMemorUsage:  lazy_materialization/no_lazy_materialization = 1.1 ~ 1.7X

```
+=======+==========+===============================+==================================+===================================+======================================+================================+===================================+
| Query | DataSkew | InputRequiredMemory(lazy_mat) | MaxInputRequiredMemory(lazy_mat) | InstancePeakMemoryUsage(lazy_mat) | InstancePeakMemoryUsage(no_lazy_mat) | QueryPeakMemoryUsage(lazy_mat) | QueryPeakMemoryUsage(no_lazy_mat) |
+=======+==========+===============================+==================================+===================================+======================================+================================+===================================+
| Q0    | 6%       | 5.38 GB                       | 394.05 MB                        | 3.40 GB                           | 3.09 GB                              | 3.484GB                        | 3.168GB                           |
| Q1    | 6%       | 13.95 GB                      | 1.23 GB                          | 7.38 GB                           | 5.77 GB                              | 7.612GB                        | 5.999GB                           |
| Q2    | 12%      | 13.95 GB                      | 1.93 GB                          | 8.81 GB                           | 6.32 GB                              | 9.048GB                        | 6.552GB                           |
| Q3    | 20%      | 13.95 GB                      | 2.89 GB                          | 11.28 GB                          | 7.11 GB                              | 11.512GB                       | 7.365GB                           |
| Q4    | 30%      | 13.95 GB                      | 4.15 GB                          | 13.94 GB                          | 8.07 GB                              | 14.207GB                       | 8.341GB                           |
| Q5    | 42%      | 13.95 GB                      | 5.71 GB                          | 17.33 GB                          | 10.23 GB                             | 17.587GB                       | 10.495GB                          |
| Q6    | 56%      | 13.95 GB                      | 7.60 GB                          | 21.22 GB                          | 12.47 GB                             | 21.474GB                       | 12.731GB                          |
+-------+----------+-------------------------------+----------------------------------+-----------------------------------+--------------------------------------+--------------------------------+-----------------------------------+
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
