### PR TITLE
[BugFix] Fix mysql client unable to change current catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -991,7 +991,8 @@ public class StmtExecutor {
     private void handleUseCatalogStmt() throws AnalysisException {
         UseCatalogStmt useCatalogStmt = (UseCatalogStmt) parsedStmt;
         try {
-            context.getGlobalStateMgr().changeCatalog(context, useCatalogStmt.getCatalogName());
+            String catalogName = useCatalogStmt.getCatalogAndItsName().split("\\s+")[1];
+            context.getGlobalStateMgr().changeCatalog(context, catalogName);
         } catch (Exception e) {
             context.getState().setError(e.getMessage());
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -991,7 +991,7 @@ public class StmtExecutor {
     private void handleUseCatalogStmt() throws AnalysisException {
         UseCatalogStmt useCatalogStmt = (UseCatalogStmt) parsedStmt;
         try {
-            String catalogName = useCatalogStmt.getCatalogAndItsName().split("\\s+")[1];
+            String catalogName = useCatalogStmt.getCatalogName();
             context.getGlobalStateMgr().changeCatalog(context, catalogName);
         } catch (Exception e) {
             context.getState().setError(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -126,6 +126,7 @@ import com.starrocks.sql.ast.SuspendWarehouseStmt;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.UninstallPluginStmt;
 import com.starrocks.sql.ast.UpdateStmt;
+import com.starrocks.sql.ast.UseCatalogStmt;
 import com.starrocks.sql.ast.UseDbStmt;
 
 public class Analyzer {
@@ -419,6 +420,12 @@ public class Analyzer {
 
         @Override
         public Void visitShowCatalogsStatement(ShowCatalogsStmt statement, ConnectContext context) {
+            CatalogAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
             CatalogAnalyzer.analyze(statement, context);
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -89,20 +89,16 @@ public class CatalogAnalyzer {
         @Override
         public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
             if (Strings.isNullOrEmpty(statement.getCatalogParts())) {
-                throw new SemanticException("'catalog name' can not be null or empty");
+                throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
             }
 
-            String[] catalogAndItsName = statement.getCatalogParts().split(WHITESPACE);
-            if (catalogAndItsName.length == 0 || !catalogAndItsName[0].equalsIgnoreCase(CATALOG)) {
-                throw new SemanticException("'catalog name' should start with 'catalog'");
+            String[] splitParts = statement.getCatalogParts().split(WHITESPACE);
+            if (!splitParts[0].equalsIgnoreCase(CATALOG) || splitParts.length != 2) {
+                throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
             }
 
-            if (catalogAndItsName.length != 2) {
-                throw new SemanticException("'catalog name' should end with a catalog name");
-            }
-
-            FeNameFormat.checkCatalogName(catalogAndItsName[1]);
-            statement.setCatalogName(catalogAndItsName[1]);
+            FeNameFormat.checkCatalogName(splitParts[1]);
+            statement.setCatalogName(splitParts[1]);
 
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -31,6 +31,10 @@ import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceM
 import static com.starrocks.sql.ast.CreateCatalogStmt.TYPE;
 
 public class CatalogAnalyzer {
+    private static final String CATALOG = "CATALOG";
+
+    private static final String WHITESPACE = "\\s+";
+
     public static void analyze(StatementBase stmt, ConnectContext session) {
         new CatalogAnalyzerVisitor().visit(stmt, session);
     }
@@ -84,12 +88,12 @@ public class CatalogAnalyzer {
 
         @Override
         public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
-            if (Strings.isNullOrEmpty(statement.getCatalogAndItsName())) {
+            if (Strings.isNullOrEmpty(statement.getCatalogParts())) {
                 throw new SemanticException("'catalog name' can not be null or empty");
             }
 
-            String[] catalogAndItsName = statement.getCatalogAndItsName().split("\\s+");
-            if (catalogAndItsName.length == 0 || !catalogAndItsName[0].equalsIgnoreCase("CATALOG")) {
+            String[] catalogAndItsName = statement.getCatalogParts().split(WHITESPACE);
+            if (catalogAndItsName.length == 0 || !catalogAndItsName[0].equalsIgnoreCase(CATALOG)) {
                 throw new SemanticException("'catalog name' should start with 'catalog'");
             }
 
@@ -98,6 +102,7 @@ public class CatalogAnalyzer {
             }
 
             FeNameFormat.checkCatalogName(catalogAndItsName[1]);
+            statement.setCatalogName(catalogAndItsName[1]);
 
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -22,6 +22,7 @@ import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.DropCatalogStmt;
 import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UseCatalogStmt;
 
 import java.util.Map;
 
@@ -77,6 +78,26 @@ public class CatalogAnalyzer {
             if (isResourceMappingCatalog(name)) {
                 throw new SemanticException("Can't drop the resource mapping catalog");
             }
+
+            return null;
+        }
+
+        @Override
+        public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
+            if (Strings.isNullOrEmpty(statement.getCatalogAndItsName())) {
+                throw new SemanticException("'catalog name' can not be null or empty");
+            }
+
+            String[] catalogAndItsName = statement.getCatalogAndItsName().split("\\s+");
+            if (catalogAndItsName.length == 0 || !catalogAndItsName[0].equalsIgnoreCase("CATALOG")) {
+                throw new SemanticException("'catalog name' should start with 'catalog'");
+            }
+
+            if (catalogAndItsName.length != 2) {
+                throw new SemanticException("'catalog name' should end with a catalog name");
+            }
+
+            FeNameFormat.checkCatalogName(catalogAndItsName[1]);
 
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -813,13 +813,14 @@ public class PrivilegeCheckerV2 {
 
         @Override
         public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
+            String catalogName = statement.getCatalogAndItsName().split("\\s+")[1];
             // No authorization check for using default_catalog
-            if (CatalogMgr.isInternalCatalog(statement.getCatalogName())) {
+            if (CatalogMgr.isInternalCatalog(catalogName)) {
                 return null;
             }
-            if (!PrivilegeActions.checkAnyActionOnCatalog(context, statement.getCatalogName())) {
+            if (!PrivilegeActions.checkAnyActionOnCatalog(context, catalogName)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
-                        context.getQualifiedUser(), statement.getCatalogName());
+                        context.getQualifiedUser(), catalogName);
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -813,7 +813,7 @@ public class PrivilegeCheckerV2 {
 
         @Override
         public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
-            String catalogName = statement.getCatalogAndItsName().split("\\s+")[1];
+            String catalogName = statement.getCatalogName();
             // No authorization check for using default_catalog
             if (CatalogMgr.isInternalCatalog(catalogName)) {
                 return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -109,10 +109,6 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(statement, context);
     }
 
-    public R visitUseCatalogStatement(UseCatalogStmt statement, C context) {
-        return visitStatement(statement, context);
-    }
-
     public R visitShowDatabasesStatement(ShowDbStmt statement, C context) {
         return visitShowStatement(statement, context);
     }
@@ -302,6 +298,10 @@ public abstract class AstVisitor<R, C> {
     }
 
     public R visitShowCreateExternalCatalogStatement(ShowCreateExternalCatalogStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
+    public R visitUseCatalogStatement(UseCatalogStmt statement, C context) {
         return visitStatement(statement, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
@@ -19,19 +19,29 @@ import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.sql.parser.NodePosition;
 
 public class UseCatalogStmt extends StatementBase {
-    private final String catalogAndItsName;
+    private final String catalogParts;
 
-    public UseCatalogStmt(String catalogAndItsName) {
-        this(catalogAndItsName, NodePosition.ZERO);
+    private String catalogName;
+
+    public UseCatalogStmt(String catalogParts) {
+        this(catalogParts, NodePosition.ZERO);
     }
 
-    public UseCatalogStmt(String catalogAndItsName, NodePosition pos) {
+    public UseCatalogStmt(String catalogParts, NodePosition pos) {
         super(pos);
-        this.catalogAndItsName = catalogAndItsName;
+        this.catalogParts = catalogParts;
     }
 
-    public String getCatalogAndItsName() {
-        return catalogAndItsName;
+    public String getCatalogParts() {
+        return catalogParts;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public void setCatalogName(String catalogName) {
+        this.catalogName = catalogName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
@@ -19,19 +19,19 @@ import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.sql.parser.NodePosition;
 
 public class UseCatalogStmt extends StatementBase {
-    private final String catalogName;
+    private final String catalogAndItsName;
 
-    public UseCatalogStmt(String catalogName) {
-        this(catalogName, NodePosition.ZERO);
+    public UseCatalogStmt(String catalogAndItsName) {
+        this(catalogAndItsName, NodePosition.ZERO);
     }
 
-    public UseCatalogStmt(String catalogName, NodePosition pos) {
+    public UseCatalogStmt(String catalogAndItsName, NodePosition pos) {
         super(pos);
-        this.catalogName = catalogName;
+        this.catalogAndItsName = catalogAndItsName;
     }
 
-    public String getCatalogName() {
-        return catalogName;
+    public String getCatalogAndItsName() {
+        return catalogAndItsName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
@@ -18,6 +18,22 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.sql.parser.NodePosition;
 
+/*
+  Use catalog specified by catalog name
+
+  syntax:
+      USE 'CATALOG catalog_name'
+      USE "CATALOG catalog_name"
+
+      Note:
+        A pair of single/double quotes are required
+
+      Examples:
+        USE 'CATALOG default_catalog'
+        use "catalog default_catalog"
+        USE 'catalog hive_metastore_catalog'
+        use "CATALOG hive_metastore_catalog"
+ */
 public class UseCatalogStmt extends StatementBase {
     private final String catalogParts;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -437,9 +437,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitUseCatalogStatement(StarRocksParser.UseCatalogStatementContext context) {
-        Identifier identifier = (Identifier) visit(context.identifierOrString());
-        String catalogName = identifier.getValue();
-        return new UseCatalogStmt(catalogName);
+        StringLiteral literal = (StringLiteral) visit(context.string());
+        String catalogAndItsName = literal.getValue();
+        return new UseCatalogStmt(catalogAndItsName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -438,8 +438,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitUseCatalogStatement(StarRocksParser.UseCatalogStatementContext context) {
         StringLiteral literal = (StringLiteral) visit(context.string());
-        String catalogAndItsName = literal.getValue();
-        return new UseCatalogStmt(catalogAndItsName);
+        return new UseCatalogStmt(literal.getValue());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -261,7 +261,7 @@ useDatabaseStatement
     ;
 
 useCatalogStatement
-    : USE CATALOG identifierOrString
+    : USE string
     ;
 
 showDatabasesStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseCatalogStmtTest.java
@@ -48,13 +48,13 @@ public class UseCatalogStmtTest {
 
     @Test
     public void testParserAndAnalyzer() {
-        String sql = "USE catalog hive_catalog";
+        String sql = "USE 'catalog hive_catalog'";
         AnalyzeTestUtil.analyzeSuccess(sql);
 
-        String sql_2 = "USE catalog default_catalog";
+        String sql_2 = "USE 'catalog default_catalog'";
         AnalyzeTestUtil.analyzeSuccess(sql_2);
 
-        String sql_3 = "USE xxxx default_catalog";
+        String sql_3 = "USE 'xxxx default_catalog'";
         AnalyzeTestUtil.analyzeFail(sql_3);
     }
 
@@ -74,21 +74,21 @@ public class UseCatalogStmtTest {
 
         ctx.setQueryId(UUIDUtil.genUUID());
         ctx.setCurrentUserIdentity(UserIdentity.ROOT);
-        StmtExecutor executor = new StmtExecutor(ctx, "use catalog hive_catalog");
+        StmtExecutor executor = new StmtExecutor(ctx, "use 'catalog hive_catalog'");
         executor.execute();
 
         Assert.assertEquals("hive_catalog", ctx.getCurrentCatalog());
 
-        executor = new StmtExecutor(ctx, "use catalog default_catalog");
+        executor = new StmtExecutor(ctx, "use 'catalog default_catalog'");
         executor.execute();
 
         Assert.assertEquals("default_catalog", ctx.getCurrentCatalog());
 
-        executor = new StmtExecutor(ctx, "use xxx default_catalog");
+        executor = new StmtExecutor(ctx, "use 'xxx default_catalog'");
         executor.execute();
         Assert.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
 
-        executor = new StmtExecutor(ctx, "use catalog default_catalog xxx");
+        executor = new StmtExecutor(ctx, "use 'catalog default_catalog xxx'");
         executor.execute();
         Assert.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2Test.java
@@ -393,21 +393,21 @@ public class PrivilegeCheckerV2Test {
         // Anyone can use default_catalog, but can't use other external catalog without any action on it
         ctxToTestUser();
         PrivilegeCheckerV2.check(
-                UtFrameUtils.parseStmtWithNewParser("use catalog default_catalog", ctx), ctx);
+                UtFrameUtils.parseStmtWithNewParser("use 'catalog default_catalog'", ctx), ctx);
         try {
             PrivilegeCheckerV2.check(
-                    UtFrameUtils.parseStmtWithNewParser("use catalog test_ex_catalog", ctx), ctx);
+                    UtFrameUtils.parseStmtWithNewParser("use 'catalog test_ex_catalog'", ctx), ctx);
         } catch (SemanticException e) {
             Assert.assertTrue(e.getMessage().contains(
                     "Access denied for user 'test' to catalog"));
         }
         verifyGrantRevoke(
-                "use catalog test_ex_catalog",
+                "use 'catalog test_ex_catalog'",
                 "grant USAGE on catalog test_ex_catalog to test",
                 "revoke USAGE on catalog test_ex_catalog from test",
                 "Access denied for user 'test' to catalog");
         verifyGrantRevoke(
-                "use catalog test_ex_catalog",
+                "use 'catalog test_ex_catalog'",
                 "grant DROP on catalog test_ex_catalog to test",
                 "revoke DROP on catalog test_ex_catalog from test",
                 "Access denied for user 'test' to catalog");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17993

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`USE 'CATALOG catalog_name'` issued by mysql client will be dispatched to `handleQuery` function. In this case, the current implementation throws parse exception, thus fails to switch the catalog in use. 

The changes made are:
* change `useCatalogStatement : USE CATALOG identifierOrString ` to `useCatalogStatement : USE string;`
* add or update parser/analyzer/executor for useCatalogStatement
* update unit tests

Limitation:
Mysql client of version 5.7.31 would raise a benign error as follows. 
```
ERROR:
USE must be followed by a database name
```
But the catalog can be changed successfully.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
