### PR TITLE
[BugFix] Fix some compatibility for auto increment column (#18443)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -872,10 +872,12 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     _tuple_desc_id = table_sink.tuple_id;
     _is_lake_table = table_sink.is_lake_table;
     _keys_type = table_sink.keys_type;
-    _null_expr_in_auto_increment = table_sink.null_expr_in_auto_increment;
-    _miss_auto_increment_column = table_sink.miss_auto_increment_column;
-    _abort_delete = table_sink.abort_delete;
-    _auto_increment_slot_id = table_sink.auto_increment_slot_id;
+    if (table_sink.__isset.null_expr_in_auto_increment) {
+        _null_expr_in_auto_increment = table_sink.null_expr_in_auto_increment;
+        _miss_auto_increment_column = table_sink.miss_auto_increment_column;
+        _abort_delete = table_sink.abort_delete;
+        _auto_increment_slot_id = table_sink.auto_increment_slot_id;
+    }
     if (table_sink.__isset.write_quorum_type) {
         _write_quorum_type = table_sink.write_quorum_type;
     }

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -62,8 +62,8 @@ struct DeltaWriterOptions {
     WriteQuorumTypePB write_quorum;
     std::string merge_condition;
     ReplicaState replica_state;
-    bool miss_auto_increment_column;
-    bool abort_delete;
+    bool miss_auto_increment_column = false;
+    bool abort_delete = false;
 };
 
 enum State {

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -165,7 +165,7 @@ static Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, 
     column_pb->set_name(t_column.column_name);
     column_pb->set_is_key(t_column.is_key);
     column_pb->set_is_nullable(t_column.is_allow_null);
-    column_pb->set_is_auto_increment(t_column.is_auto_increment);
+
     if (t_column.is_key) {
         auto agg_method = STORAGE_AGGREGATE_NONE;
         column_pb->set_aggregation(get_string_by_aggregation_type(agg_method));
@@ -184,6 +184,10 @@ static Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, 
     }
     if (t_column.__isset.is_bloom_filter_column) {
         column_pb->set_is_bf_column(t_column.is_bloom_filter_column);
+    }
+
+    if (t_column.__isset.is_auto_increment) {
+        column_pb->set_is_auto_increment(t_column.is_auto_increment);
     }
 
     return Status::OK();

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -423,9 +423,7 @@ public class BackupHandler extends LeaderDaemon implements Writable {
         }
 
         BackupMeta backupMeta = downloadAndDeserializeMetaInfo(jobInfo, repository, stmt);
-        if (backupMeta != null) {
-            backupMeta.makeDummyMap();
-        }
+
         // Create a restore job
         RestoreJob restoreJob = null;
         if (backupMeta != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -491,7 +491,7 @@ public class RestoreJob extends AbstractJob {
                         ((OlapTable) localTbl).sendDropAutoIncrementMapTask();
                     }
 
-                    backupMeta.checkAndRecoverAutoIncrementId(localTbl);
+                    tblInfo.checkAndRecoverAutoIncrementId(localTbl);
                     // table already exist, check schema
                     if (!localTbl.isOlapOrLakeTable()) {
                         status = new Status(ErrCode.COMMON_ERROR,
@@ -603,7 +603,7 @@ public class RestoreJob extends AbstractJob {
                         return;
                     }
 
-                    backupMeta.checkAndRecoverAutoIncrementId((Table) remoteOlapTbl);
+                    tblInfo.checkAndRecoverAutoIncrementId((Table) remoteOlapTbl);
 
                     // DO NOT set remote table's new name here, cause we will still need the origin name later
                     // remoteOlapTbl.setName(jobInfo.getAliasByOriginNameIfSet(tblInfo.name));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -514,7 +514,7 @@ public class Database extends MetaObject implements Writable {
         }
 
         if (table instanceof OlapTable && table.hasAutoIncrementColumn()) {
-            GlobalStateMgr.getCurrentState().removeAutoIncrementIdByTableId(tableId);
+            GlobalStateMgr.getCurrentState().removeAutoIncrementIdByTableId(tableId, isReplay);
             ((OlapTable) table).sendDropAutoIncrementMapTask();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -3533,8 +3533,8 @@ public class GlobalStateMgr {
         return localMetastore.allocateAutoIncrementId(tableId, rows);
     }
 
-    public void removeAutoIncrementIdByTableId(Long tableId) {
-        localMetastore.removeAutoIncrementIdByTableId(tableId);
+    public void removeAutoIncrementIdByTableId(Long tableId, boolean isReplay) {
+        localMetastore.removeAutoIncrementIdByTableId(tableId, isReplay);
     }
 
     public Long getCurrentAutoIncrementIdByTableId(Long tableId) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -5193,11 +5193,13 @@ public class LocalMetastore implements ConnectorMetadata {
         return oldId;
     }
 
-    public void removeAutoIncrementIdByTableId(Long tableId) {
-        ConcurrentHashMap<Long, Long> deltaMap = new ConcurrentHashMap<>();
-        deltaMap.put(tableId, 0L);
-        AutoIncrementInfo info = new AutoIncrementInfo(deltaMap);
-        GlobalStateMgr.getCurrentState().getEditLog().logSaveDeleteAutoIncrementId(info);
+    public void removeAutoIncrementIdByTableId(Long tableId, boolean isReplay) {
+        if (!isReplay) {
+            ConcurrentHashMap<Long, Long> deltaMap = new ConcurrentHashMap<>();
+            deltaMap.put(tableId, 0L);
+            AutoIncrementInfo info = new AutoIncrementInfo(deltaMap);
+            GlobalStateMgr.getCurrentState().getEditLog().logSaveDeleteAutoIncrementId(info);
+        }
 
         tableIdToIncrementId.remove(tableId);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18443

## Problem Summary(Required) ：
Problem:
1. Some new metadata persisted in BackupMeta which incompatible with older versions.
2. Auto-increment param in OlapTableSink will be init uncorrectly when FE is older versions.
3. remove Auto Increment Id map when drop database will cause dead lock when FE restart and replay dropDb. 

Solution:
1. persist the new metadata for backup in BackupJobInfo, which is JSON stored in remote but not in Image File.
2. Check Fe version when init param in OlapTableSink.
3. use isReplay to skip saving remove auto increment id editlog.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
