### PR TITLE
[BugFix] rename element_memory_usage to reference_memory_usage and fix incorrect result

### DIFF
--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -541,9 +541,9 @@ public:
         return _data_column->container_memory_usage() + _null_column->container_memory_usage();
     }
 
-    size_t element_memory_usage(size_t from, size_t size) const override {
+    size_t reference_memory_usage(size_t from, size_t size) const override {
         materialized_nullable();
-        return NullableColumn::element_memory_usage(from, size);
+        return NullableColumn::reference_memory_usage(from, size);
     }
 
     std::string debug_item(size_t idx) const override {

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -533,11 +533,11 @@ bool ArrayColumn::set_null(size_t idx) {
     return false;
 }
 
-size_t ArrayColumn::element_memory_usage(size_t from, size_t size) const {
+size_t ArrayColumn::reference_memory_usage(size_t from, size_t size) const {
     DCHECK_LE(from + size, this->size()) << "Range error";
     size_t start_offset = _offsets->get_data()[from];
     size_t elements_num = _offsets->get_data()[from + size] - start_offset;
-    return _elements->element_memory_usage(start_offset, elements_num) + _offsets->element_memory_usage(from, size);
+    return _elements->reference_memory_usage(start_offset, elements_num) + _offsets->reference_memory_usage(from, size);
 }
 
 void ArrayColumn::swap_column(Column& rhs) {

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -153,7 +153,7 @@ public:
         return _elements->container_memory_usage() + _offsets->container_memory_usage();
     }
 
-    size_t element_memory_usage(size_t from, size_t size) const override;
+    size_t reference_memory_usage(size_t from, size_t size) const override;
 
     void swap_column(Column& rhs) override;
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -290,9 +290,7 @@ public:
         return _bytes.capacity() + _offsets.capacity() * sizeof(_offsets[0]) + _slices.capacity() * sizeof(_slices[0]);
     }
 
-    size_t element_memory_usage(size_t from, size_t size) const override {
-        return _offsets[from + size] - _offsets[from] + size * sizeof(T);
-    }
+    size_t reference_memory_usage(size_t from, size_t size) const override { return 0; }
 
     void swap_column(Column& rhs) override {
         auto& r = down_cast<BinaryColumnBase<T>&>(rhs);

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -323,13 +323,13 @@ size_t Chunk::container_memory_usage() const {
     return container_memory_usage;
 }
 
-size_t Chunk::element_memory_usage(size_t from, size_t size) const {
+size_t Chunk::reference_memory_usage(size_t from, size_t size) const {
     DCHECK_LE(from + size, num_rows()) << "Range error";
-    size_t element_memory_usage = 0;
+    size_t reference_memory_usage = 0;
     for (const auto& column : _columns) {
-        element_memory_usage += column->element_memory_usage(from, size);
+        reference_memory_usage += column->reference_memory_usage(from, size);
     }
-    return element_memory_usage;
+    return reference_memory_usage;
 }
 
 size_t Chunk::bytes_usage() const {

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -232,9 +232,9 @@ public:
     // Column container memory usage
     size_t container_memory_usage() const;
     // Element memory usage that is not in the container, such as memory referenced by pointer.
-    size_t element_memory_usage() const { return element_memory_usage(0, num_rows()); }
+    size_t reference_memory_usage() const { return reference_memory_usage(0, num_rows()); }
     // Element memory usage of |size| rows from |from| in chunk
-    size_t element_memory_usage(size_t from, size_t size) const;
+    size_t reference_memory_usage(size_t from, size_t size) const;
 
     // Chunk bytes usage, used for memtable data size statistic.
     // Including element data size only.

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -376,10 +376,10 @@ public:
     //    such as memory referenced by pointer.
     //   2.1 object column: element serialize data size.
     //   2.2 other columns: 0.
-    virtual size_t memory_usage() const { return container_memory_usage() + element_memory_usage(); }
+    virtual size_t memory_usage() const { return container_memory_usage() + reference_memory_usage(); }
     virtual size_t container_memory_usage() const = 0;
-    virtual size_t element_memory_usage() const { return element_memory_usage(0, size()); }
-    virtual size_t element_memory_usage(size_t from, size_t size) const = 0;
+    virtual size_t reference_memory_usage() const { return reference_memory_usage(0, size()); }
+    virtual size_t reference_memory_usage(size_t from, size_t size) const = 0;
 
     virtual void swap_column(Column& rhs) = 0;
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -370,9 +370,9 @@ public:
 
     virtual std::string debug_string() const { return {}; }
 
-    // memory usage includes container memory usage and element memory usage.
+    // memory usage includes container memory usage and reference memory usage.
     // 1. container memory usage: container capacity * type size.
-    // 2. element memory usage: element data size that is not in the container,
+    // 2. reference memory usage: element data size that is not in the container,
     //    such as memory referenced by pointer.
     //   2.1 object column: element serialize data size.
     //   2.2 other columns: 0.

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -197,11 +197,11 @@ public:
 
     size_t container_memory_usage() const override { return _data->container_memory_usage(); }
 
-    size_t element_memory_usage() const override { return _data->element_memory_usage(); }
+    size_t reference_memory_usage() const override { return _data->reference_memory_usage(); }
 
-    size_t element_memory_usage(size_t from, size_t size) const override {
+    size_t reference_memory_usage(size_t from, size_t size) const override {
         // const column has only one element
-        return size == 0 ? 0 : element_memory_usage();
+        return size == 0 ? 0 : reference_memory_usage();
     }
 
     void swap_column(Column& rhs) override {

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -208,7 +208,7 @@ public:
     std::string debug_string() const override;
 
     size_t container_memory_usage() const override { return _data.capacity() * sizeof(ValueType); }
-    size_t element_memory_usage(size_t from, size_t size) const override { return sizeof(ValueType) * size; }
+    size_t reference_memory_usage(size_t from, size_t size) const override { return 0; }
 
     void swap_column(Column& rhs) override {
         auto& r = down_cast<FixedLengthColumnBase&>(rhs);

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -540,12 +540,12 @@ bool MapColumn::set_null(size_t idx) {
     return false;
 }
 
-size_t MapColumn::element_memory_usage(size_t from, size_t size) const {
+size_t MapColumn::reference_memory_usage(size_t from, size_t size) const {
     DCHECK_LE(from + size, this->size()) << "Range error";
     size_t start_offset = _offsets->get_data()[from];
     size_t elements_num = _offsets->get_data()[from + size] - start_offset;
-    return _keys->element_memory_usage(start_offset, elements_num) +
-           _values->element_memory_usage(start_offset, elements_num) + _offsets->element_memory_usage(from, size);
+    return _keys->reference_memory_usage(start_offset, elements_num) +
+           _values->reference_memory_usage(start_offset, elements_num) + _offsets->reference_memory_usage(from, size);
 }
 
 void MapColumn::swap_column(Column& rhs) {

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -148,7 +148,7 @@ public:
         return _keys->container_memory_usage() + _values->container_memory_usage() + _offsets->container_memory_usage();
     }
 
-    size_t element_memory_usage(size_t from, size_t size) const override;
+    size_t reference_memory_usage(size_t from, size_t size) const override;
 
     void swap_column(Column& rhs) override;
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -260,9 +260,9 @@ public:
         return _data_column->container_memory_usage() + _null_column->container_memory_usage();
     }
 
-    size_t element_memory_usage(size_t from, size_t size) const override {
+    size_t reference_memory_usage(size_t from, size_t size) const override {
         DCHECK_LE(from + size, this->size()) << "Range error";
-        return _data_column->element_memory_usage(from, size) + _null_column->element_memory_usage(from, size);
+        return _data_column->reference_memory_usage(from, size) + _null_column->reference_memory_usage(from, size);
     }
 
     void swap_column(Column& rhs) override {

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -169,9 +169,9 @@ public:
 
     size_t container_memory_usage() const override { return _pool.capacity() * type_size(); }
 
-    size_t element_memory_usage() const override { return byte_size(); }
+    size_t reference_memory_usage() const override { return byte_size(); }
 
-    size_t element_memory_usage(size_t from, size_t size) const override { return byte_size(from, size); }
+    size_t reference_memory_usage(size_t from, size_t size) const override { return byte_size(from, size); }
 
     void swap_column(Column& rhs) override {
         auto& r = down_cast<ObjectColumn&>(rhs);

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -439,14 +439,14 @@ size_t StructColumn::container_memory_usage() const {
     return memory_usage;
 }
 
-size_t StructColumn::element_memory_usage(size_t from, size_t size) const {
+size_t StructColumn::reference_memory_usage(size_t from, size_t size) const {
     DCHECK_LE(from + size, this->size()) << "Range error";
     size_t memorg_usage = 0;
     for (const auto& column : _fields) {
-        memorg_usage += column->element_memory_usage(from, size);
+        memorg_usage += column->reference_memory_usage(from, size);
     }
 
-    // Do not need to include _field_names's element_memory_usage, because it's BinaryColumn, always return 0.
+    // Do not need to include _field_names's reference_memory_usage, because it's BinaryColumn, always return 0.
     return memorg_usage;
 }
 

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -150,7 +150,7 @@ public:
 
     size_t container_memory_usage() const override;
 
-    size_t element_memory_usage(size_t from, size_t size) const override;
+    size_t reference_memory_usage(size_t from, size_t size) const override;
 
     void swap_column(Column& rhs) override;
 

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -58,7 +58,7 @@ Status PartitionExchanger::Partitioner::partition_chunk(const ChunkPtr& chunk,
     _partition_memory_usage.assign(num_partitions, 0);
     for (size_t i = 0; i < num_rows; ++i) {
         _partition_row_indexes_start_points[_shuffle_channel_id[i]]++;
-        _partition_memory_usage[_shuffle_channel_id[i]] += chunk->element_memory_usage(i, 1);
+        _partition_memory_usage[_shuffle_channel_id[i]] += chunk->reference_memory_usage(i, 1);
     }
     // We make the last item equal with number of rows of this chunk.
     for (int32_t i = 1; i <= num_partitions; ++i) {

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -58,7 +58,7 @@ Status PartitionExchanger::Partitioner::partition_chunk(const ChunkPtr& chunk,
     _partition_memory_usage.assign(num_partitions, 0);
     for (size_t i = 0; i < num_rows; ++i) {
         _partition_row_indexes_start_points[_shuffle_channel_id[i]]++;
-        _partition_memory_usage[_shuffle_channel_id[i]] += chunk->reference_memory_usage(i, 1);
+        _partition_memory_usage[_shuffle_channel_id[i]] += chunk->bytes_usage(i, 1);
     }
     // We make the last item equal with number of rows of this chunk.
     for (int32_t i = 1; i <= num_partitions; ++i) {

--- a/be/src/storage/chunk_aggregator.cpp
+++ b/be/src/storage/chunk_aggregator.cpp
@@ -202,8 +202,8 @@ void ChunkAggregator::aggregate_reset() {
     }
     _has_aggregate = false;
 
-    _element_memory_usage = 0;
-    _element_memory_usage_num_rows = 0;
+    _reference_memory_usage = 0;
+    _reference_memory_usage_num_rows = 0;
     _bytes_usage = 0;
     _bytes_usage_num_rows = 0;
 }
@@ -232,16 +232,16 @@ size_t ChunkAggregator::memory_usage() {
     }
     --num_rows;
 
-    if (_element_memory_usage_num_rows == num_rows) {
-        return container_memory_usage + _element_memory_usage;
-    } else if (_element_memory_usage_num_rows > num_rows) {
-        _element_memory_usage_num_rows = 0;
-        _element_memory_usage = 0;
+    if (_reference_memory_usage_num_rows == num_rows) {
+        return container_memory_usage + _reference_memory_usage;
+    } else if (_reference_memory_usage_num_rows > num_rows) {
+        _reference_memory_usage_num_rows = 0;
+        _reference_memory_usage = 0;
     }
-    _element_memory_usage += _aggregate_chunk->element_memory_usage(_element_memory_usage_num_rows,
-                                                                    num_rows - _element_memory_usage_num_rows);
-    _element_memory_usage_num_rows = num_rows;
-    return container_memory_usage + _element_memory_usage;
+    _reference_memory_usage += _aggregate_chunk->reference_memory_usage(_reference_memory_usage_num_rows,
+                                                                        num_rows - _reference_memory_usage_num_rows);
+    _reference_memory_usage_num_rows = num_rows;
+    return container_memory_usage + _reference_memory_usage;
 }
 
 size_t ChunkAggregator::bytes_usage() {

--- a/be/src/storage/chunk_aggregator.h
+++ b/be/src/storage/chunk_aggregator.h
@@ -113,8 +113,8 @@ private:
 
     // element memory usage and bytes usage calculation cost of object column is high,
     // so cache calculated element memory usage and bytes usage to avoid repeated calculation.
-    size_t _element_memory_usage = 0;
-    size_t _element_memory_usage_num_rows = 0;
+    size_t _reference_memory_usage = 0;
+    size_t _reference_memory_usage_num_rows = 0;
     size_t _bytes_usage = 0;
     size_t _bytes_usage_num_rows = 0;
 

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1155,43 +1155,74 @@ PARALLEL_TEST(ArrayColumnTest, test_replicate) {
     ASSERT_EQ("[]", res->debug_item(6));
 }
 
-PARALLEL_TEST(ArrayColumnTest, test_element_memory_usage) {
-    auto offsets = UInt32Column::create();
-    auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
-    auto column = ArrayColumn::create(elements, offsets);
+PARALLEL_TEST(ArrayColumnTest, test_reference_memory_usage) {
+    {
+        auto offsets = UInt32Column::create();
+        auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        auto column = ArrayColumn::create(elements, offsets);
 
-    // insert [],[1],[2, 3],[4, 5, 6]
-    offsets->append(0);
+        // insert [],[1],[2, 3],[4, 5, 6]
+        offsets->append(0);
 
-    elements->append_datum(1);
-    offsets->append(1);
+        elements->append_datum(1);
+        offsets->append(1);
 
-    elements->append_datum(2);
-    elements->append_datum(3);
-    offsets->append(3);
+        elements->append_datum(2);
+        elements->append_datum(3);
+        offsets->append(3);
 
-    elements->append_datum(4);
-    elements->append_datum(5);
-    elements->append_datum(6);
-    offsets->append(6);
+        elements->append_datum(4);
+        elements->append_datum(5);
+        elements->append_datum(6);
+        offsets->append(6);
 
-    ASSERT_EQ("[]", column->debug_item(0));
-    ASSERT_EQ("[1]", column->debug_item(1));
-    ASSERT_EQ("[2,3]", column->debug_item(2));
-    ASSERT_EQ("[4,5,6]", column->debug_item(3));
+        ASSERT_EQ("[]", column->debug_item(0));
+        ASSERT_EQ("[1]", column->debug_item(1));
+        ASSERT_EQ("[2,3]", column->debug_item(2));
+        ASSERT_EQ("[4,5,6]", column->debug_item(3));
 
-    // 1 element occupy 4 + 1 = 5 bytes, 1 offset occupy 4 bytes
-    ASSERT_EQ(46, column->Column::element_memory_usage());
-    ASSERT_EQ(4, column->element_memory_usage(0, 1));  // [] 1 offset, 0 element
-    ASSERT_EQ(13, column->element_memory_usage(0, 2)); // [][1] 2 offset, 1 element
-    ASSERT_EQ(27, column->element_memory_usage(0, 3)); // [][1][2, 3] 3 offset, 3 element
-    ASSERT_EQ(46, column->element_memory_usage(0, 4)); // [][1][2, 3][4, 5, 6] 4 offset, 6 element
-    ASSERT_EQ(9, column->element_memory_usage(1, 1));  // [1] 1 offset, 1 element
-    ASSERT_EQ(23, column->element_memory_usage(1, 2)); // [1][2, 3] 2 offset, 3 element
-    ASSERT_EQ(42, column->element_memory_usage(1, 3)); // [1][2, 3][4, 5, 6] 3 offset, 6 element
-    ASSERT_EQ(14, column->element_memory_usage(2, 1)); // [2, 3] 1 offset, 2 element
-    ASSERT_EQ(33, column->element_memory_usage(2, 2)); // [2, 3][4, 5, 6] 2 offset, 5 element
-    ASSERT_EQ(19, column->element_memory_usage(3, 1)); // [4, 5, 6] 1 offset, 3 element
+        // fixed-length elements have no reference memory
+        ASSERT_EQ(0, column->Column::reference_memory_usage());
+    }
+
+    {
+        auto offsets = UInt32Column::create();
+        auto elements = NullableColumn::create(JsonColumn::create(), NullColumn::create());
+        auto column = ArrayColumn::create(elements, offsets);
+
+        auto append_json_value = [&](const std::string& json_str) {
+            auto json_value = JsonValue::parse(json_str).value();
+            elements->append_datum(&json_value);
+        };
+        // insert [],["1"],["2","3"],["4","5","6"]
+        offsets->append(0);
+
+        append_json_value("1");
+        offsets->append(1);
+
+        append_json_value("2");
+        append_json_value("3");
+        offsets->append(3);
+
+        append_json_value("4");
+        append_json_value("5");
+        append_json_value("6");
+        offsets->append(6);
+
+        std::cout << "json size: " << column->Column::reference_memory_usage() << std::endl;
+        ASSERT_EQ(12, column->Column::reference_memory_usage());
+
+        ASSERT_EQ(0, column->reference_memory_usage(0, 1));  // [] 1 offset, 0 element
+        ASSERT_EQ(2, column->reference_memory_usage(0, 2));  // [][1] 2 offset, 1 element
+        ASSERT_EQ(6, column->reference_memory_usage(0, 3));  // [][1][2, 3] 3 offset, 3 element
+        ASSERT_EQ(12, column->reference_memory_usage(0, 4)); // [][1][2, 3][4, 5, 6] 4 offset, 6 element
+        ASSERT_EQ(2, column->reference_memory_usage(1, 1));  // [1] 1 offset, 1 element
+        ASSERT_EQ(6, column->reference_memory_usage(1, 2));  // [1][2, 3] 2 offset, 3 element
+        ASSERT_EQ(12, column->reference_memory_usage(1, 3)); // [1][2, 3][4, 5, 6] 3 offset, 6 element
+        ASSERT_EQ(4, column->reference_memory_usage(2, 1));  // [2, 3] 1 offset, 2 element
+        ASSERT_EQ(10, column->reference_memory_usage(2, 2)); // [2, 3][4, 5, 6] 2 offset, 5 element
+        ASSERT_EQ(6, column->reference_memory_usage(3, 1));  // [4, 5, 6] 1 offset, 3 element
+    }
 }
 
 } // namespace starrocks

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1212,16 +1212,16 @@ PARALLEL_TEST(ArrayColumnTest, test_reference_memory_usage) {
         std::cout << "json size: " << column->Column::reference_memory_usage() << std::endl;
         ASSERT_EQ(12, column->Column::reference_memory_usage());
 
-        ASSERT_EQ(0, column->reference_memory_usage(0, 1));  // [] 1 offset, 0 element
-        ASSERT_EQ(2, column->reference_memory_usage(0, 2));  // [][1] 2 offset, 1 element
-        ASSERT_EQ(6, column->reference_memory_usage(0, 3));  // [][1][2, 3] 3 offset, 3 element
-        ASSERT_EQ(12, column->reference_memory_usage(0, 4)); // [][1][2, 3][4, 5, 6] 4 offset, 6 element
-        ASSERT_EQ(2, column->reference_memory_usage(1, 1));  // [1] 1 offset, 1 element
-        ASSERT_EQ(6, column->reference_memory_usage(1, 2));  // [1][2, 3] 2 offset, 3 element
-        ASSERT_EQ(12, column->reference_memory_usage(1, 3)); // [1][2, 3][4, 5, 6] 3 offset, 6 element
-        ASSERT_EQ(4, column->reference_memory_usage(2, 1));  // [2, 3] 1 offset, 2 element
-        ASSERT_EQ(10, column->reference_memory_usage(2, 2)); // [2, 3][4, 5, 6] 2 offset, 5 element
-        ASSERT_EQ(6, column->reference_memory_usage(3, 1));  // [4, 5, 6] 1 offset, 3 element
+        ASSERT_EQ(0, column->reference_memory_usage(0, 1));
+        ASSERT_EQ(2, column->reference_memory_usage(0, 2));
+        ASSERT_EQ(6, column->reference_memory_usage(0, 3));
+        ASSERT_EQ(12, column->reference_memory_usage(0, 4));
+        ASSERT_EQ(2, column->reference_memory_usage(1, 1));
+        ASSERT_EQ(6, column->reference_memory_usage(1, 2));
+        ASSERT_EQ(12, column->reference_memory_usage(1, 3));
+        ASSERT_EQ(4, column->reference_memory_usage(2, 1));
+        ASSERT_EQ(10, column->reference_memory_usage(2, 2));
+        ASSERT_EQ(6, column->reference_memory_usage(3, 1));
     }
 }
 

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -655,25 +655,14 @@ PARALLEL_TEST(BinaryColumnTest, test_replicate) {
     ASSERT_EQ("def", slices[4]);
 }
 
-PARALLEL_TEST(BinaryColumnTest, test_element_memory_usage) {
+PARALLEL_TEST(BinaryColumnTest, test_reference_memory_usage) {
     auto column = BinaryColumn::create();
     column->append("");
     column->append("1");
     column->append("23");
     column->append("456");
 
-    ASSERT_EQ(22, column->Column::element_memory_usage());
-
-    std::vector<size_t> element_mem_usages = {4, 5, 6, 7};
-    size_t element_num = element_mem_usages.size();
-    for (size_t start = 0; start < element_num; start++) {
-        size_t expected_usage = 0;
-        ASSERT_EQ(0, column->element_memory_usage(start, 0));
-        for (size_t size = 1; start + size <= element_num; size++) {
-            expected_usage += element_mem_usages[start + size - 1];
-            ASSERT_EQ(expected_usage, column->element_memory_usage(start, size));
-        }
-    }
+    ASSERT_EQ(0, column->Column::reference_memory_usage());
 }
 
 } // namespace starrocks

--- a/be/test/column/const_column_test.cpp
+++ b/be/test/column/const_column_test.cpp
@@ -18,6 +18,7 @@
 
 #include "column/binary_column.h"
 #include "column/fixed_length_column.h"
+#include "column/json_column.h"
 #include "testutil/parallel_test.h"
 
 namespace starrocks {
@@ -354,21 +355,26 @@ PARALLEL_TEST(ConstColumnTest, test_replicate) {
     ASSERT_EQ(1, c2->get(6).get_int32());
 }
 
-PARALLEL_TEST(ConstColumnTest, test_element_memory_usage) {
-    auto create_const_column = [](int32_t value, size_t size) {
-        auto c = Int32Column::create();
-        c->append_numbers(&value, sizeof(value));
-        return ConstColumn::create(c, size);
-    };
+PARALLEL_TEST(ConstColumnTest, test_reference_memory_usage) {
+    {
+        auto create_int_const_column = [](int32_t value, size_t size) {
+            auto c = Int32Column::create();
+            c->append_numbers(&value, sizeof(value));
+            return ConstColumn::create(c, size);
+        };
 
-    auto column = create_const_column(1, 10);
-    ASSERT_EQ(4, column->element_memory_usage());
-
-    for (size_t start = 0; start < column->size(); start++) {
-        ASSERT_EQ(0, column->element_memory_usage(start, 0));
-        for (size_t size = 1; start + size <= column->size(); size++) {
-            ASSERT_EQ(4, column->element_memory_usage(start, size));
-        }
+        auto column = create_int_const_column(1, 10);
+        ASSERT_EQ(0, column->reference_memory_usage());
+    }
+    {
+        auto create_json_const_column = [](const std::string& json_str, size_t size) {
+            auto c = JsonColumn::create();
+            auto json_value = JsonValue::parse(json_str).value();
+            c->append_datum(&json_value);
+            return ConstColumn::create(c, size);
+        };
+        auto column = create_json_const_column("1", 10);
+        ASSERT_EQ(2, column->reference_memory_usage());
     }
 }
 

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -1192,7 +1192,7 @@ PARALLEL_TEST(MapColumnTest, test_euqals) {
     ASSERT_FALSE(lhs->equals(3, *rhs, 3));
 }
 
-PARALLEL_TEST(MapColumnTest, test_element_memory_usage) {
+PARALLEL_TEST(MapColumnTest, test_reference_memory_usage) {
     auto column = MapColumn::create(NullableColumn::create(Int32Column::create(), NullColumn::create()),
                                     NullableColumn::create(Int32Column::create(), NullColumn::create()),
                                     UInt32Column::create());
@@ -1202,17 +1202,6 @@ PARALLEL_TEST(MapColumnTest, test_element_memory_usage) {
     column->append_datum(DatumMap{{1, 2}});
     column->append_datum(DatumMap{{3, 4}, {5, 6}});
 
-    ASSERT_EQ(42, column->Column::element_memory_usage());
-
-    std::vector<size_t> element_mem_usages = {4, 14, 24};
-    size_t element_num = element_mem_usages.size();
-    for (size_t start = 0; start < element_num; start++) {
-        size_t expected_usage = 0;
-        ASSERT_EQ(0, column->element_memory_usage(start, 0));
-        for (size_t size = 1; start + size <= element_num; size++) {
-            expected_usage += element_mem_usages[start + size - 1];
-            ASSERT_EQ(expected_usage, column->element_memory_usage(start, size));
-        }
-    }
+    ASSERT_EQ(0, column->Column::reference_memory_usage());
 }
 } // namespace starrocks

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -550,7 +550,7 @@ TEST(StructColumnTest, test_unnamed) {
     ASSERT_EQ("{1,'smith'}, {2,'cruise'}", column->debug_string());
 }
 
-TEST(StructColumnTest, test_element_memory_usage) {
+TEST(StructColumnTest, test_reference_memory_usage) {
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     Columns fields{id, name};
@@ -560,18 +560,18 @@ TEST(StructColumnTest, test_element_memory_usage) {
     column->append_datum(DatumStruct{uint64_t(1), Slice("4")});
     column->append_datum(DatumStruct{uint64_t(1), Slice("6")});
 
-    ASSERT_EQ(45, column->Column::element_memory_usage());
+    ASSERT_EQ(0, column->Column::reference_memory_usage());
 
-    std::vector<size_t> element_mem_usages = {15, 15, 15};
-    size_t element_num = element_mem_usages.size();
-    for (size_t start = 0; start < element_num; start++) {
-        size_t expected_usage = 0;
-        ASSERT_EQ(0, column->element_memory_usage(start, 0));
-        for (size_t size = 1; start + size <= element_num; size++) {
-            expected_usage += element_mem_usages[start + size - 1];
-            ASSERT_EQ(expected_usage, column->element_memory_usage(start, size));
-        }
-    }
+    // std::vector<size_t> element_mem_usages = {15, 15, 15};
+    // size_t element_num = element_mem_usages.size();
+    // for (size_t start = 0; start < element_num; start++) {
+    //     size_t expected_usage = 0;
+    //     ASSERT_EQ(0, column->reference_memory_usage(start, 0));
+    //     for (size_t size = 1; start + size <= element_num; size++) {
+    //         expected_usage += element_mem_usages[start + size - 1];
+    //         ASSERT_EQ(expected_usage, column->reference_memory_usage(start, size));
+    //     }
+    // }
 }
 
 } // namespace starrocks

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -561,17 +561,6 @@ TEST(StructColumnTest, test_reference_memory_usage) {
     column->append_datum(DatumStruct{uint64_t(1), Slice("6")});
 
     ASSERT_EQ(0, column->Column::reference_memory_usage());
-
-    // std::vector<size_t> element_mem_usages = {15, 15, 15};
-    // size_t element_num = element_mem_usages.size();
-    // for (size_t start = 0; start < element_num; start++) {
-    //     size_t expected_usage = 0;
-    //     ASSERT_EQ(0, column->reference_memory_usage(start, 0));
-    //     for (size_t size = 1; start + size <= element_num; size++) {
-    //         expected_usage += element_mem_usages[start + size - 1];
-    //         ASSERT_EQ(expected_usage, column->reference_memory_usage(start, size));
-    //     }
-    // }
 }
 
 } // namespace starrocks

--- a/be/test/exec/query_cache/query_cache_test.cpp
+++ b/be/test/exec/query_cache/query_cache_test.cpp
@@ -110,18 +110,18 @@ TEST_F(QueryCacheTest, testCacheManager) {
         cache_mgr->populate(strings::Substitute("key_$0", i), create_cache_value(96));
     }
 
-    ASSERT_EQ(cache_mgr->memory_usage(), 1360);
+    ASSERT_EQ(cache_mgr->memory_usage(), 960);
     for (auto i = 0; i < 10; ++i) {
         auto status = cache_mgr->probe(strings::Substitute("key_$0", i));
         ASSERT_TRUE(status.ok());
     }
 
-    ASSERT_EQ(cache_mgr->memory_usage(), 1360);
+    ASSERT_EQ(cache_mgr->memory_usage(), 960);
     for (auto i = 10; i < 20; ++i) {
         auto status = cache_mgr->probe(strings::Substitute("key_$0", i));
         ASSERT_FALSE(status.ok());
     }
-    ASSERT_EQ(cache_mgr->memory_usage(), 1360);
+    ASSERT_EQ(cache_mgr->memory_usage(), 960);
 
     for (auto i = 20; i < 30; ++i) {
         auto status = cache_mgr->populate(strings::Substitute("key_$0", i), create_cache_value(100));


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. the name of `Column::element_memory_usage` is confusing, rename it to `Column::reference_memory_usage` and fix the error result introduced by #17184
2. after fix the first point, local_exchange should use bytes_usage instead of  element_memory_usage to calculate memory usage.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
