### PR TITLE
[BugFix] Fix NullPointerException log when load fail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -464,7 +464,7 @@ public class GlobalTransactionMgr implements Writable {
     }
 
     public void abortTransaction(long dbId, long transactionId, String reason) throws UserException {
-        abortTransaction(dbId, transactionId, reason, null);
+        abortTransaction(dbId, transactionId, reason, Lists.newArrayList());
     }
 
     public void abortTransaction(long dbId, long transactionId, String reason, List<TabletFailInfo> failedTablets)

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -262,7 +262,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                 // update write failed backend/replica
                 // use for selection of primary replica for replicated storage
                 for (TabletFailInfo failedTablet : failedTablets) {
-                    LOG.info(failedTablet);
+                    LOG.debug("failed tablet ", failedTablet);
                     if (failedTablet.getTabletId() == -1) {
                         Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(failedTablet.getBackendId());
                         if (backend != null) {
@@ -277,7 +277,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                     }
                 }
             } catch (Exception e) {
-                LOG.warn(e);
+                LOG.warn("Fail to execute postAbort", e);
             } finally {
                 db.readUnlock();
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
when load fail in prepare step, there will be no failed tablets. so that it will log a NullPointerException in PostAbort() which handle the failed tablets. the consequence is ok but log is unnecessary. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
