### PR TITLE
[Enhancement] Add BE tablets information to information schema

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -115,6 +115,7 @@ set(EXEC_FILES
     schema_scanner/schema_schema_privileges_scanner.cpp
     schema_scanner/schema_table_privileges_scanner.cpp
     schema_scanner/schema_tables_config_scanner.cpp
+    schema_scanner/schema_be_tablets_scanner.cpp
     schema_scanner/schema_helper.cpp
     jdbc_scanner.cpp
     sorting/compare_column.cpp

--- a/be/src/exec/pipeline/scan/olap_schema_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_schema_scan_context.cpp
@@ -70,6 +70,17 @@ Status OlapSchemaScanContext::_prepare_params(RuntimeState* state) {
         _param->without_db_table = true;
         _param->limit = _tnode.limit;
     }
+
+    if (_tnode.schema_scan_node.__isset.table_id) {
+        _param->table_id = _tnode.schema_scan_node.table_id;
+    }
+    if (_tnode.schema_scan_node.__isset.partition_id) {
+        _param->partition_id = _tnode.schema_scan_node.partition_id;
+    }
+    if (_tnode.schema_scan_node.__isset.tablet_id) {
+        _param->tablet_id = _tnode.schema_scan_node.tablet_id;
+    }
+
     return Status::OK();
 }
 

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -15,6 +15,7 @@
 #include "exec/schema_scanner.h"
 
 #include "column/type_traits.h"
+#include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "exec/schema_scanner/schema_charsets_scanner.h"
 #include "exec/schema_scanner/schema_collations_scanner.h"
 #include "exec/schema_scanner/schema_columns_scanner.h"
@@ -114,6 +115,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaTablesConfigScanner>();
     case TSchemaTableType::SCH_VERBOSE_SESSION_VARIABLES:
         return std::make_unique<SchemaVariablesScanner>(TVarType::VERBOSE);
+    case TSchemaTableType::SCH_BE_TABLETS:
+        return std::make_unique<SchemaBeTabletsScanner>();
     default:
         return std::make_unique<SchemaDummyScanner>();
     }

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -50,12 +50,14 @@ struct SchemaScannerParam {
     // and no longer call get_db_names() and get_table_names().
     bool without_db_table{false};
 
+    int64_t table_id{-1};
+    int64_t partition_id{-1};
+    int64_t tablet_id{-1};
+
     RuntimeProfile::Counter* _rpc_timer = nullptr;
     RuntimeProfile::Counter* _fill_chunk_timer = nullptr;
 
-    SchemaScannerParam()
-
-            = default;
+    SchemaScannerParam() = default;
 };
 
 // virtual scanner for all schema table

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_be_tablets_scanner.h"
+
+#include "agent/master_info.h"
+#include "exec/schema_scanner/schema_helper.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/string_value.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaBeTabletsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},        {"TABLE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"PARTITION_ID", TYPE_BIGINT, sizeof(int64_t), false}, {"TABLET_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NUM_VERSION", TYPE_BIGINT, sizeof(int64_t), false},  {"MAX_VERSION", TYPE_BIGINT, sizeof(int64_t), false},
+        {"MIN_VERSION", TYPE_BIGINT, sizeof(int64_t), false},  {"NUM_ROWSET", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NUM_ROW", TYPE_BIGINT, sizeof(int64_t), false},      {"DATA_SIZE", TYPE_BIGINT, sizeof(int64_t), false},
+        {"INDEX_MEM", TYPE_BIGINT, sizeof(int64_t), false},    {"CREATE_TIME", TYPE_BIGINT, sizeof(int64_t), false},
+        {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},   {"TYPE", TYPE_VARCHAR, sizeof(StringValue), false},
+};
+
+SchemaBeTabletsScanner::SchemaBeTabletsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeTabletsScanner::~SchemaBeTabletsScanner() = default;
+
+Status SchemaBeTabletsScanner::start(RuntimeState* state) {
+    auto o_id = get_backend_id();
+    _be_id = o_id.has_value() ? o_id.value() : -1;
+    _infos.clear();
+    auto manager = StorageEngine::instance()->tablet_manager();
+    manager->get_tablets_basic_infos(_param->table_id, _param->partition_id, _param->tablet_id, _infos);
+    LOG(INFO) << strings::Substitute("get_tablets_basic_infos table_id:$0 partition:$1 tablet:$2 #info:$3",
+                                     _param->table_id, _param->partition_id, _param->tablet_id, _infos.size());
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+static const char* tablet_state_to_string(TabletState state) {
+    switch (state) {
+    case TabletState::TABLET_NOTREADY:
+        return "NOTREADY";
+    case TabletState::TABLET_RUNNING:
+        return "RUNNING";
+    case TabletState::TABLET_TOMBSTONED:
+        return "TOMBSTONED";
+    case TabletState::TABLET_STOPPED:
+        return "STOPPED";
+    case TabletState::TABLET_SHUTDOWN:
+        return "SHUTDOWN";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+static const char* keys_type_to_string(KeysType type) {
+    switch (type) {
+    case KeysType::DUP_KEYS:
+        return "DUP";
+    case KeysType::UNIQUE_KEYS:
+        return "UNIQUE";
+    case KeysType::AGG_KEYS:
+        return "AGG";
+    case KeysType::PRIMARY_KEYS:
+        return "PRIMARY";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+Status SchemaBeTabletsScanner::fill_chunk(ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 14) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                // table id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.table_id);
+                break;
+            }
+            case 3: {
+                // partition id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.partition_id);
+                break;
+            }
+            case 4: {
+                // tablet id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.tablet_id);
+                break;
+            }
+            case 5: {
+                // num version
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_version);
+                break;
+            }
+            case 6: {
+                // max version
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.max_version);
+                break;
+            }
+            case 7: {
+                // min version
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.min_version);
+                break;
+            }
+            case 8: {
+                // num rowset
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_rowset);
+                break;
+            }
+            case 9: {
+                // num rowt
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_row);
+                break;
+            }
+            case 10: {
+                // data size
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.data_size);
+                break;
+            }
+            case 11: {
+                // index mem
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.index_mem);
+                break;
+            }
+            case 12: {
+                // create time
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.create_time);
+                break;
+            }
+            case 13: {
+                // state
+                Slice state = Slice(tablet_state_to_string((TabletState)info.state));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&state);
+                break;
+            }
+            case 14: {
+                // type
+                Slice type = Slice(keys_type_to_string((KeysType)info.type));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&type);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeTabletsScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.h
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "exec/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+struct TabletBasicInfo {
+    int64_t table_id{0};
+    int64_t partition_id{0};
+    int64_t tablet_id{0};
+    int64_t num_version{0};
+    int64_t max_version{0};
+    int64_t min_version{0};
+    int64_t num_rowset{0};
+    int64_t num_row{0};
+    int64_t data_size{0};
+    int64_t index_mem{0};
+    int64_t create_time{0};
+    int32_t state{0};
+    int32_t type{0};
+};
+
+class SchemaBeTabletsScanner : public SchemaScanner {
+public:
+    SchemaBeTabletsScanner();
+    ~SchemaBeTabletsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<TabletBasicInfo> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -67,6 +67,7 @@ class TabletUpdates;
 class CompactionTask;
 class CompactionCandidate;
 class CompactionContext;
+class TabletBasicInfo;
 
 using TabletSharedPtr = std::shared_ptr<Tablet>;
 
@@ -288,6 +289,8 @@ public:
     BinlogManager* binlog_manager() { return _binlog_manager == nullptr ? nullptr : _binlog_manager.get(); }
 
     Status contains_version(const Version& version);
+
+    void get_basic_info(TabletBasicInfo& info);
 
 protected:
     void on_shutdown() override;

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -60,6 +60,7 @@ namespace starrocks {
 
 class Tablet;
 class DataDir;
+class TabletBasicInfo;
 
 // RowsetsAcqRel is a RAII wrapper for invocation of Rowset::acquire_readers and Rowset::release_readers
 class RowsetsAcqRel;
@@ -187,6 +188,9 @@ public:
     std::unordered_map<TTabletId, std::vector<std::pair<uint32_t, uint32_t>>> get_tablets_need_repair_compaction();
 
     void get_tablets_by_partition(int64_t partition_id, std::vector<TabletInfo>& tablet_infos);
+
+    void get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
+                                 std::vector<TabletBasicInfo>& tablet_infos);
 
 private:
     using TabletMap = std::unordered_map<int64_t, TabletSharedPtr>;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -20,6 +20,7 @@
 
 #include "common/status.h"
 #include "common/tracer.h"
+#include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "gen_cpp/MasterService_types.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "gutil/stl_util.h"
@@ -3031,6 +3032,44 @@ Status TabletUpdates::check_and_remove_rowset() {
         return Status::InternalError(msg);
     }
     return Status::OK();
+}
+
+void TabletUpdates::get_basic_info_extra(TabletBasicInfo& info) {
+    vector<uint32_t> rowsets;
+    {
+        std::lock_guard rl(_lock);
+        if (_edit_version_infos.empty()) {
+            LOG(WARNING) << "tablet delete when get_tablet_info_extra tablet:" << _tablet.tablet_id();
+            return;
+        }
+        info.num_version = _edit_version_infos.size();
+        info.min_version = _edit_version_infos[0]->version.major();
+        auto& v = _edit_version_infos[_edit_version_infos.size() - 1];
+        info.max_version = v->version.major();
+        info.num_rowset = v->rowsets.size();
+        rowsets = v->rowsets;
+    }
+    int64_t total_row = 0;
+    int64_t total_size = 0;
+    {
+        std::lock_guard lg(_rowset_stats_lock);
+        for (uint32_t rowsetid : rowsets) {
+            auto itr = _rowset_stats.find(rowsetid);
+            if (itr != _rowset_stats.end()) {
+                // TODO(cbl): also report num deletes
+                total_row += itr->second->num_rows;
+                total_size += itr->second->byte_size;
+            }
+        }
+    }
+    info.num_row = total_row;
+    info.data_size = total_size;
+    auto& index_cache = StorageEngine::instance()->update_manager()->index_cache();
+    auto index_entry = index_cache.get(_tablet.tablet_id());
+    if (index_entry != nullptr) {
+        info.index_mem = index_entry->size();
+        index_cache.release(index_entry);
+    }
 }
 
 void TabletUpdates::_to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -39,6 +39,7 @@ class MemTracker;
 class RowsetReadOptions;
 class SnapshotMeta;
 class Tablet;
+class TabletBasicInfo;
 class TTabletInfo;
 
 class ChunkIterator;
@@ -258,6 +259,8 @@ public:
                            std::vector<RowsetMetaPB>& rowset_metas_pb);
 
     Status check_and_remove_rowset();
+
+    void get_basic_info_extra(TabletBasicInfo& info);
 
 private:
     friend class Tablet;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -503,6 +503,26 @@ public class SchemaTable extends Table {
                                             .column("SORT_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
                                             .column("PROPERTIES", ScalarType.createVarchar(MAX_FIELD_VARCHARLENGTH))
                                             .build()))
+                    .put("be_tablets", new SchemaTable(
+                            SystemId.BE_TABLETS_ID,
+                            "be_tablets",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TABLE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("PARTITION_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NUM_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("MAX_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("MIN_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NUM_ROWSET", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NUM_ROW", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("DATA_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("INDEX_MEM", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("CREATE_TIME", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .build()))
                     .build();
 
     public static class Builder {
@@ -589,6 +609,8 @@ public class SchemaTable extends Table {
         SCH_TASK_RUNS("TASK_RUNS", "TASK_RUNS", TSchemaTableType.SCH_TASK_RUNS),
         SCH_VERBOSE_SESSION_VARIABLES("VERBOSE_SESSION_VARIABLES", "VERBOSE_SESSION_VARIABLES",
                 TSchemaTableType.SCH_VERBOSE_SESSION_VARIABLES),
+        SCH_BE_TABLETS("BE_TABLETS", "BE_TABLETS",
+                TSchemaTableType.SCH_BE_TABLETS),
         SCH_INVALID("NULL", "NULL", TSchemaTableType.SCH_INVALID);
 
         private final String description;

--- a/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.common;
 
 // used for system table.
@@ -69,4 +68,5 @@ public class SystemId {
 
     public static final long VERBOSE_SESSION_VARIABLES_ID = 25L;
 
+    public static final long BE_TABLETS_ID = 26L;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1109,12 +1109,28 @@ public class PlanFragmentBuilder {
                                 case "TABLE_NAME":
                                     scanNode.setSchemaTable(constantOperator.getVarchar());
                                     break;
+                                case "BE_ID":
+                                    scanNode.setBeId(constantOperator.getBigint());
+                                    break;
+                                case "TABLE_ID":
+                                    scanNode.setTableId(constantOperator.getBigint());
+                                    break;
+                                case "PARTITION_ID":
+                                    scanNode.setPartitionId(constantOperator.getBigint());
+                                    break;
+                                case "TABLET_ID":
+                                    scanNode.setTabletId(constantOperator.getBigint());
+                                    break;
                                 default:
                                     break;
                             }
                         }
                     }
                 }
+            }
+
+            if (scanNode.isBeSchemaTable()) {
+                scanNode.computeBeScanRanges();
             }
 
             context.getScanNodes().add(scanNode);

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -137,6 +137,7 @@ enum TSchemaTableType {
     SCH_TASKS,
     SCH_TASK_RUNS,
     SCH_VERBOSE_SESSION_VARIABLES,
+    SCH_BE_TABLETS,
     SCH_INVALID
 }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -417,6 +417,9 @@ struct TSchemaScanNode {
   9: optional i64 thread_id
   10: optional string user_ip   // deprecated
   11: optional Types.TUserIdentity current_user_ident   // to replace the user and user_ip
+  12: optional i64 table_id
+  13: optional i64 partition_id
+  14: optional i64 tablet_id
 }
 
 struct TOlapScanNode {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18200

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds a new table to information_schema: be_tablets, it exposes each BE's tablets basic information to be easily queried, so developers can debug BE storage engine problems more easily. 

Note that the data is fetched from BE directly and processed in BE, so the tablets' information may be different than replica information in FE(usually use can get using show tablet/proc etc.).  So if FE and BE's information does not match/is inconsistent, it usually means a bug.

```
mysql> select * from information_schema.be_tablets;
+-------+----------+--------------+-----------+-------------+-------------+-------------+------------+---------+-----------+-----------+-------------+---------+---------+
| BE_ID | TABLE_ID | PARTITION_ID | TABLET_ID | NUM_VERSION | MAX_VERSION | MIN_VERSION | NUM_ROWSET | NUM_ROW | DATA_SIZE | INDEX_MEM | CREATE_TIME | STATE   | TYPE    |
+-------+----------+--------------+-----------+-------------+-------------+-------------+------------+---------+-----------+-----------+-------------+---------+---------+
| 10003 |    10008 |        10007 |     10010 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10012 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10014 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10016 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10018 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10020 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10022 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10024 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10026 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10008 |        10007 |     10028 |           1 |           6 |           6 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | UNIQUE  |
| 10003 |    10031 |        10030 |     10033 |           1 |          21 |          21 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10035 |           1 |          21 |          21 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10037 |           1 |          21 |          21 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10039 |           1 |          21 |          21 |          1 |       2 |      1971 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10041 |           1 |          21 |          21 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10043 |           1 |          21 |          21 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10045 |           1 |          21 |          21 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10047 |           1 |          21 |          21 |          1 |       2 |      1914 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10049 |           1 |          21 |          21 |          1 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10031 |        10030 |     10051 |           1 |          21 |          21 |          1 |       1 |      1877 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10056 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10058 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10060 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10062 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10064 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10066 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10068 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10070 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10072 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    10054 |        10053 |     10074 |           1 |           1 |           1 |          0 |       0 |         0 |         0 |  1671678747 | RUNNING | PRIMARY |
| 10003 |    16014 |        16013 |     16016 |           2 |           2 |           1 |          2 |       1 |       369 |         0 |  1672369978 | RUNNING | DUP     |
| 10003 |    18009 |        18008 |     18011 |           1 |           3 |           3 |          1 |       3 |       479 |         0 |  1676983570 | RUNNING | PRIMARY |
+-------+----------+--------------+-----------+-------------+-------------+-------------+------------+---------+-----------+-----------+-------------+---------+---------+
32 rows in set (0.01 sec)



mysql> select table_id, sum(num_rowset), sum(1) as num_tablet from information_schema.be_tablets group by table_id;
+----------+-----------------+------------+
| table_id | sum(num_rowset) | num_tablet |
+----------+-----------------+------------+
|    16014 |               2 |          1 |
|    10054 |               0 |         10 |
|    10031 |              10 |         10 |
|    10008 |              10 |         10 |
|    18009 |               1 |          1 |
+----------+-----------------+------------+
5 rows in set (0.02 sec)

```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
