### PR TITLE
[Refactor][cherry-pick][branch-2.5] Add FileName in the error message (#18038)

### DIFF
--- a/be/src/exec/vectorized/parquet_reader.cpp
+++ b/be/src/exec/vectorized/parquet_reader.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "common/logging.h"
+#include "fmt/format.h"
 #include "runtime/descriptors.h"
 
 namespace starrocks::vectorized {
@@ -32,6 +33,7 @@ ParquetReaderWrap::ParquetReaderWrap(std::shared_ptr<arrow::io::RandomAccessFile
     _properties = parquet::ReaderProperties();
     _properties.enable_buffered_stream();
     _properties.set_buffer_size(8 * 1024 * 1024);
+    _filename = (reinterpret_cast<ParquetChunkFile*>(_parquet.get()))->filename();
 }
 
 Status ParquetReaderWrap::next_selected_row_group() {
@@ -62,8 +64,9 @@ Status ParquetReaderWrap::init_parquet_reader(const std::vector<SlotDescriptor*>
         auto st = parquet::arrow::FileReader::Make(arrow::default_memory_pool(),
                                                    parquet::ParquetFileReader::Open(_parquet, _properties), &_reader);
         if (!st.ok()) {
-            LOG(WARNING) << "failed to create parquet file reader, errmsg=" << st.ToString();
-            return Status::InternalError("Failed to create file reader");
+            LOG(WARNING) << "Failed to create parquet file reader. error: " << st.ToString()
+                         << ", filename: " << _filename;
+            return Status::InternalError(fmt::format("Failed to create file reader. filename: {}", _filename));
         }
 
         if (!_reader || !_reader->parquet_reader()) {
@@ -102,8 +105,8 @@ Status ParquetReaderWrap::init_parquet_reader(const std::vector<SlotDescriptor*>
             arrow::Status status = _reader->GetRecordBatchReader({_current_group}, _parquet_column_ids, &_rb_batch);
 
             if (!status.ok()) {
-                LOG(WARNING) << "Get RecordBatch Failed. " << status.ToString();
-                return Status::InternalError(status.ToString());
+                LOG(WARNING) << "Get RecordBatch Failed. error: " << status.ToString() << ", filename: " << _filename;
+                return Status::InternalError(fmt::format("{}. filename: {}", status.ToString(), _filename));
             }
             if (!_rb_batch) {
                 LOG(INFO) << "Ignore the parquet file because of an unexpected nullptr "
@@ -112,8 +115,8 @@ Status ParquetReaderWrap::init_parquet_reader(const std::vector<SlotDescriptor*>
             }
             status = _rb_batch->ReadNext(&_batch);
             if (!status.ok()) {
-                LOG(WARNING) << "The first read record. " << status.ToString();
-                return Status::InternalError(status.ToString());
+                LOG(WARNING) << "The first read record. error: " << status.ToString() << ", filename: " << _filename;
+                return Status::InternalError(fmt::format("{}. filename: {}", status.ToString(), _filename));
             }
             if (!_batch) {
                 LOG(INFO) << "Ignore the parquet file because of an expected nullptr RecordBatch";
@@ -131,8 +134,8 @@ Status ParquetReaderWrap::init_parquet_reader(const std::vector<SlotDescriptor*>
     } catch (parquet::ParquetException& e) {
         std::stringstream str_error;
         str_error << "Init parquet reader fail. " << e.what();
-        LOG(WARNING) << str_error.str();
-        return Status::InternalError(str_error.str());
+        LOG(WARNING) << str_error.str() << " filename: " << _filename;
+        return Status::InternalError(fmt::format("{}. filename: {}", str_error.str(), _filename));
     }
 }
 
@@ -190,19 +193,19 @@ Status ParquetReaderWrap::read_record_batch(const std::vector<SlotDescriptor*>& 
         // read batch
         arrow::Status status = _reader->GetRecordBatchReader({_current_group}, _parquet_column_ids, &_rb_batch);
         if (!status.ok()) {
-            return Status::InternalError("Get RecordBatchReader Failed.");
+            return Status::InternalError(fmt::format("Get RecordBatchReader Failed. filename: {}", _filename));
         }
         status = _rb_batch->ReadNext(&_batch);
         if (!status.ok()) {
-            return Status::InternalError("Read Batch Error With Libarrow.");
+            return Status::InternalError(fmt::format("Read Batch Error With Libarrow. filename: {}", _filename));
         }
 
         // arrow::RecordBatchReader::ReadNext returns null at end of stream.
         // Since we count the batches read, EOF implies reader source failure.
         if (_batch == nullptr) {
             LOG(WARNING) << "Unexpected EOF. Row groups less than expected. expected: " << _total_groups
-                         << " got: " << _current_group;
-            return Status::InternalError("Unexpected EOF");
+                         << " got: " << _current_group << ", filename" << _filename;
+            return Status::InternalError(fmt::format("Unexpected EOF. filename: {}", _filename));
         }
 
         _current_line_of_batch = 0;
@@ -212,15 +215,15 @@ Status ParquetReaderWrap::read_record_batch(const std::vector<SlotDescriptor*>& 
                 << " is larger than batch size:" << _batch->num_rows() << ". start to read next batch";
         arrow::Status status = _rb_batch->ReadNext(&_batch);
         if (!status.ok()) {
-            return Status::InternalError("Read Batch Error With Libarrow.");
+            return Status::InternalError(fmt::format("Read Batch Error With Libarrow. filename: {}", _filename));
         }
 
         // arrow::RecordBatchReader::ReadNext returns null at end of stream.
         // Since we count the batches read, EOF implies reader source failure.
         if (_batch == nullptr) {
             LOG(WARNING) << "Unexpected EOF. Row groups less than expected. expected: " << _total_groups
-                         << " got: " << _current_group;
-            return Status::InternalError("Unexpected EOF");
+                         << " got: " << _current_group << ", filename: " << _filename;
+            return Status::InternalError(fmt::format("Unexpected EOF. filename: {}", _filename));
         }
 
         _current_line_of_batch = 0;
@@ -334,6 +337,10 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> ParquetChunkFile::Read(int64_t nby
     } else {
         return arrow::SliceBuffer(read_buf, 0, bytes_read_res.ValueOrDie());
     }
+}
+
+const std::string& ParquetChunkFile::filename() const {
+    return _file->filename();
 }
 
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/parquet_reader.h
+++ b/be/src/exec/vectorized/parquet_reader.h
@@ -39,6 +39,7 @@ public:
     arrow::Result<int64_t> Tell() const override;
     arrow::Status Close() override;
     bool closed() const override;
+    const std::string& filename() const;
 
 private:
     std::shared_ptr<starrocks::RandomAccessFile> _file;
@@ -86,6 +87,7 @@ private:
     int64_t _read_size;
 
     std::string _timezone;
+    std::string _filename;
 };
 
 // Reader of broker parquet file

--- a/be/test/column/column_helper_test.cpp
+++ b/be/test/column/column_helper_test.cpp
@@ -1,8 +1,8 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
 #include "column/column_helper.h"
-#include "column/column_builder.h"
 
+#include "column/column_builder.h"
 #include "gtest/gtest.h"
 
 namespace starrocks::vectorized {

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -242,7 +242,7 @@ TEST(QueryContextManagerTest, testSetWorkgroup) {
 
     /// Case 1: When all the fragments have come and finished, wg.num_running_queries should become to zero.
     ASSERT_OK(query_ctx1->init_query_once(wg.get()));
-    ASSERT_OK(query_ctx1->init_query_once(wg.get()));    // None-first invocations have no side-effects.
+    ASSERT_OK(query_ctx1->init_query_once(wg.get()));              // None-first invocations have no side-effects.
     ASSERT_ERROR(query_ctx_overloaded->init_query_once(wg.get())); // Exceed concurrency_limit.
     ASSERT_EQ(1, wg->num_running_queries());
     ASSERT_EQ(1, wg->concurrency_overflow_count());

--- a/be/test/exec/vectorized/json_parser_test.cpp
+++ b/be/test/exec/vectorized/json_parser_test.cpp
@@ -448,7 +448,8 @@ PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
 PARALLEL_TEST(JsonParserTest, test_big_value) {
     simdjson::ondemand::parser simdjson_parser;
     // The padded_string would allocate memory with simdjson::SIMDJSON_PADDING bytes padding.
-    simdjson::padded_string input = simdjson::padded_string::load("./be/test/exec/test_data/json_scanner/big_value.json");
+    simdjson::padded_string input =
+            simdjson::padded_string::load("./be/test/exec/test_data/json_scanner/big_value.json");
 
     std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
 

--- a/be/test/exec/vectorized/parquet_scanner_test.cpp
+++ b/be/test/exec/vectorized/parquet_scanner_test.cpp
@@ -578,4 +578,4 @@ TEST_F(ParquetScannerTest, test_arrow_null) {
     validate(scanner, 3, check);
 }
 
-} // namespace starrocks
+} // namespace starrocks::vectorized

--- a/be/test/exprs/vectorized/array_functions_test.cpp
+++ b/be/test/exprs/vectorized/array_functions_test.cpp
@@ -4685,8 +4685,7 @@ TEST_F(ArrayFunctionsTest, array_distinct_only_null) {
         src_column = std::make_shared<ConstColumn>(src_column, 3);
         auto dest_column = ArrayDistinct<TYPE_VARCHAR>::process(nullptr, {src_column});
         ASSERT_EQ(dest_column->size(), 3);
-        ASSERT_STREQ(dest_column->debug_string().c_str(),
-                     "[['5','666','33'], ['5','666','33'], ['5','666','33']]");
+        ASSERT_STREQ(dest_column->debug_string().c_str(), "[['5','666','33'], ['5','666','33'], ['5','666','33']]");
     }
     // test normal
     {

--- a/be/test/exprs/vectorized/subfield_expr_test.cpp
+++ b/be/test/exprs/vectorized/subfield_expr_test.cpp
@@ -21,7 +21,8 @@ public:
     ColumnPtr _column;
 };
 
-std::unique_ptr<Expr> create_subfield_expr(const TypeDescriptor& type, const std::vector<std::string>& used_subfield_name) {
+std::unique_ptr<Expr> create_subfield_expr(const TypeDescriptor& type,
+                                           const std::vector<std::string>& used_subfield_name) {
     TExprNode node;
     node.__set_node_type(TExprNodeType::SUBFIELD_EXPR);
     node.__set_is_nullable(true);
@@ -236,4 +237,4 @@ TEST_F(SubfieldExprTest, subfield_multi_level_test) {
     EXPECT_EQ("'cruise'", subfield_column->debug_item(2));
 }
 
-} // namespace starrocks
+} // namespace starrocks::vectorized

--- a/be/test/exprs/vectorized/time_functions_test.cpp
+++ b/be/test/exprs/vectorized/time_functions_test.cpp
@@ -2838,7 +2838,7 @@ TEST_F(TimeFunctionsTest, timeSliceTestWithThrowExceptions) {
 
         try {
             ColumnPtr result = TimeFunctions::time_slice(time_slice_context.get(), columns);
-        } catch (std::runtime_error const& e ) {
+        } catch (std::runtime_error const& e) {
             ASSERT_EQ("time used with time_slice can't before 0001-01-01 00:00:00", std::string(e.what()));
         }
 

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -1095,7 +1095,7 @@ TEST_F(OrcChunkReaderTest, TestReadArrayDecimal) {
     type_array.children.emplace_back(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 9, 9));
 
     SlotDesc slot_descs[] = {
-            {"id",  TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)},
+            {"id", TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT)},
             {"arr", type_array},
             {""},
     };
@@ -1715,9 +1715,8 @@ TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {
                 "[2, [{c11:3,c12:['danny2','Smith3']},{c11:5,c12:['poal','alan']}], "
                 "[{2:{c21:12,c22:'hi2'}},{6:{c21:24,c22:'p5'}}]]",
                 result->debug_row(1));
-        EXPECT_EQ(
-                "[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], [{3:{c21:13,c22:'hi3'}},{7:{c21:25,c22:'p6'}}]]",
-                result->debug_row(2));
+        EXPECT_EQ("[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], [{3:{c21:13,c22:'hi3'}},{7:{c21:25,c22:'p6'}}]]",
+                  result->debug_row(2));
         EXPECT_EQ(
                 "[4, [{c11:5,c12:['danny4','Smith5']},{c11:7,c12:['poal','alan']}], "
                 "[{4:{c21:14,c22:'hi4'}},{8:{c21:26,c22:'p7'}}]]",
@@ -1795,9 +1794,10 @@ TEST_F(OrcChunkReaderTest, TestReadStructArrayMap) {
                 "[2, [{c11:3,c12:['danny2','Smith3']},{c11:5,c12:['poal','alan']}], "
                 "[{2:{c22:'hi2'}},{6:{c22:'p5'}}]]",
                 result->debug_row(1));
-        EXPECT_EQ("[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], "
+        EXPECT_EQ(
+                "[3, [{c11:4,c12:['danny3']},{c11:6,c12:['poal']}], "
                 "[{3:{c22:'hi3'}},{7:{c22:'p6'}}]]",
-                  result->debug_row(2));
+                result->debug_row(2));
         EXPECT_EQ(
                 "[4, [{c11:5,c12:['danny4','Smith5']},{c11:7,c12:['poal','alan']}], "
                 "[{4:{c22:'hi4'}},{8:{c22:'p7'}}]]",

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -184,11 +184,9 @@ protected:
     std::string _file_struct_null_path =
             "./be/test/exec/test_data/parquet_scanner/file_reader_test_struct_null.parquet";
 
-    std::string _file_col_not_null_path =
-            "./be/test/exec/test_data/parquet_scanner/col_not_null.parquet";
+    std::string _file_col_not_null_path = "./be/test/exec/test_data/parquet_scanner/col_not_null.parquet";
 
-    std::string _file_map_null_path =
-            "./be/test/exec/test_data/parquet_scanner/map_null.parquet";
+    std::string _file_map_null_path = "./be/test/exec/test_data/parquet_scanner/map_null.parquet";
 
     std::shared_ptr<RowDescriptor> _row_desc = nullptr;
     RuntimeState* _runtime_state = nullptr;
@@ -574,7 +572,7 @@ HdfsScannerContext* FileReaderTest::_create_file_map_partial_materialize_context
             {"c3", type_map_map},
             {"c4", type_map_array},
             {""},
-        };
+    };
     ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
     ctx->scan_ranges.emplace_back(_create_scan_range(_file_map_path));
@@ -1479,7 +1477,7 @@ TEST_F(FileReaderTest, TestReadStructCaseSensitive) {
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(1024, chunk->num_rows());
 
-     EXPECT_EQ("[0, {F1:0,F2:'a',F3:[0,1,2]}]", chunk->debug_row(0));
+    EXPECT_EQ("[0, {F1:0,F2:'a',F3:[0,1,2]}]", chunk->debug_row(0));
 
     //    for (int i = 0; i < 1; ++i) {
     //        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
@@ -1662,7 +1660,6 @@ TEST_F(FileReaderTest, TestReadNotNull) {
     type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
     type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
 
-
     TypeDescriptor type_struct = TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_STRUCT);
     type_struct.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_VARCHAR));
     type_struct.field_names.emplace_back("a");
@@ -1671,7 +1668,10 @@ TEST_F(FileReaderTest, TestReadNotNull) {
     type_struct.field_names.emplace_back("b");
 
     SlotDesc slot_descs[] = {
-        {"col_int", type_int}, {"col_map", type_map}, {"col_struct", type_struct}, {""},
+            {"col_int", type_int},
+            {"col_map", type_map},
+            {"col_struct", type_struct},
+            {""},
     };
 
     ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
@@ -1689,7 +1689,6 @@ TEST_F(FileReaderTest, TestReadNotNull) {
     chunk->append_column(vectorized::ColumnHelper::create_column(type_map, true), chunk->num_columns());
     chunk->append_column(vectorized::ColumnHelper::create_column(type_struct, true), chunk->num_columns());
 
-
     status = file_reader->get_next(&chunk);
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(3, chunk->num_rows());
@@ -1704,8 +1703,8 @@ TEST_F(FileReaderTest, TestTwoNestedLevelArray) {
     // id: INT, b: ARRAY<ARRAY<INT>>
     const std::string filepath = "./be/test/exec/test_data/parquet_data/two_level_nested_array.parquet";
     auto file = _create_file(filepath);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(filepath));
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(filepath));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1718,7 +1717,6 @@ TEST_F(FileReaderTest, TestTwoNestedLevelArray) {
     type_array_array.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
 
     type_array.children.emplace_back(type_array_array);
-
 
     SlotDesc slot_descs[] = {
             {"id", type_int},
@@ -1769,7 +1767,7 @@ TEST_F(FileReaderTest, TestTwoNestedLevelArray) {
 TEST_F(FileReaderTest, TestReadMapNull) {
     auto file = _create_file(_file_map_null_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                std::filesystem::file_size(_file_map_null_path));
+                                                    std::filesystem::file_size(_file_map_null_path));
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -1781,7 +1779,9 @@ TEST_F(FileReaderTest, TestReadMapNull) {
     type_map.children.emplace_back(TypeDescriptor::from_primtive_type(PrimitiveType::TYPE_INT));
 
     SlotDesc slot_descs[] = {
-        {"uuid", type_int}, {"c1", type_map}, {""},
+            {"uuid", type_int},
+            {"c1", type_map},
+            {""},
     };
 
     ctx->tuple_desc = create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
@@ -1852,7 +1852,6 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
         type_struct.children.emplace_back(type_array);
         type_struct.field_names.emplace_back("b");
 
-
         SlotDesc slot_descs[] = {
                 {"id", type_int},
                 {"col", type_struct},
@@ -1900,12 +1899,10 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
         EXPECT_EQ(524288, total_row_nums);
     }
 
-
     // With 1024 chunk size
     {
         auto file = _create_file(filepath);
-        auto file_reader = std::make_shared<FileReader>(1024, file.get(),
-                                                        std::filesystem::file_size(filepath));
+        auto file_reader = std::make_shared<FileReader>(1024, file.get(), std::filesystem::file_size(filepath));
 
         // --------------init context---------------
         auto ctx = _create_scan_context();
@@ -1928,7 +1925,6 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
 
         type_struct.children.emplace_back(type_array);
         type_struct.field_names.emplace_back("b");
-
 
         SlotDesc slot_descs[] = {
                 {"id", type_int},

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -63,7 +63,7 @@ public:
 
     Status finish_batch() override { return Status::OK(); }
 
-    void set_need_parse_levels(bool need_parse_levels) override {};
+    void set_need_parse_levels(bool need_parse_levels) override{};
 
     void get_levels(int16_t** def_levels, int16_t** rep_levels, size_t* num_levels) override {}
 

--- a/be/test/storage/default_compaction_policy_test.cpp
+++ b/be/test/storage/default_compaction_policy_test.cpp
@@ -1,6 +1,6 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
-#include "storage/cumulative_compaction.h"
+#include "storage/default_compaction_policy.h"
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>
@@ -16,7 +16,7 @@
 #include "storage/compaction_context.h"
 #include "storage/compaction_manager.h"
 #include "storage/compaction_utils.h"
-#include "storage/default_compaction_policy.h"
+#include "storage/cumulative_compaction.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"

--- a/be/test/storage/size_tiered_compaction_policy_test.cpp
+++ b/be/test/storage/size_tiered_compaction_policy_test.cpp
@@ -1,6 +1,6 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 
-#include "storage/cumulative_compaction.h"
+#include "storage/size_tiered_compaction_policy.h"
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>
@@ -19,7 +19,7 @@
 #include "storage/compaction_context.h"
 #include "storage/compaction_manager.h"
 #include "storage/compaction_utils.h"
-#include "storage/size_tiered_compaction_policy.h"
+#include "storage/cumulative_compaction.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -217,7 +217,7 @@ TEST_F(ThreadPoolTest, TestRace) {
         CountDownLatch l(1);
         // CountDownLatch::count_down has multiple overloaded version,
         // so an cast is needed to use std::bind
-        ASSERT_TRUE(_pool->submit_func(std::bind((void(CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
+        ASSERT_TRUE(_pool->submit_func(std::bind((void (CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
         l.wait();
         // Sleeping a different amount in each iteration makes it more likely to hit
         // the bug.


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The filename is not included when error throws during reading data in ParquetReader. It's hard to trace the error when lots of files in one ingestion jobs. I add the filename in the error log to reduce the overhead to trace the error.

Before the pull request, the error is like the following.
```
Either the file is corrupted or this is not a parquet file.
```

After the pull request, the error is like the following.
```
Either the file is corrupted or this is not a parquet file. filename: oss://xxx/catalog_sales_1_1000.dat
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
