### PR TITLE
[Enhancement] Support JSON type for MySQL external table

### DIFF
--- a/be/src/connector/mysql_connector.cpp
+++ b/be/src/connector/mysql_connector.cpp
@@ -326,6 +326,11 @@ Status MySQLDataSource::append_text_to_column(const char* data, const int& len, 
 
     // Parse the raw-text data. Translate the text string to internal format.
     switch (slot_desc->type().type) {
+    case TYPE_JSON: {
+        ASSIGN_OR_RETURN(auto value, JsonValue::parse(Slice(data, len)));
+        reinterpret_cast<JsonColumn*>(data_column)->append(std::move(value));
+        break;
+    }
     case TYPE_VARCHAR:
     case TYPE_CHAR: {
         Slice value(data, len);


### PR DESCRIPTION
Users can create an MySQL external table for another StarRocks table. But if that table contains JSON type, StarRocks will throw an error when reading that external table. This is because of not supporting JSON.

In this CL, I support JSON type in MySQL connector.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
