### PR TITLE
[BugFix] Can not find the correct repo when repo prefix is palo after fe restart (#18015)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/Repository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/Repository.java
@@ -700,5 +700,17 @@ public class Repository implements Writable {
         location = Text.readString(in);
         storage = BlobStorage.read(in);
         createTime = in.readLong();
+
+        // list __palo_repository_ first, if success, prefixRepo = __palo_repository_
+        String listPath = Joiner.on(PATH_DELIMITER).join(location, joinPrefix("__palo_repository_", name), PREFIX_SNAPSHOT_DIR)
+                + "*";
+        List<RemoteFile> result = Lists.newArrayList();
+        Status st = storage.list(listPath, result);
+
+        if (st.ok()) {
+            prefixRepo = "__palo_repository_";
+        } else {
+            prefixRepo = "__starrocks_repository_";
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18015

## Problem Summary(Required) ：
Problem:
Now we use __starrocks prefix for repo, but if user have the __palo prefix repo, fe will get wrong prefix as __starrocks when fe restart.

Solution:
When Fe recover meta data for repo, it should try to list __palo prefix repo to check that if  __palo prefix repo is exist or not and reset prefix to the correct value. In this way, we can avoid to persist the prefix  value into the Image File.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
