### PR TITLE
[Enhancement] avoid duplicated local shuffle of lake table

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -113,10 +113,10 @@ public:
 
     virtual Status init(ObjectPool* pool, RuntimeState* state) { return Status::OK(); }
 
-    const std::vector<ExprContext*>& bucket_exprs() const { return _bucket_exprs; }
+    const std::vector<ExprContext*>& partition_exprs() const { return _partition_exprs; }
 
 protected:
-    std::vector<ExprContext*> _bucket_exprs;
+    std::vector<ExprContext*> _partition_exprs;
 };
 using DataSourceProviderPtr = std::unique_ptr<DataSourceProvider>;
 

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -110,6 +110,13 @@ public:
     virtual bool accept_empty_scan_ranges() const { return true; }
 
     virtual bool stream_data_source() const { return false; }
+
+    virtual Status init(ObjectPool* pool, RuntimeState* state) { return Status::OK(); }
+
+    const std::vector<ExprContext*>& bucket_exprs() const { return _bucket_exprs; }
+
+protected:
+    std::vector<ExprContext*> _bucket_exprs;
 };
 using DataSourceProviderPtr = std::unique_ptr<DataSourceProvider>;
 

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -153,6 +153,8 @@ public:
 
     DataSourcePtr create_data_source(const TScanRange& scan_range) override;
 
+    Status init(ObjectPool* pool, RuntimeState* state) override;
+
 protected:
     ConnectorScanNode* _scan_node;
     const TLakeScanNode _t_lake_scan_node;
@@ -611,6 +613,17 @@ LakeDataSourceProvider::LakeDataSourceProvider(ConnectorScanNode* scan_node, con
 
 DataSourcePtr LakeDataSourceProvider::create_data_source(const TScanRange& scan_range) {
     return std::make_unique<LakeDataSource>(this, scan_range);
+}
+
+Status LakeDataSourceProvider::init(ObjectPool* pool, RuntimeState* state) {
+    if (_t_lake_scan_node.__isset.bucket_exprs) {
+        const auto& bucket_exprs = _t_lake_scan_node.bucket_exprs;
+        _bucket_exprs.resize(bucket_exprs.size());
+        for (int i = 0; i < bucket_exprs.size(); ++i) {
+            RETURN_IF_ERROR(Expr::create_expr_tree(pool, bucket_exprs[i], &_bucket_exprs[i], state));
+        }
+    }
+    return Status::OK();
 }
 
 // ================================

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -618,9 +618,9 @@ DataSourcePtr LakeDataSourceProvider::create_data_source(const TScanRange& scan_
 Status LakeDataSourceProvider::init(ObjectPool* pool, RuntimeState* state) {
     if (_t_lake_scan_node.__isset.bucket_exprs) {
         const auto& bucket_exprs = _t_lake_scan_node.bucket_exprs;
-        _bucket_exprs.resize(bucket_exprs.size());
+        _partition_exprs.resize(bucket_exprs.size());
         for (int i = 0; i < bucket_exprs.size(); ++i) {
-            RETURN_IF_ERROR(Expr::create_expr_tree(pool, bucket_exprs[i], &_bucket_exprs[i], state));
+            RETURN_IF_ERROR(Expr::create_expr_tree(pool, bucket_exprs[i], &_partition_exprs[i], state));
         }
     }
     return Status::OK();

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -147,6 +147,7 @@ ConnectorScanNode::~ConnectorScanNode() {
 
 Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ScanNode::init(tnode, state));
+    RETURN_IF_ERROR(_data_source_provider->init(_pool, state));
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -51,7 +51,7 @@ OperatorPtr ConnectorScanOperatorFactory::do_create(int32_t dop, int32_t driver_
 const std::vector<ExprContext*>& ConnectorScanOperatorFactory::partition_exprs() const {
     auto* connector_scan_node = down_cast<ConnectorScanNode*>(_scan_node);
     auto* provider = connector_scan_node->data_source_provider();
-    return provider->bucket_exprs();
+    return provider->partition_exprs();
 }
 
 // ==================== ConnectorScanOperator ====================

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -48,6 +48,12 @@ OperatorPtr ConnectorScanOperatorFactory::do_create(int32_t dop, int32_t driver_
     return std::make_shared<ConnectorScanOperator>(this, _id, driver_sequence, dop, _scan_node);
 }
 
+const std::vector<ExprContext*>& ConnectorScanOperatorFactory::partition_exprs() const {
+    auto* connector_scan_node = down_cast<ConnectorScanNode*>(_scan_node);
+    auto* provider = connector_scan_node->data_source_provider();
+    return provider->bucket_exprs();
+}
+
 // ==================== ConnectorScanOperator ====================
 
 ConnectorScanOperator::ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, int32_t dop,

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -45,6 +45,7 @@ public:
     ActiveInputSet& get_active_inputs() { return _active_inputs; }
 
     TPartitionType::type partition_type() const override { return TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED; }
+    const std::vector<ExprContext*>& partition_exprs() const override;
 
 private:
     // TODO: refactor the OlapScanContext, move them into the context

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -772,6 +772,10 @@ public class OlapScanNode extends ScanNode {
             if (!olapTable.hasDelete()) {
                 msg.lake_scan_node.setUnused_output_column_name(unUsedOutputStringColumns);
             }
+
+            if (!bucketExprs.isEmpty()) {
+                msg.lake_scan_node.setBucket_exprs(Expr.treesToThrift(bucketExprs));
+            }
         } else { // If you find yourself changing this code block, see also the above code block, i.e, if (olapTable.isLakeTable) { ... }.
             msg.node_type = TPlanNodeType.OLAP_SCAN_NODE;
             msg.olap_scan_node =

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -468,6 +468,7 @@ struct TLakeScanNode {
   // which columns only be used to filter data in the stage of scan data
   10: optional list<string> unused_output_column_name
   11: optional list<string> sort_key_column_names
+  12: optional list<Exprs.TExpr> bucket_exprs
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18388 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Optimization of duplicated local shuffle removal has been done in https://github.com/StarRocks/starrocks/pull/15268, while the `ConnectorScanOperator` has not. In this PR, this optimization is also done in lake table.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
