### PR TITLE
[BugFix] Fix rewrite nested mv bugs when mv's partition/distribution predicates are not null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -186,7 +186,7 @@ public class MvRewritePreprocessor {
         // - To partition/distribution prune, need filter predicates that belong to MV.
         // - Those predicates are only used for partition/distribution pruning and don't affect the real
         // query compute.
-        // - TODO: after partition/distribution pruning, those predicates should be removed from mv rewrite result.
+        // - after partition/distribution pruning, those predicates should be removed from mv rewrite result.
         final OptExpression mvExpression = mvContext.getMvExpression();
         final List<ScalarOperator> conjuncts = MvUtils.getAllPredicates(mvExpression);
         final ColumnRefSet mvOutputColumnRefSet = mvExpression.getOutputColumns();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
@@ -69,6 +69,7 @@ public class MVPartitionPruner {
 
                 LogicalOlapScanOperator.Builder rewrittenBuilder = new LogicalOlapScanOperator.Builder();
                 scanOperator = rewrittenBuilder.withOperator(prunedOlapScanOperator)
+                        .setPredicate(MvUtils.canonizePredicate(prunedOlapScanOperator.getPredicate()))
                         .setSelectedTabletId(selectedTabletIds)
                         .build();
             } else if (scanOperator instanceof LogicalHiveScanOperator ||

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -488,9 +488,6 @@ public class MaterializedViewRewriter {
         if (mvOriginalPredicates != null && !ConstantOperator.TRUE.equals(mvOriginalPredicates)) {
             mvOriginalPredicates = rewriteMVCompensationExpression(rewriteContext, columnRewriter,
                     mvColumnRefToScalarOp, mvOriginalPredicates, false);
-            if (mvOriginalPredicates == null) {
-                return null;
-            }
             if (!ConstantOperator.TRUE.equals(mvOriginalPredicates)) {
                 mvScanBuilder.setPredicate(mvOriginalPredicates);
             }
@@ -587,6 +584,9 @@ public class MaterializedViewRewriter {
                     }
                 })
                 .collect(Collectors.toList());
+        if (rewrittenConjuncts.isEmpty()) {
+            return null;
+        }
 
         Multimap<ScalarOperator, ColumnRefOperator> normalizedMap =
                 normalizeAndReverseProjection(mvColumnRefToScalarOp, rewriteContext, isMVBased);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -34,6 +34,7 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.RangeUtils;
@@ -655,6 +656,11 @@ public class MvUtils {
         for (LogicalOlapScanOperator olapScanOperator : olapScanOperators) {
             Preconditions.checkState(olapScanOperator.getTable().isNativeTable());
             OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
+
+            if (olapTable.getPartitionInfo() instanceof SinglePartitionInfo) {
+                continue;
+            }
+
             if (olapScanOperator.getSelectedPartitionId() != null
                     && olapScanOperator.getSelectedPartitionId().size() == olapTable.getPartitions().size()) {
                 continue;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -28,6 +28,9 @@ import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MaterializedViewTestBase extends PlanTestBase {
     private static final Logger LOG = LogManager.getLogger(MaterializedViewTestBase.class);
@@ -166,5 +169,17 @@ public class MaterializedViewTestBase extends PlanTestBase {
             taskManager.createTask(task, false);
         }
         taskManager.executeTaskSync(mvTaskName);
+    }
+
+    protected void createAndRefreshMV(String db, String sql) throws Exception {
+        Pattern createMvPattern = Pattern.compile("^create materialized view (\\w+) .*");
+        Matcher matcher = createMvPattern.matcher(sql.toLowerCase(Locale.ROOT));
+        if (!matcher.find()) {
+            throw new Exception("create materialized view syntax error.");
+        }
+        String tableName = matcher.group(1);
+        System.out.println(tableName);
+        starRocksAssert.withMaterializedView(sql);
+        refreshMaterializedView(db, tableName);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -366,7 +366,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 2000")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 11: c3 < 2000, 11: c3 < 2000\n" +
+                        "     PREDICATES: 11: c3 < 2000\n" +
                         "     partitions=1/1\n" +
                         "     rollup: partial_mv_6\n" +
                         "     tabletRatio=2/2");
@@ -379,7 +379,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 2000 and t2.c3 > 100;")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 11: c3 <= 1999, 11: c3 >= 100, 11: c3 >= 101, 11: c3 < 2000, 11: c3 < 2000\n" +
+                        "     PREDICATES: 11: c3 <= 1999, 11: c3 >= 100, 11: c3 >= 101, 11: c3 < 2000\n" +
                         "     partitions=1/1\n" +
                         "     rollup: partial_mv_6\n" +
                         "     tabletRatio=2/2");
@@ -392,7 +392,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 1000;")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 11: c3 <= 999, 11: c3 < 2000, 11: c3 < 2000\n" +
+                        "     PREDICATES: 11: c3 <= 999, 11: c3 < 2000\n" +
                         "     partitions=1/1\n" +
                         "     rollup: partial_mv_6\n" +
                         "     tabletRatio=2/2");
@@ -405,7 +405,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 1000;")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 12: c3 <= 999, 12: c3 < 2000, 12: c3 < 2000\n" +
+                        "     PREDICATES: 12: c3 <= 999, 12: c3 < 2000\n" +
                         "     partitions=1/1\n" +
                         "     rollup: partial_mv_6\n" +
                         "     tabletRatio=2/2");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -71,10 +71,15 @@ public class MvRewriteOptimizationTest {
         Config.tablet_sched_checker_interval_seconds = 1;
         Config.tablet_sched_repair_delay_factor_second = 1;
         Config.enable_new_publish_mechanism = true;
+
         PseudoCluster.getOrCreateWithRandomPort(true, 3);
         GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
         cluster = PseudoCluster.getInstance();
+
         connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000000);
+        connectContext.getSessionVariable().setEnableOptimizerTraceLog(true);
+
         ConnectorPlanTestBase.mockHiveCatalog(connectContext);
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase("test").useDatabase("test");
@@ -1405,7 +1410,7 @@ public class MvRewriteOptimizationTest {
         PlanTestBase.assertContains(plan1, "  3:OlapScanNode\n" +
                 "     TABLE: union_mv_1");
         PlanTestBase.assertContains(plan1, "TABLE: emps\n" +
-                "     PREAGGREGATION: ON\n",
+                        "     PREAGGREGATION: ON\n",
                 "empid < 5,", "empid > 2");
 
         String query7 = "select deptno, empid from emps where empid < 5";
@@ -2017,5 +2022,62 @@ public class MvRewriteOptimizationTest {
         for (OptExpression child : root.getInputs()) {
             getScanOperators(child, name, results);
         }
+    }
+
+    @Test
+    public void testNestedMVs1() throws Exception {
+        createAndRefreshMv("test", "nested_mv1", "create materialized view nested_mv1 " +
+                " distributed by hash(empid) as" +
+                " select * from emps;");
+        createAndRefreshMv("test", "nested_mv2", "create materialized view nested_mv2 " +
+                " distributed by hash(empid) as" +
+                " select empid, sum(deptno) from emps group by empid;");
+        createAndRefreshMv("test", "nested_mv3", "create materialized view nested_mv3 " +
+                " distributed by hash(empid) as" +
+                " select * from nested_mv2 where empid > 1;");
+        String plan = getFragmentPlan("select empid, sum(deptno) from emps where empid > 1 group by empid");
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("0:OlapScanNode\n" +
+                "     TABLE: nested_mv3\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/1\n" +
+                "     rollup: nested_mv3"));
+        dropMv("test", "nested_mv1");
+        dropMv("test", "nested_mv2");
+        dropMv("test", "nested_mv3");
+    }
+
+    @Test
+    public void testExternalNestedMVs1() throws Exception {
+        connectContext.getSessionVariable().setEnableMaterializedViewUnionRewrite(true);
+        createAndRefreshMv("test", "hive_nested_mv_1",
+                "create materialized view hive_nested_mv_1 distributed by hash(s_suppkey) " +
+                        "PROPERTIES (\n" +
+                        "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                        ") " +
+                        " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier");
+        createAndRefreshMv("test", "hive_nested_mv_2",
+                "create materialized view hive_nested_mv_2 distributed by hash(s_suppkey) " +
+                        "PROPERTIES (\n" +
+                        "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                        ") " +
+                        " as select s_suppkey, sum(s_acctbal) from hive0.tpch.supplier group by s_suppkey");
+        createAndRefreshMv("test", "hive_nested_mv_3",
+                "create materialized view hive_nested_mv_3 distributed by hash(s_suppkey) " +
+                        "PROPERTIES (\n" +
+                        "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                        ") " +
+                        " as select * from hive_nested_mv_2 where s_suppkey > 1");
+        String query1 = "select s_suppkey, sum(s_acctbal) from hive0.tpch.supplier where s_suppkey > 1 group by s_suppkey ";
+        String plan1 = getFragmentPlan(query1);
+        System.out.println(plan1);
+        Assert.assertTrue(plan1.contains("0:OlapScanNode\n" +
+                "     TABLE: hive_nested_mv_3\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/1\n" +
+                "     rollup: hive_nested_mv_3"));
+        dropMv("test", "hive_nested_mv_1");
+        dropMv("test", "hive_nested_mv_2");
+        dropMv("test", "hive_nested_mv_3");
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
-  Fix rewrite nested mv bugs when mv's partition/distribution predicates is not null
   -  Ignore mvOriginalPredicates when `rewriteMVCompensationExpression` rewrites MVScan's predicates to null, which cannot prune partitions/distributions from MV's define.
```
        // Rewrite original mv's predicates into query if needed.
        final ColumnRewriter columnRewriter = new ColumnRewriter(rewriteContext);
        final Map<ColumnRefOperator, ScalarOperator> mvColumnRefToScalarOp = rewriteContext.getMVColumnRefToScalarOp();
        ScalarOperator mvOriginalPredicates = mvScanOperator.getPredicate();
        if (mvOriginalPredicates != null && !ConstantOperator.TRUE.equals(mvOriginalPredicates)) {
            mvOriginalPredicates = rewriteMVCompensationExpression(rewriteContext, columnRewriter,
                    mvColumnRefToScalarOp, mvOriginalPredicates, false);
         
            if (mvOriginalPredicates == null) {
                return null;
            }
            if (!ConstantOperator.TRUE.equals(mvOriginalPredicates)) {
                mvScanBuilder.setPredicate(mvOriginalPredicates);
            }
        }
```
- use `MvUtils.canonizePredicate(prunedOlapScanOperator.getPredicate()` to canonize predicates after  partition/distribution pruning.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
