### PR TITLE
[Enhancement] tablet sink dop and scan node dop is not equal in some case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -683,6 +683,10 @@ public class CoordinatorPreprocessor {
                                 int expectedDop = Math.max(1, Math.min(pipelineDop, scanRangeParams.size()));
                                 List<List<TScanRangeParams>> scanRangeParamsPerDriverSeq =
                                         ListUtil.splitBySize(scanRangeParams, expectedDop);
+                                if (fragment.isForceAssignScanRangesPerDriverSeq() && scanRangeParamsPerDriverSeq.size() 
+                                        != pipelineDop) {
+                                    fragment.setPipelineDop(scanRangeParamsPerDriverSeq.size());
+                                }
                                 instanceParam.pipelineDop = scanRangeParamsPerDriverSeq.size();
                                 if (fragment.isUseRuntimeAdaptiveDop()) {
                                     instanceParam.pipelineDop = Utils.computeMinGEPower2(instanceParam.pipelineDop);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18548

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In insert into table_a select * from table_b case, we expect the tablet sink dop
and scan node dop is equal. However, in some special case, tablet_b is very small,
we can not split so much scan range for tablet_b, at this time, scan node dop will be small
than tablet sink dop, and we will introduce extra local exchange.

In this pr, if we find the  scan node dop is small tablet sink dop, then we will refactor
tablet sink's dop, and avoid introducing extra local exchange.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
