### PR TITLE
[Enhancement] Optimize insert into select error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1394,6 +1394,9 @@ public class StmtExecutor {
 
             if (!coord.getExecStatus().ok()) {
                 String errMsg = coord.getExecStatus().getErrorMsg();
+                if (errMsg.length() == 0) {
+                    errMsg = coord.getExecStatus().getErrorCodeString();
+                }
                 LOG.warn("insert failed: {}", errMsg);
                 ErrorReport.reportDdlException(errMsg, ErrorCode.ERR_FAILED_WHEN_INSERT);
             }
@@ -1531,7 +1534,7 @@ public class StmtExecutor {
             } catch (Exception abortTxnException) {
                 LOG.warn("errors when cancel insert load job {}", jobId);
             }
-            return;
+            throw new UserException(t.getMessage());
         } finally {
             if (insertError) {
                 try {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18092, https://github.com/StarRocks/StarRocksBenchmark/issues/312

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, for cancelled and timeout insert into sql, the return msg in mysql client is 'Unknown error', which is confusing to users.
In this pr, we enhance the error msg to user in the following two cases:
1. If user cancel the insert into select, the return msg is 'Canncelled'
2. If the insert into select is timeout, the return msg is ' [E1008]Reached timeout=500ms @172.26.92.139:38061'


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
