### PR TITLE
[Enhancement] disable aws-sdk-cpp curl debug logging

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -876,6 +876,7 @@ build_aws_cpp_sdk() {
     # only build s3, s3-crt, transfer manager, identity-management and sts, you can add more components if you want.
     $CMAKE_CMD -Bbuild -DBUILD_ONLY="core;s3;s3-crt;transfer;identity-management;sts" -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=${TP_INSTALL_DIR} -DENABLE_TESTING=OFF \
+               -DENABLE_CURL_LOGGING=OFF \
                -G "${CMAKE_GENERATOR}" \
                -D_POSIX_C_SOURCE=200112L \
                -DCURL_LIBRARY_RELEASE=${TP_INSTALL_DIR}/lib/libcurl.a   \


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We could trace aws-sdk-cpp log if we enable `aws_sdk_logging_trace_enabled=true`. However, if we enable curl logging, the input / output data will also be logged. And for almost all cases, data is in binary format, which makes hard for us to analyse(and hurts performance)

![a7d06f64-92eb-4302-9dce-2b013bef264a](https://user-images.githubusercontent.com/1081215/218948485-58eee033-88f5-464f-82a3-5c31c73e05a3.jpeg)

![6b928b21-efaa-4154-8455-9025d81a5142](https://user-images.githubusercontent.com/1081215/218948739-efc044b2-98d4-4d93-adbe-dda022b70a9c.jpeg)

So I think we'better to disable curl logging.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
