### PR TITLE
[BugFix][Cherry-Pick][2.5.2.2] Fix parquet delimit row error for repeated column

### DIFF
--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -259,14 +259,15 @@ void RepeatedStoredColumnReader::_delimit_rows(size_t* num_rows, size_t* num_lev
     for (; levels_pos < _levels_decoded && rows_read < *num_rows; ++levels_pos) {
         rows_read += _rep_levels[levels_pos] == 0;
     }
-    if (levels_pos < _levels_decoded) {
-        // means rows_read == *num_rows, but notice, ++levels_pos in for-loop will take one step forward, so we need -1
+
+    if (rows_read == *num_rows) {
+        // Notice, ++levels_pos in for-loop will take one step forward, so we need -1
         levels_pos--;
         DCHECK_EQ(0, _rep_levels[levels_pos]);
     } // else {
-      //    means  rows_read < *num_rows, levels_pos >= _levels_decoded,
-      //    so we need to decode more levels to obtain a complete line or
-      //    we have read all the records in this column chunk.
+      //  means  rows_read < *num_rows, levels_pos >= _levels_decoded,
+      //  so we need to decode more levels to obtain a complete line or
+      //  we have read all the records in this column chunk.
     // }
 
     VLOG_FILE << "rows_reader=" << rows_read << ", level_parsed=" << levels_pos - _levels_parsed;

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1831,4 +1831,263 @@ TEST_F(FileReaderTest, TestReadMapNull) {
 
 }
 
+// Enable in next pr
+// TEST_F(FileReaderTest, TestStructArrayNull) {
+//     // message table {
+//     //  optional int32 id = 1;
+//     //  optional group col = 2 {
+//     //    optional int32 a = 3;
+//     //    optional group b (LIST) = 4 {
+//     //      repeated group list {
+//     //        optional group element = 5 {
+//     //          optional int32 c = 6;
+//     //          optional binary d (STRING) = 7;
+//     //        }
+//     //      }
+//     //    }
+//     //  }
+//     // }
+//     std::string filepath = "./be/test/exec/test_data/parquet_data/struct_array_null.parquet";
+
+//     // With config's vector chunk size
+//     {
+//         auto file = _create_file(filepath);
+//         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+//                                                         std::filesystem::file_size(filepath));
+
+//         // --------------init context---------------
+//         auto ctx = _create_scan_context();
+
+//         TypeDescriptor type_int = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+
+//         TypeDescriptor type_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+//         type_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//         type_struct.field_names.emplace_back("a");
+
+//         TypeDescriptor type_array = TypeDescriptor::from_logical_type(LogicalType::TYPE_ARRAY);
+
+//         TypeDescriptor type_array_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+//         type_array_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//         type_array_struct.field_names.emplace_back("c");
+//         type_array_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+//         type_array_struct.field_names.emplace_back("d");
+
+//         type_array.children.emplace_back(type_array_struct);
+
+//         type_struct.children.emplace_back(type_array);
+//         type_struct.field_names.emplace_back("b");
+
+
+//         SlotDesc slot_descs[] = {
+//                 {"id", type_int},
+//                 {"col", type_struct},
+//                 {""},
+//         };
+
+//         ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+//         make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
+//         ctx->scan_ranges.emplace_back(_create_scan_range(_file_col_not_null_path));
+//         // --------------finish init context---------------
+
+//         Status status = file_reader->init(ctx);
+//         ASSERT_TRUE(status.ok());
+
+//         EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
+
+//         auto chunk = std::make_shared<Chunk>();
+//         chunk->append_column(ColumnHelper::create_column(type_int, true), chunk->num_columns());
+//         chunk->append_column(ColumnHelper::create_column(type_struct, true), chunk->num_columns());
+
+//         status = file_reader->get_next(&chunk);
+//         ASSERT_TRUE(status.ok());
+
+//         EXPECT_EQ("[1, NULL]", chunk->debug_row(0));
+//         EXPECT_EQ("[2, {a:2,b:NULL}]", chunk->debug_row(1));
+//         EXPECT_EQ("[3, {a:NULL,b:[NULL]}]", chunk->debug_row(2));
+//         EXPECT_EQ("[4, {a:4,b:[NULL]}]", chunk->debug_row(3));
+//         EXPECT_EQ("[5, {a:5,b:[NULL,{c:5,d:'hello'},{c:5,d:'world'},NULL,{c:5,d:NULL}]}]", chunk->debug_row(4));
+//         EXPECT_EQ("[6, {a:NULL,b:[{c:6,d:'hello'},NULL,{c:NULL,d:'world'}]}]", chunk->debug_row(5));
+//         EXPECT_EQ("[7, {a:7,b:[NULL,NULL,NULL,NULL]}]", chunk->debug_row(6));
+//         EXPECT_EQ("[8, {a:8,b:[{c:8,d:'hello'},{c:NULL,d:'danny'},{c:8,d:'world'}]}]", chunk->debug_row(7));
+
+//         size_t total_row_nums = 0;
+//         chunk->check_or_die();
+//         total_row_nums += chunk->num_rows();
+
+//         {
+//             while (!status.is_end_of_file()) {
+//                 chunk->reset();
+//                 status = file_reader->get_next(&chunk);
+//                 chunk->check_or_die();
+//                 total_row_nums += chunk->num_rows();
+//             }
+//         }
+//         EXPECT_EQ(524288, total_row_nums);
+//     }
+
+
+//     // With 1024 chunk size
+//     {
+//         auto file = _create_file(filepath);
+//         auto file_reader = std::make_shared<FileReader>(1024, file.get(),
+//                                                         std::filesystem::file_size(filepath));
+
+//         // --------------init context---------------
+//         auto ctx = _create_scan_context();
+
+//         TypeDescriptor type_int = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+
+//         TypeDescriptor type_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+//         type_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//         type_struct.field_names.emplace_back("a");
+
+//         TypeDescriptor type_array = TypeDescriptor::from_logical_type(LogicalType::TYPE_ARRAY);
+
+//         TypeDescriptor type_array_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+//         type_array_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//         type_array_struct.field_names.emplace_back("c");
+//         type_array_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+//         type_array_struct.field_names.emplace_back("d");
+
+//         type_array.children.emplace_back(type_array_struct);
+
+//         type_struct.children.emplace_back(type_array);
+//         type_struct.field_names.emplace_back("b");
+
+
+//         SlotDesc slot_descs[] = {
+//                 {"id", type_int},
+//                 {"col", type_struct},
+//                 {""},
+//         };
+
+//         ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+//         make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
+//         ctx->scan_ranges.emplace_back(_create_scan_range(_file_col_not_null_path));
+//         // --------------finish init context---------------
+
+//         Status status = file_reader->init(ctx);
+//         ASSERT_TRUE(status.ok());
+
+//         EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
+
+//         auto chunk = std::make_shared<Chunk>();
+//         chunk->append_column(ColumnHelper::create_column(type_int, true), chunk->num_columns());
+//         chunk->append_column(ColumnHelper::create_column(type_struct, true), chunk->num_columns());
+
+//         status = file_reader->get_next(&chunk);
+//         ASSERT_TRUE(status.ok());
+
+//         EXPECT_EQ("[1, NULL]", chunk->debug_row(0));
+//         EXPECT_EQ("[2, {a:2,b:NULL}]", chunk->debug_row(1));
+//         EXPECT_EQ("[3, {a:NULL,b:[NULL]}]", chunk->debug_row(2));
+//         EXPECT_EQ("[4, {a:4,b:[NULL]}]", chunk->debug_row(3));
+//         EXPECT_EQ("[5, {a:5,b:[NULL,{c:5,d:'hello'},{c:5,d:'world'},NULL,{c:5,d:NULL}]}]", chunk->debug_row(4));
+//         EXPECT_EQ("[6, {a:NULL,b:[{c:6,d:'hello'},NULL,{c:NULL,d:'world'}]}]", chunk->debug_row(5));
+//         EXPECT_EQ("[7, {a:7,b:[NULL,NULL,NULL,NULL]}]", chunk->debug_row(6));
+//         EXPECT_EQ("[8, {a:8,b:[{c:8,d:'hello'},{c:NULL,d:'danny'},{c:8,d:'world'}]}]", chunk->debug_row(7));
+
+//         size_t total_row_nums = 0;
+//         chunk->check_or_die();
+//         total_row_nums += chunk->num_rows();
+
+//         {
+//             while (!status.is_end_of_file()) {
+//                 chunk->reset();
+//                 status = file_reader->get_next(&chunk);
+//                 chunk->check_or_die();
+//                 total_row_nums += chunk->num_rows();
+//             }
+//         }
+//         EXPECT_EQ(524288, total_row_nums);
+//     }
+// }
+
+// TEST_F(FileReaderTest, TestComplexTypeNotNull) {
+//     // message table {
+//     //  optional int32 id = 1;
+//     //  optional group col = 2 {
+//     //    optional int32 a = 3;
+//     //    optional group b (LIST) = 4 {
+//     //      repeated group list {
+//     //        optional group element = 5 {
+//     //          optional int32 c = 6;
+//     //          optional binary d (STRING) = 7;
+//     //        }
+//     //      }
+//     //    }
+//     //  }
+//     // }
+
+//     std::string filepath = "./be/test/exec/test_data/parquet_data/complex_subfield_not_null.parquet";
+//     auto file = _create_file(filepath);
+//     auto file_reader =
+//             std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(filepath));
+
+//     // --------------init context---------------
+//     auto ctx = _create_scan_context();
+
+//     TypeDescriptor type_int = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+
+//     TypeDescriptor type_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+//     type_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//     type_struct.field_names.emplace_back("a");
+
+//     TypeDescriptor type_array = TypeDescriptor::from_logical_type(LogicalType::TYPE_ARRAY);
+
+//     TypeDescriptor type_array_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+//     type_array_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//     type_array_struct.field_names.emplace_back("c");
+//     type_array_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+//     type_array_struct.field_names.emplace_back("d");
+
+//     type_array.children.emplace_back(type_array_struct);
+
+//     type_struct.children.emplace_back(type_array);
+//     type_struct.field_names.emplace_back("b");
+
+//     SlotDesc slot_descs[] = {
+//             {"id", type_int},
+//             {"col", type_struct},
+//             {""},
+//     };
+
+//     ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+//     make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
+//     ctx->scan_ranges.emplace_back(_create_scan_range(_file_col_not_null_path));
+//     // --------------finish init context---------------
+
+//     Status status = file_reader->init(ctx);
+//     ASSERT_TRUE(status.ok());
+
+//     EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
+
+//     auto chunk = std::make_shared<Chunk>();
+//     chunk->append_column(ColumnHelper::create_column(type_int, true), chunk->num_columns());
+//     chunk->append_column(ColumnHelper::create_column(type_struct, true), chunk->num_columns());
+
+//     status = file_reader->get_next(&chunk);
+//     ASSERT_TRUE(status.ok());
+
+//     EXPECT_EQ("[1, {a:1,b:[{c:1,d:'hello'}]}]", chunk->debug_row(0));
+//     EXPECT_EQ("[2, {a:2,b:[{c:2,d:'hello'},NULL,{c:2,d:NULL}]}]", chunk->debug_row(1));
+//     EXPECT_EQ("[3, {a:3,b:[NULL,NULL]}]", chunk->debug_row(2));
+//     EXPECT_EQ("[4, {a:4,b:[NULL,{c:4,d:NULL}]}]", chunk->debug_row(3));
+
+//     size_t total_row_nums = 0;
+//     chunk->check_or_die();
+//     total_row_nums += chunk->num_rows();
+
+//     {
+//         while (!status.is_end_of_file()) {
+//             chunk->reset();
+//             status = file_reader->get_next(&chunk);
+//             chunk->check_or_die();
+//             total_row_nums += chunk->num_rows();
+//         }
+//     }
+
+//     EXPECT_EQ(262144, total_row_nums);
+// }
+
 } // namespace starrocks::parquet


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
