### PR TITLE
[Enhancement] optimize storage medium infer when having mixed types

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DataProperty.java
@@ -38,6 +38,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.TimeUtils;
@@ -97,11 +98,16 @@ public class DataProperty implements Writable {
 
         Preconditions.checkState(mediumSet.size() <= 2, "current medium set: " + mediumSet);
         TStorageMedium m = TStorageMedium.SSD;
-        // If the storage paths reported by all the backends all have storage medium type HDD,
-        // we infer that user wants to create a table or partition with storage_medium=HDD when not explicitly
-        // specify the storage_medium property, otherwise it's SSD
+        // When storage_medium property is not explicitly specified on creating table, we infer the storage medium type
+        // based on the types of storage paths reported by backends. Here is the rules,
+        //   1. If the storage paths reported by all the backends all have storage medium type HDD,
+        //      we infer that user wants to create a table or partition with storage_medium=HDD.
+        //   2. If the reported storage paths have both SSD type and HDD type, and storage cool down feature is
+        //      not used, we also infer with HDD type.
+        //   3. In other cases, it's SSD type.
         if (mediumSet.size() == 0 ||
-                (mediumSet.size() == 1 && mediumSet.iterator().next() == TStorageMedium.HDD)) {
+                (mediumSet.size() == 1 && mediumSet.iterator().next() == TStorageMedium.HDD) ||
+                (mediumSet.size() == 2 && Config.tablet_sched_storage_cooldown_second < 0)) {
             m = TStorageMedium.HDD;
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18653

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When storage_medium property is not explicitly specified on creating table, we infer the storage medium type
based on the types of storage paths reported by backends. Here is the rules,
   1. If the storage paths reported by all the backends all have storage medium type HDD,
      we infer that user wants to create a table or partition with storage_medium=HDD.
   2. If the reported storage paths have both SSD type and HDD type, and storage cool down feature is
      not used, we also infer with HDD type.
   3. In other cases, it's SSD type.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
