### PR TITLE
[BugFix] BE maybe crash when we delete all records in PrimaryKey table with persistent index in branch-2.5+

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3373,7 +3373,7 @@ Status PersistentIndex::_merge_compaction() {
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
     RETURN_IF_ERROR(writer->init(idx_file_path, _version, true));
     RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage, _size, false));
-    // _usage should be equal to total_kv_size. But they may be differen because of compatibility problemw when we upgrade
+    // _usage should be equal to total_kv_size. But they may be differen because of compatibility problem when we upgrade
     // from old version and _usage maybe not accurate.
     // so we use total_kv_size to correct the _usage.
     if (_usage != writer->total_kv_size()) {

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3155,8 +3155,114 @@ static Status merge_shard_kvs(size_t key_size, std::vector<KVRef>& l0_kvs, std::
     return Status::OK();
 }
 
+template <size_t KeySize>
+Status merge_shard_kvs_fixed_len_with_delete(std::vector<KVRef>& l0_kvs, std::vector<std::vector<KVRef>>& l1_kvs,
+                                             size_t estimated_size, std::vector<KVRef>& ret) {
+    phmap::flat_hash_set<KVRef, KVRefHash, KVRefEq<KeySize>> kvs_set;
+    kvs_set.reserve(estimated_size);
+    DCHECK(!l1_kvs.empty());
+    for (size_t i = 0; i < l1_kvs.size(); i++) {
+        for (const auto& kv : l1_kvs[i]) {
+            auto [it, inserted] = kvs_set.emplace(kv);
+            if (!inserted) {
+                DCHECK(it->hash == kv.hash) << "upsert kv in set, hash should be the same";
+                kvs_set.erase(it);
+                kvs_set.emplace(kv);
+            }
+        }
+    }
+    for (const auto& kv : l0_kvs) {
+        auto [it, inserted] = kvs_set.emplace(kv);
+        if (!inserted) {
+            DCHECK(it->hash == kv.hash) << "upsert kv in set, hash should be the same";
+            // TODO: find a way to modify iterator directly, currently just erase then re-insert
+            // it->kv_pos = kv.kv_pos;
+            kvs_set.erase(it);
+            kvs_set.emplace(kv);
+        }
+    }
+    ret.reserve(ret.size() + kvs_set.size());
+    for (const auto& kv : kvs_set) {
+        ret.emplace_back(kv);
+    }
+    return Status::OK();
+}
+
+Status merge_shard_kvs_var_len_with_delete(std::vector<KVRef>& l0_kvs, std::vector<std::vector<KVRef>>& l1_kvs,
+                                           size_t estimate_size, std::vector<KVRef>& ret) {
+    phmap::flat_hash_set<KVRef, KVRefHash, KVRefEq<0>> kvs_set;
+    kvs_set.reserve(estimate_size);
+    DCHECK(!l1_kvs.empty());
+    for (size_t i = 0; i < l1_kvs.size(); i++) {
+        for (const auto& kv : l1_kvs[i]) {
+            auto [it, inserted] = kvs_set.emplace(kv);
+            if (!inserted) {
+                DCHECK(it->hash == kv.hash) << "upsert kv in set, hash should be the same";
+                kvs_set.erase(it);
+                kvs_set.emplace(kv);
+            }
+        }
+    }
+    for (auto& kv : l0_kvs) {
+        if (auto [it, inserted] = kvs_set.emplace(kv); !inserted) {
+            DCHECK(it->hash == kv.hash) << "upsert kv in set, hash should be the same";
+            // TODO: find a way to modify iterator directly, currently just erase then re-insert
+            // it->kv_pos = kv.kv_pos;
+            kvs_set.erase(it);
+            kvs_set.emplace(kv);
+        }
+    }
+    ret.reserve(ret.size() + kvs_set.size());
+    for (const auto& kv : kvs_set) {
+        ret.emplace_back(kv);
+    }
+    return Status::OK();
+}
+
+static Status merge_shard_kvs_with_delete(size_t key_size, std::vector<KVRef>& l0_kvs,
+                                          std::vector<std::vector<KVRef>>& l1_kvs, size_t estimated_size,
+                                          std::vector<KVRef>& ret) {
+    if (key_size > 0) {
+#define CASE_SIZE(s) \
+    case s:          \
+        return merge_shard_kvs_fixed_len_with_delete<s>(l0_kvs, l1_kvs, estimated_size, ret);
+#define CASE_SIZE_8(s) \
+    CASE_SIZE(s)       \
+    CASE_SIZE(s + 1)   \
+    CASE_SIZE(s + 2)   \
+    CASE_SIZE(s + 3)   \
+    CASE_SIZE(s + 4)   \
+    CASE_SIZE(s + 5)   \
+    CASE_SIZE(s + 6)   \
+    CASE_SIZE(s + 7)
+        switch (key_size) {
+            CASE_SIZE_8(1)
+            CASE_SIZE_8(9)
+            CASE_SIZE_8(17)
+            CASE_SIZE_8(25)
+            CASE_SIZE_8(33)
+            CASE_SIZE_8(41)
+            CASE_SIZE_8(49)
+            CASE_SIZE_8(57)
+            CASE_SIZE_8(65)
+            CASE_SIZE_8(73)
+            CASE_SIZE_8(81)
+            CASE_SIZE_8(89)
+            CASE_SIZE_8(97)
+            CASE_SIZE_8(105)
+            CASE_SIZE_8(113)
+            CASE_SIZE_8(121)
+#undef CASE_SIZE_8
+#undef CASE_SIZE
+        }
+    } else if (key_size == 0) {
+        return merge_shard_kvs_var_len_with_delete(l0_kvs, l1_kvs, estimated_size, ret);
+    }
+    return Status::OK();
+}
+
 Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer, int l1_start_idx, int l1_end_idx,
-                                                   size_t total_usage, size_t total_size) {
+                                                   size_t total_usage, size_t total_size, bool keep_delete) {
     for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
         auto [l0_shard_offset, l0_shard_size] = shard_info;
         const auto [nshard, npage_hint] = MutableIndex::estimate_nshard_and_npage(total_usage);
@@ -3232,8 +3338,13 @@ Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer,
             for (size_t i = 0; i < merge_l1_num; i++) {
                 l1_kvs[i].swap(l1_kvs_by_shard[i][shard_idx]);
             }
-            RETURN_IF_ERROR(
-                    merge_shard_kvs(key_size, l0_kvs_by_shard[shard_idx], l1_kvs, estimate_size_per_shard, kvs));
+            if (keep_delete) {
+                RETURN_IF_ERROR(merge_shard_kvs_with_delete(key_size, l0_kvs_by_shard[shard_idx], l1_kvs,
+                                                            estimate_size_per_shard, kvs));
+            } else {
+                RETURN_IF_ERROR(
+                        merge_shard_kvs(key_size, l0_kvs_by_shard[shard_idx], l1_kvs, estimate_size_per_shard, kvs));
+            }
             // write shard
             RETURN_IF_ERROR(writer->write_shard(key_size, npage_hint, nbucket, kvs));
             // clear shard
@@ -3261,7 +3372,7 @@ Status PersistentIndex::_merge_compaction() {
     const std::string idx_file_path =
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
     RETURN_IF_ERROR(writer->init(idx_file_path, _version, true));
-    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage, _size));
+    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage, _size, false));
     // _usage should be equal to total_kv_size. But they may be differen because of compatibility problemw when we upgrade
     // from old version and _usage maybe not accurate.
     // so we use total_kv_size to correct the _usage.
@@ -3280,14 +3391,15 @@ Status PersistentIndex::_merge_compaction_advance() {
     int merge_l1_start_idx = _l1_vec.size() - config::max_tmp_l1_num;
     int merge_l1_end_idx = _l1_vec.size();
     LOG(INFO) << "merge compaction advance, start_idx: " << merge_l1_start_idx << " end_idx: " << merge_l1_end_idx;
+    bool keep_delete = (merge_l1_start_idx != 0);
     size_t total_usage = _l0->memory_usage();
     size_t total_size = _l0->size();
     for (int i = merge_l1_start_idx; i < merge_l1_end_idx; i++) {
         total_usage += _l1_vec[i]->total_usage();
         total_size += _l1_vec[i]->total_size();
     }
-    RETURN_IF_ERROR(
-            _merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx, total_usage, total_size));
+    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx, total_usage,
+                                               total_size, keep_delete));
     RETURN_IF_ERROR(writer->finish());
     std::vector<std::unique_ptr<ImmutableIndex>> new_l1_vec;
     std::vector<int> new_l1_merged_num;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -586,7 +586,7 @@ private:
     Status _flush_l0();
 
     Status _merge_compaction_internal(ImmutableIndexWriter* writer, int l1_start_idx, int l1_end_idx,
-                                      size_t total_usage, size_t total_size);
+                                      size_t total_usage, size_t total_size, bool keep_delete);
     Status _merge_compaction_advance();
     // merge l0 and l1 into new l1, then clear l0
     Status _merge_compaction();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/18616

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This bug is introduced by the pr(https://github.com/StarRocks/starrocks/pull/15729) which enable flush persistent index in advance.

If we delete a record and we will keep the record which value is NullIndexValue. In following `_merge_compaction`, we will merge them and skip the old record if new record value is NullIndexValue. If we import a lot of data at once, we will select some tmp l1 file do merge compaction in advance and the delete operation in these files will be skip, but there are maybe some record in older l1 files which should be delete. So the delete operation will lost in merge compaction advance.  In the following merge compaction, we will create an empty shard if all records in this shard are delete, but we maybe read some expired record which should be delete which will cause BE crash.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
