### PR TITLE
[Enhancement]Support iceberg local disk metadata cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1704,6 +1704,30 @@ public class Config extends ConfigBase {
     public static int iceberg_table_refresh_expire_sec = 86400;
 
     /**
+     * iceberg metadata cache dir
+     */
+    @ConfField
+    public static String iceberg_metadata_cache_disk_path = StarRocksFE.STARROCKS_HOME_DIR + "/caches/iceberg";
+
+    /**
+     * iceberg metadata cache total size, default 2GB
+     */
+    @ConfField
+    public static long iceberg_metadata_cache_capacity = 2147483648L;
+
+    /**
+     * iceberg metadata cache max entry size, default 8MB
+     */
+    @ConfField
+    public static long iceberg_metadata_cache_max_entry_size = 8388608L;
+
+    /**
+     * iceberg metadata cache expire after access
+     */
+    @ConfField
+    public static long iceberg_metadata_cache_expiration_seconds = 7L * 24L * 60L * 60L;
+
+    /**
      * fe will call es api to get es index shard info every es_state_sync_interval_secs
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -51,23 +51,33 @@ package com.starrocks.connector.iceberg.io;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Weigher;
+import com.starrocks.common.Config;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
+import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
@@ -75,14 +85,12 @@ import java.util.function.Function;
  */
 public class IcebergCachingFileIO implements FileIO {
     private static final Logger LOG = LogManager.getLogger(IcebergCachingFileIO.class);
-    private static final int BUFFER_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
-    private static final long DEFAULT_FILEIO_CACHE_MAX_CONTENT_LENGTH = 8L * 1024L * 1024L;
-    private static final long DEFAULT_FILEIO_CACHE_MAX_TOTAL_BYTES = 128L * 1024L * 1024L;
-
+    protected static final int BUFFER_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
     public static final String FILEIO_CACHE_MAX_TOTAL_BYTES = "fileIO.cache.max-total-bytes";
+    public static final String METADATA_CACHE_DISK_PATH = Config.iceberg_metadata_cache_disk_path;
 
     private ContentCache fileContentCache;
-    private FileIO wrappedIO;
+    private final FileIO wrappedIO;
 
     public IcebergCachingFileIO(FileIO io) {
         this.wrappedIO = io;
@@ -91,8 +99,35 @@ public class IcebergCachingFileIO implements FileIO {
     @Override
     public void initialize(Map<String, String> properties) {
         long maxTotalBytes = PropertyUtil.propertyAsLong(properties, FILEIO_CACHE_MAX_TOTAL_BYTES,
-                                                        DEFAULT_FILEIO_CACHE_MAX_TOTAL_BYTES);
-        this.fileContentCache = new ContentCache(DEFAULT_FILEIO_CACHE_MAX_CONTENT_LENGTH, maxTotalBytes);
+                Config.iceberg_metadata_cache_capacity);
+        this.fileContentCache = new ContentCache(Config.iceberg_metadata_cache_max_entry_size, maxTotalBytes);
+        loadMetadataDiskCache();
+    }
+
+    public void loadMetadataDiskCache() {
+        //loadMetadataDiskCache asynchronous
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        FileSystem fs = Util.getFs(IOUtil.getLocalDiskDirPath(METADATA_CACHE_DISK_PATH), new Configuration());
+        executor.submit(() -> {
+            try {
+                RemoteIterator<LocatedFileStatus> it = fs.listFiles(IOUtil.getLocalDiskDirPath(METADATA_CACHE_DISK_PATH), true);
+                while (it.hasNext()) {
+                    LocatedFileStatus locatedFileStatus = it.next();
+                    if (locatedFileStatus.isDirectory()) {
+                        continue;
+                    }
+                    Path localPath = locatedFileStatus.getPath();
+                    OutputFile localOutputFile = IOUtil.getOutputFile(localPath);
+                    String s3aKey = IOUtil.localFileToS3a(localPath, METADATA_CACHE_DISK_PATH).toString();
+                    LOG.info("load iceberg disk metadata to cache: {} from {}", s3aKey, localPath.toString());
+                    fileContentCache.put(s3aKey,
+                            new CacheEntry(locatedFileStatus.getLen(), localOutputFile.toInputFile()));
+                }
+            } catch (Exception e) {
+                // Ignore
+            }
+        });
+        executor.shutdown();
     }
 
     @Override
@@ -112,33 +147,54 @@ public class IcebergCachingFileIO implements FileIO {
         fileContentCache.invalidate(path);
     }
 
-    private static class CacheEntry {
+    protected static class CacheEntry {
         private final long length;
-        private final List<ByteBuffer> buffers;
+        private final InputFile inputFile;
 
-        private CacheEntry(long length, List<ByteBuffer> buffers) {
+        protected CacheEntry(long length, InputFile inputFile) {
             this.length = length;
-            this.buffers = buffers;
+            this.inputFile = inputFile;
+        }
+
+        public SeekableInputStream toSeekableInputStream() {
+            return this.inputFile.newStream();
+        }
+
+        public boolean isExistOnDisk() {
+            return this.inputFile != null && this.inputFile.exists();
         }
     }
 
     public static class ContentCache {
-        private final long maxTotalBytes;
         private final long maxContentLength;
         private final Cache<String, CacheEntry> cache;
 
         private ContentCache(long maxContentLength, long maxTotalBytes) {
-            this.maxTotalBytes = maxTotalBytes;
             this.maxContentLength = maxContentLength;
 
             Caffeine<Object, Object> builder = Caffeine.newBuilder();
             this.cache = builder.maximumWeight(maxTotalBytes)
-                        .weigher((Weigher<String, CacheEntry>) (key, value) -> (int) Math.min(value.length, Integer.MAX_VALUE))
-                        .recordStats()
-                        .removalListener(((key, value, cause) -> {
-                            LOG.debug(key + " to be eliminated, reason: " + cause);
-                        }))
-                        .build();
+                    .expireAfterAccess(Config.iceberg_metadata_cache_expiration_seconds, TimeUnit.SECONDS)
+                    .weigher((Weigher<String, CacheEntry>) (key, value) -> (int) Math.min(value.length, Integer.MAX_VALUE))
+                    .recordStats()
+                    .removalListener(((key, value, cause) -> {
+                        // COLLECTED: The entry was removed automatically because its key or value was garbage-collected.
+                        // EXPIRED: The entry's expiration timestamp has passed.
+                        // EXPLICIT: The entry was manually removed by the user.
+                        // REPLACED: The entry itself was not actually removed, but its value was replaced by the user.
+                        // SIZE: The entry was evicted due to size constraints.
+                        LOG.info(key + " to be eliminated, reason: " + cause);
+                        // delete local file
+                        HadoopOutputFile hadoopOutputFile = (HadoopOutputFile) IOUtil.getOutputFile(
+                                METADATA_CACHE_DISK_PATH,
+                                key);
+                        try {
+                            hadoopOutputFile.getFileSystem().delete(hadoopOutputFile.getPath());
+                        } catch (Exception e) {
+                            LOG.warn("evict iceberg local disk file: {} failed: {}", key, e.getMessage());
+                        }
+                    }))
+                    .build();
         }
 
         public long maxContentLength() {
@@ -147,6 +203,10 @@ public class IcebergCachingFileIO implements FileIO {
 
         public CacheEntry get(String key, Function<String, CacheEntry> mappingFunction) {
             return cache.get(key, mappingFunction);
+        }
+
+        public void put(String key, CacheEntry cacheEntry) {
+            cache.put(key, cacheEntry);
         }
 
         public CacheEntry getIfPresent(String location) {
@@ -180,7 +240,8 @@ public class IcebergCachingFileIO implements FileIO {
                 if (getLength() <= contentCache.maxContentLength()) {
                     return cachedStream();
                 }
-
+                LOG.info("iceberg matadata file {} size {} large than max content length, skip cache",
+                        location(), getLength());
                 // fallback to non-caching input stream.
                 return wrappedInputFile.newStream();
             } catch (FileNotFoundException e) {
@@ -202,11 +263,18 @@ public class IcebergCachingFileIO implements FileIO {
         }
 
         private CacheEntry newCacheEntry() {
+            LOG.debug("iceberg metadata cache hit rate: {}", contentCache.cache.stats().hitRate());
+            long fileLength = getLength();
+            long totalBytesToRead = fileLength;
+            OutputFile tmpOutputFile = IOUtil.getTmpOutputFile(METADATA_CACHE_DISK_PATH, location());
+            HadoopOutputFile hadoopOutputFile = (HadoopOutputFile) tmpOutputFile;
             try {
-                long fileLength = getLength();
-                long totalBytesToRead = fileLength;
+                OutputFile localOutputFile = IOUtil.getOutputFile(METADATA_CACHE_DISK_PATH, location());
+                if (localOutputFile.toInputFile().exists()) {
+                    return new CacheEntry(fileLength, localOutputFile.toInputFile());
+                }
                 SeekableInputStream stream = wrappedInputFile.newStream();
-                List<ByteBuffer> buffers = Lists.newArrayList();
+                PositionOutputStream positionOutputStream =  tmpOutputFile.createOrOverwrite();
 
                 while (totalBytesToRead > 0) {
                     // read the stream in 4MB chunk
@@ -218,16 +286,26 @@ public class IcebergCachingFileIO implements FileIO {
                     if (bytesRead < bytesToRead) {
                         // Read less than it should be, possibly hitting EOF.
                         // Set smaller ByteBuffer limit and break out of the loop.
-                        buffers.add(ByteBuffer.wrap(buf, 0, bytesRead));
+                        positionOutputStream.write(buf, 0, bytesRead);
                         break;
                     } else {
-                        buffers.add(ByteBuffer.wrap(buf));
+                        positionOutputStream.write(buf);
                     }
                 }
-
                 stream.close();
-                return new CacheEntry(fileLength - totalBytesToRead, buffers);
+                positionOutputStream.close();
+                hadoopOutputFile.getFileSystem().rename(
+                        hadoopOutputFile.getPath(),
+                        IOUtil.s3aToLocalFilePath(METADATA_CACHE_DISK_PATH, location()));
+                LOG.debug("load iceberg metadata {}:{} to cache", location(), FileUtils.byteCountToDisplaySize(fileLength));
+                return new CacheEntry(fileLength - totalBytesToRead, localOutputFile.toInputFile());
             } catch (IOException ex) {
+                // remove local tmp file
+                try {
+                    hadoopOutputFile.getFileSystem().deleteOnExit(hadoopOutputFile.getPath());
+                } catch (Exception e) {
+                    // Ignore
+                }
                 throw new RuntimeIOException(ex);
             }
         }
@@ -236,7 +314,14 @@ public class IcebergCachingFileIO implements FileIO {
             try {
                 CacheEntry entry = contentCache.get(location(), k -> newCacheEntry());
                 Preconditions.checkNotNull(entry, "CacheEntry should not be null when there is no RuntimeException occurs");
-                return ByteBufferInputStream.wrap(entry.buffers);
+                // someone have deleted local files, but still in cache
+                if (!entry.isExistOnDisk()) {
+                    LOG.info("local file {} has been deleted, but still in cache, reload it", location());
+                    contentCache.invalidate(location());
+                    entry = contentCache.get(location(), k -> newCacheEntry());
+                }
+                Preconditions.checkNotNull(entry, "CacheEntry should not be null when there is no RuntimeException occurs");
+                return entry.toSeekableInputStream();
             } catch (RuntimeIOException ex) {
                 throw ex.getCause();
             } catch (RuntimeException ex) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18111

## Problem Summary(Required) ：
iceberg metadata cached in memory cause high miss rate and  sql plan will take a lot of time, so I  change cached medium, save metadata(metadata.json,   manifest list,  manifest file) in local disk

Config usage: 
iceberg_metadata_cache_disk_path:   which dir to save iceberg metadata
iceberg_metadata_cache_capacity:   total cache size, default 2GB
iceberg_metadata_cache_max_entry_size:    max  single file size to cache
iceberg_metadata_cache_expire_seconds:   expiration policy, default 7 day

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
