### PR TITLE
[Enhancement] Make in predicates length configurable for range partition pruner

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
@@ -46,6 +46,8 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -105,7 +107,11 @@ public class RangePartitionPruner implements PartitionPruner {
             return result;
         }
         List<LiteralExpr> inPredicateLiterals = filter.getInPredicateLiterals();
-        if (null == inPredicateLiterals || inPredicateLiterals.size() * complex > 100) {
+        int inPredicateMaxLen = 100;
+        if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable() != null) {
+            inPredicateMaxLen = ConnectContext.get().getSessionVariable().getRangePrunerPredicateMaxLen();
+        }
+        if (null == inPredicateLiterals || inPredicateLiterals.size() * complex > inPredicateMaxLen) {
             if (filter.lowerBoundInclusive && filter.upperBoundInclusive
                     && filter.lowerBound != null && filter.upperBound != null
                     && 0 == filter.lowerBound.compareLiteral(filter.upperBound)) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -363,6 +363,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_REWRITE_SUM_BY_ASSOCIATIVE_RULE = "enable_rewrite_sum_by_associative_rule";
 
     public static final String ENABLE_PRUNE_COMPLEX_TYPES = "enable_prune_complex_types";
+    public static final String RANGE_PRUNER_PREDICATES_MAX_LEN = "range_pruner_max_predicate";
 
     public static final String GROUP_CONCAT_MAX_LEN = "group_concat_max_len";
 
@@ -969,6 +970,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PRUNE_COMPLEX_TYPES)
     private boolean enablePruneComplexTypes = true;
+
+    @VarAttr(name = RANGE_PRUNER_PREDICATES_MAX_LEN)
+    public int rangePrunerPredicateMaxLen = 100;
 
     @VarAttr(name = SQL_QUOTE_SHOW_CREATE)
     private boolean quoteShowCreate = true; // Defined but unused now, for compatibility with MySQL
@@ -1903,6 +1907,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnablePruneComplexTypes(boolean enablePruneComplexTypes) {
         this.enablePruneComplexTypes = enablePruneComplexTypes;
+    }
+
+    public int getRangePrunerPredicateMaxLen() {
+        return rangePrunerPredicateMaxLen;
+    }
+
+    public void setRangePrunerPredicateMaxLen(int rangePrunerPredicateMaxLen) {
+        this.rangePrunerPredicateMaxLen = rangePrunerPredicateMaxLen;
     }
 
     public String getDefaultTableCompression() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When in predicates number for range partition is larger than 100, the query performance will drops dramatically because it will scan all the tablets. For example:
```
  51:OlapScanNode
     TABLE: ads_se_app_report_merge
     PREAGGREGATION: ON
     PREDICATES: DictExpr(267: user_code,[<place-holder> = '1fca0a4b93fa7170']), 132: biz_date >= 20221201, 132: biz_date <= 20221226, 136: biz_pt IN (120221201, 220221201, 320221201, 420221201, 120221202, 220221202, 320221202, 420221202, 120221203, 220221203, 320221203, 420221203, 120221204, 220221204, 320221204, 420221204, 120221205, 220221205, 320221205, 420221205, 120221206, 220221206, 320221206, 420221206, 120221207, 220221207, 320221207, 420221207, 120221208, 220221208, 320221208, 420221208, 120221209, 220221209, 320221209, 420221209, 120221210, 220221210, 320221210, 420221210, 120221211, 220221211, 320221211, 420221211, 120221212, 220221212, 320221212, 420221212, 120221213, 220221213, 320221213, 420221213, 120221214, 220221214, 320221214, 420221214, 120221215, 220221215, 320221215, 420221215, 120221216, 220221216, 320221216, 420221216, 120221217, 220221217, 320221217, 420221217, 120221218, 220221218, 320221218, 420221218, 120221219, 220221219, 320221219, 420221219, 120221220, 220221220, 320221220, 420221220, 120221221, 220221221, 320221221, 420221221, 120221222, 220221222, 320221222, 420221222, 120221223, 220221223, 320221223, 420221223, 120221224, 220221224, 320221224, 420221224, 120221225, 220221225, 320221225, 420221225, 120221226, 220221226, 320221226, 420221226), NOT (139: delivery_platform LIKE '%Tiktok Installs%'), 144: dims IN (-2, 0)
     partitions=932/932
     rollup: ads_se_app_report_merge
     tabletRatio=22368/22368
     tabletList=1088613,1088615,1088617,1088619,1088621,1088623,1088625,1088627,1088629,1088631 ...
     cardinality=33
     avgRowSize=125.08442
     numNodes=0
``` 
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
