### PR TITLE
[Enhancement] remove excessive log in tablet_updates.cpp

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3395,7 +3395,6 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
         }
         std::string seg_path =
                 Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), rssid - iter->first);
-        LOG(INFO) << "segment path is " << seg_path;
         auto segment = Segment::open(fs, seg_path, rssid - iter->first, &rowset->schema());
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Remove log like this:
```
I0216 15:38:59.318625 289623 local_tablet_reader.cpp:146] multi_get tablet:1919221059 version:2 #columns:2 #rows:245 found:2 time:0ms
I0216 15:38:59.318727 289623 tablet_updates.cpp:3398] segment path is /tmp/.org.chromium.Chromium.e2EkT7/data/3/1919221060/163217297/020000000000000400000000000000000000000000000000_0.dat
I0216 15:38:59.318922 289623 tablet_updates.cpp:3398] segment path is /tmp/.org.chromium.Chromium.e2EkT7/data/4/1919221061/1310930315/020000000000000500000000000000000000000000000000_0.dat
I0216 15:38:59.319116 289623 tablet_updates.cpp:3398] segment path is /tmp/.org.chromium.Chromium.e2EkT7/data/1/1919221058/228749314/020000000000000200000000000000000000000000000000_0.dat

```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
