### PR TITLE
[Enhancement] TableReader remote multiget support

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -150,7 +150,10 @@ Status OlapTablePartitionParam::init(RuntimeState* state) {
     }
     _distributed_columns.resize(_distributed_slot_descs.size());
 
-    if (_t_param.__isset.partition_exprs) {
+    if (_t_param.__isset.partition_exprs && _t_param.partition_exprs.size() > 0) {
+        if (state == nullptr) {
+            return Status::InternalError("state is null when partition_exprs is not empty");
+        }
         RETURN_IF_ERROR(Expr::create_expr_trees(&_obj_pool, _t_param.partition_exprs, &_partitions_expr_ctxs, state));
     }
 

--- a/be/src/serde/protobuf_serde.h
+++ b/be/src/serde/protobuf_serde.h
@@ -135,6 +135,8 @@ private:
     std::vector<int> _encode_level;
 };
 
+StatusOr<Chunk> deserialize_chunk_pb_with_schema(const Schema& schema, std::string_view buff);
+
 StatusOr<ProtobufChunkMeta> build_protobuf_chunk_meta(const RowDescriptor& row_desc, const ChunkPB& chunk_pb);
 
 } // namespace starrocks::serde

--- a/be/src/service/service_be/internal_service.cpp
+++ b/be/src/service/service_be/internal_service.cpp
@@ -47,6 +47,7 @@
 #include "runtime/routine_load/routine_load_task_executor.h"
 #include "runtime/runtime_filter_worker.h"
 #include "service/brpc.h"
+#include "storage/local_tablet_reader.h"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -120,31 +121,53 @@ template <typename T>
 void BackendInternalServiceImpl<T>::local_tablet_reader_open(google::protobuf::RpcController* controller,
                                                              const PTabletReaderOpenRequest* request,
                                                              PTabletReaderOpenResult* response,
-                                                             google::protobuf::Closure* done) {}
+                                                             google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    response->mutable_status()->set_status_code(TStatusCode::NOT_IMPLEMENTED_ERROR);
+}
 
 template <typename T>
 void BackendInternalServiceImpl<T>::local_tablet_reader_close(google::protobuf::RpcController* controller,
                                                               const PTabletReaderCloseRequest* request,
                                                               PTabletReaderCloseResult* response,
-                                                              google::protobuf::Closure* done) {}
+                                                              google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    response->mutable_status()->set_status_code(TStatusCode::NOT_IMPLEMENTED_ERROR);
+}
 
 template <typename T>
 void BackendInternalServiceImpl<T>::local_tablet_reader_multi_get(google::protobuf::RpcController* controller,
                                                                   const PTabletReaderMultiGetRequest* request,
                                                                   PTabletReaderMultiGetResult* response,
-                                                                  google::protobuf::Closure* done) {}
+                                                                  google::protobuf::Closure* done) {
+    LOG(INFO) << "call local_tablet_reader_multi_get tablet: " << request->tablet_id()
+              << " version:" << request->version();
+    ClosureGuard closure_guard(done);
+    auto st = handle_tablet_multi_get_rpc(*request, *response);
+    if (!st.ok()) {
+        LOG(WARNING) << "handle tablet multi get rpc failed: " << st << " tablet: " << request->tablet_id()
+                     << " version:" << request->version();
+    }
+    st.to_protobuf(response->mutable_status());
+}
 
 template <typename T>
 void BackendInternalServiceImpl<T>::local_tablet_reader_scan_open(google::protobuf::RpcController* controller,
                                                                   const PTabletReaderScanOpenRequest* request,
                                                                   PTabletReaderScanOpenResult* response,
-                                                                  google::protobuf::Closure* done) {}
+                                                                  google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    response->mutable_status()->set_status_code(TStatusCode::NOT_IMPLEMENTED_ERROR);
+}
 
 template <typename T>
 void BackendInternalServiceImpl<T>::local_tablet_reader_scan_get_next(google::protobuf::RpcController* controller,
                                                                       const PTabletReaderScanGetNextRequest* request,
                                                                       PTabletReaderScanGetNextResult* response,
-                                                                      google::protobuf::Closure* done) {}
+                                                                      google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    response->mutable_status()->set_status_code(TStatusCode::NOT_IMPLEMENTED_ERROR);
+}
 
 template class BackendInternalServiceImpl<PInternalService>;
 template class BackendInternalServiceImpl<doris::PBackendService>;

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -14,10 +14,14 @@
 
 #include "storage/local_tablet_reader.h"
 
+#include "gen_cpp/internal_service.pb.h"
+#include "serde/protobuf_serde.h"
 #include "storage/chunk_helper.h"
 #include "storage/primary_index.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/projection_iterator.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
 #include "storage/tablet_reader.h"
 #include "storage/tablet_updates.h"
 
@@ -82,24 +86,30 @@ static void plan_read_by_rssid(const vector<uint64_t>& rowids, vector<bool>& fou
 
 Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<std::string>& value_columns,
                                     std::vector<bool>& found, Chunk& values) {
+    // get read column ids by values_columns
+    const auto& tablet_schema = _tablet->tablet_schema();
+    std::vector<uint32_t> value_column_ids;
+    for (const auto& name : value_columns) {
+        auto cid = tablet_schema.field_index(name);
+        if (cid == -1) {
+            return Status::InvalidArgument(strings::Substitute("multi_get value_column $0 not found", name));
+        }
+        value_column_ids.push_back(cid);
+    }
+    return multi_get(keys, value_column_ids, found, values);
+}
+
+Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_t>& value_column_ids,
+                                    std::vector<bool>& found, Chunk& values) {
     int64_t t_start = MonotonicMillis();
     size_t n = keys.num_rows();
     if (n > UINT32_MAX) {
         return Status::InvalidArgument(
                 strings::Substitute("multi_get number of keys exceed limit $0 > $1", n, UINT32_MAX));
     }
-    // get read column ids by values_columns
-    const auto& tablet_schema = _tablet->tablet_schema();
-    std::vector<uint32_t> read_column_ids;
-    for (const auto& name : value_columns) {
-        auto cid = tablet_schema.field_index(name);
-        if (cid == -1) {
-            return Status::InvalidArgument(strings::Substitute("multi_get value_column $0 not found", name));
-        }
-        read_column_ids.push_back(cid);
-    }
 
     // convert keys to pk single column format
+    const auto& tablet_schema = _tablet->tablet_schema();
     vector<uint32_t> pk_columns;
     for (size_t i = 0; i < tablet_schema.num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
@@ -130,22 +140,22 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<std::st
     vector<uint32_t> idxes;
     plan_read_by_rssid(rowids, found, rowids_by_rssid, idxes);
 
-    auto read_column_schema = ChunkHelper::convert_schema(tablet_schema, read_column_ids);
-    std::vector<std::unique_ptr<Column>> read_columns(read_column_ids.size());
+    auto read_column_schema = ChunkHelper::convert_schema(tablet_schema, value_column_ids);
+    std::vector<std::unique_ptr<Column>> read_columns(value_column_ids.size());
     for (uint32_t i = 0; i < read_columns.size(); ++i) {
         read_columns[i] = ChunkHelper::column_from_field(*read_column_schema.field(i).get())->clone_empty();
     }
     RETURN_IF_ERROR(
-            _tablet->updates()->get_column_values(read_column_ids, false, rowids_by_rssid, &read_columns, nullptr));
+            _tablet->updates()->get_column_values(value_column_ids, false, rowids_by_rssid, &read_columns, nullptr));
 
     // reorder read values to input keys' order and put into values output parameter
     values.reset();
-    for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
+    for (size_t col_idx = 0; col_idx < value_column_ids.size(); col_idx++) {
         values.get_column_by_index(col_idx)->append_selective(*read_columns[col_idx], idxes.data(), 0, idxes.size());
     }
     int64_t t_end = MonotonicMillis();
     LOG(INFO) << strings::Substitute("multi_get tablet:$0 version:$1 #columns:$2 #rows:$3 found:$4 time:$5ms",
-                                     _tablet->tablet_id(), _version, value_columns.size(), n, idxes.size(),
+                                     _tablet->tablet_id(), _version, value_column_ids.size(), n, idxes.size(),
                                      t_end - t_start);
     return Status::OK();
 }
@@ -169,6 +179,54 @@ StatusOr<ChunkIteratorPtr> LocalTabletReader::scan(const std::vector<std::string
     RETURN_IF_ERROR(reader->open(tablet_reader_params));
     // TODO: remove projection
     return new_projection_iterator(values_schema, reader);
+}
+
+Status handle_tablet_multi_get_rpc(const PTabletReaderMultiGetRequest& request, PTabletReaderMultiGetResult& result) {
+    int64_t tablet_id = request.tablet_id();
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+    if (tablet == nullptr) {
+        return Status::InternalError(strings::Substitute("mult-get rpc failed, tablet $0 not found", tablet_id));
+    }
+    int64_t version = request.version();
+    vector<string> value_columns(request.values_columns().begin(), request.values_columns().end());
+    auto local_tablet_reader = std::make_unique<LocalTabletReader>();
+    RETURN_IF_ERROR(local_tablet_reader->init(tablet, version));
+
+    const auto& tablet_schema = tablet->tablet_schema();
+    const auto& keys_pb = request.keys();
+    vector<ColumnId> key_column_ids;
+    for (size_t i = 0; i < tablet_schema.num_key_columns(); i++) {
+        key_column_ids.push_back(i);
+    }
+    Schema key_schema(tablet_schema.schema(), key_column_ids);
+    std::vector<uint32_t> value_column_ids;
+    for (const auto& name : value_columns) {
+        auto cid = tablet_schema.field_index(name);
+        if (cid == -1) {
+            return Status::InvalidArgument(strings::Substitute("multi_get value_column $0 not found", name));
+        }
+        value_column_ids.push_back(cid);
+    }
+    Schema values_schema(tablet->tablet_schema().schema(), value_column_ids);
+    auto keys_st = serde::deserialize_chunk_pb_with_schema(key_schema, keys_pb.data());
+    if (!keys_st.ok()) {
+        return keys_st.status();
+    }
+    vector<bool> found;
+    ChunkPtr values = ChunkHelper::new_chunk(values_schema, keys_st.value().num_rows());
+    RETURN_IF_ERROR(local_tablet_reader->multi_get(keys_st.value(), value_column_ids, found, *values));
+    auto* found_pb = result.mutable_found();
+    found_pb->Reserve(found.size());
+    for (auto f : found) {
+        found_pb->Add(f);
+    }
+    StatusOr<ChunkPB> values_pb;
+    TRY_CATCH_BAD_ALLOC(values_pb = serde::ProtobufChunkSerde::serialize(*values, nullptr));
+    if (!values_pb.ok()) {
+        return values_pb.status();
+    }
+    result.mutable_values()->Swap(&values_pb.value());
+    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/storage/local_tablet_reader.h
+++ b/be/src/storage/local_tablet_reader.h
@@ -20,6 +20,8 @@
 namespace starrocks {
 
 class ColumnPredicate;
+class PTabletReaderMultiGetRequest;
+class PTabletReaderMultiGetResult;
 
 // A tablet reader supports multiple get and scan snapshot reads
 // this class is used for remote accessible TableReader, do not confuse with TabletReader
@@ -36,6 +38,10 @@ public:
                      Chunk& values);
 
     // for detail document, see TableReader::scan
+    Status multi_get(const Chunk& keys, const std::vector<uint32_t>& value_column_ids, std::vector<bool>& found,
+                     Chunk& values);
+
+    // for detail document, see TableReader::scan
     StatusOr<ChunkIteratorPtr> scan(const std::vector<std::string>& value_columns,
                                     const std::vector<const ColumnPredicate*>& predicates);
 
@@ -43,6 +49,8 @@ private:
     TabletSharedPtr _tablet;
     int64_t _version{0};
 };
+
+Status handle_tablet_multi_get_rpc(const PTabletReaderMultiGetRequest& request, PTabletReaderMultiGetResult& result);
 
 // Manage remotely opened LocalTabletReaders
 class LocalTabletReaderManager {

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -14,10 +14,18 @@
 
 #include "storage/table_reader.h"
 
+#include <algorithm>
+#include <queue>
+
+#include "exec/tablet_info.h"
+#include "gen_cpp/doris_internal_service.pb.h"
+#include "serde/protobuf_serde.h"
 #include "storage/local_tablet_reader.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/tablet_reader.h"
+#include "util/brpc_stub_cache.h"
+#include "util/ref_count_closure.h"
 
 namespace starrocks {
 
@@ -41,15 +49,248 @@ Status TableReader::init(const LocalTableReaderParams& local_params) {
 }
 
 Status TableReader::init(const TableReaderParams& params) {
-    return Status::NotSupported("remote table reader not supported");
+    if (_local_params || _params) {
+        return Status::InternalError("TableReader already initialized");
+    }
+    _params = std::make_unique<TableReaderParams>(params);
+    _schema_param = std::make_shared<OlapTableSchemaParam>();
+    RETURN_IF_ERROR(_schema_param->init(params.schema));
+    _partition_param = std::make_unique<OlapTablePartitionParam>(_schema_param, params.partition_param);
+    // currently RuntimeState and partition expr is not supported
+    // so prepare/open/close is not called
+    RETURN_IF_ERROR(_partition_param->init(nullptr));
+    _location_param = std::make_unique<OlapTableLocationParam>(params.location_param);
+    _nodes_info = std::make_unique<StarRocksNodesInfo>(params.nodes_info);
+    _row_desc = std::make_unique<RowDescriptor>(_schema_param->tuple_desc(), false);
+    return Status::OK();
 }
 
-Status TableReader::multi_get(const Chunk& keys, const std::vector<std::string>& value_columns,
-                              std::vector<bool>& found, Chunk& values) {
+struct TabletMultiGet {
+    int64_t tablet_id{0};
+    int64_t version{0};
+    std::shared_ptr<Chunk> keys;
+    std::vector<uint32_t> orig_idxs;
+
+    std::unique_ptr<Chunk> values;
+    std::vector<uint32_t> found_idxs;
+    size_t num_rows{0};
+    size_t cur_row{0};
+
+    void add(Chunk& keys, size_t idx, uint32_t orig_idx) {
+        this->keys->append(keys, idx, 1);
+        orig_idxs.push_back(orig_idx);
+    }
+
+    bool operator<(const TabletMultiGet& other) const { return found_idxs[cur_row] < other.found_idxs[other.cur_row]; }
+
+    bool empty() { return cur_row >= num_rows; }
+
+    Status pop_value_to(Chunk& dest) {
+        if (cur_row >= num_rows) {
+            return Status::InternalError("pop value from empty TabletMultiGet");
+        }
+        dest.append(*this->values, cur_row, 1);
+        ++cur_row;
+        return Status::OK();
+    }
+};
+
+struct TabletMultiGetPtrCmp {
+    bool operator()(const TabletMultiGet* lhs, const TabletMultiGet* rhs) const { return *rhs < *lhs; }
+};
+
+Status TableReader::multi_get(Chunk& keys, const std::vector<std::string>& value_columns, std::vector<bool>& found,
+                              Chunk& values) {
     if (_local_tablet_reader) {
         return _local_tablet_reader->multi_get(keys, value_columns, found, values);
     }
-    return Status::NotSupported("multi_get for remote table reader not supported");
+    size_t num_rows = keys.num_rows();
+    found.assign(num_rows, false);
+    std::vector<OlapTablePartition*> partitions;
+    std::vector<uint32_t> tablet_indexes;
+    std::vector<uint8_t> validate_selection;
+    std::vector<uint32_t> validate_select_idx;
+    validate_selection.assign(num_rows, 1);
+    int invalid_row_index = 0;
+    RETURN_IF_ERROR(_partition_param->find_tablets(&keys, &partitions, &tablet_indexes, &validate_selection,
+                                                   &invalid_row_index, 0, nullptr));
+    // Arrange selection_idx by merging _validate_selection
+    // If chunk num_rows is 6
+    // _validate_selection is [1, 0, 0, 0, 1, 1]
+    // selection_idx after arrange will be : [0, 4, 5]
+    validate_select_idx.resize(num_rows);
+    size_t selected_size = 0;
+    for (uint16_t i = 0; i < num_rows; ++i) {
+        validate_select_idx[selected_size] = i;
+        selected_size += (validate_selection[i] & 0x1);
+    }
+    validate_select_idx.resize(selected_size);
+    if (selected_size == 0) {
+        return Status::OK();
+    }
+    std::unordered_map<uint64_t, std::unique_ptr<TabletMultiGet>> multi_gets_by_tablet;
+    for (size_t i = 0; i < selected_size; ++i) {
+        size_t key_index = validate_select_idx[i];
+        int64_t tablet_id = partitions[key_index]->indexes[0].tablets[tablet_indexes[key_index]];
+        auto iter = multi_gets_by_tablet.find(tablet_id);
+        TabletMultiGet* multi_get = nullptr;
+        if (iter == multi_gets_by_tablet.end()) {
+            multi_gets_by_tablet[tablet_id] = std::make_unique<TabletMultiGet>();
+            multi_get = multi_gets_by_tablet[tablet_id].get();
+            multi_get->tablet_id = tablet_id;
+            auto partition_id = partitions[key_index]->id;
+            auto itr = _params->partition_versions.find(partition_id);
+            if (itr == _params->partition_versions.end()) {
+                return Status::InternalError(strings::Substitute(
+                        "partition version not found: partition:$0 tablet:$1 not found", partition_id, tablet_id));
+            }
+            multi_get->version = itr->second;
+            multi_get->keys = keys.clone_empty();
+        } else {
+            multi_get = iter->second.get();
+        }
+        multi_get->add(keys, key_index, key_index);
+    }
+    vector<TabletMultiGet*> multi_gets;
+    for (auto& iter : multi_gets_by_tablet) {
+        multi_gets.push_back(iter.second.get());
+    }
+    // TODO: parallel get
+    // a cache var to init chunk_meta only once
+    std::unique_ptr<serde::ProtobufChunkMeta> chunk_meta;
+    for (auto multi_get : multi_gets) {
+        multi_get->values = values.clone_empty();
+        vector<bool> found;
+        RETURN_IF_ERROR(_tablet_multi_get(multi_get->tablet_id, multi_get->version, *multi_get->keys, value_columns,
+                                          found, *multi_get->values, chunk_meta));
+        multi_get->found_idxs.clear();
+        DCHECK(multi_get->keys->num_rows() == found.size());
+        for (size_t i = 0; i < found.size(); ++i) {
+            if (found[i]) {
+                multi_get->found_idxs.push_back(multi_get->orig_idxs[i]);
+            }
+        }
+        multi_get->num_rows = multi_get->found_idxs.size();
+    }
+    std::priority_queue<TabletMultiGet*, std::vector<TabletMultiGet*>, TabletMultiGetPtrCmp> pq;
+    for (auto multi_get : multi_gets) {
+        if (!multi_get->empty()) {
+            pq.push(multi_get);
+        }
+    }
+    while (!pq.empty()) {
+        TabletMultiGet* multi_get = pq.top();
+        pq.pop();
+        size_t idx = multi_get->found_idxs[multi_get->cur_row];
+        found[idx] = true;
+        RETURN_IF_ERROR(multi_get->pop_value_to(values));
+        if (!multi_get->empty()) {
+            pq.push(multi_get);
+        }
+    }
+    return Status::OK();
+}
+
+Status TableReader::_tablet_multi_get(int64_t tablet_id, int64_t version, Chunk& keys,
+                                      const std::vector<std::string>& value_columns, std::vector<bool>& found,
+                                      Chunk& values, std::unique_ptr<serde::ProtobufChunkMeta>& chunk_meta) {
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+    // get from local tablet
+    // TODO: if local tablet's version is missing, switch to remote replica
+    if (tablet != nullptr) {
+        auto local_tablet_reader = std::make_unique<LocalTabletReader>();
+        RETURN_IF_ERROR(local_tablet_reader->init(tablet, version));
+        RETURN_IF_ERROR(local_tablet_reader->multi_get(keys, value_columns, found, values));
+        return Status::OK();
+    }
+    return _tablet_multi_get_remote(tablet_id, version, keys, value_columns, found, values, chunk_meta);
+}
+
+Status TableReader::_tablet_multi_get_remote(int64_t tablet_id, int64_t version, Chunk& keys,
+                                             const std::vector<std::string>& value_columns, std::vector<bool>& found,
+                                             Chunk& values, std::unique_ptr<serde::ProtobufChunkMeta>& chunk_meta) {
+    auto location = _location_param->find_tablet(tablet_id);
+    if (location == nullptr) {
+        return Status::InternalError(strings::Substitute("tablet $0 not found in OlapTableLocationParam", tablet_id));
+    }
+    Status st;
+    for (int64_t node_id : location->node_ids) {
+        auto node_info = _nodes_info->find_node(node_id);
+        if (node_info == nullptr) {
+            string msg = strings::Substitute("multi_get fail: be $0 not found tablet:$1", node_id, tablet_id);
+            LOG(WARNING) << msg;
+            st = Status::InternalError(msg);
+        } else {
+            doris::PBackendService_Stub* stub =
+                    ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(node_info->host, node_info->brpc_port);
+            if (stub == nullptr) {
+                string msg = strings::Substitute("multi_get fail to get brpc stub for $0:$1 tablet:$2", node_info->host,
+                                                 node_info->brpc_port, tablet_id);
+                LOG(WARNING) << msg;
+                st = Status::InternalError(msg);
+            } else {
+                st = _tablet_multi_get_rpc(stub, tablet_id, version, keys, value_columns, found, values, chunk_meta);
+                if (st.ok()) {
+                    break;
+                }
+            }
+        }
+    }
+    return st;
+}
+
+Status TableReader::_tablet_multi_get_rpc(doris::PBackendService_Stub* stub, int64_t tablet_id, int64_t version,
+                                          Chunk& keys, const std::vector<std::string>& value_columns,
+                                          std::vector<bool>& found, Chunk& values,
+                                          std::unique_ptr<serde::ProtobufChunkMeta>& chunk_meta) {
+    PTabletReaderMultiGetRequest request;
+    request.set_tablet_id(tablet_id);
+    request.set_version(version);
+    for (size_t i = 0; i < value_columns.size(); ++i) {
+        request.add_values_columns(value_columns[i]);
+    }
+    StatusOr<ChunkPB> keys_pb;
+    TRY_CATCH_BAD_ALLOC(keys_pb = serde::ProtobufChunkSerde::serialize(keys, nullptr));
+    RETURN_IF_ERROR(keys_pb);
+    request.mutable_keys()->Swap(&keys_pb.value());
+    RefCountClosure<PTabletReaderMultiGetResult>* closure = new RefCountClosure<PTabletReaderMultiGetResult>();
+    closure->ref();
+    DeferOp op([&]() {
+        if (closure->unref()) {
+            delete closure;
+            closure = nullptr;
+        }
+    });
+    if (_params->timeout_ms > 0) {
+        closure->cntl.set_timeout_ms(_params->timeout_ms);
+    }
+    stub->local_tablet_reader_multi_get(&closure->cntl, &request, &closure->result, closure);
+    closure->join();
+    if (closure->cntl.Failed()) {
+        return Status::InternalError(closure->cntl.ErrorText());
+    }
+    auto& result = closure->result;
+    Status st = result.status();
+    if (!st.ok()) {
+        return st;
+    }
+    found.resize(result.found().size());
+    for (size_t i = 0; i < result.found().size(); ++i) {
+        found[i] = result.found(i);
+    }
+    auto& values_pb = result.values();
+    if (!chunk_meta) {
+        StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(*_row_desc, values_pb);
+        if (!res.ok()) return res.status();
+        chunk_meta.reset(new serde::ProtobufChunkMeta(std::move(res).value()));
+    }
+    TRY_CATCH_BAD_ALLOC({
+        serde::ProtobufChunkDeserializer des(*chunk_meta);
+        StatusOr<Chunk> res = des.deserialize(values_pb.data());
+        if (!res.ok()) return res.status();
+        values.columns().swap(res.value().columns());
+    });
+    return Status::OK();
 }
 
 StatusOr<ChunkIteratorPtr> TableReader::scan(const std::vector<std::string>& value_columns,

--- a/be/src/storage/table_reader.h
+++ b/be/src/storage/table_reader.h
@@ -22,9 +22,20 @@
 #include "storage/column_predicate.h"
 #include "storage/tablet.h"
 
+namespace doris {
+class PBackendService_Stub;
+}
+
 namespace starrocks {
 
+class OlapTablePartitionParam;
+class OlapTableLocationParam;
+class StarRocksNodesInfo;
 class LocalTabletReader;
+
+namespace serde {
+class ProtobufChunkMeta;
+}
 
 // Parameters used to create a TableReader supporting only single local tablet access
 struct LocalTableReaderParams {
@@ -36,14 +47,14 @@ struct LocalTableReaderParams {
 struct TableReaderParams {
     // table schema
     TOlapTableSchemaParam schema;
-    // Version of data to read
-    int64_t version;
     // table and partition info, used to find the tablet that a key belongs to
     TOlapTablePartitionParam partition_param;
     // tablet id -> { node id list }, used to find BE nodes that a tablet locates on
     TOlapTableLocationParam location_param;
     // node id -> host address map, used to find the RPC port of BE nodes
     TNodesInfo nodes_info;
+    std::map<int64_t, int64_t> partition_versions;
+    int64_t timeout_ms{-1};
 };
 
 // Table reader provides storage interfaces for multi_get and scan. It can read from local
@@ -66,7 +77,7 @@ public:
      * @param values output, a chunk with columns in the same order as `value_columns`, and append the column values of
      *                    each founded row to corresponding column
      * @return Status::OK() if no error, otherwise return error status
-     *
+     * @note not thread-safe, concurrent calls not supported
      * Example:
      *     table schema:
      *         k1 int primary key, v1 int, v2 int, v3 int
@@ -85,7 +96,7 @@ public:
      *         3  | 3
      *         5  | 5
      */
-    Status multi_get(const Chunk& keys, const std::vector<std::string>& value_columns, std::vector<bool>& found,
+    Status multi_get(Chunk& keys, const std::vector<std::string>& value_columns, std::vector<bool>& found,
                      Chunk& values);
 
     /**
@@ -95,7 +106,8 @@ public:
      *                   contents of predicates must remain valid when using the returned ChunkIteratorPtr
      * @return A ChunkIterator which can be used to iterate over the rows of the table satisfying the predicates, or
      *         error status
-     * note: specifying ordering is not supported, user cannot assume the order of the returned rows,
+     * @note not thread-safe, concurrent calls not supported
+     * @note specifying ordering is not supported, user cannot assume the order of the returned rows,
      *       its complex/inefficient to merge data from multiple remote sources and maintain some ordering requirements,
      *       it's better to let execution engine to do the ordering(rather then storage engine)
      */
@@ -103,12 +115,28 @@ public:
                                     const std::vector<const ColumnPredicate*>& predicates);
 
 private:
+    Status _tablet_multi_get(int64_t tablet_id, int64_t version, Chunk& keys,
+                             const std::vector<std::string>& value_columns, std::vector<bool>& found, Chunk& values,
+                             std::unique_ptr<serde::ProtobufChunkMeta>& chunk_meta);
+
+    Status _tablet_multi_get_remote(int64_t tablet_id, int64_t version, Chunk& keys,
+                                    const std::vector<std::string>& value_columns, std::vector<bool>& found,
+                                    Chunk& values, std::unique_ptr<serde::ProtobufChunkMeta>& chunk_meta);
+
+    Status _tablet_multi_get_rpc(doris::PBackendService_Stub* stub, int64_t tablet_id, int64_t version, Chunk& keys,
+                                 const std::vector<std::string>& value_columns, std::vector<bool>& found, Chunk& values,
+                                 std::unique_ptr<serde::ProtobufChunkMeta>& chunk_meta);
     // fields for local tablet reader
     std::unique_ptr<LocalTableReaderParams> _local_params;
     std::unique_ptr<LocalTabletReader> _local_tablet_reader;
 
     // fields for remote tablet reader
     std::unique_ptr<TableReaderParams> _params;
+    std::shared_ptr<OlapTableSchemaParam> _schema_param;
+    std::unique_ptr<OlapTablePartitionParam> _partition_param;
+    std::unique_ptr<OlapTableLocationParam> _location_param;
+    std::unique_ptr<StarRocksNodesInfo> _nodes_info;
+    std::unique_ptr<RowDescriptor> _row_desc;
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3429,7 +3429,7 @@ void TabletUpdates::_update_total_stats(const std::vector<uint32_t>& rowsets, si
     }
 }
 
-Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool with_default,
+Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids, bool with_default,
                                         std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                                         vector<std::unique_ptr<Column>>* columns, void* state) {
     std::map<uint32_t, RowsetSharedPtr> rssid_to_rowsets;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -235,7 +235,7 @@ public:
     //          column 2 value@rssid:6 rowid:4,
     //   ]
     // ]
-    Status get_column_values(std::vector<uint32_t>& column_ids, bool with_default,
+    Status get_column_values(const std::vector<uint32_t>& column_ids, bool with_default,
                              std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                              vector<std::unique_ptr<Column>>* columns, void* state);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -218,6 +218,7 @@ set(EXEC_FILES
         ./storage/storage_types_test.cpp
         ./storage/tablet_meta_test.cpp
         ./storage/tablet_meta_manager_test.cpp
+        ./storage/table_reader_remote_test.cpp
         ./storage/table_reader_test.cpp
         ./storage/table_schema_test.cpp
         ./storage/tablet_updates_test.cpp

--- a/be/test/storage/table_reader_remote_test.cpp
+++ b/be/test/storage/table_reader_remote_test.cpp
@@ -1,0 +1,362 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+
+#include "column/column_helper.h"
+#include "column/datum_tuple.h"
+#include "column/vectorized_fwd.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/descriptor_helper.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/schema_change.h"
+#include "storage/snapshot_manager.h"
+#include "storage/storage_engine.h"
+#include "storage/table_reader.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "storage/union_iterator.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+using DatumTupleVector = std::vector<DatumTuple>;
+
+class TableReaderRemoteTest : public testing::Test {
+public:
+    static void create_row(vector<DatumTuple>& data, int64_t pk1, int64_t v1, int32_t v2) {
+        DatumTuple tuple;
+        tuple.append(Datum(pk1));
+        tuple.append(Datum(v1));
+        tuple.append(Datum(v2));
+        data.push_back(tuple);
+    }
+
+    static void create_rowset(const TabletSharedPtr& tablet, int version, const vector<DatumTuple>& data, int start_pos,
+                              int end_pos) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = &tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, data.size());
+        auto& cols = chunk->columns();
+        for (int pos = start_pos; pos < end_pos; pos++) {
+            const DatumTuple& row = data[pos];
+            DatumTuple tmp_row;
+            for (size_t i = 0; i < row.size(); i++) {
+                cols[i]->append_datum(row.get(i));
+            }
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        auto row_set = *writer->build();
+        ASSERT_TRUE(tablet->rowset_commit(version, row_set, 0).ok());
+        ASSERT_EQ(version, tablet->updates()->max_version());
+    }
+
+    static TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn pk1;
+        pk1.column_name = "pk1";
+        pk1.__set_is_key(true);
+        pk1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(pk1);
+
+        TColumn v1;
+        v1.column_name = "v1";
+        v1.__set_is_key(false);
+        v1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(v1);
+
+        TColumn v2;
+        v2.column_name = "v2";
+        v2.__set_is_key(false);
+        v2.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(v2);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    void create_table_reader_params(TableReaderParams& params, int64_t version) {
+        params.schema.db_id = db_id;
+        params.schema.table_id = table_id;
+        params.schema.version = version;
+        TDescriptorTableBuilder dtb;
+        TTupleDescriptorBuilder tuple_builder;
+
+        tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("pk1").column_pos(0).build());
+        tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("v1").column_pos(1).build());
+        tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("v2").column_pos(2).build());
+
+        tuple_builder.build(&dtb);
+
+        TDescriptorTable t_desc_tbl = dtb.desc_tbl();
+        params.schema.slot_descs = t_desc_tbl.slotDescriptors;
+        params.schema.tuple_desc = t_desc_tbl.tupleDescriptors[0];
+        params.schema.indexes.resize(1);
+        params.schema.indexes[0].id = 1111;
+        params.schema.indexes[0].columns = {"pk1", "v1", "v2"};
+
+        params.partition_param.db_id = db_id;
+        params.partition_param.table_id = table_id;
+        params.partition_param.version = version;
+        params.partition_param.__set_distributed_columns({"pk1"});
+        params.partition_param.partitions.resize(1);
+        params.partition_param.partitions[0].id = 1;
+        params.partition_param.partitions[0].num_buckets = num_buckets;
+        params.partition_param.partitions[0].indexes.resize(1);
+        params.partition_param.partitions[0].indexes[0].index_id = 1111;
+        params.partition_param.partitions[0].indexes[0].tablets = _tablet_ids;
+        params.partition_param.distributed_columns = {"pk1"};
+        params.partition_versions[1] = version;
+    }
+
+    void TearDown() override {
+        for (TabletSharedPtr& tablet : _tablets) {
+            StorageEngine::instance()->tablet_manager()->drop_tablet(tablet->tablet_id());
+            tablet.reset();
+        }
+    }
+
+    void run_multi_get() {}
+
+protected:
+    int64_t db_id;
+    std::string table_name;
+    int64_t table_id;
+    size_t num_buckets = 4;
+    std::vector<int64_t> _tablet_ids;
+    std::vector<TabletSharedPtr> _tablets;
+    ObjectPool _object_pool;
+    Schema _key_schema;
+    Schema _value_schema;
+};
+
+TEST_F(TableReaderRemoteTest, test_multi_get_1_tablet) {
+    num_buckets = 1;
+    const size_t pk_size = 1000;
+    const int64_t multi_get_size = 500;
+
+    srand(GetCurrentTimeMicros());
+    db_id = 1;
+    table_name = "table_reader_remote_1_tablet_test";
+    table_id = 2;
+    int64_t tablet_id = rand();
+    for (int i = 0; i < num_buckets; i++) {
+        TabletSharedPtr tablet = create_tablet(tablet_id + i, rand());
+        _tablets.push_back(tablet);
+        _tablet_ids.push_back(tablet_id + i);
+    }
+    _key_schema = ChunkHelper::convert_schema(_tablets[0]->tablet_schema(), {0});
+    _value_schema = ChunkHelper::convert_schema(_tablets[0]->tablet_schema(), {1, 2});
+
+    std::set<int64_t> all_ints;
+    for (size_t i = 0; i < pk_size; i++) {
+        all_ints.insert(i);
+    }
+    vector<int64_t> pk_array(all_ints.begin(), all_ints.end());
+    auto pk_column = Int64Column::create();
+    for (int64_t i : pk_array) {
+        pk_column->append(i);
+    }
+    std::vector<uint32_t> buckets(pk_array.size(), 0);
+    pk_column->crc32_hash(buckets.data(), 0, all_ints.size());
+    for (int i = 0; i < buckets.size(); i++) {
+        buckets[i] = buckets[i] % num_buckets;
+    }
+    for (size_t i = 0; i < num_buckets; i++) {
+        vector<DatumTuple> data;
+        for (size_t j = 0; j < pk_column->size(); j++) {
+            if (buckets[j] == i) {
+                int64_t pk = pk_column->get(j).get_int64();
+                create_row(data, pk, pk * 2, pk * 3);
+            }
+        }
+        create_rowset(_tablets[i], 2, data, 0, data.size());
+    }
+    DatumTupleVector rows;
+    while (true) {
+        bool ok = true;
+        for (int i = 0; i < num_buckets; i++) {
+            std::vector<RowsetSharedPtr> dummy_rowsets;
+            EditVersion full_version;
+            ASSERT_TRUE(_tablets[0]->updates()->get_applied_rowsets(2, &dummy_rowsets, &full_version).ok());
+            if (full_version.major() < 2) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) {
+            break;
+        }
+        std::cerr << "waiting for version 2\n";
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    TableReaderParams read_params;
+    create_table_reader_params(read_params, 2);
+    std::shared_ptr<TableReader> table_reader = std::make_shared<TableReader>();
+    EXPECT_TRUE(table_reader->init(read_params).ok());
+
+    // construct multi_get
+    ChunkPtr key_chunk = std::make_shared<Chunk>();
+    TypeDescriptor key_type = TypeDescriptor::from_thrift(read_params.schema.slot_descs[0].slotType);
+    key_chunk->append_column(ColumnHelper::create_column(key_type, false), read_params.schema.slot_descs[0].id);
+    key_chunk->get_column_by_index(0)->reserve(multi_get_size);
+    ChunkPtr values_chunk = ChunkHelper::new_chunk(_value_schema, multi_get_size);
+    vector<int64_t> expected_values;
+    vector<bool> expected_found(multi_get_size, false);
+    for (int64_t i = 0; i < multi_get_size; i++) {
+        int64_t pk = i * 2;
+        key_chunk->get_column_by_index(0)->append_datum(Datum(pk));
+        if (all_ints.find(pk) != all_ints.end()) {
+            expected_found[i] = true;
+            expected_values.push_back(pk * 2);
+        }
+    }
+    vector<bool> found;
+    EXPECT_TRUE(table_reader->multi_get(*key_chunk, {"v1", "v2"}, found, *values_chunk).ok());
+    ASSERT_EQ(expected_found.size(), found.size());
+    ASSERT_EQ(expected_found, found);
+    ASSERT_EQ(expected_values.size(), values_chunk->num_rows());
+    for (size_t i = 0; i < expected_values.size(); i++) {
+        ASSERT_EQ(expected_values[i], values_chunk->get_column_by_index(0)->get(i).get_int64());
+    }
+}
+
+TEST_F(TableReaderRemoteTest, test_multi_get_4_tablet) {
+    num_buckets = 4;
+    const int64_t pk_range = 1000000;
+    const int64_t pk_num = 10000;
+    const int64_t multi_get_size = 1000;
+    const size_t multi_get_time = 10;
+
+    srand(GetCurrentTimeMicros());
+    db_id = 1;
+    table_name = "table_reader_remote_4_tablet_test";
+    table_id = 2;
+    int64_t tablet_id = rand();
+    for (int i = 0; i < num_buckets; i++) {
+        TabletSharedPtr tablet = create_tablet(tablet_id + i, rand());
+        _tablets.push_back(tablet);
+        _tablet_ids.push_back(tablet_id + i);
+    }
+    _key_schema = ChunkHelper::convert_schema(_tablets[0]->tablet_schema(), {0});
+    _value_schema = ChunkHelper::convert_schema(_tablets[0]->tablet_schema(), {1, 2});
+
+    srand(0);
+    std::set<int64_t> all_ints;
+    for (int i = 0; i < pk_num; i++) {
+        all_ints.insert(rand() % pk_range);
+    }
+    vector<int64_t> pk_array(all_ints.begin(), all_ints.end());
+    auto pk_column = Int64Column::create();
+    for (int64_t i : pk_array) {
+        pk_column->append(i);
+    }
+    std::vector<uint32_t> buckets(pk_array.size(), 0);
+    pk_column->crc32_hash(buckets.data(), 0, all_ints.size());
+    for (int i = 0; i < buckets.size(); i++) {
+        buckets[i] = buckets[i] % num_buckets;
+    }
+    for (size_t i = 0; i < num_buckets; i++) {
+        vector<DatumTuple> data;
+        for (size_t j = 0; j < pk_column->size(); j++) {
+            if (buckets[j] == i) {
+                int64_t pk = pk_column->get(j).get_int64();
+                create_row(data, pk, pk * 2, pk * 3);
+            }
+        }
+        create_rowset(_tablets[i], 2, data, 0, data.size());
+    }
+    DatumTupleVector rows;
+    while (true) {
+        bool ok = true;
+        for (int i = 0; i < num_buckets; i++) {
+            std::vector<RowsetSharedPtr> dummy_rowsets;
+            EditVersion full_version;
+            ASSERT_TRUE(_tablets[0]->updates()->get_applied_rowsets(2, &dummy_rowsets, &full_version).ok());
+            if (full_version.major() < 2) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) {
+            break;
+        }
+        std::cerr << "waiting for version 2\n";
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    TableReaderParams read_params;
+    create_table_reader_params(read_params, 2);
+    std::shared_ptr<TableReader> table_reader = std::make_shared<TableReader>();
+    EXPECT_TRUE(table_reader->init(read_params).ok());
+
+    for (size_t i = 0; i < multi_get_time; i++) {
+        // construct multi_get
+        ChunkPtr key_chunk = std::make_shared<Chunk>();
+        TypeDescriptor key_type = TypeDescriptor::from_thrift(read_params.schema.slot_descs[0].slotType);
+        key_chunk->append_column(ColumnHelper::create_column(key_type, false), read_params.schema.slot_descs[0].id);
+        key_chunk->get_column_by_index(0)->reserve(multi_get_size);
+        ChunkPtr values_chunk = ChunkHelper::new_chunk(_value_schema, multi_get_size);
+        vector<int64_t> expected_values;
+        vector<bool> expected_found(multi_get_size, false);
+        for (int64_t i = 0; i < multi_get_size; i++) {
+            int64_t pk = rand() % pk_range;
+            key_chunk->get_column_by_index(0)->append_datum(Datum(pk));
+            if (all_ints.find(pk) != all_ints.end()) {
+                expected_found[i] = true;
+                expected_values.push_back(pk * 2);
+            }
+        }
+        vector<bool> found;
+        EXPECT_TRUE(table_reader->multi_get(*key_chunk, {"v1", "v2"}, found, *values_chunk).ok());
+        ASSERT_EQ(expected_found.size(), found.size());
+        ASSERT_EQ(expected_found, found);
+        ASSERT_EQ(expected_values.size(), values_chunk->num_rows());
+        for (size_t i = 0; i < expected_values.size(); i++) {
+            ASSERT_EQ(expected_values[i], values_chunk->get_column_by_index(0)->get(i).get_int64());
+        }
+    }
+}
+
+} // namespace starrocks

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -273,12 +273,10 @@ message PTabletReaderOpenRequest {
 
 message PTabletReaderOpenResult {
     optional StatusPB status = 1;
-    optional int64 reader_id = 2;
 }
 
 message PTabletReaderCloseRequest {
     optional PUniqueId id = 1;
-    optional int64 reader_id = 2;
 }
 
 message PTabletReaderCloseResult {
@@ -286,9 +284,10 @@ message PTabletReaderCloseResult {
 }
 
 message PTabletReaderMultiGetRequest {
-    optional PUniqueId id = 1;
-    optional ChunkPB keys = 2;
-    repeated string values_columns = 3;
+    optional int64 tablet_id = 1;
+    optional int64 version = 2;
+    optional ChunkPB keys = 3;
+    repeated string values_columns = 4;
 }
 
 message PTabletReaderMultiGetResult {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17266

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds multi-tablet & remote support for TableReader's mult_get internal API. It uses similar util classes in TabletSink(like OlapTableSchemaParam/OlapTablePartitionParam/OlapTableLocationParam/StarRocksNodesInfo) to route PKs to different partitions/buckets/tablets, batch get requests by tablet, and uses RPC to call multi_get on remote tablets, get all the results and then merge them into a single response.

Note: partition with expression is not supported yet

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
