### PR TITLE
[BugFix][Hdfs] Fix hdfs path not found for the getePath function does not return the exact value of path without decoding the sequence of escaped octets if any

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
@@ -61,12 +61,11 @@ public class HiveRemoteFileIO implements RemoteFileIO {
             } else {
                 fileSystem = this.fileSystem;
             }
-
             RemoteIterator<LocatedFileStatus> blockIterator;
             if (!pathKey.isRecursive()) {
-                blockIterator = fileSystem.listLocatedStatus(new Path(uri.getPath()));
+                blockIterator = fileSystem.listLocatedStatus(new Path(uri.getRawPath()));
             } else {
-                blockIterator = fileSystem.listFiles(new Path(uri.getPath()), true);
+                blockIterator = fileSystem.listFiles(new Path(uri.getRawPath()), true);
             }
             while (blockIterator.hasNext()) {
                 LocatedFileStatus locatedFileStatus = blockIterator.next();
@@ -74,7 +73,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
                     continue;
                 }
                 String locateName = locatedFileStatus.getPath().toUri().getPath();
-                String fileName = PartitionUtil.getSuffixName(uri.getPath(), locateName);
+                String fileName = PartitionUtil.getSuffixName(uri.getRawPath(), locateName);
 
                 BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
                 List<RemoteFileBlockDesc> fileBlockDescs = getRemoteFileBlockDesc(blockLocations);


### PR DESCRIPTION


## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18115 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
