### PR TITLE
[Enhancement] Add PrivilegeType.OPERATE check to be_ prefixed tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -62,6 +62,10 @@ public class SchemaTable extends Table {
         return name.startsWith("be_");
     }
 
+    public boolean isBeSchemaTable() {
+        return SchemaTable.isBeSchemaTable(getName());
+    }
+
     protected SchemaTable(long id, String name, TableType type, List<Column> baseSchema) {
         super(id, name, type, baseSchema);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSearchDesc;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.SchemaTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
@@ -684,7 +685,11 @@ public class PrivilegeCheckerV2 {
 
             @Override
             public Void visitTable(TableRelation node, Void session) {
-                if (node.getTable().isMaterializedView()) {
+                Table table = node.getTable();
+                if (table instanceof SchemaTable && ((SchemaTable) table).isBeSchemaTable()) {
+                    checkStmtOperatePrivilege(context);
+                }
+                if (table.isMaterializedView()) {
                     checkMvAction(context, node.getName(), PrivilegeType.SELECT);
                 } else {
                     checkTableAction(context, node.getName(), PrivilegeType.SELECT);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add PrivilegeType.OPERATE check to be_ prefixed tables, so only adim can query be_ prefixed tables in informatin_schema

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
