### PR TITLE
[BugFix] [branch-2.4] Fix split sql parse bug when sql scripts contain both '\'' and ';'

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -129,7 +129,7 @@ public class SqlParser {
             if (!inString && (sql.charAt(i) == '\"' || sql.charAt(i) == '\'' || sql.charAt(i) == '`')) {
                 inString = true;
                 inStringStart = sql.charAt(i);
-            } else if (inString && (sql.charAt(i) == inStringStart)) {
+            } else if (inString && (sql.charAt(i) == inStringStart) && (sql.charAt(i - 1) != '\\')) {
                 inString = false;
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -543,6 +543,10 @@ public class AnalyzeSingleTest {
         list = SqlParser.parse("select array_contains([], cast('2021-01--1 08:00:00' as datetime)) --x;x\n from t0", 0);
         Assert.assertEquals(1, list.size());
         Assert.assertTrue(list.get(0) instanceof QueryStatement);
+
+        list = SqlParser.parse("select '\\'', ';';", 0);
+        Assert.assertEquals(1, list.size());
+        Assert.assertTrue(list.get(0) instanceof QueryStatement);
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16526, #16552

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
