### PR TITLE
[Enhancement] add `RequestBytesReadUncompressed` metric

### DIFF
--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -49,6 +49,7 @@ struct HdfsScanStats {
     // parquet only!
     // read & decode
     int64_t request_bytes_read = 0;
+    int64_t request_bytes_read_uncompressed = 0;
     int64_t level_decode_ns = 0;
     int64_t value_decode_ns = 0;
     int64_t page_read_ns = 0;

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -27,6 +27,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 
 void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* request_bytes_read = nullptr;
+    RuntimeProfile::Counter* request_bytes_read_uncompressed = nullptr;
     RuntimeProfile::Counter* level_decode_timer = nullptr;
     RuntimeProfile::Counter* value_decode_timer = nullptr;
     RuntimeProfile::Counter* page_read_timer = nullptr;
@@ -43,6 +44,8 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile* root = profile->runtime_profile;
     ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::UNIT);
     request_bytes_read = ADD_CHILD_COUNTER(root, "RequestBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
+    request_bytes_read_uncompressed =
+            ADD_CHILD_COUNTER(root, "RequestBytesReadUncompressed", TUnit::BYTES, kParquetProfileSectionPrefix);
 
     level_decode_timer = ADD_CHILD_TIMER(root, "LevelDecodeTime", kParquetProfileSectionPrefix);
     value_decode_timer = ADD_CHILD_TIMER(root, "ValueDecodeTime", kParquetProfileSectionPrefix);
@@ -56,6 +59,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
 
     COUNTER_UPDATE(request_bytes_read, _stats.request_bytes_read);
+    COUNTER_UPDATE(request_bytes_read_uncompressed, _stats.request_bytes_read_uncompressed);
     COUNTER_UPDATE(value_decode_timer, _stats.value_decode_ns);
     COUNTER_UPDATE(level_decode_timer, _stats.level_decode_ns);
     COUNTER_UPDATE(page_read_timer, _stats.page_read_ns);

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -103,6 +103,7 @@ Status ColumnChunkReader::_parse_page_header() {
     RETURN_IF_ERROR(_page_reader->next_header());
     size_t now = _page_reader->get_offset();
     _opts.stats->request_bytes_read += (now - off);
+    _opts.stats->request_bytes_read_uncompressed += (now - off);
 
     // The page num values will be used for late materialization before parsing page data,
     // so we set _num_values when parsing header.
@@ -156,7 +157,7 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
         _data.size = uncompressed_size;
         RETURN_IF_ERROR(_page_reader->read_bytes((const uint8_t**)&_data.data, _data.size));
     }
-
+    _opts.stats->request_bytes_read_uncompressed += uncompressed_size;
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -92,6 +92,7 @@ Status FileReader::_parse_footer() {
     }
 
     _scanner_ctx->stats->request_bytes_read += footer_size + 8;
+    _scanner_ctx->stats->request_bytes_read_uncompressed += footer_size + 8;
 
     tparquet::FileMetaData t_metadata;
     // deserialize footer

--- a/be/test/exec/parquet_scanner_test.cpp
+++ b/be/test/exec/parquet_scanner_test.cpp
@@ -221,7 +221,8 @@ class ParquetScannerTest : public ::testing::Test {
                 {"col_json_json_string", TypeDescriptor::create_json_type()},
                 {"issue_17693_c0", TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(TYPE_VARCHAR))},
                 {"issue_17822_c0", TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(TYPE_VARCHAR))},
-                {"nested_array_c0", TypeDescriptor::create_array_type(TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(TYPE_VARCHAR)))}};
+                {"nested_array_c0", TypeDescriptor::create_array_type(TypeDescriptor::create_array_type(
+                                            TypeDescriptor::from_logical_type(TYPE_VARCHAR)))}};
         SlotTypeDescInfoArray slot_infos;
         slot_infos.reserve(column_names.size());
         for (auto& name : column_names) {
@@ -335,9 +336,9 @@ class ParquetScannerTest : public ::testing::Test {
                                          test_exec_dir + "/test_data/parquet_data/issue_17693_2.parquet"};
         _issue_17822_file_names =
                 std::vector<std::string>{test_exec_dir + "/test_data/parquet_data/issue_17822.parquet"};
-        _nested_array_file_names = 
+        _nested_array_file_names =
                 std::vector<std::string>{test_exec_dir + "/test_data/parquet_data/nested_array_test1.parquet",
-                                        test_exec_dir + "/test_data/parquet_data/nested_array_test2.parquet"};
+                                         test_exec_dir + "/test_data/parquet_data/nested_array_test2.parquet"};
     }
 
 private:


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is to record, how many uncompressed bytes are used by parquet parser.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
