### PR TITLE
[BugFix] Fix hudi mor does not initialize `offsetData[0]`

### DIFF
--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
@@ -155,6 +155,12 @@ public class OffHeapColumnVector {
         this.nulls = Platform.reallocateMemory(nulls, oldCapacity, newCapacity);
         Platform.setMemory(nulls + oldCapacity, (byte) 0, newCapacity - oldCapacity);
         capacity = newCapacity;
+
+        if (offsetData != 0) {
+            // offsetData[0] == 0 always.
+            // we have to set it explicitly otherwise it's undefined value here.
+            Platform.putInt(null, offsetData, 0);
+        }
     }
 
     private void reset() {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://starrocks.atlassian.net/browse/SR-15756

https://starrocks.atlassian.net/browse/SR-15841

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
