### PR TITLE
[BugFix] Use rollup not table to check UnusedOutputColumns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -38,6 +38,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
@@ -374,7 +375,8 @@ public class PlanFragmentBuilder {
             // Key columns and value columns cannot be pruned in the non-skip-aggr scan stage.
             // - All the keys columns must be retained to merge and aggregate rows.
             // - Value columns can only be used after merging and aggregating.
-            if (referenceTable.getKeysType().isAggregationFamily() && !node.isPreAggregation()) {
+            MaterializedIndexMeta materializedIndexMeta = referenceTable.getIndexMetaByIndexId(node.getSelectedIndexId());
+            if (materializedIndexMeta.getKeysType().isAggregationFamily() && !node.isPreAggregation()) {
                 return;
             }
 
@@ -396,12 +398,12 @@ public class PlanFragmentBuilder {
             Set<Integer> singlePredColumnIds = new HashSet<Integer>();
             Set<Integer> complexPredColumnIds = new HashSet<Integer>();
             Set<String> aggOrPrimaryKeyTableValueColumnNames = new HashSet<String>();
-            if (referenceTable.getKeysType().isAggregationFamily() ||
-                    referenceTable.getKeysType() == KeysType.PRIMARY_KEYS) {
+            if (materializedIndexMeta.getKeysType().isAggregationFamily() ||
+                    materializedIndexMeta.getKeysType() == KeysType.PRIMARY_KEYS) {
                 aggOrPrimaryKeyTableValueColumnNames =
-                        referenceTable.getFullSchema().stream()
+                        materializedIndexMeta.getSchema().stream()
                                 .filter(col -> !col.isKey())
-                                .map(col -> col.getName())
+                                .map(Column::getName)
                                 .collect(Collectors.toSet());
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -70,6 +70,10 @@ public class FilterUnusedColumnTest extends PlanTestBase {
                 "\"in_memory\" = \"false\",\n" +
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW tpcds_100g_date_dim_mv as \n" +
+                "SELECT d_dow, d_day_name, max(d_date) \n" +
+                "FROM tpcds_100g_date_dim\n" +
+                "GROUP BY d_dow, d_day_name");
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setSqlMode(2);
         connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
@@ -120,7 +124,6 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             // Key columns cannot be pruned in the non-skip-aggr scan stage.
             String sql = "select timestamp from metrics_detail where tags_id > 1";
             String plan = getThriftPlan(sql);
-            System.out.println(plan);
             Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
 
             sql = "select max(value) from metrics_detail where tags_id > 1";
@@ -136,6 +139,33 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             sql = "select timestamp from metrics_detail where value is NULL limit 10;";
             plan = getThriftPlan(sql);
             Assert.assertTrue(plan.contains("unused_output_column_name:[]"));
+        } finally {
+            connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(prevEnable);
+        }
+    }
+
+    @Test
+    public void testFilterAggMV() throws Exception {
+        boolean prevEnable = connectContext.getSessionVariable().isEnableFilterUnusedColumnsInScanStage();
+
+        try {
+            connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
+
+            String sql;
+            String plan;
+
+            // Key columns cannot be pruned in the non-skip-aggr scan stage of MV.
+            sql = "select distinct d_day_name from tpcds_100g_date_dim where d_dow > 1";
+            plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[]");
+            assertContains(plan, "rollup_name:tpcds_100g_date_dim_mv");
+
+            // Columns can be pruned when not using MV.
+            sql = "select d_day_name from tpcds_100g_date_dim where d_dow > 1";
+            plan = getThriftPlan(sql);
+            assertContains(plan, "unused_output_column_name:[d_dow]");
+            assertContains(plan, "rollup_name:tpcds_100g_date_dim");
+
         } finally {
             connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(prevEnable);
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18216

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
All the columns of aggregate table cannot be pruned by the `UnusedOutputColumns` optimization.
Therefore, we check it as follows: 
```java
        private void setUnUsedOutputColumns(PhysicalOlapScanOperator node, OlapScanNode scanNode,
                                            List<ScalarOperator> predicates, OlapTable referenceTable) {
            if (referenceTable.getKeysType().isAggregationFamily() && !node.isPreAggregation()) {
                return;
            }
            // ...
        }
```

However, there is a case we doesn't consider, where the original table is not aggregate table, but the hit MV is aggregate table.

Therefore, we check the rollup table not the original table.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
