### PR TITLE
[Feature] support transform_keys/values based on map_apply

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -405,6 +405,10 @@ public class FunctionSet {
     public static final String MAP_FILTER = "map_filter";
     public static final String MAP_VALUES = "map_values";
     public static final String MAP_KEYS = "map_keys";
+    public static final String MAP_SIZE = "map_size";
+    public static final String TRANSFORM_VALUES = "transform_values";
+    public static final String TRANSFORM_KEYS = "transform_keys";
+
     // Struct functions:
     public static final String ROW = "row";
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -138,6 +138,8 @@ public class ExpressionAnalyzer {
     private boolean isMapHighOrderFunction(Expr expr) {
         if (expr instanceof FunctionCallExpr) {
             if (((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.MAP_FILTER) ||
+                    ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.TRANSFORM_VALUES) ||
+                    ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.TRANSFORM_KEYS) ||
                     ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.MAP_APPLY)) {
                 return true;
             }
@@ -229,11 +231,18 @@ public class ExpressionAnalyzer {
             Preconditions.checkState(expression instanceof FunctionCallExpr);
             FunctionCallExpr functionCallExpr = (FunctionCallExpr) expression;
             // map_apply(func, map)
-            if (functionCallExpr.getFnName().getFunction().equals(FunctionSet.MAP_APPLY) &&
-                    !(expression.getChild(0).getChild(0) instanceof MapExpr)) {
-                throw new SemanticException("The right part of map lambda function (" +
-                        expression.getChild(0).toSql() + ") should have key and value arguments",
-                        expression.getChild(0).getPos());
+            if (functionCallExpr.getFnName().getFunction().equals(FunctionSet.MAP_APPLY)) {
+                    if (!(expression.getChild(0).getChild(0) instanceof MapExpr)) {
+                        throw new SemanticException("The right part of map lambda function (" +
+                                expression.getChild(0).toSql() + ") should have key and value arguments",
+                                expression.getChild(0).getPos());
+                    }
+            } else {
+                if (expression.getChild(0).getChild(0) instanceof MapExpr) {
+                    throw new SemanticException("The right part of map lambda function (" +
+                            expression.getChild(0).toSql() + ") should have only one arguments",
+                            expression.getChild(0).getPos());
+                }
             }
             if (expression.getChild(0).getChildren().size() != 3) {
                 Expr child = expression.getChild(0);
@@ -254,13 +263,25 @@ public class ExpressionAnalyzer {
             scope.putLambdaInput(new PlaceHolderExpr(-1, true, keyType));
             scope.putLambdaInput(new PlaceHolderExpr(-2, true, valueType));
             // lambda functions should be rewritten before visited
-            if ((functionCallExpr.getFnName().getFunction().equals(FunctionSet.MAP_FILTER))) {
+            if ((functionCallExpr.getFnName().getFunction().equals(FunctionSet.MAP_FILTER)) ||
+                    functionCallExpr.getFnName().getFunction().equals(FunctionSet.TRANSFORM_VALUES)) {
                 // (k,v) -> expr => (k,v) -> (k,expr)
                 Expr lambdaFunc = functionCallExpr.getChild(0);
                 LambdaArgument larg = (LambdaArgument) lambdaFunc.getChild(1);
                 Expr slotRef = new SlotRef(null, larg.getName(), larg.getName());
                 lambdaFunc.setChild(0, new MapExpr(Type.ANY_MAP, Lists.newArrayList(slotRef,
                         lambdaFunc.getChild(0))));
+                if (functionCallExpr.getFnName().getFunction().equals(FunctionSet.TRANSFORM_VALUES)) {
+                    functionCallExpr.resetFnName("", FunctionSet.MAP_APPLY);
+                }
+            } else if ((functionCallExpr.getFnName().getFunction().equals(FunctionSet.TRANSFORM_KEYS))) {
+                // (k,v) -> expr => (k,v) -> (expr, v)
+                Expr lambdaFunc = functionCallExpr.getChild(0);
+                LambdaArgument larg = (LambdaArgument) lambdaFunc.getChild(2);
+                Expr slotRef = new SlotRef(null, larg.getName(), larg.getName());
+                lambdaFunc.setChild(0, new MapExpr(Type.ANY_MAP, Lists.newArrayList(
+                        lambdaFunc.getChild(0), slotRef)));
+                functionCallExpr.resetFnName("", FunctionSet.MAP_APPLY);
             }
         }
         // visit LambdaFunction

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -232,11 +232,11 @@ public class ExpressionAnalyzer {
             FunctionCallExpr functionCallExpr = (FunctionCallExpr) expression;
             // map_apply(func, map)
             if (functionCallExpr.getFnName().getFunction().equals(FunctionSet.MAP_APPLY)) {
-                    if (!(expression.getChild(0).getChild(0) instanceof MapExpr)) {
-                        throw new SemanticException("The right part of map lambda function (" +
-                                expression.getChild(0).toSql() + ") should have key and value arguments",
-                                expression.getChild(0).getPos());
-                    }
+                if (!(expression.getChild(0).getChild(0) instanceof MapExpr)) {
+                    throw new SemanticException("The right part of map lambda function (" +
+                            expression.getChild(0).toSql() + ") should have key and value arguments",
+                            expression.getChild(0).getPos());
+                }
             } else {
                 if (expression.getChild(0).getChild(0) instanceof MapExpr) {
                     throw new SemanticException("The right part of map lambda function (" +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.ComplexTypeAccessGroup;
 import com.starrocks.catalog.ComplexTypeAccessPath;
 import com.starrocks.catalog.ComplexTypeAccessPathType;
 import com.starrocks.catalog.ComplexTypeAccessPaths;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Type;
@@ -253,9 +254,9 @@ public class PruneComplexTypeUtil {
 
         @Override
         public Void visitCall(CallOperator call, Context context) {
-            if (call.getFnName().equalsIgnoreCase("map_keys") || call.getFnName().equalsIgnoreCase("map_size")) {
+            if (call.getFnName().equals(FunctionSet.MAP_KEYS) || call.getFnName().equals(FunctionSet.MAP_SIZE)) {
                 complexTypeAccessPaths.push(new ComplexTypeAccessPath(ComplexTypeAccessPathType.MAP_KEY));
-            } else if (call.getFnName().equalsIgnoreCase("map_values")) {
+            } else if (call.getFnName().equals(FunctionSet.MAP_VALUES)) {
                 complexTypeAccessPaths.push(new ComplexTypeAccessPath(ComplexTypeAccessPathType.MAP_VALUE));
             }
 
@@ -263,8 +264,8 @@ public class PruneComplexTypeUtil {
                 child.accept(this, context);
             }
 
-            if (call.getFnName().equalsIgnoreCase("map_keys") || call.getFnName().equalsIgnoreCase("map_size") ||
-                    call.getFnName().equalsIgnoreCase("map_values")) {
+            if (call.getFnName().equals(FunctionSet.MAP_KEYS) || call.getFnName().equals(FunctionSet.MAP_SIZE) ||
+                    call.getFnName().equals(FunctionSet.MAP_VALUES)) {
                 complexTypeAccessPaths.pop();
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -187,6 +187,14 @@ public class AnalyzeExprTest {
                 "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'']) as col_map " +
                 "union all select map_from_arrays(null,null) union all select map_from_arrays([],[]) " +
                 "union all select map_from_arrays([null],[null]))A;");
+        analyzeSuccess("select transform_keys((k,v)->(k+1>length(v)), col_map) from " +
+                "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A");
+        analyzeSuccess("select transform_values((k,v)->(k+1>length(v)), col_map) from " +
+                "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;");
+        analyzeSuccess("select transform_values((k,v)->(k is null), col_map) from " +
+                "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;");
+        analyzeSuccess("select transform_values((k,v)->null, col_map) from " +
+                "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;");
 
         analyzeFail("select map_apply((k,v)->(k+1,length(v)), col_map) from (select null as col_map)A;");
         analyzeFail(" select map_apply((k)->(k,k), col_map) from (select map_from_arrays([1,3,null,2,null]," +
@@ -209,6 +217,12 @@ public class AnalyzeExprTest {
                 "null],['ab','cdd',null,null,'']) as col_map)A;");
         analyzeFail("select map_apply((k,v)->(v,k), col_map,col_map) from (select map_from_arrays" +
                 "([1,3,null,2,null],['ab','cdd',null,null,'']) as col_map)A;");
+        analyzeFail("select transform_keys((k,v)->(k,v), col_map) from " +
+                "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;");
+        analyzeFail(" select transform_values((k)->null, col_map) from " +
+                "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;");
+        analyzeFail("select transform_values((k,null)->null, col_map) from " +
+                "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
mysql> select transform_keys((k,v)->(k+1>length(v)), col_map) from (select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;
+----------------------------------------------------------+
| transform_keys((k, v) -> (k + 1) > (length(v)), col_map) |
+----------------------------------------------------------+
| {0:"ab",1:"cdd",null:null,null:null,null:"abc"}          |
+----------------------------------------------------------+

mysql> select transform_values((k,v)->1, col_map) from (select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;
+----------------------------------------+
| transform_values((k, v) -> 1, col_map) |
+----------------------------------------+
| {1:1,3:1,null:1,2:1,null:1}            |
+----------------------------------------+
1 row in set (0.02 sec)

mysql> select transform_values((k,v)->null, col_map) from (select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'abc']) as col_map)A;
+--------------------------------------------+
| transform_values((k, v) -> NULL, col_map)  |
+--------------------------------------------+
| {1:null,3:null,null:null,2:null,null:null} |
+--------------------------------------------+
1 row in set (0.01 sec)
```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0 
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
