### PR TITLE
[Enhancement] Remove the partition size display in the explain iceberg scan node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -325,16 +325,6 @@ public class IcebergScanNode extends ScanNode {
                     getExplainString(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
 
-        if (srIcebergTable.isCatalogTbl()) {
-            List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
-                    srIcebergTable.getCatalog(), srIcebergTable.getDb(), srIcebergTable.getTable());
-
-            output.append(prefix).append(
-                    String.format("partitions=%s/%s", scanNodePredicates.getSelectedPartitionIds().size(),
-                            partitionNames.size() == 0 ? 1 : partitionNames.size()));
-            output.append("\n");
-        }
-
         output.append(prefix).append(String.format("cardinality=%s", cardinality));
         output.append("\n");
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Currently, to show the partition size when explain iceberg table, we parse the partition values by calling `TableScan.planFiles` in iceberg jar. this will scan and access all iceberg partitions remote metadata file. This could take a lot of time if the metadata is large.  In iceberg structure, partition is hidden. it will be parsed and transformed according to the partition column data value. Unless planFiles, it's not possible to get it from iceberg metadata file. The hive metastore also doesn't record the partition info.  

So we remove the partition size info from the iceberg scan node.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
