### PR TITLE
[BugFix] Fix ORC's SearchArgument not followed with case sensitive behavior

### DIFF
--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -117,7 +117,7 @@ bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
     ChunkPtr max_chunk = ChunkHelper::new_chunk(*min_max_tuple_desc, 0);
     for (size_t i = 0; i < min_max_tuple_desc->slots().size(); i++) {
         SlotDescriptor* slot = min_max_tuple_desc->slots()[i];
-        int32_t column_index = _reader->get_column_id_by_name(slot->col_name());
+        int32_t column_index = _reader->get_column_id_by_slot_name(slot->col_name());
         if (column_index >= 0) {
             auto row_idx_iter = rowIndexes.find(column_index);
             // there is no column stats, skip filter process.
@@ -163,6 +163,7 @@ bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
         auto min = min_col->get(0).get_int8();
         auto max = max_col->get(0).get_int8();
         if (min == 0 && max == 0) {
+            // Means this row group dont stastisfy min-max predicates, we can filter this row group.
             return true;
         }
     }
@@ -190,7 +191,7 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
             if (!_scanner_ctx.can_use_dict_filter_on_slot(slot)) {
                 continue;
             }
-            int32_t column_index = _reader->get_column_id_by_name(col.col_name);
+            int32_t column_index = _reader->get_column_id_by_slot_name(col.col_name);
             if (column_index < 0) {
                 continue;
             }

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -30,10 +30,7 @@
 #include "exprs/cast_expr.h"
 #include "exprs/literal.h"
 #include "formats/orc/fill_function.h"
-#include "formats/orc/orc_input_stream.h"
 #include "formats/orc/orc_mapping.h"
-#include "fs/fs.h"
-#include "gen_cpp/orc_proto.pb.h"
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h"
 #include "simd/simd.h"
@@ -134,8 +131,8 @@ Status OrcChunkReader::_slot_to_orc_column_name(const SlotDescriptor* desc,
                                                 const std::unordered_map<int, std::string>& column_id_to_orc_name,
                                                 std::string* orc_column_name) {
     auto col_name = format_column_name(desc->col_name(), _case_sensitive);
-    auto it = _name_to_column_id.find(col_name);
-    if (it == _name_to_column_id.end()) {
+    auto it = _formatted_slot_name_to_column_id.find(col_name);
+    if (it == _formatted_slot_name_to_column_id.end()) {
         auto s = strings::Substitute("OrcChunkReader::init_include_columns. col name = $0 not found, file = $1",
                                      desc->col_name(), _current_file_name);
         return Status::NotFound(s);
@@ -152,7 +149,7 @@ Status OrcChunkReader::_slot_to_orc_column_name(const SlotDescriptor* desc,
 
 Status OrcChunkReader::_init_include_columns(const std::unique_ptr<OrcMapping>& mapping) {
     // TODO(SmithCruise) delete _name_to_column_id, _hive_column_names when develop subfield lazy load.
-    build_column_name_to_id_mapping(&_name_to_column_id, _hive_column_names, _reader->getType(), _case_sensitive);
+    build_column_name_to_id_mapping(&_formatted_slot_name_to_column_id, _hive_column_names, _reader->getType(), _case_sensitive);
 
     std::list<uint64_t> include_column_id;
 
@@ -261,8 +258,8 @@ Status OrcChunkReader::_init_position_in_orc() {
 
         if (slot_desc == nullptr) continue;
         std::string col_name = format_column_name(slot_desc->col_name(), _case_sensitive);
-        auto it = _name_to_column_id.find(col_name);
-        if (it == _name_to_column_id.end()) {
+        auto it = _formatted_slot_name_to_column_id.find(col_name);
+        if (it == _formatted_slot_name_to_column_id.end()) {
             auto s = strings::Substitute(
                     "OrcChunkReader::init_position_in_orc. failed to find position. col_name = $0, file = $1", col_name,
                     _current_file_name);
@@ -1202,9 +1199,10 @@ void OrcChunkReader::report_error_message(const std::string& error_msg) {
     _state->append_error_msg_to_file("", error_msg);
 }
 
-int OrcChunkReader::get_column_id_by_name(const std::string& name) const {
-    const auto& it = _name_to_column_id.find(name);
-    if (it != _name_to_column_id.end()) {
+int OrcChunkReader::get_column_id_by_slot_name(const std::string& slot_name) const {
+    const std::string& formatted_slot_name = format_column_name(slot_name, _case_sensitive);
+    const auto& it = _formatted_slot_name_to_column_id.find(formatted_slot_name);
+    if (it != _formatted_slot_name_to_column_id.end()) {
         return it->second;
     }
     return -1;

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -149,7 +149,8 @@ Status OrcChunkReader::_slot_to_orc_column_name(const SlotDescriptor* desc,
 
 Status OrcChunkReader::_init_include_columns(const std::unique_ptr<OrcMapping>& mapping) {
     // TODO(SmithCruise) delete _name_to_column_id, _hive_column_names when develop subfield lazy load.
-    build_column_name_to_id_mapping(&_formatted_slot_name_to_column_id, _hive_column_names, _reader->getType(), _case_sensitive);
+    build_column_name_to_id_mapping(&_formatted_slot_name_to_column_id, _hive_column_names, _reader->getType(),
+                                    _case_sensitive);
 
     std::list<uint64_t> include_column_id;
 

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -124,7 +124,7 @@ public:
     SlotDescriptor* get_current_slot() const { return _current_slot; }
     void set_current_file_name(const std::string& name) { _current_file_name = name; }
     void report_error_message(const std::string& error_msg);
-    int get_column_id_by_name(const std::string& name) const;
+    int get_column_id_by_slot_name(const std::string& name) const;
 
     void set_lazy_load_context(LazyLoadContext* ctx) { _lazy_load_ctx = ctx; }
     bool has_lazy_load_context() { return _lazy_load_ctx != nullptr; }
@@ -196,7 +196,8 @@ private:
     size_t _num_rows_filtered;
     const std::vector<std::string>* _hive_column_names = nullptr;
     bool _case_sensitive = false;
-    std::unordered_map<std::string, int> _name_to_column_id;
+    // Key is slot name formatted with case sensitive
+    std::unordered_map<std::string, int> _formatted_slot_name_to_column_id;
     RuntimeState* _state = nullptr;
     SlotDescriptor* _current_slot = nullptr;
     std::string _current_file_name;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Fix orc SearchArgument not follow with case sensitive behavior.

For example, we have an orc file's schema as `struct<a int, b int>`, and the SlotDescriptor's name is `A` and `B`.

In `OrcChunkReader`, we use non case sensitive by default, but our SearchArgument has not followed it. So if the user run query: `select * from tbl where A=5`,  it will throw an error message in `OrcRowReaderFilter::filterMinMax()`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
