### PR TITLE
[Enhancement] Support for asterisk operator about jsonpath for parsing avro union type

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -159,7 +159,8 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
         if (i == 1) {
             if (col == "*") {
                 // There should be no jsonpath for this pattern, $.*
-                return Status::InvalidArgument(fmt::format("invalid json path: {}", jsonpath[i].key));
+                return Status::InvalidArgument(fmt::format(
+                        "extracting * from root-object is not supported, the json path: {}", jsonpath[i].key));
             } else {
                 HANDLE_SIMDJSON_ERROR(obj.find_field_unordered(col).get(tvalue),
                                       fmt::format("unable to find field: {}", col));
@@ -175,7 +176,8 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
                     return Status::NotFound("null value");
                 }
                 if (tvalue.type() != simdjson::ondemand::json_type::object) {
-                    return Status::InvalidArgument(fmt::format("invalid json path: {}", jsonpath[i].key));
+                    return Status::InvalidArgument(fmt::format(
+                            "extracting * from non-object type is not supported, the json path: {}", jsonpath[i].key));
                 }
                 for (auto field : tvalue.get_object()) {
                     tvalue = field.value();

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -153,39 +153,12 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
         const std::string& col = jsonpath[i].key;
         int index = jsonpath[i].idx;
 
-        /*
-         * 梳理下现在的问题：
-         * 如果当前的path的col是*, 表示要检索union字段：
-         * 
-         * [{
-            "k1":"v2",
-            "kind":"server",
-            "keyname":{
-                "int":20
-            }
-            }]
-
-            [{
-            "k1":"v2",
-            "kind":"server",
-            "keyname": null
-            }]
-
-            {"keyname": null}
-            {"keyname": {"int":20}}
-         * 比如我们当前在keyname对应的value域，而且操作符是*，类似这样：$.keyname.*
-         * 此时有两种情况，一种对应的value是null, 一种对应的是一个字典{"typename": value}
-         * 那就意味着这个value要么是null类型，要么是字典类型。
-         * 
-         *  
-         */
-
         // Since the simdjson::ondemand::object cannot be converted to simdjson::ondemand::value,
         // we have to do some special treatment for the second elem of json path.
         // If the key is not found in json object, simdjson::NO_SUCH_FIELD would be returned.
         if (i == 1) {
             if (col == "*") {
-                // 不应该出现这种模式的jsonpath: $.*
+                // There should be no jsonpath for this pattern, $.*
                 return Status::InvalidArgument(fmt::format("invalid json path: {}", jsonpath[i].key));
             } else {
                 HANDLE_SIMDJSON_ERROR(obj.find_field_unordered(col).get(tvalue),
@@ -193,6 +166,11 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
             }
         } else {
             if (col == "*") {
+                // There are always two patterns.
+                // 1. {"field_name": null}
+                // 2. {"field_name": {"field_type": data}}
+                // For pattern1, we just return null value.
+                // For pattern2, we get the first field of object as next value.
                 if (tvalue.is_null()) {
                     return Status::NotFound("null value");
                 }
@@ -200,9 +178,7 @@ Status JsonFunctions::extract_from_object(simdjson::ondemand::object& obj, const
                     return Status::InvalidArgument(fmt::format("invalid json path: {}", jsonpath[i].key));
                 }
                 for (auto field : tvalue.get_object()) {
-                    std::string_view keyv = field.unescaped_key();
                     tvalue = field.value();
-                    std::cout << keyv << std::endl;
                     break;
                 }
             } else {

--- a/be/test/exec/json_scanner_test.cpp
+++ b/be/test/exec/json_scanner_test.cpp
@@ -211,6 +211,126 @@ TEST_F(JsonScannerTest, test_json_without_path) {
     EXPECT_EQ("['fiction', 'EvelynWaugh', 'SwordofHonour', 12.99]", chunk->debug_row(1));
 }
 
+TEST_F(JsonScannerTest, test_json_path_with_asterisk_basic) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_INT);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.strip_outer_array = true;
+    range.__isset.strip_outer_array = true;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.keyname.*", "$.k1", "$.kind"])";
+    range.__isset.json_root = false;
+    range.__set_path("./be/test/exec/test_data/json_scanner/test10.json");
+    ranges.emplace_back(range);
+
+    auto scanner = create_json_scanner(types, ranges, {"keyname", "k1", "kind"});
+
+    Status st;
+    st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    ChunkPtr chunk = scanner->get_next().value();
+    EXPECT_EQ(3, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+
+    EXPECT_EQ("[20, 'v2', 'server']", chunk->debug_row(0));
+}
+
+TEST_F(JsonScannerTest, test_json_path_with_asterisk_null) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_INT);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.strip_outer_array = true;
+    range.__isset.strip_outer_array = true;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.keyname.*", "$.k1", "$.kind"])";
+    range.__isset.json_root = false;
+    range.__set_path("./be/test/exec/test_data/json_scanner/test11.json");
+    ranges.emplace_back(range);
+
+    auto scanner = create_json_scanner(types, ranges, {"keyname", "k1", "kind"});
+
+    Status st;
+    st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    ChunkPtr chunk = scanner->get_next().value();
+    EXPECT_EQ(3, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+
+    EXPECT_EQ("[NULL, 'v2', 'server']", chunk->debug_row(0));
+}
+
+TEST_F(JsonScannerTest, test_json_path_with_asterisk_record) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_INT);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.strip_outer_array = true;
+    range.__isset.strip_outer_array = true;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.keyname.*.a", "$.k1", "$.kind"])";
+    range.__isset.json_root = false;
+    range.__set_path("./be/test/exec/test_data/json_scanner/test12.json");
+    ranges.emplace_back(range);
+
+    auto scanner = create_json_scanner(types, ranges, {"keyname", "k1", "kind"});
+
+    Status st;
+    st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    ChunkPtr chunk = scanner->get_next().value();
+    EXPECT_EQ(3, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+
+    EXPECT_EQ("[1, 'v2', 'server']", chunk->debug_row(0));
+}
+
+TEST_F(JsonScannerTest, test_json_path_with_asterisk_array) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_INT);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_JSON;
+    range.strip_outer_array = true;
+    range.__isset.strip_outer_array = true;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.keyname.*[0]", "$.k1", "$.kind"])";
+    range.__isset.json_root = false;
+    range.__set_path("./be/test/exec/test_data/json_scanner/test13.json");
+    ranges.emplace_back(range);
+
+    auto scanner = create_json_scanner(types, ranges, {"keyname", "k1", "kind"});
+
+    Status st;
+    st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    ChunkPtr chunk = scanner->get_next().value();
+    EXPECT_EQ(3, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+
+    EXPECT_EQ("[25, 'v2', 'server']", chunk->debug_row(0));
+}
+
 TEST_F(JsonScannerTest, test_json_with_path) {
     std::vector<TypeDescriptor> types;
     types.emplace_back(TypeDescriptor::create_varchar_type(20));

--- a/be/test/exec/test_data/json_scanner/test10.json
+++ b/be/test/exec/test_data/json_scanner/test10.json
@@ -1,0 +1,7 @@
+[{
+   "k1":"v2",
+   "kind":"server",
+   "keyname":{
+      "int":20
+   }
+}]

--- a/be/test/exec/test_data/json_scanner/test11.json
+++ b/be/test/exec/test_data/json_scanner/test11.json
@@ -1,0 +1,5 @@
+[{
+   "k1":"v2",
+   "kind":"server",
+   "keyname": null
+}]

--- a/be/test/exec/test_data/json_scanner/test12.json
+++ b/be/test/exec/test_data/json_scanner/test12.json
@@ -1,0 +1,10 @@
+[{
+   "k1":"v2",
+   "kind":"server",
+   "keyname": {
+      "record" : {
+         "a":1,
+         "b":"abcde"
+      }
+   }
+}]

--- a/be/test/exec/test_data/json_scanner/test13.json
+++ b/be/test/exec/test_data/json_scanner/test13.json
@@ -1,0 +1,5 @@
+[{
+   "k1":"v2",
+   "kind":"server",
+   "keyname": {"array": [25, 64]}
+}]


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We use jsonpath to support AVRO union type parsing. This PR introduces a simple asterisk operator semantics.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
