### PR TITLE
[BugFix] fix bugs from reusing common expressions with nested high-order functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
@@ -33,6 +33,15 @@ public class Projection {
     // common sub operators firstly in BE
     private final Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap;
 
+    public void setNeedReuseLambdaExpr(boolean needReuseLambdaExpr) {
+        this.needReuseLambdaExpr = needReuseLambdaExpr;
+    }
+
+    public boolean needReuseLambdaExpr() {
+        return needReuseLambdaExpr;
+    }
+    private boolean needReuseLambdaExpr;
+
     public Projection(Map<ColumnRefOperator, ScalarOperator> columnRefMap) {
         this.columnRefMap = columnRefMap;
         this.commonSubOperatorMap = new HashMap<>();
@@ -46,6 +55,17 @@ public class Projection {
         } else {
             this.commonSubOperatorMap = commonSubOperatorMap;
         }
+    }
+
+    public Projection(Map<ColumnRefOperator, ScalarOperator> columnRefMap,
+                      Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap, boolean needReuseLambdaExpr) {
+        this.columnRefMap = columnRefMap;
+        if (commonSubOperatorMap == null) {
+            this.commonSubOperatorMap = new HashMap<>();
+        } else {
+            this.commonSubOperatorMap = commonSubOperatorMap;
+        }
+        this.needReuseLambdaExpr = needReuseLambdaExpr;
     }
 
     public List<ColumnRefOperator> getOutputColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Projection.java
@@ -33,14 +33,15 @@ public class Projection {
     // common sub operators firstly in BE
     private final Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap;
 
-    public void setNeedReuseLambdaExpr(boolean needReuseLambdaExpr) {
-        this.needReuseLambdaExpr = needReuseLambdaExpr;
+    public void setNeedReuseLambdaDependentExpr(boolean needReuseLambdaExpr) {
+        this.needReuseLambdaDependentExpr = needReuseLambdaExpr;
     }
 
-    public boolean needReuseLambdaExpr() {
-        return needReuseLambdaExpr;
+    public boolean needReuseLambdaDependentExpr() {
+        return needReuseLambdaDependentExpr;
     }
-    private boolean needReuseLambdaExpr;
+
+    private boolean needReuseLambdaDependentExpr;
 
     public Projection(Map<ColumnRefOperator, ScalarOperator> columnRefMap) {
         this.columnRefMap = columnRefMap;
@@ -58,14 +59,14 @@ public class Projection {
     }
 
     public Projection(Map<ColumnRefOperator, ScalarOperator> columnRefMap,
-                      Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap, boolean needReuseLambdaExpr) {
+                      Map<ColumnRefOperator, ScalarOperator> commonSubOperatorMap, boolean needReuseLambdaDependentExpr) {
         this.columnRefMap = columnRefMap;
         if (commonSubOperatorMap == null) {
             this.commonSubOperatorMap = new HashMap<>();
         } else {
             this.commonSubOperatorMap = commonSubOperatorMap;
         }
-        this.needReuseLambdaExpr = needReuseLambdaExpr;
+        this.needReuseLambdaDependentExpr = needReuseLambdaDependentExpr;
     }
 
     public List<ColumnRefOperator> getOutputColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -96,9 +96,6 @@ public final class ColumnRefOperator extends ScalarOperator {
         return new ColumnRefSet(id);
     }
 
-    public boolean isVirtualColumnRef() {
-        return this.opType.equals(OperatorType.LAMBDA_ARGUMENT);
-    }
 
     @Override
     public String toString() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -275,6 +275,10 @@ public class ScalarOperatorsReuse {
 
 
         private int collectCommonOperatorsByDepth(int depth, ScalarOperator operator) {
+            // a lambda function like  x->x+1 can't be reused anymore.
+            if (operator instanceof LambdaFunctionOperator) {
+                return depth;
+            }
             Set<ScalarOperator> operators = getOperatorsByDepth(depth, operatorsByDepth);
             Set<ColumnRefOperator> lambdaArgumentsID = Sets.newHashSet();
             isLambdaDependent = false;
@@ -304,12 +308,6 @@ public class ScalarOperatorsReuse {
 
             return collectCommonOperatorsByDepth(scalarOperator.getChildren().stream().map(argument ->
                     argument.accept(this, context)).reduce(Math::max).map(m -> m + 1).orElse(1), scalarOperator);
-        }
-
-        @Override
-        public Integer visitLambdaFunctionOperator(LambdaFunctionOperator scalarOperator, Void context) {
-            return collectCommonOperatorsByDepth(scalarOperator.getLambdaExpr().accept(this, null),
-                    scalarOperator.getLambdaExpr());
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -263,10 +263,10 @@ public class ScalarOperatorsReuse {
 
         // isLambdaDependent means whether an expression is dependent on outer lambda arguments,
         // it works when not reuse lambda-dependent sub expressions. For example, select array_length(a), array_sum(a)
-        // from (select array_map(x->2x+1+2x, array) as a from t)A; when reuseLambdaDependentExpr is
-        // false, the 2x+1 is lambda dependent, but array_map(x->2x+1+2x, array) isn't,
-        // so 2x+1 can't be reused, array_map(x->2x+1+2x, array) can be reused.
-        // 2x+1 can be reused when reuseLambdaDependentExpr is true.
+        // from (select array_map(x->2*x+1+2*x, array) as a from t)A; when reuseLambdaDependentExpr is
+        // false, the 2*x is lambda dependent, but array_map(x->2*x+1+2*x, array) isn't,
+        // so 2*x can't be reused, array_map(x->2*x+1+2*x, array) can be reused.
+        // 2*x can be reused within the array_map when reuseLambdaDependentExpr is true.
         private boolean isLambdaDependent;
 
         private final boolean reuseLambdaDependentExpr;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
@@ -61,7 +61,7 @@ public class ScalarOperatorsReuseRule implements TreeRewriteRule {
             projection = ScalarOperatorsReuse.rewriteProjectionOrLambdaExpr(projection,
                     context.getOptimizerContext().getColumnRefFactory(), false);
 
-            if (projection.needReuseLambdaExpr()) {
+            if (projection.needReuseLambdaDependentExpr()) {
                 // rewrite lambda functions with lambda arguments
                 rewriteLambdaFunction(projection.getCommonSubOperatorMap(),
                         context.getOptimizerContext().getColumnRefFactory());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuseRule.java
@@ -61,10 +61,12 @@ public class ScalarOperatorsReuseRule implements TreeRewriteRule {
             projection = ScalarOperatorsReuse.rewriteProjectionOrLambdaExpr(projection,
                     context.getOptimizerContext().getColumnRefFactory(), false);
 
-            // rewrite lambda functions with lambda arguments
-            rewriteLambdaFunction(projection.getCommonSubOperatorMap(),
-                    context.getOptimizerContext().getColumnRefFactory());
-            rewriteLambdaFunction(projection.getColumnRefMap(), context.getOptimizerContext().getColumnRefFactory());
+            if (projection.needReuseLambdaExpr()) {
+                // rewrite lambda functions with lambda arguments
+                rewriteLambdaFunction(projection.getCommonSubOperatorMap(),
+                        context.getOptimizerContext().getColumnRefFactory());
+                rewriteLambdaFunction(projection.getColumnRefMap(), context.getOptimizerContext().getColumnRefFactory());
+            }
             return projection;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -227,8 +227,10 @@ public class TrinoQueryTest extends TrinoTestBase {
         sql = "select c0, c2[1] + array[1,2,3][1] as v, sum(c2[1]) from test_array group by c0, v order by v";
         assertPlanContains(sql, "1:Project\n" +
                 "  |  <slot 1> : 1: c0\n" +
-                "  |  <slot 4> : CAST(3: c2[1] AS BIGINT) + CAST(ARRAY<tinyint(4)>[1,2,3][1] AS BIGINT)\n" +
-                "  |  <slot 5> : 3: c2[1]");
+                "  |  <slot 4> : CAST(7: expr AS BIGINT) + CAST(ARRAY<tinyint(4)>[1,2,3][1] AS BIGINT)\n" +
+                "  |  <slot 5> : 7: expr\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 7> : 3: c2[1]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
@@ -117,7 +117,7 @@ public class ScalarOperatorsReuseTest {
         List<ScalarOperator> oldOperators = Lists.newArrayList(add1, add3, multi);
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
 
         // FixMe(kks): This case could improve
         assertEquals(commonSubScalarOperators.size(), 3);
@@ -145,7 +145,7 @@ public class ScalarOperatorsReuseTest {
         List<ScalarOperator> oldOperators = Lists.newArrayList(addABC, addBCD);
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
 
         // FixMe(kks): could we improve this case?
         assertTrue(commonSubScalarOperators.isEmpty());
@@ -170,7 +170,7 @@ public class ScalarOperatorsReuseTest {
                 Lists.newArrayList(add3, ConstantOperator.createInt(1)));
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(ImmutableList.of(add1, add2, add3, add4),
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
                         columnRefFactory, false);
         assertTrue(commonSubScalarOperators.isEmpty());
     }
@@ -194,7 +194,7 @@ public class ScalarOperatorsReuseTest {
                 Lists.newArrayList(add3, column3));
 
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(ImmutableList.of(add1, add2, add3, add4),
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
                         columnRefFactory, false);
         assertEquals(2, commonSubScalarOperators.size());
     }
@@ -221,7 +221,7 @@ public class ScalarOperatorsReuseTest {
 
         // reuse lambda argument non-related sub expressions : t1*2
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(oldOperators, columnRefFactory, false);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, false);
         assertEquals(commonSubScalarOperators.size(), 1);
     }
 
@@ -247,7 +247,7 @@ public class ScalarOperatorsReuseTest {
 
         // reuse lambda argument related sub expressions : x*2
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
-                ScalarOperatorsReuse.collectCommonSubScalarOperators(oldOperators, columnRefFactory, true);
+                ScalarOperatorsReuse.collectCommonSubScalarOperators(null, oldOperators, columnRefFactory, true);
         assertEquals(commonSubScalarOperators.size(), 1);
 
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -98,8 +98,10 @@ public class ArrayTypeTest extends PlanTestBase {
                 "  |  \n" +
                 "  1:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
-                "  |  <slot 4> : 3: v3[1] + CAST(ARRAY<tinyint(4)>[1,2,3][1] AS BIGINT)\n" +
-                "  |  <slot 5> : 3: v3[1]\n"));
+                "  |  <slot 4> : 7: expr + CAST(ARRAY<tinyint(4)>[1,2,3][1] AS BIGINT)\n" +
+                "  |  <slot 5> : 7: expr\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 7> : 3: v3[1]"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -602,20 +602,76 @@ public class ExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testReuseNestedHighOrderLambdaFunctions() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE action1(uid int(11), event_type varchar(65533), time datetime)" +
+                " duplicate key(uid, event_type) distributed by hash(uid) buckets 1 " +
+                "properties('replication_num'='1');");
+        starRocksAssert.withTable("create table test_array23(c0 INT, c1 array<varchar(65533)>, c2 array<int>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+        String sql = "WITH `CASE_006` AS\n" +
+                "  (SELECT array_map((arg_001) -> (arg_001), `c1`) AS `argument_003`,\n" +
+                "          array_map((arg_002) -> (CAST(1 AS BIGINT)), `c1`) AS `argument_004`\n" +
+                "   FROM test_array23)\n" +
+                "\n" +
+                "select argument_004, ARRAY_FILTER((x, y) -> y IS NOT NULL, " +
+                "`argument_003`, `argument_004`) AS `source_target_005` from CASE_006;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  common expressions:\n" +
+                "  |  <slot 14> : array_map(<slot 5> -> 1, 8: c1)");
+
+        sql = "WITH `CASE_006` AS\n" +
+                "  (SELECT array_map((arg_001) -> (arg_001), `c1`) AS `argument_003`,\n" +
+                "          array_map((arg_002) -> (arg_002 + 1), `c1`) AS `argument_004`\n" +
+                "   FROM test_array23)\n" +
+                "\n" +
+                "select argument_004, ARRAY_FILTER((x, y) -> y IS NOT NULL, " +
+                "`argument_003`, `argument_004`) AS `source_target_005` from CASE_006;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  common expressions:\n" +
+                "  |  <slot 14> : array_map(<slot 5> -> CAST(<slot 5> AS DOUBLE) + 1.0, 8: c1)");
+
+        sql = "SELECT uid, times, actions, step0_time, step1_time, array_filter((x, y)->(y = '支付' AND (x BETWEEN " +
+                "step1_time AND date_add(step1_time, INTERVAL 90 MINUTE)) AND (step1_time <> '2020-01-01 00:00:00')" +
+                " ), times, actions)[1] AS step2_time FROM (SELECT uid, times, actions, step0_time, array_filter( " +
+                "(x, y)-> (y = '下单' AND (x BETWEEN step0_time AND date_add(step0_time, INTERVAL 90 MINUTE)) AND " +
+                "(step0_time <> '2020-01-01 00:00:00' ) ), times, actions)[1] AS step1_time FROM (SELECT uid, times" +
+                ", actions, array_filter((x, y) -> (y= '浏览' AND x BETWEEN '2020-01-02 00:00:00' AND " +
+                "'2020-01-02 23:59:59'), times, actions)[1] AS step0_time FROM (SELECT uid, " +
+                "array_sort(array_agg(time)) AS times, array_sortby(array_agg(event_type), array_agg(time)) " +
+                "AS actions FROM action1 GROUP BY uid) AS t ) AS t1) AS t2;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  common expressions:\n" +
+                "  |  <slot 17> : array_sort(4: array_agg)\n" +
+                "  |  <slot 18> : array_sortby(5: array_agg, 4: array_agg)\n" +
+                "  |  <slot 19> : array_map((<slot 8>, <slot 9>) -> (<slot 9> = '浏览') AND ((<slot 8> >= " +
+                "'2020-01-02 00:00:00') AND (<slot 8> <= '2020-01-02 23:59:59'))," +
+                " 17: array_sort, 18: array_sortby)\n" +
+                "  |  <slot 20> : array_filter(17: array_sort, 19: array_map)\n" +
+                "  |  <slot 21> : 20: array_filter[1]\n" +
+                "  |  <slot 22> : minutes_add(21: expr, 90)\n" +
+                "  |  <slot 23> : 21: expr != '2020-01-01 00:00:00'\n" +
+                "  |  <slot 24> : array_map((<slot 11>, <slot 12>) -> ((<slot 12> = '下单') AND ((<slot 11> >= 21:" +
+                " expr) AND (<slot 11> <= 22: minutes_add))) AND (23: expr), 17: array_sort, 18: array_sortby)\n" +
+                "  |  <slot 25> : array_filter(17: array_sort, 24: array_map)\n" +
+                "  |  <slot 26> : 25: array_filter[1]");
+    }
+
+    @Test
     public void testLambdaWithAggAndWindowFunctions() throws Exception {
-        starRocksAssert.withTable("create table if not exists test_array " +
+        starRocksAssert.withTable("create table if not exists test_array12 " +
                 "(c0 INT,c1 int, c2 array<int>) " +
                 " duplicate key(c0) distributed by hash(c0) buckets 1 " +
                 "properties('replication_num'='1');");
         // aggregations
-        String sql = "select array_agg(array_length(array_map(x->x*2, c2))) from test_array";
+        String sql = "select array_agg(array_length(array_map(x->x*2, c2))) from test_array12";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  2:AGGREGATE (update finalize)\n" +
                 "  |  output: array_agg(array_length(array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) * 2, 3: c2)))"));
         Assert.assertTrue(plan.contains("  1:Project\n" +
                 "  |  <slot 3> : 3: c2"));
 
-        sql = "select array_map(x->x > count(c1), c2) from test_array group by c2";
+        sql = "select array_map(x->x > count(c1), c2) from test_array12 group by c2";
         plan = getFragmentPlan(sql);
 
         Assert.assertTrue(plan.contains("  2:Project\n" +
@@ -625,7 +681,7 @@ public class ExpressionTest extends PlanTestBase {
                 "  |  group by: 3: c2"));
 
         // window functions
-        sql = "select count(c1) over (partition by array_sum(array_map(x->x+1, [1]))) from test_array";
+        sql = "select count(c1) over (partition by array_sum(array_map(x->x+1, [1]))) from test_array12";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  4:ANALYTIC\n" +
                 "  |  functions: [, count(6: c1), ]\n" +


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. introduce `isLambdaDependent` to control whether reuse lambda-dependent expressions.

        // isLambdaDependent means whether an expression is dependent on outer lambda arguments,
        // it works when not reuse lambda arguments. For example, when reuseLambda is false, for expression
        // array_map(x -> x+1, array), the x+1 is lambda dependent, but array_map(x -> x+1, array) is not. 

2. introduce `hasLambdaFunction` to eable specific logic for lambda functions, reducing extra costs for non-lambda expressions in most cases.

3. add `needReuseLambdaExpr` for projection to avoid rewrite if the projection without lambda functions.


TODO: found a problem that two identical expressions, their sub expressions also listed in common expressions, a example listed below,  `<slot 7>` and `<slot 8>` should remove, only keep `<slot 9>`. This problem can be alleviated by reusing alias expressions in the future work.



```
mysql> explain select aa+1, ceil(aa) from (select abs(a+pv) as aa from t)A;
+-----------------------------------------------------------------------------+
| Explain String                                                              |
+-----------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                             |
|  OUTPUT EXPRS:5: expr | 6: ceil                                             |
|   PARTITION: UNPARTITIONED                                                  |
|                                                                             |
|   RESULT SINK                                                               |
|                                                                             |
|   2:EXCHANGE                                                                |
|                                                                             |
| PLAN FRAGMENT 1                                                             |
|  OUTPUT EXPRS:                                                              |
|   PARTITION: RANDOM                                                         |
|                                                                             |
|   STREAM DATA SINK                                                          |
|     EXCHANGE ID: 02                                                         |
|     UNPARTITIONED                                                           |
|                                                                             |
|   1:Project                                                                 |
|   |  <slot 5> : 9: abs + 1.0                                                |
|   |  <slot 6> : ceil(9: abs)                                                |
|   |  common expressions:                                                    |
|   |  <slot 7> : CAST(1: a AS DOUBLE)                                        |
|   |  <slot 8> : 7: cast + 3: pv                                             |
|   |  <slot 9> : abs(8: add)                                                 |
|   |                                                                         |
|   0:OlapScanNode                                                            |
|      TABLE: t                                                               |
|      PREAGGREGATION: ON                                                     |
|      partitions=1/1                                                         |
|      rollup: t                                                              |
|      tabletRatio=10/10                                                      |
|      tabletList=11004,11006,11008,11010,11012,11014,11016,11018,11020,11022 |
|      cardinality=1                                                          |
|      avgRowSize=4.0                                                         |
|      numNodes=0                                                             |
+-----------------------------------------------------------------------------+
34 rows in set (0.01 sec)
```

### resulsts

```
mysql> explain SELECT     sum(step0_time != '2020-01-02 00:00:00') AS step0,     sum(step1_time != '2020-01-02 00:00:00') AS step1 from( select uid, times, actions, step0_time,  array_filter((x,y)-> (y = 'buy'   AND (x BETWEEN step0_time AND date_add(step0_time, INTERVAL 90 MINUTE))  AND (step0_time <> '2020-01-01 00:0
0:00' ) ), times, actions)[1] as step1_time   from  (  select uid, times, actions,   array_filter(x -> (x = 'pv'), actions)[1] AS step0_time  from      (select
uid, array_sort(array_agg(time_stamp)) as times,  array_sortby(array_agg(action),array_agg(time_stamp)) as actions  from taobao_actions where to_date(time_stamp)='2017-11-25' group by uid) as t ) as t1) as t2;
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                                                                                                                                                                                                      |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                                                                                                                                                                                                                                     |
|  OUTPUT EXPRS:17: sum | 18: sum                                                                                                                                                                                                                                                                                                     |
|   PARTITION: RANDOM                                                                                                                                                                                                                                                                                                                 |
|                                                                                                                                                                                                                                                                                                                                     |
|   RESULT SINK                                                                                                                                                                                                                                                                                                                       |
|                                                                                                                                                                                                                                                                                                                                     |
|   3:AGGREGATE (update finalize)                                                                                                                                                                                                                                                                                                     |
|   |  output: sum(23: expr != '2020-01-02 00:00:00'), sum(array_filter(20: array_sort, array_map((<slot 12>, <slot 13>) -> ((<slot 13> = 'buy') AND ((<slot 12> >= 24: cast) AND (<slot 12> <= minutes_add(24: cast, 90)))) AND (23: expr != '2020-01-01 00:00:00'), 20: array_sort, 19: array_sortby))[1] != '2020-01-02 00:00:00') |
|   |  group by:                                                                                                                                                                                                                                                                                                                      |
|   |                                                                                                                                                                                                                                                                                                                                 |
|   2:Project                                                                                                                                                                                                                                                                                                                         |
|   |  <slot 19> : 19: array_sortby                                                                                                                                                                                                                                                                                                   |
|   |  <slot 20> : 20: array_sort                                                                                                                                                                                                                                                                                                     |
|   |  <slot 23> : 23: expr                                                                                                                                                                                                                                                                                                           |
|   |  <slot 24> : 24: cast                                                                                                                                                                                                                                                                                                           |
|   |  common expressions:                                                                                                                                                                                                                                                                                                            |
|   |  <slot 19> : array_sortby(7: array_agg, 6: array_agg)                                                                                                                                                                                                                                                                           |
|   |  <slot 20> : array_sort(6: array_agg)                                                                                                                                                                                                                                                                                           |
|   |  <slot 21> : array_map(<slot 10> -> <slot 10> = 'pv', 19: array_sortby)                                                                                                                                                                                                                                                         |
|   |  <slot 22> : array_filter(19: array_sortby, 21: array_map)                                                                                                                                                                                                                                                                      |
|   |  <slot 23> : 22: array_filter[1]                                                                                                                                                                                                                                                                                                |
|   |  <slot 24> : CAST(23: expr AS DATETIME)                                                                                                                                                                                                                                                                                         |
|   |                                                                                                                                                                                                                                                                                                                                 |
|   1:AGGREGATE (update finalize)                                                                                                                                                                                                                                                                                                     |
|   |  output: array_agg(5: time_stamp), array_agg(4: action)                                                                                                                                                                                                                                                                         |
|   |  group by: 1: uid                                                                                                                                                                                                                                                                                                               |
|   |                                                                                                                                                                                                                                                                                                                                 |
|   0:OlapScanNode                                                                                                                                                                                                                                                                                                                    |
|      TABLE: taobao_actions                                                                                                                                                                                                                                                                                                          |
|      PREAGGREGATION: ON                                                                                                                                                                                                                                                                                                             |
|      PREDICATES: to_date(5: time_stamp) = '2017-11-25'                                                                                                                                                                                                                                                                              |
|      partitions=0/1                                                                                                                                                                                                                                                                                                                 |
|      rollup: taobao_actions                                                                                                                                                                                                                                                                                                         |
|      tabletRatio=0/0                                                                                                                                                                                                                                                                                                                |
|      tabletList=                                                                                                                                                                                                                                                                                                                    |
|      cardinality=1                                                                                                                                                                                                                                                                                                                  |
|      avgRowSize=3.0                                                                                                                                                                                                                                                                                                                 |
|      numNodes=0                                                                                                                                                                                                                                                                                                                     |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
38 rows in set (0.05 sec)

mysql> explain SELECT uid, times, actions, step0_time, step1_time, array_filter((x, y)->(y = '支付' AND (x BETWEEN step1_time AND date_add(step1_time, INTERVAL 90 MINUTE)) AND (step1_time <> '2020-01-01 00:00:00') ), times, actions)[1] AS step2_time FROM (SELECT uid, times, actions, step0_time, array_filter( (x, y)-> (y = '下单'
AND (x BETWEEN step0_time AND date_add(step0_time, INTERVAL 90 MINUTE)) AND (step0_time <> '2020-01-01 00:00:00' ) ), times, actions)[1] AS step1_time FROM (SELECT uid, times, actions, array_filter((x, y) -> (y= '浏览' AND x BETWEEN '2020-01-02 00:00:00' AND '2020-01-02 23:59:59'), times, actions)[1] AS step0_time FROM (SELECT uid, array_sort(array_agg(time)) AS times, array_sortby(array_agg(event_type), array_agg(time)) AS actions FROM action1 GROUP BY uid) AS t ) AS t1) AS t2;
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                                                                                                                                       |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                                                                                                                                                                      |
|  OUTPUT EXPRS:1: uid | 6: array_sort | 7: array_sortby | 10: expr | 13: expr | 16: expr                                                                                                                                                                              |
|   PARTITION: RANDOM                                                                                                                                                                                                                                                  |
|                                                                                                                                                                                                                                                                      |
|   RESULT SINK                                                                                                                                                                                                                                                        |
|                                                                                                                                                                                                                                                                      |
|   2:Project                                                                                                                                                                                                                                                          |
|   |  <slot 1> : 1: uid                                                                                                                                                                                                                                               |
|   |  <slot 6> : 17: array_sort                                                                                                                                                                                                                                       |
|   |  <slot 7> : 18: array_sortby                                                                                                                                                                                                                                     |
|   |  <slot 10> : 21: expr                                                                                                                                                                                                                                            |
|   |  <slot 13> : 26: expr                                                                                                                                                                                                                                            |
|   |  <slot 16> : array_filter(17: array_sort, array_map((<slot 14>, <slot 15>) -> ((<slot 15> = '支付') AND ((<slot 14> >= 26: expr) AND (<slot 14> <= minutes_add(26: expr, 90)))) AND (26: expr != '2020-01-01 00:00:00'), 17: array_sort, 18: array_sortby))[1]   |
|   |  common expressions:                                                                                                                                                                                                                                             |
|   |  <slot 17> : array_sort(4: array_agg)                                                                                                                                                                                                                            |
|   |  <slot 18> : array_sortby(5: array_agg, 4: array_agg)                                                                                                                                                                                                            |
|   |  <slot 19> : array_map((<slot 8>, <slot 9>) -> (<slot 9> = '浏览') AND ((<slot 8> >= '2020-01-02 00:00:00') AND (<slot 8> <= '2020-01-02 23:59:59')), 17: array_sort, 18: array_sortby)                                                                          |
|   |  <slot 20> : array_filter(17: array_sort, 19: array_map)                                                                                                                                                                                                         |
|   |  <slot 21> : 20: array_filter[1]                                                                                                                                                                                                                                 |
|   |  <slot 22> : minutes_add(21: expr, 90)                                                                                                                                                                                                                           |
|   |  <slot 23> : 21: expr != '2020-01-01 00:00:00'                                                                                                                                                                                                                   |
|   |  <slot 24> : array_map((<slot 11>, <slot 12>) -> ((<slot 12> = '下单') AND ((<slot 11> >= 21: expr) AND (<slot 11> <= 22: minutes_add))) AND (23: expr), 17: array_sort, 18: array_sortby)                                                                       |
|   |  <slot 25> : array_filter(17: array_sort, 24: array_map)                                                                                                                                                                                                         |
|   |  <slot 26> : 25: array_filter[1]                                                                                                                                                                                                                                 |
|   |                                                                                                                                                                                                                                                                  |
|   1:AGGREGATE (update finalize)                                                                                                                                                                                                                                      |
|   |  output: array_agg(3: time), array_agg(2: event_type)                                                                                                                                                                                                            |
|   |  group by: 1: uid                                                                                                                                                                                                                                                |
|   |                                                                                                                                                                                                                                                                  |
|   0:OlapScanNode                                                                                                                                                                                                                                                     |
|      TABLE: action1                                                                                                                                                                                                                                                  |
|      PREAGGREGATION: ON                                                                                                                                                                                                                                              |
|      partitions=0/1                                                                                                                                                                                                                                                  |
|      rollup: action1                                                                                                                                                                                                                                                 |
|      tabletRatio=0/0                                                                                                                                                                                                                                                 |
|      tabletList=                                                                                                                                                                                                                                                     |
|      cardinality=1                                                                                                                                                                                                                                                   |
|      avgRowSize=3.0                                                                                                                                                                                                                                                  |
|      numNodes=0                                                                                                                                                                                                                                                      |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
39 rows in set (0.03 sec)
```
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
