### PR TITLE
[BugFix] Fix wrong hierarchy of sink's profile

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -535,10 +535,6 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
         }
         RETURN_IF_ERROR(DataSink::create_data_sink(runtime_state, tsink, fragment.output_exprs, params,
                                                    request.sender_id(), plan->row_desc(), &datasink));
-        RuntimeProfile* sink_profile = datasink->profile();
-        if (sink_profile != nullptr) {
-            runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);
-        }
         RETURN_IF_ERROR(_decompose_data_sink_to_operator(runtime_state, &context, request, datasink, tsink,
                                                          fragment.output_exprs));
     }
@@ -829,10 +825,6 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
             RETURN_IF_ERROR(st);
             if (sink != nullptr) {
                 RETURN_IF_ERROR(sink->init(thrift_sink, runtime_state));
-            }
-            RuntimeProfile* sink_profile = sink->profile();
-            if (sink_profile != nullptr) {
-                runtime_state->runtime_profile()->add_child(sink_profile, true, nullptr);
             }
             tablet_sinks.emplace_back(std::move(sink));
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/1914

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Sink's profile should not be attached to instance's profile. And all the sink's metrics will be copy to OlapTableSinkOperator's profile correctly(see the code below).

```cpp
void OlapTableSinkOperator::close(RuntimeState* state) {
    _unique_metrics->copy_all_info_strings_from(_sink->profile());
    _unique_metrics->copy_all_counters_from(_sink->profile());

    Operator::close(state);
}
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
