### PR TITLE
[BugFix] fix log4j ClassLoader issue running on JDK11

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -294,7 +294,7 @@ public class Log4jConfig extends XmlConfiguration {
         Log4jConfig config = new Log4jConfig(source);
 
         // LoggerContext.start(new Configuration)
-        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        LoggerContext context = (LoggerContext) LogManager.getContext(LogManager.class.getClassLoader(), false);
         context.start(config);
     }
 


### PR DESCRIPTION
* on ubuntu22, jdk11 is the default java sdk
* In Java 11, the boot class loader only loads core modules. If you create a class loader with a null parent, it may not find all platform classes.

  https://learn.microsoft.com/en-us/java/openjdk/transition-from-java-8-to-java-11

## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
