### PR TITLE
[BugFix] fix pk lake table key range scan

### DIFF
--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -247,7 +247,7 @@ Status TabletReader::init_collector(const TabletReaderParams& params) {
 
     if (seg_iters.empty()) {
         _collect_iter = new_empty_iterator(_schema, params.chunk_size);
-    } else if (is_compaction(params.reader_type) && keys_type == DUP_KEYS) {
+    } else if (is_compaction(params.reader_type) && (keys_type == DUP_KEYS || keys_type == PRIMARY_KEYS)) {
         //             MergeIterator
         //                   |
         //       +-----------+-----------+


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18386

## Problem Summary(Required) ：
In primary lake table, scan table by key range will return error result. This bug happen when compaction happen, build incorrect ordinal index, which key in ordinal index isn't in order. So when we use key to range scan table, error ordinal index will lead to error result.

The error ordinal index is generated because the rowsets been compacted isn't in order.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
