### PR TITLE
[Enhancement] Disable Dynamic Partition in replay dump test

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
@@ -134,10 +134,6 @@ public class DynamicPartitionProperty {
         return enable;
     }
 
-    public void disable() {
-        this.enable = false;
-    }
-
     public StartOfDate getStartOfWeek() {
         return startOfWeek;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/dump/ReplayDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/dump/ReplayDumpTestBase.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.dump;
 
+import com.starrocks.common.Config;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
@@ -31,6 +32,8 @@ public class ReplayDumpTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
+        // Should disable Dynamic Partition in replay dump test
+        Config.dynamic_partition_enable = false;
     }
 
     public static QueryDumpRegressionTesting getCaseFromJsonConfig(String fileName) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.plan;
 
 import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.persist.gson.GsonUtils;
@@ -56,6 +57,8 @@ public class ReplayFromDumpTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
+        // Should disable Dynamic Partition in replay dump test
+        Config.dynamic_partition_enable = false;
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -562,11 +562,6 @@ public class UtFrameUtils {
             OlapTable replayTable = (OlapTable) connectContext.getGlobalStateMgr().getDb("" + dbName)
                     .getTable(entry.getKey().split("\\.")[1]);
 
-            // Should disable Dynamic Partition in replay dump test
-            if (replayTable.getTableProperty() != null) {
-                replayTable.getTableProperty().getDynamicPartitionProperty().disable();
-            }
-
             for (Map.Entry<String, Long> partitionEntry : entry.getValue().entrySet()) {
                 setPartitionStatistics(replayTable, partitionEntry.getKey(), partitionEntry.getValue());
             }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

The issus reason if same with https://github.com/StarRocks/starrocks/pull/17522

```
2023-02-17 12:43:39 [BackgroundDynamicPartitionThread] WARN  Database:154 - slow db lock. type: writeLock, db id: 13201, db name: bi_secure, wait time: 21509ms, former , current stack trace:
java.lang.Exception: null
    at com.starrocks.catalog.Database.logSlowLockEventIfNeeded(Database.java:156) ~[classes/:?]
    at com.starrocks.catalog.Database.writeLockAndCheckExist(Database.java:243) ~[classes/:?]
    at com.starrocks.server.LocalMetastore.addPartitions(LocalMetastore.java:1380) ~[classes/:?]
    at com.starrocks.server.LocalMetastore.addPartitions(LocalMetastore.java:869) ~[classes/:?]
    at com.starrocks.server.GlobalStateMgr.addPartitions(GlobalStateMgr.java:2124) ~[classes/:?]
    at com.starrocks.clone.DynamicPartitionScheduler.executeDynamicPartitionForTable(DynamicPartitionScheduler.java:406) ~[classes/:?]
    at com.starrocks.server.LocalMetastore.lambda$createOlapOrLakeTable$6(LocalMetastore.java:2510) ~[classes/:?]
    at java.lang.Thread.run(Thread.java:748) [?:1.8.0_221]
```

But in https://github.com/StarRocks/starrocks/pull/17522, we didn't disable Dynamic Partition, In this PR,we directly disable Dynamic Partition by config.


