### PR TITLE
[Cherry-pick][Branch-2.5] Fix refresh mv error with multi external partitioned table (#18391)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -130,6 +130,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                 // 3. generate insert stmt
                 // 4. generate insert ExecPlan
 
+                // refresh external table meta cache before check the partition changed
+                refreshExternalTable(context);
                 // check whether there are partition changes for base tables, eg: partition rename
                 // retry to sync partitions if any base table changed the partition infos
                 if (checkBaseTablePartitionChange()) {
@@ -142,8 +144,6 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                     continue;
                 }
                 checked = true;
-                // refresh external table meta cache
-                refreshExternalTable(context);
                 Set<String> partitionsToRefresh = getPartitionsToRefreshForMaterializedView(context.getProperties());
                 if (partitionsToRefresh.isEmpty()) {
                     LOG.info("no partitions to refresh for materialized view {}", materializedView.getName());
@@ -692,8 +692,13 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                         if  (!(mvPartitionInfo instanceof ExpressionRangePartitionInfo)) {
                             return false;
                         }
+
                         Pair<Table, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
                         Column partitionColumn = partitionTableAndColumn.second;
+                        // For Non-partition based base table, it's not necessary to check the partition changed.
+                        if (!snapshotTable.containColumn(partitionColumn.getName())) {
+                            continue;
+                        }
 
                         Map<String, Range<PartitionKey>> snapshotPartitionMap = PartitionUtil.
                                 getPartitionRange(snapshotTable, partitionColumn);
@@ -717,8 +722,13 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                         if  (!(mvPartitionInfo instanceof ExpressionRangePartitionInfo)) {
                             return false;
                         }
+
                         Pair<Table, Column> partitionTableAndColumn = getPartitionTableAndColumn(snapshotBaseTables);
                         Column partitionColumn = partitionTableAndColumn.second;
+                        // For Non-partition based base table, it's not necessary to check the partition changed.
+                        if (!snapShotIcebergTable.containColumn(partitionColumn.getName())) {
+                            continue;
+                        }
 
                         Map<String, Range<PartitionKey>> snapshotPartitionMap = PartitionUtil.
                                 getPartitionRange(snapshotTable, partitionColumn);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -583,9 +583,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         columnStatisticMap.put("par_date", partitionColumnStats2);
 
         List<RemoteFileInfo> partitions = Lists.newArrayList();
-        partitions.add(new RemoteFileInfo(null, ImmutableList.of(), null));
-        partitions.add(new RemoteFileInfo(null, ImmutableList.of(), null));
-        partitions.add(new RemoteFileInfo(null, ImmutableList.of(), null));
+        partitionNames.forEach(k -> partitions.add(new RemoteFileInfo(null, ImmutableList.of(), null)));
 
         mockTables.put(t1.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(t1, MOCKED_HIVE_CATALOG_NAME),
                 partitionNames, (long) rowCount, columnStatisticMap, partitions));

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
@@ -187,8 +187,18 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                         "\"replication_num\" = \"1\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT c1, c2, par_date, par_col FROM `hive0`.`partitioned_db`.`t1_par`;");
-
+                        "AS SELECT c1, c2, par_date, par_col FROM `hive0`.`partitioned_db`.`t1_par`;")
+                .withNewMaterializedView("CREATE MATERIALIZED VIEW `test`.`hive_join_mv1`\n" +
+                    "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                    "PARTITION BY (`par_date`)\n" +
+                    "DISTRIBUTED BY HASH(`c1`) BUCKETS 10\n" +
+                    "REFRESH MANUAL\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"storage_medium\" = \"HDD\"\n" +
+                    ")\n" +
+                    "AS SELECT t1.c1, t1.c2, t1_par.par_col, t1_par.par_date FROM `hive0`.`partitioned_db`.`t1` join " +
+                        "`hive0`.`partitioned_db`.`t1_par` using (par_col)");
     }
 
     //@Test
@@ -416,6 +426,41 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         Assert.assertEquals(2, materializedView.getPartition("p202202_202203").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p202203_202204").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p202204_202205").getVisibleVersion());
+    }
+
+    @Test
+    public void testRefreshWithHiveTableJoin() throws Exception {
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                if (stmt instanceof InsertStmt) {
+                    InsertStmt insertStmt = (InsertStmt) stmt;
+                    TableName tableName = insertStmt.getTableName();
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    for (Partition partition : tbl.getPartitions()) {
+                        if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
+                            setPartitionVersion(partition, partition.getVisibleVersion() + 1);
+                        }
+                    }
+                }
+            }
+        };
+
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_join_mv1"));
+
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+                taskRun.getProcessor();
+
+        MvTaskRunContext mvContext = processor.getMvContext();
+        ExecPlan execPlan = mvContext.getExecPlan();
+        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+        Assert.assertTrue(plan.contains("4:HASH JOIN"));
     }
 
     @Test


### PR DESCRIPTION

* [BugFix] Fix refresh mv error with multi external partitioned table

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
