### PR TITLE
[Enhancement] Optimize fe log print when rpc fail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/ReadListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/ReadListener.java
@@ -35,6 +35,7 @@ package com.starrocks.mysql.nio;
 
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectProcessor;
+import com.starrocks.rpc.RpcException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.xnio.ChannelListener;
@@ -72,6 +73,10 @@ public class ReadListener implements ChannelListener<ConduitStreamSourceChannel>
                         ctx.stopAcceptQuery();
                         ctx.cleanup();
                     }
+                } catch (RpcException rpce) {
+                    LOG.debug("Exception happened in one session(" + ctx + ").", rpce);
+                    ctx.setKilled();
+                    ctx.cleanup();
                 } catch (Exception e) {
                     LOG.warn("Exception happened in one session(" + ctx + ").", e);
                     ctx.setKilled();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -58,6 +58,7 @@ import com.starrocks.mysql.MysqlSerializer;
 import com.starrocks.mysql.MysqlServerStatusFlag;
 import com.starrocks.plugin.AuditEvent.EventType;
 import com.starrocks.proto.PQueryStatistics;
+import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
@@ -700,7 +701,7 @@ public class ConnectProcessor {
         try {
             packetBuf = channel.fetchOnePacket();
             if (packetBuf == null) {
-                throw new IOException("Error happened when receiving packet.");
+                throw new RpcException(ctx.getRemoteIP(), "Error happened when receiving packet.");
             }
         } catch (AsynchronousCloseException e) {
             // when this happened, timeout checker close this channel
@@ -720,6 +721,10 @@ public class ConnectProcessor {
         while (!ctx.isKilled()) {
             try {
                 processOnce();
+            } catch (RpcException rpce) {
+                LOG.debug("Exception happened in one session(" + ctx + ").", rpce);
+                ctx.setKilled();
+                break;
             } catch (Exception e) {
                 // TODO(zhaochun): something wrong
                 LOG.warn("Exception happened in one seesion(" + ctx + ").", e);

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/RpcException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/RpcException.java
@@ -16,8 +16,9 @@
 // under the License.
 
 package com.starrocks.rpc;
+import java.io.IOException;
 
-public class RpcException extends Exception {
+public class RpcException extends IOException {
 
     public RpcException(String host, String message) {
         super(message + ", host: " + host);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11751

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When connection fail, it will print too much log: "java.io.IOException: Error happened when receiving packet" as warn log, make it debug log.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
