### PR TITLE
[Enhancement] avoid rebuild lake pk index when retry publish txn

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -403,7 +403,12 @@ Status UpdateManager::check_meta_version(const Tablet& tablet, int64_t base_vers
         return Status::OK();
     } else {
         auto& index = index_entry->value();
-        if (index.data_version() != base_version) {
+        if (index.data_version() > base_version) {
+            // return error, and ignore this publish later
+            LOG(WARNING) << "Lake check_meta_version and publish already finished txn, tablet_id: " << tablet.id()
+                         << " index_ver: " << index.data_version() << " base_ver: " << base_version;
+            return Status::AlreadyExist("lake primary publish txn already finish");
+        } else if (index.data_version() < base_version) {
             // clear cache, and continue publish
             LOG(WARNING) << "Lake check_meta_version and remove primary index cache, tablet_id: " << tablet.id()
                          << " index_ver: " << index.data_version() << " base_ver: " << base_version;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -405,13 +405,14 @@ Status UpdateManager::check_meta_version(const Tablet& tablet, int64_t base_vers
         auto& index = index_entry->value();
         if (index.data_version() > base_version) {
             // return error, and ignore this publish later
-            LOG(WARNING) << "Lake check_meta_version and publish already finished txn, tablet_id: " << tablet.id()
-                         << " index_ver: " << index.data_version() << " base_ver: " << base_version;
+            LOG(INFO) << "Primary index version is greater than the base version. tablet_id: " << tablet.id()
+                      << " index_version: " << index.data_version() << " base_version: " << base_version;
             return Status::AlreadyExist("lake primary publish txn already finish");
         } else if (index.data_version() < base_version) {
             // clear cache, and continue publish
-            LOG(WARNING) << "Lake check_meta_version and remove primary index cache, tablet_id: " << tablet.id()
-                         << " index_ver: " << index.data_version() << " base_ver: " << base_version;
+            LOG(WARNING)
+                    << "Primary index version is less than the base version, remove primary index cache, tablet_id: "
+                    << tablet.id() << " index_version: " << index.data_version() << " base_version: " << base_version;
             if (!_index_cache.remove(index_entry)) {
                 return Status::InternalError("lake primary index cache ref mismatch");
             }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14853

## Problem Summary(Required) ：
In lake primary table, when many load tasks exist, and retry to publish one hotspot tablet, duplicate publish msg will try to clear pk index cache, and make publish more slow.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
