### PR TITLE
[Enhancement] print BE version info when BE crashed

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -51,6 +51,8 @@ static bool iequals(const std::string& a, const std::string& b) {
     return true;
 }
 
+size_t get_build_version(char* buffer, size_t max_size);
+
 // avoid to allocate extra memory
 static int print_unique_id(char* buffer, const TUniqueId& uid) {
     char buff[32];
@@ -84,17 +86,22 @@ static void dump_trace_info() {
         auto query_id = CurrentThread::current().query_id();
         auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
         char buffer[256] = {};
-        int res = sprintf(buffer, "query_id:");
+
+        // write build version
+        int res = get_build_version(buffer, sizeof(buffer));
+        [[maybe_unused]] auto wt = write(STDERR_FILENO, buffer, res);
+
+        res = sprintf(buffer, "query_id:");
         res = print_unique_id(buffer + res, query_id) + res;
         res = sprintf(buffer + res, ", ") + res;
         res = sprintf(buffer + res, "fragment_instance:") + res;
         res = print_unique_id(buffer + res, fragment_instance_id) + res;
         res = sprintf(buffer + res, "\n") + res;
-        [[maybe_unused]] auto wt = write(STDERR_FILENO, buffer, res);
+        wt = write(STDERR_FILENO, buffer, res);
         // dump memory usage
+        // copy trackers
         auto trackers = ExecEnv::GetInstance()->mem_trackers();
-        // copy tracker to add reference
-        for (auto tracker : trackers) {
+        for (const auto& tracker : trackers) {
             if (tracker) {
                 size_t len = tracker->debug_string(buffer, sizeof(buffer));
                 wt = write(STDERR_FILENO, buffer, len);

--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -71,6 +71,14 @@ std::string get_build_version(bool compact) {
     return ss.str();
 }
 
+size_t get_build_version(char* buffer, size_t max_size) {
+    size_t length = 0;
+    length = snprintf(buffer + length, max_size - length, "%s ", STARROCKS_VERSION) + length;
+    length = snprintf(buffer + length, max_size - length, "%s ", STARROCKS_BUILD_TYPE) + length;
+    length = snprintf(buffer + length, max_size - length, "(build %s)\n", STARROCKS_COMMIT_HASH) + length;
+    return length;
+}
+
 std::string get_short_version() {
     static std::string short_version(std::string(STARROCKS_VERSION) + "-" + STARROCKS_COMMIT_HASH);
     return short_version;

--- a/be/src/util/debug_util.h
+++ b/be/src/util/debug_util.h
@@ -44,6 +44,9 @@ std::string PrintTMetricKind(const TMetricKind::type& type);
 // This is used to set gflags build version
 std::string get_build_version(bool compact);
 
+// similar with std::string get_build_version(bool), but without allocate any memory from heap
+size_t get_build_version(char* buffer, size_t max_size);
+
 // Returns a string "<product version number> (<short build hash>)"
 std::string get_short_version();
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
print build version log when BE crashed, the log looks like:
```
UNKNOWN ASAN (build 3f707b3b63)
query_id:0e17cbb9-b715-11ed-b282-0242d9cc9872, fragment_instance:0e17cbb9-b715-11ed-b282-0242d
9cc9873
tracker:process consumption: 0
tracker:query_pool consumption: 0
tracker:load consumption: 0
tracker:metadata consumption: 2674959
tracker:tablet_metadata consumption: 1631864
tracker:rowset_metadata consumption: 1000439
tracker:segment_metadata consumption: 8000
tracker:column_metadata consumption: 34656
tracker:tablet_schema consumption: 36920
tracker:segment_zonemap consumption: 6720
tracker:short_key_index consumption: 0
tracker:column_zonemap_index consumption: 13440
tracker:ordinal_index consumption: 11424
tracker:bitmap_index consumption: 0
tracker:bloom_filter_index consumption: 0
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 0
tracker:update consumption: 0
tracker:chunk_allocator consumption: -20480
tracker:clone consumption: 0
tracker:consistency consumption: 0
*** Aborted at 1677553657 (unix time) try "date -d @1677553657" if you are using GNU date ***
PC: @          0xed47f2f starrocks::pipeline::OlapChunkSource::_read_chunk()
*** SIGSEGV (@0x3355) received by PID 704810 (TID 0x7fec9907d640) from PID 13141; stack trace: ***
    @         0x16a06bea google::(anonymous namespace)::FailureSignalHandler()
    @     0x7ff1b8fbb520 (unknown)
    @          0xed47f2f starrocks::pipeline::OlapChunkSource::_read_chunk()
    @          0xecc1935 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0xed028e2 _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlvE_clEv
    @          0xed082cc _ZSt13__invoke_implIvRZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @          0xed0816d _ZSt10__invoke_rIvRZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES8_E4typeEOS9_DpOSA_
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
