### PR TITLE
[Enhancement] Fix performance problem of operator's mem tracker

### DIFF
--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -62,7 +62,7 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
 
 Status Operator::prepare(RuntimeState* state) {
     _mem_tracker = std::make_shared<MemTracker>(_common_metrics.get(), std::make_tuple(true, true, true), "Operator",
-                                                -1, _name, state->instance_mem_tracker());
+                                                -1, _name, nullptr);
     _total_timer = ADD_TIMER(_common_metrics, "OperatorTotalTime");
     _push_timer = ADD_TIMER(_common_metrics, "PushTotalTime");
     _pull_timer = ADD_TIMER(_common_metrics, "PullTotalTime");

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -33,10 +33,6 @@
 
 namespace starrocks::pipeline {
 
-#define SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op)                          \
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_is_profile_enabled ? op->mem_tracker() \
-                                                               : _runtime_state->instance_mem_tracker())
-
 PipelineDriver::~PipelineDriver() noexcept {
     if (_workgroup != nullptr) {
         _workgroup->decr_num_running_drivers();
@@ -45,7 +41,6 @@ PipelineDriver::~PipelineDriver() noexcept {
 
 Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _runtime_state = runtime_state;
-    _is_profile_enabled = _runtime_state->query_ctx()->is_report_profile();
 
     auto* prepare_timer = ADD_TIMER(_runtime_profile, "DriverPrepareTime");
     SCOPED_TIMER(prepare_timer);
@@ -251,7 +246,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 // operator
                 StatusOr<ChunkPtr> maybe_chunk;
                 {
-                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(curr_op);
+                    SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(curr_op);
                     SCOPED_TIMER(curr_op->_pull_timer);
                     QUERY_TRACE_SCOPED(curr_op->get_name(), "pull_chunk");
                     maybe_chunk = curr_op->pull_chunk(runtime_state);
@@ -274,7 +269,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                         size_t row_num = maybe_chunk.value()->num_rows();
                         total_rows_moved += row_num;
                         {
-                            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(next_op);
+                            SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(next_op);
                             SCOPED_TIMER(next_op->_push_timer);
                             QUERY_TRACE_SCOPED(next_op->get_name(), "push_chunk");
                             return_status = next_op->push_chunk(runtime_state, maybe_chunk.value());
@@ -529,7 +524,7 @@ Status PipelineDriver::_mark_operator_finishing(OperatorPtr& op, RuntimeState* s
     VLOG_ROW << strings::Substitute("[Driver] finishing operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op);
+        SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(op);
         SCOPED_TIMER(op->_finishing_timer);
         op_state = OperatorStage::FINISHING;
         QUERY_TRACE_SCOPED(op->get_name(), "set_finishing");
@@ -547,7 +542,7 @@ Status PipelineDriver::_mark_operator_finished(OperatorPtr& op, RuntimeState* st
     VLOG_ROW << strings::Substitute("[Driver] finished operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op);
+        SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(op);
         SCOPED_TIMER(op->_finished_timer);
         op_state = OperatorStage::FINISHED;
         QUERY_TRACE_SCOPED(op->get_name(), "set_finished");
@@ -570,7 +565,7 @@ Status PipelineDriver::_mark_operator_cancelled(OperatorPtr& op, RuntimeState* s
     VLOG_ROW << strings::Substitute("[Driver] cancelled operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op);
+        SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(op);
         op_state = OperatorStage::CANCELLED;
         return op->set_cancelled(state);
     }
@@ -591,7 +586,7 @@ Status PipelineDriver::_mark_operator_closed(OperatorPtr& op, RuntimeState* stat
     VLOG_ROW << strings::Substitute("[Driver] close operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER_FOR_OP(op);
+        SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(op);
         SCOPED_TIMER(op->_close_timer);
         op_state = OperatorStage::CLOSED;
         QUERY_TRACE_SCOPED(op->get_name(), "close");

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -473,8 +473,6 @@ protected:
     size_t _driver_queue_level = 0;
     std::atomic<bool> _in_ready_queue{false};
 
-    bool _is_profile_enabled = false;
-
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;
     RuntimeProfile::Counter* _active_timer = nullptr;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -347,8 +347,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             // set driver_id/query_id/fragment_instance_id to thread local
             // driver_id will be used in some Expr such as regex_replace
             SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(
-                    state->query_ctx()->is_report_profile() ? mem_tracker() : state->instance_mem_tracker());
+            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+            SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(this);
 
             auto& chunk_source = _chunk_sources[chunk_source_index];
             [[maybe_unused]] std::string category;

--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -25,7 +25,7 @@ CurrentThread::~CurrentThread() {
         tls_is_thread_status_init = false;
         return;
     }
-    commit(true);
+    mem_tracker_ctx_shift();
     tls_is_thread_status_init = false;
 }
 
@@ -34,6 +34,10 @@ starrocks::MemTracker* CurrentThread::mem_tracker() {
         tls_mem_tracker = ExecEnv::GetInstance()->process_mem_tracker();
     }
     return tls_mem_tracker;
+}
+
+starrocks::MemTracker* CurrentThread::operator_mem_tracker() {
+    return tls_operator_mem_tracker;
 }
 
 CurrentThread& CurrentThread::current() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Enhancement
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Frequent invocation of `pull_chunk`/`push_chunk` can lead to performance deduction, especially when query has to deal with lot of data but with few computation, such as `select count(*) from t`.

And here comes the explanation. Operator's MemTracker is attaching to Instance's MemTracker, the whole MemTracker tree looks like

```
                            NULL
                             丨
                             v
              process MemTracker (shared by all threads)
                             丨
                             v
                 query MemTracker (shared by some threads)
                             丨
                             v
             instance MemTracker (shared by some threads)
                             丨
                             v
             operator MemTracker (local)
```

atomic operation will be issued every time when calling `pull_chunk`/`push_chunk`, operator's MemTracker has little impact, but all the three ancestors has drastic concurrency conflicts, which is the reason that leading to performance deduction.

The solution is simple, we extract the operator's MemTracker from the hierarchy tree, like below

```
                            NULL
                             丨
                             v
              process MemTracker (shared by all threads)
                             丨
                             v
                 query MemTracker (shared by some threads)
                             丨
                             v
             instance MemTracker (shared by some threads)


                            NULL
                             丨
                             v
             operator MemTracker (local)
```

So, after this modification, context swiching for operator's MemTracker will not bring concurrency conflicts.

## Experiment

3be/1fe, with equal hardware attributes of 16c/64g

```sql
select count(*) from lineitem;
```

| | disable profile | enable profile |
|:--|:--|:--|
| Before | 0.077s | 0.166s |
| This Pr | 0.074s | 0.088s |

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
