### PR TITLE
[Refactor] Lazy materialization of cascading merging

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -278,7 +278,7 @@ public:
     }
 
     size_t element_memory_usage(size_t from, size_t size) const override {
-        return _offsets[from + size] - _offsets[from] + size * sizeof(T);
+        return _offsets[from + size] - _offsets[from] + size * sizeof(T) + _slices.size() * sizeof(_slices[0]);
     }
 
     void swap_column(Column& rhs) override {

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -49,7 +49,7 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
 }
 
 Status Operator::prepare(RuntimeState* state) {
-    _mem_tracker = std::make_shared<MemTracker>(_common_metrics.get(), -1, _name, nullptr);
+    _mem_tracker = std::make_shared<MemTracker>(_common_metrics.get(), -1, _name, state->instance_mem_tracker());
     _total_timer = ADD_TIMER(_common_metrics, "OperatorTotalTime");
     _push_timer = ADD_TIMER(_common_metrics, "PushTotalTime");
     _pull_timer = ADD_TIMER(_common_metrics, "PullTotalTime");

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -16,7 +16,9 @@ using namespace starrocks::vectorized;
 namespace starrocks::pipeline {
 Status PartitionSortSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    _chunks_sorter->setup_runtime(_unique_metrics.get());
+    _sort_context->ref();
+    _chunks_sorter->setup_runtime(_unique_metrics.get(), this->_mem_tracker.get());
+
     return Status::OK();
 }
 
@@ -76,9 +78,9 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
                     _sort_keys, 0, _limit + _offset, _topn_type, max_buffered_chunks);
         }
     } else {
-        chunks_sorter = std::make_unique<vectorized::ChunksSorterFullSort>(runtime_state(),
-                                                                           &(_sort_exec_exprs.lhs_ordering_expr_ctxs()),
-                                                                           &_is_asc_order, &_is_null_first, _sort_keys);
+        chunks_sorter = std::make_unique<ChunksSorterFullSort>(
+                runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
+                _sort_keys, _max_buffered_rows, _max_buffered_bytes, _eager_materialized_slots);
     }
 
     auto sort_context = _sort_context_factory->create(driver_sequence);

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -109,6 +109,10 @@ public:
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
 
+    void set_max_buffered_rows(int64_t max_buffered_rows) { _max_buffered_rows = max_buffered_rows; }
+    void set_max_buffered_bytes(int64_t max_buffered_bytes) { _max_buffered_bytes = max_buffered_bytes; }
+    void set_eager_materialized_slots(const std::vector<SlotId>& slots) { _eager_materialized_slots = slots; }
+
 protected:
     std::shared_ptr<SortContextFactory> _sort_context_factory;
     // _sort_exec_exprs contains the ordering expressions
@@ -118,6 +122,8 @@ protected:
     const std::string _sort_keys;
     int64_t _offset;
     int64_t _limit;
+    int64_t _max_buffered_rows;
+    int64_t _max_buffered_bytes;
     const TTopNType::type _topn_type;
     const std::vector<OrderByType>& _order_by_types;
 
@@ -129,6 +135,7 @@ protected:
     const RowDescriptor& _parent_node_child_row_desc;
     std::vector<ExprContext*> _analytic_partition_exprs;
     SpillProcessChannelFactoryPtr _spill_channel_factory;
+    std::vector<SlotId> _eager_materialized_slots;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -86,7 +86,8 @@ OperatorPtr SpillablePartitionSortSinkOperatorFactory::create(int32_t degree_of_
     std::shared_ptr<ChunksSorter> chunks_sorter;
 
     chunks_sorter = std::make_unique<ChunksSorterSpillableFullSort>(
-            runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys);
+            runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys,
+            _max_buffered_rows, _max_buffered_bytes, _eager_materialized_slots);
 
     auto spiller = _spill_factory->create(*_spill_options);
     auto spill_channel = _spill_channel_factory->get_or_create(driver_sequence);

--- a/be/src/exec/vectorized/chunks_sorter.cpp
+++ b/be/src/exec/vectorized/chunks_sorter.cpp
@@ -141,7 +141,7 @@ ChunksSorter::ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>*
 
 ChunksSorter::~ChunksSorter() = default;
 
-void ChunksSorter::setup_runtime(RuntimeProfile* profile) {
+void ChunksSorter::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
     _build_timer = ADD_TIMER(profile, "BuildingTime");
     _sort_timer = ADD_TIMER(profile, "SortingTime");
     _merge_timer = ADD_TIMER(profile, "MergingTime");

--- a/be/src/exec/vectorized/chunks_sorter.h
+++ b/be/src/exec/vectorized/chunks_sorter.h
@@ -94,7 +94,7 @@ public:
                                                                         const SortExecExprs& sort_exec_exprs,
                                                                         const std::vector<OrderByType>& order_by_types);
 
-    virtual void setup_runtime(RuntimeProfile* profile);
+    virtual void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker);
 
     void set_spiller(std::shared_ptr<Spiller> spiller) { _spiller = std::move(spiller); }
 

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.cpp
@@ -2,10 +2,13 @@
 
 #include "exec/vectorized/chunks_sorter_full_sort.h"
 
+#include "column/column_helper.h"
 #include "exec/vectorized/sorting/merge.h"
 #include "exec/vectorized/sorting/sort_permute.h"
 #include "exec/vectorized/sorting/sorting.h"
 #include "exprs/expr.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 #include "util/stopwatch.hpp"
 
@@ -13,11 +16,24 @@ namespace starrocks::vectorized {
 
 ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                            const std::vector<bool>* is_asc_order,
-                                           const std::vector<bool>* is_null_first, const std::string& sort_keys)
-        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false) {}
+                                           const std::vector<bool>* is_null_first, const std::string& sort_keys,
+                                           int64_t max_buffered_rows, int64_t max_buffered_bytes,
+                                           const std::vector<SlotId>& eager_materialized_slots)
+        : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, false),
+          max_buffered_rows(static_cast<size_t>(max_buffered_rows)),
+          max_buffered_bytes(max_buffered_bytes),
+          _eager_materialized_slots(eager_materialized_slots.begin(), eager_materialized_slots.end()) {}
 
 ChunksSorterFullSort::~ChunksSorterFullSort() = default;
-
+void ChunksSorterFullSort::setup_runtime(starrocks::RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
+    _runtime_profile = profile;
+    _parent_mem_tracker = parent_mem_tracker;
+    _object_pool = std::make_unique<ObjectPool>();
+    _runtime_profile->add_info_string("MaxBufferedRows", strings::Substitute("$0", max_buffered_rows));
+    _runtime_profile->add_info_string("MaxBufferedBytes", strings::Substitute("$0", max_buffered_bytes));
+    _profiler = _object_pool->add(new ChunksSorterFullSortProfiler(profile, parent_mem_tracker));
+}
 Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) {
     RETURN_IF_ERROR(_merge_unsorted(state, chunk));
     RETURN_IF_ERROR(_partial_sort(state, false));
@@ -28,29 +44,54 @@ Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) 
 // Accumulate unsorted input chunks into a larger chunk
 Status ChunksSorterFullSort::_merge_unsorted(RuntimeState* state, const ChunkPtr& chunk) {
     SCOPED_TIMER(_build_timer);
-
-    if (_unsorted_chunk == nullptr) {
-        // TODO: optimize the copy
-        _unsorted_chunk.reset(chunk->clone_unique().release());
-    } else {
-        _unsorted_chunk->append(*chunk);
-    }
-
+    _staging_unsorted_chunks.push_back(std::move(chunk));
+    _staging_unsorted_rows += chunk->num_rows();
+    _staging_unsorted_bytes += chunk->bytes_usage();
     return Status::OK();
 }
 
+template <typename BinaryColumnType>
+static void reserve_memory(Column* dst_col, const std::vector<ChunkPtr>& src_chunks, size_t col_idx) {
+    auto* binary_dst_col = down_cast<BinaryColumnType*>(dst_col);
+    size_t total_num_bytes = 0;
+    for (const auto& src_chk : src_chunks) {
+        const auto* src_data_col = ColumnHelper::get_data_column(src_chk->get_column_by_index(col_idx).get());
+        const auto* src_binary_col = down_cast<const BinaryColumnType*>(src_data_col);
+        total_num_bytes += src_binary_col->get_bytes().size();
+    }
+    binary_dst_col->get_bytes().reserve(total_num_bytes);
+}
+
+static void concat_chunks(ChunkPtr& dst_chunk, const std::vector<ChunkPtr>& src_chunks, size_t num_rows) {
+    DCHECK(!src_chunks.empty());
+    dst_chunk = src_chunks.front()->clone_empty(num_rows);
+    const auto num_columns = dst_chunk->num_columns();
+    for (auto i = 0; i < num_columns; ++i) {
+        auto dst_col = dst_chunk->get_column_by_index(i);
+        auto* dst_data_col = ColumnHelper::get_data_column(dst_col.get());
+        if (dst_data_col->is_binary()) {
+            reserve_memory<BinaryColumn>(dst_data_col, src_chunks, i);
+        } else if (dst_col->is_large_binary()) {
+            reserve_memory<LargeBinaryColumn>(dst_data_col, src_chunks, i);
+        }
+    }
+    for (const auto& src_chk : src_chunks) {
+        dst_chunk->append(*src_chk);
+    }
+}
 // Sort the large chunk
 Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
-    if (!_unsorted_chunk) {
+    if (!_staging_unsorted_rows) {
         return Status::OK();
     }
-    bool reach_limit = _unsorted_chunk->num_rows() >= kMaxBufferedChunkSize ||
-                       _unsorted_chunk->bytes_usage() >= kMaxBufferedChunkBytes;
+    bool reach_limit = _staging_unsorted_rows >= max_buffered_rows || _staging_unsorted_bytes >= max_buffered_bytes;
     if (done || reach_limit) {
-        SCOPED_TIMER(_sort_timer);
-
+        _max_num_rows = std::max<int>(_max_num_rows, _staging_unsorted_rows);
+        _profiler->input_required_memory->update(_staging_unsorted_bytes);
+        concat_chunks(_unsorted_chunk, _staging_unsorted_chunks, _staging_unsorted_rows);
         RETURN_IF_ERROR(_unsorted_chunk->upgrade_if_overflow());
 
+        SCOPED_TIMER(_sort_timer);
         DataSegment segment(_sort_exprs, _unsorted_chunk);
         _sort_permutation.resize(0);
         RETURN_IF_ERROR(
@@ -61,7 +102,10 @@ Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
 
         _sorted_chunks.emplace_back(std::move(sorted_chunk));
         _total_rows += _unsorted_chunk->num_rows();
-        _unsorted_chunk.reset();
+        _unsorted_chunk->reset();
+        _staging_unsorted_rows = 0;
+        _staging_unsorted_bytes = 0;
+        _staging_unsorted_chunks.clear();
     }
 
     return Status::OK();
@@ -69,14 +113,127 @@ Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
 
 Status ChunksSorterFullSort::_merge_sorted(RuntimeState* state) {
     SCOPED_TIMER(_merge_timer);
-
-    RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _sorted_chunks, &_merged_runs));
+    _profiler->num_sorted_runs->set((int64_t)_sorted_chunks.size());
+    if (_eager_materialized_slots.empty() || _sorted_chunks.size() < 3) {
+        _runtime_profile->add_info_string("LazyMaterialization", "false");
+        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _sorted_chunks, &_merged_runs));
+    } else {
+        _runtime_profile->add_info_string("LazyMaterialization", "true");
+        _split_lazy_and_eager_chunks();
+        _assign_ordinals();
+        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _eager_materialized_chunks, &_merged_runs));
+    }
 
     return Status::OK();
 }
 
+void ChunksSorterFullSort::_assign_ordinals() {
+    _chunk_idx_bits = (int)std::ceil(std::log2(_eager_materialized_chunks.size()));
+    _chunk_idx_bits = std::max(1, _chunk_idx_bits);
+    _offset_in_chunk_bits = (int)std::ceil(std::log2(_max_num_rows));
+    _offset_in_chunk_bits = std::max(1, _offset_in_chunk_bits);
+    auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
+    _runtime_profile->add_info_string("LazyMaterializationUse64BitOrdinal",
+                                      strings::Substitute("$0", use_64bit_ordinal));
+    if (use_64bit_ordinal) {
+        _assign_ordinals_tmpl<uint64_t>();
+    } else {
+        _assign_ordinals_tmpl<uint32_t>();
+    }
+}
+TYPE_GUARD(OrdinalGuard, type_is_ordinal, uint32_t, uint64_t);
+
+template <typename T, typename = OrdinalGuard<T>>
+using OrdinalColumn = FixedLengthColumn<T>;
+
+template <typename T>
+void ChunksSorterFullSort::_assign_ordinals_tmpl() {
+    static_assert(type_is_ordinal<T>, "T must be uint32_t or uint64_t");
+    size_t chunk_idx = 0;
+    for (auto& partial_sort_chunk : _eager_materialized_chunks) {
+        if (partial_sort_chunk->is_empty()) {
+            ++chunk_idx;
+            continue;
+        }
+        size_t num_rows = partial_sort_chunk->num_rows();
+        auto ordinal_column = OrdinalColumn<T>::create();
+        auto& ordinal_data = down_cast<OrdinalColumn<T>*>(ordinal_column.get())->get_data();
+        raw::make_room(&ordinal_data, num_rows);
+        for (T off = 0; off < num_rows; ++off) {
+            ordinal_data[off] = static_cast<T>((chunk_idx << _offset_in_chunk_bits) | off);
+        }
+        partial_sort_chunk->append_column(ordinal_column, ORDINAL_COLUMN_SLOT_ID);
+        ++chunk_idx;
+    }
+}
+
+void ChunksSorterFullSort::_split_lazy_and_eager_chunks() {
+    _eager_materialized_chunks.reserve(_sorted_chunks.size());
+    _lazy_materialized_chunks.reserve(_sorted_chunks.size());
+    auto& slot_id_to_column_id = _sorted_chunks[0]->get_slot_id_to_index_map();
+    _column_id_to_slot_id.resize(slot_id_to_column_id.size());
+    for (auto it : _sorted_chunks[0]->get_slot_id_to_index_map()) {
+        _column_id_to_slot_id[it.second] = it.first;
+    }
+    for (auto& chunk : _sorted_chunks) {
+        auto eager_chunk = std::make_unique<Chunk>();
+        auto lazy_chunk = std::make_unique<Chunk>();
+        for (auto column_id = 0; column_id < chunk->num_columns(); ++column_id) {
+            auto slot_id = _column_id_to_slot_id[column_id];
+            auto column = chunk->columns()[column_id];
+            if (_eager_materialized_slots.count(slot_id)) {
+                eager_chunk->append_column(column, slot_id);
+            } else {
+                lazy_chunk->append_column(column, slot_id);
+            }
+        }
+        _eager_materialized_chunks.push_back(std::move(eager_chunk));
+        _lazy_materialized_chunks.push_back(std::move(lazy_chunk));
+    }
+    _sorted_chunks.clear();
+}
+
+ChunkPtr ChunksSorterFullSort::_lazy_materialize(const ChunkPtr& chunk) {
+    auto use_64bit_ordinal = (_chunk_idx_bits + _offset_in_chunk_bits) > 32;
+    if (use_64bit_ordinal) {
+        return _lazy_materialize_tmpl<uint64_t>(chunk);
+    } else {
+        return _lazy_materialize_tmpl<uint32_t>(chunk);
+    }
+}
+
+template <typename T>
+ChunkPtr ChunksSorterFullSort::_lazy_materialize_tmpl(const ChunkPtr& sorted_eager_chunk) {
+    static_assert(type_is_ordinal<T>, "T must be uint32_t or uint64_t");
+    const auto num_rows = sorted_eager_chunk->num_rows();
+    auto sorted_lazy_chunk = _lazy_materialized_chunks[0]->clone_empty(num_rows);
+    auto ordinal_column = sorted_eager_chunk->get_column_by_slot_id(ORDINAL_COLUMN_SLOT_ID);
+    auto& ordinal_data = down_cast<OrdinalColumn<T>*>(ordinal_column.get())->get_data();
+    T _offset_in_chunk_mask = static_cast<T>((1L << _offset_in_chunk_bits) - 1);
+    for (auto i = 0; i < num_rows; ++i) {
+        T ordinal = ordinal_data[i];
+        T chunk_idx = ordinal >> _offset_in_chunk_bits;
+        T off_in_chunk = ordinal & _offset_in_chunk_mask;
+        sorted_lazy_chunk->append(*_lazy_materialized_chunks[chunk_idx], off_in_chunk, 1);
+    }
+    auto final_chunk = std::make_shared<Chunk>();
+    for (auto slot_id : _column_id_to_slot_id) {
+        if (_eager_materialized_slots.count(slot_id)) {
+            final_chunk->append_column(sorted_eager_chunk->get_column_by_slot_id(slot_id), slot_id);
+        } else {
+            final_chunk->append_column(sorted_lazy_chunk->get_column_by_slot_id(slot_id), slot_id);
+        }
+    }
+    return final_chunk;
+}
+
 Status ChunksSorterFullSort::do_done(RuntimeState* state) {
     RETURN_IF_ERROR(_partial_sort(state, true));
+    {
+        typeof(_sort_permutation) tmp;
+        tmp.swap(_sort_permutation);
+        _unsorted_chunk.reset();
+    }
     RETURN_IF_ERROR(_merge_sorted(state));
 
     return Status::OK();
@@ -93,6 +250,9 @@ Status ChunksSorterFullSort::get_next(ChunkPtr* chunk, bool* eos) {
     SortedRun& run = _merged_runs.front();
     *chunk = run.steal_chunk(chunk_size);
     if (*chunk != nullptr) {
+        if (!_eager_materialized_slots.empty()) {
+            *chunk = _lazy_materialize(*chunk);
+        }
         RETURN_IF_ERROR((*chunk)->downgrade());
     }
     if (run.empty()) {

--- a/be/src/exec/vectorized/chunks_sorter_full_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_full_sort.h
@@ -8,9 +8,34 @@
 
 namespace starrocks {
 class ExprContext;
+struct ChunksSorterFullSortProfiler {
+    ChunksSorterFullSortProfiler(RuntimeProfile* runtime_profile, MemTracker* parent_mem_tracker)
+            : profile(runtime_profile) {
+        partial_sort_retention_memory = ADD_COUNTER(profile, "PartialSortRetentionMemory", TUnit::BYTES);
+        final_retention_memory = ADD_COUNTER(profile, "FinalRetentionMemory", TUnit::BYTES);
+        input_alloc_memory = ADD_COUNTER(profile, "InputAllocMemory", TUnit::BYTES);
+        input_required_memory = ADD_COUNTER(profile, "InputRequiredMemory", TUnit::BYTES);
+        input_max_alloc_extra_memory = ADD_COUNTER(profile, "InputMaxAllocExtraMemory", TUnit::BYTES);
+        permutation_used_memory = ADD_COUNTER(profile, "PermutationUsedMemory", TUnit::BYTES);
 
+        unsorted_alloc_memory = ADD_COUNTER(profile, "UnsortedAllocMemory", TUnit::BYTES);
+        unsorted_required_memory = ADD_COUNTER(profile, "UnSortedRequiredMemory", TUnit::BYTES);
+        num_sorted_runs = ADD_COUNTER(profile, "NumSortedRuns", TUnit::UNIT);
+    }
+
+    RuntimeProfile* profile{};
+    RuntimeProfile::Counter* partial_sort_retention_memory = nullptr;
+    RuntimeProfile::Counter* final_retention_memory = nullptr;
+    RuntimeProfile::Counter* input_alloc_memory = nullptr;
+    RuntimeProfile::Counter* input_required_memory = nullptr;
+    RuntimeProfile::Counter* input_max_alloc_extra_memory = nullptr;
+    RuntimeProfile::Counter* permutation_used_memory = nullptr;
+
+    RuntimeProfile::Counter* unsorted_alloc_memory = nullptr;
+    RuntimeProfile::Counter* unsorted_required_memory = nullptr;
+    RuntimeProfile::Counter* num_sorted_runs = nullptr;
+};
 namespace vectorized {
-
 class ChunksSorterFullSort : public ChunksSorter {
 public:
     /**
@@ -22,7 +47,8 @@ public:
      */
     ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                          const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
-                         const std::string& sort_keys);
+                         const std::string& sort_keys, int64_t max_buffered_rows, int64_t max_buffered_bytes,
+                         const std::vector<SlotId>& eager_materialized_slots);
     ~ChunksSorterFullSort() override;
 
     // Append a Chunk for sort.
@@ -33,9 +59,11 @@ public:
     size_t get_output_rows() const override;
 
     int64_t mem_usage() const override;
+    void setup_runtime(starrocks::RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
 
 protected:
     Status _init(RuntimeState* state);
+
     // Three stages of sorting procedure:
     // 1. Accumulate input chunks into a big chunk(but not exceed the kMaxBufferedChunkSize), to reduce the memory copy during merge
     // 2. Sort the accumulated big chunk partially
@@ -43,16 +71,42 @@ protected:
     Status _merge_unsorted(RuntimeState* state, const ChunkPtr& chunk);
     Status _partial_sort(RuntimeState* state, bool done);
     Status _merge_sorted(RuntimeState* state);
+    void _split_lazy_and_eager_chunks();
+    static constexpr SlotId ORDINAL_COLUMN_SLOT_ID = -2;
+    void _assign_ordinals();
+    template <typename T>
+    void _assign_ordinals_tmpl();
+    ChunkPtr _lazy_materialize(const ChunkPtr& chunk);
+    template <typename T>
+    ChunkPtr _lazy_materialize_tmpl(const ChunkPtr& chunk);
 
-    size_t _total_rows = 0;                     // Total rows of sorting data
-    Permutation _sort_permutation;              // Temp permutation for sorting
+    size_t _total_rows = 0;        // Total rows of sorting data
+    Permutation _sort_permutation; // Temp permutation for sorting
+    size_t _staging_unsorted_rows = 0;
+    size_t _staging_unsorted_bytes = 0;
+    std::vector<ChunkPtr> _staging_unsorted_chunks;
     ChunkPtr _unsorted_chunk;                   // Unsorted chunk, accumulate it to a larger chunk
     std::vector<ChunkUniquePtr> _sorted_chunks; // Partial sorted, but not merged
     SortedRuns _merged_runs;                    // After merge
+    RuntimeProfile* _runtime_profile = nullptr;
+    MemTracker* _parent_mem_tracker = nullptr;
+    std::unique_ptr<ObjectPool> _object_pool = nullptr;
+    ChunksSorterFullSortProfiler* _profiler = nullptr;
 
     // TODO: further tunning the buffer parameter
-    static constexpr size_t kMaxBufferedChunkSize = 1024000;   // Max buffer 1024000 rows
-    static constexpr size_t kMaxBufferedChunkBytes = 16 << 20; // Max buffer 16MB bytes
+    const size_t max_buffered_rows;  // Max buffer 1024000 rows
+    const size_t max_buffered_bytes; // Max buffer 16MB bytes
+
+    // only when order-by columns(_sort_exprs) are all ColumnRefs and the cost of eager-materialization of
+    // other columns is large than ordinal column, then we materialize order-by columns and ordinal columns eagerly,
+    // and other columns are lazy-materialized.
+    std::unordered_set<SlotId> _eager_materialized_slots;
+    int _max_num_rows = 0;
+    int _offset_in_chunk_bits = 0;
+    int _chunk_idx_bits = 0;
+    std::vector<SlotId> _column_id_to_slot_id;
+    std::vector<ChunkUniquePtr> _eager_materialized_chunks;
+    std::vector<ChunkUniquePtr> _lazy_materialized_chunks;
 };
 
 } // namespace vectorized

--- a/be/src/exec/vectorized/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_heap_sort.cpp
@@ -250,8 +250,8 @@ int ChunksSorterHeapSort::_filter_data(detail::ChunkHolder* chunk_holder, int ro
     return chunk_holder->value()->chunk->filter(filter);
 }
 
-void ChunksSorterHeapSort::setup_runtime(RuntimeProfile* profile) {
-    ChunksSorter::setup_runtime(profile);
+void ChunksSorterHeapSort::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
     _sort_filter_costs = ADD_TIMER(profile, "SortFilterCost");
     _sort_filter_rows = ADD_COUNTER(profile, "SortFilterRows", TUnit::UNIT);
 }

--- a/be/src/exec/vectorized/chunks_sorter_heap_sort.h
+++ b/be/src/exec/vectorized/chunks_sorter_heap_sort.h
@@ -233,7 +233,7 @@ public:
 
     size_t get_output_rows() const override;
 
-    void setup_runtime(RuntimeProfile* profile) override;
+    void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
 
 private:
     size_t _number_of_rows_to_sort() const { return _offset + _limit; }

--- a/be/src/exec/vectorized/chunks_sorter_topn.cpp
+++ b/be/src/exec/vectorized/chunks_sorter_topn.cpp
@@ -33,8 +33,8 @@ ChunksSorterTopn::ChunksSorterTopn(RuntimeState* state, const std::vector<ExprCo
 
 ChunksSorterTopn::~ChunksSorterTopn() = default;
 
-void ChunksSorterTopn::setup_runtime(RuntimeProfile* profile) {
-    ChunksSorter::setup_runtime(profile);
+void ChunksSorterTopn::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
     _sort_filter_timer = ADD_TIMER(profile, "SortFilterTime");
     _sort_filter_rows = ADD_COUNTER(profile, "SortFilterRows", TUnit::UNIT);
 }

--- a/be/src/exec/vectorized/chunks_sorter_topn.h
+++ b/be/src/exec/vectorized/chunks_sorter_topn.h
@@ -64,7 +64,7 @@ public:
 
     int64_t mem_usage() const override { return _raw_chunks.mem_usage() + _merged_segment.mem_usage(); }
 
-    void setup_runtime(RuntimeProfile* profile) override;
+    void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
 
 private:
     size_t _get_number_of_rows_to_sort() const { return _offset + _limit; }

--- a/be/src/exec/vectorized/sorting/sorting.h
+++ b/be/src/exec/vectorized/sorting/sorting.h
@@ -70,7 +70,6 @@ struct SortDesc {
     bool is_null_first() const { return (null_first * sort_order) == -1; }
     bool asc_order() const { return sort_order == 1; }
 };
-
 struct SortDescs {
     std::vector<SortDesc> descs;
 

--- a/be/src/exec/vectorized/topn_node.h
+++ b/be/src/exec/vectorized/topn_node.h
@@ -44,6 +44,7 @@ private:
 
     // _sort_exec_exprs contains the ordering expressions
     SortExecExprs _sort_exec_exprs;
+    std::vector<SlotId> _eager_materialized_slots{};
     std::vector<bool> _is_asc_order;
     std::vector<bool> _is_null_first;
     std::vector<OrderByType> _order_by_types;

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -342,7 +342,6 @@ int TypeDescriptor::get_slot_size() const {
     case INVALID_TYPE:
     case TYPE_BINARY:
     case TYPE_FUNCTION:
-        DCHECK(false);
         break;
     }
     // For llvm complain

--- a/be/test/exec/vectorized/chunks_sorter_heap_sort_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_heap_sort_test.cpp
@@ -166,7 +166,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.done(nullptr);
 
@@ -186,7 +187,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.done(nullptr);
@@ -209,7 +211,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.done(nullptr);
@@ -244,7 +247,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 5;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 
@@ -269,7 +273,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 10;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 
@@ -295,7 +300,8 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 5;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")));
+            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+                                 _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
 

--- a/be/test/exec/vectorized/chunks_sorter_test.cpp
+++ b/be/test/exec/vectorized/chunks_sorter_test.cpp
@@ -298,8 +298,11 @@ TEST_F(ChunksSorterTest, full_sort_incremental) {
     sort_exprs.push_back(new ExprContext(_expr_cust_key.get()));
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
-
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -504,7 +507,11 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -539,7 +546,11 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -577,7 +588,11 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -618,7 +633,11 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
     ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
     ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
 
-    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "");
+    auto pool = std::make_unique<ObjectPool>();
+    std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
+    ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
+                                slots);
+    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -32,6 +32,8 @@ import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.SortInfo;
 import com.starrocks.common.UserException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TPlanNode;
@@ -131,6 +133,10 @@ public class SortNode extends PlanNode {
 
         msg.sort_node = new TSortNode(sortInfo, useTopN);
         msg.sort_node.setOffset(offset);
+        SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
+        msg.sort_node.setMax_buffered_rows(sessionVariable.getFullSortMaxBufferedRows());
+        msg.sort_node.setMax_buffered_bytes(sessionVariable.getFullSortMaxBufferedBytes());
+        msg.sort_node.setLazy_materialization(sessionVariable.isFullSortLazyMaterialization());
 
         if (info.getPartitionExprs() != null) {
             msg.sort_node.setPartition_exprs(Expr.treesToThrift(info.getPartitionExprs()));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -148,6 +148,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // them do the real work on core.
     public static final String ENABLE_PIPELINE = "enable_pipeline";
 
+    public static final String ENABLE_RUNTIME_ADAPTIVE_DOP = "enable_runtime_adaptive_dop";
+    public static final String ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ =
+            "runtime_adaptive_dop_max_block_rows_per_driver_seq";
+
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
     public static final String ENABLE_PIPELINE_QUERY_STATISTIC = "enable_pipeline_query_statistic";
 
@@ -318,6 +322,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String SPILL_MEM_TABLE_NUM = "spill_mem_table_num";
     public static final String SPILL_MEM_LIMIT_THRESHOLD = "spill_mem_limit_threshold";
     public static final String SPILL_OPERATOR_MIN_BYTES = "spill_operator_min_bytes";
+    // full_sort_max_buffered_{rows,bytes} are thresholds that limits input size of partial_sort
+    // in full sort.
+    public static final String FULL_SORT_MAX_BUFFERED_ROWS = "full_sort_max_buffered_rows";
+
+    public static final String FULL_SORT_MAX_BUFFERED_BYTES = "full_sort_max_buffered_bytes";
+
+    // Used by full sort inorder to permute only order-by columns in cascading merging phase, after
+    // that, non-order-by output columns are permuted according to the ordinal column.
+    public static final String FULL_SORT_LAZY_MATERIALIZATION = "full_sort_lazy_materialization";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -800,10 +813,43 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = SPILL_OPERATOR_MIN_BYTES)
     private long spillOperatorMinBytes = 1024 * 1024 * 10;
 
+    @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_ROWS, flag = VariableMgr.INVISIBLE)
+    private long fullSortMaxBufferedRows = 1024000;
+
+    @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_BYTES, flag = VariableMgr.INVISIBLE)
+    private long fullSortMaxBufferedBytes = 16 * 1024 * 1024;
+
+    @VariableMgr.VarAttr(name = FULL_SORT_LAZY_MATERIALIZATION)
+    private boolean fullSortLazyMaterialization = false;
+
+    public void setFullSortMaxBufferedRows(long v) {
+        fullSortMaxBufferedRows = v;
+    }
+
+    public void setFullSortMaxBufferedBytes(long v) {
+        fullSortMaxBufferedBytes = v;
+    }
+
+    public long getFullSortMaxBufferedRows() {
+        return fullSortMaxBufferedRows;
+    }
+
+    public long getFullSortMaxBufferedBytes() {
+        return fullSortMaxBufferedBytes;
+    }
+
+    public void setFullSortLazyMaterialization(boolean v) {
+        fullSortLazyMaterialization = v;
+    }
+
+    public boolean isFullSortLazyMaterialization() {
+        return !enableSpilling && fullSortLazyMaterialization;
+    }
 
     public boolean getEnablePopulateBlockCache() {
         return enablePopulateBlockCache;
     }
+
     public boolean getHudiMORForceJNIReader() {
         return hudiMORForceJNIReader;
     }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -673,6 +673,10 @@ struct TSortNode {
   23: optional list<Exprs.TExpr> partition_exprs
   24: optional i64 partition_limit
   25: optional TTopNType topn_type;
+  26: optional list<RuntimeFilter.TRuntimeFilterDescription> build_runtime_filters;
+  27: optional i64 max_buffered_rows;
+  28: optional i64 max_buffered_bytes;
+  29: optional bool lazy_materialization;
 }
 
 enum TAnalyticWindowType {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
### Description
Cascading merging phase in full sort is time-consuming, especially, when encoutering data skew.  so after parial sortting, each chunk in sorted runs are split into two group vertically, the first group contains order-by columns(eager materialized chunks), the other group contains non-order-by output columns(lazy materialized chunks). an ordinal column is added to the first group(eager materialized chunks), so in the cascading merging, the first group of columns are permuted instead of all of the output columns, when then cascading merger output ordered chunks on command, then permute the non-order-by output columns according to ordinal column in thes sorted eager chunks.  

The higher the cascading merging tree, the more time spent to permute non-order-by columns in order version, the permutation times is height(cascading merging tree) - 1, so in the lazy materialization, the non-order-by columns is permuted only once.

Because an ordinal column is added to the eager materialized chunks, cascading take extra time to permutation it along with order by columns, so in some corner cases, lazy materialization version would lag order version. for examples:
1. there are only  a few non-group-by columns, the cost of permuting these columns in cascading merging is less than permuting an ordinal column.
2. the cascading merging tree is short, there are sorted runs the number of whom is less than 3.

so, in these two scenarios, lazy materialization is turned off in BE.

Lazy materialization version outperform order version for 1.25 X ~ 2X, especially, in cases of many non-order by output columns  is present in full sort and the data skew is very drastic.

Because the rows in lazy materialized chunks are selected and append to output chunks of cascading merger in a streaming way, so all of the lazy materialized chunks are kept in memory until the entire results are fetched by downstream operator. So when lazy materialized is enabled, full sort will use 1.5X~ 2X memory of input data.


### Test

Tests conducted on dataset that has 13.95GB and 100000000 rows and very skew.

Queries
```
Q0: skew=6%
select c1,c2,sum(c8) over (partition by c1,c2) as c8_sum from data_skew;
Q1: skew=6%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c1,c2) as c8_sum from data_skew;
Q2: skew=12%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c2,c3) as c8_sum from data_skew;
Q3: skew=20%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c3,c4) as c8_sum from data_skew;
Q4: skew=30%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c4,c5) as c8_sum from data_skew;
Q5: skew=42%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c5,c6) as c8_sum from data_skew;
Q6: skew=56%
select c1,c2,c3,c4,c5,c6,c7,sum(c8) over (partition by c6,c7) as c8_sum from data_skew;
```

#### Respond Time:  lazy_materialization/no_lazy_materialization = 1.30X ~ 1.93X

```
+=======+==========+==============+=================+
| Query | DataSkew | RT(lazy_mat) | RT(no_lazy_mat) |
+=======+==========+==============+=================+
| Q0    | 6%       | 10s156ms     | 9s13ms          |
| Q1    | 6%       | 20s250ms     | 26s253ms        |
| Q2    | 12%      | 26s76ms      | 40s826ms        |
| Q3    | 20%      | 37s115ms     | 59s440ms        |
| Q4    | 30%      | 49s795ms     | 1m33s           |
| Q5    | 42%      | 1m1s         | 2m7s            |
| Q6    | 56%      | 1m22s        | 2m50s           |
+-------+----------+--------------+-----------------+
```

#### InstancePeakMemorUsage:  lazy_materialization/no_lazy_materialization = 1.1 ~ 1.7X

```
+=======+==========+===============================+==================================+===================================+======================================+================================+===================================+
| Query | DataSkew | InputRequiredMemory(lazy_mat) | MaxInputRequiredMemory(lazy_mat) | InstancePeakMemoryUsage(lazy_mat) | InstancePeakMemoryUsage(no_lazy_mat) | QueryPeakMemoryUsage(lazy_mat) | QueryPeakMemoryUsage(no_lazy_mat) |
+=======+==========+===============================+==================================+===================================+======================================+================================+===================================+
| Q0    | 6%       | 5.38 GB                       | 394.05 MB                        | 3.40 GB                           | 3.09 GB                              | 3.484GB                        | 3.168GB                           |
| Q1    | 6%       | 13.95 GB                      | 1.23 GB                          | 7.38 GB                           | 5.77 GB                              | 7.612GB                        | 5.999GB                           |
| Q2    | 12%      | 13.95 GB                      | 1.93 GB                          | 8.81 GB                           | 6.32 GB                              | 9.048GB                        | 6.552GB                           |
| Q3    | 20%      | 13.95 GB                      | 2.89 GB                          | 11.28 GB                          | 7.11 GB                              | 11.512GB                       | 7.365GB                           |
| Q4    | 30%      | 13.95 GB                      | 4.15 GB                          | 13.94 GB                          | 8.07 GB                              | 14.207GB                       | 8.341GB                           |
| Q5    | 42%      | 13.95 GB                      | 5.71 GB                          | 17.33 GB                          | 10.23 GB                             | 17.587GB                       | 10.495GB                          |
| Q6    | 56%      | 13.95 GB                      | 7.60 GB                          | 21.22 GB                          | 12.47 GB                             | 21.474GB                       | 12.731GB                          |
+-------+----------+-------------------------------+----------------------------------+-----------------------------------+--------------------------------------+--------------------------------+-----------------------------------+
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
