### PR TITLE
[Enhancement] Keep all different string infos when merging profile if there is conflict

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -410,8 +410,24 @@ void RuntimeProfile::copy_all_info_strings_from(RuntimeProfile* src_profile) {
     }
 
     std::lock_guard<std::mutex> l(src_profile->_info_strings_lock);
-    for (auto& [key, value] : src_profile->_info_strings) {
-        add_info_string(key, value);
+    for (const auto& [key, value] : src_profile->_info_strings) {
+        const std::string* exist_ptr = get_info_string(key);
+        if (exist_ptr == nullptr) {
+            add_info_string(key, value);
+        } else if (value != *exist_ptr) {
+            std::string original_key = key;
+            if (size_t pos; (pos = key.find("__DUP(")) != std::string::npos) {
+                original_key = key.substr(0, pos);
+            }
+            size_t i = 0;
+            while (true) {
+                const std::string indexed_key = strings::Substitute("$0__DUP($1)", original_key, i++);
+                if (get_info_string(indexed_key) == nullptr) {
+                    add_info_string(indexed_key, value);
+                    break;
+                }
+            }
+        }
     }
 }
 
@@ -788,6 +804,13 @@ void RuntimeProfile::merge_isomorphic_profiles(std::vector<RuntimeProfile*>& pro
 
     // all metrics will be merged into the first profile
     auto* profile0 = profiles[0];
+
+    // Merge into string, if contents are different, only the last will be preserved;
+    {
+        for (size_t i = 1; i < profiles.size(); i++) {
+            profile0->copy_all_info_strings_from(profiles[i]);
+        }
+    }
 
     // Merge counters
     {

--- a/be/test/util/runtime_profile_test.cpp
+++ b/be/test/util/runtime_profile_test.cpp
@@ -256,7 +256,7 @@ TEST(TestRuntimeProfile, testConflictInfoString) {
     }
     auto profile2 = std::make_shared<RuntimeProfile>("profile");
     {
-        profile2->add_info_string("key1", "value2"); // key1__DUP(0)
+        profile2->add_info_string("key1", "value2");
         profiles.push_back(profile2.get());
     }
     auto profile3 = std::make_shared<RuntimeProfile>("profile");
@@ -266,14 +266,14 @@ TEST(TestRuntimeProfile, testConflictInfoString) {
     }
     auto profile4 = std::make_shared<RuntimeProfile>("profile");
     {
-        profile4->add_info_string("key1__DUP(1)", "value3"); // key1__DUP(1)
-        profile4->add_info_string("key1", "value4");         // key1__DUP(2)
+        profile4->add_info_string("key1__DUP(1)", "value3");
+        profile4->add_info_string("key1", "value4");
         profiles.push_back(profile4.get());
     }
     auto profile5 = std::make_shared<RuntimeProfile>("profile");
     {
-        profile5->add_info_string("key1", "value5");         // key1__DUP(3)
-        profile5->add_info_string("key1__DUP(1)", "value6"); // key1__DUP(4)
+        profile5->add_info_string("key1", "value5");
+        profile5->add_info_string("key1__DUP(1)", "value6");
         profiles.push_back(profile5.get());
     }
 

--- a/be/test/util/runtime_profile_test.cpp
+++ b/be/test/util/runtime_profile_test.cpp
@@ -247,4 +247,55 @@ TEST(TestRuntimeProfile, testProfileMergeStrategy) {
     ASSERT_EQ(8, merged_max_of_count2->value());
 }
 
+TEST(TestRuntimeProfile, testConflictInfoString) {
+    std::vector<RuntimeProfile*> profiles;
+    auto profile1 = std::make_shared<RuntimeProfile>("profile");
+    {
+        profile1->add_info_string("key1", "value1");
+        profiles.push_back(profile1.get());
+    }
+    auto profile2 = std::make_shared<RuntimeProfile>("profile");
+    {
+        profile2->add_info_string("key1", "value2"); // key1__DUP(0)
+        profiles.push_back(profile2.get());
+    }
+    auto profile3 = std::make_shared<RuntimeProfile>("profile");
+    {
+        profile3->add_info_string("key1", "value1");
+        profiles.push_back(profile3.get());
+    }
+    auto profile4 = std::make_shared<RuntimeProfile>("profile");
+    {
+        profile4->add_info_string("key1__DUP(1)", "value3"); // key1__DUP(1)
+        profile4->add_info_string("key1", "value4");         // key1__DUP(2)
+        profiles.push_back(profile4.get());
+    }
+    auto profile5 = std::make_shared<RuntimeProfile>("profile");
+    {
+        profile5->add_info_string("key1", "value5");         // key1__DUP(3)
+        profile5->add_info_string("key1__DUP(1)", "value6"); // key1__DUP(4)
+        profiles.push_back(profile5.get());
+    }
+
+    RuntimeProfile::merge_isomorphic_profiles(profiles);
+
+    auto* merged_profile = profiles[0];
+    const std::set<std::string> expected_values{"value1", "value2", "value3", "value4", "value5", "value6"};
+    std::set<std::string> actual_values;
+    ASSERT_TRUE(merged_profile->get_info_string("key1") != nullptr);
+    actual_values.insert(*(merged_profile->get_info_string("key1")));
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(0)") != nullptr);
+    actual_values.insert(*(merged_profile->get_info_string("key1__DUP(0)")));
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(1)") != nullptr);
+    actual_values.insert(*(merged_profile->get_info_string("key1__DUP(1)")));
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(2)") != nullptr);
+    actual_values.insert(*(merged_profile->get_info_string("key1__DUP(2)")));
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(3)") != nullptr);
+    actual_values.insert(*(merged_profile->get_info_string("key1__DUP(3)")));
+    ASSERT_TRUE(merged_profile->get_info_string("key1__DUP(4)") != nullptr);
+    actual_values.insert(*(merged_profile->get_info_string("key1__DUP(4)")));
+
+    ASSERT_EQ(expected_values, actual_values);
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -482,7 +482,25 @@ public class RuntimeProfile {
             return;
         }
 
-        this.infoStrings.putAll(srcProfile.infoStrings);
+        srcProfile.infoStrings.forEach((key, value) -> {
+            if (!this.infoStrings.containsKey(key)) {
+                this.infoStrings.put(key, value);
+            } else if (!Objects.equals(value, this.infoStrings.get(key))) {
+                String originalKey = key;
+                int pos;
+                if ((pos = key.indexOf("__DUP(")) != -1) {
+                    originalKey = key.substring(0, pos);
+                }
+                int i = 0;
+                while (true) {
+                    String indexedKey = String.format("%s__DUP(%d)", originalKey, i++);
+                    if (!this.infoStrings.containsKey(indexedKey)) {
+                        this.infoStrings.put(indexedKey, value);
+                        break;
+                    }
+                }
+            }
+        });
     }
 
     public void setName(String name) {
@@ -520,6 +538,10 @@ public class RuntimeProfile {
         }
 
         RuntimeProfile profile0 = profiles.get(0);
+
+        for (int i = 1; i < profiles.size(); i++) {
+            profile0.copyAllInfoStringsFrom(profiles.get(i));
+        }
 
         // Find all counters, although these profiles are expected to be isomorphic,
         // some counters are only attached to one of them

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -504,6 +504,58 @@ public class RuntimeProfileTest {
     }
 
     @Test
+    public void testConflictInfoString() {
+        List<RuntimeProfile> profiles = Lists.newArrayList();
+
+        RuntimeProfile profile1 = new RuntimeProfile("profile");
+        {
+            profile1.addInfoString("key1", "value1");
+            profiles.add(profile1);
+        }
+
+        RuntimeProfile profile2 = new RuntimeProfile("profile");
+        {
+            profile2.addInfoString("key1", "value2");
+            profiles.add(profile2);
+        }
+
+        RuntimeProfile profile3 = new RuntimeProfile("profile");
+        {
+            profile3.addInfoString("key1", "value1");
+            profiles.add(profile3);
+        }
+
+        RuntimeProfile profile4 = new RuntimeProfile("profile");
+        {
+            profile4.addInfoString("key1__DUP(1)", "value3");
+            profile4.addInfoString("key1", "value4");
+            profiles.add(profile4);
+        }
+
+        RuntimeProfile profile5 = new RuntimeProfile("profile");
+        {
+            profile5.addInfoString("key1", "value5");
+            profile5.addInfoString("key1__DUP(1)", "value6");
+            profiles.add(profile5);
+        }
+
+        RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = profiles.get(0);
+
+        Set<String> expectedValues = Sets.newHashSet("value1", "value2", "value3", "value4", "value5", "value6");
+        Set<String> actualValues = Sets.newHashSet();
+
+        actualValues.add(mergedProfile.getInfoString("key1"));
+        actualValues.add(mergedProfile.getInfoString("key1__DUP(0)"));
+        actualValues.add(mergedProfile.getInfoString("key1__DUP(1)"));
+        actualValues.add(mergedProfile.getInfoString("key1__DUP(2)"));
+        actualValues.add(mergedProfile.getInfoString("key1__DUP(3)"));
+        actualValues.add(mergedProfile.getInfoString("key1__DUP(4)"));
+
+        Assert.assertEquals(expectedValues, actualValues);
+    }
+
+    @Test
     public void testJsonProfileFormater() {
         //profile
         RuntimeProfile profile = new RuntimeProfile("profile");


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Enhancement

After #18150, we can get profile if query abort execution. But under current profile merge mechanims, some string info will be missed.

So, this pr enhance the profile merge mechanism on the merge of info string. Examples are listed as belows:

```
        EXCHANGE_SOURCE (plan_node_id=1):
          CommonMetrics:
             - ErrorMsg: Memory of query_pool exceed limit. try consume:224 Used: 40784057845, Limit: 40877351239. Mem usage has exceed the limit of query pool
             - ErrorMsg__DUP(0): Memory of query_pool exceed limit. try consume:117440512 Used: 40787074317, Limit: 40877351239. Mem usage has exceed the limit of query pool
             - ErrorMsg__DUP(1): Memory of query_pool exceed limit. try consume:160 Used: 40861113432, Limit: 40877351239. Mem usage has exceed the limit of query pool
             - ErrorMsg__DUP(2): Memory of query_pool exceed limit. try consume:160 Used: 40856209344, Limit: 40877351239. Mem usage has exceed the limit of query pool
             - ErrorMsg__DUP(3): Memory of query_pool exceed limit. try consume:160 Used: 40845399952, Limit: 40877351239. Mem usage has exceed the limit of query pool
             - ErrorMsg__DUP(4): Memory of query_pool exceed limit. try consume:117440512 Used: 40870606280, Limit: 40877351239. Mem usage has exceed the limit of query pool
             - ErrorMsg__DUP(5): Memory of query_pool exceed limit. try consume:160 Used: 40849431752, Limit: 40877351239. Mem usage has exceed the limit of query pool
             - CloseTime: 919ns
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
