### PR TITLE
[Enhancement] Report some block cache statistics to profile and local file

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -98,6 +98,10 @@ Status BlockCache::remove_cache(const CacheKey& cache_key, off_t offset, size_t 
     return Status::OK();
 }
 
+std::unordered_map<std::string, double> BlockCache::cache_stats() {
+    return _kv_cache->cache_stats();
+}
+
 Status BlockCache::shutdown() {
     return _kv_cache->shutdown();
 }

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -44,6 +44,8 @@ public:
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove_cache(const CacheKey& cache_key, off_t offset, size_t size);
 
+    std::unordered_map<std::string, double> cache_stats();
+
     // Shutdown the cache instance to save some state meta
     Status shutdown();
 

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -33,6 +33,8 @@ struct CacheOptions {
     // advanced
     size_t block_size;
     bool checksum;
+    size_t max_parcel_memory_mb;
+    size_t max_concurrent_inserts;
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -32,6 +32,8 @@ Status FbCacheLib::init(const CacheOptions& options) {
 
         for (auto& dir : options.disk_spaces) {
             nvm_files.emplace_back(dir.path + "/cachelib_data");
+            // If exist, truncate it to empty file
+            FileSystemUtil::resize_file(nvm_files.back(), 0);
         }
         if (nvm_files.size() == 1) {
             nvmConfig.navyConfig.setSimpleFile(nvm_files[0], options.disk_spaces[0].size, false);
@@ -47,6 +49,7 @@ Status FbCacheLib::init(const CacheOptions& options) {
 
     _cache = std::make_unique<Cache>(config);
     _default_pool = _cache->addPool("default pool", _cache->getCacheMemoryStats().cacheSize);
+    _meta_path = options.meta_path;
     return Status::OK();
 }
 
@@ -84,8 +87,14 @@ Status FbCacheLib::remove_cache(const std::string& key) {
     return Status::OK();
 }
 
+std::unordered_map<std::string, double> FbCacheLib::cache_stats() {
+    const auto navy_stats = _cache->getNvmCacheStatsMap().toMap();
+    return navy_stats;
+}
+
 Status FbCacheLib::shutdown() {
     if (_cache) {
+        _dump_cache_stats();
         auto res = _cache->shutDown();
         if (res != Cache::ShutDownStatus::kSuccess) {
             LOG(WARNING) << "block cache shutdown failed";
@@ -93,6 +102,16 @@ Status FbCacheLib::shutdown() {
         }
     }
     return Status::OK();
+}
+
+void FbCacheLib::_dump_cache_stats() {
+    std::ofstream of;
+    of.open(_meta_path + "/cachelib_stat", std::ios::out | std::ios::trunc);
+    const auto stats = cache_stats();
+    for (auto& stat : stats) {
+        of << stat.first << " : " << stat.second << "\n";
+    }
+    of.close();
 }
 
 } // namespace starrocks

--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -40,6 +40,8 @@ Status FbCacheLib::init(const CacheOptions& options) {
         }
         nvmConfig.navyConfig.blockCache().setRegionSize(16 * 1024 * 1024);
         nvmConfig.navyConfig.blockCache().setDataChecksum(options.checksum);
+        nvmConfig.navyConfig.setMaxParcelMemoryMB(options.max_parcel_memory_mb);
+        nvmConfig.navyConfig.setMaxConcurrentInserts(options.max_concurrent_inserts);
         config.enableNvmCache(nvmConfig);
     }
 

--- a/be/src/block_cache/fb_cachelib.h
+++ b/be/src/block_cache/fb_cachelib.h
@@ -50,11 +50,16 @@ public:
 
     Status remove_cache(const std::string& key) override;
 
+    std::unordered_map<std::string, double> cache_stats() override;
+
     Status shutdown() override;
 
 private:
+    void _dump_cache_stats();
+
     std::unique_ptr<Cache> _cache = nullptr;
     PoolId _default_pool;
+    std::string _meta_path;
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -36,6 +36,8 @@ public:
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove_cache(const std::string& key) = 0;
 
+    virtual std::unordered_map<std::string, double> cache_stats() = 0;
+
     virtual Status shutdown() = 0;
 };
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -861,13 +861,14 @@ CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
 CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
 CONF_Int64(block_cache_block_size, "1048576");  // 1MB
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
-CONF_Bool(block_cache_checksum_enable, "true");
+CONF_Bool(block_cache_checksum_enable, "false");
 // Maximum number of concurrent inserts we allow globally for block cache.
 // 0 means unlimited.
 CONF_Int64(block_cache_max_concurrent_inserts, "1000000");
 // Total memory limit for in-flight parcels.
 // Once this is reached, requests will be rejected until the parcel memory usage gets under the limit.
 CONF_Int64(block_cache_max_parcel_memory_mb, "256");
+CONF_Bool(block_cache_report_stats, "false");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -862,6 +862,12 @@ CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
 CONF_Int64(block_cache_block_size, "1048576");  // 1MB
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 CONF_Bool(block_cache_checksum_enable, "true");
+// Maximum number of concurrent inserts we allow globally for block cache.
+// 0 means unlimited.
+CONF_Int64(block_cache_max_concurrent_inserts, "1000000");
+// Total memory limit for in-flight parcels.
+// Once this is reached, requests will be rejected until the parcel memory usage gets under the limit.
+CONF_Int64(block_cache_max_parcel_memory_mb, "256");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -255,6 +255,10 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
         _profile.block_cache_write_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteBytes", TUnit::BYTES, prefix);
         _profile.block_cache_write_timer = ADD_CHILD_TIMER(_runtime_profile, "BlockCacheWriteTimer", prefix);
+        _profile.block_cache_reject_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheRejectCounter", TUnit::UNIT, prefix);
+        _profile.block_cache_write_fail_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteFailCounter", TUnit::UNIT, prefix);
     }
 
     if (hdfs_scan_node.__isset.table_name) {

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -270,6 +270,8 @@ void HdfsScanner::update_counter() {
         COUNTER_UPDATE(profile->block_cache_write_counter, stats.write_cache_count);
         COUNTER_UPDATE(profile->block_cache_write_bytes, stats.write_cache_bytes);
         COUNTER_UPDATE(profile->block_cache_write_timer, stats.write_cache_ns);
+        COUNTER_UPDATE(profile->block_cache_reject_counter, stats.reject_cache_count);
+        COUNTER_UPDATE(profile->block_cache_write_fail_counter, stats.write_cache_fail_count);
     }
     // update scanner private profile.
     do_update_counter(profile);

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -93,6 +93,8 @@ struct HdfsScanProfile {
     RuntimeProfile::Counter* block_cache_write_counter = nullptr;
     RuntimeProfile::Counter* block_cache_write_bytes = nullptr;
     RuntimeProfile::Counter* block_cache_write_timer = nullptr;
+    RuntimeProfile::Counter* block_cache_reject_counter = nullptr;
+    RuntimeProfile::Counter* block_cache_write_fail_counter = nullptr;
 };
 
 struct HdfsScannerParams {

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -30,6 +30,8 @@ public:
         int64_t write_cache_count = 0;
         int64_t read_cache_bytes = 0;
         int64_t write_cache_bytes = 0;
+        int64_t reject_cache_count = 0;
+        int64_t write_cache_fail_count = 0;
     };
 
     static constexpr int64_t BLOCK_SIZE = 1 * 1024 * 1024;
@@ -45,7 +47,7 @@ public:
 
     StatusOr<int64_t> get_size() override;
 
-    const Stats& stats() { return _stats; }
+    const Stats& stats();
 
     void set_enable_populate_cache(bool v) { _enable_populate_cache = v; }
 
@@ -57,6 +59,7 @@ private:
     std::string _buffer;
     Stats _stats;
     int64_t _size;
+    int64_t _cache_rejects = 0;
     bool _enable_populate_cache = false;
 };
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -209,6 +209,8 @@ int main(int argc, char** argv) {
         cache_options.meta_path = starrocks::config::block_cache_meta_path;
         cache_options.block_size = starrocks::config::block_cache_block_size;
         cache_options.checksum = starrocks::config::block_cache_checksum_enable;
+        cache_options.max_parcel_memory_mb = starrocks::config::block_cache_max_parcel_memory_mb;
+        cache_options.max_concurrent_inserts = starrocks::config::block_cache_max_concurrent_inserts;
         cache->init(cache_options);
     }
 #endif


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We dump some block cache statistics to local file in metadata directory. As the file will be updated before the StarRocks BE shutdown procedure, so you need to shutdown the BE process with graceful mode, such as `./bin/stop_be.sh -g`.
Also, we report some statistics to query profile.

In this PR, we also export some configurations which can control the job concurrency to optimize the cache performance in some cases.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
