### PR TITLE
[Feature] Binlog connector can read binlog from tablet

### DIFF
--- a/be/src/connector/binlog_connector.cpp
+++ b/be/src/connector/binlog_connector.cpp
@@ -113,6 +113,8 @@ Status BinlogDataSource::_prepare_non_stream_pipeline() {
     _max_version_exclusive.store(binlog_range.end_version() + 1);
 
     VLOG(3) << "Prepare to scan binlog, tablet: " << _tablet->full_name() << ", " << binlog_range.debug_string();
+
+    return Status::OK();
 }
 
 Status BinlogDataSource::set_offset(int64_t table_version, int64_t changelog_id) {

--- a/be/src/connector/binlog_connector.cpp
+++ b/be/src/connector/binlog_connector.cpp
@@ -137,24 +137,27 @@ Status BinlogDataSource::reset_status() {
 BinlogMetaFieldMap BinlogDataSource::_build_binlog_meta_fields(ColumnId start_cid) {
     BinlogMetaFieldMap fields;
     ColumnId cid = start_cid;
-    FieldPtr op_field = std::make_shared<Field>(cid, BINLOG_OP, get_type_info(TYPE_TINYINT), STORAGE_AGGREGATE_NONE, 1,
-                                                false, false);
-    fields.emplace(BINLOG_OP, op_field);
+    FieldPtr op_field = std::make_shared<Field>(cid, g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME,
+                                                get_type_info(TYPE_TINYINT), STORAGE_AGGREGATE_NONE, 1, false, false);
+    fields.emplace(g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME, op_field);
     cid += 1;
 
-    FieldPtr version_field = std::make_shared<Field>(cid, BINLOG_VERSION, get_type_info(TYPE_BIGINT),
-                                                     STORAGE_AGGREGATE_NONE, 8, false, false);
-    fields.emplace(BINLOG_VERSION, version_field);
+    FieldPtr version_field =
+            std::make_shared<Field>(cid, g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME, get_type_info(TYPE_BIGINT),
+                                    STORAGE_AGGREGATE_NONE, 8, false, false);
+    fields.emplace(g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME, version_field);
     cid += 1;
 
-    FieldPtr seq_id_field = std::make_shared<Field>(cid, BINLOG_SEQ_ID, get_type_info(TYPE_BIGINT),
-                                                    STORAGE_AGGREGATE_NONE, 8, false, false);
-    fields.emplace(BINLOG_SEQ_ID, seq_id_field);
+    FieldPtr seq_id_field =
+            std::make_shared<Field>(cid, g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME, get_type_info(TYPE_BIGINT),
+                                    STORAGE_AGGREGATE_NONE, 8, false, false);
+    fields.emplace(g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME, seq_id_field);
     cid += 1;
 
-    FieldPtr timestamp_field = std::make_shared<Field>(cid, BINLOG_TIMESTAMP, get_type_info(TYPE_BIGINT),
-                                                       STORAGE_AGGREGATE_NONE, 8, false, false);
-    fields.emplace(BINLOG_TIMESTAMP, timestamp_field);
+    FieldPtr timestamp_field =
+            std::make_shared<Field>(cid, g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME, get_type_info(TYPE_BIGINT),
+                                    STORAGE_AGGREGATE_NONE, 8, false, false);
+    fields.emplace(g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME, timestamp_field);
     cid += 1;
 
     return fields;
@@ -172,18 +175,18 @@ StatusOr<Schema> BinlogDataSource::_build_binlog_schema() {
         int32_t index = _tablet->field_index(slot->col_name());
         if (index >= 0) {
             data_column_cids.push_back(index);
-        } else if (slot->col_name() == BINLOG_OP) {
+        } else if (slot->col_name() == g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME) {
             meta_column_slot_index.push_back(slot_index);
-            meta_fields.emplace_back(binlog_meta_map[BINLOG_OP]);
-        } else if (slot->col_name() == BINLOG_VERSION) {
+            meta_fields.emplace_back(binlog_meta_map[g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME]);
+        } else if (slot->col_name() == g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME) {
             meta_column_slot_index.push_back(slot_index);
-            meta_fields.emplace_back(binlog_meta_map[BINLOG_VERSION]);
-        } else if (slot->col_name() == BINLOG_SEQ_ID) {
+            meta_fields.emplace_back(binlog_meta_map[g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME]);
+        } else if (slot->col_name() == g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME) {
             meta_column_slot_index.push_back(slot_index);
-            meta_fields.emplace_back(binlog_meta_map[BINLOG_SEQ_ID]);
-        } else if (slot->col_name() == BINLOG_TIMESTAMP) {
+            meta_fields.emplace_back(binlog_meta_map[g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME]);
+        } else if (slot->col_name() == g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME) {
             meta_column_slot_index.push_back(slot_index);
-            meta_fields.emplace_back(binlog_meta_map[BINLOG_TIMESTAMP]);
+            meta_fields.emplace_back(binlog_meta_map[g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME]);
         } else {
             std::string msg = fmt::format("invalid field name: {}", slot->col_name());
             LOG(WARNING) << msg;

--- a/be/src/connector/binlog_connector.cpp
+++ b/be/src/connector/binlog_connector.cpp
@@ -137,27 +137,27 @@ Status BinlogDataSource::reset_status() {
 BinlogMetaFieldMap BinlogDataSource::_build_binlog_meta_fields(ColumnId start_cid) {
     BinlogMetaFieldMap fields;
     ColumnId cid = start_cid;
-    FieldPtr op_field = std::make_shared<Field>(cid, g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME,
+    FieldPtr op_field = std::make_shared<Field>(cid, _column_name_constants.BINLOG_OP_COLUMN_NAME,
                                                 get_type_info(TYPE_TINYINT), STORAGE_AGGREGATE_NONE, 1, false, false);
-    fields.emplace(g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME, op_field);
+    fields.emplace(_column_name_constants.BINLOG_OP_COLUMN_NAME, op_field);
     cid += 1;
 
     FieldPtr version_field =
-            std::make_shared<Field>(cid, g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME, get_type_info(TYPE_BIGINT),
+            std::make_shared<Field>(cid, _column_name_constants.BINLOG_VERSION_COLUMN_NAME, get_type_info(TYPE_BIGINT),
                                     STORAGE_AGGREGATE_NONE, 8, false, false);
-    fields.emplace(g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME, version_field);
+    fields.emplace(_column_name_constants.BINLOG_VERSION_COLUMN_NAME, version_field);
     cid += 1;
 
     FieldPtr seq_id_field =
-            std::make_shared<Field>(cid, g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME, get_type_info(TYPE_BIGINT),
+            std::make_shared<Field>(cid, _column_name_constants.BINLOG_SEQ_ID_COLUMN_NAME, get_type_info(TYPE_BIGINT),
                                     STORAGE_AGGREGATE_NONE, 8, false, false);
-    fields.emplace(g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME, seq_id_field);
+    fields.emplace(_column_name_constants.BINLOG_SEQ_ID_COLUMN_NAME, seq_id_field);
     cid += 1;
 
     FieldPtr timestamp_field =
-            std::make_shared<Field>(cid, g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME, get_type_info(TYPE_BIGINT),
-                                    STORAGE_AGGREGATE_NONE, 8, false, false);
-    fields.emplace(g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME, timestamp_field);
+            std::make_shared<Field>(cid, _column_name_constants.BINLOG_TIMESTAMP_COLUMN_NAME,
+                                    get_type_info(TYPE_BIGINT), STORAGE_AGGREGATE_NONE, 8, false, false);
+    fields.emplace(_column_name_constants.BINLOG_TIMESTAMP_COLUMN_NAME, timestamp_field);
     cid += 1;
 
     return fields;
@@ -175,18 +175,18 @@ StatusOr<Schema> BinlogDataSource::_build_binlog_schema() {
         int32_t index = _tablet->field_index(slot->col_name());
         if (index >= 0) {
             data_column_cids.push_back(index);
-        } else if (slot->col_name() == g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME) {
+        } else if (slot->col_name() == _column_name_constants.BINLOG_OP_COLUMN_NAME) {
             meta_column_slot_index.push_back(slot_index);
-            meta_fields.emplace_back(binlog_meta_map[g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME]);
-        } else if (slot->col_name() == g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME) {
+            meta_fields.emplace_back(binlog_meta_map[_column_name_constants.BINLOG_OP_COLUMN_NAME]);
+        } else if (slot->col_name() == _column_name_constants.BINLOG_VERSION_COLUMN_NAME) {
             meta_column_slot_index.push_back(slot_index);
-            meta_fields.emplace_back(binlog_meta_map[g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME]);
-        } else if (slot->col_name() == g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME) {
+            meta_fields.emplace_back(binlog_meta_map[_column_name_constants.BINLOG_VERSION_COLUMN_NAME]);
+        } else if (slot->col_name() == _column_name_constants.BINLOG_SEQ_ID_COLUMN_NAME) {
             meta_column_slot_index.push_back(slot_index);
-            meta_fields.emplace_back(binlog_meta_map[g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME]);
-        } else if (slot->col_name() == g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME) {
+            meta_fields.emplace_back(binlog_meta_map[_column_name_constants.BINLOG_SEQ_ID_COLUMN_NAME]);
+        } else if (slot->col_name() == _column_name_constants.BINLOG_TIMESTAMP_COLUMN_NAME) {
             meta_column_slot_index.push_back(slot_index);
-            meta_fields.emplace_back(binlog_meta_map[g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME]);
+            meta_fields.emplace_back(binlog_meta_map[_column_name_constants.BINLOG_TIMESTAMP_COLUMN_NAME]);
         } else {
             std::string msg = fmt::format("invalid field name: {}", slot->col_name());
             LOG(WARNING) << msg;

--- a/be/src/connector/binlog_connector.h
+++ b/be/src/connector/binlog_connector.h
@@ -111,11 +111,6 @@ private:
     Status _mock_chunk(Chunk* chunk);
     Status _mock_chunk_test(ChunkPtr* chunk);
     std::atomic<int32_t> _mock_chunk_num = 0;
-
-    const std::string BINLOG_OP = g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME;
-    const std::string BINLOG_VERSION = g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME;
-    const std::string BINLOG_SEQ_ID = g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME;
-    const std::string BINLOG_TIMESTAMP = g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME;
 };
 
 } // namespace starrocks::connector

--- a/be/src/connector/binlog_connector.h
+++ b/be/src/connector/binlog_connector.h
@@ -56,10 +56,6 @@ protected:
 };
 
 using BinlogMetaFieldMap = std::unordered_map<std::string, FieldPtr>;
-const std::string BINLOG_OP = g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME;
-const std::string BINLOG_VERSION = g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME;
-const std::string BINLOG_SEQ_ID = g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME;
-const std::string BINLOG_TIMESTAMP = g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME;
 
 class BinlogDataSource final : public StreamDataSource {
 public:
@@ -115,6 +111,11 @@ private:
     Status _mock_chunk(Chunk* chunk);
     Status _mock_chunk_test(ChunkPtr* chunk);
     std::atomic<int32_t> _mock_chunk_num = 0;
+
+    const std::string BINLOG_OP = g_PlanNodes_constants.BINLOG_OP_COLUMN_NAME;
+    const std::string BINLOG_VERSION = g_PlanNodes_constants.BINLOG_VERSION_COLUMN_NAME;
+    const std::string BINLOG_SEQ_ID = g_PlanNodes_constants.BINLOG_SEQ_ID_COLUMN_NAME;
+    const std::string BINLOG_TIMESTAMP = g_PlanNodes_constants.BINLOG_TIMESTAMP_COLUMN_NAME;
 };
 
 } // namespace starrocks::connector

--- a/be/src/connector/binlog_connector.h
+++ b/be/src/connector/binlog_connector.h
@@ -85,6 +85,7 @@ private:
     StatusOr<Schema> _build_binlog_schema();
     Status _prepare_non_stream_pipeline();
 
+    const PlanNodesConstants _column_name_constants;
     const BinlogDataSourceProvider* _provider;
     const TBinlogScanRange _scan_range;
     RuntimeState* _runtime_state = nullptr;

--- a/be/src/connector/binlog_connector.h
+++ b/be/src/connector/binlog_connector.h
@@ -87,13 +87,22 @@ private:
     StatusOr<TabletSharedPtr> _get_tablet();
     BinlogMetaFieldMap _build_binlog_meta_fields(ColumnId start_cid);
     StatusOr<Schema> _build_binlog_schema();
+    Status _prepare_non_stream_pipeline();
 
     const BinlogDataSourceProvider* _provider;
     const TBinlogScanRange _scan_range;
     RuntimeState* _runtime_state = nullptr;
+    bool _is_stream_pipeline = false;
+
     TabletSharedPtr _tablet;
-    // TODO this will be used by BinlogReader
     Schema _binlog_read_schema;
+    BinlogReaderSharedPtr _binlog_reader;
+
+    // whether to need do a seek before read data
+    std::atomic<bool> _need_seek_binlog{true};
+    std::atomic<int64_t> _start_version;
+    std::atomic<int64_t> _start_seq_id;
+    std::atomic<int64_t> _max_version_exclusive;
 
     int64_t _rows_read_number = 0;
     int64_t _bytes_read = 0;
@@ -105,12 +114,7 @@ private:
     // Mock data for testing
     Status _mock_chunk(Chunk* chunk);
     Status _mock_chunk_test(ChunkPtr* chunk);
-    std::atomic<int32_t> _chunk_num = 0;
-
-    // for binlog offset
-    int64_t _table_version;
-    int64_t _changelog_id;
-    bool _is_stream_pipeline = false;
+    std::atomic<int32_t> _mock_chunk_num = 0;
 };
 
 } // namespace starrocks::connector

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -191,16 +191,24 @@ void ConnectorChunkSource::close(RuntimeState* state) {
     _data_source->close(state);
 }
 
-Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
-    if (!_opened) {
-        RETURN_IF_ERROR(_data_source->open(state));
-        if (_data_source->skip_predicate() && _limit != -1 && _limit < state->chunk_size()) {
-            _ck_acc.set_max_size(_limit);
-        } else {
-            _ck_acc.set_max_size(state->chunk_size());
-        }
-        _opened = true;
+Status ConnectorChunkSource::_open_data_source(RuntimeState* state) {
+    if (_opened) {
+        return Status::OK();
     }
+
+    RETURN_IF_ERROR(_data_source->open(state));
+    if (_data_source->skip_predicate() && _limit != -1 && _limit < state->chunk_size()) {
+        _ck_acc.set_max_size(_limit);
+    } else {
+        _ck_acc.set_max_size(state->chunk_size());
+    }
+    _opened = true;
+
+    return Status::OK();
+}
+
+Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
+    RETURN_IF_ERROR(_open_data_source(state));
 
     if (state->is_cancelled()) {
         return Status::Cancelled("canceled state");

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -90,6 +90,8 @@ public:
 
 protected:
     virtual bool _reach_eof() { return _limit != -1 && _rows_read >= _limit; }
+    Status _open_data_source(RuntimeState* state);
+
     connector::DataSourcePtr _data_source;
     [[maybe_unused]] ConnectorScanNode* _scan_node;
 

--- a/be/src/exec/stream/scan/stream_scan_operator.cpp
+++ b/be/src/exec/stream/scan/stream_scan_operator.cpp
@@ -337,6 +337,14 @@ StreamChunkSource::StreamChunkSource(int32_t scan_operator_id, RuntimeProfile* r
                                      ScanOperator* op, ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer)
         : ConnectorChunkSource(scan_operator_id, runtime_profile, std::move(morsel), op, scan_node, chunk_buffer) {}
 
+Status StreamChunkSource::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(ConnectorChunkSource::prepare(state));
+    // open data source eagerly rather than delay until to read data so that
+    // it can interact with stream pipeline engine normally, such as set_offset()
+    RETURN_IF_ERROR(_open_data_source(state));
+    return Status::OK();
+}
+
 Status StreamChunkSource::set_stream_offset(int64_t table_version, int64_t changelog_id) {
     return _get_stream_data_source()->set_offset(table_version, changelog_id);
 }

--- a/be/src/exec/stream/scan/stream_scan_operator.h
+++ b/be/src/exec/stream/scan/stream_scan_operator.h
@@ -105,6 +105,8 @@ public:
     StreamChunkSource(int32_t scan_operator_id, RuntimeProfile* runtime_profile, MorselPtr&& morsel, ScanOperator* op,
                       ConnectorScanNode* scan_node, BalancedChunkBuffer& chunk_buffer);
 
+    Status prepare(RuntimeState* state) override;
+
     Status set_stream_offset(int64_t table_version, int64_t changelog_id);
     void set_epoch_limit(int64_t epoch_rows_limit, int64_t epoch_time_limit);
     void reset_status();

--- a/be/src/exec/stream/scan/stream_scan_operator.h
+++ b/be/src/exec/stream/scan/stream_scan_operator.h
@@ -93,7 +93,7 @@ private:
     bool _is_stream_pipeline{false};
     int64_t _run_time = 0;
 
-    StreamEpochManager* _stream_epoch_manager;
+    StreamEpochManager* _stream_epoch_manager = nullptr;
     starrocks::EpochInfo _current_epoch_info;
 
     std::queue<ChunkSourcePtr> _old_chunk_sources;

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -187,6 +187,17 @@ StatusOr<BinlogFileMetaPBPtr> BinlogManager::find_binlog_meta(int64_t version, i
     return file_meta;
 }
 
+BinlogRange BinlogManager::current_binlog_range() {
+    std::shared_lock lock(_meta_lock);
+    if (_binlog_file_metas.empty()) {
+        return {0, 0, -1, -1};
+    }
+
+    BinlogFileMetaPBPtr& start = _binlog_file_metas.begin()->second;
+    BinlogFileMetaPBPtr& end = _binlog_file_metas.rbegin()->second;
+    return BinlogRange(start->start_version(), start->start_seq_id(), end->end_version(), end->end_seq_id());
+}
+
 void BinlogManager::close_active_writer() {
     if (_active_binlog_writer != nullptr) {
         _active_binlog_writer->close(true);

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -92,6 +92,37 @@ private:
     Tablet& _tablet;
 };
 
+class BinlogRange {
+public:
+    BinlogRange(int64_t start_version, int64_t start_seq_id, int64_t end_version, int64_t end_seq_id)
+            : _start_version(start_version),
+              _start_seq_id(start_seq_id),
+              _end_version(end_version),
+              _end_seq_id(end_seq_id) {}
+
+    bool is_empty() {
+        return _start_version > _end_version || (_start_version == _end_version && _start_seq_id > _end_seq_id);
+    }
+
+    int64_t start_version() const { return _start_version; }
+    int64_t start_seq_id() const { return _start_seq_id; }
+    int64_t end_version() const { return _end_version; }
+    int64_t end_seq_id() const { return _end_seq_id; }
+
+    std::string debug_string() const {
+        std::stringstream out;
+        out << "BinlogRange(start_version=" << _start_version << ", start_seq_id=" << _start_seq_id
+            << ", end_version=" << _end_version << ", end_seq_id=" << _end_seq_id << ")";
+        return out.str();
+    }
+
+private:
+    int64_t _start_version;
+    int64_t _start_seq_id;
+    int64_t _end_version;
+    int64_t _end_seq_id;
+};
+
 // Manages the binlog metas and files, including generation, deletion and read.
 class BinlogManager {
 public:
@@ -152,6 +183,8 @@ public:
     StatusOr<BinlogFileMetaPBPtr> find_binlog_meta(int64_t version, int64_t seq_id);
 
     std::string get_binlog_file_path(int64_t file_id) { return BinlogUtil::binlog_file_path(_path, file_id); }
+
+    BinlogRange current_binlog_range();
 
     // For testing
     int64_t next_file_id() { return _next_file_id; }

--- a/be/src/storage/binlog_reader.h
+++ b/be/src/storage/binlog_reader.h
@@ -104,6 +104,8 @@ public:
 
     void close();
 
+    int64_t reader_id() { return _reader_id; }
+
 private:
     Status _seek_binlog_file_reader(int64_t version, int64_t seq_id);
     Status _init_segment_iterator();

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -360,6 +360,15 @@ RowsetSharedPtr Tablet::rowset_with_max_version() const {
     return iter->second;
 }
 
+Status Tablet::support_binlog() {
+    // TODO support primary key
+    if (keys_type() == DUP_KEYS) {
+        return Status::OK();
+    }
+
+    return Status::InternalError("Not support binlog, keys type: " + KeysType_Name(keys_type()));
+}
+
 bool Tablet::binlog_enable() {
     auto config = _tablet_meta->get_binlog_config();
     return config != nullptr && config->binlog_enable;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -284,6 +284,8 @@ public:
         return _tablet_meta->set_enable_persistent_index(enable_persistent_index);
     }
 
+    Status support_binlog();
+
     void set_binlog_config(TBinlogConfig binlog_config) { _tablet_meta->set_binlog_config(binlog_config); }
 
     BinlogManager* binlog_manager() { return _binlog_manager == nullptr ? nullptr : _binlog_manager.get(); }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Binlog connector can read binlog from tablet using `BinlogReader`, and there are two use cases
1. scan **full of binlog** using `select * from t [_BINLOG_]` which is only used for testing currently
2. realtime mv read binlog from **the given offset** for incremental computation

Binlog connector will distinguish the two cases using the flag `is_stream_pipeline`,  `false` for case 1, and `true` for case 2. This PR includes codes to support both cases, but actually the code can only run in case 1 currently, and there are still some problems for case 2 which need more work to debug the end-to-end mv pipeline. I still include the code for case 2 in this PR so that reviewers can have a full context.

## How to use
You can test case 1 in following steps

1. create table with binlog enabled
```
CREATE TABLE `test_binlog` (
  `c0` int(11) NULL COMMENT "",
  `c1` int(11) NULL COMMENT "",
  `c2` varchar(100) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`c0`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`c0`) BUCKETS 2
PROPERTIES (
    "replication_num" = "1",
    "binlog_enable" = "true",
    "binlog_ttl_second" = "3600",
    "binlog_max_size" = "107374182400"
);
```
2.  insert some data to the table

```
INSERT INTO `test_binlog` VALUES (1, 2, "12"), (2, 3, "23"), (3, 4, "34"), (4, 5, "45");
```

3. enable mv planner and execute select with hint `[_BINLOG_]`
```
SET enable_mv_planner=true;
SELECT * from `test_binlog` [_BINLOG_];
```

And the result will be like this
```
+------+------+------+------------+-----------------+----------------+-------------------+
| c0   | c1   | c2   | _binlog_op | _binlog_version | _binlog_seq_id | _binlog_timestamp |
+------+------+------+------------+-----------------+----------------+-------------------+
|    3 |    4 | 34   |          0 |               2 |              0 |  1677571530000000 |
|    1 |    2 | 12   |          0 |               2 |              0 |  1677571530000000 |
|    2 |    3 | 23   |          0 |               2 |              1 |  1677571530000000 |
|    4 |    5 | 45   |          0 |               2 |              2 |  1677571530000000 |
+------+------+------+------------+-----------------+----------------+-------------------+
4 rows in set (0.02 sec)

```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
