### PR TITLE
[BugFix] Fix inconsistent column count bug in TransPartitionProcNode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/TransPartitionProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/TransPartitionProcNode.java
@@ -46,7 +46,6 @@ public class TransPartitionProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("PartitionId")
             .add("CommittedVersion")
-            .add("CommittedVersionHash")
             .build();
 
     private long dbId;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18320 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Title has an extra useless version hash column, which will cause malformed package error.

`show proc "/transactions/dbid/finished/tableid/partitionid";`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
