### PR TITLE
[BugFix] fix lake primary table handle condition update in memtable

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -201,9 +201,9 @@ inline Status DeltaWriterImpl::reset_memtable() {
         _vectorized_schema = MemTable::convert_schema(_tablet_schema.get(), _slots);
         _schema_initialized = true;
     }
-    if (_slots != nullptr) {
+    if (_slots != nullptr || !_merge_condition.empty()) {
         _mem_table = std::make_unique<MemTable>(_tablet_id, &_vectorized_schema, _slots, _mem_table_sink.get(),
-                                                _mem_tracker);
+                                                _merge_condition, _mem_tracker);
     } else {
         _mem_table = std::make_unique<MemTable>(_tablet_id, &_vectorized_schema, _mem_table_sink.get(),
                                                 _max_buffer_size, _mem_tracker);

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -68,7 +68,8 @@ MemTable::MemTable(int64_t tablet_id, const Schema* schema, const std::vector<Sl
           _aggregator(nullptr),
           _merge_condition(std::move(merge_condition)),
           _mem_tracker(mem_tracker) {
-    if (_keys_type == KeysType::PRIMARY_KEYS && _slot_descs->back()->col_name() == LOAD_OP_COLUMN) {
+    if (_keys_type == KeysType::PRIMARY_KEYS && _slot_descs != nullptr &&
+        _slot_descs->back()->col_name() == LOAD_OP_COLUMN) {
         _has_op_slot = true;
     }
     _init_aggregator_if_needed();

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -320,4 +320,36 @@ TEST_F(ConditionUpdateTest, test_condition_update_multi_segment) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
 }
 
+TEST_F(ConditionUpdateTest, test_condition_update_in_memtable) {
+    // condition update
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+    VChunk chunks[2];
+    chunks[0] = generate_data(kChunkSize, 0, 4, 5);
+    chunks[1] = generate_data(kChunkSize, 0, 3, 6);
+    std::pair<int, int> result = std::make_pair(4, 5);
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    _txn_id++;
+    auto delta_writer = DeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr, "c1",
+                                            _mem_tracker.get());
+    ASSERT_OK(delta_writer->open());
+    // finish condition merge in one memtable
+    ASSERT_OK(delta_writer->write(chunks[0], indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->write(chunks[1], indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->finish());
+    delta_writer->close();
+    // Publish version
+    ASSERT_OK(_tablet_manager->publish_version(tablet_id, version, version + 1, &_txn_id, 1).status());
+    version++;
+    ASSERT_EQ(kChunkSize, check(version, [&](int c0, int c1, int c2) {
+                  return (c0 * result.first == c1) && (c0 * result.second == c2);
+              }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18572

## Problem Summary(Required) ：
In lake primary table, missing create memtable with `merge_condition`, which will cause condition update doesn't work when rows are writen to the same memtable.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
