### PR TITLE
[Tool] support numa in startup script

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -30,6 +30,7 @@ OPTS=$(getopt \
     -l 'daemon' \
     -l 'cn' \
     -l 'be' \
+    -l numa: \
 -- "$@")
 
 eval set -- "$OPTS"
@@ -37,14 +38,16 @@ eval set -- "$OPTS"
 RUN_DAEMON=0
 RUN_CN=0
 RUN_BE=0
+RUN_NUMA="-1"
 
 while true; do
     case "$1" in
         --daemon) RUN_DAEMON=1 ; shift ;;
         --cn) RUN_CN=1; RUN_BE=0; shift ;;
         --be) RUN_BE=1; RUN_CN=0; shift ;;
+        --numa) RUN_NUMA=$2; shift 2 ;;
         --) shift ;  break ;;
-        *) ehco "Internal error" ; exit 1 ;;
+        *) echo "Internal error" ; exit 1 ;;
     esac
 done
 
@@ -108,6 +111,15 @@ if [[ "$JAVA_VERSION" -gt 8 ]]; then
     fi
 fi
 
+# check NUMA setting
+NUMA_CMD=""
+if [[ "${RUN_NUMA}" -ne "-1" ]]; then
+    set -e
+    NUMA_CMD="numactl --cpubind ${RUN_NUMA} --membind ${RUN_NUMA}"
+    ${NUMA_CMD} echo "Running on NUMA ${RUN_NUMA}"
+    set +e
+fi
+
 export LIBHDFS_OPTS=$final_java_opt
 # Prevent JVM from handling any internally or externally generated signals.
 # Otherwise, JVM will overwrite the signal handlers for SIGINT and SIGTERM.
@@ -158,23 +170,16 @@ if [[ $(ulimit -n) -lt 60000 ]]; then
     ulimit -n 65535
 fi
 
-if [ ${RUN_BE} -eq 1 ]; then
-    echo "start time: "$(date) >> $LOG_DIR/be.out
-    if [ ${RUN_DAEMON} -eq 1 ]; then
-        nohup ${STARROCKS_HOME}/lib/starrocks_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null &
-    else
-        ${STARROCKS_HOME}/lib/starrocks_be "$@" >> $LOG_DIR/be.out 2>&1 </dev/null
-    fi
-fi
-
+START_BE_CMD="${NUMA_CMD} ${STARROCKS_HOME}/lib/starrocks_be"
+LOG_FILE=$LOG_DIR/be.out
 if [ ${RUN_CN} -eq 1 ]; then
-    echo "start time: "$(date) >> $LOG_DIR/cn.out
-    if [ ${RUN_DAEMON} -eq 1 ]; then
-        nohup ${STARROCKS_HOME}/lib/starrocks_be --cn "$@" >> $LOG_DIR/cn.out 2>&1 </dev/null &
-    else
-        exec ${STARROCKS_HOME}/lib/starrocks_be --cn "$@" >> $LOG_DIR/cn.out 2>&1 </dev/null
-    fi
+    START_BE_CMD="${START_BE_CMD} --cn"
+    LOG_FILE=${LOG_DIR}/cn.out
 fi
 
-
-
+echo "start time: "$(date) >> ${LOG_FILE}
+if [ ${RUN_DAEMON} -eq 1 ]; then
+    nohup ${START_BE_CMD} "$@" >> ${LOG_FILE} 2>&1 </dev/null &
+else
+    ${START_BE_CMD} "$@" >> ${LOG_FILE} 2>&1 </dev/null
+fi


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Support NUMA binding in the startup script:
```bash
# Bind process to NUMA Node 0
be/bin/start_be.sh --daemon --numa 0 

# Bind process to NUMA Node 1
be/bin/start_be.sh --daemon --numa 1

# Bind to invalid NUMA Node would get error
be/bin/start_be.sh --daemon --numa 1024
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
