### PR TITLE
[Refactor] Add FileName in the error message

### DIFF
--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -51,6 +51,7 @@ public:
     arrow::Result<int64_t> Tell() const override;
     arrow::Status Close() override;
     bool closed() const override;
+    const std::string& filename() const;
 
 private:
     std::shared_ptr<starrocks::RandomAccessFile> _file;
@@ -98,6 +99,7 @@ private:
     int64_t _read_size;
 
     std::string _timezone;
+    std::string _filename;
 };
 
 // Reader of broker parquet file

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1843,7 +1843,6 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
         type_struct.children.emplace_back(type_array);
         type_struct.field_names.emplace_back("b");
 
-
         SlotDesc slot_descs[] = {
                 {"id", type_int},
                 {"col", type_struct},
@@ -1891,12 +1890,10 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
         EXPECT_EQ(524288, total_row_nums);
     }
 
-
     // With 1024 chunk size
     {
         auto file = _create_file(filepath);
-        auto file_reader = std::make_shared<FileReader>(1024, file.get(),
-                                                        std::filesystem::file_size(filepath));
+        auto file_reader = std::make_shared<FileReader>(1024, file.get(), std::filesystem::file_size(filepath));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -1919,7 +1916,6 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
 
         type_struct.children.emplace_back(type_array);
         type_struct.field_names.emplace_back("b");
-
 
         SlotDesc slot_descs[] = {
                 {"id", type_int},


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The filename is not included when error throws during reading data in ParquetReader. It's hard to trace the error when lots of files in one ingestion jobs. I add the filename in the error log to reduce the overhead to trace the error.

Before the pull request, the error is like the following.
```
Either the file is corrupted or this is not a parquet file.
```

After the pull request, the error is like the following.
```
Either the file is corrupted or this is not a parquet file. filename: oss://xxx/catalog_sales_1_1000.dat
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
