### PR TITLE
[Enhancement] Add BE metrics to information_schema

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -115,6 +115,7 @@ set(EXEC_FILES
     schema_scanner/schema_schema_privileges_scanner.cpp
     schema_scanner/schema_table_privileges_scanner.cpp
     schema_scanner/schema_tables_config_scanner.cpp
+    schema_scanner/schema_be_metrics_scanner.cpp
     schema_scanner/schema_be_tablets_scanner.cpp
     schema_scanner/schema_helper.cpp
     jdbc_scanner.cpp

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -15,6 +15,7 @@
 #include "exec/schema_scanner.h"
 
 #include "column/type_traits.h"
+#include "exec/schema_scanner/schema_be_metrics_scanner.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "exec/schema_scanner/schema_charsets_scanner.h"
 #include "exec/schema_scanner/schema_collations_scanner.h"
@@ -117,6 +118,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaVariablesScanner>(TVarType::VERBOSE);
     case TSchemaTableType::SCH_BE_TABLETS:
         return std::make_unique<SchemaBeTabletsScanner>();
+    case TSchemaTableType::SCH_BE_METRICS:
+        return std::make_unique<SchemaBeMetricsScanner>();
     default:
         return std::make_unique<SchemaDummyScanner>();
     }

--- a/be/src/exec/schema_scanner/schema_be_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_metrics_scanner.cpp
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_be_metrics_scanner.h"
+
+#include "agent/master_info.h"
+#include "exec/schema_scanner/schema_helper.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/string_value.h"
+#include "types/logical_type.h"
+#include "util/metrics.h"
+#include "util/starrocks_metrics.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaBeMetricsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NAME", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"LABELS", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"VALUE", TYPE_BIGINT, sizeof(int64_t), false},
+};
+
+SchemaBeMetricsScanner::SchemaBeMetricsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeMetricsScanner::~SchemaBeMetricsScanner() = default;
+
+class SchemaCoreMetricsVisitor : public MetricsVisitor {
+public:
+    SchemaCoreMetricsVisitor(std::vector<MetricsInfo>& infos) : _infos(infos) {}
+    ~SchemaCoreMetricsVisitor() override = default;
+    void visit(const std::string& prefix, const std::string& name, MetricCollector* collector) override {
+        if (collector->empty() || name.empty()) {
+            return;
+        }
+        for (auto& it : collector->metrics()) {
+            auto& labels = it.first;
+            std::stringstream ss;
+            bool first = true;
+            for (auto& label : labels.labels) {
+                if (first) {
+                    first = false;
+                } else {
+                    ss << ",";
+                }
+                ss << label.name << "=" << label.value;
+            }
+            auto& info = _infos.emplace_back();
+            info.name = name;
+            info.labels = ss.str();
+            info.value = std::strtoll(it.second->to_string().c_str(), nullptr, 10);
+        }
+    }
+
+private:
+    std::vector<MetricsInfo>& _infos;
+};
+
+Status SchemaBeMetricsScanner::start(RuntimeState* state) {
+    auto o_id = get_backend_id();
+    _be_id = o_id.has_value() ? o_id.value() : -1;
+    _infos.clear();
+    SchemaCoreMetricsVisitor visitor(_infos);
+    StarRocksMetrics::instance()->metrics()->collect(&visitor);
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+Status SchemaBeMetricsScanner::fill_chunk(ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 14) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                // name
+                Slice v(info.name);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 3: {
+                // labels
+                Slice v(info.labels);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 4: {
+                // value
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.value);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_be_metrics_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_metrics_scanner.h
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "exec/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+struct MetricsInfo {
+    std::string name;
+    std::string labels;
+    int64_t value{0};
+};
+
+class SchemaBeMetricsScanner : public SchemaScanner {
+public:
+    SchemaBeMetricsScanner();
+    ~SchemaBeMetricsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<MetricsInfo> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -523,6 +523,16 @@ public class SchemaTable extends Table {
                                     .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .build()))
+                    .put("be_metrics", new SchemaTable(
+                            SystemId.BE_METRICS_ID,
+                            "be_metrics",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("LABELS", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("VALUE", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .build()))
                     .build();
 
     public static class Builder {
@@ -611,7 +621,8 @@ public class SchemaTable extends Table {
                 TSchemaTableType.SCH_VERBOSE_SESSION_VARIABLES),
         SCH_BE_TABLETS("BE_TABLETS", "BE_TABLETS",
                 TSchemaTableType.SCH_BE_TABLETS),
-        SCH_INVALID("NULL", "NULL", TSchemaTableType.SCH_INVALID);
+        SCH_BE_METRICS("BE_METRICS", "BE_METRICS",
+                TSchemaTableType.SCH_BE_METRICS);
 
         private final String description;
         private final String tableName;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -58,6 +58,10 @@ public class SchemaTable extends Table {
     private static final int MAX_FIELD_VARCHARLENGTH = 65535;
     private static final int MY_CS_NAME_SIZE = 32;
 
+    public static boolean isBeSchemaTable(String name) {
+        return name.startsWith("be_");
+    }
+
     protected SchemaTable(long id, String name, TableType type, List<Column> baseSchema) {
         super(id, name, type, baseSchema);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
@@ -69,4 +69,6 @@ public class SystemId {
     public static final long VERBOSE_SESSION_VARIABLES_ID = 25L;
 
     public static final long BE_TABLETS_ID = 26L;
+
+    public static final long BE_METRICS_ID = 27L;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -38,6 +38,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.catalog.SchemaTable;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -179,7 +180,7 @@ public class SchemaScanNode extends ScanNode {
     }
 
     public boolean isBeSchemaTable() {
-        return tableName.startsWith("be_");
+        return SchemaTable.isBeSchemaTable(tableName);
     }
 
     public void computeBeScanRanges() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -71,6 +71,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.SchemaTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -779,6 +780,10 @@ public class ShowExecutor {
             try {
                 for (Table tbl : db.getTables()) {
                     if (matcher != null && !matcher.match(tbl.getName())) {
+                        continue;
+                    }
+                    // hide BE schema tables from user to prevent misuse
+                    if (tbl instanceof SchemaTable && SchemaTable.isBeSchemaTable(tbl.getName())) {
                         continue;
                     }
                     // check tbl privs
@@ -2373,7 +2378,6 @@ public class ShowExecutor {
 
         resultSet = new ShowResultSet(showStmt.getMetaData(), rowSet);
     }
-
 
     private List<List<String>> doPredicate(ShowStmt showStmt,
                                            ShowResultSetMetaData showResultSetMetaData,

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -138,7 +138,7 @@ enum TSchemaTableType {
     SCH_TASK_RUNS,
     SCH_VERBOSE_SESSION_VARIABLES,
     SCH_BE_TABLETS,
-    SCH_INVALID
+    SCH_BE_METRICS
 }
 
 enum THdfsCompression {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds BE's metrics to information_schema


```
mysql> select * from information_schema.be_metrics;
+-------+-----------------------------------------------+-----------------------------------------------------------+--------------+
| BE_ID | NAME                                          | LABELS                                                    | VALUE        |
+-------+-----------------------------------------------+-----------------------------------------------------------+--------------+
| 10003 | active_scan_context_count                     |                                                           |            0 |
| 10003 | binary_column_pool_bytes                      |                                                           |            0 |
| 10003 | bitmap_index_mem_bytes                        |                                                           |            0 |
| 10003 | blocks_created_total                          |                                                           |            0 |
| 10003 | blocks_deleted_total                          |                                                           |            0 |
| 10003 | blocks_open_reading                           |                                                           |            0 |
| 10003 | blocks_open_writing                           |                                                           |            0 |
| 10003 | bloom_filter_index_mem_bytes                  |                                                           |            0 |
| 10003 | broker_count                                  |                                                           |            0 |
| 10003 | brpc_endpoint_stub_count                      |                                                           |            0 |
| 10003 | bytes_read_total                              |                                                           |            0 |
| 10003 | bytes_written_total                           |                                                           |            0 |
| 10003 | central_cache_free_bytes                      |                                                           |       311856 |
...


mysql> select * from information_schema.be_metrics where like(labels, '%mode=user%');
+-------+------+-----------+----------+
| BE_ID | NAME | LABELS    | VALUE    |
+-------+------+-----------+----------+
| 10003 | cpu  | mode=user | 30653342 |
+-------+------+-----------+----------+
1 row in set (0.03 sec)

```
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
