### PR TITLE
[Enhancement] Aggreagte push down support local aggregate mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -774,9 +774,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             show = CBO_PUSH_DOWN_AGGREGATE_MODE, flag = VariableMgr.INVISIBLE)
     private int cboPushDownAggregateMode = -1;
 
-    // auto, fullaggregation, preaggregation
+    // auto, global, local
     @VarAttr(name = CBO_PUSH_DOWN_AGGREGATE, flag = VariableMgr.INVISIBLE)
-    private String cboPushDownAggregate = "fullaggregation";
+    private String cboPushDownAggregate = "global";
 
     @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
     private int parseTokensLimit = 3500000;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -250,6 +250,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
     public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
     public static final String CBO_PUSH_DOWN_AGGREGATE_MODE = "cbo_push_down_aggregate_mode";
+    public static final String CBO_PUSH_DOWN_AGGREGATE = "cbo_push_down_aggregate";
     public static final String CBO_DEBUG_ALIVE_BACKEND_NUMBER = "cbo_debug_alive_backend_number";
     public static final String ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL =
             "enable_rewrite_groupingsets_to_union_all";
@@ -772,6 +773,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = "cboPushDownAggregateMode_v1", alias = CBO_PUSH_DOWN_AGGREGATE_MODE,
             show = CBO_PUSH_DOWN_AGGREGATE_MODE, flag = VariableMgr.INVISIBLE)
     private int cboPushDownAggregateMode = -1;
+
+    // auto, fullaggregation, preaggregation
+    @VarAttr(name = CBO_PUSH_DOWN_AGGREGATE, flag = VariableMgr.INVISIBLE)
+    private String cboPushDownAggregate = "fullaggregation";
 
     @VariableMgr.VarAttr(name = PARSE_TOKENS_LIMIT)
     private int parseTokensLimit = 3500000;
@@ -1444,6 +1449,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboPushDownAggregateMode(int cboPushDownAggregateMode) {
         this.cboPushDownAggregateMode = cboPushDownAggregateMode;
+    }
+
+    public String getCboPushDownAggregate() {
+        return cboPushDownAggregate;
+    }
+
+    public void setCboPushDownAggregate(String cboPushDownAggregate) {
+        this.cboPushDownAggregate = cboPushDownAggregate;
     }
 
     public boolean isEnableSQLDigest() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -184,6 +184,10 @@ public class LogicalAggregationOperator extends LogicalOperator {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
         if (!super.equals(o)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -43,7 +43,7 @@ public class LogicalAggregationOperator extends LogicalOperator {
     private final AggType type;
     // The flag for this aggregate operator has split to
     // two stage aggregate or three stage aggregate
-    private boolean isSplit = false;
+    private boolean isSplit;
     /**
      * aggregation key is output variable of aggregate function
      */
@@ -84,7 +84,7 @@ public class LogicalAggregationOperator extends LogicalOperator {
         this.groupingKeys = ImmutableList.copyOf(groupingKeys);
         this.partitionByColumns = partitionByColumns;
         this.aggregations = ImmutableMap.copyOf(aggregations);
-        this.isSplit = isSplit;
+        this.isSplit = !type.isGlobal() || isSplit;
         this.singleDistinctFunctionPos = singleDistinctFunctionPos;
     }
 
@@ -94,7 +94,7 @@ public class LogicalAggregationOperator extends LogicalOperator {
         this.groupingKeys = builder.groupingKeys;
         this.partitionByColumns = builder.partitionByColumns;
         this.aggregations = builder.aggregations;
-        this.isSplit = builder.isSplit;
+        this.isSplit = !builder.type.isGlobal() || builder.isSplit;
         this.singleDistinctFunctionPos = builder.singleDistinctFunctionPos;
     }
 
@@ -114,8 +114,8 @@ public class LogicalAggregationOperator extends LogicalOperator {
         return isSplit;
     }
 
-    public void setSplit() {
-        isSplit = true;
+    public void setOnlyLocalAggregate() {
+        isSplit = false;
     }
 
     public int getSingleDistinctFunctionPos() {
@@ -149,7 +149,8 @@ public class LogicalAggregationOperator extends LogicalOperator {
 
     public Map<ColumnRefOperator, ScalarOperator> getColumnRefMap() {
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = Maps.newHashMap();
-        Map<ColumnRefOperator, ScalarOperator> keyMap = groupingKeys.stream().collect(Collectors.toMap(identity(), identity()));
+        Map<ColumnRefOperator, ScalarOperator> keyMap =
+                groupingKeys.stream().collect(Collectors.toMap(identity(), identity()));
         columnRefMap.putAll(keyMap);
         columnRefMap.putAll(aggregations);
         return columnRefMap;
@@ -183,22 +184,20 @@ public class LogicalAggregationOperator extends LogicalOperator {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
         if (!super.equals(o)) {
             return false;
         }
-
         LogicalAggregationOperator that = (LogicalAggregationOperator) o;
-        return type == that.type && Objects.equals(aggregations, that.aggregations) &&
-                Objects.equals(groupingKeys, that.groupingKeys);
+        return isSplit == that.isSplit && singleDistinctFunctionPos == that.singleDistinctFunctionPos &&
+                type == that.type && Objects.equals(aggregations, that.aggregations) &&
+                Objects.equals(groupingKeys, that.groupingKeys) &&
+                Objects.equals(partitionByColumns, that.partitionByColumns);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), type, aggregations, groupingKeys);
+        return Objects.hash(super.hashCode(), type, isSplit, aggregations, groupingKeys, partitionByColumns,
+                singleDistinctFunctionPos);
     }
 
     public static Builder builder() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
@@ -392,7 +392,7 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
 
         LogicalAggregationOperator aggregate;
         List<ColumnRefOperator> groupBys = Lists.newArrayList(context.groupBys.keySet());
-        if ("preaggregation".equalsIgnoreCase(sessionVariable.getCboPushDownAggregate()) ||
+        if ("local".equalsIgnoreCase(sessionVariable.getCboPushDownAggregate()) ||
                 ("auto".equalsIgnoreCase(sessionVariable.getCboPushDownAggregate()) && groupBys.size() <= 1)) {
             // local && un-split
             aggregate = new LogicalAggregationOperator(AggType.LOCAL, groupBys, context.aggregations);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.tree.pdagg;
 
 import com.google.common.base.Preconditions;
@@ -23,6 +22,7 @@ import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -64,6 +64,7 @@ import java.util.stream.Collectors;
 public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpression, AggregatePushDownContext> {
     private final ColumnRefFactory factory;
     private final PushDownAggregateCollector collector;
+    private final SessionVariable sessionVariable;
 
     private Map<LogicalAggregationOperator, List<AggregatePushDownContext>> allRewriteContext;
     // record all push down column on scan node
@@ -73,6 +74,7 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
     public PushDownAggregateRewriter(TaskContext taskContext) {
         this.factory = taskContext.getOptimizerContext().getColumnRefFactory();
         this.collector = new PushDownAggregateCollector(taskContext);
+        this.sessionVariable = taskContext.getOptimizerContext().getSessionVariable();
     }
 
     public OptExpression rewrite(OptExpression root) {
@@ -146,7 +148,8 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
 
     // rewrite groupBys/aggregation by project expression, maybe needs push down
     // expression with aggregation or rewrite project expression
-    private void rewriteProject(AggregatePushDownContext context, Map<ColumnRefOperator, ScalarOperator> originProjectMap) {
+    private void rewriteProject(AggregatePushDownContext context,
+                                Map<ColumnRefOperator, ScalarOperator> originProjectMap) {
         // rewrite group bys
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(originProjectMap);
         context.groupBys.replaceAll((k, v) -> rewriter.rewrite(v));
@@ -387,9 +390,16 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
             result = OptExpression.create(new LogicalProjectOperator(refs), result);
         }
 
-        LogicalAggregationOperator aggregate = new LogicalAggregationOperator(AggType.GLOBAL,
-                Lists.newArrayList(context.groupBys.keySet()), context.aggregations);
-
+        LogicalAggregationOperator aggregate;
+        List<ColumnRefOperator> groupBys = Lists.newArrayList(context.groupBys.keySet());
+        if ("preaggregation".equalsIgnoreCase(sessionVariable.getCboPushDownAggregate()) ||
+                ("auto".equalsIgnoreCase(sessionVariable.getCboPushDownAggregate()) && groupBys.size() <= 1)) {
+            // local && un-split
+            aggregate = new LogicalAggregationOperator(AggType.LOCAL, groupBys, context.aggregations);
+            aggregate.setOnlyLocalAggregate();
+        } else {
+            aggregate = new LogicalAggregationOperator(AggType.GLOBAL, groupBys, context.aggregations);
+        }
         return OptExpression.create(aggregate, result);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1555,7 +1555,7 @@ public class PlanFragmentBuilder {
             ArrayList<Expr> intermediateAggrExprs = aggExpr.intermediateExpr;
 
             AggregationNode aggregationNode;
-            if (node.getType().isLocal()) {
+            if (node.getType().isLocal() && node.isSplit()) {
                 AggregateInfo aggInfo = AggregateInfo.create(
                         groupingExpressions,
                         aggregateExprList,
@@ -1574,7 +1574,9 @@ public class PlanFragmentBuilder {
                 if (!withLocalShuffle && !node.isUseStreamingPreAgg() && hasColocateOlapScanChildInFragment(aggregationNode)) {
                     aggregationNode.setColocate(true);
                 }
-            } else if (node.getType().isGlobal()) {
+            } else if (node.getType().isGlobal() || (node.getType().isLocal() && !node.isSplit())) {
+                // Local && un-split aggregate meanings only execute local pre-aggregation, we need promise
+                // output type match other node, so must use `update finalized` phase
                 if (node.hasSingleDistinct()) {
                     // For SQL: select count(id_int) as a, sum(DISTINCT id_bigint) as b from test_basic group by id_int;
                     // sum function is update function, but count is merge function

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -35,11 +35,11 @@ public class AggregatePushDownTest extends PlanTestBase {
 
     @Test
     public void testPushDownPreAgg() {
-        connectContext.getSessionVariable().setCboPushDownAggregate("preaggregation");
+        connectContext.getSessionVariable().setCboPushDownAggregate("local");
         try {
             runFileUnitTest("optimized-plan/preagg-pushdown");
         } finally {
-            connectContext.getSessionVariable().setCboPushDownAggregate("auto");
+            connectContext.getSessionVariable().setCboPushDownAggregate("global");
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
@@ -32,5 +31,15 @@ public class AggregatePushDownTest extends PlanTestBase {
     @Test
     public void testPushDown() {
         runFileUnitTest("optimized-plan/agg-pushdown");
+    }
+
+    @Test
+    public void testPushDownPreAgg() {
+        connectContext.getSessionVariable().setCboPushDownAggregate("preaggregation");
+        try {
+            runFileUnitTest("optimized-plan/preagg-pushdown");
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownAggregate("auto");
+        }
     }
 }

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/preagg-pushdown.sql
@@ -1,0 +1,316 @@
+[sql]
+select sum(v2) from t0 join t1 on t0.v1 = t1.v4 group by t0.v3 + t1.v6;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{8: sum=sum(9: sum)}] group by [[7: expr]] having [null]
+    EXCHANGE SHUFFLE[7]
+        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            AGGREGATE ([LOCAL] aggregate [{9: sum=sum(2: v2)}] group by [[1: v1, 3: v3]] having [null]
+                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 6: v6] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select max(v2), sum(2) from t0 join t1 on t0.v1 = t1.v4 group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{7: max=max(9: max), 8: sum=sum(10: sum)}] group by [[1: v1]] having [null]
+    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+        AGGREGATE ([LOCAL] aggregate [{9: max=max(2: v2), 10: sum=sum(11: expr)}] group by [[1: v1]] having [null]
+            SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+        EXCHANGE SHUFFLE[4]
+            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select max(v2 + 3), sum(v2 + 3) from t0 join t1 on t0.v1 = t1.v4 group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{9: sum=sum(10: sum), 8: max=max(11: max)}] group by [[1: v1]] having [null]
+    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+        AGGREGATE ([LOCAL] aggregate [{10: sum=sum(12: add), 11: max=max(13: add)}] group by [[1: v1]] having [null]
+            SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+        EXCHANGE SHUFFLE[4]
+            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select max(v2 + 3), sum(v2 + 3) from t0 join t1 on t0.v1 = t1.v4 group by t0.v3 + t1.v6;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{9: max=max(11: max), 10: sum=sum(12: sum)}] group by [[7: expr]] having [null]
+    EXCHANGE SHUFFLE[7]
+        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            AGGREGATE ([LOCAL] aggregate [{11: max=max(13: add), 12: sum=sum(14: add)}] group by [[1: v1, 3: v3]] having [null]
+                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 6: v6] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select max(v2 + v3), sum(v2 + 3) from t0 join t1 on t0.v1 = t1.v4 group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{9: max=max(11: max), 10: sum=sum(12: sum)}] group by [[1: v1]] having [null]
+    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+        AGGREGATE ([LOCAL] aggregate [{11: max=max(13: add), 12: sum=sum(14: add)}] group by [[1: v1]] having [null]
+            SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+        EXCHANGE SHUFFLE[4]
+            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select max(case when t1.v4 = 3 then t0.v2
+                when t1.v5 = 5 then t0.v3
+                else t0.v1 end), sum(v2 + 3)
+from t0 join t1 on t0.v1 = t1.v4 group by t0.v3 + t1.v6;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{10: max=max(12: max), 11: sum=sum(13: sum)}] group by [[7: expr]] having [null]
+    EXCHANGE SHUFFLE[7]
+        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            AGGREGATE ([LOCAL] aggregate [{13: sum=sum(17: add), 14: max=max(2: v2), 15: max=max(3: v3), 16: max=max(1: v1)}] group by [[1: v1, 3: v3]] having [null]
+                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select max(case when t1.v4 = t0.v2 then t0.v2
+                when t1.v5 = 5 then t0.v3
+                else t0.v1 end), sum(v2 + 3)
+from t0 join t1 on t0.v1 = t1.v4 group by t0.v3 + t1.v6;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{10: max=max(12: max), 11: sum=sum(13: sum)}] group by [[7: expr]] having [null]
+    EXCHANGE SHUFFLE[7]
+        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            AGGREGATE ([LOCAL] aggregate [{13: sum=sum(17: add), 14: max=max(2: v2), 15: max=max(3: v3), 16: max=max(1: v1)}] group by [[1: v1, 2: v2, 3: v3]] having [null]
+                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select sum(if(t1.v4 = t1.v6, t0.v2, t0.v3))
+from t0 join t1 on t0.v1 = t1.v4
+where t0.v2 + t1.v5 = 3
+group by t0.v3 + t1.v6;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{9: sum=sum(10: sum)}] group by [[7: expr]] having [null]
+    EXCHANGE SHUFFLE[7]
+        INNER JOIN (join-predicate [1: v1 = 4: v4 AND add(2: v2, 5: v5) = 3] post-join-predicate [null])
+            AGGREGATE ([LOCAL] aggregate [{11: sum=sum(2: v2), 12: sum=sum(3: v3)}] group by [[1: v1, 2: v2, 3: v3]] having [null]
+                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 5: v5, 6: v6] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select sum(if(t1.v4 = t0.v1, t0.v2, t0.v3))
+from t0 join t1 on t0.v1 = t1.v4 group by t0.v3 + t1.v6;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{9: sum=sum(10: sum)}] group by [[7: expr]] having [null]
+    EXCHANGE SHUFFLE[7]
+        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            AGGREGATE ([LOCAL] aggregate [{11: sum=sum(2: v2), 12: sum=sum(3: v3)}] group by [[1: v1, 3: v3]] having [null]
+                SCAN (columns[1: v1, 2: v2, 3: v3] predicate[1: v1 IS NOT NULL])
+            EXCHANGE SHUFFLE[4]
+                SCAN (columns[4: v4, 6: v6] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select sum(v2) from (select * from t0 union all select * from t1) x group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{10: sum=sum(11: sum)}] group by [[7: v1]] having [null]
+    EXCHANGE SHUFFLE[7]
+        UNION
+            AGGREGATE ([LOCAL] aggregate [{12: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                SCAN (columns[1: v1, 2: v2] predicate[null])
+            AGGREGATE ([LOCAL] aggregate [{13: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                SCAN (columns[4: v4, 5: v5] predicate[null])
+[end]
+
+[sql]
+select sum(v2) from (select t0.* from t0 join t1 on t0.v1 = t1.v4 union all select * from t1) x group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
+    EXCHANGE SHUFFLE[10]
+        UNION
+            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+                EXCHANGE SHUFFLE[4]
+                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                SCAN (columns[7: v4, 8: v5] predicate[null])
+[end]
+
+[sql]
+select sum(v2) from (
+    select t0.* from t0 join t1 on t0.v1 = t1.v4 where abs(t0.v2) = 1 union all select * from t1
+) x group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{13: sum=sum(14: sum)}] group by [[10: v1]] having [null]
+    EXCHANGE SHUFFLE[10]
+        UNION
+            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                AGGREGATE ([LOCAL] aggregate [{15: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 1])
+                EXCHANGE SHUFFLE[4]
+                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            AGGREGATE ([LOCAL] aggregate [{16: sum=sum(8: v5)}] group by [[7: v4]] having [null]
+                SCAN (columns[7: v4, 8: v5] predicate[null])
+[end]
+
+
+[sql]
+select sum(v2) from
+(
+    select t0.* from t0 join t1 on t0.v1 = t1.v4
+    union all
+    select t2.* from t1 join t2 on t1.v5 = t2.v8
+) x
+where abs(x.v2) = 2
+group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
+    EXCHANGE SHUFFLE[13]
+        UNION
+            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                EXCHANGE SHUFFLE[4]
+                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                EXCHANGE BROADCAST
+                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+[end]
+
+[sql]
+select sum(v2) from
+(
+    select t0.* from t0 join t1 on t0.v1 = t1.v4
+    union all
+    select t2.* from t1 join t2 on t1.v5 = t2.v8
+) x
+where abs(x.v2) = 2
+group by x.v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{16: sum=sum(17: sum)}] group by [[13: v1]] having [null]
+    EXCHANGE SHUFFLE[13]
+        UNION
+            INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+                AGGREGATE ([LOCAL] aggregate [{18: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[abs(2: v2) = 2])
+                EXCHANGE SHUFFLE[4]
+                    SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+            INNER JOIN (join-predicate [11: v8 = 8: v5] post-join-predicate [null])
+                AGGREGATE ([LOCAL] aggregate [{19: sum=sum(11: v8)}] group by [[10: v7, 11: v8]] having [null]
+                    SCAN (columns[10: v7, 11: v8] predicate[abs(11: v8) = 2])
+                EXCHANGE BROADCAST
+                    SCAN (columns[8: v5] predicate[abs(8: v5) = 2])
+[end]
+
+[sql]
+select sum(v2) from
+(
+    select * from (select * from t0 union all select * from t1) c0
+    union all
+    select * from (select * from t1 union all select * from t2) c1
+) x
+group by v1
+[result]
+AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
+    EXCHANGE SHUFFLE[19]
+        UNION
+            UNION
+                AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[null])
+                AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
+            UNION
+                AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                    SCAN (columns[10: v4, 11: v5] predicate[null])
+                AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                    SCAN (columns[13: v7, 14: v8] predicate[null])
+[end]
+
+[sql]
+select sum(v2) from
+(
+    select * from (select * from t0 union all select * from t1) c0
+    union all
+    select * from (select * from t1 union all select * from t2) c1
+) x
+group by v1
+[result]
+AGGREGATE ([GLOBAL] aggregate [{22: sum=sum(23: sum)}] group by [[19: v1]] having [null]
+    EXCHANGE SHUFFLE[19]
+        UNION
+            UNION
+                AGGREGATE ([LOCAL] aggregate [{26: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+                    SCAN (columns[1: v1, 2: v2] predicate[null])
+                AGGREGATE ([LOCAL] aggregate [{27: sum=sum(5: v5)}] group by [[4: v4]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
+            UNION
+                AGGREGATE ([LOCAL] aggregate [{28: sum=sum(11: v5)}] group by [[10: v4]] having [null]
+                    SCAN (columns[10: v4, 11: v5] predicate[null])
+                AGGREGATE ([LOCAL] aggregate [{29: sum=sum(14: v8)}] group by [[13: v7]] having [null]
+                    SCAN (columns[13: v7, 14: v8] predicate[null])
+[end]
+
+[sql]
+select sum(v2) from
+(
+    select * from (select * from t0 union all select * from t1) c0
+    join (select * from t1 union all select * from t2) c1 on c0.v2 = c1.v5
+) x
+where x.v2 + x.v5 = 1
+group by x.v2
+[result]
+AGGREGATE ([GLOBAL] aggregate [{19: sum=sum(20: sum)}] group by [[8: v2]] having [null]
+    EXCHANGE SHUFFLE[8]
+        INNER JOIN (join-predicate [8: v2 = 17: v5 AND add(8: v2, 17: v5) = 1] post-join-predicate [null])
+            UNION
+                AGGREGATE ([LOCAL] aggregate [{21: sum=sum(2: v2)}] group by [[2: v2]] having [null]
+                    SCAN (columns[2: v2] predicate[2: v2 IS NOT NULL])
+                AGGREGATE ([LOCAL] aggregate [{22: sum=sum(5: v5)}] group by [[5: v5]] having [null]
+                    SCAN (columns[5: v5] predicate[5: v5 IS NOT NULL])
+            EXCHANGE BROADCAST
+                UNION
+                    SCAN (columns[11: v5] predicate[11: v5 IS NOT NULL])
+                    SCAN (columns[14: v8] predicate[14: v8 IS NOT NULL])
+[end]
+
+
+[sql]
+select sum(v2) from t0, t1 group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(10: sum)}] group by [[1: v1]] having [null]
+    CROSS JOIN (join-predicate [null] post-join-predicate [null])
+        AGGREGATE ([LOCAL] aggregate [{10: sum=sum(2: v2)}] group by [[1: v1]] having [null]
+            SCAN (columns[1: v1, 2: v2] predicate[null])
+        EXCHANGE BROADCAST
+            SCAN (columns[4: v4] predicate[null])
+[end]
+
+[sql]
+select t0.v2, t1.v5 from t0 join t1 on t0.v1 = t1.v4 group by t0.v2, t1.v5;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{}] group by [[2: v2, 5: v5]] having [null]
+    EXCHANGE SHUFFLE[2, 5]
+        INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+            AGGREGATE ([LOCAL] aggregate [{}] group by [[1: v1, 2: v2]] having [null]
+                SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+            EXCHANGE SHUFFLE[4]
+                AGGREGATE ([LOCAL] aggregate [{}] group by [[4: v4, 5: v5]] having [null]
+                    SCAN (columns[4: v4, 5: v5] predicate[4: v4 IS NOT NULL])
+[end]
+
+[sql]
+select sum(t0.v2), sum(1) from t0 join t1 on t0.v1 = t1.v4 group by v1;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{7: sum=sum(9: sum), 8: sum=sum(10: sum)}] group by [[1: v1]] having [null]
+    INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
+        AGGREGATE ([LOCAL] aggregate [{9: sum=sum(2: v2), 10: sum=sum(11: expr)}] group by [[1: v1]] having [null]
+            SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])
+        EXCHANGE SHUFFLE[4]
+            SCAN (columns[4: v4] predicate[4: v4 IS NOT NULL])
+[end]


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Modify aggreagte push down.
for aggregate node, when finish split rule, all aggregate state must be:
* Global && un-split (one stage aggregate)
* Global && split (two stage aggregate)
* Local && split (two stage aggregate)
* Global Distinct && split
* Local Distinct && split

1. modify set isSplit logical. all types will set isSplit to true except Global type, because other type always come from `SplitAggRule`, but isSplit was not set correctly before this pr
2. add a special stage: Local && un-split, meanings this aggregate don't promise complete aggregation result, just do pre-aggregate on local node.

can be controll the enhancement by session:
```
set cbo_push_down_aggregate='auto';
set cbo_push_down_aggregate='preaggregation';
```

example:
1. don't push down aggregation
```
set
MySQL td> explain   select sum(t1.v2) from t0 join t1 on t0.v2 = t1.v2 group by t1.v3;
+-----------------------------------------+
| Explain String                          |
+-----------------------------------------+
..........
|   |                                     |
|   8:AGGREGATE (merge finalize)          |
|   |  output: sum(7: sum)                |
|   |  group by: 6: v3                    |
|   |                                     |
|   7:EXCHANGE                            |
|                                         |
| PLAN FRAGMENT 2                         |
|  OUTPUT EXPRS:                          |
|   PARTITION: HASH_PARTITIONED: 2: v2    |
|                                         |
|   STREAM DATA SINK                      |
|     EXCHANGE ID: 07                     |
|     HASH_PARTITIONED: 6: v3             |
|                                         |
|   6:AGGREGATE (update serialize)        |
|   |  STREAMING                          |
|   |  output: sum(5: v2)                 |
|   |  group by: 6: v3                    |
|   |                                     |
|   5:Project                             |
|   |  <slot 5> : 5: v2                   |
|   |  <slot 6> : 6: v3                   |
|   |                                     |
|   4:HASH JOIN                           |
|   |  join op: INNER JOIN (PARTITIONED)  |
|   |  colocate: false, reason:           |
|   |  equal join conjunct: 2: v2 = 5: v2 |
|   |                                     |
|   |----3:EXCHANGE                       |
|   |                                     |
|   1:EXCHANGE                            |
|                                         |
| PLAN FRAGMENT 3                         |
|  OUTPUT EXPRS:                          |
|   PARTITION: RANDOM                     |
|                                         |
|   STREAM DATA SINK                      |
|     EXCHANGE ID: 03                     |
|     HASH_PARTITIONED: 5: v2             |
|                                         |
|   2:OlapScanNode                        |
|      TABLE: t1                          |
..........
|                                         |
| PLAN FRAGMENT 4                         |
|  OUTPUT EXPRS:                          |
|   PARTITION: RANDOM                     |
|                                         |
|   STREAM DATA SINK                      |
|     EXCHANGE ID: 01                     |
|     HASH_PARTITIONED: 2: v2             |
|                                         |
|   0:OlapScanNode                        |
|      TABLE: t0                          |
..........
+-----------------------------------------+
```

3. Push down a complate aggregation, like node 3&5
```
MySQL td> set cbo_push_down_aggregate='auto';
Query OK, 0 rows affected
Time: 0.002s
MySQL td> set cbo_push_down_aggregate_mode=1;
Query OK, 0 rows affected
Time: 0.001s
MySQL td> explain   select sum(t1.v2) from t0 join t1 on t0.v2 = t1.v2 group by t1.v3;
+---------------------------------------------+
| Explain String                              |
+---------------------------------------------+
| PLAN FRAGMENT 0                             |
..........
|   |                                         |
|   11:AGGREGATE (merge finalize)             |
|   |  output: sum(7: sum)                    |
|   |  group by: 6: v3                        |
|   |                                         |
|   10:EXCHANGE                               |
|                                             |
| PLAN FRAGMENT 2                             |
|  OUTPUT EXPRS:                              |
|   PARTITION: HASH_PARTITIONED: 2: v2        |
|                                             |
|   STREAM DATA SINK                          |
|     EXCHANGE ID: 10                         |
|     HASH_PARTITIONED: 6: v3                 |
|                                             |
|   9:AGGREGATE (update serialize)            |
|   |  STREAMING                              |
|   |  output: sum(8: sum)                    |
|   |  group by: 6: v3                        |
|   |                                         |
|   8:Project                                 |
|   |  <slot 6> : 6: v3                       |
|   |  <slot 8> : 8: sum                      |
|   |                                         |
|   7:HASH JOIN                               |
|   |  join op: INNER JOIN (PARTITIONED)      |
|   |  colocate: false, reason:               |
|   |  equal join conjunct: 2: v2 = 5: v2     |
|   |                                         |
|   |----6:EXCHANGE                           |
|   |                                         |
|   1:EXCHANGE                                |
|                                             |
| PLAN FRAGMENT 3                             |
|  OUTPUT EXPRS:                              |
|   PARTITION: HASH_PARTITIONED: 5: v2, 6: v3 |
|                                             |
|   STREAM DATA SINK                          |
|     EXCHANGE ID: 06                         |
|     HASH_PARTITIONED: 5: v2                 |
|                                             |
|   5:AGGREGATE (merge finalize)              |
|   |  output: sum(8: sum)                    |
|   |  group by: 5: v2, 6: v3                 |
|   |                                         |
|   4:EXCHANGE                                |
|                                             |
| PLAN FRAGMENT 4                             |
|  OUTPUT EXPRS:                              |
|   PARTITION: RANDOM                         |
|                                             |
|   STREAM DATA SINK                          |
|     EXCHANGE ID: 04                         |
|     HASH_PARTITIONED: 5: v2, 6: v3          |
|                                             |
|   3:AGGREGATE (update serialize)            |
|   |  STREAMING                              |
|   |  output: sum(5: v2)                     |
|   |  group by: 5: v2, 6: v3                 |
|   |                                         |
|   2:OlapScanNode                            |
|      TABLE: t1                              |
..........
|                                             |
| PLAN FRAGMENT 5                             |
|  OUTPUT EXPRS:                              |
|   PARTITION: RANDOM                         |
|                                             |
|   STREAM DATA SINK                          |
|     EXCHANGE ID: 01                         |
|     HASH_PARTITIONED: 2: v2                 |
|                                             |
|   0:OlapScanNode                            |
|      TABLE: t0                              |
..........
+---------------------------------------------+
109 rows in set
Time: 0.021s
```

4. Push down a pre-aggregation, like node 3
```
MySQL td> set cbo_push_down_aggregate='preaggregation';
Query OK, 0 rows affected
Time: 0.002s
MySQL td> set cbo_push_down_aggregate_mode=1;
Query OK, 0 rows affected
Time: 0.001s
MySQL td> explain   select sum(t1.v2) from t0 join t1 on t0.v2 = t1.v2 group by t1.v3;
+-----------------------------------------+
| Explain String                          |
+-----------------------------------------+
| PLAN FRAGMENT 0                         |
..........
|   |                                     |
|   9:AGGREGATE (merge finalize)          |
|   |  output: sum(7: sum)                |
|   |  group by: 6: v3                    |
|   |                                     |
|   8:EXCHANGE                            |
|                                         |
| PLAN FRAGMENT 2                         |
|  OUTPUT EXPRS:                          |
|   PARTITION: HASH_PARTITIONED: 2: v2    |
|                                         |
|   STREAM DATA SINK                      |
|     EXCHANGE ID: 08                     |
|     HASH_PARTITIONED: 6: v3             |
|                                         |
|   7:AGGREGATE (update serialize)        |
|   |  STREAMING                          |
|   |  output: sum(8: sum)                |
|   |  group by: 6: v3                    |
|   |                                     |
|   6:Project                             |
|   |  <slot 6> : 6: v3                   |
|   |  <slot 8> : 8: sum                  |
|   |                                     |
|   5:HASH JOIN                           |
|   |  join op: INNER JOIN (PARTITIONED)  |
|   |  colocate: false, reason:           |
|   |  equal join conjunct: 2: v2 = 5: v2 |
|   |                                     |
|   |----4:EXCHANGE                       |
|   |                                     |
|   1:EXCHANGE                            |
|                                         |
| PLAN FRAGMENT 3                         |
|  OUTPUT EXPRS:                          |
|   PARTITION: RANDOM                     |
|                                         |
|   STREAM DATA SINK                      |
|     EXCHANGE ID: 04                     |
|     HASH_PARTITIONED: 5: v2             |
|                                         |
|   3:AGGREGATE (update finalize)         |
|   |  output: sum(5: v2)                 |
|   |  group by: 5: v2, 6: v3             |
|   |                                     |
|   2:OlapScanNode                        |
|      TABLE: t1                          |
..........
|                                         |
| PLAN FRAGMENT 4                         |
|  OUTPUT EXPRS:                          |
|   PARTITION: RANDOM                     |
|                                         |
|   STREAM DATA SINK                      |
|     EXCHANGE ID: 01                     |
|     HASH_PARTITIONED: 2: v2             |
|                                         |
|   0:OlapScanNode                        |
|      TABLE: t0                          |
..........
+-----------------------------------------+
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
