### PR TITLE
[BugFix] Divide arithmetic expr error `No match for 'xxx/xxx' with operand types xxx and xxx`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
@@ -325,8 +325,7 @@ public class ArithmeticExpr extends Expr {
                 break;
             case DIVIDE:
                 commonType = getCommonType(t1, t2);
-                if (commonType.getPrimitiveType() == PrimitiveType.BIGINT
-                        || commonType.getPrimitiveType() == PrimitiveType.LARGEINT) {
+                if (commonType.getPrimitiveType().isIntegerType()) {
                     commonType = Type.DOUBLE;
                 }
                 break;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ArithmeticExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ArithmeticExprTest.java
@@ -2,6 +2,7 @@ package com.starrocks.analysis;
 
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
@@ -149,6 +150,25 @@ public class ArithmeticExprTest {
                 Assert.fail("should throw exception");
             } catch (AnalysisException ignored) {
             }
+        }
+    }
+
+    @Test
+    public void testTinyintDivideAnalyze() throws IOException {
+        UtFrameUtils.createDefaultCtx();
+        ArithmeticExpr expr = new ArithmeticExpr(
+                ArithmeticExpr.Operator.DIVIDE, new IntLiteral(15, Type.TINYINT), new IntLiteral(30, Type.TINYINT));
+        try {
+            // The expr in integer type would be cast to double type.
+            expr.analyzeImpl(null);
+            Assert.assertNotNull(expr.fn);
+            Assert.assertEquals(expr.type, Type.DOUBLE);
+            Assert.assertTrue(expr.getChild(0) instanceof LiteralExpr);
+            Assert.assertTrue(expr.getChild(1) instanceof LiteralExpr);
+            Assert.assertEquals(expr.getChild(0).type, Type.DOUBLE);
+            Assert.assertEquals(expr.getChild(1).type, Type.DOUBLE);
+        } catch (AnalysisException e) {
+            Assert.fail("Should not throw exception");
         }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/17853

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
With https://github.com/StarRocks/starrocks/pull/4691, we no longer treat all integer types as `BIGINT`.
![image](https://user-images.githubusercontent.com/16649269/219017842-4b9ce157-f37b-40af-b6ac-48f2afc2cc06.png)
The `DIVIDE` only accepts `DOUBLE` as inputs and would cast inputs in `BIGINT` and `LARGEINT` as `DOUBLE`.
Since the inputs only in `BIGINT` and `LARGEINT` are cast, the ones in `INT` and `TINYINT` would get this error `No match for 'xxx/xxx' with operand types xxx and xxx`.
![image](https://user-images.githubusercontent.com/16649269/219017962-e811c164-08fd-4e08-ba69-cea5da9006e7.png)
This PR cast all integer types to `DOUBLE` to fix this problem.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [x] 2.3
  - [ ] 2.2
