### PR TITLE
[Refactor] Mark utf8_len inline to suppress -Wunused-function

### DIFF
--- a/be/src/util/utf8.h
+++ b/be/src/util/utf8.h
@@ -116,7 +116,7 @@ static inline const char* skip_trailing_utf8(const char* p, const char* begin, s
 // is to say, counting bytes which do not match 10xx_xxxx pattern.
 // All 0xxx_xxxx, 110x_xxxx, 1110_xxxx and 1111_0xxx are greater than 1011_1111 when use int8_t arithmetic,
 // so just count bytes greater than 1011_1111 in a byte string as the result of utf8_length.
-static int utf8_len(const char* begin, const char* end) {
+inline static int utf8_len(const char* begin, const char* end) {
     int len = 0;
     const char* p = begin;
 #if defined(__AVX2__)


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [X] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Suppress `-Wunused-function` due to `utf8_len`.

```
/build/starrocks/be/src/util/utf8.h:107:12: error: 'int starrocks::vectorized::utf8_len(const char*, const char*)' defined but not used [-Werror=unused-function]
static int utf8_len(const char* begin, const char* end) {
              ^~~~~~~~
cc1plus: all warnings being treated as errors
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [X] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
