### PR TITLE
[Feature] Routine load support for confluent avro data format

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -74,6 +74,10 @@ Status FileDataSource::_create_scanner() {
         _scanner = std::make_unique<ParquetScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
     } else if (_scan_range.ranges[0].format_type == TFileFormatType::FORMAT_JSON) {
         _scanner = std::make_unique<JsonScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
+    } else if (_scan_range.ranges[0].format_type == TFileFormatType::FORMAT_AVRO) {
+        // TODO(yangzaorang): we use json as an intermediate format to parse avro format, but there are
+        // performance issues here, and we could directly parse avro format data later.
+        _scanner = std::make_unique<JsonScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
     } else {
         _scanner = std::make_unique<CSVScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
     }

--- a/be/src/exec/file_scan_node.cpp
+++ b/be/src/exec/file_scan_node.cpp
@@ -208,6 +208,8 @@ std::unique_ptr<FileScanner> FileScanNode::_create_scanner(const TBrokerScanRang
         return std::make_unique<ParquetScanner>(runtime_state(), runtime_profile(), scan_range, counter);
     } else if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_JSON) {
         return std::make_unique<JsonScanner>(runtime_state(), runtime_profile(), scan_range, counter);
+    } else if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_AVRO) {
+        return std::make_unique<JsonScanner>(runtime_state(), runtime_profile(), scan_range, counter);
     } else {
         return std::make_unique<CSVScanner>(runtime_state(), runtime_profile(), scan_range, counter);
     }

--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -242,6 +242,8 @@ Status FileScanner::create_sequential_file(const TBrokerRangeDesc& range_desc, c
         compression = CompressionTypePB::DEFLATE;
     } else if (range_desc.format_type == TFileFormatType::FORMAT_CSV_ZSTD) {
         compression = CompressionTypePB::ZSTD;
+    } else if (range_desc.format_type == TFileFormatType::FORMAT_AVRO) {
+        compression = CompressionTypePB::NO_COMPRESSION;
     } else {
         return Status::NotSupported("Unsupported compression algorithm: " + std::to_string(range_desc.format_type));
     }

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -38,6 +38,15 @@
 #include "runtime/routine_load/data_consumer.h"
 #include "runtime/routine_load/kafka_consumer_pipe.h"
 #include "runtime/stream_load/stream_load_context.h"
+#include "util/defer_op.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "libserdes/serdes-avro.h"
+#ifdef __cplusplus
+}
+#endif
 
 namespace starrocks {
 
@@ -104,6 +113,25 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
         }
     }
 
+    char errstr[512];
+
+    serdes_conf_t* sconf = nullptr;
+    serdes_t* serdes = nullptr;
+    if (ctx->format == TFileFormatType::FORMAT_AVRO) {
+        sconf = serdes_conf_new(NULL, 0, "schema.registry.url", ctx->kafka_info->confluent_schema_registry_url.c_str(),
+                                NULL);
+        serdes = serdes_new(sconf, errstr, sizeof(errstr));
+        if (!serdes) {
+            LOG(ERROR) << "failed to create serdes handle: " << errstr;
+            return Status::InternalError("failed to create serdes handle");
+        }
+    }
+    DeferOp serdesDeleter([&] {
+        if (serdes != nullptr) {
+            free(serdes);
+        }
+    });
+
     // consuming from queue and put data to stream load pipe
     int64_t left_time = ctx->max_interval_s * 1000;
     int64_t received_rows = 0;
@@ -120,7 +148,7 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
     //improve performance
     Status (KafkaConsumerPipe::*append_data)(const char* data, size_t size, char row_delimiter);
     char row_delimiter = '\n';
-    if (ctx->format == TFileFormatType::FORMAT_JSON) {
+    if (ctx->format == TFileFormatType::FORMAT_JSON || ctx->format == TFileFormatType::FORMAT_AVRO) {
         append_data = &KafkaConsumerPipe::append_json;
     } else {
         append_data = &KafkaConsumerPipe::append_with_row_delimiter;
@@ -209,8 +237,28 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
                     cmt_offset[msg->partition()] = msg->offset() - 1;
                 }
             } else {
-                Status st = (kafka_pipe.get()->*append_data)(static_cast<const char*>(msg->payload()),
-                                                             static_cast<size_t>(msg->len()), row_delimiter);
+                Status st = Status::OK();
+                if (ctx->format == TFileFormatType::FORMAT_AVRO) {
+                    avro_value_t avro;
+                    DeferOp op([&] { avro_value_decref(&avro); });
+                    serdes_schema_t* schema;
+                    serdes_err_t err = serdes_deserialize_avro(serdes, &avro, &schema, msg->payload(), msg->len(),
+                                                               errstr, sizeof(errstr));
+                    if (err) {
+                        LOG(ERROR) << "serdes deserialize avro failed: " << errstr;
+                        return Status::InternalError("serdes deserialize avro failed");
+                    }
+                    char* as_json;
+                    if (avro_value_to_json(&avro, 1, &as_json)) {
+                        LOG(ERROR) << "avro to json failed: %s" << avro_strerror();
+                        return Status::InternalError("avro to json failed");
+                    }
+                    st = (kafka_pipe.get()->*append_data)(as_json, strlen(as_json), row_delimiter);
+                    free(as_json);
+                } else {
+                    st = (kafka_pipe.get()->*append_data)(static_cast<const char*>(msg->payload()),
+                                                          static_cast<size_t>(msg->len()), row_delimiter);
+                }
                 if (st.ok()) {
                     received_rows++;
                     left_bytes -= msg->len();

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -63,6 +63,7 @@ public:
     explicit KafkaLoadInfo(const TKafkaLoadInfo& t_info)
             : brokers(t_info.brokers),
               topic(t_info.topic),
+              confluent_schema_registry_url(t_info.confluent_schema_registry_url),
               begin_offset(t_info.partition_begin_offset),
               properties(t_info.properties) {
         // The offset(begin_offset) sent from FE is the starting offset,
@@ -83,6 +84,7 @@ public:
 public:
     std::string brokers;
     std::string topic;
+    std::string confluent_schema_registry_url;
 
     // partition -> begin offset, inclusive.
     std::map<int32_t, int64_t> begin_offset;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -46,6 +46,7 @@ public class PrintableMap<K, V> {
         SENSITIVE_KEY.add("fs.cosn.userinfo.secretKey");
         SENSITIVE_KEY.add("property.sasl.password");
         SENSITIVE_KEY.add("broker.password");
+        SENSITIVE_KEY.add("confluent.schema.registry.url");
     }
 
     public PrintableMap(Map<K, V> map, String keyValueSaperator,

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -106,6 +106,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     // kafka properties, property prefix will be mapped to kafka custom parameters, which can be extended in the future
     private Map<String, String> customProperties = Maps.newHashMap();
     private Map<String, String> convertedCustomProperties = Maps.newHashMap();
+    private String confluentSchemaRegistryUrl = null;
 
     public KafkaRoutineLoadJob() {
         // for serialization, id is dummy
@@ -118,6 +119,14 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         this.brokerList = brokerList;
         this.topic = topic;
         this.progress = new KafkaProgress();
+    }
+
+    public String getConfluentSchemaRegistryUrl() {
+        return confluentSchemaRegistryUrl;
+    }
+
+    public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
+        this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
     }
 
     public String getTopic() {
@@ -464,6 +473,10 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         }
         if (!stmt.getCustomKafkaProperties().isEmpty()) {
             setCustomKafkaProperties(stmt.getCustomKafkaProperties());
+        }
+
+        if (stmt.getConfluentSchemaRegistryUrl() != null) {
+            setConfluentSchemaRegistryUrl(stmt.getConfluentSchemaRegistryUrl());
         }
 
         setDefaultKafkaGroupID();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -166,6 +166,9 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         tKafkaLoadInfo.setBrokers((routineLoadJob).getBrokerList());
         tKafkaLoadInfo.setPartition_begin_offset(partitionIdToOffset);
         tKafkaLoadInfo.setProperties(routineLoadJob.getConvertedCustomProperties());
+        if ((routineLoadJob).getConfluentSchemaRegistryUrl() != null) {
+            tKafkaLoadInfo.setConfluent_schema_registry_url((routineLoadJob).getConfluentSchemaRegistryUrl());
+        }
         tRoutineLoadTask.setKafka_load_info(tKafkaLoadInfo);
         tRoutineLoadTask.setType(TLoadSourceType.KAFKA);
         tRoutineLoadTask.setParams(plan(routineLoadJob));
@@ -174,6 +177,8 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         tRoutineLoadTask.setMax_batch_size(Config.max_routine_load_batch_size);
         if (!routineLoadJob.getFormat().isEmpty() && routineLoadJob.getFormat().equalsIgnoreCase("json")) {
             tRoutineLoadTask.setFormat(TFileFormatType.FORMAT_JSON);
+        } else if (!routineLoadJob.getFormat().isEmpty() && routineLoadJob.getFormat().equalsIgnoreCase("avro")) {
+            tRoutineLoadTask.setFormat(TFileFormatType.FORMAT_AVRO);
         } else {
             tRoutineLoadTask.setFormat(TFileFormatType.FORMAT_CSV_PLAIN);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -335,6 +335,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             } else {
                 jobProperties.put(PROPS_STRIP_OUTER_ARRAY, "false");
             }
+        } else if (stmt.getFormat().equals("avro")) {
+            jobProperties.put(PROPS_FORMAT, "avro");
         } else {
             throw new UserException("Invalid format type.");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -387,6 +387,9 @@ public class StreamLoadInfo {
         if (routineLoadJob.getFormat().equals("json")) {
             fileFormatType = TFileFormatType.FORMAT_JSON;
         }
+        if (routineLoadJob.getFormat().equals("avro")) {
+            fileFormatType = TFileFormatType.FORMAT_AVRO;
+        }
         StreamLoadInfo streamLoadInfo = new StreamLoadInfo(dummyId, -1L /* dummy txn id */,
                 TFileType.FILE_STREAM, fileFormatType);
         streamLoadInfo.setOptionalFromRoutineLoadJob(routineLoadJob);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -516,11 +516,11 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                 jsonPaths = jobProperties.get(JSONPATHS);
                 jsonRoot = jobProperties.get(JSONROOT);
                 stripOuterArray = Boolean.valueOf(jobProperties.getOrDefault(STRIP_OUTER_ARRAY, "false"));
+            } else if (format.equalsIgnoreCase("avro")) {
+                format = "avro";
             } else {
                 throw new UserException("Format type is invalid. format=`" + format + "`");
             }
-        } else if (format.equalsIgnoreCase("avro")) {
-            format = "avro";
         } else {
             format = "csv"; // default csv
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -115,6 +115,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String KAFKA_PARTITIONS_PROPERTY = "kafka_partitions";
     public static final String KAFKA_OFFSETS_PROPERTY = "kafka_offsets";
     public static final String KAFKA_DEFAULT_OFFSETS = "kafka_default_offsets";
+    // optional
+    public static final String CONFLUENT_SCHEMA_REGISTRY_URL = "confluent.schema.registry.url";
 
     // pulsar type properties
     public static final String PULSAR_SERVICE_URL_PROPERTY = "pulsar_service_url";
@@ -152,6 +154,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(KAFKA_TOPIC_PROPERTY)
             .add(KAFKA_PARTITIONS_PROPERTY)
             .add(KAFKA_OFFSETS_PROPERTY)
+            .add(CONFLUENT_SCHEMA_REGISTRY_URL)
             .build();
 
     private static final ImmutableSet<String> PULSAR_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -161,7 +164,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(PULSAR_PARTITIONS_PROPERTY)
             .add(PULSAR_INITIAL_POSITIONS_PROPERTY)
             .build();
-
+        
+    private String confluentSchemaRegistryUrl;
     private LabelName labelName;
     private final String tableName;
     private final List<ParseNode> loadPropertyList;
@@ -232,6 +236,14 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         this.jobProperties = jobProperties == null ? Maps.newHashMap() : jobProperties;
         this.typeName = typeName.toUpperCase();
         this.dataSourceProperties = dataSourceProperties;
+    }
+
+    public String getConfluentSchemaRegistryUrl() {
+        return confluentSchemaRegistryUrl;
+    }
+
+    public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
+        this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
     }
 
     public boolean isTrimspace() {
@@ -507,6 +519,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             } else {
                 throw new UserException("Format type is invalid. format=`" + format + "`");
             }
+        } else if (format.equalsIgnoreCase("avro")) {
+            format = "avro";
         } else {
             format = "csv"; // default csv
         }
@@ -585,6 +599,22 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         String kafkaOffsetsString = dataSourceProperties.get(KAFKA_OFFSETS_PROPERTY);
         if (kafkaOffsetsString != null) {
             analyzeKafkaOffsetProperty(kafkaOffsetsString, kafkaPartitionOffsets);
+        }
+        String confluentSchemaRegistryUrlString = dataSourceProperties.get(CONFLUENT_SCHEMA_REGISTRY_URL);
+        if (confluentSchemaRegistryUrlString == null) {
+            if (format == null) {
+                format = jobProperties.get(FORMAT);
+                if (format != null) {
+                    if (format.equalsIgnoreCase("avro")) {
+                        format = "avro";
+                    }
+                }
+            }
+            if (format.equals("avro")) {
+                throw new AnalysisException(CONFLUENT_SCHEMA_REGISTRY_URL + " is a required property");
+            }
+        } else {
+            confluentSchemaRegistryUrl = confluentSchemaRegistryUrlString;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -339,6 +339,33 @@ public class CreateRoutineLoadStmtTest {
     }
 
     @Test
+    public void testAnalyzeCSVConfig() throws Exception {
+        String createSQL = "CREATE ROUTINE LOAD db0.routine_load_1 ON t1 " +
+                "PROPERTIES(\"format\" = \"csv\", \"trim_space\"=\"true\", \"enclose\"=\"'\", \"escape\"=\"|\") " +
+                "FROM KAFKA(\"kafka_broker_list\" = \"xxx.xxx.xxx.xxx:xxx\",\"kafka_topic\" = \"topic_0\");";
+        ConnectContext ctx = starRocksAssert.getCtx();
+        CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) SqlParser.parse(createSQL, 32).get(0);
+        CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+        Assert.assertEquals(createRoutineLoadStmt.isTrimspace(), true);
+        Assert.assertEquals(createRoutineLoadStmt.getEnclose(), '\'');
+        Assert.assertEquals(createRoutineLoadStmt.getEscape(), '|');
+    }
+
+    @Test
+    public void testAnalyzeCSVDefalultValue() throws Exception {
+        String createSQL = "CREATE ROUTINE LOAD db0.routine_load_1 ON t1 " +
+                "PROPERTIES(\"max_error_number\" = \"10\") " +
+                "FROM KAFKA(\"kafka_broker_list\" = \"xxx.xxx.xxx.xxx:xxx\",\"kafka_topic\" = \"topic_0\");";
+        ConnectContext ctx = starRocksAssert.getCtx();
+        CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) SqlParser.parse(createSQL, 32).get(0);
+        CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+        Assert.assertEquals(createRoutineLoadStmt.getMaxErrorNum(), 10);
+        Assert.assertEquals(createRoutineLoadStmt.getEnclose(), 0);
+        Assert.assertEquals(createRoutineLoadStmt.getEscape(), 0);
+        Assert.assertEquals(createRoutineLoadStmt.isTrimspace(), false);
+    }
+
+    @Test
     public void testKafkaOffset() {
 
         String jobName = "job1";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -104,6 +104,7 @@ public class CreateRoutineLoadStmtTest {
                 + "FROM KAFKA\n"
                 + "(\n"
                 + "\"kafka_broker_list\" = \"kafkahost1:9092,kafkahost2:9092\",\n"
+                + "\"confluent.schema.registry.url\" = \"https://user:password@confluent.west.us\",\n"
                 + "\"kafka_topic\" = \"topictest\"\n"
                 + ");";
         List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, 32);
@@ -121,6 +122,7 @@ public class CreateRoutineLoadStmtTest {
         Assert.assertEquals("kafkahost1:9092,kafkahost2:9092", createRoutineLoadStmt.getKafkaBrokerList());
         Assert.assertEquals("topictest", createRoutineLoadStmt.getKafkaTopic());
         Assert.assertEquals("Asia/Shanghai", createRoutineLoadStmt.getTimezone());
+        Assert.assertEquals("https://user:password@confluent.west.us", createRoutineLoadStmt.getConfluentSchemaRegistryUrl());
     }
 
     @Test
@@ -337,33 +339,6 @@ public class CreateRoutineLoadStmtTest {
     }
 
     @Test
-    public void testAnalyzeCSVConfig() throws Exception {
-        String createSQL = "CREATE ROUTINE LOAD db0.routine_load_1 ON t1 " +
-                "PROPERTIES(\"format\" = \"csv\", \"trim_space\"=\"true\", \"enclose\"=\"'\", \"escape\"=\"|\") " +
-                "FROM KAFKA(\"kafka_broker_list\" = \"xxx.xxx.xxx.xxx:xxx\",\"kafka_topic\" = \"topic_0\");";
-        ConnectContext ctx = starRocksAssert.getCtx();
-        CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) SqlParser.parse(createSQL, 32).get(0);
-        CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
-        Assert.assertEquals(createRoutineLoadStmt.isTrimspace(), true);
-        Assert.assertEquals(createRoutineLoadStmt.getEnclose(), '\'');
-        Assert.assertEquals(createRoutineLoadStmt.getEscape(), '|');
-    }
-
-    @Test
-    public void testAnalyzeCSVDefalultValue() throws Exception {
-        String createSQL = "CREATE ROUTINE LOAD db0.routine_load_1 ON t1 " +
-                "PROPERTIES(\"max_error_number\" = \"10\") " +
-                "FROM KAFKA(\"kafka_broker_list\" = \"xxx.xxx.xxx.xxx:xxx\",\"kafka_topic\" = \"topic_0\");";
-        ConnectContext ctx = starRocksAssert.getCtx();
-        CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) SqlParser.parse(createSQL, 32).get(0);
-        CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
-        Assert.assertEquals(createRoutineLoadStmt.getMaxErrorNum(), 10);
-        Assert.assertEquals(createRoutineLoadStmt.getEnclose(), 0);
-        Assert.assertEquals(createRoutineLoadStmt.getEscape(), 0);
-        Assert.assertEquals(createRoutineLoadStmt.isTrimspace(), false);
-    }
-
-    @Test
     public void testKafkaOffset() {
 
         String jobName = "job1";
@@ -459,12 +434,13 @@ public class CreateRoutineLoadStmtTest {
                 + "FROM KAFKA\n"
                 + "(\n"
                 + "\"kafka_broker_list\" = \"kafkahost1:9092,kafkahost2:9092\",\n"
-                + "\"kafka_topic\" = \"topictest\"\n"
+                + "\"kafka_topic\" = \"topictest\",\n"
+                + "\"confluent.schema.registry.url\" = \"https://user:password@confluent.west.us\"\n"
                 + ");";
         ConnectContext ctx = starRocksAssert.getCtx();
         CreateRoutineLoadStmt stmt = (CreateRoutineLoadStmt) com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
         Assert.assertEquals("CREATE ROUTINE LOAD null.null ON table1PROPERTIES ( \"desired_concurrent_number\" = \"3\", \"timezone\" = \"Asia/Shanghai\", \"strict_mode\" = \"false\", \"max_batch_interval\" = \"20\" ) " +
-                "FROM KAFKA ( \"kafka_broker_list\" = \"kafkahost1:9092,kafkahost2:9092\", \"kafka_topic\" = \"topictest\" )", AstToStringBuilder.toString(stmt));
+        "FROM KAFKA ( \"kafka_broker_list\" = \"kafkahost1:9092,kafkahost2:9092\", \"kafka_topic\" = \"topictest\", \"confluent.schema.registry.url\" = \"***\" )", AstToStringBuilder.toString(stmt));
     }
 
     private Map<String, String> getCustomProperties() {

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -63,6 +63,7 @@ struct TKafkaLoadInfo {
     2: required string topic;
     3: required map<i32, i64> partition_begin_offset;
     4: optional map<string, string> properties;
+    5: optional string confluent_schema_registry_url;
 }
 
 struct TPulsarLoadInfo {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -140,6 +140,7 @@ enum TFileFormatType {
     FORMAT_ORC = 8,
     FORMAT_JSON = 9,
     FORMAT_CSV_ZSTD = 10,
+    FORMAT_AVRO = 11,
 }
 
 // One broker range information.


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16445

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR allows routine load to support  confluent avro data format. Here's an example of how to use this feature. For the example_tbl2 table
```
CREATE TABLE `example_tbl2` ( 
    `commodity_id` varchar(26) NULL COMMENT "commodity ID", 
    `customer_name` varchar(26) NULL COMMENT "customer name", 
    `country` varchar(26) NULL COMMENT "country", 
    `pay_time` bigint(20) NULL COMMENT "pay time", 
    `price` double NULL COMMENT "price"
) 
DUPLICATE KEY(`commodity_id`,`customer_name`,`country`,`pay_time`) 
DISTRIBUTED BY HASH(commodity_id) BUCKETS 1;
```

You can complete the data import with the following SQL
```
CREATE ROUTINE LOAD test.example_tbl2_ordertest22 ON example_tbl2
PROPERTIES
(
    "desired_concurrent_number"="5",
    "format" ="avro"
)
FROM KAFKA
(
   "kafka_broker_list"="broker address",
   "confluent.schema.registry.url"="https://username:password@aws.confluent.cloud",
        ...
);
```
SR will search for the corresponding column in avro according to the column in the table and complete the data import. Of course, just like json format data import, you can specify the mapping between avro and SR table columns using the COLUMNS statement.
```
CREATE ROUTINE LOAD test.example_tbl2_ordertest22 ON example_tbl2
COLUMNS(commodity_id, customer_name, country, pay_time, price, price=price_avro)
PROPERTIES
(
    "desired_concurrent_number"="5",
    "format" ="avro"
 )
FROM KAFKA
(
   "kafka_broker_list"="broker address",
   "confluent.schema.registry.url"="https://username:password@aws.confluent.cloud",
        ...
);
```
The COLUMNS statement above maps the price_avro field of avro to the price field of the SR table. Note that this feature introduces a new attribute, confluent.schema.registry.url, to express the confluent schema registry url. Currently, only record data of the root type is supported.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2