### PR TITLE
[Feature][WIP] support column mode partial update

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -128,6 +128,15 @@ void Chunk::set_num_rows(size_t count) {
     }
 }
 
+Status Chunk::update_rows(const Chunk& src, const uint32_t* indexes) {
+    DCHECK(_columns.size() == src.num_columns());
+    for (int i = 0; i < _columns.size(); i++) {
+        ColumnPtr& c = _columns[i];
+        RETURN_IF_ERROR(c->update_rows(*src.columns()[i], indexes));
+    }
+    return Status::OK();
+}
+
 std::string_view Chunk::get_column_name(size_t idx) const {
     DCHECK_LT(idx, _columns.size());
     return _schema->field(idx)->name();

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -116,6 +116,8 @@ public:
     void update_column(ColumnPtr column, SlotId slot_id);
     void update_column_by_index(ColumnPtr column, size_t idx);
 
+    Status update_rows(const Chunk& src, const uint32_t* indexes);
+
     void append_tuple_column(const ColumnPtr& column, TupleId tuple_id);
 
     void remove_column_by_index(size_t idx);

--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -69,7 +69,8 @@ public:
               _type(rhs._type),
               _sub_fields(rhs._sub_fields ? new Buffer<Field>(*rhs._sub_fields) : nullptr),
               _short_key_length(rhs._short_key_length),
-              _flags(rhs._flags) {}
+              _flags(rhs._flags),
+              _uid(rhs._uid) {}
 
     Field(Field&& rhs) noexcept
             : _id(rhs._id),
@@ -78,7 +79,8 @@ public:
               _type(std::move(rhs._type)),
               _sub_fields(rhs._sub_fields),
               _short_key_length(rhs._short_key_length),
-              _flags(rhs._flags) {
+              _flags(rhs._flags),
+              _uid(rhs._uid) {
         rhs._sub_fields = nullptr;
     }
 
@@ -92,6 +94,7 @@ public:
             _short_key_length = rhs._short_key_length;
             _flags = rhs._flags;
             _sub_fields = rhs._sub_fields ? new Buffer<Field>(*rhs._sub_fields) : nullptr;
+            _uid = rhs._uid;
         }
         return *this;
     }
@@ -104,6 +107,7 @@ public:
             _agg_method = rhs._agg_method;
             _short_key_length = rhs._short_key_length;
             _flags = rhs._flags;
+            _uid = rhs._uid;
             std::swap(_sub_fields, rhs._sub_fields);
         }
         return *this;
@@ -157,6 +161,9 @@ public:
 
     ColumnPtr create_column() const;
 
+    void set_uid(ColumnUID uid) { _uid = uid; }
+    ColumnUID uid() const { return _uid; }
+
     static FieldPtr convert_to_dict_field(const Field& field) {
         DCHECK(field.type()->type() == TYPE_VARCHAR);
         FieldPtr res = std::make_shared<Field>(field);
@@ -176,6 +183,7 @@ private:
     int32_t _length = 0;
     uint8_t _short_key_length;
     uint8_t _flags;
+    ColumnUID _uid = -1;
 };
 
 inline bool Field::is_nullable() const {
@@ -222,7 +230,7 @@ inline FieldPtr Field::with_nullable(bool nullable) {
 inline std::ostream& operator<<(std::ostream& os, const Field& field) {
     os << field.id() << ":" << field.name() << " " << field.type()->type() << " "
        << (field.is_nullable() ? "NULL" : "NOT NULL") << (field.is_key() ? " KEY" : "") << " "
-       << field.aggregate_method();
+       << field.aggregate_method() << " uid:" << field.uid();
     return os;
 }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -918,4 +918,5 @@ CONF_Int32(binlog_page_max_size, "1048576");
 
 CONF_mInt64(txn_info_history_size, "20000");
 
+CONF_Bool(enable_preload_column_mode_update_cache, "true");
 } // namespace starrocks::config

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -195,6 +195,11 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
                         std::vector<PTabletWithPartition>& tablets, bool incremental_open) {
     PTabletWriterOpenRequest request;
     request.set_merge_condition(_parent->_merge_condition);
+    if (_parent->_partial_update_mode == TPartialUpdateMode::type::ROW_MODE) {
+        request.set_partial_update_mode(PartialUpdateMode::ROW_MODE);
+    } else {
+        request.set_partial_update_mode(PartialUpdateMode::COLUMN_MODE);
+    }
     request.set_allocated_id(&_parent->_load_id);
     request.set_index_id(index_id);
     request.set_txn_id(_parent->_txn_id);
@@ -862,6 +867,7 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     DCHECK(t_sink.__isset.olap_table_sink);
     const auto& table_sink = t_sink.olap_table_sink;
     _merge_condition = table_sink.merge_condition;
+    _partial_update_mode = table_sink.partial_update_mode;
     _load_id.set_hi(table_sink.load_id.hi);
     _load_id.set_lo(table_sink.load_id.lo);
     _txn_id = table_sink.txn_id;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -403,6 +403,7 @@ private:
     bool _need_gen_rollup = false;
     int _tuple_desc_id = -1;
     std::string _merge_condition;
+    TPartialUpdateMode::type _partial_update_mode;
 
     // this is tuple descriptor of destination OLAP table
     TupleDescriptor* _output_tuple_desc = nullptr;

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -520,6 +520,13 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     if (!http_req->header(HTTP_MERGE_CONDITION).empty()) {
         request.__set_merge_condition(http_req->header(HTTP_MERGE_CONDITION));
     }
+    if (!http_req->header(HTTP_PARTIAL_UPDATE_MODE).empty()) {
+        if (http_req->header(HTTP_PARTIAL_UPDATE_MODE) == "row") {
+            request.__set_partial_update_mode(TPartialUpdateMode::type::ROW_MODE);
+        } else {
+            request.__set_partial_update_mode(TPartialUpdateMode::type::COLUMN_MODE);
+        }
+    }
     if (!http_req->header(HTTP_TRANSMISSION_COMPRESSION_TYPE).empty()) {
         request.__set_transmission_compression_type(http_req->header(HTTP_TRANSMISSION_COMPRESSION_TYPE));
     }

--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -70,6 +70,7 @@ static const std::string HTTP_TRANSMISSION_COMPRESSION_TYPE = "transmission_comp
 static const std::string HTTP_LOAD_DOP = "load_dop";
 static const std::string HTTP_ENABLE_REPLICATED_STORAGE = "enable_replicated_storage";
 static const std::string HTTP_MERGE_CONDITION = "merge_condition";
+static const std::string HTTP_PARTIAL_UPDATE_MODE = "partial_update_mode";
 
 static const std::string HTTP_100_CONTINUE = "100-continue";
 static const std::string HTTP_CHANNEL_ID = "channel_id";

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -499,6 +499,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
             options.replica_state = Peer;
         }
         options.merge_condition = params.merge_condition();
+        options.partial_update_mode = params.partial_update_mode();
 
         auto res = AsyncDeltaWriter::open(options, _mem_tracker);
         if (res.status().ok()) {

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(Storage STATIC
     decimal_type_info.cpp
     delete_handler.cpp
     del_vector.cpp
+    delta_column_group.cpp
+    rowset_column_update_state.cpp
     key_coder.cpp
     memtable_flush_executor.cpp
     segment_flush_executor.cpp

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -119,6 +119,7 @@ Field ChunkHelper::convert_field(ColumnId id, const TabletColumn& c) {
     starrocks::Field f(id, std::string(c.name()), type_info, c.is_nullable());
     f.set_is_key(c.is_key());
     f.set_length(c.length());
+    f.set_uid(c.unique_id());
 
     if (type == TYPE_ARRAY) {
         const TabletColumn& sub_column = c.subcolumn(0);

--- a/be/src/storage/delta_column_group.cpp
+++ b/be/src/storage/delta_column_group.cpp
@@ -25,10 +25,16 @@ void DeltaColumnGroup::init(int64_t version, const std::vector<uint32_t>& column
     _version = version;
     _column_ids = column_ids;
     _column_file = column_file;
+    _calc_memory_usage();
 }
 
 void DeltaColumnGroup::rename_column_file(const std::string& dir, RowsetId new_rowset_id, int segment_id) {
     _column_file = Rowset::delta_column_group_path(dir, new_rowset_id, segment_id, _version);
+    _calc_memory_usage();
+}
+
+void DeltaColumnGroup::_calc_memory_usage() {
+    _memory_usage = sizeof(size_t) + sizeof(int64_t) + sizeof(uint32_t) * _column_ids.size() + _column_file.length();
 }
 
 Status DeltaColumnGroup::load(int64_t version, const char* data, size_t length) {
@@ -41,6 +47,7 @@ Status DeltaColumnGroup::load(int64_t version, const char* data, size_t length) 
     for (uint32_t cid : dcg_pb.column_ids()) {
         _column_ids.push_back(cid);
     }
+    _calc_memory_usage();
     return Status::OK();
 }
 

--- a/be/src/storage/delta_column_group.cpp
+++ b/be/src/storage/delta_column_group.cpp
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/delta_column_group.h"
+
+#include <memory>
+
+#include "gen_cpp/olap_common.pb.h"
+#include "storage/rowset/rowset.h"
+
+namespace starrocks {
+
+void DeltaColumnGroup::init(int64_t version, const std::vector<uint32_t>& column_ids, const std::string& column_file) {
+    _version = version;
+    _column_ids = column_ids;
+    _column_file = column_file;
+}
+
+void DeltaColumnGroup::rename_column_file(const std::string& dir, RowsetId new_rowset_id, int segment_id) {
+    _column_file = Rowset::delta_column_group_path(dir, new_rowset_id, segment_id, _version);
+}
+
+Status DeltaColumnGroup::load(int64_t version, const char* data, size_t length) {
+    _version = version;
+    DeltaColumnGroupPB dcg_pb;
+    if (!dcg_pb.ParseFromArray(data, length)) {
+        return Status::Corruption("DeltaColumnGroup load failed");
+    }
+    _column_file = dcg_pb.column_file();
+    for (uint32_t cid : dcg_pb.column_ids()) {
+        _column_ids.push_back(cid);
+    }
+    return Status::OK();
+}
+
+std::string DeltaColumnGroup::save() const {
+    DeltaColumnGroupPB dcg_pb;
+    dcg_pb.set_column_file(_column_file);
+    for (uint32_t cid : _column_ids) {
+        dcg_pb.add_column_ids(cid);
+    }
+    std::string result;
+    dcg_pb.SerializeToString(&result);
+    return result;
+}
+
+std::string DeltaColumnGroupListSerializer::serialize_delta_column_group_list(const DeltaColumnGroupList& dcgs) {
+    DeltaColumnGroupListPB dcgs_pb;
+    for (const auto& dcg : dcgs) {
+        dcgs_pb.add_versions(dcg->version());
+        DeltaColumnGroupPB dcg_pb;
+        dcg_pb.set_column_file(dcg->column_file());
+        for (uint32_t cid : dcg->column_ids()) {
+            dcg_pb.add_column_ids(cid);
+        }
+        dcgs_pb.add_dcgs()->CopyFrom(dcg_pb);
+    }
+    std::string result;
+    dcgs_pb.SerializeToString(&result);
+    return result;
+}
+
+Status DeltaColumnGroupListSerializer::deserialize_delta_column_group_list(const char* data, size_t length,
+                                                                           DeltaColumnGroupList& dcgs) {
+    DeltaColumnGroupListPB dcgs_pb;
+    if (!dcgs_pb.ParseFromArray(data, length)) {
+        return Status::Corruption("parse delta column group failed");
+    }
+    DCHECK(dcgs_pb.versions_size() == dcgs_pb.dcgs_size());
+    for (int i = 0; i < dcgs_pb.versions_size(); i++) {
+        auto dcg = std::make_shared<DeltaColumnGroup>();
+        std::vector<uint32_t> column_ids;
+        for (uint32_t cid : dcgs_pb.dcgs(i).column_ids()) {
+            column_ids.push_back(cid);
+        }
+        dcg->init(dcgs_pb.versions(i), column_ids, dcgs_pb.dcgs(i).column_file());
+        dcgs.push_back(dcg);
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/delta_column_group.h
+++ b/be/src/storage/delta_column_group.h
@@ -55,10 +55,16 @@ public:
         return ss.str();
     }
 
+    size_t memory_usage() const { return _memory_usage; }
+
+private:
+    void _calc_memory_usage();
+
 private:
     int64_t _version = 0;
     std::vector<uint32_t> _column_ids;
     std::string _column_file;
+    size_t _memory_usage = 0;
 };
 
 using DeltaColumnGroupPtr = std::shared_ptr<DeltaColumnGroup>;

--- a/be/src/storage/delta_column_group.h
+++ b/be/src/storage/delta_column_group.h
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/status.h"
+#include "storage/olap_common.h"
+
+namespace starrocks {
+
+// `DeltaColumnGroup` is used for record the new update columns data
+// It is generated when column mode partial update happen.
+// `_column_ids` record the columns which have been updated, and `_column_file` points to the data file
+// which contains update columns.
+// Column data file end as `.cols`.
+class DeltaColumnGroup {
+public:
+    DeltaColumnGroup() {}
+    ~DeltaColumnGroup() {}
+    void init(int64_t version, const std::vector<uint32_t>& column_ids, const std::string& column_file);
+    Status load(int64_t version, const char* data, size_t length);
+    std::string save() const;
+    int get_column_idx(uint32_t cid) {
+        for (int idx = 0; idx < _column_ids.size(); idx++) {
+            if (_column_ids[idx] == cid) {
+                return idx;
+            }
+        }
+        return -1;
+    }
+    std::string column_file() const { return _column_file; }
+    std::vector<uint32_t> column_ids() const { return _column_ids; }
+    int64_t version() const { return _version; }
+    void rename_column_file(const std::string& dir, RowsetId new_rowset_id, int segment_id);
+
+    std::string debug_string() {
+        std::stringstream ss;
+        ss << "ver:" << _version << ", ";
+        ss << "file:" << _column_file << ", ";
+        ss << "cids:";
+        for (uint32_t cid : _column_ids) {
+            ss << cid << "|";
+        }
+        return ss.str();
+    }
+
+private:
+    int64_t _version = 0;
+    std::vector<uint32_t> _column_ids;
+    std::string _column_file;
+};
+
+using DeltaColumnGroupPtr = std::shared_ptr<DeltaColumnGroup>;
+using DeltaColumnGroupList = std::vector<DeltaColumnGroupPtr>;
+
+class DeltaColumnGroupLoader {
+public:
+    DeltaColumnGroupLoader() = default;
+    virtual ~DeltaColumnGroupLoader() = default;
+    virtual Status load(const TabletSegmentId& tsid, int64_t version, DeltaColumnGroupList& pdcgs) = 0;
+};
+
+class DeltaColumnGroupListSerializer {
+public:
+    static std::string serialize_delta_column_group_list(const DeltaColumnGroupList& dcgs);
+    static Status deserialize_delta_column_group_list(const char* data, size_t length, DeltaColumnGroupList& dcgs);
+};
+
+} // namespace starrocks

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -219,6 +219,7 @@ Status DeltaWriter::_init() {
             return Status::NotSupported("table with sort key do not support partial update");
         }
         writer_context.tablet_schema = writer_context.partial_update_tablet_schema.get();
+        writer_context.partial_update_mode = _opt.partial_update_mode;
     } else {
         writer_context.tablet_schema = &_tablet->tablet_schema();
         if (_tablet->tablet_schema().keys_type() == KeysType::PRIMARY_KEYS && !_opt.merge_condition.empty()) {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -64,6 +64,7 @@ struct DeltaWriterOptions {
     ReplicaState replica_state;
     bool miss_auto_increment_column = false;
     bool abort_delete = false;
+    PartialUpdateMode partial_update_mode = PartialUpdateMode::ROW_MODE;
 };
 
 enum State {

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -269,6 +269,7 @@ struct OlapReaderStatistics {
 };
 
 typedef uint32_t ColumnId;
+typedef int32_t ColumnUID;
 // Column unique id set
 typedef std::set<uint32_t> UniqueIdSet;
 // Column unique Id -> column id map

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2596,7 +2596,7 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
     int64_t apply_version = 0;
     std::vector<RowsetSharedPtr> rowsets;
     std::vector<uint32_t> rowset_ids;
-    RETURN_IF_ERROR(tablet->updates()->_get_apply_version_and_rowsets(&apply_version, &rowsets, &rowset_ids));
+    RETURN_IF_ERROR(tablet->updates()->get_apply_version_and_rowsets(&apply_version, &rowsets, &rowset_ids));
 
     size_t total_data_size = 0;
     size_t total_segments = 0;

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1039,7 +1039,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     int64_t apply_version = 0;
     std::vector<RowsetSharedPtr> rowsets;
     std::vector<uint32_t> rowset_ids;
-    RETURN_IF_ERROR(tablet->updates()->_get_apply_version_and_rowsets(&apply_version, &rowsets, &rowset_ids));
+    RETURN_IF_ERROR(tablet->updates()->get_apply_version_and_rowsets(&apply_version, &rowsets, &rowset_ids));
 
     size_t total_data_size = 0;
     size_t total_segments = 0;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -54,6 +54,8 @@
 #include "storage/projection_iterator.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_meta_manager.h"
 #include "storage/union_iterator.h"
 #include "storage/update_manager.h"
 #include "storage/utils.h"
@@ -135,6 +137,15 @@ std::string Rowset::segment_temp_file_path(const std::string& dir, const RowsetI
 
 std::string Rowset::segment_del_file_path(const std::string& dir, const RowsetId& rowset_id, int segment_id) {
     return strings::Substitute("$0/$1_$2.del", dir, rowset_id.to_string(), segment_id);
+}
+
+std::string Rowset::segment_upt_file_path(const std::string& dir, const RowsetId& rowset_id, int segment_id) {
+    return strings::Substitute("$0/$1_$2.upt", dir, rowset_id.to_string(), segment_id);
+}
+
+std::string Rowset::delta_column_group_path(const std::string& dir, const RowsetId& rowset_id, int segment_id,
+                                            int64_t version) {
+    return strings::Substitute("$0/$1_$2_$3.cols", dir, rowset_id.to_string(), segment_id, version);
 }
 
 Status Rowset::init() {
@@ -257,7 +268,47 @@ Status Rowset::remove() {
         LOG_IF(WARNING, !st.ok()) << "Fail to delete " << path << ": " << st;
         merge_status(st);
     }
+    for (int i = 0, sz = num_update_files(); i < sz; ++i) {
+        std::string path = segment_upt_file_path(_rowset_path, rowset_id(), i);
+        VLOG(1) << "Deleting " << path;
+        auto st = fs->delete_file(path);
+        LOG_IF(WARNING, !st.ok()) << "Fail to delete " << path << ": " << st;
+        merge_status(st);
+    }
+    auto st = _remove_delta_column_group_files(fs);
+    merge_status(st);
     return result;
+}
+
+Status Rowset::_remove_delta_column_group_files(std::shared_ptr<FileSystem> fs) {
+    if (num_segments() > 0) {
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_rowset_meta->tablet_id());
+        if (tablet == nullptr) {
+            // when tablet not exist, skip this step
+            LOG(WARNING) << "remove delta column group, and tablet not exist, tid: " << _rowset_meta->tablet_id();
+            return Status::OK();
+        }
+        // 1. remove dcg files
+        for (int i = 0; i < num_segments(); i++) {
+            DeltaColumnGroupList list;
+            RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
+                    tablet->data_dir()->get_meta(), _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id() + i, 0,
+                    INT64_MAX, list));
+            for (const auto& dcg : list) {
+                auto st = fs->delete_file(dcg->column_file());
+                if (st.ok() || st.is_not_found()) {
+                    LOG(INFO) << "Deleting delta column group's file: " << dcg->debug_string() << " st: " << st;
+                } else {
+                    return st;
+                }
+            }
+        }
+        // 2. remove dcg from rocksdb
+        RETURN_IF_ERROR(
+                TabletMetaManager::delete_delta_column_group(tablet->data_dir()->get_meta(), _rowset_meta->tablet_id(),
+                                                             _rowset_meta->get_rowset_seg_id(), num_segments()));
+    }
+    return Status::OK();
 }
 
 Status Rowset::link_files_to(const std::string& dir, RowsetId new_rowset_id) {
@@ -275,6 +326,46 @@ Status Rowset::link_files_to(const std::string& dir, RowsetId new_rowset_id) {
         if (link(src_file_path.c_str(), dst_link_path.c_str()) != 0) {
             PLOG(WARNING) << "Fail to link " << src_file_path << " to " << dst_link_path;
             return Status::RuntimeError("Fail to link segment delete file");
+        }
+    }
+    for (int i = 0; i < num_update_files(); ++i) {
+        std::string src_file_path = segment_upt_file_path(_rowset_path, rowset_id(), i);
+        std::string dst_link_path = segment_upt_file_path(dir, new_rowset_id, i);
+        if (link(src_file_path.c_str(), dst_link_path.c_str()) != 0) {
+            PLOG(WARNING) << "Fail to link " << src_file_path << " to " << dst_link_path;
+            return Status::RuntimeError("Fail to link segment update file");
+        } else {
+            LOG(INFO) << "success to link " << src_file_path << " to " << dst_link_path;
+        }
+    }
+    RETURN_IF_ERROR(_link_delta_column_group_files(dir, new_rowset_id));
+    return Status::OK();
+}
+
+Status Rowset::_link_delta_column_group_files(const std::string& dir, RowsetId new_rowset_id) {
+    if (num_segments() > 0) {
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_rowset_meta->tablet_id());
+        if (tablet == nullptr) {
+            // when tablet not exist, skip this step
+            LOG(WARNING) << "link delta column group, and tablet not exist, tid: " << _rowset_meta->tablet_id();
+            return Status::OK();
+        }
+        // link dcg files
+        for (int i = 0; i < num_segments(); i++) {
+            DeltaColumnGroupList list;
+            RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
+                    tablet->data_dir()->get_meta(), _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id() + i, 0,
+                    INT64_MAX, list));
+            for (const auto& dcg : list) {
+                std::string src_file_path = dcg->column_file();
+                std::string dst_link_path = delta_column_group_path(dir, new_rowset_id, i, dcg->version());
+                if (link(src_file_path.c_str(), dst_link_path.c_str()) != 0) {
+                    PLOG(WARNING) << "Fail to link " << src_file_path << " to " << dst_link_path;
+                    return Status::RuntimeError("Fail to link segment update file");
+                } else {
+                    LOG(INFO) << "success to link " << src_file_path << " to " << dst_link_path;
+                }
+            }
         }
     }
     return Status::OK();
@@ -298,6 +389,22 @@ Status Rowset::copy_files_to(const std::string& dir) {
         std::string src_path = segment_del_file_path(_rowset_path, rowset_id(), i);
         if (fs::path_exist(src_path)) {
             std::string dst_path = segment_del_file_path(dir, rowset_id(), i);
+            if (fs::path_exist(dst_path)) {
+                LOG(WARNING) << "Path already exist: " << dst_path;
+                return Status::AlreadyExist(fmt::format("Path already exist: {}", dst_path));
+            }
+            if (!fs::copy_file(src_path, dst_path).ok()) {
+                LOG(WARNING) << "Error to copy file. src:" << src_path << ", dst:" << dst_path
+                             << ", errno=" << Errno::no();
+                return Status::IOError(fmt::format("Error to copy file. src: {}, dst: {}, error:{} ", src_path,
+                                                   dst_path, std::strerror(Errno::no())));
+            }
+        }
+    }
+    for (int i = 0; i < num_update_files(); ++i) {
+        std::string src_path = segment_upt_file_path(_rowset_path, rowset_id(), i);
+        if (fs::path_exist(src_path)) {
+            std::string dst_path = segment_upt_file_path(dir, rowset_id(), i);
             if (fs::path_exist(dst_path)) {
                 LOG(WARNING) << "Path already exist: " << dst_path;
                 return Status::AlreadyExist(fmt::format("Path already exist: {}", dst_path));
@@ -386,6 +493,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
         seg_options.rowset_id = rowset_meta()->get_rowset_seg_id();
         seg_options.version = options.version;
         seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(options.meta);
+        seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(options.meta);
     }
     seg_options.rowid_range_option = options.rowid_range_option;
     seg_options.short_key_ranges = options.short_key_ranges;
@@ -460,6 +568,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_segment_iterators2(const Sch
     seg_options.rowset_id = rowset_meta()->get_rowset_seg_id();
     seg_options.version = version;
     seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(meta);
+    seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(meta);
 
     std::vector<ChunkIteratorPtr> seg_iterators(num_segments());
     TabletSegmentId tsid;
@@ -470,6 +579,39 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_segment_iterators2(const Sch
             seg_iterators[i] = new_empty_iterator(schema, config::vector_chunk_size);
             continue;
         }
+        auto res = seg_ptr->new_iterator(schema, seg_options);
+        if (res.status().is_end_of_file()) {
+            seg_iterators[i] = new_empty_iterator(schema, config::vector_chunk_size);
+            continue;
+        }
+        if (!res.ok()) {
+            return res.status();
+        }
+        seg_iterators[i] = std::move(res).value();
+    }
+    return seg_iterators;
+}
+
+StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_update_file_iterators(const Schema& schema,
+                                                                          OlapReaderStatistics* stats) {
+    SegmentReadOptions seg_options;
+    ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(_rowset_path));
+    seg_options.stats = stats;
+    seg_options.tablet_id = rowset_meta()->tablet_id();
+    seg_options.rowset_id = rowset_meta()->get_rowset_seg_id();
+
+    std::vector<ChunkIteratorPtr> seg_iterators(num_update_files());
+    TabletSegmentId tsid;
+    tsid.tablet_id = rowset_meta()->tablet_id();
+    for (int64_t i = 0; i < num_update_files(); i++) {
+        // open update file
+        std::string seg_path = segment_upt_file_path(_rowset_path, rowset_id(), i);
+        ASSIGN_OR_RETURN(auto seg_ptr, Segment::open(seg_options.fs, seg_path, i, _schema));
+        if (seg_ptr->num_rows() == 0) {
+            seg_iterators[i] = new_empty_iterator(schema, config::vector_chunk_size);
+            continue;
+        }
+        // create iterator
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
             seg_iterators[i] = new_empty_iterator(schema, config::vector_chunk_size);

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -183,6 +183,16 @@ public:
     StatusOr<std::vector<ChunkIteratorPtr>> get_segment_iterators2(const Schema& schema, KVStore* meta, int64_t version,
                                                                    OlapReaderStatistics* stats);
 
+    // only used for updatable tablets' rowset in column mode partial update
+    // simply get iterators to iterate all rows without complex options like predicates
+    // |schema| read schema
+    // |stats| used for iterator read stats
+    // return iterator list, an iterator for each segment,
+    // if the segment is empty, put an empty pointer in list
+    // caller is also responsible to call rowset's acquire/release
+    StatusOr<std::vector<ChunkIteratorPtr>> get_update_file_iterators(const Schema& schema,
+                                                                      OlapReaderStatistics* stats);
+
     // publish rowset to make it visible to read
     void make_visible(Version version);
 
@@ -205,7 +215,8 @@ public:
     int64_t partition_id() const { return rowset_meta()->partition_id(); }
     int64_t num_segments() const { return rowset_meta()->num_segments(); }
     uint32_t num_delete_files() const { return rowset_meta()->get_num_delete_files(); }
-    bool has_data_files() const { return num_segments() > 0 || num_delete_files() > 0; }
+    uint32_t num_update_files() const { return rowset_meta()->get_num_update_files(); }
+    bool has_data_files() const { return num_segments() > 0 || num_delete_files() > 0 || num_update_files() > 0; }
 
     // remove all files in this rowset
     // TODO should we rename the method to remove_files() to be more specific?
@@ -250,7 +261,9 @@ public:
     static std::string segment_file_path(const std::string& segment_dir, const RowsetId& rowset_id, int segment_id);
     static std::string segment_temp_file_path(const std::string& dir, const RowsetId& rowset_id, int segment_id);
     static std::string segment_del_file_path(const std::string& segment_dir, const RowsetId& rowset_id, int segment_id);
-
+    static std::string segment_upt_file_path(const std::string& segment_dir, const RowsetId& rowset_id, int segment_id);
+    static std::string delta_column_group_path(const std::string& dir, const RowsetId& rowset_id, int segment_id,
+                                               int64_t version);
     // return an unique identifier string for this rowset
     std::string unique_id() const { return _rowset_path + "/" + rowset_id().to_string(); }
 
@@ -316,6 +329,8 @@ public:
         std::for_each(rowsets.begin(), rowsets.end(), [](const RowsetSharedPtr& rowset) { rowset->close(); });
     }
 
+    bool is_column_mode_partial_update() const { return _rowset_meta->is_column_mode_partial_update(); }
+
 protected:
     friend class RowsetFactory;
 
@@ -344,6 +359,10 @@ protected:
 
 private:
     int64_t _mem_usage() const { return sizeof(Rowset) + _rowset_path.length(); }
+
+    Status _remove_delta_column_group_files(std::shared_ptr<FileSystem> fs);
+
+    Status _link_delta_column_group_files(const std::string& dir, RowsetId new_rowset_id);
 
     std::vector<SegmentSharedPtr> _segments;
 };

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -52,7 +52,11 @@ Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::strin
 
 Status RowsetFactory::create_rowset_writer(const RowsetWriterContext& context, std::unique_ptr<RowsetWriter>* output) {
     if (context.writer_type == kHorizontal) {
-        *output = std::make_unique<HorizontalRowsetWriter>(context);
+        if (context.partial_update_mode == PartialUpdateMode::COLUMN_MODE) {
+            *output = std::make_unique<HorizontalUpdateRowsetWriter>(context);
+        } else {
+            *output = std::make_unique<HorizontalRowsetWriter>(context);
+        }
     } else {
         DCHECK(context.writer_type == kVertical);
         *output = std::make_unique<VerticalRowsetWriter>(context);

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -117,6 +117,14 @@ public:
         return &_rowset_meta_pb->txn_meta().partial_rowset_footers(segment_id);
     }
 
+    bool is_column_mode_partial_update() const {
+        if (_rowset_meta_pb->has_txn_meta() &&
+            _rowset_meta_pb->txn_meta().partial_update_mode() == PartialUpdateMode::COLUMN_MODE) {
+            return true;
+        }
+        return false;
+    }
+
     void clear_txn_meta() { _rowset_meta_pb->clear_txn_meta(); }
 
     bool empty() const { return _rowset_meta_pb->empty(); }
@@ -189,6 +197,8 @@ public:
     void set_rowset_seg_id(uint32_t id) { _rowset_meta_pb->set_rowset_seg_id(id); }
 
     uint32_t get_num_delete_files() const { return _rowset_meta_pb->num_delete_files(); }
+
+    uint32_t get_num_update_files() const { return _rowset_meta_pb->num_update_files(); }
 
     const RowsetMetaPB& get_meta_pb() const { return *_rowset_meta_pb; }
 

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -89,8 +89,7 @@ ssize_t SegmentFileWriter::WriteV(const iovec* iov, int iovcnt) {
     }
 }
 
-RowsetWriter::RowsetWriter(const RowsetWriterContext& context)
-        : _context(context), _num_rows_written(0), _total_row_size(0), _total_data_size(0), _total_index_size(0) {}
+RowsetWriter::RowsetWriter(const RowsetWriterContext& context) : _context(context) {}
 
 Status RowsetWriter::init() {
     _rowset_meta_pb = std::make_unique<RowsetMetaPB>();
@@ -150,6 +149,7 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
             _rowset_meta_pb->mutable_delfile_idxes()->Add(_delfile_idxes.begin(), _delfile_idxes.end());
         }
         _rowset_meta_pb->set_num_delete_files(_num_delfile);
+        _rowset_meta_pb->set_num_update_files(_num_uptfile);
         if (_num_segment <= 1) {
             _rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
         }
@@ -177,6 +177,8 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
                     }
                 }
             }
+            // set partial update mode
+            _rowset_txn_meta_pb->set_partial_update_mode(_context.partial_update_mode);
             *_rowset_meta_pb->mutable_txn_meta() = *_rowset_txn_meta_pb;
         } else if (!_context.merge_condition.empty()) {
             _rowset_txn_meta_pb->set_merge_condition(_context.merge_condition);
@@ -209,6 +211,145 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
     return rowset;
 }
 
+Status RowsetWriter::_flush_segment(const SegmentPB& segment_pb, butil::IOBuf& data) {
+    // 1. create segment file
+    auto path = Rowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, segment_pb.segment_id());
+    // use MUST_CREATE make sure atomic
+    ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(path));
+
+    // 2. flush segment file
+    auto writer = std::make_unique<SegmentFileWriter>(wfile.get());
+
+    butil::IOBuf segment_data;
+    int64_t remaining_bytes = data.cutn(&segment_data, segment_pb.data_size());
+    if (remaining_bytes != segment_pb.data_size()) {
+        return Status::InternalError(fmt::format("segment {} file size {} not equal attachment size {}",
+                                                 segment_pb.DebugString(), remaining_bytes, segment_pb.data_size()));
+    }
+    while (remaining_bytes > 0) {
+        auto written_bytes = segment_data.cut_into_writer(writer.get(), remaining_bytes);
+        if (written_bytes < 0) {
+            return io::io_error(wfile->filename(), errno);
+        }
+        remaining_bytes -= written_bytes;
+    }
+    if (remaining_bytes != 0) {
+        return Status::InternalError(fmt::format("segment {} write size {} not equal expected size {}",
+                                                 wfile->filename(), segment_pb.data_size() - remaining_bytes,
+                                                 segment_pb.data_size()));
+    }
+    if (config::sync_tablet_meta) {
+        RETURN_IF_ERROR(wfile->sync());
+    }
+    RETURN_IF_ERROR(wfile->close());
+
+    if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && _context.partial_update_tablet_schema) {
+        auto* partial_rowset_footer = _rowset_txn_meta_pb->add_partial_rowset_footers();
+        partial_rowset_footer->set_position(segment_pb.partial_footer_position());
+        partial_rowset_footer->set_size(segment_pb.partial_footer_size());
+    }
+
+    // 3. update statistic
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        _total_data_size += segment_pb.data_size();
+        _total_index_size += segment_pb.index_size();
+        _num_rows_written += segment_pb.num_rows();
+        _total_row_size += segment_pb.row_size();
+        _num_segment++;
+    }
+
+    VLOG(2) << "Flush segment to " << path << " size " << segment_pb.data_size();
+
+    return Status::OK();
+}
+
+Status RowsetWriter::_flush_delete_file(const SegmentPB& segment_pb, butil::IOBuf& data) {
+    // 1. create delete file
+    auto path = Rowset::segment_del_file_path(_context.rowset_path_prefix, _context.rowset_id, segment_pb.delete_id());
+    // use MUST_CREATE make sure atomic
+    ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(path));
+
+    // 2. flush delete file
+    auto writer = std::make_unique<SegmentFileWriter>(wfile.get());
+
+    butil::IOBuf delete_data;
+    int64_t remaining_bytes = data.cutn(&delete_data, segment_pb.delete_data_size());
+    if (remaining_bytes != segment_pb.delete_data_size()) {
+        return Status::InternalError(fmt::format("segment {} delete size {} not equal attachment size {}",
+                                                 segment_pb.DebugString(), remaining_bytes,
+                                                 segment_pb.delete_data_size()));
+    }
+    while (remaining_bytes > 0) {
+        auto written_bytes = delete_data.cut_into_writer(writer.get(), remaining_bytes);
+        if (written_bytes < 0) {
+            return io::io_error(wfile->filename(), errno);
+        }
+        remaining_bytes -= written_bytes;
+    }
+    if (remaining_bytes != 0) {
+        return Status::InternalError(fmt::format("segment delete file {} write size {} not equal expected size {}",
+                                                 wfile->filename(), segment_pb.delete_data_size() - remaining_bytes,
+                                                 segment_pb.delete_data_size()));
+    }
+
+    if (config::sync_tablet_meta) {
+        RETURN_IF_ERROR(wfile->sync());
+    }
+    RETURN_IF_ERROR(wfile->close());
+
+    _num_delfile++;
+    _num_rows_del += segment_pb.delete_num_rows();
+
+    VLOG(2) << "Flush delete file to " << path << " size " << segment_pb.delete_data_size();
+
+    return Status::OK();
+}
+
+Status RowsetWriter::_flush_update_file(const SegmentPB& segment_pb, butil::IOBuf& data) {
+    // 1. create segment file
+    auto path = Rowset::segment_upt_file_path(_context.rowset_path_prefix, _context.rowset_id, segment_pb.update_id());
+    // use MUST_CREATE make sure atomic
+    ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(path));
+
+    // 2. flush segment file
+    auto writer = std::make_unique<SegmentFileWriter>(wfile.get());
+
+    butil::IOBuf segment_data;
+    int64_t remaining_bytes = data.cutn(&segment_data, segment_pb.data_size());
+    if (remaining_bytes != segment_pb.data_size()) {
+        return Status::InternalError(fmt::format("update segment {} file size {} not equal attachment size {}",
+                                                 segment_pb.DebugString(), remaining_bytes, segment_pb.data_size()));
+    }
+    while (remaining_bytes > 0) {
+        auto written_bytes = segment_data.cut_into_writer(writer.get(), remaining_bytes);
+        if (written_bytes < 0) {
+            return io::io_error(wfile->filename(), errno);
+        }
+        remaining_bytes -= written_bytes;
+    }
+    if (remaining_bytes != 0) {
+        return Status::InternalError(fmt::format("update segment {} write size {} not equal expected size {}",
+                                                 wfile->filename(), segment_pb.data_size() - remaining_bytes,
+                                                 segment_pb.data_size()));
+    }
+    if (config::sync_tablet_meta) {
+        RETURN_IF_ERROR(wfile->sync());
+    }
+    RETURN_IF_ERROR(wfile->close());
+
+    // 3. update statistic
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        _num_uptfile++;
+        _num_rows_upt += segment_pb.update_num_rows();
+    }
+
+    VLOG(2) << "Flush update segment to " << path << " size " << segment_pb.data_size();
+
+    return Status::OK();
+}
+
 Status RowsetWriter::flush_segment(const SegmentPB& segment_pb, butil::IOBuf& data) {
     if (data.size() != segment_pb.data_size() + segment_pb.delete_data_size()) {
         return Status::InternalError(fmt::format("segment size {} + delete file size {} not equal attachment size {}",
@@ -216,97 +357,15 @@ Status RowsetWriter::flush_segment(const SegmentPB& segment_pb, butil::IOBuf& da
     }
 
     if (segment_pb.has_path()) {
-        // 1. create segment file
-        auto path = Rowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, segment_pb.segment_id());
-        // use MUST_CREATE make sure atomic
-        ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(path));
-
-        // 2. flush segment file
-        auto writer = std::make_unique<SegmentFileWriter>(wfile.get());
-
-        butil::IOBuf segment_data;
-        int64_t remaining_bytes = data.cutn(&segment_data, segment_pb.data_size());
-        if (remaining_bytes != segment_pb.data_size()) {
-            return Status::InternalError(fmt::format("segment {} file size {} not equal attachment size {}",
-                                                     segment_pb.DebugString(), remaining_bytes,
-                                                     segment_pb.data_size()));
-        }
-        while (remaining_bytes > 0) {
-            auto written_bytes = segment_data.cut_into_writer(writer.get(), remaining_bytes);
-            if (written_bytes < 0) {
-                return io::io_error(wfile->filename(), errno);
-            }
-            remaining_bytes -= written_bytes;
-        }
-        if (remaining_bytes != 0) {
-            return Status::InternalError(fmt::format("segment {} write size {} not equal expected size {}",
-                                                     wfile->filename(), segment_pb.data_size() - remaining_bytes,
-                                                     segment_pb.data_size()));
-        }
-        if (config::sync_tablet_meta) {
-            RETURN_IF_ERROR(wfile->sync());
-        }
-        RETURN_IF_ERROR(wfile->close());
-
-        if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && _context.partial_update_tablet_schema) {
-            auto* partial_rowset_footer = _rowset_txn_meta_pb->add_partial_rowset_footers();
-            partial_rowset_footer->set_position(segment_pb.partial_footer_position());
-            partial_rowset_footer->set_size(segment_pb.partial_footer_size());
-        }
-
-        // 3. update statistic
-        {
-            std::lock_guard<std::mutex> l(_lock);
-            _total_data_size += segment_pb.data_size();
-            _total_index_size += segment_pb.index_size();
-            _num_rows_written += segment_pb.num_rows();
-            _total_row_size += segment_pb.row_size();
-            _num_segment++;
-        }
-
-        VLOG(2) << "Flush segment to " << path << " size " << segment_pb.data_size();
+        RETURN_IF_ERROR(_flush_segment(segment_pb, data));
     }
 
     if (segment_pb.has_delete_path()) {
-        // 1. create delete file
-        auto path =
-                Rowset::segment_del_file_path(_context.rowset_path_prefix, _context.rowset_id, segment_pb.delete_id());
-        // use MUST_CREATE make sure atomic
-        ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(path));
+        RETURN_IF_ERROR(_flush_delete_file(segment_pb, data));
+    }
 
-        // 2. flush delete file
-        auto writer = std::make_unique<SegmentFileWriter>(wfile.get());
-
-        butil::IOBuf delete_data;
-        int64_t remaining_bytes = data.cutn(&delete_data, segment_pb.delete_data_size());
-        if (remaining_bytes != segment_pb.delete_data_size()) {
-            return Status::InternalError(fmt::format("segment {} delete size {} not equal attachment size {}",
-                                                     segment_pb.DebugString(), remaining_bytes,
-                                                     segment_pb.delete_data_size()));
-        }
-        while (remaining_bytes > 0) {
-            auto written_bytes = delete_data.cut_into_writer(writer.get(), remaining_bytes);
-            if (written_bytes < 0) {
-                return io::io_error(wfile->filename(), errno);
-            }
-            remaining_bytes -= written_bytes;
-        }
-        if (remaining_bytes != 0) {
-            return Status::InternalError(fmt::format("segment delete file {} write size {} not equal expected size {}",
-                                                     wfile->filename(), segment_pb.delete_data_size() - remaining_bytes,
-                                                     segment_pb.delete_data_size()));
-        }
-
-        if (config::sync_tablet_meta) {
-            RETURN_IF_ERROR(wfile->sync());
-        }
-        RETURN_IF_ERROR(wfile->close());
-
-        _delfile_idxes.emplace_back(_num_segment + _num_delfile);
-        _num_delfile++;
-        _num_rows_del += segment_pb.delete_num_rows();
-
-        VLOG(2) << "Flush delete file to " << path << " size " << segment_pb.delete_data_size();
+    if (segment_pb.has_update_path()) {
+        RETURN_IF_ERROR(_flush_update_file(segment_pb, data));
     }
 
     return Status::OK();
@@ -342,26 +401,6 @@ HorizontalRowsetWriter::~HorizontalRowsetWriter() {
                 LOG_IF(WARNING, !(st.ok() || st.is_not_found()))
                         << "Fail to delete file=" << path << ", " << st.to_string();
             }
-            //// only deleting segment files may not delete all delete files or temporary files
-            //// during final merge, should iterate directory and delete all files with rowset_id prefix
-            //std::vector<std::string> files;
-            //Status st = _context.env->get_children(_context.rowset_path_prefix, &files);
-            //if (!st.ok()) {
-            //    LOG(WARNING) << "list dir failed: " << _context.rowset_path_prefix << " "
-            //                 << st.to_string();
-            //}
-            //string prefix = _context.rowset_id.to_string();
-            //for (auto& f : files) {
-            //    if (strncmp(f.c_str(), prefix.c_str(), prefix.size()) == 0) {
-            //        string path = _context.rowset_path_prefix + "/" + f;
-            //        // Even if an error is encountered, these files that have not been cleaned up
-            //        // will be cleaned up by the GC background. So here we only print the error
-            //        // message when we encounter an error.
-            //        Status st = _context.env->delete_file(path);
-            //        LOG_IF(WARNING, !st.ok())
-            //                << "Fail to delete file=" << path << ", " << st.to_string();
-            //    }
-            //}
         } else {
             for (int i = 0; i < _num_segment; ++i) {
                 auto path = Rowset::segment_file_path(_context.rowset_path_prefix, _context.rowset_id, i);
@@ -955,6 +994,93 @@ Status HorizontalRowsetWriter::_flush_segment_writer(std::unique_ptr<SegmentWrit
     }
 
     (*segment_writer).reset();
+    return Status::OK();
+}
+
+HorizontalUpdateRowsetWriter::HorizontalUpdateRowsetWriter(const RowsetWriterContext& context)
+        : RowsetWriter(context), _update_file_writer(nullptr) {}
+
+HorizontalUpdateRowsetWriter::~HorizontalUpdateRowsetWriter() {
+    if (!_already_built) {           // abnormal exit, remove all files generated
+        _update_file_writer.reset(); // ensure all files are closed
+        for (auto i = 0; i < _num_uptfile; ++i) {
+            auto path = Rowset::segment_upt_file_path(_context.rowset_path_prefix, _context.rowset_id, i);
+            auto st = _fs->delete_file(path);
+            LOG_IF(WARNING, !(st.ok() || st.is_not_found()))
+                    << "Fail to delete file=" << path << ", " << st.to_string();
+        }
+        // if _already_built is false, we need to release rowset_id to avoid rowset_id leak
+        StorageEngine::instance()->release_rowset_id(_context.rowset_id);
+    }
+}
+
+StatusOr<std::unique_ptr<SegmentWriter>> HorizontalUpdateRowsetWriter::_create_update_file_writer() {
+    std::lock_guard<std::mutex> l(_lock);
+    std::string path = Rowset::segment_upt_file_path(_context.rowset_path_prefix, _context.rowset_id, _num_uptfile);
+    ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(path));
+    const auto* schema = _context.tablet_schema;
+    auto segment_writer = std::make_unique<SegmentWriter>(std::move(wfile), _num_uptfile, schema, _writer_options);
+    RETURN_IF_ERROR(segment_writer->init());
+    return std::move(segment_writer);
+}
+
+Status HorizontalUpdateRowsetWriter::add_chunk(const Chunk& chunk) {
+    if (_update_file_writer == nullptr) {
+        ASSIGN_OR_RETURN(_update_file_writer, _create_update_file_writer());
+    } else if (_update_file_writer->estimate_segment_size() >= config::max_segment_file_size) {
+        uint64_t segment_size = 0;
+        uint64_t index_size = 0;
+        uint64_t footer_position = 0;
+        RETURN_IF_ERROR(_update_file_writer->finalize(&segment_size, &index_size, &footer_position));
+        {
+            std::lock_guard<std::mutex> l(_lock);
+            _num_rows_upt += _update_file_writer->num_rows_written();
+            _num_uptfile++;
+        }
+        ASSIGN_OR_RETURN(_update_file_writer, _create_update_file_writer());
+    }
+
+    return _update_file_writer->append_chunk(chunk);
+}
+
+Status HorizontalUpdateRowsetWriter::flush_chunk(const Chunk& chunk, SegmentPB* seg_info) {
+    auto segment_writer = _create_update_file_writer();
+    if (!segment_writer.ok()) {
+        return segment_writer.status();
+    }
+    RETURN_IF_ERROR((*segment_writer)->append_chunk(chunk));
+    uint64_t segment_size = 0;
+    uint64_t index_size = 0;
+    uint64_t footer_position = 0;
+    RETURN_IF_ERROR((*segment_writer)->finalize(&segment_size, &index_size, &footer_position));
+    if (seg_info) {
+        seg_info->set_update_num_rows(static_cast<int64_t>(chunk.num_rows()));
+        seg_info->set_update_id(_num_uptfile);
+        seg_info->set_update_data_size(segment_size);
+        seg_info->set_update_path((*segment_writer)->segment_path());
+    }
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        _num_rows_upt += chunk.num_rows();
+        _num_uptfile++;
+    }
+    (*segment_writer).reset();
+    return Status::OK();
+}
+
+Status HorizontalUpdateRowsetWriter::flush() {
+    if (_update_file_writer != nullptr) {
+        uint64_t segment_size = 0;
+        uint64_t index_size = 0;
+        uint64_t footer_position = 0;
+        RETURN_IF_ERROR(_update_file_writer->finalize(&segment_size, &index_size, &footer_position));
+        {
+            std::lock_guard<std::mutex> l(_lock);
+            _num_rows_upt += _update_file_writer->num_rows_written();
+            _num_uptfile++;
+        }
+        _update_file_writer.reset();
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -160,6 +160,13 @@ public:
         return _global_dict_columns_valid_info;
     }
 
+private:
+    Status _flush_segment(const SegmentPB& segment_pb, butil::IOBuf& data);
+
+    Status _flush_delete_file(const SegmentPB& segment_pb, butil::IOBuf& data);
+
+    Status _flush_update_file(const SegmentPB& segment_pb, butil::IOBuf& data);
+
 protected:
     RowsetWriterContext _context;
     std::shared_ptr<FileSystem> _fs;
@@ -167,21 +174,23 @@ protected:
     std::unique_ptr<RowsetTxnMetaPB> _rowset_txn_meta_pb;
     SegmentWriterOptions _writer_options;
 
-    int _num_segment{0};
-    int _num_delfile{0};
+    int _num_segment = 0;
+    int _num_delfile = 0;
+    int _num_uptfile = 0;
     vector<uint32> _delfile_idxes;
     vector<std::string> _tmp_segment_files;
     // mutex lock for vectorized add chunk and flush
     std::mutex _lock;
 
     // counters and statistics maintained during data write
-    int64_t _num_rows_written;
+    int64_t _num_rows_written = 0;
     int64_t _num_rows_flushed = 0;
     std::vector<int64_t> _num_rows_of_tmp_segment_files;
-    int64_t _num_rows_del;
-    int64_t _total_row_size;
-    int64_t _total_data_size;
-    int64_t _total_index_size;
+    int64_t _num_rows_del = 0;
+    int64_t _total_row_size = 0;
+    int64_t _total_data_size = 0;
+    int64_t _total_index_size = 0;
+    int64_t _num_rows_upt = 0;
 
     bool _is_pending = false;
     bool _already_built = false;
@@ -227,6 +236,23 @@ private:
 
     std::unique_ptr<SegmentWriter> _segment_writer;
     std::unique_ptr<VerticalRowsetWriter> _vertical_rowset_writer;
+};
+
+// used for column mode partial update
+class HorizontalUpdateRowsetWriter final : public RowsetWriter {
+public:
+    explicit HorizontalUpdateRowsetWriter(const RowsetWriterContext& context);
+    ~HorizontalUpdateRowsetWriter() override;
+    Status add_chunk(const Chunk& chunk) override;
+
+    Status flush_chunk(const Chunk& chunk, SegmentPB* seg_info = nullptr) override;
+
+    Status flush() override;
+
+private:
+    StatusOr<std::unique_ptr<SegmentWriter>> _create_update_file_writer();
+
+    std::unique_ptr<SegmentWriter> _update_file_writer;
 };
 
 // Chunk contains partial columns data corresponding to column_indexes.

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -88,6 +88,8 @@ public:
     bool miss_auto_increment_column = false;
 
     bool abort_delete = false;
+    // partial update mode
+    PartialUpdateMode partial_update_mode = PartialUpdateMode::ROW_MODE;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -370,24 +370,9 @@ Status Segment::new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** it
     return Status::OK();
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_dcg_column_iterator(DeltaColumnGroupList dcgs, uint32_t ucid,
-                                                                           std::string* filename) {
-    // build column iter from delta column group
-    // iterate dcg from new ver to old ver
-    for (const auto& dcg : dcgs) {
-        int idx = dcg->get_column_idx(ucid);
-        if (idx >= 0) {
-            ASSIGN_OR_RETURN(auto dcg_segment,
-                             Segment::open(_fs, dcg->column_file(), 0,
-                                           TabletSchema::create_with_uid(*_tablet_schema, dcg->column_ids()), nullptr));
-            _dcg_segments.push_back(dcg_segment);
-            if (filename != nullptr) {
-                *filename = dcg->column_file();
-            }
-            return dcg_segment->new_column_iterator(idx);
-        }
-    }
-    return nullptr;
+StatusOr<std::shared_ptr<Segment>> Segment::new_dcg_segment(const DeltaColumnGroup& dcg) {
+    return Segment::open(_fs, dcg.column_file(), 0, TabletSchema::create_with_uid(*_tablet_schema, dcg.column_ids()),
+                         nullptr);
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -370,16 +370,16 @@ Status Segment::new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** it
     return Status::OK();
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_dcg_column_iterator(DeltaColumnGroupList dcgs, uint32_t cid,
+StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_dcg_column_iterator(DeltaColumnGroupList dcgs, uint32_t ucid,
                                                                            std::string* filename) {
     // build column iter from delta column group
     // iterate dcg from new ver to old ver
     for (const auto& dcg : dcgs) {
-        int idx = dcg->get_column_idx(cid);
+        int idx = dcg->get_column_idx(ucid);
         if (idx >= 0) {
             ASSIGN_OR_RETURN(auto dcg_segment,
                              Segment::open(_fs, dcg->column_file(), 0,
-                                           TabletSchema::create(*_tablet_schema, dcg->column_ids()), nullptr));
+                                           TabletSchema::create_with_uid(*_tablet_schema, dcg->column_ids()), nullptr));
             _dcg_segments.push_back(dcg_segment);
             if (filename != nullptr) {
                 *filename = dcg->column_file();

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -370,4 +370,24 @@ Status Segment::new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** it
     return Status::OK();
 }
 
+StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_dcg_column_iterator(DeltaColumnGroupList dcgs, uint32_t cid,
+                                                                           std::string* filename) {
+    // build column iter from delta column group
+    // iterate dcg from new ver to old ver
+    for (const auto& dcg : dcgs) {
+        int idx = dcg->get_column_idx(cid);
+        if (idx >= 0) {
+            ASSIGN_OR_RETURN(auto dcg_segment,
+                             Segment::open(_fs, dcg->column_file(), 0,
+                                           TabletSchema::create(*_tablet_schema, dcg->column_ids()), nullptr));
+            _dcg_segments.push_back(dcg_segment);
+            if (filename != nullptr) {
+                *filename = dcg->column_file();
+            }
+            return dcg_segment->new_column_iterator(idx);
+        }
+    }
+    return nullptr;
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -164,7 +164,7 @@ public:
 
     int64_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage(); }
 
-    StatusOr<std::unique_ptr<ColumnIterator>> new_dcg_column_iterator(DeltaColumnGroupList dcgs, uint32_t cid,
+    StatusOr<std::unique_ptr<ColumnIterator>> new_dcg_column_iterator(DeltaColumnGroupList dcgs, uint32_t ucid,
                                                                       std::string* filename);
 
     DISALLOW_COPY_AND_MOVE(Segment);

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -110,6 +110,8 @@ public:
     // may return EndOfFile
     StatusOr<ChunkIteratorPtr> new_iterator(const Schema& schema, const SegmentReadOptions& read_options);
 
+    StatusOr<std::shared_ptr<Segment>> new_dcg_segment(const DeltaColumnGroup& dcg);
+
     uint64_t id() const { return _segment_id; }
 
     // TODO: remove this method, create `ColumnIterator` via `ColumnReader`.
@@ -163,9 +165,6 @@ public:
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
 
     int64_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage(); }
-
-    StatusOr<std::unique_ptr<ColumnIterator>> new_dcg_column_iterator(DeltaColumnGroupList dcgs, uint32_t ucid,
-                                                                      std::string* filename);
 
     DISALLOW_COPY_AND_MOVE(Segment);
 
@@ -240,9 +239,6 @@ private:
     std::unique_ptr<std::vector<LogicalType>> _column_storage_types;
     // When reading old type format data this will be set to true.
     bool _needs_chunk_adapter = false;
-
-    // used for store delta column group's segment
-    std::vector<std::shared_ptr<Segment>> _dcg_segments;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -44,6 +44,7 @@
 #include "gen_cpp/olap_file.pb.h"
 #include "gen_cpp/segment.pb.h"
 #include "gutil/macros.h"
+#include "storage/delta_column_group.h"
 #include "storage/rowset/page_handle.h"
 #include "storage/rowset/page_pointer.h"
 #include "storage/short_key_index.h"
@@ -163,6 +164,9 @@ public:
 
     int64_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage(); }
 
+    StatusOr<std::unique_ptr<ColumnIterator>> new_dcg_column_iterator(DeltaColumnGroupList dcgs, uint32_t cid,
+                                                                      std::string* filename);
+
     DISALLOW_COPY_AND_MOVE(Segment);
 
 private:
@@ -236,6 +240,9 @@ private:
     std::unique_ptr<std::vector<LogicalType>> _column_storage_types;
     // When reading old type format data this will be set to true.
     bool _needs_chunk_adapter = false;
+
+    // used for store delta column group's segment
+    std::vector<std::shared_ptr<Segment>> _dcg_segments;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -30,6 +30,7 @@ class Condition;
 struct OlapReaderStatistics;
 class RuntimeProfile;
 class TabletSchema;
+class DeltaColumnGroupLoader;
 } // namespace starrocks
 
 namespace starrocks {
@@ -59,6 +60,8 @@ public:
     uint64_t tablet_id = 0;
     uint32_t rowset_id = 0;
     int64_t version = 0;
+    // used for primary key tablet to get delta column group
+    std::shared_ptr<DeltaColumnGroupLoader> dcg_loader;
 
     // REQUIRED (null is not allowed)
     OlapReaderStatistics* stats = nullptr;

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -1,0 +1,535 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rowset_column_update_state.h"
+
+#include "common/tracer.h"
+#include "fs/fs_util.h"
+#include "gutil/strings/substitute.h"
+#include "serde/column_array_serde.h"
+#include "storage/chunk_helper.h"
+#include "storage/delta_column_group.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/rowset/column_iterator.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/rowset/segment_rewriter.h"
+#include "storage/tablet.h"
+#include "storage/tablet_meta_manager.h"
+#include "storage/update_manager.h"
+#include "util/defer_op.h"
+#include "util/phmap/phmap.h"
+#include "util/stack_util.h"
+#include "util/time.h"
+
+namespace starrocks {
+
+Status ColumnIteratorWrapper::create(std::shared_ptr<FileSystem> fs, const std::string& path,
+                                     std::shared_ptr<Segment> segment, uint32_t cid) {
+    _segment = segment;
+    _row_nums = _segment->num_rows();
+    _iter_opts.stats = &_stats;
+    ASSIGN_OR_RETURN(_read_file, fs->new_random_access_file(_segment->file_name()));
+    _iter_opts.read_file = _read_file.get();
+    ASSIGN_OR_RETURN(_column_iter, _segment->new_column_iterator(cid));
+    RETURN_IF_ERROR(_column_iter->init(_iter_opts));
+    return Status::OK();
+}
+
+RowsetColumnUpdateState::RowsetColumnUpdateState() = default;
+
+RowsetColumnUpdateState::~RowsetColumnUpdateState() {
+    if (!_status.ok()) {
+        LOG(WARNING) << "bad RowsetColumnUpdateState released tablet:" << _tablet_id;
+    }
+}
+
+Status RowsetColumnUpdateState::load(Tablet* tablet, Rowset* rowset) {
+    if (UNLIKELY(!_status.ok())) {
+        return _status;
+    }
+    std::call_once(_load_once_flag, [&] {
+        _tablet_id = tablet->tablet_id();
+        _status = _do_load(tablet, rowset);
+        if (!_status.ok()) {
+            LOG(WARNING) << "load RowsetColumnUpdateState error: " << _status << " tablet:" << _tablet_id << " stack:\n"
+                         << get_stack_trace();
+            if (_status.is_mem_limit_exceeded()) {
+                LOG(WARNING) << CurrentThread::mem_tracker()->debug_string();
+            }
+        }
+    });
+    return _status;
+}
+
+Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx, Column* pk_column) {
+    RowsetReleaseGuard guard(rowset->shared_from_this());
+    DCHECK(_upserts.size() >= idx);
+    if (_upserts.size() == 0) {
+        _upserts.resize(rowset->num_update_files());
+        _update_chunk_cache.resize(rowset->num_update_files());
+    }
+    if (_upserts.size() == 0 || _upserts[idx] != nullptr) {
+        return Status::OK();
+    }
+
+    OlapReaderStatistics stats;
+    auto& schema = rowset->schema();
+    vector<uint32_t> pk_columns;
+    for (size_t i = 0; i < schema.num_key_columns(); i++) {
+        pk_columns.push_back((uint32_t)i);
+    }
+    std::vector<uint32_t> update_columns;
+    const auto& txn_meta = rowset->rowset_meta()->get_meta_pb().txn_meta();
+    for (uint32_t cid : txn_meta.partial_update_column_ids()) {
+        update_columns.push_back(cid);
+    }
+    Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
+    Schema update_schema = ChunkHelper::convert_schema(schema, update_columns);
+
+    // iterators for each update segments;
+    std::vector<ChunkIteratorPtr> itrs;
+
+    std::shared_ptr<Chunk> chunk_shared_ptr;
+    // if we want to preload update cache, create chunk with update columns
+    if (config::enable_preload_column_mode_update_cache) {
+        _update_chunk_cache[idx] = std::move(ChunkHelper::new_chunk(update_schema, 4096));
+        chunk_shared_ptr = ChunkHelper::new_chunk(update_schema, 4096);
+        ASSIGN_OR_RETURN(itrs, rowset->get_update_file_iterators(update_schema, &stats));
+    } else {
+        _update_chunk_cache[idx] = std::move(ChunkHelper::new_chunk(update_schema, 0));
+        chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
+        ASSIGN_OR_RETURN(itrs, rowset->get_update_file_iterators(pkey_schema, &stats));
+    }
+
+    CHECK(itrs.size() == rowset->num_update_files()) << "itrs.size != num_update_files";
+    auto chunk = chunk_shared_ptr.get();
+    auto& dest = _upserts[idx];
+    auto& dest_chunk = _update_chunk_cache[idx];
+    auto col = pk_column->clone();
+    auto itr = itrs[idx].get();
+    if (itr != nullptr) {
+        col->reserve(1024);
+        while (true) {
+            chunk->reset();
+            auto st = itr->get_next(chunk);
+            if (st.is_end_of_file()) {
+                break;
+            } else if (!st.ok()) {
+                return st;
+            } else {
+                _total_read_chunk_bytes += chunk->bytes_usage();
+                PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+                if (config::enable_preload_column_mode_update_cache) {
+                    dest_chunk->append(*chunk);
+                }
+            }
+        }
+    }
+    for (const auto& itr : itrs) {
+        itr->close();
+    }
+    dest = std::move(col);
+    // This is a little bit trick. If pk column is a binary column, we will call function `raw_data()` in the following
+    // And the function `raw_data()` will build slice of pk column which will increase the memory usage of pk column
+    // So we try build slice in advance in here to make sure the correctness of memory statistics
+    dest->raw_data();
+    _memory_usage += dest != nullptr ? dest->memory_usage() : 0;
+
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
+    auto span = Tracer::Instance().start_trace_txn_tablet("rowset_column_update_state_load", rowset->txn_id(),
+                                                          tablet->tablet_id());
+    _tablet_id = tablet->tablet_id();
+    auto& schema = rowset->schema();
+    vector<uint32_t> pk_columns;
+    for (size_t i = 0; i < schema.num_key_columns(); i++) {
+        pk_columns.push_back((uint32_t)i);
+    }
+    Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
+    std::unique_ptr<Column> pk_column;
+    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+        CHECK(false) << "create column for primary key encoder failed";
+    }
+
+    for (size_t i = 0; i < rowset->num_update_files(); i++) {
+        RETURN_IF_ERROR(_load_upserts(rowset, i, pk_column.get()));
+    }
+
+    return _prepare_partial_update_states(tablet, rowset, 0, true);
+}
+
+Status RowsetColumnUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx,
+                                                               bool need_lock) {
+    if (_partial_update_states.size() == 0) {
+        _partial_update_states.resize(rowset->num_update_files());
+    }
+
+    if (_partial_update_states[idx].inited == true) {
+        return Status::OK();
+    }
+
+    // we only need to fill src_rss_rowids and rss_rowid_to_update_rowid when
+    // prepare column partial update states
+
+    int64_t t_start = MonotonicMillis();
+
+    _partial_update_states[idx].src_rss_rowids.resize(_upserts[idx]->size());
+
+    int64_t t_read_rss = MonotonicMillis();
+    if (need_lock) {
+        RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states(
+                tablet, _upserts[idx], &(_partial_update_states[idx].read_version),
+                &(_partial_update_states[idx].src_rss_rowids)));
+    } else {
+        RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states_unlock(
+                tablet, _upserts[idx], &(_partial_update_states[idx].read_version),
+                &(_partial_update_states[idx].src_rss_rowids)));
+    }
+    // build `rss_rowid_to_update_rowid`
+    _partial_update_states[idx].build_rss_rowid_to_update_rowid();
+    int64_t t_end = MonotonicMillis();
+
+    _partial_update_states[idx].inited = true;
+
+    LOG(INFO) << strings::Substitute(
+            "prepare ColumnPartialUpdateState tablet:$0 segment:$1 "
+            "time:$2ms(src_rss:$3)",
+            _tablet_id, idx, t_end - t_start, t_end - t_read_rss);
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t segment_id,
+                                                  EditVersion latest_applied_version, const PrimaryIndex& index) {
+    int64_t t_start = MonotonicMillis();
+    // rebuild src_rss_rowids;
+    DCHECK(_upserts[segment_id]->size() == _partial_update_states[segment_id].src_rss_rowids.size());
+    index.get(*_upserts[segment_id], &_partial_update_states[segment_id].src_rss_rowids);
+    int64_t t_read_index = MonotonicMillis();
+    // rebuild rss_rowid_to_update_rowid
+    _partial_update_states[segment_id].build_rss_rowid_to_update_rowid();
+    int64_t t_end = MonotonicMillis();
+    LOG(INFO) << strings::Substitute(
+            "_resolve_conflict_column_mode tablet:$0 rowset:$1 segmet:$2 version:($3 $4) "
+            "time:$5ms(index:$6/build:$7)",
+            tablet->tablet_id(), rowset_id, segment_id, _partial_update_states[segment_id].read_version.to_string(),
+            latest_applied_version.to_string(), t_end - t_start, t_read_index - t_start, t_end - t_read_index);
+
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::_check_and_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t segment_id,
+                                                            EditVersion latest_applied_version,
+                                                            const PrimaryIndex& index) {
+    if (_partial_update_states.size() <= segment_id || !_partial_update_states[segment_id].inited) {
+        std::string msg = strings::Substitute(
+                "_check_and_reslove_conflict tablet:$0 rowset:$1 segment:$2 failed, partial_update_states size:$3",
+                tablet->tablet_id(), rowset_id, segment_id, _partial_update_states.size());
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
+
+    // _read_version is equal to latest_applied_version which means there is no other rowset is applied
+    // the data of write_columns can be write to segment file directly
+    LOG(INFO) << "latest_applied_version is " << latest_applied_version.to_string() << " read version is "
+              << _partial_update_states[segment_id].read_version.to_string();
+    if (latest_applied_version == _partial_update_states[segment_id].read_version) {
+        return Status::OK();
+    }
+
+    return _resolve_conflict(tablet, rowset_id, segment_id, latest_applied_version, index);
+}
+
+Status RowsetColumnUpdateState::finalize_partial_update_state(Tablet* tablet, Rowset* rowset, uint32_t rowset_id,
+                                                              EditVersion latest_applied_version,
+                                                              const PrimaryIndex& index) {
+    const auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
+    if (!rowset_meta_pb.has_txn_meta() || rowset->num_update_files() == 0 ||
+        rowset_meta_pb.txn_meta().has_merge_condition()) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(_init_rowset_seg_id(tablet, latest_applied_version.major()));
+    for (uint32_t i = 0; i < rowset->num_update_files(); i++) {
+        // check and resolve conflict
+        if (_partial_update_states.size() == 0 || !_partial_update_states[i].inited) {
+            RETURN_IF_ERROR(_prepare_partial_update_states(tablet, rowset, i, false));
+        } else {
+            // reslove conflict
+            RETURN_IF_ERROR(_check_and_resolve_conflict(tablet, rowset_id, i, latest_applied_version, index));
+        }
+    }
+
+    return Status::OK();
+}
+
+static StatusOr<ChunkPtr> read_from_source_segment(Rowset* rowset, const Schema& schema, Tablet* tablet,
+                                                   OlapReaderStatistics* stats, int64_t version,
+                                                   RowsetSegmentId rowset_seg_id, const std::string& path) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(rowset->rowset_path()));
+    auto segment = Segment::open(fs, path, rowset_seg_id.segment_id, &rowset->schema());
+    if (!segment.ok()) {
+        LOG(WARNING) << "Fail to open " << path << ": " << segment.status();
+        return segment.status();
+    }
+    if ((*segment)->num_rows() == 0) {
+        return Status::InternalError("empty segment");
+    }
+    SegmentReadOptions seg_options;
+    seg_options.fs = fs;
+    seg_options.stats = stats;
+    seg_options.is_primary_keys = true;
+    seg_options.tablet_id = rowset->rowset_meta()->tablet_id();
+    seg_options.rowset_id = rowset_seg_id.rowset_seg_id;
+    seg_options.version = version;
+    // not use delvec loader
+    seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(tablet->data_dir()->get_meta());
+    ASSIGN_OR_RETURN(auto seg_iter, (*segment)->new_iterator(schema, seg_options));
+    auto source_chunk_ptr = ChunkHelper::new_chunk(schema, (*segment)->num_rows());
+    auto tmp_chunk_ptr = ChunkHelper::new_chunk(schema, 1024);
+    while (true) {
+        tmp_chunk_ptr->reset();
+        auto st = seg_iter->get_next(tmp_chunk_ptr.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (!st.ok()) {
+            return st;
+        } else {
+            source_chunk_ptr->append(*tmp_chunk_ptr);
+        }
+    }
+    return source_chunk_ptr;
+}
+
+// this function build delta writer for delta column group's file.(end with `.col`)
+StatusOr<std::unique_ptr<SegmentWriter>> RowsetColumnUpdateState::_prepare_delta_column_group_writer(
+        Rowset* rowset, std::shared_ptr<TabletSchema> tschema, uint32_t rssid, int64_t ver) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(rowset->rowset_path()));
+    ASSIGN_OR_RETURN(auto rowsetid_segid, _find_rowset_seg_id(rssid));
+    const std::string path = Rowset::delta_column_group_path(rowset->rowset_path(), rowsetid_segid.rowset_id,
+                                                             rowsetid_segid.segment_id, ver);
+    (void)fs->delete_file(path); // delete .cols if already exist
+    WritableFileOptions opts{.sync_on_close = true};
+    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(opts, path));
+    SegmentWriterOptions writer_options;
+    auto segment_writer = std::make_unique<SegmentWriter>(std::move(wfile), rssid, tschema.get(), writer_options);
+    RETURN_IF_ERROR(segment_writer->init());
+    return std::move(segment_writer);
+}
+
+static Status read_chunk_from_update_file(ChunkIteratorPtr iter, ChunkPtr result_chunk) {
+    auto chunk = result_chunk->clone_empty(1024);
+    while (true) {
+        chunk->reset();
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (!st.ok()) {
+            return st;
+        } else {
+            result_chunk->append(*chunk);
+        }
+    }
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::_read_chunk_from_update(
+        const std::map<uint32_t, std::pair<uint32_t, uint32_t>>& rowid_to_update_rowid,
+        std::vector<ChunkIteratorPtr>& update_iterators, std::vector<uint32_t>& rowids, Chunk* result_chunk) {
+    std::vector<uint32_t> batch_append_rowids;
+    uint32_t cur_update_seg_id = UINT32_MAX;
+    for (const auto& each : rowid_to_update_rowid) {
+        rowids.push_back(each.first);
+        if (cur_update_seg_id == UINT32_MAX) {
+            cur_update_seg_id = each.second.first;
+            batch_append_rowids.push_back(each.second.second);
+        } else if (cur_update_seg_id == each.second.first) {
+            batch_append_rowids.push_back(each.second.second);
+        } else {
+            if (!config::enable_preload_column_mode_update_cache) {
+                _update_chunk_cache[cur_update_seg_id]->reserve(4096);
+                RETURN_IF_ERROR(read_chunk_from_update_file(update_iterators[cur_update_seg_id],
+                                                            _update_chunk_cache[cur_update_seg_id]));
+                result_chunk->append_selective(*_update_chunk_cache[cur_update_seg_id], batch_append_rowids.data(), 0,
+                                               batch_append_rowids.size());
+                _update_chunk_cache[cur_update_seg_id]->reset();
+            } else {
+                result_chunk->append_selective(*_update_chunk_cache[cur_update_seg_id], batch_append_rowids.data(), 0,
+                                               batch_append_rowids.size());
+            }
+            cur_update_seg_id = each.second.first;
+            batch_append_rowids.clear();
+            batch_append_rowids.push_back(each.second.second);
+        }
+    }
+    if (!batch_append_rowids.empty()) {
+        if (!config::enable_preload_column_mode_update_cache) {
+            _update_chunk_cache[cur_update_seg_id]->reserve(4096);
+            RETURN_IF_ERROR(read_chunk_from_update_file(update_iterators[cur_update_seg_id],
+                                                        _update_chunk_cache[cur_update_seg_id]));
+            result_chunk->append_selective(*_update_chunk_cache[cur_update_seg_id], batch_append_rowids.data(), 0,
+                                           batch_append_rowids.size());
+            _update_chunk_cache[cur_update_seg_id]->reset();
+        } else {
+            result_chunk->append_selective(*_update_chunk_cache[cur_update_seg_id], batch_append_rowids.data(), 0,
+                                           batch_append_rowids.size());
+        }
+    }
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::finalize(Rowset* rowset, Tablet* tablet, int64_t version) {
+    if (_finalize_finished) return Status::OK();
+    std::stringstream cost_str;
+    MonotonicStopWatch watch;
+    watch.start();
+
+    DCHECK(rowset->num_update_files() == _partial_update_states.size());
+    const auto& txn_meta = rowset->rowset_meta()->get_meta_pb().txn_meta();
+
+    std::vector<uint32_t> update_column_ids;
+    const auto& tschema = rowset->schema();
+    for (uint32_t cid : txn_meta.partial_update_column_ids()) {
+        update_column_ids.push_back(cid);
+    }
+    auto partial_tschema = TabletSchema::create(tschema, update_column_ids);
+    Schema partial_schema = ChunkHelper::convert_schema(tschema, update_column_ids);
+
+    // rss_id -> delta column group writer
+    std::map<uint32_t, std::unique_ptr<SegmentWriter>> delta_column_group_writer;
+    // 1. getter all rss_rowid_to_update_rowid, and prepare .col writer by the way
+    // rss_id -> rowid -> <segment_id, update_rowids>
+    std::map<uint32_t, std::map<uint32_t, std::pair<uint32_t, uint32_t>>> rss_rowid_to_update_rowid;
+    for (int seg_id = 0; seg_id < _partial_update_states.size(); seg_id++) {
+        for (const auto& each : _partial_update_states[seg_id].rss_rowid_to_update_rowid) {
+            uint32_t rssid = (uint32_t)(each.first >> 32);
+            uint32_t rowid = (uint32_t)(each.first & ROWID_MASK);
+            rss_rowid_to_update_rowid[rssid][rowid] = std::make_pair(seg_id, each.second);
+            // prepare delta column writers by the way
+            if (delta_column_group_writer.count(rssid) == 0) {
+                ASSIGN_OR_RETURN(auto writer,
+                                 _prepare_delta_column_group_writer(rowset, partial_tschema, rssid, version + 1));
+                delta_column_group_writer[rssid] = std::move(writer);
+            }
+        }
+    }
+    cost_str << " [generate delta column group writer] " << watch.elapsed_time();
+    watch.reset();
+    // 2. create update segment's iterator
+    OlapReaderStatistics stats;
+    std::vector<ChunkIteratorPtr> update_segment_iters;
+    if (!config::enable_preload_column_mode_update_cache) {
+        ASSIGN_OR_RETURN(update_segment_iters, rowset->get_update_file_iterators(partial_schema, &stats));
+    }
+    cost_str << " [prepare upt column iter] " << watch.elapsed_time();
+    watch.reset();
+
+    int64_t total_seek_source_segment_time = 0;
+    int64_t total_read_column_from_update_time = 0;
+    int64_t total_finalize_dcg_time = 0;
+    int64_t total_merge_column_time = 0;
+    const size_t rss_cnt = rss_rowid_to_update_rowid.size();
+    const size_t column_cnt = update_column_ids.size();
+    const size_t update_seg_cnt = _partial_update_states.size();
+    // 3. read from raw segment file and update file, and generate `.col` files one by one
+    for (const auto& each : rss_rowid_to_update_rowid) {
+        int64_t t1 = MonotonicMillis();
+        ASSIGN_OR_RETURN(auto rowsetid_segid, _find_rowset_seg_id(each.first));
+        const std::string seg_path =
+                Rowset::segment_file_path(rowset->rowset_path(), rowsetid_segid.rowset_id, rowsetid_segid.segment_id);
+        // 3.1 read from source segment
+        ASSIGN_OR_RETURN(auto source_chunk_ptr, read_from_source_segment(rowset, partial_schema, tablet, &stats,
+                                                                         version, rowsetid_segid, seg_path));
+        _total_read_chunk_bytes += source_chunk_ptr->bytes_usage();
+        _read_io_cnt++;
+        // 3.2 read from update segment
+        int64_t t2 = MonotonicMillis();
+        std::vector<uint32_t> rowids;
+        auto update_chunk_ptr = ChunkHelper::new_chunk(partial_schema, each.second.size());
+        RETURN_IF_ERROR(_read_chunk_from_update(each.second, update_segment_iters, rowids, update_chunk_ptr.get()));
+        int64_t t3 = MonotonicMillis();
+        // 3.3 merge source chunk and update chunk
+        RETURN_IF_ERROR(source_chunk_ptr->update_rows(*update_chunk_ptr, rowids.data()));
+        // 3.4 write column to delta column file
+        int64_t t4 = MonotonicMillis();
+        uint64_t segment_file_size = 0;
+        uint64_t index_size = 0;
+        uint64_t footer_position = 0;
+        RETURN_IF_ERROR(delta_column_group_writer[each.first]->append_chunk(*source_chunk_ptr));
+        RETURN_IF_ERROR(
+                delta_column_group_writer[each.first]->finalize(&segment_file_size, &index_size, &footer_position));
+        _write_io_cnt++;
+        int64_t t5 = MonotonicMillis();
+        total_seek_source_segment_time += t2 - t1;
+        total_read_column_from_update_time += t3 - t2;
+        total_merge_column_time += t4 - t3;
+        total_finalize_dcg_time += t5 - t4;
+        _total_write_chunk_bytes += source_chunk_ptr->bytes_usage();
+        // 3.5 generate delta columngroup
+        _rssid_to_delta_column_group[each.first] = std::make_shared<DeltaColumnGroup>();
+        _rssid_to_delta_column_group[each.first]->init(version + 1, update_column_ids,
+                                                       delta_column_group_writer[each.first]->segment_path());
+    }
+    cost_str << " [generate delta column group] " << watch.elapsed_time();
+    watch.reset();
+
+    cost_str << strings::Substitute(
+            " rss_cnt/column_cnt/update_rss_cnt/write_bytes/read_bytes/write_io/read_io:$0/$1/$2/$3/$4/$5/$6", rss_cnt,
+            column_cnt, update_seg_cnt, _total_write_chunk_bytes, _total_read_chunk_bytes, _write_io_cnt, _read_io_cnt);
+    cost_str << strings::Substitute(" avg_seek_source_segment/total_seek_source_segment(ms):$0/$1",
+                                    total_seek_source_segment_time / (rss_cnt * column_cnt),
+                                    total_seek_source_segment_time);
+    cost_str << strings::Substitute(" avg_read_column_from_update/total_read_column_from_update(ms):$0/$1",
+                                    total_read_column_from_update_time / (update_seg_cnt * column_cnt),
+                                    total_read_column_from_update_time);
+    cost_str << strings::Substitute(" avg_merge_column_time/total_merge_column_time(ms):$0/$1",
+                                    total_merge_column_time / (update_seg_cnt * column_cnt), total_merge_column_time);
+    cost_str << strings::Substitute(" avg_finalize_dcg_time/total_finalize_dcg_time(ms):$0/$1",
+                                    total_finalize_dcg_time / rss_cnt, total_finalize_dcg_time);
+
+    LOG(INFO) << "RowsetColumnUpdateState status: " << cost_str.str();
+    _finalize_finished = true;
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::_init_rowset_seg_id(Tablet* tablet, int64_t version) {
+    std::vector<RowsetSharedPtr> rowsets;
+    RETURN_IF_ERROR(tablet->updates()->get_applied_rowsets(version, &rowsets, nullptr));
+    for (const auto& rs_ptr : rowsets) {
+        for (uint32_t seg_id = 0; seg_id < rs_ptr->num_segments(); seg_id++) {
+            _rssid_to_rowsetid_segid[rs_ptr->rowset_meta()->get_rowset_seg_id() + seg_id] =
+                    RowsetSegmentId{.rowset_id = rs_ptr->rowset_id(),
+                                    .rowset_seg_id = rs_ptr->rowset_meta()->get_rowset_seg_id(),
+                                    .segment_id = seg_id};
+        }
+    }
+    return Status::OK();
+}
+
+StatusOr<RowsetSegmentId> RowsetColumnUpdateState::_find_rowset_seg_id(uint32_t rssid) {
+    auto rowsetid_segid = _rssid_to_rowsetid_segid.find(rssid);
+    if (rowsetid_segid == _rssid_to_rowsetid_segid.end()) {
+        LOG(ERROR) << "prepare_segment_writer meet invalid rssid: " << rssid;
+        return Status::InternalError("prepare_segment_writer meet invalid rssid");
+    }
+    return rowsetid_segid->second;
+}
+
+std::string RowsetColumnUpdateState::to_string() const {
+    return strings::Substitute("RowsetColumnUpdateState tablet:$0", _tablet_id);
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -118,7 +118,7 @@ public:
     const std::map<uint32_t, DeltaColumnGroupPtr>& delta_column_groups() { return _rssid_to_delta_column_group; }
 
 private:
-    Status _load_upserts(Rowset* rowset, uint32_t upsert_id, Column* pk_column);
+    Status _load_upserts(Rowset* rowset, uint32_t upsert_id);
 
     Status _do_load(Tablet* tablet, Rowset* rowset);
 

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -76,6 +76,7 @@ struct ColumnPartialUpdateState {
 
     // build `rss_rowid_to_update_rowid` from `src_rss_rowids`
     void build_rss_rowid_to_update_rowid() {
+        rss_rowid_to_update_rowid.clear();
         for (uint32_t upt_id = 0; upt_id < src_rss_rowids.size(); upt_id++) {
             uint64_t each_rss_rowid = src_rss_rowids[upt_id];
             // build rssid & rowid -> update file's rowid
@@ -142,7 +143,7 @@ private:
     // find <RowsetId, segment id> by rssid
     StatusOr<RowsetSegmentId> _find_rowset_seg_id(uint32_t rssid);
     // build the map from rssid to <RowsetId, segment id>
-    Status _init_rowset_seg_id(Tablet* tablet, int64_t version);
+    Status _init_rowset_seg_id(Tablet* tablet);
 
     Status _read_chunk_from_update(const std::map<uint32_t, std::pair<uint32_t, uint32_t>>& rowid_to_update_rowid,
                                    std::vector<ChunkIteratorPtr>& update_iterators, std::vector<uint32_t>& rowids,

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "storage/olap_common.h"
+#include "storage/primary_index.h"
+#include "storage/rowset/column_iterator.h"
+#include "storage/tablet_updates.h"
+
+namespace starrocks {
+
+class Tablet;
+class DeltaColumnGroup;
+class FileSystem;
+class Segment;
+class RandomAccessFile;
+class ColumnIterator;
+
+struct RowsetSegmentId {
+    RowsetId rowset_id;
+    uint32_t rowset_seg_id;
+    uint32_t segment_id;
+};
+
+class ColumnIteratorWrapper {
+public:
+    ColumnIteratorWrapper() {}
+    ~ColumnIteratorWrapper() {}
+    ColumnIteratorWrapper(ColumnIteratorWrapper&&) = default;
+    Status create(std::shared_ptr<FileSystem> fs, const std::string& path, std::shared_ptr<Segment> segment,
+                  uint32_t cid);
+
+    ColumnIterator* operator->() const { return _column_iter.get(); }
+
+    ColumnIterator& operator*() const { return *_column_iter; }
+
+    size_t row_nums() const { return _row_nums; }
+
+private:
+    ColumnIteratorOptions _iter_opts;
+    OlapReaderStatistics _stats;
+    std::unique_ptr<RandomAccessFile> _read_file;
+    std::unique_ptr<ColumnIterator> _column_iter;
+    std::shared_ptr<Segment> _segment;
+    size_t _row_nums = 0;
+};
+
+struct ColumnPartialUpdateState {
+    // Maintains the mapping of each row of data in the update segment to source row
+    std::vector<uint64_t> src_rss_rowids;
+    bool inited = false;
+    EditVersion read_version;
+    // Maintains the mapping of source row to update segment's row
+    std::map<uint64_t, uint32_t> rss_rowid_to_update_rowid;
+
+    void release() {
+        src_rss_rowids.clear();
+        rss_rowid_to_update_rowid.clear();
+        inited = false;
+    }
+
+    // build `rss_rowid_to_update_rowid` from `src_rss_rowids`
+    void build_rss_rowid_to_update_rowid() {
+        for (uint32_t upt_id = 0; upt_id < src_rss_rowids.size(); upt_id++) {
+            uint64_t each_rss_rowid = src_rss_rowids[upt_id];
+            // build rssid & rowid -> update file's rowid
+            // each_rss_rowid == UINT64_MAX means that key not exist in pk index
+            if (each_rss_rowid < UINT64_MAX) {
+                rss_rowid_to_update_rowid[each_rss_rowid] = upt_id;
+            }
+        }
+    }
+};
+
+class RowsetColumnUpdateState {
+public:
+    using ColumnUniquePtr = std::unique_ptr<Column>;
+    using DeltaColumnGroupPtr = std::shared_ptr<DeltaColumnGroup>;
+
+    RowsetColumnUpdateState();
+    ~RowsetColumnUpdateState();
+
+    RowsetColumnUpdateState(const RowsetColumnUpdateState&) = delete;
+    const RowsetColumnUpdateState& operator=(const RowsetColumnUpdateState&) = delete;
+
+    Status load(Tablet* tablet, Rowset* rowset);
+
+    Status finalize_partial_update_state(Tablet* tablet, Rowset* rowset, uint32_t rowset_id,
+                                         EditVersion latest_applied_version, const PrimaryIndex& index);
+
+    // Generate delta columns by partial update states and rowset,
+    // And distribute partial update column data to different `.col` files
+    Status finalize(Rowset* rowset, Tablet* tablet, int64_t version);
+
+    const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
+
+    std::size_t memory_usage() const { return _memory_usage; }
+
+    std::string to_string() const;
+
+    const std::vector<ColumnPartialUpdateState>& parital_update_states() { return _partial_update_states; }
+
+    const std::map<uint32_t, DeltaColumnGroupPtr>& delta_column_groups() { return _rssid_to_delta_column_group; }
+
+private:
+    Status _load_upserts(Rowset* rowset, uint32_t upsert_id, Column* pk_column);
+
+    Status _do_load(Tablet* tablet, Rowset* rowset);
+
+    Status _check_and_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t segment_id,
+                                       EditVersion latest_applied_version, const PrimaryIndex& index);
+
+    StatusOr<std::unique_ptr<SegmentWriter>> _prepare_delta_column_group_writer(Rowset* rowset,
+                                                                                std::shared_ptr<TabletSchema> tschema,
+                                                                                uint32_t rssid, int64_t ver);
+
+    // to build `_partial_update_states`
+    Status _prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx, bool need_lock);
+
+    // rebuild src_rss_rowids and rss_rowid_to_update_rowid
+    Status _resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t segment_id,
+                             EditVersion latest_applied_version, const PrimaryIndex& index);
+
+    /// To reduce memory usage in primary index, we use 32-bit rssid as value.
+    /// But we use <RowsetId, segment id> to spell out segment file names,
+    /// so we need `_find_rowset_seg_id` and `_init_rowset_seg_id` to build this connection between them.
+    // find <RowsetId, segment id> by rssid
+    StatusOr<RowsetSegmentId> _find_rowset_seg_id(uint32_t rssid);
+    // build the map from rssid to <RowsetId, segment id>
+    Status _init_rowset_seg_id(Tablet* tablet, int64_t version);
+
+    Status _read_chunk_from_update(const std::map<uint32_t, std::pair<uint32_t, uint32_t>>& rowid_to_update_rowid,
+                                   std::vector<ChunkIteratorPtr>& update_iterators, std::vector<uint32_t>& rowids,
+                                   Chunk* result_chunk);
+
+private:
+    std::once_flag _load_once_flag;
+    Status _status;
+    // it contains primary key seriable column for each update segment file
+    std::vector<ColumnUniquePtr> _upserts;
+    // cache chunks read from update segment files
+    std::vector<ChunkPtr> _update_chunk_cache;
+
+    size_t _memory_usage = 0;
+    int64_t _tablet_id = 0;
+
+    std::vector<ColumnPartialUpdateState> _partial_update_states;
+
+    // maintain from rssid to rowsetid & segid
+    std::map<uint32_t, RowsetSegmentId> _rssid_to_rowsetid_segid;
+
+    // when generate delta column group finish, these fields will be filled
+    bool _finalize_finished = false;
+    std::map<uint32_t, DeltaColumnGroupPtr> _rssid_to_delta_column_group;
+
+    // stats, only used for performence debug, remove later
+    int64_t _total_write_chunk_bytes = 0;
+    int64_t _total_read_chunk_bytes = 0;
+    int64_t _write_io_cnt = 0;
+    int64_t _read_io_cnt = 0;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const RowsetColumnUpdateState& o) {
+    os << o.to_string();
+    return os;
+}
+
+} // namespace starrocks

--- a/be/src/storage/seek_tuple.h
+++ b/be/src/storage/seek_tuple.h
@@ -34,7 +34,7 @@ public:
         if (_schema.sort_key_idxes().empty()) {
             // Ensure the columns are continuous and started from zero.
             for (size_t i = 0; i < _schema.num_fields(); i++) {
-                CHECK_EQ(ColumnId(i), _schema.field(i)->id());
+                //CHECK_EQ(ColumnId(i), _schema.field(i)->id());
             }
         }
 #endif

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -599,6 +599,9 @@ Status SnapshotManager::make_snapshot_on_tablet_meta(SnapshotTypePB snapshot_typ
                 DelVector* delvec = &snapshot_meta.delete_vectors()[new_segment_id];
                 RETURN_IF_ERROR(TabletMetaManager::get_del_vector(meta_store, tablet->tablet_id(), old_segment_id,
                                                                   snapshot_version, delvec, &dummy /*latest_version*/));
+                DeltaColumnGroupList* dcg = &snapshot_meta.delta_column_groups()[new_segment_id];
+                RETURN_IF_ERROR(TabletMetaManager::get_delta_column_group(meta_store, tablet->tablet_id(),
+                                                                          old_segment_id, snapshot_version, *dcg));
             }
             rowset_meta_pb.set_rowset_seg_id(new_rsid);
             new_rsid += std::max<uint32_t>(rowset_meta_pb.num_segments(), 1);
@@ -658,6 +661,11 @@ Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const 
         for (int del_id = 0; del_id < rowset_meta_pb.num_delete_files(); del_id++) {
             auto old_path = Rowset::segment_del_file_path(clone_dir, old_rowset_id, del_id);
             auto new_path = Rowset::segment_del_file_path(clone_dir, new_rowset_id, del_id);
+            RETURN_IF_ERROR(FileSystem::Default()->link_file(old_path, new_path));
+        }
+        for (int upt_id = 0; upt_id < rowset_meta_pb.num_update_files(); upt_id++) {
+            auto old_path = Rowset::segment_upt_file_path(clone_dir, old_rowset_id, upt_id);
+            auto new_path = Rowset::segment_upt_file_path(clone_dir, new_rowset_id, upt_id);
             RETURN_IF_ERROR(FileSystem::Default()->link_file(old_path, new_path));
         }
         rowset_meta_pb.set_rowset_id(new_rowset_id.to_string());

--- a/be/src/storage/snapshot_meta.cpp
+++ b/be/src/storage/snapshot_meta.cpp
@@ -40,6 +40,8 @@ Status SnapshotMeta::serialize_to_file(const std::string& file_path) {
 // +-------------------------------------+
 // |      Serialized delete vector       |
 // +-------------------------------------+
+// |      Serialized delta column group  |
+// +-------------------------------------+
 // |             ......                  |
 // +-------------------------------------+
 // |      Serialized tablet meta         |  variant length
@@ -79,6 +81,16 @@ Status SnapshotMeta::serialize_to_file(WritableFile* file) {
     footer.add_delvec_segids(-1);
     footer.add_delvec_versions(-1);
 
+    for (const auto& [segment_id, dcg] : _dcgs) {
+        footer.add_dcg_segids(segment_id);
+        footer.add_dcg_offsets(static_cast<int64_t>(stream.size()));
+        auto st = stream.append(DeltaColumnGroupListSerializer::serialize_delta_column_group_list(dcg));
+        LOG_IF(WARNING, !st.ok()) << "Fail to save delta column group: " << st;
+        RETURN_IF_ERROR(st);
+    }
+    footer.add_dcg_offsets(static_cast<int64_t>(stream.size()));
+    footer.add_dcg_segids(-1);
+
     footer.set_tablet_meta_offset(static_cast<int64_t>(stream.size()));
     if (!_tablet_meta.SerializeToOstream(&stream)) {
         return Status::IOError("fail to serialize tablet meta to file");
@@ -94,6 +106,60 @@ Status SnapshotMeta::serialize_to_file(WritableFile* file) {
     put_fixed64_le(&s, BigEndian::FromHost64(stream.size() + 16));
     DCHECK_EQ(16, s.size());
     RETURN_IF_ERROR(stream.append(s));
+    return Status::OK();
+}
+
+Status SnapshotMeta::_parse_delvec(SnapshotMetaFooterPB& footer, RandomAccessFile* file, int num_segments) {
+    if (footer.delvec_offsets_size() <= 0) {
+        return Status::InternalError("empty delete vector list");
+    }
+    if (footer.delvec_offsets_size() != footer.delvec_segids_size()) {
+        return Status::InternalError("mismatched delete vector size and segment id size");
+    }
+    if (footer.delvec_offsets_size() != footer.delvec_versions_size()) {
+        return Status::InternalError("mismatched delete vector size and version size");
+    }
+    std::string buff;
+    const int num_delvecs = footer.delvec_offsets_size() - 1;
+    for (int i = 0; i < num_delvecs; i++) {
+        auto segment_id = footer.delvec_segids(i);
+        auto version = footer.delvec_versions(i);
+        auto start = footer.delvec_offsets(i);
+        auto end = footer.delvec_offsets(i + 1);
+        raw::stl_string_resize_uninitialized(&buff, end - start);
+        RETURN_IF_ERROR(file->read_at_fully(start, buff.data(), buff.size()));
+        DelVector delvec;
+        RETURN_IF_ERROR(delvec.load(version, buff.data(), buff.size()));
+        (void)_delete_vectors.emplace(static_cast<uint32_t>(segment_id), std::move(delvec));
+    }
+    if (_delete_vectors.size() != num_delvecs) {
+        return Status::InternalError("has duplicate segment id of delete vector");
+    }
+    if (_snapshot_type == SNAPSHOT_TYPE_FULL && num_segments != num_delvecs) {
+        return Status::InternalError("#segment mismatch #delvec");
+    }
+    return Status::OK();
+}
+
+Status SnapshotMeta::_parse_delta_column_group(SnapshotMetaFooterPB& footer, RandomAccessFile* file) {
+    if (footer.dcg_offsets_size() != footer.dcg_segids_size()) {
+        return Status::InternalError("mismatched delta column group size and segment id size");
+    }
+    // Parse delta column group
+    std::string buff;
+    const int num_dcglists = footer.dcg_offsets_size() - 1;
+    for (int i = 0; i < num_dcglists; i++) {
+        auto segment_id = footer.dcg_segids(i);
+        auto start = footer.dcg_offsets(i);
+        auto end = footer.dcg_offsets(i + 1);
+        raw::stl_string_resize_uninitialized(&buff, end - start);
+        RETURN_IF_ERROR(file->read_at_fully(start, buff.data(), buff.size()));
+        RETURN_IF_ERROR(DeltaColumnGroupListSerializer::deserialize_delta_column_group_list(
+                buff.data(), buff.size(), _dcgs[static_cast<uint32_t>(segment_id)]));
+    }
+    if (_dcgs.size() != num_dcglists) {
+        return Status::InternalError("has duplicate segment id of delta column group");
+    }
     return Status::OK();
 }
 
@@ -122,17 +188,8 @@ Status SnapshotMeta::parse_from_file(RandomAccessFile* file) {
     if (!footer.ParseFromString(buff)) {
         return Status::Corruption("parse snapshot meta footer failed");
     }
-    if (footer.delvec_offsets_size() <= 0) {
-        return Status::InternalError("empty delete vector list");
-    }
     if (footer.rowset_meta_offsets_size() <= 0) {
         return Status::InternalError("empty rowset meta list");
-    }
-    if (footer.delvec_offsets_size() != footer.delvec_segids_size()) {
-        return Status::InternalError("mismatched delete vector size and segment id size");
-    }
-    if (footer.delvec_offsets_size() != footer.delvec_versions_size()) {
-        return Status::InternalError("mismatched delete vector size and version size");
     }
     if (!footer.has_tablet_meta_offset()) {
         return Status::InternalError("no tablet meta");
@@ -165,24 +222,9 @@ Status SnapshotMeta::parse_from_file(RandomAccessFile* file) {
         num_segments += static_cast<int>(_rowset_metas[i].num_segments());
     }
     // Parse delete vector
-    const int num_delvecs = footer.delvec_offsets_size() - 1;
-    for (int i = 0; i < num_delvecs; i++) {
-        auto segment_id = footer.delvec_segids(i);
-        auto version = footer.delvec_versions(i);
-        auto start = footer.delvec_offsets(i);
-        auto end = footer.delvec_offsets(i + 1);
-        raw::stl_string_resize_uninitialized(&buff, end - start);
-        RETURN_IF_ERROR(file->read_at_fully(start, buff.data(), buff.size()));
-        DelVector delvec;
-        RETURN_IF_ERROR(delvec.load(version, buff.data(), buff.size()));
-        (void)_delete_vectors.emplace(static_cast<uint32_t>(segment_id), std::move(delvec));
-    }
-    if (_delete_vectors.size() != num_delvecs) {
-        return Status::InternalError("has duplicate segment id of delete vector");
-    }
-    if (_snapshot_type == SNAPSHOT_TYPE_FULL && num_segments != num_delvecs) {
-        return Status::InternalError("#segment mismatch #delvec");
-    }
+    RETURN_IF_ERROR(_parse_delvec(footer, file, num_segments));
+    // Parse delta column group
+    RETURN_IF_ERROR(_parse_delta_column_group(footer, file));
     // Tablet meta
     auto tablet_meta_offset = footer.tablet_meta_offset();
     raw::stl_string_resize_uninitialized(&buff, footer_offset - tablet_meta_offset);

--- a/be/src/storage/snapshot_meta.h
+++ b/be/src/storage/snapshot_meta.h
@@ -22,6 +22,7 @@
 #include "gen_cpp/olap_file.pb.h"
 #include "gen_cpp/snapshot.pb.h"
 #include "storage/del_vector.h"
+#include "storage/delta_column_group.h"
 
 namespace starrocks {
 
@@ -59,6 +60,14 @@ public:
 
     const std::unordered_map<uint32_t, DelVector>& delete_vectors() const { return _delete_vectors; }
 
+    std::unordered_map<uint32_t, DeltaColumnGroupList>& delta_column_groups() { return _dcgs; }
+
+    const std::unordered_map<uint32_t, DeltaColumnGroupList>& delta_column_groups() const { return _dcgs; }
+
+private:
+    Status _parse_delta_column_group(SnapshotMetaFooterPB& footer, RandomAccessFile* file);
+    Status _parse_delvec(SnapshotMetaFooterPB& footer, RandomAccessFile* file, int num_segments);
+
 private:
     SnapshotTypePB _snapshot_type = SNAPSHOT_TYPE_UNKNOWN;
     int32_t _format_version = -1 /* default invalid value*/;
@@ -66,6 +75,7 @@ private:
     TabletMetaPB _tablet_meta; // only valid in full snapshot mode, will empty in incremental snapshot mode
     std::vector<RowsetMetaPB> _rowset_metas;
     std::unordered_map<uint32_t, DelVector> _delete_vectors;
+    std::unordered_map<uint32_t, DeltaColumnGroupList> _dcgs;
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1494,6 +1494,7 @@ Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId
         LOG(WARNING) << "Fail to init cloned tablet " << tablet_id << ", try to clear meta store";
         wb.Clear();
         RETURN_IF_ERROR(TabletMetaManager::clear_del_vector(store, &wb, tablet_id));
+        RETURN_IF_ERROR(TabletMetaManager::clear_delta_column_group(store, &wb, tablet_id));
         RETURN_IF_ERROR(TabletMetaManager::clear_rowset(store, &wb, tablet_id));
         RETURN_IF_ERROR(TabletMetaManager::clear_log(store, &wb, tablet_id));
         RETURN_IF_ERROR(TabletMetaManager::remove_tablet_meta(store, &wb, tablet_id, schema_hash));

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -52,6 +52,7 @@
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/substitute.h"
 #include "storage/del_vector.h"
+#include "storage/delta_column_group.h"
 #include "storage/kv_store.h"
 #include "storage/olap_define.h"
 #include "storage/rocksdb_status_adapter.h"
@@ -70,6 +71,7 @@ static const std::string TABLET_META_ROWSET_PREFIX = "trs_";
 static const std::string TABLET_META_PENDING_ROWSET_PREFIX = "tpr_";
 static const std::string TABLET_DELVEC_PREFIX = "dlv_";
 static const std::string TABLET_PERSISTENT_INDEX_META_PREFIX = "tpi_";
+static const std::string TABLET_DELTA_COLUMN_GROUP_PREFIX = "dcg_";
 
 static string encode_meta_log_key(TTabletId id, uint64_t logid);
 static bool decode_meta_log_key(std::string_view key, TTabletId* id, uint64_t* logid);
@@ -81,6 +83,9 @@ std::string encode_del_vector_key(TTabletId tablet_id, uint32_t segment_id, int6
 void decode_del_vector_key(std::string_view enc_key, TTabletId* tablet_id, uint32_t* segment_id, int64_t* version);
 std::string encode_persistent_index_key(TTabletId tablet_id);
 void decode_persistent_index_key(std::string_view enc_key, TTabletId* tablet_id);
+std::string encode_delta_column_group_key(TTabletId tablet_id, uint32_t segment_id, int64_t version);
+void decode_delta_column_group_key(std::string_view enc_key, TTabletId* tablet_id, uint32_t* segment_id,
+                                   int64_t* version);
 
 static std::string encode_tablet_meta_key(TTabletId tablet_id, TSchemaHash schema_hash) {
     return strings::Substitute("$0$1_$2", HEADER_PREFIX, tablet_id, schema_hash);
@@ -474,6 +479,9 @@ Status TabletMetaManager::build_primary_meta(DataDir* store, rapidjson::Document
     if (!clear_del_vector(store, &batch, tablet_id).ok()) {
         return Status::IOError("clear delvec add to batch failed");
     }
+    if (!clear_delta_column_group(store, &batch, tablet_id).ok()) {
+        return Status::IOError("clear dcg add to batch failed");
+    }
     if (!clear_rowset(store, &batch, tablet_id).ok()) {
         return Status::IOError("clear rowset add to batch failed");
     }
@@ -694,6 +702,27 @@ int64_t decode_del_vector_key_version(std::string_view key) {
     return std::numeric_limits<int64_t>::max() - BigEndian::ToHost64(v);
 }
 
+std::string encode_delta_column_group_key(TTabletId tablet_id, uint32_t segment_id, int64_t version) {
+    std::string key;
+    key.reserve(24);
+    key.append(TABLET_DELTA_COLUMN_GROUP_PREFIX);
+    put_fixed64_le(&key, BigEndian::FromHost64(tablet_id));
+    put_fixed32_le(&key, BigEndian::FromHost32(segment_id));
+    // If a segment attached with multiple delta column group, make them
+    // sorted by version in reverse order in RocksDB.
+    int64_t v = std::numeric_limits<int64_t>::max() - version;
+    put_fixed64_le(&key, BigEndian::FromHost64(v));
+    return key;
+}
+
+void decode_delta_column_group_key(std::string_view enc_key, TTabletId* tablet_id, uint32_t* segment_id,
+                                   int64_t* version) {
+    DCHECK_EQ(4 + sizeof(TTabletId) + sizeof(uint32_t) + sizeof(int64_t), enc_key.size());
+    *tablet_id = BigEndian::ToHost64(UNALIGNED_LOAD64(enc_key.data() + 4));
+    *segment_id = BigEndian::ToHost32(UNALIGNED_LOAD32(enc_key.data() + 12));
+    *version = INT64_MAX - BigEndian::ToHost64(UNALIGNED_LOAD64(enc_key.data() + 16));
+}
+
 Status TabletMetaManager::rowset_commit(DataDir* store, TTabletId tablet_id, int64_t logid, EditVersionMetaPB* edit,
                                         const RowsetMetaPB& rowset, const string& rowset_meta_key) {
     WriteBatch batch;
@@ -843,6 +872,59 @@ Status TabletMetaManager::apply_rowset_commit(DataDir* store, TTabletId tablet_i
     return store->get_meta()->write_batch(&batch);
 }
 
+// used in column mode partial update
+Status TabletMetaManager::apply_rowset_commit(DataDir* store, TTabletId tablet_id, int64_t logid,
+                                              const EditVersion& version,
+                                              const std::map<uint32_t, DeltaColumnGroupPtr>& delta_column_groups,
+                                              const starrocks::RowsetMetaPB* rowset_meta) {
+    auto span = Tracer::Instance().start_trace_tablet("apply_save_meta", tablet_id);
+    span->SetAttribute("version", version.to_string());
+    WriteBatch batch;
+    auto handle = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
+    string logkey = encode_meta_log_key(tablet_id, logid);
+    TabletMetaLogPB log;
+    auto ops = log.add_ops();
+    ops->set_type(TabletMetaOpType::OP_APPLY);
+    auto version_pb = ops->mutable_apply();
+    version_pb->set_major(version.major());
+    version_pb->set_minor(version.minor());
+    auto logval = log.SerializeAsString();
+    rocksdb::Status st = batch.Put(handle, logkey, logval);
+    if (!st.ok()) {
+        LOG(WARNING) << "rowset_commit failed, rocksdb.batch.put failed";
+        return to_status(st);
+    }
+    TabletSegmentId tsid;
+    tsid.tablet_id = tablet_id;
+    span->AddEvent("delta_column_group_start");
+    int64_t total_bytes = 0;
+    for (const auto& delta_column : delta_column_groups) {
+        tsid.segment_id = delta_column.first;
+        auto dcg_key = encode_delta_column_group_key(tsid.tablet_id, tsid.segment_id, version.major());
+        auto dcg_value = delta_column.second->save();
+        total_bytes += dcg_value.size();
+        st = batch.Put(handle, dcg_key, dcg_value);
+        if (!st.ok()) {
+            LOG(WARNING) << "rowset_commit failed, rocksdb.batch.put failed";
+            return to_status(st);
+        }
+    }
+    span->SetAttribute("delta_column_group_bytes", total_bytes);
+    span->AddEvent("delta_column_group_end");
+
+    if (rowset_meta != nullptr) {
+        string rowset_key = encode_meta_rowset_key(tablet_id, rowset_meta->rowset_seg_id());
+        auto rowset_value = rowset_meta->SerializeAsString();
+        st = batch.Put(handle, rowset_key, rowset_value);
+        if (!st.ok()) {
+            LOG(WARNING) << "rowset_commit failed, rocksdb.batch.put failed";
+            return to_status(st);
+        }
+    }
+
+    return store->get_meta()->write_batch(&batch);
+}
+
 Status TabletMetaManager::traverse_meta_logs(DataDir* store, TTabletId tablet_id,
                                              const std::function<bool(uint64_t, const TabletMetaLogPB&)>& func) {
     Status ret;
@@ -908,8 +990,10 @@ Status TabletMetaManager::get_del_vector(KVStore* meta, TTabletId tablet_id, uin
         return st;
     }
     if (!found) {
-        return Status::NotFound(strings::Substitute("no delete vector found tablet:$0 segment:$1 version:$2", tablet_id,
-                                                    segment_id, version));
+        *latest_version = 1;
+        delvec->set_empty();
+        //return Status::NotFound(strings::Substitute("no delete vector found tablet:$0 segment:$1 version:$2", tablet_id,
+        //                                            segment_id, version));
     }
     VLOG(3) << strings::Substitute("get_del_vec in-meta tablet_id=$0 segment_id=$1 version=$2 actual_version=$3",
                                    tablet_id, segment_id, version, delvec ? delvec->version() : -1);
@@ -1018,6 +1102,48 @@ Status TabletMetaManager::delete_del_vector_range(KVStore* meta, TTabletId table
     return meta->write_batch(&batch);
 }
 
+Status TabletMetaManager::get_delta_column_group(KVStore* meta, TTabletId tablet_id, uint32_t segment_id,
+                                                 int64_t version, DeltaColumnGroupList& dcgs) {
+    return scan_delta_column_group(meta, tablet_id, segment_id, 0, version, dcgs);
+}
+
+Status TabletMetaManager::scan_delta_column_group(KVStore* meta, TTabletId tablet_id, uint32_t segment_id,
+                                                  int64_t begin_version, int64_t end_version,
+                                                  DeltaColumnGroupList& dcgs) {
+    std::string lower = encode_delta_column_group_key(tablet_id, segment_id, end_version);
+    std::string upper = encode_delta_column_group_key(tablet_id, segment_id, begin_version);
+    auto st = meta->iterate_range(META_COLUMN_FAMILY_INDEX, lower, upper,
+                                  [&](std::string_view key, std::string_view value) -> bool {
+                                      TTabletId dummy;
+                                      uint32_t dummy_segment_id;
+                                      int64_t decode_version;
+                                      decode_delta_column_group_key(key, &dummy, &dummy_segment_id, &decode_version);
+                                      CHECK(segment_id == dummy_segment_id);
+                                      DeltaColumnGroupPtr dcg_ptr = std::make_shared<DeltaColumnGroup>();
+                                      CHECK(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
+                                      dcgs.push_back(std::move(dcg_ptr));
+                                      return true;
+                                  });
+    if (!st.ok()) {
+        LOG(WARNING) << "fail to iterate rocksdb delvecs. tablet_id=" << tablet_id;
+        return st;
+    }
+    return Status::OK();
+}
+
+Status TabletMetaManager::delete_delta_column_group(KVStore* meta, TTabletId tablet_id, uint32_t rowset_id,
+                                                    uint32_t segments) {
+    std::string lower = encode_delta_column_group_key(tablet_id, rowset_id, INT64_MAX);
+    std::string upper = encode_delta_column_group_key(tablet_id, rowset_id + segments, INT64_MAX);
+    auto h = meta->handle(META_COLUMN_FAMILY_INDEX);
+    WriteBatch batch;
+    rocksdb::Status st = batch.DeleteRange(h, lower, upper);
+    if (!st.ok()) {
+        return to_status(st);
+    }
+    return meta->write_batch(&batch);
+}
+
 Status TabletMetaManager::put_rowset_meta(DataDir* store, WriteBatch* batch, TTabletId tablet_id,
                                           const RowsetMetaPB& rowset_meta) {
     auto h = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
@@ -1032,6 +1158,17 @@ Status TabletMetaManager::put_del_vector(DataDir* store, WriteBatch* batch, TTab
     auto v = delvec.save();
     auto h = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
     return to_status(batch->Put(h, k, v));
+}
+
+Status TabletMetaManager::put_delta_column_group(DataDir* store, WriteBatch* batch, TTabletId tablet_id,
+                                                 uint32_t segment_id, const DeltaColumnGroupList& dcgs) {
+    for (const auto& dcg : dcgs) {
+        auto k = encode_delta_column_group_key(tablet_id, segment_id, dcg->version());
+        auto v = dcg->save();
+        auto h = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
+        RETURN_IF_ERROR(to_status(batch->Put(h, k, v)));
+    }
+    return Status::OK();
 }
 
 Status TabletMetaManager::put_tablet_meta(DataDir* store, WriteBatch* batch, const TabletMetaPB& meta) {
@@ -1058,6 +1195,13 @@ Status TabletMetaManager::clear_log(DataDir* store, WriteBatch* batch, TTabletId
 Status TabletMetaManager::clear_del_vector(DataDir* store, WriteBatch* batch, TTabletId tablet_id) {
     auto lower = encode_del_vector_key(tablet_id, 0, INT64_MAX);
     auto upper = encode_del_vector_key(tablet_id, UINT32_MAX, INT64_MAX);
+    auto h = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
+    return to_status(batch->DeleteRange(h, lower, upper));
+}
+
+Status TabletMetaManager::clear_delta_column_group(DataDir* store, WriteBatch* batch, TTabletId tablet_id) {
+    auto lower = encode_delta_column_group_key(tablet_id, 0, INT64_MAX);
+    auto upper = encode_delta_column_group_key(tablet_id, UINT32_MAX, INT64_MAX);
     auto h = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
     return to_status(batch->DeleteRange(h, lower, upper));
 }
@@ -1235,6 +1379,9 @@ Status TabletMetaManager::remove_primary_key_meta(DataDir* store, WriteBatch* ba
     }
     if (!clear_del_vector(store, batch, tablet_id).ok()) {
         LOG(WARNING) << "clear delvec add to batch failed";
+    }
+    if (!clear_delta_column_group(store, batch, tablet_id).ok()) {
+        LOG(WARNING) << "clear dcg add to batch failed";
     }
     if (!clear_rowset(store, batch, tablet_id).ok()) {
         LOG(WARNING) << "clear rowset add to batch failed";

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -41,6 +41,7 @@
 #include "common/compiler_util.h"
 #include "gen_cpp/persistent_index.pb.h"
 #include "storage/data_dir.h"
+#include "storage/delta_column_group.h"
 #include "storage/kv_store.h"
 #include "storage/olap_define.h"
 #include "storage/tablet_meta.h"
@@ -157,6 +158,11 @@ public:
                                       const PersistentIndexMetaPB& index_meta, bool enable_persistent_index,
                                       const starrocks::RowsetMetaPB* rowset_meta);
 
+    // used in column mode partial update
+    static Status apply_rowset_commit(DataDir* store, TTabletId tablet_id, int64_t logid, const EditVersion& version,
+                                      const std::map<uint32_t, DeltaColumnGroupPtr>& delta_column_groups,
+                                      const starrocks::RowsetMetaPB* rowset_meta);
+
     // traverse all the op logs for a tablet
     static Status traverse_meta_logs(DataDir* store, TTabletId tablet_id,
                                      const std::function<bool(uint64_t, const TabletMetaLogPB&)>& func);
@@ -172,6 +178,14 @@ public:
     using DeleteVectorList = std::vector<std::pair<uint32_t, int64_t>>;
 
     static StatusOr<DeleteVectorList> list_del_vector(KVStore* meta, TTabletId tablet_id, int64_t max_version);
+
+    static Status get_delta_column_group(KVStore* meta, TTabletId tablet_id, uint32_t segment_id, int64_t version,
+                                         DeltaColumnGroupList& dcgs);
+
+    static Status scan_delta_column_group(KVStore* meta, TTabletId tablet_id, uint32_t segment_id,
+                                          int64_t begin_version, int64_t end_version, DeltaColumnGroupList& dcgs);
+
+    static Status delete_delta_column_group(KVStore* meta, TTabletId tablet_id, uint32_t rowset_id, uint32_t segments);
 
     // delete all delete vectors of a tablet not useful anymore for query version < `version`, for example
     // suppose we have delete vectors of version 1, 3, 5, 6, 7, 12, 16
@@ -189,6 +203,9 @@ public:
     static Status put_del_vector(DataDir* store, WriteBatch* batch, TTabletId tablet_id, uint32_t segment_id,
                                  const DelVector& delvec);
 
+    static Status put_delta_column_group(DataDir* store, WriteBatch* batch, TTabletId tablet_id, uint32_t segment_id,
+                                         const DeltaColumnGroupList& dcgs);
+
     static Status put_tablet_meta(DataDir* store, WriteBatch* batch, const TabletMetaPB& tablet_meta);
 
     static Status delete_pending_rowset(DataDir* store, WriteBatch* batch, TTabletId tablet_id, int64_t version);
@@ -203,6 +220,8 @@ public:
     static Status clear_log(DataDir* store, WriteBatch* batch, TTabletId tablet_id);
 
     static Status clear_del_vector(DataDir* store, WriteBatch* batch, TTabletId tablet_id);
+
+    static Status clear_delta_column_group(DataDir* store, WriteBatch* batch, TTabletId tablet_id);
 
     static Status clear_persistent_index(DataDir* store, WriteBatch* batch, TTabletId tablet_id);
 

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -301,9 +301,21 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchema& tablet_sc
                                                    const std::vector<uint32_t>& column_indexes) {
     std::vector<int32_t> column_indexes2;
     for (uint32_t ci : column_indexes) {
-        column_indexes2.push_back((int)ci);
+        column_indexes2.push_back((int32_t)ci);
     }
     return TabletSchema::create(tablet_schema, column_indexes2);
+}
+
+std::shared_ptr<TabletSchema> TabletSchema::create_with_uid(const TabletSchema& tablet_schema,
+                                                            const std::vector<uint32_t>& unique_column_ids) {
+    std::unordered_set<int32_t> unique_cid_filter(unique_column_ids.begin(), unique_column_ids.end());
+    std::vector<int32_t> column_indexes;
+    for (int cid = 0; cid < tablet_schema.columns().size(); cid++) {
+        if (unique_cid_filter.count(tablet_schema.column(cid).unique_id()) > 0) {
+            column_indexes.push_back(cid);
+        }
+    }
+    return TabletSchema::create(tablet_schema, column_indexes);
 }
 
 void TabletSchema::_init_schema() const {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -297,6 +297,15 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchema& src_table
     return std::make_shared<TabletSchema>(partial_tablet_schema_pb);
 }
 
+std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchema& tablet_schema,
+                                                   const std::vector<uint32_t>& column_indexes) {
+    std::vector<int32_t> column_indexes2;
+    for (uint32_t ci : column_indexes) {
+        column_indexes2.push_back((int)ci);
+    }
+    return TabletSchema::create(tablet_schema, column_indexes2);
+}
+
 void TabletSchema::_init_schema() const {
     starrocks::Fields fields;
     for (ColumnId cid = 0; cid < num_columns(); ++cid) {

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -224,6 +224,8 @@ public:
                                                 const std::vector<int32_t>& column_indexes);
     static std::shared_ptr<TabletSchema> create(const TabletSchema& tablet_schema,
                                                 const std::vector<uint32_t>& column_indexes);
+    static std::shared_ptr<TabletSchema> create_with_uid(const TabletSchema& tablet_schema,
+                                                         const std::vector<uint32_t>& unique_column_ids);
 
     // Must be consistent with MaterializedIndexMeta.INVALID_SCHEMA_ID defined in
     // file ./fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -222,6 +222,8 @@ public:
     static std::shared_ptr<TabletSchema> create(const TabletSchemaPB& schema_pb, TabletSchemaMap* schema_map);
     static std::shared_ptr<TabletSchema> create(const TabletSchema& tablet_schema,
                                                 const std::vector<int32_t>& column_indexes);
+    static std::shared_ptr<TabletSchema> create(const TabletSchema& tablet_schema,
+                                                const std::vector<uint32_t>& column_indexes);
 
     // Must be consistent with MaterializedIndexMeta.INVALID_SCHEMA_ID defined in
     // file ./fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -259,6 +259,9 @@ public:
 
     void get_basic_info_extra(TabletBasicInfo& info);
 
+    Status get_apply_version_and_rowsets(int64_t* version, std::vector<RowsetSharedPtr>* rowsets,
+                                         std::vector<uint32_t>* rowset_ids);
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -286,10 +289,6 @@ private:
         int64_t compaction_score = 0;
         std::string to_string() const;
     };
-
-    // used for PrimaryIndex load
-    Status _get_apply_version_and_rowsets(int64_t* version, std::vector<RowsetSharedPtr>* rowsets,
-                                          std::vector<uint32_t>* rowset_ids);
 
     void _redo_edit_version_log(const EditVersionMetaPB& v);
 
@@ -365,7 +364,7 @@ private:
 
     void _check_creation_time_increasing();
 
-    Status _check_conflict_with_partial_update(CompactionInfo* info, int64_t output_version);
+    Status _check_conflict_with_partial_update(CompactionInfo* info);
 
     // these functions is only used in ut
     void stop_apply(bool apply_stopped) { _apply_stopped = apply_stopped; }

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -307,6 +307,11 @@ private:
 
     void _apply_rowset_commit(const EditVersionInfo& version_info);
 
+    // used for normal update or row-mode partial update
+    void _apply_normal_rowset_commit(const EditVersionInfo& version_info, RowsetSharedPtr rowset);
+    // used for column-mode partial update
+    void _apply_column_partial_update_commit(const EditVersionInfo& version_info, RowsetSharedPtr rowset);
+
     void _apply_compaction_commit(const EditVersionInfo& version_info);
 
     RowsetSharedPtr _get_rowset(uint32_t rowset_id);
@@ -359,6 +364,8 @@ private:
                                      const std::unique_ptr<RowsetWriter>& rowset_writer);
 
     void _check_creation_time_increasing();
+
+    Status _check_conflict_with_partial_update(CompactionInfo* info, int64_t output_version);
 
     // these functions is only used in ut
     void stop_apply(bool apply_stopped) { _apply_stopped = apply_stopped; }

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -100,6 +100,8 @@ public:
 
     void clear_cached_del_vec(const std::vector<TabletSegmentId>& tsids);
 
+    void clear_cached_delta_column_group(const std::vector<TabletSegmentId>& tsids);
+
     void expire_cache();
 
     MemTracker* mem_tracker() const { return _update_mem_tracker; }
@@ -131,6 +133,11 @@ private:
     std::mutex _del_vec_cache_lock;
     std::unordered_map<TabletSegmentId, DelVectorPtr> _del_vec_cache;
     std::unique_ptr<MemTracker> _del_vec_cache_mem_tracker;
+
+    // Delta Column Group cache, dcg is short for `Delta Column Group`
+    std::mutex _delta_column_group_cache_lock;
+    std::unordered_map<TabletSegmentId, DeltaColumnGroupList> _delta_column_group_cache;
+    std::unique_ptr<MemTracker> _delta_column_group_cache_mem_tracker;
 
     std::unique_ptr<ThreadPool> _apply_thread_pool;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -166,6 +166,7 @@ set(EXEC_FILES
         ./storage/utils_test.cpp
         ./storage/del_vector_test.cpp
         ./storage/delete_handler_test.cpp
+        ./storage/delta_column_group_test.cpp
         ./storage/file_utils_test.cpp
         ./storage/tablet_schema_map_test.cpp
         ./storage/hll_test.cpp
@@ -195,6 +196,8 @@ set(EXEC_FILES
         ./storage/lake/primary_key_compaction_task_test.cpp
         ./storage/lake/primary_key_publish_test.cpp
         ./storage/rowset_update_state_test.cpp
+        ./storage/rowset_column_update_state_test.cpp
+        ./storage/rowset_column_partial_update_test.cpp
         ./storage/rowset/rowset_test.cpp
         ./storage/rowset/binary_dict_page_test.cpp
         ./storage/rowset/binary_plain_page_test.cpp

--- a/be/test/storage/delta_column_group_test.cpp
+++ b/be/test/storage/delta_column_group_test.cpp
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/delta_column_group.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+TEST(TestDeltaColumnGroup, testLoad) {
+    DeltaColumnGroup dcg;
+    dcg.init(100, {1, 10, 100}, "abc.cols");
+    std::string pb_str = dcg.save();
+    DeltaColumnGroup new_dcg;
+    ASSERT_TRUE(new_dcg.load(100, pb_str.data(), pb_str.length()).ok());
+    ASSERT_TRUE(dcg.column_file() == new_dcg.column_file());
+    std::vector<uint32_t> v1 = dcg.column_ids();
+    std::vector<uint32_t> v2 = new_dcg.column_ids();
+    ASSERT_TRUE(v1.size() == v2.size());
+    for (int i = 0; i < v1.size(); i++) {
+        ASSERT_TRUE(v1[i] == v2[i]);
+    }
+};
+
+TEST(TestDeltaColumnGroup, testGet) {
+    DeltaColumnGroup dcg;
+    dcg.init(100, {10, 1, 100}, "abc.cols");
+    ASSERT_TRUE(0 == dcg.get_column_idx(10));
+    ASSERT_TRUE(1 == dcg.get_column_idx(1));
+    ASSERT_TRUE(2 == dcg.get_column_idx(100));
+    ASSERT_TRUE(-1 == dcg.get_column_idx(2));
+    ASSERT_TRUE(-1 == dcg.get_column_idx(1000));
+};
+
+} // namespace starrocks

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -1,0 +1,270 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <iostream>
+#include <memory>
+
+#include "column/datum_tuple.h"
+#include "fs/fs_memory.h"
+#include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
+#include "storage/chunk_helper.h"
+#include "storage/empty_iterator.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset_column_update_state.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_reader.h"
+#include "storage/tablet_reader_params.h"
+#include "storage/tablet_schema.h"
+#include "storage/union_iterator.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+class RowsetColumnPartialUpdateTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
+    }
+
+    void TearDown() override {
+        if (_tablet) {
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
+            _tablet.reset();
+        }
+    }
+
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                  Column* one_delete = nullptr) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = &tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (long key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+        }
+        if (one_delete == nullptr && !keys.empty()) {
+            CHECK_OK(writer->flush_chunk(*chunk));
+        } else if (one_delete == nullptr) {
+            CHECK_OK(writer->flush());
+        } else if (one_delete != nullptr) {
+            CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+        }
+        return *writer->build();
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    RowsetSharedPtr create_partial_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                          std::vector<int32_t>& column_indexes,
+                                          const std::shared_ptr<TabletSchema>& partial_schema) {
+        // create partial rowset
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+
+        writer_context.partial_update_tablet_schema = partial_schema;
+        writer_context.referenced_column_ids = column_indexes;
+        writer_context.tablet_schema = partial_schema.get();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        writer_context.partial_update_mode = PartialUpdateMode::COLUMN_MODE;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(*partial_schema.get());
+
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        EXPECT_TRUE(2 == chunk->num_columns());
+        auto& cols = chunk->columns();
+        for (long key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(key % 100 + 3)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        RowsetSharedPtr partial_rowset = *writer->build();
+
+        return partial_rowset;
+    }
+
+protected:
+    TabletSharedPtr _tablet;
+    std::unique_ptr<MemTracker> _compaction_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
+};
+
+static ChunkIteratorPtr create_tablet_iterator(TabletReader& reader, Schema& schema) {
+    TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
+        return nullptr;
+    }
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
+        return new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
+    }
+    return new_union_iterator(seg_iters);
+}
+
+static bool check_until_eof(const ChunkIteratorPtr& iter, int64_t check_rows_cnt,
+                            std::function<bool(int64_t, int16_t, int32_t)> check_fn) {
+    auto chunk = ChunkHelper::new_chunk(iter->schema(), 100);
+    int64_t rows_cnt = 0;
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (st.ok()) {
+            rows_cnt += chunk->num_rows();
+            for (int r = 0; r < chunk->num_rows(); r++) {
+                if (!check_fn(chunk->columns()[0]->get(r).get_int64(), chunk->columns()[1]->get(r).get_int16(),
+                              chunk->columns()[2]->get(r).get_int32())) {
+                    return false;
+                }
+            }
+            chunk->reset();
+        } else {
+            LOG(WARNING) << "read error: " << st.to_string();
+            return false;
+        }
+    }
+    return rows_cnt == check_rows_cnt;
+}
+
+static bool check_tablet(const TabletSharedPtr& tablet, int64_t version, int64_t check_rows_cnt,
+                         std::function<bool(int64_t, int16_t, int32_t)> check_fn) {
+    Schema schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
+    if (iter == nullptr) {
+        return -1;
+    }
+    return check_until_eof(iter, check_rows_cnt, check_fn);
+}
+
+TEST_F(RowsetColumnPartialUpdateTest, partial_update_and_check) {
+    const int N = 100;
+    _tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, _tablet->updates()->version_history_count());
+
+    // create full rowsets first
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(10);
+    for (int i = 0; i < 10; i++) {
+        rowsets.emplace_back(create_rowset(_tablet, keys));
+    }
+    auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
+    int64_t version = 1;
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto st = _tablet->rowset_commit(++version, rowsets[i], 10000);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        // Ensure that there is at most one thread doing the version apply job.
+        ASSERT_LE(pool->num_threads(), 1);
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+    }
+    // check data
+    ASSERT_TRUE(check_tablet(_tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
+        return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v1;
+    }));
+
+    std::vector<int32_t> column_indexes = {0, 1};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(_tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset = create_partial_rowset(_tablet, keys, column_indexes, partial_schema);
+    // check data of write column
+    RowsetColumnUpdateState state;
+    state.load(_tablet.get(), partial_rowset.get());
+    const std::vector<ColumnPartialUpdateState>& parital_update_states = state.parital_update_states();
+    ASSERT_EQ(parital_update_states.size(), 1);
+    ASSERT_EQ(parital_update_states[0].src_rss_rowids.size(), N);
+    ASSERT_EQ(parital_update_states[0].rss_rowid_to_update_rowid.size(), N);
+    for (int upt_id = 0; upt_id < parital_update_states[0].src_rss_rowids.size(); upt_id++) {
+        uint64_t src_rss_rowid = parital_update_states[0].src_rss_rowids[upt_id];
+        ASSERT_EQ(parital_update_states[0].rss_rowid_to_update_rowid.find(src_rss_rowid)->second, upt_id);
+    }
+    // commit partial update
+    auto st = _tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // check data
+    ASSERT_TRUE(check_tablet(_tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v1;
+    }));
+}
+
+} // namespace starrocks

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -241,7 +241,7 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_and_check) {
     }
     // check data
     ASSERT_TRUE(check_tablet(_tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
-        return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v1;
+        return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
     }));
 
     std::vector<int32_t> column_indexes = {0, 1};
@@ -263,7 +263,7 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_and_check) {
     ASSERT_TRUE(st.ok()) << st.to_string();
     // check data
     ASSERT_TRUE(check_tablet(_tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
-        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v1;
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
     }));
 }
 

--- a/be/test/storage/rowset_column_update_state_test.cpp
+++ b/be/test/storage/rowset_column_update_state_test.cpp
@@ -1,0 +1,272 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset_column_update_state.h"
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <iostream>
+#include <memory>
+
+#include "column/datum_tuple.h"
+#include "fs/fs_memory.h"
+#include "runtime/mem_pool.h"
+#include "runtime/mem_tracker.h"
+#include "storage/chunk_helper.h"
+#include "storage/empty_iterator.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_reader.h"
+#include "storage/tablet_reader_params.h"
+#include "storage/tablet_schema.h"
+#include "storage/union_iterator.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class RowsetColumnUpdateStateTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
+    }
+
+    void TearDown() override {
+        if (_tablet) {
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
+            _tablet.reset();
+        }
+    }
+
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                  Column* one_delete = nullptr) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = &tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (long key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+        }
+        if (one_delete == nullptr && !keys.empty()) {
+            CHECK_OK(writer->flush_chunk(*chunk));
+        } else if (one_delete == nullptr) {
+            CHECK_OK(writer->flush());
+        } else if (one_delete != nullptr) {
+            CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+        }
+        return *writer->build();
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    RowsetSharedPtr create_partial_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                          std::vector<int32_t>& column_indexes,
+                                          const std::shared_ptr<TabletSchema>& partial_schema) {
+        // create partial rowset
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+
+        writer_context.partial_update_tablet_schema = partial_schema;
+        writer_context.referenced_column_ids = column_indexes;
+        writer_context.tablet_schema = partial_schema.get();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        writer_context.partial_update_mode = PartialUpdateMode::COLUMN_MODE;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(*partial_schema.get());
+
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        EXPECT_TRUE(2 == chunk->num_columns());
+        auto& cols = chunk->columns();
+        for (long key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(key % 100 + 3)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        RowsetSharedPtr partial_rowset = *writer->build();
+
+        return partial_rowset;
+    }
+
+protected:
+    TabletSharedPtr _tablet;
+    std::unique_ptr<MemTracker> _compaction_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
+};
+
+static ChunkIteratorPtr create_tablet_iterator(TabletReader& reader, Schema& schema) {
+    TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
+        return nullptr;
+    }
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
+        return new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
+    }
+    return new_union_iterator(seg_iters);
+}
+
+static ssize_t read_until_eof(const ChunkIteratorPtr& iter) {
+    auto chunk = ChunkHelper::new_chunk(iter->schema(), 100);
+    size_t count = 0;
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (st.ok()) {
+            count += chunk->num_rows();
+            chunk->reset();
+        } else {
+            LOG(WARNING) << "read error: " << st.to_string();
+            return -1;
+        }
+    }
+    return count;
+}
+
+static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
+    Schema schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
+    if (iter == nullptr) {
+        return -1;
+    }
+    return read_until_eof(iter);
+}
+
+TEST_F(RowsetColumnUpdateStateTest, prepare_partial_update_states) {
+    const int N = 100;
+    _tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, _tablet->updates()->version_history_count());
+
+    // create full rowsets first
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(10);
+    for (int i = 0; i < 10; i++) {
+        rowsets.emplace_back(create_rowset(_tablet, keys));
+    }
+    auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto version = i + 2;
+        auto st = _tablet->rowset_commit(version, rowsets[i], 0);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        // Ensure that there is at most one thread doing the version apply job.
+        ASSERT_LE(pool->num_threads(), 1);
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+    }
+    ASSERT_EQ(N, read_tablet(_tablet, rowsets.size()));
+
+    std::vector<int32_t> column_indexes = {0, 1};
+    {
+        std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(_tablet->tablet_schema(), column_indexes);
+        RowsetSharedPtr partial_rowset = create_partial_rowset(_tablet, keys, column_indexes, partial_schema);
+        // check data of write column
+        RowsetColumnUpdateState state;
+        state.load(_tablet.get(), partial_rowset.get());
+        const std::vector<ColumnPartialUpdateState>& parital_update_states = state.parital_update_states();
+        ASSERT_EQ(parital_update_states.size(), 1);
+        ASSERT_EQ(parital_update_states[0].src_rss_rowids.size(), N);
+        ASSERT_EQ(parital_update_states[0].rss_rowid_to_update_rowid.size(), N);
+        for (int upt_id = 0; upt_id < parital_update_states[0].src_rss_rowids.size(); upt_id++) {
+            uint64_t src_rss_rowid = parital_update_states[0].src_rss_rowids[upt_id];
+            ASSERT_EQ(parital_update_states[0].rss_rowid_to_update_rowid.find(src_rss_rowid)->second, upt_id);
+        }
+    }
+    {
+        // partial update keys that not exist
+        std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(_tablet->tablet_schema(), column_indexes);
+        std::vector<int64_t> keys_no_exist(N);
+        for (int i = 0; i < N; i++) {
+            keys_no_exist[i] = i + N;
+        }
+        RowsetSharedPtr partial_rowset = create_partial_rowset(_tablet, keys_no_exist, column_indexes, partial_schema);
+        // check data of write column
+        RowsetColumnUpdateState state;
+        state.load(_tablet.get(), partial_rowset.get());
+        const std::vector<ColumnPartialUpdateState>& parital_update_states = state.parital_update_states();
+        ASSERT_EQ(parital_update_states.size(), 1);
+        ASSERT_EQ(parital_update_states[0].src_rss_rowids.size(), N);
+        ASSERT_EQ(parital_update_states[0].rss_rowid_to_update_rowid.size(), 0);
+    }
+}
+
+} // namespace starrocks

--- a/be/test/storage/tablet_meta_manager_test.cpp
+++ b/be/test/storage/tablet_meta_manager_test.cpp
@@ -390,6 +390,56 @@ protected:
     inline static std::unique_ptr<DataDir> _s_data_dir;
 };
 
+TEST_F(TabletMetaManagerTest, delta_column_group_operations) {
+    // insert 20 delta_column_group with 20 version
+    auto meta = _data_dir->get_meta();
+    const int64_t tablet_id = 1001;
+    for (int segid = 1; segid <= 20; segid++) {
+        DeltaColumnGroupList dcgs;
+        for (int v = 1; v <= 20; v++) {
+            auto dcg = std::make_shared<DeltaColumnGroup>();
+            dcg->init(v, {1, 10, 100}, "111.cols");
+            dcgs.push_back(std::move(dcg));
+        }
+        WriteBatch wb;
+        CHECK(TabletMetaManager::put_delta_column_group(_data_dir.get(), &wb, tablet_id, segid, dcgs).ok());
+        CHECK(meta->write_batch(&wb).ok());
+    }
+    // get delta column group
+    for (int i = 1; i <= 10; i++) {
+        DeltaColumnGroupList dcgs;
+        int segid = (rand() % 20) + 1;
+        CHECK(TabletMetaManager::get_delta_column_group(meta, tablet_id, segid, i, dcgs).ok());
+        ASSERT_EQ(dcgs.size(), i);
+        ASSERT_EQ(dcgs[0]->column_file(), "111.cols");
+        ASSERT_EQ(dcgs[0]->get_column_idx(10), 1);
+        ASSERT_EQ(dcgs[0]->get_column_idx(11), -1);
+        ASSERT_EQ(dcgs[0]->version(), i);
+    }
+    // scan delta column group
+    for (int i = 1; i <= 5; i++) {
+        DeltaColumnGroupList dcgs;
+        int len = (rand() % 5) + 1;
+        int segid = (rand() % 20) + 1;
+        CHECK(TabletMetaManager::scan_delta_column_group(meta, tablet_id, segid, i, i + len, dcgs).ok());
+        ASSERT_EQ(dcgs.size(), len);
+        ASSERT_EQ(dcgs[0]->column_file(), "111.cols");
+        ASSERT_EQ(dcgs[0]->get_column_idx(10), 1);
+        ASSERT_EQ(dcgs[0]->get_column_idx(11), -1);
+        ASSERT_EQ(dcgs[0]->version(), i + len);
+    }
+    // delete delta column group
+    for (int segid = 1; segid < 10; segid++) {
+        CHECK(TabletMetaManager::delete_delta_column_group(meta, tablet_id, 1, 20).ok());
+    }
+    // check empty
+    for (int segid = 1; segid <= 20; segid++) {
+        DeltaColumnGroupList dcgs;
+        CHECK(TabletMetaManager::scan_delta_column_group(meta, tablet_id, segid, 1, 20, dcgs).ok());
+        ASSERT_EQ(dcgs.size(), 0);
+    }
+}
+
 /*
 // NOLINTNEXTLINE
 TEST_F(TabletMetaManagerPerformanceTest, rowset_iterate) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -241,7 +241,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 }
 
                 String mergeCondition = (brokerDesc == null) ? "" : brokerDesc.getMergeConditionStr();
-                TPartialUpdateMode mode = partialUpdateMode == "column" 
+                TPartialUpdateMode mode = partialUpdateMode.equals("column")
                         ? TPartialUpdateMode.COLUMN_MODE : TPartialUpdateMode.ROW_MODE;
                 // Generate loading task and init the plan of task
                 LoadLoadingTask task = new LoadLoadingTask(db, table, brokerDesc,

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -67,6 +67,7 @@ import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.thrift.TLoadJobType;
+import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.BeginTransactionException;
 import com.starrocks.transaction.TransactionState;
@@ -240,12 +241,14 @@ public class BrokerLoadJob extends BulkLoadJob {
                 }
 
                 String mergeCondition = (brokerDesc == null) ? "" : brokerDesc.getMergeConditionStr();
+                TPartialUpdateMode mode = partialUpdateMode == "column" 
+                        ? TPartialUpdateMode.COLUMN_MODE : TPartialUpdateMode.ROW_MODE;
                 // Generate loading task and init the plan of task
                 LoadLoadingTask task = new LoadLoadingTask(db, table, brokerDesc,
                         brokerFileGroups, getDeadlineMs(), loadMemLimit,
                         strictMode, transactionId, this, timezone, timeoutSecond,
                         createTimestamp, partialUpdate, mergeCondition, sessionVariables,
-                        context,  TLoadJobType.BROKER, priority, originStmt);
+                        context,  TLoadJobType.BROKER, priority, originStmt, mode);
                 UUID uuid = UUID.randomUUID();
                 TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
                 task.init(loadId, attachment.getFileStatusByTable(aggKey), attachment.getFileNumByTable(aggKey));

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -123,6 +123,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected boolean strictMode = false; // default is false
     protected String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     protected boolean partialUpdate = false;
+    protected String partialUpdateMode = "row";
     protected int priority = LoadPriority.NORMAL_VALUE;
     // reuse deleteFlag as partialUpdate
     // @Deprecated
@@ -316,6 +317,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             }
             if (properties.containsKey(LoadStmt.PARTIAL_UPDATE)) {
                 partialUpdate = Boolean.valueOf(properties.get(LoadStmt.PARTIAL_UPDATE));
+            }
+            if (properties.containsKey(LoadStmt.PARTIAL_UPDATE_MODE)) {
+                partialUpdateMode = properties.get(LoadStmt.PARTIAL_UPDATE_MODE);
             }
 
             if (properties.containsKey(LoadStmt.LOAD_MEM_LIMIT)) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
@@ -71,6 +71,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.thrift.TBrokerFileStatus;
+import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TPartitionType;
 import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.thrift.TUniqueId;
@@ -100,6 +101,7 @@ public class LoadingTaskPlanner {
     private final int parallelInstanceNum;
     private final long startTime;
     private String mergeConditionStr;
+    private TPartialUpdateMode partialUpdateMode;
 
     // Something useful
     // ConnectContext here is just a dummy object to avoid some NPE problem, like ctx.getDatabase()
@@ -123,7 +125,8 @@ public class LoadingTaskPlanner {
     public LoadingTaskPlanner(Long loadJobId, long txnId, long dbId, OlapTable table,
             BrokerDesc brokerDesc, List<BrokerFileGroup> brokerFileGroups,
             boolean strictMode, String timezone, long timeoutS,
-            long startTime, boolean partialUpdate, Map<String, String> sessionVariables, String mergeConditionStr) {
+            long startTime, boolean partialUpdate, Map<String, String> sessionVariables, String mergeConditionStr, 
+            TPartialUpdateMode partialUpdateMode) {
         this.loadJobId = loadJobId;
         this.txnId = txnId;
         this.dbId = dbId;
@@ -138,6 +141,7 @@ public class LoadingTaskPlanner {
         this.parallelInstanceNum = Config.load_parallel_instance_num;
         this.startTime = startTime;
         this.sessionVariables = sessionVariables;
+        this.partialUpdateMode = partialUpdateMode;
     }
 
     public void setConnectContext(ConnectContext context) {
@@ -233,6 +237,7 @@ public class LoadingTaskPlanner {
                 table.writeQuorum(), table.enableReplicatedStorage(), checkNullExprInAutoIncrement());
         olapTableSink.init(loadId, txnId, dbId, timeoutS);
         Load.checkMergeCondition(mergeConditionStr, table, false);
+        olapTableSink.setPartialUpdateMode(partialUpdateMode);
         olapTableSink.complete(mergeConditionStr);
 
         // 3. Plan fragment
@@ -307,6 +312,7 @@ public class LoadingTaskPlanner {
                 table.writeQuorum(), table.enableReplicatedStorage(), checkNullExprInAutoIncrement());
         olapTableSink.init(loadId, txnId, dbId, timeoutS);
         Load.checkMergeCondition(mergeConditionStr, table, false);
+        olapTableSink.setPartialUpdateMode(partialUpdateMode);
         olapTableSink.complete(mergeConditionStr);
 
         // 6. Sink plan fragment

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -305,6 +305,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             this.maxBatchRows = stmt.getMaxBatchRows();
         }
         jobProperties.put(LoadStmt.PARTIAL_UPDATE, String.valueOf(stmt.isPartialUpdate()));
+        jobProperties.put(LoadStmt.PARTIAL_UPDATE_MODE, String.valueOf(stmt.getPartialUpdateMode()));
         jobProperties.put(LoadStmt.TIMEZONE, stmt.getTimezone());
         jobProperties.put(LoadStmt.STRICT_MODE, String.valueOf(stmt.isStrictMode()));
         if (stmt.getMergeConditionStr() != null) {
@@ -520,6 +521,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             return false;
         }
         return Boolean.valueOf(value);
+    }
+
+    public String getPartialUpdateMode() {
+        return jobProperties.get(LoadStmt.PARTIAL_UPDATE_MODE);
     }
 
     public RoutineLoadProgress getProgress() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -295,7 +295,7 @@ public class StreamLoadInfo {
             loadParallelRequestNum = context.loadDop;
         }
         if (context.partialUpdateMode != null) {
-            if (context.partialUpdateMode == "column") {
+            if (context.partialUpdateMode.equals("column")) {
                 partialUpdateMode = TPartialUpdateMode.COLUMN_MODE;
             } else {
                 partialUpdateMode = TPartialUpdateMode.ROW_MODE;
@@ -436,7 +436,7 @@ public class StreamLoadInfo {
         }
         stripOuterArray = routineLoadJob.isStripOuterArray();
         partialUpdate = routineLoadJob.isPartialUpdate();
-        if (routineLoadJob.getPartialUpdateMode() == "column") {
+        if (routineLoadJob.getPartialUpdateMode().equals("column")) {
             partialUpdateMode = TPartialUpdateMode.COLUMN_MODE;
         } else {
             partialUpdateMode = TPartialUpdateMode.ROW_MODE;

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadParam.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadParam.java
@@ -19,8 +19,11 @@ import com.starrocks.common.UserException;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TFileType;
 import io.netty.handler.codec.http.HttpHeaders;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class StreamLoadParam {
+    private static final Logger LOG = LogManager.getLogger(StreamLoadParam.class);
     private static final String FORMAT_KEY = "format";
     private static final String COLUMNS = "columns";
     private static final String WHERE = "where";
@@ -42,6 +45,7 @@ public class StreamLoadParam {
     private static final String LOAD_DOP = "load_dop";
     private static final String MAX_FILTER_RATIO = "max_filter_ratio";
     private static final String IDLE_TRANSACTION_TIMEOUT = "idle_transaction_timeout";
+    private static final String PARTIAL_UPDATE_MODE = "partial_update_mode";
 
     public TFileFormatType formatType = TFileFormatType.FORMAT_CSV_PLAIN;
     public TFileType fileType = TFileType.FILE_STREAM;
@@ -68,6 +72,7 @@ public class StreamLoadParam {
     public int loadDop = 1;
     public double maxFilterRatio = 0.0;
     public int idleTransactionTimeout = 1000;
+    public String partialUpdateMode = "row";
 
     public TFileFormatType parseStreamLoadFormat(String formatKey) {
         if (formatKey.equalsIgnoreCase("csv")) {
@@ -175,6 +180,9 @@ public class StreamLoadParam {
             if (context.idleTransactionTimeout <= 0) {
                 throw new UserException("idle transaction timeout must be greater than 0");
             }
+        }
+        if (headers.contains(PARTIAL_UPDATE_MODE)) {
+            context.partialUpdateMode = headers.get(PARTIAL_UPDATE_MODE);
         }
         return context;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -122,6 +122,7 @@ public class OlapTableSink extends DataSink {
     private boolean missAutoIncrementColumn;
     private boolean abortDelete;
     private int autoIncrementSlotId;
+    private TPartialUpdateMode partialUpdateMode;
 
     public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
                          TWriteQuorumType writeQuorum, boolean enableReplicatedStorage, boolean nullExprInAutoIncrement) {
@@ -153,6 +154,7 @@ public class OlapTableSink extends DataSink {
                 }
             }
         }
+        this.partialUpdateMode = TPartialUpdateMode.ROW_MODE;
     }
 
     public void init(TUniqueId loadId, long txnId, long dbId, long loadChannelTimeoutS)
@@ -197,8 +199,7 @@ public class OlapTableSink extends DataSink {
     }
 
     public void setPartialUpdateMode(TPartialUpdateMode mode) {
-        TOlapTableSink tSink = tDataSink.getOlap_table_sink();
-        tSink.setPartial_update_mode(mode);
+        this.partialUpdateMode = mode;
     }
 
     public void complete(String mergeCondition) throws UserException {
@@ -228,7 +229,7 @@ public class OlapTableSink extends DataSink {
         tSink.setPartition(createPartition(tSink.getDb_id(), dstTable));
         tSink.setLocation(createLocation(dstTable));
         tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(clusterId));
-        tSink.setPartial_update_mode(TPartialUpdateMode.COLUMN_MODE);
+        tSink.setPartial_update_mode(this.partialUpdateMode);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -87,6 +87,7 @@ import com.starrocks.thrift.TOlapTableSink;
 import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWriteQuorumType;
+import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.transaction.TransactionState;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -193,6 +194,11 @@ public class OlapTableSink extends DataSink {
 
     public void updateLoadId(TUniqueId newLoadId) {
         tDataSink.getOlap_table_sink().setLoad_id(newLoadId);
+    }
+
+    public void setPartialUpdateMode(TPartialUpdateMode mode) {
+        TOlapTableSink tSink = tDataSink.getOlap_table_sink();
+        tSink.setPartial_update_mode(mode);
     }
 
     public void complete(String mergeCondition) throws UserException {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -228,6 +228,7 @@ public class OlapTableSink extends DataSink {
         tSink.setPartition(createPartition(tSink.getDb_id(), dstTable));
         tSink.setLocation(createLocation(dstTable));
         tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(clusterId));
+        tSink.setPartial_update_mode(TPartialUpdateMode.COLUMN_MODE);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -181,6 +181,7 @@ public class StreamLoadPlanner {
         }
         olapTableSink.init(loadId, streamLoadInfo.getTxnId(), db.getId(), streamLoadInfo.getTimeout());
         Load.checkMergeCondition(streamLoadInfo.getMergeConditionStr(), destTable, olapTableSink.missAutoIncrementColumn());
+        olapTableSink.setPartialUpdateMode(streamLoadInfo.getPartialUpdateMode());
         olapTableSink.complete(streamLoadInfo.getMergeConditionStr());
 
         // for stream load, we only need one fragment, ScanNode -> DataSink.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -83,7 +83,8 @@ public class UpdatePlanner {
             long tableId = table.getId();
             List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
             for (Column column : table.getFullSchema()) {
-                if (!updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
+                if (updateStmt.usePartialUpdate() && !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
+                    // When using partial update, skip columns which aren't key column and not be assign
                     continue;
                 }
                 SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
+import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TResultSinkType;
 
 import java.util.List;
@@ -109,6 +110,10 @@ public class UpdatePlanner {
                 DataSink dataSink =
                         new OlapTableSink(((OlapTable) table), olapTuple, partitionIds, ((OlapTable) table).writeQuorum(),
                                 ((OlapTable) table).enableReplicatedStorage(), updateStmt.nullExprInAutoIncrement());
+                if (updateStmt.usePartialUpdate()) {
+                    // only support column mode partial update in UPDATE stmt
+                    ((OlapTableSink) dataSink).setPartialUpdateMode(TPartialUpdateMode.COLUMN_MODE);
+                }
                 execPlan.getFragments().get(0).setSink(dataSink);
                 execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);
             } else if (table instanceof SchemaTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -83,6 +83,9 @@ public class UpdatePlanner {
             long tableId = table.getId();
             List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
             for (Column column : table.getFullSchema()) {
+                if (!updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
+                    continue;
+                }
                 SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
                 slotDescriptor.setIsMaterialized(true);
                 slotDescriptor.setType(column.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -141,6 +141,9 @@ public class UpdateAnalyzer {
 
         List<Expr> outputExpression = queryStatement.getQueryRelation().getOutputExpression();
         Preconditions.checkState(outputExpression.size() == assignColumnList.size());
+        if (!updateStmt.usePartialUpdate()) {
+            Preconditions.checkState(table.getBaseSchema().size() == assignColumnList.size());   
+        }
         List<Expr> castOutputExpressions = Lists.newArrayList();
         for (int i = 0; i < assignColumnList.size(); ++i) {
             Expr e = outputExpression.get(i);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -45,6 +45,15 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
 public class UpdateAnalyzer {
+
+    private static boolean checkIfUsePartialUpdate(int updateColumnCnt, int tableColumnCnt) {
+        if (updateColumnCnt <= 3 && updateColumnCnt < tableColumnCnt * 0.3) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public static void analyze(UpdateStmt updateStmt, ConnectContext session) {
         TableName tableName = updateStmt.getTableName();
         MetaUtils.normalizationTableName(session, tableName);
@@ -61,9 +70,6 @@ public class UpdateAnalyzer {
         if (!table.supportsUpdate()) {
             throw unsupportedException("table " + table.getName() + " does not support update");
         }
-        if (updateStmt.getWherePredicate() == null) {
-            throw new SemanticException("must specify where clause to prevent full table update");
-        }
 
         List<ColumnAssignment> assignmentList = updateStmt.getAssignments();
         Map<String, ColumnAssignment> assignmentByColName = assignmentList.stream().collect(
@@ -73,6 +79,19 @@ public class UpdateAnalyzer {
                 throw new SemanticException("table '%s' do not existing column '%s'", tableName.getTbl(), colName);
             }
         }
+
+        if (updateStmt.getWherePredicate() == null) {
+            if (checkIfUsePartialUpdate(assignmentList.size(), table.getBaseSchema().size())) {
+                // use partial update if:
+                // 1. Columns updated are less than 4
+                // 2. The proportion of columns updated is less than 30%
+                // 3. No where predicate in update stmt
+                updateStmt.setUsePartialUpdate();
+            } else {
+                throw new SemanticException("must specify where clause to prevent full table update");
+            }
+        }
+
         SelectList selectList = new SelectList();
         List<Column> assignColumnList = Lists.newArrayList();
         for (Column col : table.getBaseSchema()) {
@@ -95,7 +114,7 @@ public class UpdateAnalyzer {
                 item = new SelectListItem(assign.getExpr(), col.getName());
                 selectList.addItem(item);
                 assignColumnList.add(col);
-            } else if (col.isKey()) {
+            } else if (!updateStmt.usePartialUpdate() || col.isKey()) {
                 item = new SelectListItem(new SlotRef(tableName, col.getName()), col.getName());
                 selectList.addItem(item);
                 assignColumnList.add(col);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -187,6 +187,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     private String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     private boolean partialUpdate = false;
     private String mergeConditionStr;
+    private String partialUpdateMode = "row";
     /**
      * RoutineLoad support json data.
      * Require Params:
@@ -334,6 +335,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     public boolean isPartialUpdate() {
         return partialUpdate;
+    }
+
+    public String getPartialUpdateMode() {
+        return partialUpdateMode;
     }
 
     public String getMergeConditionStr() {
@@ -511,6 +516,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
                 LoadStmt.PARTIAL_UPDATE + " should be a boolean");
 
         mergeConditionStr = jobProperties.get(LoadStmt.MERGE_CONDITION);
+
+        partialUpdateMode = jobProperties.get(LoadStmt.PARTIAL_UPDATE_MODE);
 
         if (ConnectContext.get() != null) {
             timezone = ConnectContext.get().getSessionVariable().getTimeZone();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LoadStmt.java
@@ -99,7 +99,7 @@ public class LoadStmt extends DdlStmt {
     public static final String PRIORITY = "priority";
     public static final String MERGE_CONDITION = "merge_condition";
     public static final String CASE_SENSITIVE = "case_sensitive";
-
+    public static final String PARTIAL_UPDATE_MODE = "partial_update_mode";
 
     // for load data from Baidu Object Store(BOS)
     public static final String BOS_ENDPOINT = "bos_endpoint";
@@ -138,6 +138,7 @@ public class LoadStmt extends DdlStmt {
             .add(PARTIAL_UPDATE)
             .add(PRIORITY)
             .add(CASE_SENSITIVE)
+            .add(PARTIAL_UPDATE_MODE)
             .build();
 
     public LoadStmt(LabelName label, List<DataDescription> dataDescriptions, BrokerDesc brokerDesc,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
@@ -36,6 +36,8 @@ public class UpdateStmt extends DmlStmt {
 
     private boolean nullExprInAutoIncrement;
 
+    private boolean usePartialUpdate;
+
     public UpdateStmt(TableName tableName, List<ColumnAssignment> assignments, List<Relation> fromRelations,
                       Expr wherePredicate, List<CTERelation> commonTableExpressions) {
         this(tableName, assignments, fromRelations, wherePredicate, commonTableExpressions, NodePosition.ZERO);
@@ -54,6 +56,7 @@ public class UpdateStmt extends DmlStmt {
         for (ColumnAssignment each : assignments) {
             this.assignmentColumns.add(each.getColumn());
         }
+        this.usePartialUpdate = false;
     }
 
     public boolean isAssignmentColumn(String colName) {
@@ -103,6 +106,14 @@ public class UpdateStmt extends DmlStmt {
 
     public QueryStatement getQueryStatement() {
         return queryStatement;
+    }
+
+    public void setUsePartialUpdate() {
+        this.usePartialUpdate = true;
+    }
+
+    public boolean usePartialUpdate() {
+        return this.usePartialUpdate;
     }
 
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
@@ -14,12 +14,14 @@
 
 package com.starrocks.sql.ast;
 
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
+import java.util.Set;
 
 public class UpdateStmt extends DmlStmt {
     private final TableName tableName;
@@ -27,6 +29,7 @@ public class UpdateStmt extends DmlStmt {
     private final List<Relation> fromRelations;
     private final Expr wherePredicate;
     private final List<CTERelation> commonTableExpressions;
+    private final Set<String> assignmentColumns;
 
     private Table table;
     private QueryStatement queryStatement;
@@ -47,6 +50,14 @@ public class UpdateStmt extends DmlStmt {
         this.wherePredicate = wherePredicate;
         this.commonTableExpressions = commonTableExpressions;
         this.nullExprInAutoIncrement = true;
+        this.assignmentColumns = Sets.newHashSet();
+        for (ColumnAssignment each : assignments) {
+            this.assignmentColumns.add(each.getColumn());
+        }
+    }
+
+    public boolean isAssignmentColumn(String colName) {
+        return assignmentColumns.contains(colName);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadingTaskPlannerTest.java
@@ -73,6 +73,7 @@ import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TOpType;
+import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TPlanFragment;
 import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
@@ -196,7 +197,7 @@ public class LoadingTaskPlannerTest {
         Config.load_parallel_instance_num = 1;
         long startTime = System.currentTimeMillis();
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap(), "", TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 2);
         Assert.assertEquals(1, planner.getScanNodes().size());
         FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
@@ -206,7 +207,7 @@ public class LoadingTaskPlannerTest {
         // load_parallel_instance_num: 2
         Config.load_parallel_instance_num = 2;
         planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap(), "", TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 2);
         scanNode = (FileScanNode) planner.getScanNodes().get(0);
         locationsList = scanNode.getScanRangeLocations(0);
@@ -216,7 +217,7 @@ public class LoadingTaskPlannerTest {
         Config.load_parallel_instance_num = 2;
         Config.max_broker_concurrency = 3;
         planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, startTime, false, Maps.newHashMap(), "", TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 2);
         scanNode = (FileScanNode) planner.getScanNodes().get(0);
         locationsList = scanNode.getScanRangeLocations(0);
@@ -298,7 +299,8 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "", 
+                TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 1. check fragment
@@ -436,7 +438,8 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "", 
+                TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 1. check fragment
@@ -519,7 +522,8 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "", 
+                TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -606,7 +610,8 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "", 
+                TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -712,7 +717,8 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "", 
+                TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -808,7 +814,8 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "", 
+                TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 1);
 
         // 2. check scan node column expr
@@ -912,7 +919,8 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "", 
+                TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 1);
 
         // check fragment
@@ -1013,7 +1021,8 @@ public class LoadingTaskPlannerTest {
 
         // plan
         LoadingTaskPlanner planner = new LoadingTaskPlanner(jobId, txnId, db.getId(), table, brokerDesc, fileGroups,
-                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "");
+                false, TimeUtils.DEFAULT_TIME_ZONE, 3600, System.currentTimeMillis(), false, Maps.newHashMap(), "", 
+                TPartialUpdateMode.ROW_MODE);
         planner.plan(loadId, fileStatusesList, 1);
 
         // check fragment

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -32,7 +32,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-syntax="proto2";
+syntax = "proto2";
 
 package starrocks;
 option java_package = "com.starrocks.proto";
@@ -75,15 +75,15 @@ message ChunkPB {
     optional CompressionTypePB compress_type = 2;
     // Helper to allocate memory to decompress compressed data.
     optional int64 uncompressed_size = 3;
-    repeated int32 slot_id_map = 4 ; // slot id to column id map
-    repeated bool is_nulls = 5; // column is nullable
-    repeated bool is_consts = 6; // column is const
+    repeated int32 slot_id_map = 4;  // slot id to column id map
+    repeated bool is_nulls = 5;      // column is nullable
+    repeated bool is_consts = 6;     // column is const
     repeated int32 tuple_id_map = 7; // tuple id to column id map
-    optional int64 data_size = 8; // used to record size using brpc attachment
+    optional int64 data_size = 8;    // used to record size using brpc attachment
     // For some object column types like bitmap/hll/percentile.
     // we may estimate larger serialized_size but actually don't use that much space.
-    optional int64 serialized_size  = 9; // how many bytes are really written into data.
-    repeated int32 encode_level = 10; // the encode level for data columns, during upgrade, this must be 0.
+    optional int64 serialized_size = 9; // how many bytes are really written into data.
+    repeated int32 encode_level = 10;   // the encode level for data columns, during upgrade, this must be 0.
     repeated ChunkExtraColumnsMetaPB extra_data_metas = 11; // chunk's extra data meta.
 };
 
@@ -91,7 +91,7 @@ message SegmentPB {
     optional int64 segment_id = 1;
     optional bytes data = 2;
     optional int64 data_size = 3;
-    optional int64 index_size= 4;
+    optional int64 index_size = 4;
     optional int64 num_rows = 5;
     optional int64 row_size = 6;
     optional string path = 7;
@@ -102,4 +102,10 @@ message SegmentPB {
     optional string delete_path = 11;
     optional int64 partial_footer_position = 12;
     optional int64 partial_footer_size = 13;
+
+    // for column mode partial update
+    optional int64 update_id = 14;
+    optional int64 update_data_size = 15;
+    optional int64 update_num_rows = 16;
+    optional string update_path = 17;
 };

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -32,7 +32,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-syntax="proto2";
+syntax = "proto2";
 
 package starrocks;
 option java_package = "com.starrocks.proto";
@@ -42,6 +42,7 @@ import "descriptors.proto";
 import "status.proto";
 import "types.proto";
 import "olap_common.proto";
+import "olap_file.proto";
 
 option cc_generic_services = true;
 
@@ -111,7 +112,7 @@ message PTransmitRuntimeFilterParams {
     // if this runtime filter is partial
     // if it's partial, then it's supposed to be merged.
     // otherwise it's supported to be consumed.
-    
+
     optional bool is_partial = 1;
     optional PUniqueId query_id = 3;
     optional int32 filter_id = 4;
@@ -170,6 +171,7 @@ message PTabletWriterOpenRequest {
     // When the data load in progress, the partition created by automatic partition needs incremental open
     optional bool is_incremental = 29 [default = false];
     optional int32 sender_id = 30;
+    optional PartialUpdateMode partial_update_mode = 31;
 };
 
 message PTabletWriterOpenResult {
@@ -206,7 +208,7 @@ message PTabletWriterAddChunkRequest {
     optional int64 packet_seq = 5;
     repeated int64 tablet_ids = 6;
     // Unset if and only if eos is true.
-    optional ChunkPB chunk  = 7;
+    optional ChunkPB chunk = 7;
     // only valid when eos is true
     // valid partition ids that would write in this writer
     repeated int64 partition_ids = 8;
@@ -260,11 +262,9 @@ message PTabletWriterCancelRequest {
     repeated int64 tablet_ids = 6;
 };
 
-message PTabletWriterCancelResult {
-};
+message PTabletWriterCancelResult{};
 
-message PExecPlanFragmentRequest {
-};
+message PExecPlanFragmentRequest{};
 
 message PTabletReaderOpenRequest {
     optional PUniqueId id = 1;
@@ -272,17 +272,11 @@ message PTabletReaderOpenRequest {
     optional int64 version = 3;
 }
 
-message PTabletReaderOpenResult {
-    optional StatusPB status = 1;
-}
+message PTabletReaderOpenResult { optional StatusPB status = 1; }
 
-message PTabletReaderCloseRequest {
-    optional PUniqueId id = 1;
-}
+message PTabletReaderCloseRequest { optional PUniqueId id = 1; }
 
-message PTabletReaderCloseResult {
-    optional StatusPB status = 1;
-}
+message PTabletReaderCloseResult { optional StatusPB status = 1; }
 
 message PTabletReaderMultiGetRequest {
     optional int64 tablet_id = 1;
@@ -327,8 +321,7 @@ message PExecPlanFragmentResult {
     required StatusPB status = 1;
 };
 
-message PExecBatchPlanFragmentsRequest {
-};
+message PExecBatchPlanFragmentsRequest{};
 
 message PExecBatchPlanFragmentsResult {
     optional StatusPB status = 1;
@@ -431,9 +424,7 @@ message PKafkaOffsetProxyResult {
     repeated int64 latest_offsets = 3;
 }
 
-message PKafkaOffsetBatchProxyResult {
-    repeated PKafkaOffsetProxyResult results = 1;
-}
+message PKafkaOffsetBatchProxyResult { repeated PKafkaOffsetProxyResult results = 1; }
 
 message PProxyResult {
     required StatusPB status = 1;
@@ -478,9 +469,7 @@ message PPulsarBacklogProxyResult {
     repeated int64 backlog_nums = 2;
 }
 
-message PPulsarBacklogBatchProxyResult {
-    repeated PPulsarBacklogProxyResult results = 1;
-}
+message PPulsarBacklogBatchProxyResult { repeated PPulsarBacklogProxyResult results = 1; }
 
 message PPulsarProxyResult {
     required StatusPB status = 1;
@@ -489,8 +478,7 @@ message PPulsarProxyResult {
     optional PPulsarBacklogBatchProxyResult pulsar_backlog_batch_result = 102;
 };
 
-message PMVMaintenanceTaskRequest {
-};
+message PMVMaintenanceTaskRequest{};
 
 message PMVMaintenanceTaskResult {
     required StatusPB status = 1;
@@ -506,39 +494,39 @@ message ExecuteCommandResultPB {
     optional string result = 2;
 };
 
-
 // NOTE(zc): If you want to add new method here,
 // you must add same method to 'doris_internal_service.proto'.
 service PInternalService {
-    rpc transmit_data(PTransmitDataParams) returns (PTransmitDataResult);
-    rpc exec_plan_fragment(PExecPlanFragmentRequest) returns (PExecPlanFragmentResult);
-    rpc exec_batch_plan_fragments(PExecBatchPlanFragmentsRequest) returns (PExecBatchPlanFragmentsResult);
-    rpc cancel_plan_fragment(PCancelPlanFragmentRequest) returns (PCancelPlanFragmentResult);
-    rpc fetch_data(PFetchDataRequest) returns (PFetchDataResult);
-    rpc tablet_writer_open(PTabletWriterOpenRequest) returns (PTabletWriterOpenResult);
-    rpc tablet_writer_add_batch(PTabletWriterAddBatchRequest) returns (PTabletWriterAddBatchResult);
-    rpc tablet_writer_cancel(PTabletWriterCancelRequest) returns (PTabletWriterCancelResult);
-    rpc trigger_profile_report(PTriggerProfileReportRequest) returns (PTriggerProfileReportResult);
-    rpc collect_query_statistics(PCollectQueryStatisticsRequest) returns (PCollectQueryStatisticsResult);
-    rpc get_info(PProxyRequest) returns (PProxyResult); 
-    rpc get_pulsar_info(PPulsarProxyRequest) returns (PPulsarProxyResult); 
+    rpc transmit_data(PTransmitDataParams) returns(PTransmitDataResult);
+    rpc exec_plan_fragment(PExecPlanFragmentRequest) returns(PExecPlanFragmentResult);
+    rpc exec_batch_plan_fragments(PExecBatchPlanFragmentsRequest) returns(PExecBatchPlanFragmentsResult);
+    rpc cancel_plan_fragment(PCancelPlanFragmentRequest) returns(PCancelPlanFragmentResult);
+    rpc fetch_data(PFetchDataRequest) returns(PFetchDataResult);
+    rpc tablet_writer_open(PTabletWriterOpenRequest) returns(PTabletWriterOpenResult);
+    rpc tablet_writer_add_batch(PTabletWriterAddBatchRequest) returns(PTabletWriterAddBatchResult);
+    rpc tablet_writer_cancel(PTabletWriterCancelRequest) returns(PTabletWriterCancelResult);
+    rpc trigger_profile_report(PTriggerProfileReportRequest) returns(PTriggerProfileReportResult);
+    rpc collect_query_statistics(PCollectQueryStatisticsRequest) returns(PCollectQueryStatisticsResult);
+    rpc get_info(PProxyRequest) returns(PProxyResult);
+    rpc get_pulsar_info(PPulsarProxyRequest) returns(PPulsarProxyResult);
 
     // Transmit vectorized data between backends.
-    rpc transmit_chunk(PTransmitChunkParams) returns (PTransmitChunkResult);
-    rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
-    rpc tablet_writer_add_chunks(starrocks.PTabletWriterAddChunksRequest) returns (starrocks.PTabletWriterAddBatchResult);
-    rpc tablet_writer_add_segment(starrocks.PTabletWriterAddSegmentRequest) returns (starrocks.PTabletWriterAddSegmentResult);
-    rpc transmit_runtime_filter(PTransmitRuntimeFilterParams) returns (PTransmitRuntimeFilterResult);
+    rpc transmit_chunk(PTransmitChunkParams) returns(PTransmitChunkResult);
+    rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns(starrocks.PTabletWriterAddBatchResult);
+    rpc tablet_writer_add_chunks(starrocks.PTabletWriterAddChunksRequest)
+            returns(starrocks.PTabletWriterAddBatchResult);
+    rpc tablet_writer_add_segment(starrocks.PTabletWriterAddSegmentRequest)
+            returns(starrocks.PTabletWriterAddSegmentResult);
+    rpc transmit_runtime_filter(PTransmitRuntimeFilterParams) returns(PTransmitRuntimeFilterResult);
 
-    rpc submit_mv_maintenance_task(PMVMaintenanceTaskRequest) returns (PMVMaintenanceTaskResult);
+    rpc submit_mv_maintenance_task(PMVMaintenanceTaskRequest) returns(PMVMaintenanceTaskResult);
 
     // local tablet reader
-    rpc local_tablet_reader_open(PTabletReaderOpenRequest) returns (PTabletReaderOpenResult);
-    rpc local_tablet_reader_close(PTabletReaderCloseRequest) returns (PTabletReaderCloseResult);
-    rpc local_tablet_reader_multi_get(PTabletReaderMultiGetRequest) returns (PTabletReaderMultiGetResult);
-    rpc local_tablet_reader_scan_open(PTabletReaderScanOpenRequest) returns (PTabletReaderScanOpenResult);
-    rpc local_tablet_reader_scan_get_next(PTabletReaderScanGetNextRequest) returns (PTabletReaderScanGetNextResult);
+    rpc local_tablet_reader_open(PTabletReaderOpenRequest) returns(PTabletReaderOpenResult);
+    rpc local_tablet_reader_close(PTabletReaderCloseRequest) returns(PTabletReaderCloseResult);
+    rpc local_tablet_reader_multi_get(PTabletReaderMultiGetRequest) returns(PTabletReaderMultiGetResult);
+    rpc local_tablet_reader_scan_open(PTabletReaderScanOpenRequest) returns(PTabletReaderScanOpenResult);
+    rpc local_tablet_reader_scan_get_next(PTabletReaderScanGetNextRequest) returns(PTabletReaderScanGetNextResult);
 
-    rpc execute_command(ExecuteCommandRequestPB) returns (ExecuteCommandResultPB);
+    rpc execute_command(ExecuteCommandRequestPB) returns(ExecuteCommandResultPB);
 };
-

--- a/gensrc/proto/olap_common.proto
+++ b/gensrc/proto/olap_common.proto
@@ -33,7 +33,7 @@
 // under the License.
 // Define common messages shared by other proto files.
 
-syntax="proto2";
+syntax = "proto2";
 
 package starrocks;
 option java_package = "com.starrocks.proto";
@@ -47,10 +47,21 @@ message EditVersionPB {
     optional int64 minor = 2;
 }
 
+// used in partial update for primary key tablet
+message DeltaColumnGroupPB {
+    repeated uint32 column_ids = 1;
+    required string column_file = 2;
+}
+
+message DeltaColumnGroupListPB {
+    repeated DeltaColumnGroupPB dcgs = 1;
+    repeated int64 versions = 2;
+}
+
 // page position info for segment file and persistent index file
 message PagePointerPB {
     required uint64 offset = 1; // offset in segment file
-    required uint32 size = 2; // size of page in byte
+    required uint32 size = 2;   // size of page in byte
 }
 
 message PNetworkAddress {
@@ -58,4 +69,3 @@ message PNetworkAddress {
     optional int32 port = 2;
     optional int64 node_id = 3;
 }
-

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -33,7 +33,7 @@
 // under the License.
 // Define file format struct, like data header, index header.
 
-syntax="proto2";
+syntax = "proto2";
 
 package starrocks;
 option java_package = "com.starrocks.proto";
@@ -51,7 +51,7 @@ message ZoneMapOfRowset {
 
 enum RowsetTypePB {
     ALPHA_ROWSET = 0; // Deleted
-    BETA_ROWSET  = 1;
+    BETA_ROWSET = 1;
 }
 
 enum RowsetStatePB {
@@ -84,6 +84,10 @@ message FooterPointerPB {
 //      rows if old row doesn't exists, and default values etc
 //   2. conditional update txn may add some meta to describe condition
 //   3. more general read-write txn may add complex expressions
+enum PartialUpdateMode {
+    ROW_MODE = 0;
+    COLUMN_MODE = 1;
+}
 message RowsetTxnMetaPB {
     repeated uint32 partial_update_column_ids = 1;
     repeated uint32 partial_update_column_unique_ids = 2;
@@ -94,6 +98,8 @@ message RowsetTxnMetaPB {
     optional string merge_condition = 4;
 
     optional int32 auto_increment_partial_update_column_id = 5;
+    // recode partial update mode
+    optional PartialUpdateMode partial_update_mode = 6;
 }
 
 message RowsetMetaPB {
@@ -151,10 +157,12 @@ message RowsetMetaPB {
     optional RowsetTxnMetaPB txn_meta = 55;
     // delete file index
     repeated uint32 delfile_idxes = 56;
+    // number of update files
+    optional uint32 num_update_files = 57;
 }
 
 enum DataFileType {
-    OLAP_DATA_FILE = 0; //Deprecated. Only columnar-wise format is supported.
+    OLAP_DATA_FILE = 0; // Deprecated. Only columnar-wise format is supported.
     COLUMN_ORIENTED_FILE = 1;
 }
 
@@ -178,7 +186,7 @@ message AlterTabletPB {
 }
 
 enum TabletStatePB {
-    PB_NOTREADY  = 0; // under alter table, rollup, clone
+    PB_NOTREADY = 0; // under alter table, rollup, clone
     PB_RUNNING = 1;
     PB_TOMBSTONED = 2;
     PB_STOPPED = 3;
@@ -200,7 +208,7 @@ message CompactionInfoPB {
 message EditVersionMetaPB {
     optional EditVersionPB version = 1;
     optional int64 creation_time = 2;
-    repeated uint32 rowsets = 3; // full data, optional
+    repeated uint32 rowsets = 3;     // full data, optional
     repeated uint32 rowsets_add = 4; // incremental optional
     repeated uint32 rowsets_del = 5; // incremental optional
     repeated uint32 deltas = 6;
@@ -221,9 +229,7 @@ message TabletMetaOpPB {
     optional EditVersionPB apply = 3;
 }
 
-message TabletMetaLogPB {
-    repeated TabletMetaOpPB ops = 1;
-}
+message TabletMetaLogPB { repeated TabletMetaOpPB ops = 1; }
 
 message TabletUpdatesPB {
     repeated EditVersionMetaPB versions = 1;
@@ -243,13 +249,13 @@ message BinlogConfigPB {
 }
 
 message TabletMetaPB {
-    optional int64 table_id = 1;    // ?
-    optional int64 partition_id = 2;    // ?
-    optional int64 tablet_id = 3;   // OlapHeaderMessage.tablet_id
-    optional int32 schema_hash = 4; // OlapHeaderMessage.schema_hash
-    optional int32 shard_id = 5;    // OlapHeaderMessage.shard
-    optional int64 creation_time = 6;   // OlapHeaderMessage.creation_time
-    optional int64 cumulative_layer_point = 7;  // OlapHeaderMessage.cumulative_layer_point
+    optional int64 table_id = 1;               // ?
+    optional int64 partition_id = 2;           // ?
+    optional int64 tablet_id = 3;              // OlapHeaderMessage.tablet_id
+    optional int32 schema_hash = 4;            // OlapHeaderMessage.schema_hash
+    optional int32 shard_id = 5;               // OlapHeaderMessage.shard
+    optional int64 creation_time = 6;          // OlapHeaderMessage.creation_time
+    optional int64 cumulative_layer_point = 7; // OlapHeaderMessage.cumulative_layer_point
 
     optional TabletStatePB tablet_state = 8;
     optional TabletSchemaPB schema = 9;
@@ -258,13 +264,13 @@ message TabletMetaPB {
     optional AlterTabletPB alter_task = 12 [deprecated = true];
     // if true, this tablet will not do compaction,
     // and does not create init version
-    optional bool in_restore_mode = 13 [default = false];   // OlapHeaderMessage.in_restore_mode
+    optional bool in_restore_mode = 13 [default = false]; // OlapHeaderMessage.in_restore_mode
     // a uniqued id to identified tablet with same tablet_id and schema hash
     optional PUniqueId tablet_uid = 14;
     optional int64 end_rowset_id = 15;
-    optional RowsetTypePB preferred_rowset_type = 16 [default = BETA_ROWSET, deprecated = true];
+    optional RowsetTypePB preferred_rowset_type = 16 [ default = BETA_ROWSET, deprecated = true ];
     optional TabletTypePB tablet_type = 17;
-    optional TabletUpdatesPB updates = 50; // used for new updatable tablet
+    optional TabletUpdatesPB updates = 50;                        // used for new updatable tablet
     optional bool enable_persistent_index = 51 [default = false]; // used for persistent index in primary index
     optional BinlogConfigPB binlog_config = 52;
 }
@@ -280,10 +286,6 @@ message OLAPIndexHeaderMessage {
     optional bool delete_flag = 7;
 }
 
-message OLAPDataHeaderMessage {
-    required uint32 segment = 2;
-}
+message OLAPDataHeaderMessage { required uint32 segment = 2; }
 
-message OLAPRawDeltaHeaderMessage {
-    required int32 schema_hash = 2;
-}
+message OLAPRawDeltaHeaderMessage { required int32 schema_hash = 2; }

--- a/gensrc/proto/snapshot.proto
+++ b/gensrc/proto/snapshot.proto
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-syntax="proto2";
+syntax = "proto2";
 
 package starrocks;
 option java_package = "com.starrocks.proto";
@@ -36,5 +36,8 @@ message SnapshotMetaFooterPB {
     // delvec_versions[i] is the version of i'th delete vector.
     repeated int64 delvec_versions = 7;
     optional int64 tablet_meta_offset = 8;
+    // dcg_segids[i] is the segment id of the i'th delta column group list
+    repeated int64 dcg_segids = 9;
+    // dcg_offsets[i] is the file offset of the i'th delta column group list.
+    repeated int64 dcg_offsets = 10;
 }
-

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -195,7 +195,8 @@ struct TOlapTableSink {
     21: optional bool null_expr_in_auto_increment
     22: optional bool miss_auto_increment_column
     23: optional bool abort_delete
-    24: optional i32 auto_increment_slot_id;
+    24: optional i32 auto_increment_slot_id
+    25: optional Types.TPartialUpdateMode partial_update_mode
 }
 
 struct TSchemaTableSink {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -643,6 +643,7 @@ struct TStreamLoadPutRequest {
     29: optional i32 load_dop
     30: optional bool enable_replicated_storage
     31: optional string merge_condition
+    32: optional Types.TPartialUpdateMode partial_update_mode
     // only valid when file type is CSV
     50: optional string rowDelimiter
     // only valid when file type is CSV

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -496,3 +496,8 @@ struct TBinlogOffset {
     2: optional TVersion version
     3: optional i64 lsn
 }
+
+enum TPartialUpdateMode {
+    ROW_MODE = 0;
+    COLUMN_MODE = 1;
+}

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update
@@ -1,0 +1,91 @@
+-- name: test_partial_update
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE table tab2 (
+      k1 INTEGER,
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+200	k2_200	200	200	200	v4_200	v5_200
+300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
+-- !result
+insert into tab2 values (100, 100, 100, 100);
+-- result:
+-- !result
+insert into tab2 values (200, 200, 200, 200);
+-- result:
+-- !result
+insert into tab2 values (300, 300, 300, 300);
+-- result:
+-- !result
+select * from tab2;
+-- result:
+300	300	300	300
+100	100	100	100
+200	200	200	200
+-- !result
+update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2), v3 = 1000;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: must specify where clause to prevent full table update.')
+-- !result
+select * from tab1;
+-- result:
+200	k2_200	200	200	200	v4_200	v5_200
+300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
+-- !result
+update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2) where k1 = 100;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+200	k2_200	200	200	200	v4_200	v5_200
+100	k2_100	600	600	100	v4_100	v5_100
+300	k3_300	300	300	300	v4_300	v5_300
+-- !result
+update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	600	600	100	v4_100	v5_100
+200	k2_200	600	600	200	v4_200	v5_200
+300	k3_300	600	600	300	v4_300	v5_300
+-- !result

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_after_schema_change
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_after_schema_change
@@ -1,0 +1,85 @@
+-- name: test_partial_update_after_schema_change
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE table tab2 (
+      k1 INTEGER,
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+200	k2_200	200	200	200	v4_200	v5_200
+100	k2_100	100	100	100	v4_100	v5_100
+300	k3_300	300	300	300	v4_300	v5_300
+-- !result
+insert into tab2 values (100, 100, 100, 100);
+-- result:
+-- !result
+insert into tab2 values (200, 200, 200, 200);
+-- result:
+-- !result
+insert into tab2 values (300, 300, 300, 300);
+-- result:
+-- !result
+select * from tab2;
+-- result:
+200	200	200	200
+100	100	100	100
+300	300	300	300
+-- !result
+alter table tab1 add column (v6 INTEGER DEFAULT "100");
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+200	k2_200	200	200	200	v4_200	v5_200	100
+300	k3_300	300	300	300	v4_300	v5_300	100
+100	k2_100	100	100	100	v4_100	v5_100	100
+-- !result
+update tab1 set v6 = (select sum(tab2.v1) from tab2);
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100	600
+200	k2_200	200	200	200	v4_200	v5_200	600
+300	k3_300	300	300	300	v4_300	v5_300	600
+-- !result

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_before_schema_change
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_before_schema_change
@@ -1,0 +1,137 @@
+-- name: test_partial_update_before_schema_change
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE table tab2 (
+      k1 INTEGER,
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+300	k3_300	300	300	300	v4_300	v5_300
+-- !result
+insert into tab2 values (100, 100, 100, 100);
+-- result:
+-- !result
+insert into tab2 values (200, 200, 200, 200);
+-- result:
+-- !result
+insert into tab2 values (300, 300, 300, 300);
+-- result:
+-- !result
+select * from tab2;
+-- result:
+200	200	200	200
+100	100	100	100
+300	300	300	300
+-- !result
+update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
+-- result:
+-- !result
+select * from tab1;
+-- result:
+200	k2_200	600	600	200	v4_200	v5_200
+300	k3_300	600	600	300	v4_300	v5_300
+100	k2_100	600	600	100	v4_100	v5_100
+-- !result
+alter table tab1 add column (v6 INTEGER DEFAULT "100");
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+200	k2_200	600	600	200	v4_200	v5_200	100
+300	k3_300	600	600	300	v4_300	v5_300	100
+100	k2_100	600	600	100	v4_100	v5_100	100
+-- !result
+alter table tab1 drop column v2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+200	k2_200	600	200	v4_200	v5_200	100
+100	k2_100	600	100	v4_100	v5_100	100
+300	k3_300	600	300	v4_300	v5_300	100
+-- !result
+alter table tab1 drop column v5;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+300	k3_300	600	300	v4_300	100
+100	k2_100	600	100	v4_100	100
+200	k2_200	600	200	v4_200	100
+-- !result
+alter table tab1 modify column v1 BIGINT;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+300	k3_300	600	300	v4_300	100
+200	k2_200	600	200	v4_200	100
+100	k2_100	600	100	v4_100	100
+-- !result
+alter table tab1 modify column v3 BIGINT;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	600	100	v4_100	100
+300	k3_300	600	300	v4_300	100
+200	k2_200	600	200	v4_200	100
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update
@@ -1,0 +1,43 @@
+-- name: test_partial_update
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+CREATE table tab2 (
+      k1 INTEGER,
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+select * from tab1;
+insert into tab2 values (100, 100, 100, 100);
+insert into tab2 values (200, 200, 200, 200);
+insert into tab2 values (300, 300, 300, 300);
+select * from tab2;
+update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2), v3 = 1000;
+select * from tab1;
+update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2) where k1 = 100;
+select * from tab1;
+update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
+select * from tab1;

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_after_schema_change
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_after_schema_change
@@ -1,0 +1,42 @@
+-- name: test_partial_update_after_schema_change
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+CREATE table tab2 (
+      k1 INTEGER,
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+select * from tab1;
+insert into tab2 values (100, 100, 100, 100);
+insert into tab2 values (200, 200, 200, 200);
+insert into tab2 values (300, 300, 300, 300);
+select * from tab2;
+alter table tab1 add column (v6 INTEGER DEFAULT "100");
+function: wait_alter_table_finish()
+select * from tab1;
+update tab1 set v6 = (select sum(tab2.v1) from tab2);
+select * from tab1;

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_before_schema_change
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_before_schema_change
@@ -1,0 +1,54 @@
+-- name: test_partial_update_before_schema_change
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+CREATE table tab2 (
+      k1 INTEGER,
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+select * from tab1;
+insert into tab2 values (100, 100, 100, 100);
+insert into tab2 values (200, 200, 200, 200);
+insert into tab2 values (300, 300, 300, 300);
+select * from tab2;
+update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
+select * from tab1;
+alter table tab1 add column (v6 INTEGER DEFAULT "100");
+function: wait_alter_table_finish()
+select * from tab1;
+alter table tab1 drop column v2;
+function: wait_alter_table_finish()
+select * from tab1;
+alter table tab1 drop column v5;
+function: wait_alter_table_finish()
+select * from tab1;
+alter table tab1 modify column v1 BIGINT;
+function: wait_alter_table_finish()
+select * from tab1;
+alter table tab1 modify column v3 BIGINT;
+function: wait_alter_table_finish()
+select * from tab1;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：

This PR propose a method to optimize partial update in specific scenarios. We call it `ColumnMode` partial update, and the original update mode is `RowMode`.

In current implement, partial update's basic logic contains two step:
1) Data load. Write partial column to segment files.
2) Transaction commit/apply. Read missing columns from source segment files and fill up current segment files.

Assume we have 100 column table, and we only partial update one column in this table, `RowMode` partial update need to read missing 99 columns from source segment, and write to current segment. It's write/read amplification is too large.

So I propose `ColumnMode` partial update to handle this scenario:
1) Update most of rows in table.
2) Only update a small number of columns.

The basic working flow of `ColumnMode partial` column update looks like:

```
Before update:

|    Segment-1 |
| c0 | c1 | c2 |
| 100 | 100 | 100 |
| 200 | 200 | 200 |
| 300 | 300 | 300 |
| 400 | 400 | 400 |

update load:

| Update-Segment-1 |
| c0 | c1 |
| 300 | 345 |
| 400 | 456 |

Transfer update segment to DeltaColumnGroup files:

|    Segment-1 |           | Update-Segment-1 |      | DeltaColumnGroup |
| c0 | c1 | c2 |           | c0 | c1 |               | c0 | c1 |
| 100 | 100 | 100 | ------------------------------>  | 100 | 100 |
| 200 | 200 | 200 | ------------------------------>  | 200 | 200 |
| 300 | 300 | 300 |        | 300 | 345 |  -------->  | 300 | 345 |
| 400 | 400 | 400 |        | 400 | 456 |  -------->  | 400 | 456 |

Final files looks like:

|    Segment-1 |          | DeltaColumnGroup |
| c0 | c1 | c2 |          | c0 | c1 |
| 100 | 100 | 100 |       | 100 | 100 |
| 200 | 200 | 200 |   +   | 200 | 200 |
| 300 | 300 | 300 |       | 300 | 345 |
| 400 | 400 | 400 |       | 400 | 456 |

Reading result will be:

| c0 | c1 | c2 |
| 100 | 100 | 100 |
| 200 | 200 | 200 |
| 300 | 345 | 300 |
| 400 | 456 | 400 |
```

We use `partial_update_mode=row/column` to decide the update mode, when `partial_update_mode=column`, this new update logic will be used. 
By streamload:
```
curl --location-trusted -u root: \
    -H "label:label7" -H "column_separator:," \
    -H "partial_update:true" \
    -H "partial_update_mode:column" \
    -H "columns:id,name" \
    -T example4.csv -XPUT\
    http://<fe_host>:<fe_http_port>/api/test_db/table4/_stream_load
```
By broker load:
```
LOAD LABEL test_db.table4
(
    data infile("hdfs://<hdfs_host>:<hdfs_port>/example4.csv")
    into table table4
    format as "csv"
    (id, name)
)
with broker
properties
(
    "partial_update" = "true",
    "partial_update_mode" = "column"
);
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
