### PR TITLE
[Enhancement] backport BE related information schema tables

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -791,4 +791,6 @@ CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 
 CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache=128M}");
 
+CONF_mInt64(txn_info_history_size, "20000");
+
 } // namespace starrocks::config

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -99,6 +99,10 @@ set(EXEC_FILES
     vectorized/table_function_node.cpp
     vectorized/schema_scanner.cpp
     vectorized/schema_scan_node.cpp
+    vectorized/schema_scanner/schema_be_metrics_scanner.cpp
+    vectorized/schema_scanner/schema_be_tablets_scanner.cpp
+    vectorized/schema_scanner/schema_be_txns_scanner.cpp
+    vectorized/schema_scanner/schema_be_configs_scanner.cpp
     vectorized/schema_scanner/schema_tables_scanner.cpp
     vectorized/schema_scanner/schema_dummy_scanner.cpp
     vectorized/schema_scanner/schema_schemata_scanner.cpp

--- a/be/src/exec/vectorized/schema_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner.cpp
@@ -3,6 +3,10 @@
 #include "exec/vectorized/schema_scanner.h"
 
 #include "column/type_traits.h"
+#include "exec/vectorized/schema_scanner/schema_be_configs_scanner.h"
+#include "exec/vectorized/schema_scanner/schema_be_metrics_scanner.h"
+#include "exec/vectorized/schema_scanner/schema_be_tablets_scanner.h"
+#include "exec/vectorized/schema_scanner/schema_be_txns_scanner.h"
 #include "exec/vectorized/schema_scanner/schema_charsets_scanner.h"
 #include "exec/vectorized/schema_scanner/schema_collations_scanner.h"
 #include "exec/vectorized/schema_scanner/schema_columns_scanner.h"
@@ -96,6 +100,14 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<vectorized::SchemaTaskRunsScanner>();
     case TSchemaTableType::SCH_MATERIALIZED_VIEWS:
         return std::make_unique<vectorized::SchemaMaterializedViewsScanner>();
+    case TSchemaTableType::SCH_BE_TABLETS:
+        return std::make_unique<SchemaBeTabletsScanner>();
+    case TSchemaTableType::SCH_BE_METRICS:
+        return std::make_unique<SchemaBeMetricsScanner>();
+    case TSchemaTableType::SCH_BE_TXNS:
+        return std::make_unique<SchemaBeTxnsScanner>();
+    case TSchemaTableType::SCH_BE_CONFIGS:
+        return std::make_unique<SchemaBeConfigsScanner>();
     default:
         return std::make_unique<vectorized::SchemaDummyScanner>();
     }

--- a/be/src/exec/vectorized/schema_scanner.h
+++ b/be/src/exec/vectorized/schema_scanner.h
@@ -38,12 +38,15 @@ struct SchemaScannerParam {
     // and no longer call get_db_names() and get_table_names().
     bool without_db_table{false};
 
+    int64_t table_id{-1};
+    int64_t partition_id{-1};
+    int64_t tablet_id{-1};
+    int64_t txn_id{-1};
+
     RuntimeProfile::Counter* _rpc_timer = nullptr;
     RuntimeProfile::Counter* _fill_chunk_timer = nullptr;
 
-    SchemaScannerParam()
-
-    {}
+    SchemaScannerParam() = default;
 };
 
 // virtual scanner for all schema table

--- a/be/src/exec/vectorized/schema_scanner/schema_be_configs_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_be_configs_scanner.cpp
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/vectorized/schema_scanner/schema_be_configs_scanner.h"
+
+#include "exec/vectorized/schema_scanner/schema_helper.h"
+#include "gen_cpp/HeartbeatService_types.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/exec_env.h"
+#include "runtime/string_value.h"
+#include "util/metrics.h"
+
+namespace starrocks {
+
+using vectorized::fill_column_with_slot;
+
+vectorized::SchemaScanner::ColumnDesc SchemaBeConfigsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NAME", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"VALUE", TYPE_VARCHAR, sizeof(StringValue), false},
+};
+
+SchemaBeConfigsScanner::SchemaBeConfigsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeConfigsScanner::~SchemaBeConfigsScanner() = default;
+
+Status SchemaBeConfigsScanner::start(RuntimeState* state) {
+    auto master_info = ExecEnv::GetInstance()->master_info();
+    _be_id = master_info->__isset.backend_id ? master_info->backend_id : -1;
+    _infos.clear();
+    for (const auto& it : *(config::full_conf_map)) {
+        auto& info = _infos.emplace_back();
+        info.first = it.first;
+        info.second = it.second;
+    }
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+Status SchemaBeConfigsScanner::fill_chunk(vectorized::ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 3) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            vectorized::ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                // name
+                Slice v(info.first);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 3: {
+                // value
+                Slice v(info.second);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeConfigsScanner::get_next(vectorized::ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/vectorized/schema_scanner/schema_be_configs_scanner.h
+++ b/be/src/exec/vectorized/schema_scanner/schema_be_configs_scanner.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "exec/vectorized/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+class SchemaBeConfigsScanner : public vectorized::SchemaScanner {
+public:
+    SchemaBeConfigsScanner();
+    ~SchemaBeConfigsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(vectorized::ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(vectorized::ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<std::pair<std::string, std::string>> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/exec/vectorized/schema_scanner/schema_be_metrics_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_be_metrics_scanner.cpp
@@ -1,0 +1,137 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/vectorized/schema_scanner/schema_be_metrics_scanner.h"
+
+#include "exec/vectorized/schema_scanner/schema_helper.h"
+#include "gen_cpp/HeartbeatService_types.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/exec_env.h"
+#include "runtime/string_value.h"
+#include "util/metrics.h"
+#include "util/starrocks_metrics.h"
+
+namespace starrocks {
+
+using vectorized::fill_column_with_slot;
+
+vectorized::SchemaScanner::ColumnDesc SchemaBeMetricsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NAME", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"LABELS", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"VALUE", TYPE_BIGINT, sizeof(int64_t), false},
+};
+
+SchemaBeMetricsScanner::SchemaBeMetricsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeMetricsScanner::~SchemaBeMetricsScanner() = default;
+
+class SchemaCoreMetricsVisitor : public MetricsVisitor {
+public:
+    SchemaCoreMetricsVisitor(std::vector<MetricsInfo>& infos) : _infos(infos) {}
+    ~SchemaCoreMetricsVisitor() override = default;
+    void visit(const std::string& prefix, const std::string& name, MetricCollector* collector) override {
+        if (collector->empty() || name.empty()) {
+            return;
+        }
+        for (auto& it : collector->metrics()) {
+            auto& labels = it.first;
+            std::stringstream ss;
+            bool first = true;
+            for (auto& label : labels.labels) {
+                if (first) {
+                    first = false;
+                } else {
+                    ss << ",";
+                }
+                ss << label.name << "=" << label.value;
+            }
+            auto& info = _infos.emplace_back();
+            info.name = name;
+            info.labels = ss.str();
+            info.value = std::strtoll(it.second->to_string().c_str(), nullptr, 10);
+        }
+    }
+
+private:
+    std::vector<MetricsInfo>& _infos;
+};
+
+Status SchemaBeMetricsScanner::start(RuntimeState* state) {
+    auto master_info = ExecEnv::GetInstance()->master_info();
+    _be_id = master_info->__isset.backend_id ? master_info->backend_id : -1;
+    _infos.clear();
+    SchemaCoreMetricsVisitor visitor(_infos);
+    StarRocksMetrics::instance()->metrics()->collect(&visitor);
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+Status SchemaBeMetricsScanner::fill_chunk(vectorized::ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 14) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            vectorized::ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                // name
+                Slice v(info.name);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 3: {
+                // labels
+                Slice v(info.labels);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 4: {
+                // value
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.value);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeMetricsScanner::get_next(vectorized::ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/vectorized/schema_scanner/schema_be_metrics_scanner.h
+++ b/be/src/exec/vectorized/schema_scanner/schema_be_metrics_scanner.h
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "exec/vectorized/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+struct MetricsInfo {
+    std::string name;
+    std::string labels;
+    int64_t value{0};
+};
+
+class SchemaBeMetricsScanner : public vectorized::SchemaScanner {
+public:
+    SchemaBeMetricsScanner();
+    ~SchemaBeMetricsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(vectorized::ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(vectorized::ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<MetricsInfo> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/exec/vectorized/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_be_tablets_scanner.cpp
@@ -1,0 +1,194 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/vectorized/schema_scanner/schema_be_tablets_scanner.h"
+
+#include "exec/vectorized/schema_scanner/schema_helper.h"
+#include "gen_cpp/HeartbeatService_types.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/exec_env.h"
+#include "runtime/string_value.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+
+using starrocks::vectorized::fill_column_with_slot;
+
+namespace starrocks {
+
+vectorized::SchemaScanner::ColumnDesc SchemaBeTabletsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},        {"TABLE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"PARTITION_ID", TYPE_BIGINT, sizeof(int64_t), false}, {"TABLET_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NUM_VERSION", TYPE_BIGINT, sizeof(int64_t), false},  {"MAX_VERSION", TYPE_BIGINT, sizeof(int64_t), false},
+        {"MIN_VERSION", TYPE_BIGINT, sizeof(int64_t), false},  {"NUM_ROWSET", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NUM_ROW", TYPE_BIGINT, sizeof(int64_t), false},      {"DATA_SIZE", TYPE_BIGINT, sizeof(int64_t), false},
+        {"INDEX_MEM", TYPE_BIGINT, sizeof(int64_t), false},    {"CREATE_TIME", TYPE_BIGINT, sizeof(int64_t), false},
+        {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},   {"TYPE", TYPE_VARCHAR, sizeof(StringValue), false},
+};
+
+SchemaBeTabletsScanner::SchemaBeTabletsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeTabletsScanner::~SchemaBeTabletsScanner() = default;
+
+Status SchemaBeTabletsScanner::start(RuntimeState* state) {
+    auto master_info = ExecEnv::GetInstance()->master_info();
+    _be_id = master_info->__isset.backend_id ? master_info->backend_id : -1;
+    _infos.clear();
+    auto manager = StorageEngine::instance()->tablet_manager();
+    manager->get_tablets_basic_infos(_param->table_id, _param->partition_id, _param->tablet_id, _infos);
+    LOG(INFO) << strings::Substitute("get_tablets_basic_infos table_id:$0 partition:$1 tablet:$2 #info:$3",
+                                     _param->table_id, _param->partition_id, _param->tablet_id, _infos.size());
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+static const char* tablet_state_to_string(TabletState state) {
+    switch (state) {
+    case TabletState::TABLET_NOTREADY:
+        return "NOTREADY";
+    case TabletState::TABLET_RUNNING:
+        return "RUNNING";
+    case TabletState::TABLET_TOMBSTONED:
+        return "TOMBSTONED";
+    case TabletState::TABLET_STOPPED:
+        return "STOPPED";
+    case TabletState::TABLET_SHUTDOWN:
+        return "SHUTDOWN";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+static const char* keys_type_to_string(KeysType type) {
+    switch (type) {
+    case KeysType::DUP_KEYS:
+        return "DUP";
+    case KeysType::UNIQUE_KEYS:
+        return "UNIQUE";
+    case KeysType::AGG_KEYS:
+        return "AGG";
+    case KeysType::PRIMARY_KEYS:
+        return "PRIMARY";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+Status SchemaBeTabletsScanner::fill_chunk(vectorized::ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 14) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            vectorized::ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                // table id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.table_id);
+                break;
+            }
+            case 3: {
+                // partition id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.partition_id);
+                break;
+            }
+            case 4: {
+                // tablet id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.tablet_id);
+                break;
+            }
+            case 5: {
+                // num version
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_version);
+                break;
+            }
+            case 6: {
+                // max version
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.max_version);
+                break;
+            }
+            case 7: {
+                // min version
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.min_version);
+                break;
+            }
+            case 8: {
+                // num rowset
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_rowset);
+                break;
+            }
+            case 9: {
+                // num rowt
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_row);
+                break;
+            }
+            case 10: {
+                // data size
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.data_size);
+                break;
+            }
+            case 11: {
+                // index mem
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.index_mem);
+                break;
+            }
+            case 12: {
+                // create time
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.create_time);
+                break;
+            }
+            case 13: {
+                // state
+                Slice state = Slice(tablet_state_to_string((TabletState)info.state));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&state);
+                break;
+            }
+            case 14: {
+                // type
+                Slice type = Slice(keys_type_to_string((KeysType)info.type));
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&type);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeTabletsScanner::get_next(vectorized::ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/vectorized/schema_scanner/schema_be_tablets_scanner.h
+++ b/be/src/exec/vectorized/schema_scanner/schema_be_tablets_scanner.h
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "exec/vectorized/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+struct TabletBasicInfo {
+    int64_t table_id{0};
+    int64_t partition_id{0};
+    int64_t tablet_id{0};
+    int64_t num_version{0};
+    int64_t max_version{0};
+    int64_t min_version{0};
+    int64_t num_rowset{0};
+    int64_t num_row{0};
+    int64_t data_size{0};
+    int64_t index_mem{0};
+    int64_t create_time{0};
+    int32_t state{0};
+    int32_t type{0};
+};
+
+class SchemaBeTabletsScanner : public vectorized::SchemaScanner {
+public:
+    SchemaBeTabletsScanner();
+    ~SchemaBeTabletsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(vectorized::ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(vectorized::ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<TabletBasicInfo> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/exec/vectorized/schema_scanner/schema_be_txns_scanner.cpp
+++ b/be/src/exec/vectorized/schema_scanner/schema_be_txns_scanner.cpp
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/vectorized/schema_scanner/schema_be_txns_scanner.h"
+
+#include "exec/vectorized/schema_scanner/schema_helper.h"
+#include "gen_cpp/HeartbeatService_types.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/exec_env.h"
+#include "runtime/string_value.h"
+#include "storage/storage_engine.h"
+#include "storage/txn_manager.h"
+#include "util/metrics.h"
+
+namespace starrocks {
+
+using vectorized::fill_column_with_slot;
+
+vectorized::SchemaScanner::ColumnDesc SchemaBeTxnsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},          {"LOAD_ID", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"TXN_ID", TYPE_BIGINT, sizeof(int64_t), false},         {"PARTITION_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"TABLET_ID", TYPE_BIGINT, sizeof(int64_t), false},      {"CREATE_TIME", TYPE_BIGINT, sizeof(int64_t), false},
+        {"COMMIT_TIME", TYPE_BIGINT, sizeof(int64_t), false},    {"PUBLISH_TIME", TYPE_BIGINT, sizeof(int64_t), false},
+        {"ROWSET_ID", TYPE_VARCHAR, sizeof(StringValue), false}, {"NUM_SEGMENT", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NUM_DELFILE", TYPE_BIGINT, sizeof(int64_t), false},    {"NUM_ROW", TYPE_BIGINT, sizeof(int64_t), false},
+        {"DATA_SIZE", TYPE_BIGINT, sizeof(int64_t), false},      {"VERSION", TYPE_BIGINT, sizeof(int64_t), false},
+};
+
+SchemaBeTxnsScanner::SchemaBeTxnsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeTxnsScanner::~SchemaBeTxnsScanner() = default;
+
+Status SchemaBeTxnsScanner::start(RuntimeState* state) {
+    auto master_info = ExecEnv::GetInstance()->master_info();
+    _be_id = master_info->__isset.backend_id ? master_info->backend_id : -1;
+    _infos.clear();
+    StorageEngine::instance()->txn_manager()->get_txn_infos(_param->txn_id, _param->tablet_id, _infos);
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+Status SchemaBeTxnsScanner::fill_chunk(vectorized::ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 14) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            vectorized::ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                // load id
+                auto load_id_str = info.load_id.to_string();
+                Slice v(load_id_str);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 3: {
+                // txn id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.txn_id);
+                break;
+            }
+            case 4: {
+                // partition id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.partition_id);
+                break;
+            }
+            case 5: {
+                // tablet id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.tablet_id);
+                break;
+            }
+            case 6: {
+                // create time
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.create_time);
+                break;
+            }
+            case 7: {
+                // commit time
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.commit_time);
+                break;
+            }
+            case 8: {
+                // publish time
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.publish_time);
+                break;
+            }
+            case 9: {
+                // rowset id
+                Slice v(info.rowset_id);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 10: {
+                // num segment
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_segment);
+                break;
+            }
+            case 11: {
+                // num delfile
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_delfile);
+                break;
+            }
+            case 12: {
+                // num row
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_row);
+                break;
+            }
+            case 13: {
+                // data size
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.data_size);
+                break;
+            }
+            case 14: {
+                // version
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.version);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeTxnsScanner::get_next(vectorized::ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/vectorized/schema_scanner/schema_be_txns_scanner.h
+++ b/be/src/exec/vectorized/schema_scanner/schema_be_txns_scanner.h
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "exec/vectorized/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+struct TxnInfo {
+    UniqueId load_id;
+    int64_t txn_id{0};
+    int64_t partition_id{0};
+    int64_t tablet_id{0};
+    int64_t create_time{0};
+    int64_t commit_time{0};
+    int64_t publish_time{0};
+    std::string rowset_id;
+    int64_t num_segment{0};
+    int64_t num_delfile{0};
+    int64_t num_row{0};
+    int64_t data_size{0};
+    int64_t version{0};
+};
+
+class SchemaBeTxnsScanner : public vectorized::SchemaScanner {
+public:
+    SchemaBeTxnsScanner();
+    ~SchemaBeTxnsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(vectorized::ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(vectorized::ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<TxnInfo> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -53,6 +53,7 @@ class TabletUpdates;
 class CompactionTask;
 class CompactionContext;
 class CompactionCandidate;
+class TabletBasicInfo;
 
 using TabletSharedPtr = std::shared_ptr<Tablet>;
 
@@ -270,6 +271,8 @@ public:
     void set_enable_persistent_index(bool enable_persistent_index) {
         return _tablet_meta->set_enable_persistent_index(enable_persistent_index);
     }
+
+    void get_basic_info(TabletBasicInfo& info);
 
 protected:
     void on_shutdown() override;

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -32,6 +32,7 @@ DIAGNOSTIC_POP
 #include <memory>
 
 #include "common/config.h"
+#include "exec/vectorized/schema_scanner/schema_be_tablets_scanner.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "runtime/current_thread.h"
@@ -1386,6 +1387,56 @@ void TabletManager::_remove_tablet_from_partition(const Tablet& tablet) {
     _partition_tablet_map[tablet.partition_id()].erase(tablet.get_tablet_info());
     if (_partition_tablet_map[tablet.partition_id()].empty()) {
         _partition_tablet_map.erase(tablet.partition_id());
+    }
+}
+
+void TabletManager::get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
+                                            std::vector<TabletBasicInfo>& tablet_infos) {
+    if (tablet_id != -1) {
+        auto tablet = get_tablet(tablet_id, true, nullptr);
+        if (tablet) {
+            auto& info = tablet_infos.emplace_back();
+            tablet->get_basic_info(info);
+        }
+    } else if (partition_id != -1) {
+        vector<int64_t> tablet_ids;
+        {
+            std::shared_lock rlock(_partition_tablet_map_lock);
+            auto search = _partition_tablet_map.find(partition_id);
+            if (search != _partition_tablet_map.end()) {
+                for (auto tablet_id : search->second) {
+                    tablet_ids.push_back(tablet_id.tablet_id);
+                }
+            }
+        }
+        for (int64_t tablet_id : tablet_ids) {
+            auto tablet = get_tablet(tablet_id, true, nullptr);
+            if (tablet) {
+                auto& info = tablet_infos.emplace_back();
+                tablet->get_basic_info(info);
+            }
+        }
+    } else {
+        for (auto& shard : _tablets_shards) {
+            std::shared_lock rlock(shard.lock);
+            for (auto& itr : shard.tablet_map) {
+                auto& tablet = itr.second;
+                if (table_id == -1 || tablet->tablet_meta()->table_id() == table_id) {
+                    auto& info = tablet_infos.emplace_back();
+                    tablet->get_basic_info(info);
+                }
+            }
+        }
+        // order by table_id, partition_id, tablet_id by default
+        std::sort(tablet_infos.begin(), tablet_infos.end(), [](const TabletBasicInfo& a, const TabletBasicInfo& b) {
+            if (a.partition_id == b.partition_id) {
+                return a.tablet_id < b.tablet_id;
+            }
+            if (a.table_id == b.table_id) {
+                return a.partition_id < b.partition_id;
+            }
+            return a.table_id < b.table_id;
+        });
     }
 }
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -46,6 +46,7 @@ namespace starrocks {
 
 class Tablet;
 class DataDir;
+class TabletBasicInfo;
 
 enum TabletDropFlag {
     kMoveFilesToTrash = 0,
@@ -149,6 +150,9 @@ public:
 
     // return true if all tablets visited
     bool get_next_batch_tablets(size_t batch_size, std::vector<TabletSharedPtr>* tablets);
+
+    void get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
+                                 std::vector<TabletBasicInfo>& tablet_infos);
 
 private:
     using TabletMap = std::unordered_map<int64_t, TabletSharedPtr>;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "common/status.h"
+#include "exec/vectorized/schema_scanner/schema_be_tablets_scanner.h"
 #include "gen_cpp/MasterService_types.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "gutil/stl_util.h"
@@ -2475,6 +2476,44 @@ Status TabletUpdates::check_and_remove_rowset() {
         return Status::InternalError(msg);
     }
     return Status::OK();
+}
+
+void TabletUpdates::get_basic_info_extra(TabletBasicInfo& info) {
+    vector<uint32_t> rowsets;
+    {
+        std::lock_guard rl(_lock);
+        if (_edit_version_infos.empty()) {
+            LOG(WARNING) << "tablet delete when get_tablet_info_extra tablet:" << _tablet.tablet_id();
+            return;
+        }
+        info.num_version = _edit_version_infos.size();
+        info.min_version = _edit_version_infos[0]->version.major();
+        auto& v = _edit_version_infos[_edit_version_infos.size() - 1];
+        info.max_version = v->version.major();
+        info.num_rowset = v->rowsets.size();
+        rowsets = v->rowsets;
+    }
+    int64_t total_row = 0;
+    int64_t total_size = 0;
+    {
+        std::lock_guard lg(_rowset_stats_lock);
+        for (uint32_t rowsetid : rowsets) {
+            auto itr = _rowset_stats.find(rowsetid);
+            if (itr != _rowset_stats.end()) {
+                // TODO(cbl): also report num deletes
+                total_row += itr->second->num_rows;
+                total_size += itr->second->byte_size;
+            }
+        }
+    }
+    info.num_row = total_row;
+    info.data_size = total_size;
+    auto& index_cache = StorageEngine::instance()->update_manager()->index_cache();
+    auto index_entry = index_cache.get(_tablet.tablet_id());
+    if (index_entry != nullptr) {
+        info.index_mem = index_entry->size();
+        index_cache.release(index_entry);
+    }
 }
 
 void TabletUpdates::_to_updates_pb_unlocked(TabletUpdatesPB* updates_pb) const {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -26,6 +26,7 @@ using DelVectorPtr = std::shared_ptr<DelVector>;
 class MemTracker;
 class SnapshotMeta;
 class Tablet;
+class TabletBasicInfo;
 class TTabletInfo;
 
 namespace vectorized {
@@ -222,6 +223,8 @@ public:
                            std::vector<RowsetMetaPB>& rowset_metas_pb);
 
     Status check_and_remove_rowset();
+
+    void get_basic_info_extra(TabletBasicInfo& info);
 
 private:
     friend class Tablet;

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -26,6 +26,7 @@
 #include <queue>
 #include <set>
 
+#include "exec/vectorized/schema_scanner/schema_be_txns_scanner.h"
 #include "storage/data_dir.h"
 #include "storage/rowset/rowset_meta_manager.h"
 #include "storage/storage_engine.h"
@@ -35,6 +36,67 @@
 #include "util/time.h"
 
 namespace starrocks {
+
+// keep recently published txns in memory for a while
+static std::mutex txn_info_history_lock;
+static std::deque<TxnInfo> txn_info_history;
+
+static void add_txn_info_history(TxnInfo& info) {
+    std::lock_guard<std::mutex> l(txn_info_history_lock);
+    txn_info_history.push_back(info);
+    while (txn_info_history.size() > config::txn_info_history_size) {
+        txn_info_history.pop_front();
+    }
+}
+
+static void to_txn_info(int64_t txn_id, int64_t partition_id,
+                        const std::pair<TabletInfo, TabletTxnInfo>& tablet_load_it, TxnInfo& info) {
+    info.load_id = tablet_load_it.second.load_id;
+    info.txn_id = txn_id;
+    info.partition_id = partition_id;
+    info.tablet_id = tablet_load_it.first.tablet_id;
+    info.create_time = tablet_load_it.second.creation_time;
+    info.commit_time = tablet_load_it.second.commit_time;
+    if (tablet_load_it.second.rowset != nullptr) {
+        auto& rowset = tablet_load_it.second.rowset;
+        info.rowset_id = rowset->rowset_id().to_string();
+        info.num_segment = rowset->num_segments();
+        info.num_delfile = rowset->num_delete_files();
+        info.num_row = rowset->num_rows();
+        info.data_size = rowset->data_disk_size();
+    }
+}
+
+void TxnManager::get_txn_infos(int64_t txn_id, int64_t tablet_id, std::vector<TxnInfo>& txn_infos) {
+    for (int32_t i = 0; i < _txn_map_shard_size; i++) {
+        std::shared_lock txn_rdlock(_txn_map_locks[i]);
+        for (auto& it : _txn_tablet_maps[i]) {
+            auto& txn_key = it.first;
+            if (txn_id != -1 && txn_key.second != txn_id) {
+                continue;
+            }
+            for (auto& tablet_load_it : it.second) {
+                if (tablet_id != -1 && tablet_load_it.first.tablet_id != tablet_id) {
+                    continue;
+                }
+                auto& info = txn_infos.emplace_back();
+                to_txn_info(txn_key.second, txn_key.first, tablet_load_it, info);
+            }
+        }
+    }
+    std::lock_guard lg(txn_info_history_lock);
+    for (auto& info : txn_info_history) {
+        if (txn_id != -1 && info.txn_id != txn_id) {
+            continue;
+        }
+        if (tablet_id != -1 && info.tablet_id != tablet_id) {
+            continue;
+        }
+        txn_infos.push_back(info);
+    }
+    LOG(INFO) << "get txn infos, txn_id=" << txn_id << ", tablet_id=" << tablet_id
+              << ", txn_infos.size=" << txn_infos.size();
+}
 
 TxnManager::TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size, int32_t store_num)
         : _txn_map_shard_size(txn_map_shard_size), _txn_shard_size(txn_shard_size) {
@@ -197,9 +259,19 @@ Status TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTransac
 
     {
         std::unique_lock wrlock(_get_txn_map_lock(transaction_id));
-        TabletTxnInfo load_info(load_id, rowset_ptr);
         txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
-        txn_tablet_map[key][tablet_info] = load_info;
+        auto& tablet_txn_infos = txn_tablet_map[key];
+        auto itr = tablet_txn_infos.find(tablet_info);
+        if (itr == tablet_txn_infos.end()) {
+            TabletTxnInfo info(load_id, rowset_ptr);
+            info.commit_time = UnixSeconds();
+            tablet_txn_infos[tablet_info] = info;
+        } else {
+            itr->second.load_id = load_id;
+            itr->second.rowset = rowset_ptr;
+            itr->second.commit_time = UnixSeconds();
+        }
+        // [tablet_info] = load_info;
         _insert_txn_partition_map_unlocked(transaction_id, partition_id);
         LOG(INFO) << "Commit txn successfully. "
                   << " tablet: " << tablet_id << ", txn_id: " << key.second << ", rowsetid: " << rowset_ptr->rowset_id()
@@ -249,7 +321,18 @@ Status TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr&
     TabletInfo tablet_info(tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
     auto it = txn_tablet_map.find(key);
     if (it != txn_tablet_map.end()) {
-        it->second.erase(tablet_info);
+        auto tablet_txn_info_itr = it->second.find(tablet_info);
+        if (tablet_txn_info_itr != it->second.end()) {
+            TxnInfo txn_info;
+            to_txn_info(transaction_id, partition_id, *tablet_txn_info_itr, txn_info);
+            txn_info.publish_time = UnixSeconds();
+            txn_info.version = version;
+            add_txn_info_history(txn_info);
+            it->second.erase(tablet_txn_info_itr);
+            LOG(INFO) << "add txn info history. txn_id: " << transaction_id << ", partition_id: " << partition_id
+                      << ", tablet_id: " << tablet->tablet_id() << ", schema_hash: " << tablet->schema_hash()
+                      << ", rowset_id: " << rowset->rowset_id() << ", version: " << version;
+        }
         if (it->second.empty()) {
             txn_tablet_map.erase(it);
             _clear_txn_partition_map_unlocked(transaction_id, partition_id);

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -54,10 +54,13 @@
 
 namespace starrocks {
 
+class TxnInfo;
+
 struct TabletTxnInfo {
     PUniqueId load_id;
     RowsetSharedPtr rowset;
-    int64_t creation_time;
+    int64_t creation_time{0};
+    int64_t commit_time{0};
 
     TabletTxnInfo(PUniqueId load_id, RowsetSharedPtr rowset)
             : load_id(std::move(load_id)), rowset(std::move(rowset)), creation_time(UnixSeconds()) {}
@@ -129,6 +132,8 @@ public:
                                             const TabletUid& tablet_uid);
 
     void get_partition_ids(const TTransactionId transaction_id, std::vector<TPartitionId>* partition_ids);
+
+    void get_txn_infos(int64_t txn_id, int64_t tablet_id, std::vector<TxnInfo>& txn_infos);
 
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SchemaTableType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SchemaTableType.java
@@ -72,7 +72,13 @@ public enum SchemaTableType {
     SCH_CREATE_TABLE("CREATE_TABLE", "CREATE_TABLE", TSchemaTableType.SCH_CREATE_TABLE),
     SCH_TASKS("TASKS", "TASKS", TSchemaTableType.SCH_TASKS),
     SCH_TASK_RUNS("TASK_RUNS", "TASK_RUNS", TSchemaTableType.SCH_TASK_RUNS),
-    SCH_INVALID("NULL", "NULL", TSchemaTableType.SCH_INVALID);
+    SCH_BE_TABLETS("BE_TABLETS", "BE_TABLETS",
+            TSchemaTableType.SCH_BE_TABLETS),
+    SCH_BE_METRICS("BE_METRICS", "BE_METRICS",
+            TSchemaTableType.SCH_BE_METRICS),
+    SCH_BE_TXNS("BE_TXNS", "BE_TXNS",
+            TSchemaTableType.SCH_BE_TXNS),
+    SCH_BE_CONFIGS("BE_CONFIGS", "BE_CONFIGS", TSchemaTableType.SCH_BE_CONFIGS);
 
     private static final String dbName = "INFORMATION_SCHEMA";
     private static SelectList fullSelectLists;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -46,6 +46,14 @@ public class SchemaTable extends Table {
     private static final int MY_CS_NAME_SIZE = 32;
     private SchemaTableType schemaTableType;
 
+    public static boolean isBeSchemaTable(String name) {
+        return name.startsWith("be_");
+    }
+
+    public boolean isBeSchemaTable() {
+        return SchemaTable.isBeSchemaTable(getName());
+    }
+
     protected SchemaTable(long id, String name, TableType type, List<Column> baseSchema) {
         super(id, name, type, baseSchema);
     }
@@ -459,6 +467,65 @@ public class SchemaTable extends Table {
                                                     ScalarType.createVarchar(MAX_FIELD_VARCHARLENGTH))
                                             .column("TABLE_ROWS", ScalarType.createVarchar(50))
                                             .build()))
+                    .put("be_tablets", new SchemaTable(
+                            SystemId.BE_TABLETS_ID,
+                            "be_tablets",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TABLE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("PARTITION_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NUM_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("MAX_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("MIN_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NUM_ROWSET", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NUM_ROW", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("DATA_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("INDEX_MEM", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("CREATE_TIME", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .build()))
+                    .put("be_metrics", new SchemaTable(
+                            SystemId.BE_METRICS_ID,
+                            "be_metrics",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("LABELS", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("VALUE", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .build()))
+                    .put("be_txns", new SchemaTable(
+                            SystemId.BE_TXNS_ID,
+                            "be_txns",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("LOAD_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("TXN_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("PARTITION_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("CREATE_TIME", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("COMMIT_TIME", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("PUBLISH_TIME", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("ROWSET_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("NUM_SEGMENT", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NUM_DELFILE", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NUM_ROW", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("DATA_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .build()))
+                    .put("be_configs", new SchemaTable(
+                            SystemId.BE_CONFIGS_ID,
+                            "be_configs",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("VALUE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .build()))
                     .build();
 
     public static class Builder {

--- a/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
@@ -52,4 +52,14 @@ public class SystemId {
 
     public static final long MATERIALIZED_VIEWS_ID = 23L;
 
+    public static final long VERBOSE_SESSION_VARIABLES_ID = 25L;
+
+    public static final long BE_TABLETS_ID = 26L;
+
+    public static final long BE_METRICS_ID = 27L;
+
+    public static final long BE_TXNS_ID = 28L;
+
+    public static final long BE_CONFIGS_ID = 29L;
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -22,15 +22,20 @@
 package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.SchemaTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
+import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TSchemaScanNode;
 import com.starrocks.thrift.TUserIdentity;
@@ -56,6 +61,14 @@ public class SchemaScanNode extends ScanNode {
     private String userIp;
     private String frontendIP;
     private int frontendPort;
+
+    // only used for BE related schema scans
+    private Long beId = null;
+    private Long tableId = null;
+    private Long partitionId = null;
+    private Long tabletId = null;
+    private Long txnId = null;
+    private List<TScanRangeLocations> beScanRanges = null;
 
     public void setSchemaDb(String schemaDb) {
         this.schemaDb = schemaDb;
@@ -145,6 +158,60 @@ public class SchemaScanNode extends ScanNode {
 
         TUserIdentity tCurrentUser = ConnectContext.get().getCurrentUserIdentity().toThrift();
         msg.schema_scan_node.setCurrent_user_ident(tCurrentUser);
+
+        if (tableId != null) {
+            msg.schema_scan_node.setTable_id(tableId);
+        }
+
+        if (partitionId != null) {
+            msg.schema_scan_node.setPartition_id(partitionId);
+        }
+
+        if (tabletId != null) {
+            msg.schema_scan_node.setTablet_id(tabletId);
+        }
+    }
+
+    public void setBeId(long beId) {
+        this.beId = beId;
+    }
+
+    public void setTableId(long tableId) {
+        this.tableId = tableId;
+    }
+
+    public void setPartitionId(long partitionId) {
+        this.partitionId = partitionId;
+    }
+
+    public void setTabletId(long tabletId) {
+        this.tabletId = tabletId;
+    }
+
+    public void setTxnId(long txnId) {
+        this.txnId = txnId;
+    }
+
+    public boolean isBeSchemaTable() {
+        return SchemaTable.isBeSchemaTable(tableName);
+    }
+
+    public void computeBeScanRanges() {
+        for (Backend be : GlobalStateMgr.getCurrentSystemInfo().getIdToBackend().values()) {
+            // if user specifies BE id, we try to scan all BEs(including bad BE)
+            // if user doesn't specify BE id, we only scan live BEs
+            if ((be.isAlive() && beId == null) || be.getId() == beId) {
+                if (beScanRanges == null) {
+                    beScanRanges = Lists.newArrayList();
+                }
+                TScanRangeLocations locations = new TScanRangeLocations();
+                TScanRangeLocation location = new TScanRangeLocation();
+                location.setBackend_id(be.getId());
+                location.setServer(new TNetworkAddress(be.getHost(), be.getBePort()));
+                locations.addToLocations(location);
+                beScanRanges.add(locations);
+            }
+        }
     }
 
     /**
@@ -153,12 +220,12 @@ public class SchemaScanNode extends ScanNode {
      */
     @Override
     public List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
-        return null;
+        return beScanRanges;
     }
 
     @Override
     public int getNumInstances() {
-        return 1;
+        return beScanRanges == null ? 1 : beScanRanges.size();
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -64,6 +64,7 @@ import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ResultSink;
 import com.starrocks.planner.RuntimeFilterDescription;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.SchemaScanNode;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.proto.StatusPB;
@@ -1621,7 +1622,10 @@ public class Coordinator {
 
             FragmentScanRangeAssignment assignment =
                     fragmentExecParamsMap.get(scanNode.getFragmentId()).scanRangeAssignment;
-            if ((scanNode instanceof HdfsScanNode) || (scanNode instanceof IcebergScanNode) ||
+            if (scanNode instanceof SchemaScanNode) {
+                BackendSelector selector = new NormalBackendSelector(scanNode, locations, assignment);
+                selector.computeScanRangeAssignment();
+            } else if ((scanNode instanceof HdfsScanNode) || (scanNode instanceof IcebergScanNode) ||
                     scanNode instanceof HudiScanNode) {
                 HDFSBackendSelector selector = new HDFSBackendSelector(scanNode, locations, assignment,
                         ScanRangeAssignType.SCAN_DATA_SIZE, usedBackendIDs);
@@ -2783,8 +2787,9 @@ public class Coordinator {
 
     /**
      * Whether it can use pipeline engine.
+     *
      * @param connectContext It is null for broker broker export.
-     * @param fragments All the fragments need to execute.
+     * @param fragments      All the fragments need to execute.
      * @return true if enabling pipeline in the session variable and all the fragments can use pipeline,
      * otherwise false.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -943,12 +943,31 @@ public class PlanFragmentBuilder {
                                 case "TABLE_NAME":
                                     scanNode.setSchemaTable(constantOperator.getVarchar());
                                     break;
+                                case "BE_ID":
+                                    scanNode.setBeId(constantOperator.getBigint());
+                                    break;
+                                case "TABLE_ID":
+                                    scanNode.setTableId(constantOperator.getBigint());
+                                    break;
+                                case "PARTITION_ID":
+                                    scanNode.setPartitionId(constantOperator.getBigint());
+                                    break;
+                                case "TABLET_ID":
+                                    scanNode.setTabletId(constantOperator.getBigint());
+                                    break;
+                                case "TXN_ID":
+                                    scanNode.setTxnId(constantOperator.getBigint());
+                                    break;
                                 default:
                                     break;
                             }
                         }
                     }
                 }
+            }
+
+            if (scanNode.isBeSchemaTable()) {
+                scanNode.computeBeScanRanges();
             }
 
             context.getScanNodes().add(scanNode);

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -113,7 +113,11 @@ enum TSchemaTableType {
     SCH_VIEWS,
     SCH_TASKS,
     SCH_TASK_RUNS,
-    SCH_INVALID
+    SCH_VERBOSE_SESSION_VARIABLES,
+    SCH_BE_TABLETS,
+    SCH_BE_METRICS,
+    SCH_BE_TXNS,
+    SCH_BE_CONFIGS
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -303,6 +303,10 @@ struct TSchemaScanNode {
   9: optional i64 thread_id
   10: optional string user_ip   // deprecated
   11: optional Types.TUserIdentity current_user_ident   // to replace the user and user_ip
+  12: optional i64 table_id
+  13: optional i64 partition_id
+  14: optional i64 tablet_id
+  15: optional i64 txn_id
 }
 
 struct TOlapScanNode {


### PR DESCRIPTION
This PR backport BE related information schema tables including:

* 7a183a644 2023-02-27 | [Enhancement] Add PrivilegeType.OPERATE check to be_ prefixed tables (#18474) [Binglin Chang]
* 43e0793f1 2023-02-24 | [Enhancement] Add BE configs to information_schema (#18457) [Binglin Chang]
* 36929a865 2023-02-24 | [Enhancement] revert hiding of schema tables with be_ prefix (#18455) [Binglin Chang]
* 17bd98f84 2023-02-24 | [Enhancement] Add BE transactions information to information_schema (#18376) [Binglin Chang]
* 88b993cb9 2023-02-23 | [Enhancement] Add BE metrics to information_schema (#18325) [Binglin Chang]
* 4b0adb908 2023-02-22 | [Enhancement] Add BE tablets information to information schema (#18210) [Binglin Chang]

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
