### PR TITLE
[BugFix] Use the schema from hudi sdk to create external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -166,7 +166,7 @@ public class ColumnTypeConverter {
             case STRING:
                 return ScalarType.createDefaultExternalTableString();
             case ARRAY:
-                Type type = fromHudiTypeToArrayType(avroSchema);
+                Type type = new ArrayType(fromHudiType(avroSchema.getElementType()));
                 if (type.isArrayType()) {
                     return type;
                 } else {
@@ -176,14 +176,8 @@ public class ColumnTypeConverter {
             case FIXED:
             case BYTES:
                 if (logicalType instanceof LogicalTypes.Decimal) {
-                    int precision = 0;
-                    int scale = 0;
-                    if (avroSchema.getObjectProp("precision") instanceof Integer) {
-                        precision = (int) avroSchema.getObjectProp("precision");
-                    }
-                    if (avroSchema.getObjectProp("scale") instanceof Integer) {
-                        scale = (int) avroSchema.getObjectProp("scale");
-                    }
+                    int precision = ((LogicalTypes.Decimal) logicalType).getPrecision();
+                    int scale = ((LogicalTypes.Decimal) logicalType).getScale();
                     return ScalarType.createUnifiedDecimalType(precision, scale);
                 } else {
                     primitiveType = PrimitiveType.VARCHAR;
@@ -241,6 +235,78 @@ public class ColumnTypeConverter {
         }
 
         return ScalarType.createType(primitiveType);
+    }
+
+    // used for HUDI MOR reader only
+    // convert hudi column type(avroSchema) to hive type string with some customization
+    public static String fromHudiTypeToHiveTypeString(Schema avroSchema) {
+        Schema.Type columnType = avroSchema.getType();
+        LogicalType logicalType = avroSchema.getLogicalType();
+
+        switch (columnType) {
+            case BOOLEAN:
+                return "boolean";
+            case INT:
+                if (logicalType instanceof LogicalTypes.Date) {
+                    return "date";
+                } else if (logicalType instanceof LogicalTypes.TimeMillis) {
+                    throw new StarRocksConnectorException("Unsupported hudi {} type of column {}",
+                            logicalType.getName(), avroSchema.getName());
+                } else {
+                    return "int";
+                }
+            case LONG:
+                if (logicalType instanceof LogicalTypes.TimeMicros) {
+                    throw new StarRocksConnectorException("Unsupported hudi {} type of column {}",
+                            logicalType.getName(), avroSchema.getName());
+                } else if (logicalType instanceof LogicalTypes.TimestampMillis
+                        || logicalType instanceof LogicalTypes.TimestampMicros) {
+                    // customized value for int64 based timestamp
+                    return logicalType.getName();
+                } else {
+                    return "bigint";
+                }
+            case FLOAT:
+                return "float";
+            case DOUBLE:
+                return "double";
+            case STRING:
+                return "string";
+            case ARRAY:
+                String elementType = fromHudiTypeToHiveTypeString(avroSchema.getElementType());
+                return String.format("array<%s>", elementType);
+            case FIXED:
+            case BYTES:
+                if (logicalType instanceof LogicalTypes.Decimal) {
+                    int precision = ((LogicalTypes.Decimal) logicalType).getPrecision();
+                    int scale = ((LogicalTypes.Decimal) logicalType).getScale();
+                    return String.format("decimal(%s,%s)", precision, scale);
+                } else {
+                    return "string";
+                }
+            case RECORD:
+                // Struct type
+                List<Schema.Field> fields = avroSchema.getFields();
+                Preconditions.checkArgument(fields.size() > 0);
+                String nameToType = fields.stream()
+                        .map(f -> String.format("%s:%s", f.name(),
+                                fromHudiTypeToHiveTypeString(f.schema())))
+                        .collect(Collectors.joining(","));
+                return String.format("struct<%s>", nameToType);
+            case MAP:
+                Schema value = avroSchema.getValueType();
+                String valueType = fromHudiTypeToHiveTypeString(value);
+                return String.format("map<%s,%s>", "string", valueType);
+            case UNION:
+                List<Schema> nonNullMembers = avroSchema.getTypes().stream()
+                        .filter(schema -> !Schema.Type.NULL.equals(schema.getType()))
+                        .collect(Collectors.toList());
+                return fromHudiTypeToHiveTypeString(nonNullMembers.get(0));
+            case ENUM:
+            default:
+                throw new StarRocksConnectorException("Unsupported hudi {} type of column {}",
+                        avroSchema.getType().getName(), avroSchema.getName());
+        }
     }
 
     public static Type fromDeltaLakeType(DataType dataType) {
@@ -426,10 +492,6 @@ public class ColumnTypeConverter {
             return Integer.parseInt(matcher.group(1));
         }
         throw new StarRocksConnectorException("Failed to get varchar length at " + typeStr);
-    }
-
-    private static ArrayType fromHudiTypeToArrayType(Schema typeSchema) {
-        return new ArrayType(fromHudiType(typeSchema.getElementType()));
     }
 
     public static boolean validateHiveColumnType(Type type, Type otherType) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -33,15 +33,12 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hudi.HudiConnector;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.server.GlobalStateMgr;
-import org.apache.avro.LogicalType;
-import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -64,11 +61,11 @@ import static com.starrocks.catalog.HudiTable.HUDI_TABLE_INPUT_FOAMT;
 import static com.starrocks.catalog.HudiTable.HUDI_TABLE_SERDE_LIB;
 import static com.starrocks.catalog.HudiTable.HUDI_TABLE_TYPE;
 import static com.starrocks.connector.ColumnTypeConverter.fromHudiType;
+import static com.starrocks.connector.ColumnTypeConverter.fromHudiTypeToHiveTypeString;
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.toResourceName;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.hive.common.StatsSetupConst.ROW_COUNT;
 import static org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE;
-import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils.getTypeInfoFromTypeString;
 
 public class HiveMetastoreApiConverter {
     private static final Logger LOG = LogManager.getLogger(HiveMetastoreApiConverter.class);
@@ -273,34 +270,17 @@ public class HiveMetastoreApiConverter {
                 columnTypesBuilder.append("#");
             }
 
+            String columnName = hudiField.name().toLowerCase(Locale.ROOT);
             Optional<FieldSchema> field = allFields.stream()
-                    .filter(f -> f.getName().equals(hudiField.name().toLowerCase(Locale.ROOT))).findFirst();
+                    .filter(f -> f.getName().equals(columnName)).findFirst();
             if (!field.isPresent()) {
                 throw new StarRocksConnectorException(
                         "Hudi column [" + hudiField.name() + "] not exists in hive metastore.");
             }
+            columnNamesBuilder.append(columnName);
+            String columnType = fromHudiTypeToHiveTypeString(hudiField.schema());
+            columnTypesBuilder.append(columnType);
 
-            TypeInfo fieldInfo = getTypeInfoFromTypeString(field.get().getType());
-            columnNamesBuilder.append(field.get().getName());
-
-            String type = fieldInfo.getTypeName();
-            if (type.equals("timestamp")) {
-                Schema fieldSchema = hudiField.schema();
-                List<Schema> nonNullMembers = fieldSchema.getTypes().stream()
-                        .filter(schema -> !Schema.Type.NULL.equals(schema.getType()))
-                        .collect(Collectors.toList());
-                LogicalType logicalType = nonNullMembers.get(0).getLogicalType();
-                // INT64 based timestamp mark
-                if (logicalType instanceof LogicalTypes.TimestampMicros) {
-                    columnTypesBuilder.append("TimestampMicros");
-                } else if (logicalType instanceof LogicalTypes.TimestampMillis) {
-                    columnTypesBuilder.append("TimestampMillis");
-                } else {
-                    columnTypesBuilder.append(type);
-                }
-            } else {
-                columnTypesBuilder.append(type);
-            }
             isFirst = false;
         }
         hudiProperties.put(HUDI_TABLE_COLUMN_NAMES, columnNamesBuilder.toString());

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
@@ -37,8 +37,8 @@ public class HudiScannerUtils {
         builder.append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         DATETIME_FORMATTER = builder.toFormatter();
 
-        HIVE_TYPE_MAPPING.put("TimestampMicros", "timestamp");
-        HIVE_TYPE_MAPPING.put("TimestampMillis", "timestamp");
+        HIVE_TYPE_MAPPING.put("timestamp-micros", "timestamp");
+        HIVE_TYPE_MAPPING.put("timestamp-millis", "timestamp");
 
         TIMESTAMP_UNIT_MAPPING.put(ColumnType.TypeValue.DATETIME_MICROS, TimeUnit.MICROSECONDS);
         TIMESTAMP_UNIT_MAPPING.put(ColumnType.TypeValue.DATETIME_MILLIS, TimeUnit.MILLISECONDS);

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
@@ -173,7 +173,7 @@ public class HudiSliceScanner extends ConnectorScanner {
         String realtimePath = dataFileLength != -1 ? dataFilePath : deltaFilePaths[0];
         long realtimeLength = dataFileLength != -1 ? dataFileLength : 0;
         Path path = new Path(realtimePath);
-        FileSplit fileSplit = new FileSplit(path, 0, realtimeLength, new String[] {""});
+        FileSplit fileSplit = new FileSplit(path, 0, realtimeLength, (String[]) null);
         List<HoodieLogFile> logFiles = Arrays.stream(deltaFilePaths).map(HoodieLogFile::new).collect(toList());
         FileSplit hudiSplit =
                 new HoodieRealtimeFileSplit(fileSplit, basePath, logFiles, instantTime, false, Option.empty());

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -60,7 +60,6 @@ public class ColumnType {
 
     static {
         PRIMITIVE_TYPE_VALUE_MAPPING.put("byte", TypeValue.BYTE);
-        PRIMITIVE_TYPE_VALUE_MAPPING.put("bool", TypeValue.BOOLEAN);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("boolean", TypeValue.BOOLEAN);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("short", TypeValue.SHORT);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("int", TypeValue.INT);
@@ -71,8 +70,8 @@ public class ColumnType {
         PRIMITIVE_TYPE_VALUE_MAPPING.put("binary", TypeValue.BINARY);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("date", TypeValue.DATE);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("timestamp", TypeValue.DATETIME);
-        PRIMITIVE_TYPE_VALUE_MAPPING.put("TimestampMicros", TypeValue.DATETIME_MICROS);
-        PRIMITIVE_TYPE_VALUE_MAPPING.put("TimestampMillis", TypeValue.DATETIME_MILLIS);
+        PRIMITIVE_TYPE_VALUE_MAPPING.put("timestamp-micros", TypeValue.DATETIME_MICROS);
+        PRIMITIVE_TYPE_VALUE_MAPPING.put("timestamp-millis", TypeValue.DATETIME_MILLIS);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("decimal", TypeValue.DECIMAL);
 
         PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.BYTE, 1);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17900 

Fix the wrong query result of LONG type field in hudi table created by pyspark and hudi.

The root cause of the problem is the bug of hudi that write the INT field as the wrong LONG type into data file and sync the wrong INT type to HMS. So we should use the actual schema of HUDI table from Hudi SDK interface (obtained by commit meta and file footer internally) instead of HMS and use it as the single source of truth.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
