### PR TITLE
[Enhancement] Use conflict detection + shallow copy to avoid db lock when query plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -517,7 +517,9 @@ public class Alter {
         boolean needProcessOutsideDatabaseLock = false;
         String tableName = dbTableName.getTbl();
 
+        boolean isSynchronous = true;
         db.writeLock();
+        OlapTable olapTable;
         try {
             Table table = db.getTable(tableName);
             if (table == null) {
@@ -527,7 +529,7 @@ public class Alter {
             if (!table.isOlapOrLakeTable()) {
                 throw new DdlException("Do not support alter non-OLAP or non-LAKE table[" + tableName + "]");
             }
-            OlapTable olapTable = (OlapTable) table;
+            olapTable = (OlapTable) table;
 
             if (olapTable.getState() != OlapTableState.NORMAL) {
                 throw new DdlException(
@@ -537,8 +539,10 @@ public class Alter {
             if (currentAlterOps.hasSchemaChangeOp()) {
                 // if modify storage type to v2, do schema change to convert all related tablets to segment v2 format
                 schemaChangeHandler.process(alterClauses, db, olapTable);
+                isSynchronous = false;
             } else if (currentAlterOps.hasRollupOp()) {
                 materializedViewHandler.process(alterClauses, db, olapTable);
+                isSynchronous = false;
             } else if (currentAlterOps.hasPartitionOp()) {
                 Preconditions.checkState(alterClauses.size() == 1);
                 AlterClause alterClause = alterClauses.get(0);
@@ -621,7 +625,7 @@ public class Alter {
                 List<String> partitionNames = clause.getPartitionNames();
                 // currently, only in memory property could reach here
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY));
-                OlapTable olapTable = (OlapTable) db.getTable(tableName);
+                olapTable = (OlapTable) db.getTable(tableName);
                 if (olapTable.isLakeTable()) {
                     throw new DdlException("Lake table not support alter in_memory");
                 }
@@ -647,7 +651,7 @@ public class Alter {
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT));
 
-                OlapTable olapTable = (OlapTable) db.getTable(tableName);
+                olapTable = (OlapTable) db.getTable(tableName);
                 if (olapTable.isLakeTable()) {
                     throw new DdlException("Lake table not support alter in_memory or enable_persistent_index or write_quorum");
                 }
@@ -679,6 +683,10 @@ public class Alter {
                     throw new DdlException("Invalid alter operation: " + alterClause.getOpType());
                 }
             }
+        }
+
+        if (isSynchronous) {
+            olapTable.lastSchemaUpdateTime.set(System.currentTimeMillis());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -529,6 +529,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         }
 
         tbl.rebuildFullSchema();
+        tbl.lastSchemaUpdateTime.set(System.currentTimeMillis());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -786,6 +786,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         }
 
         tbl.setState(OlapTableState.NORMAL);
+        tbl.lastSchemaUpdateTime.set(System.currentTimeMillis());
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -114,6 +114,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.zip.Adler32;
 
@@ -213,6 +214,12 @@ public class OlapTable extends Table {
     // then binlog is available
     protected long binlogTxnId = -1;
 
+    // Record the alter, schema change, MV update time
+    public final AtomicLong lastSchemaUpdateTime = new AtomicLong(-1);
+    // Record the start and end time for data load version update phase
+    public final AtomicLong lastVersionUpdateStartTime = new AtomicLong(-1);
+    public final AtomicLong lastVersionUpdateEndTime = new AtomicLong(0);
+
     public OlapTable() {
         this(TableType.OLAP);
     }
@@ -272,6 +279,35 @@ public class OlapTable extends Table {
         this.indexes = indexes;
 
         this.tableProperty = null;
+    }
+
+    // Only Copy necessary metadata for query.
+    // We don't do deep copy, because which is very expensive;
+    public OlapTable copyOnlyForQuery() {
+        OlapTable olapTable = new OlapTable();
+        olapTable.id = this.id;
+        olapTable.name = this.name;
+        olapTable.fullSchema = Lists.newArrayList(this.fullSchema);
+        olapTable.nameToColumn = Maps.newHashMap(this.nameToColumn);
+        olapTable.relatedMaterializedViews = Sets.newHashSet(this.relatedMaterializedViews);
+        olapTable.state = this.state;
+        olapTable.indexNameToId = Maps.newHashMap(this.indexNameToId);
+        olapTable.indexIdToMeta = Maps.newHashMap(this.indexIdToMeta);
+        olapTable.keysType = this.keysType;
+        olapTable.partitionInfo = new PartitionInfo();
+        if (this.partitionInfo instanceof RangePartitionInfo) {
+            olapTable.partitionInfo = new RangePartitionInfo((RangePartitionInfo) this.partitionInfo);
+        } else if (this.partitionInfo instanceof SinglePartitionInfo) {
+            olapTable.partitionInfo = this.partitionInfo;
+        }
+        olapTable.defaultDistributionInfo = this.defaultDistributionInfo;
+        olapTable.idToPartition = Maps.newHashMap(this.idToPartition);
+        olapTable.nameToPartition = Maps.newHashMap(this.nameToPartition);
+        olapTable.baseIndexId = this.baseIndexId;
+        if (this.tableProperty != null) {
+            olapTable.tableProperty = this.tableProperty.copy();
+        }
+        return olapTable;
     }
 
     public BinlogConfig getCurBinlogConfig() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -75,9 +75,9 @@ public class RangePartitionInfo extends PartitionInfo {
     @SerializedName(value = "partitionColumns")
     private List<Column> partitionColumns = Lists.newArrayList();
     // formal partition id -> partition range
-    private Map<Long, Range<PartitionKey>> idToRange = Maps.newConcurrentMap();
+    private Map<Long, Range<PartitionKey>> idToRange = Maps.newHashMap();
     // temp partition id -> partition range
-    private Map<Long, Range<PartitionKey>> idToTempRange = Maps.newConcurrentMap();
+    private Map<Long, Range<PartitionKey>> idToTempRange = Maps.newHashMap();
 
     // partitionId -> serialized Range<PartitionKey>
     // because Range<PartitionKey> and PartitionKey can not be serialized by gson
@@ -99,6 +99,14 @@ public class RangePartitionInfo extends PartitionInfo {
     public RangePartitionInfo(List<Column> partitionColumns) {
         super(PartitionType.RANGE);
         this.partitionColumns = partitionColumns;
+        this.isMultiColumnPartition = partitionColumns.size() > 1;
+    }
+
+    public RangePartitionInfo(RangePartitionInfo other) {
+        super(other.type);
+        this.partitionColumns = Lists.newArrayList(other.partitionColumns);
+        this.idToRange = Maps.newHashMap(other.idToRange);
+        this.idToTempRange = Maps.newHashMap(other.idToTempRange);
         this.isMultiColumnPartition = partitionColumns.size() > 1;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -143,7 +143,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
     // not serialized field
     // record all materialized views based on this Table
     @SerializedName(value = "mvs")
-    private Set<MvId> relatedMaterializedViews;
+    protected Set<MvId> relatedMaterializedViews;
 
     public Table(TableType type) {
         this.type = type;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -35,6 +35,7 @@
 package com.starrocks.catalog;
 
 import com.clearspring.analytics.util.Lists;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -163,6 +164,18 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public TableProperty(Map<String, String> properties) {
         this.properties = properties;
+    }
+
+    public TableProperty copy() {
+        TableProperty newTableProperty = new TableProperty(Maps.newHashMap(this.properties));
+        try {
+            newTableProperty.gsonPostProcess();
+        } catch (IOException e) {
+            Preconditions.checkState(false, "gsonPostProcess shouldn't fail");
+        }
+        newTableProperty.hasDelete = this.hasDelete;
+        newTableProperty.hasForbitGlobalDict = this.hasDelete;
+        return newTableProperty;
     }
 
     public static boolean isSamePrefixProperties(Map<String, String> properties, String prefix) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -324,6 +324,7 @@ public class InsertOverwriteJobRunner {
                     LOG.error("table {} update colocation info failed after insert overwrite, {}.", tableId, e.getMessage());
                 }
 
+                targetTable.lastSchemaUpdateTime.set(System.currentTimeMillis());
             }
         } catch (Exception e) {
             LOG.warn("replace partitions failed when insert overwrite into dbId:{}, tableId:{}",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -14,7 +14,11 @@
 
 package com.starrocks.sql;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ResultSink;
 import com.starrocks.qe.ConnectContext;
@@ -42,6 +46,7 @@ import com.starrocks.thrift.TResultSinkType;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class StatementPlanner {
@@ -75,21 +80,15 @@ public class StatementPlanner {
             unLock(dbs);
         }
 
-        // 2. For only olap table queries, we have snapshot the olap table metadata, so we needn't db lock again
         boolean isOnlyOlapTableQueries = AnalyzerUtils.isOnlyHasOlapTables(stmt);
         if (isOnlyOlapTableQueries && stmt instanceof QueryStatement) {
-            dbs = null;
+            return planQuery(stmt, resultSinkType, session, true);
         }
 
         try {
             lock(dbs);
             if (stmt instanceof QueryStatement) {
-                QueryStatement queryStmt = (QueryStatement) stmt;
-                resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
-                ExecPlan plan = createQueryPlan(queryStmt.getQueryRelation(), session, resultSinkType);
-                setOutfileSink(queryStmt, plan);
-
-                return plan;
+                return planQuery(stmt, resultSinkType, session, false);
             } else if (stmt instanceof InsertStmt) {
                 return new InsertPlanner().plan((InsertStmt) stmt, session);
             } else if (stmt instanceof UpdateStmt) {
@@ -103,10 +102,27 @@ public class StatementPlanner {
         return null;
     }
 
-    public static ExecPlan createQueryPlan(Relation relation, ConnectContext session, TResultSinkType resultSinkType) {
+    private static ExecPlan planQuery(StatementBase stmt,
+                                      TResultSinkType resultSinkType,
+                                      ConnectContext session,
+                                      boolean isOnlyOlapTable) {
+        QueryStatement queryStmt = (QueryStatement) stmt;
+        resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
+        ExecPlan plan;
+        if (!isOnlyOlapTable) {
+            plan = createQueryPlan(queryStmt.getQueryRelation(), session, resultSinkType);
+        } else {
+            plan = createQueryPlanWithReTry(queryStmt, session, resultSinkType);
+        }
+        setOutfileSink(queryStmt, plan);
+        return plan;
+    }
+
+    private static ExecPlan createQueryPlan(Relation relation,
+                                            ConnectContext session,
+                                            TResultSinkType resultSinkType) {
         QueryRelation query = (QueryRelation) relation;
         List<String> colNames = query.getColumnOutputNames();
-
         //1. Build Logical plan
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         LogicalPlan logicalPlan;
@@ -127,7 +143,6 @@ public class StatementPlanner {
                     columnRefFactory);
         }
         try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("ExecPlanBuild")) {
-
             //3. Build fragment exec plan
             /*
              * SingleNodeExecPlan is set in TableQueryPlanAction to generate a single-node Plan,
@@ -139,6 +154,79 @@ public class StatementPlanner {
                     resultSinkType,
                     !session.getSessionVariable().isSingleNodeExecPlan());
         }
+    }
+
+
+    public static ExecPlan createQueryPlanWithReTry(QueryStatement queryStmt,
+                                                    ConnectContext session,
+                                                    TResultSinkType resultSinkType) {
+        QueryRelation query = queryStmt.getQueryRelation();
+        List<String> colNames = query.getColumnOutputNames();
+
+        //1. Build Logical plan
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        LogicalPlan logicalPlan;
+
+        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Transformer")) {
+            logicalPlan = new RelationTransformer(columnRefFactory, session).transformWithSelectLimit(query);
+        }
+
+        boolean isSchemaValid = true;
+        boolean isPartitionVersionConsistent = false;
+
+        // Because we don't hold db lock outer, if the olap table schema change, we need to regenerate the query plan
+        for (int i = 0; i < Config.max_query_retry_time; ++i) {
+            long planStartTime = System.currentTimeMillis();
+
+            Set<OlapTable> olapTables = Sets.newHashSet();
+            AnalyzerUtils.copyOlapTable(queryStmt, olapTables);
+
+            // Only need to re analyze and re transform when schema isn't valid
+            if (i > 0 && !isSchemaValid) {
+                Analyzer.analyze(queryStmt, session);
+                try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Transformer")) {
+                    logicalPlan = new RelationTransformer(columnRefFactory, session).transformWithSelectLimit(query);
+                }
+            }
+
+            OptExpression optimizedPlan;
+            try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Optimizer")) {
+                //2. Optimize logical plan and build physical plan
+                Optimizer optimizer = new Optimizer();
+                optimizedPlan = optimizer.optimize(
+                        session,
+                        logicalPlan.getRoot(),
+                        new PhysicalPropertySet(),
+                        new ColumnRefSet(logicalPlan.getOutputColumn()),
+                        columnRefFactory);
+            }
+            try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("ExecPlanBuild")) {
+                //3. Build fragment exec plan
+                /*
+                 * SingleNodeExecPlan is set in TableQueryPlanAction to generate a single-node Plan,
+                 * currently only used in Spark/Flink Connector
+                 * Because the connector sends only simple queries, it only needs to remove the output fragment
+                 */
+                // For only olap table queries, we need to lock db here.
+                // Because we need to ensure multi partition visible versions are consistent.
+                long buildFragmentStartTime = System.currentTimeMillis();
+                ExecPlan plan = PlanFragmentBuilder.createPhysicalPlan(
+                        optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
+                        resultSinkType,
+                        !session.getSessionVariable().isSingleNodeExecPlan());
+                isSchemaValid = olapTables.stream().noneMatch(t ->
+                        t.lastSchemaUpdateTime.get() > planStartTime);
+                isPartitionVersionConsistent = olapTables.stream().allMatch(t ->
+                        t.lastVersionUpdateEndTime.get() < buildFragmentStartTime &&
+                                t.lastVersionUpdateEndTime.get() >= t.lastVersionUpdateStartTime.get());
+                if (isSchemaValid && isPartitionVersionConsistent) {
+                    return plan;
+                }
+            }
+        }
+        Preconditions.checkState(false, "The tablet write operation update metadata " +
+                "take a long time");
+        return null;
     }
 
     // Lock all database before analyze

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -40,7 +40,6 @@ import com.starrocks.catalog.View;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
-import com.starrocks.common.io.DeepCopy;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
@@ -277,13 +276,7 @@ public class QueryAnalyzer {
                     }
 
                     if (table.isSupported()) {
-                        if (table.isOlapTable()) {
-                            // Copying the olap table meta to avoid the lock when plan query
-                            Table copied = DeepCopy.copyWithGson(table, OlapTable.class);
-                            tableRelation.setTable(copied);
-                        } else {
-                            tableRelation.setTable(table);
-                        }
+                        tableRelation.setTable(table);
                         return tableRelation;
                     } else {
                         throw unsupportedException("unsupported scan table type: " + table.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -72,6 +72,9 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
         }
         List<String> validDictCacheColumns = Lists.newArrayList();
         long maxPartitionVersionTime = -1;
+
+        table.lastVersionUpdateStartTime.set(System.currentTimeMillis());
+
         for (PartitionCommitInfo partitionCommitInfo : commitInfo.getIdToPartitionCommitInfo().values()) {
             long partitionId = partitionCommitInfo.getPartitionId();
             Partition partition = table.getPartition(partitionId);
@@ -135,6 +138,8 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             }
             maxPartitionVersionTime = Math.max(maxPartitionVersionTime, versionTime);
         }
+
+        table.lastVersionUpdateEndTime.set(System.currentTimeMillis());
         for (String column : validDictCacheColumns) {
             IDictManager.getInstance().updateGlobalDict(tableId, column, maxPartitionVersionTime);
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
When there are a lot of partitions and tablets, the olaptable deep copy need a lot of time. mainly for idToPartition and partitionInfo, in fact, for idToPartition and partitionInfo, shallow copy is enough.

After this PR, in the ReplayFromDumpTest.testManyPartitions UT, the copt time from 3s to 3ms.


**1， we use conflict detection to ensure multi partition visible versions are consistent**

**2， we use conflict detection to check the schema change when query plan**

**3， we use shallow copy to avoid the ConcurrentModificationException of olap table maps**

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
