### PR TITLE
[BugFix] Fix mysql client unable to change current catalog (backport #18266)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -961,7 +961,8 @@ public class StmtExecutor {
     private void handleUseCatalogStmt() throws AnalysisException {
         UseCatalogStmt useCatalogStmt = (UseCatalogStmt) parsedStmt;
         try {
-            context.getGlobalStateMgr().changeCatalog(context, useCatalogStmt.getCatalogName());
+            String catalogName = useCatalogStmt.getCatalogName();
+            context.getGlobalStateMgr().changeCatalog(context, catalogName);
         } catch (Exception e) {
             context.getState().setError(e.getMessage());
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -106,6 +106,7 @@ import com.starrocks.sql.ast.SubmitTaskStmt;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.UninstallPluginStmt;
 import com.starrocks.sql.ast.UpdateStmt;
+import com.starrocks.sql.ast.UseCatalogStmt;
 import com.starrocks.sql.ast.UseDbStmt;
 
 public class Analyzer {
@@ -453,6 +454,12 @@ public class Analyzer {
 
         @Override
         public Void visitShowCatalogsStatement(ShowCatalogsStmt statement, ConnectContext context) {
+            CatalogAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
             CatalogAnalyzer.analyze(statement, context);
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -90,7 +90,11 @@ public class CatalogAnalyzer {
                 throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
             }
 
-            FeNameFormat.checkCatalogName(splitParts[1]);
+            try {
+                FeNameFormat.checkCatalogName(splitParts[1]);
+            } catch (AnalysisException e) {
+                throw new SemanticException(e.getMessage());
+            }
             statement.setCatalogName(splitParts[1]);
 
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -12,6 +12,7 @@ import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.DropCatalogStmt;
 import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UseCatalogStmt;
 
 import java.util.Map;
 
@@ -20,6 +21,10 @@ import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceM
 import static com.starrocks.sql.ast.CreateCatalogStmt.TYPE;
 
 public class CatalogAnalyzer {
+    private static final String CATALOG = "CATALOG";
+
+    private static final String WHITESPACE = "\\s+";
+
     public static void analyze(StatementBase stmt, ConnectContext session) {
         new CatalogAnalyzerVisitor().visit(stmt, session);
     }
@@ -70,6 +75,23 @@ public class CatalogAnalyzer {
             if (isResourceMappingCatalog(name)) {
                 throw new SemanticException("Can't drop the resource mapping catalog");
             }
+
+            return null;
+        }
+
+        @Override
+        public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
+            if (Strings.isNullOrEmpty(statement.getCatalogParts())) {
+                throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
+            }
+
+            String[] splitParts = statement.getCatalogParts().split(WHITESPACE);
+            if (!splitParts[0].equalsIgnoreCase(CATALOG) || splitParts.length != 2) {
+                throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
+            }
+
+            FeNameFormat.checkCatalogName(splitParts[1]);
+            statement.setCatalogName(splitParts[1]);
 
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -54,6 +54,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UninstallPluginStmt;
+import com.starrocks.sql.ast.UseCatalogStmt;
 import com.starrocks.sql.ast.UseDbStmt;
 import com.starrocks.sql.ast.ViewRelation;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -54,7 +54,6 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UninstallPluginStmt;
-import com.starrocks.sql.ast.UseCatalogStmt;
 import com.starrocks.sql.ast.UseDbStmt;
 import com.starrocks.sql.ast.ViewRelation;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -65,10 +65,6 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(statement, context);
     }
 
-    public R visitUseCatalogStatement(UseCatalogStmt statement, C context) {
-        return visitStatement(statement, context);
-    }
-
     public R visitShowDatabasesStatement(ShowDbStmt statement, C context) {
         return visitShowStatement(statement, context);
     }
@@ -262,6 +258,10 @@ public abstract class AstVisitor<R, C> {
     }
 
     public R visitShowCatalogsStatement(ShowCatalogsStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
+    public R visitUseCatalogStatement(UseCatalogStmt statement, C context) {
         return visitStatement(statement, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UseCatalogStmt.java
@@ -4,15 +4,41 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.RedirectStatus;
 
-public class UseCatalogStmt extends StatementBase {
-    private final String catalogName;
+/*
+  Use catalog specified by catalog name
 
-    public UseCatalogStmt(String catalogName) {
-        this.catalogName = catalogName;
+  syntax:
+      USE 'CATALOG catalog_name'
+      USE "CATALOG catalog_name"
+
+      Note:
+        A pair of single/double quotes are required
+
+      Examples:
+        USE 'CATALOG default_catalog'
+        use "catalog default_catalog"
+        USE 'catalog hive_metastore_catalog'
+        use "CATALOG hive_metastore_catalog"
+ */
+public class UseCatalogStmt extends StatementBase {
+    private final String catalogParts;
+
+    private String catalogName;
+
+    public UseCatalogStmt(String catalogParts) {
+        this.catalogParts = catalogParts;
+    }
+
+    public String getCatalogParts() {
+        return catalogParts;
     }
 
     public String getCatalogName() {
         return catalogName;
+    }
+
+    public void setCatalogName(String catalogName) {
+        this.catalogName = catalogName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -405,9 +405,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitUseCatalogStatement(StarRocksParser.UseCatalogStatementContext context) {
-        Identifier identifier = (Identifier) visit(context.identifierOrString());
-        String catalogName = identifier.getValue();
-        return new UseCatalogStmt(catalogName);
+        StringLiteral literal = (StringLiteral) visit(context.string());
+        return new UseCatalogStmt(literal.getValue());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -237,7 +237,7 @@ useDatabaseStatement
     ;
 
 useCatalogStatement
-    : USE CATALOG identifierOrString
+    : USE string
     ;
 
 showDatabasesStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseCatalogStmtTest.java
@@ -34,13 +34,13 @@ public class UseCatalogStmtTest {
 
     @Test
     public void testParserAndAnalyzer() {
-        String sql = "USE catalog hive_catalog";
+        String sql = "USE 'catalog hive_catalog'";
         AnalyzeTestUtil.analyzeSuccess(sql);
 
-        String sql_2 = "USE catalog default_catalog";
+        String sql_2 = "USE 'catalog default_catalog'";
         AnalyzeTestUtil.analyzeSuccess(sql_2);
 
-        String sql_3 = "USE xxxx default_catalog";
+        String sql_3 = "USE 'xxxx default_catalog'";
         AnalyzeTestUtil.analyzeFail(sql_3);
     }
 
@@ -59,21 +59,22 @@ public class UseCatalogStmtTest {
         };
 
         ctx.setQueryId(UUIDUtil.genUUID());
-        StmtExecutor executor = new StmtExecutor(ctx, "use catalog hive_catalog");
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        StmtExecutor executor = new StmtExecutor(ctx, "use 'catalog hive_catalog'");
         executor.execute();
 
         Assert.assertEquals("hive_catalog", ctx.getCurrentCatalog());
 
-        executor = new StmtExecutor(ctx, "use catalog default_catalog");
+        executor = new StmtExecutor(ctx, "use 'catalog default_catalog'");
         executor.execute();
 
         Assert.assertEquals("default_catalog", ctx.getCurrentCatalog());
 
-        executor = new StmtExecutor(ctx, "use xxx default_catalog");
+        executor = new StmtExecutor(ctx, "use 'xxx default_catalog'");
         executor.execute();
         Assert.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
 
-        executor = new StmtExecutor(ctx, "use catalog default_catalog xxx");
+        executor = new StmtExecutor(ctx, "use 'catalog default_catalog xxx'");
         executor.execute();
         Assert.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17993

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`USE 'CATALOG catalog_name'` issued by mysql client will be dispatched to `handleQuery` function. In this case, the current implementation throws parse exception, thus fails to switch the catalog in use. 

The changes made are:
* change `useCatalogStatement : USE CATALOG identifierOrString ` to `useCatalogStatement : USE string;`
* add or update parser/analyzer/executor for useCatalogStatement
* update unit tests

Limitation:
Mysql client of version 5.7.31 would raise a benign error as follows. 
```
ERROR:
USE must be followed by a database name
```
But the catalog can be changed successfully.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
