### PR TITLE
[Enhancement] Don't fetch column Statistics when there is no need for Iceberg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -171,10 +171,14 @@ public class IcebergUtil {
      */
     public static TableScan getTableScan(Table table,
                                          Snapshot snapshot,
-                                         Expression icebergPredicate) {
+                                         Expression icebergPredicate,
+                                         Boolean includeColumnStats) {
         // TODO: use planWith(executorService) after
         // https://github.com/apache/iceberg/commit/74db81f4dd81360bf3c0ad438d4be937c7a812d9 release
-        TableScan tableScan = table.newScan().useSnapshot(snapshot.snapshotId()).includeColumnStats();
+        TableScan tableScan = table.newScan().useSnapshot(snapshot.snapshotId());
+        if (includeColumnStats) {
+            tableScan = tableScan.includeColumnStats();
+        }
         if (icebergPredicate != null) {
             tableScan = tableScan.filter(icebergPredicate);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergTableStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergTableStatisticCalculator.java
@@ -225,7 +225,7 @@ public class IcebergTableStatisticCalculator {
                 .collect(toImmutableList());
 
         TableScan tableScan = IcebergUtil.getTableScan(icebergTable,
-                snapshot.get(), icebergPredicate);
+                snapshot.get(), icebergPredicate, true);
 
         IcebergFileStats icebergFileStats = null;
         for (CombinedScanTask combinedScanTask : tableScan.planTasks()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -238,7 +238,7 @@ public class IcebergScanNode extends ScanNode {
         Map<StructLike, Long> partitionMap = Maps.newHashMap();
 
         for (CombinedScanTask combinedScanTask : IcebergUtil.getTableScan(
-                srIcebergTable.getIcebergTable(), snapshot.get(), icebergPredicate).planTasks()) {
+                srIcebergTable.getIcebergTable(), snapshot.get(), icebergPredicate, false).planTasks()) {
             for (FileScanTask task : combinedScanTask.files()) {
                 DataFile file = task.file();
                 LOG.debug("Scan with file " + file.path() + ", file record count " + file.recordCount());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -138,7 +138,8 @@ public class IcebergScanNodeTest {
             @Mock
             public TableScan getTableScan(Table table,
                                           Snapshot snapshot,
-                                          Expression icebergPredicate) {
+                                          Expression icebergPredicate,
+                                          Boolean includeColumnStats) {
                 return new DataTableScan(null, iTable);
             }
         };


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Avro decode is cpu intensive, so we shouldn't fetch column statistics when there is no need
## Checklist:
#18560

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
