### PR TITLE
[BugFix] Fix Backend get stuck on startup

### DIFF
--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -31,7 +31,9 @@ CurrentThread::~CurrentThread() {
 
 starrocks::MemTracker* CurrentThread::mem_tracker() {
     if (UNLIKELY(tls_mem_tracker == nullptr)) {
-        tls_mem_tracker = ExecEnv::GetInstance()->process_mem_tracker();
+        if (ExecEnv::is_init()) {
+            tls_mem_tracker = ExecEnv::GetInstance()->process_mem_tracker();
+        }
     }
     return tls_mem_tracker;
 }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -138,8 +138,15 @@ static int64_t calc_max_consistency_memory(int64_t process_mem_limit) {
     return std::min<int64_t>(limit, process_mem_limit * percent / 100);
 }
 
+bool ExecEnv::_is_init = false;
+
 Status ExecEnv::init(ExecEnv* env, const std::vector<StorePath>& store_paths) {
+    DeferOp op([]() { ExecEnv::_is_init = true; });
     return env->_init(store_paths);
+}
+
+bool ExecEnv::is_init() {
+    return _is_init;
 }
 
 Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -106,6 +106,7 @@ class ExecEnv {
 public:
     // Initial exec environment. must call this to init all
     static Status init(ExecEnv* env, const std::vector<StorePath>& store_paths);
+    static bool is_init();
     static void destroy(ExecEnv* exec_env);
 
     /// Returns the first created exec env instance. In a normal starrocks, this is
@@ -240,6 +241,7 @@ private:
     Status _init_storage_page_cache();
 
 private:
+    static bool _is_init;
     std::vector<StorePath> _store_paths;
     // Leave protected so that subclasses can override
     ExternalScanContextMgr* _external_scan_context_mgr = nullptr;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18665

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Here is the calling stack:

```
Thread 1 (Thread 0x7f5382288b80 (LWP 42202) "starrocks_be"):
#0  0x00007f53804a0e29 in syscall () from /lib64/libc.so.6
#1  0x00000000084a3594 in __cxxabiv1::__cxa_guard_acquire (g=g@entry=0x86b3a60 <guard variable for starrocks::ExecEnv::GetInstance()::s_exec_env>) at ../../../../libstdc++-v3/libsupc++/guard.cc:302
#2  0x00000000055dc11e in starrocks::ExecEnv::GetInstance () at ../src/runtime/exec_env.h:115
#3  starrocks::CurrentThread::mem_tracker () at ../src/runtime/current_thread.cpp:34
#4  0x0000000005619f2e in std::function<starrocks::MemTracker* ()>::operator()() const (this=<optimized out>) at /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
#5  starrocks::CurrentThread::MemCacheManager::commit (is_ctx_shift=false, this=<optimized out>) at ../src/runtime/current_thread.h:102
#6  starrocks::CurrentThread::MemCacheManager::consume (size=1280, this=<optimized out>) at ../src/runtime/current_thread.h:68
#7  starrocks::CurrentThread::mem_consume (size=1280, this=<optimized out>) at ../src/runtime/current_thread.h:200
#8  my_calloc (n=1, size=<optimized out>) at ../src/service/mem_hook.cpp:364
#9  0x00007f53803e1ec4 in __new_exitfn () from /lib64/libc.so.6
#10 0x00007f53803e1f49 in __cxa_atexit () from /lib64/libc.so.6
#11 0x00000000055dc349 in starrocks::ExecEnv::GetInstance () at ../src/runtime/exec_env.h:115
#12 starrocks::ExecEnv::GetInstance () at ../src/runtime/exec_env.h:114
#13 starrocks::CurrentThread::mem_tracker () at ../src/runtime/current_thread.cpp:34
#14 0x0000000005617a0e in std::function<starrocks::MemTracker* ()>::operator()() const (this=<optimized out>) at /home/disk5/sr-deps/toolchain/installed/gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622
#15 starrocks::CurrentThread::MemCacheManager::commit (is_ctx_shift=false, this=<optimized out>) at ../src/runtime/current_thread.h:102
#16 starrocks::CurrentThread::MemCacheManager::consume (size=65536, this=<optimized out>) at ../src/runtime/current_thread.h:68
#17 starrocks::CurrentThread::mem_consume (size=65536, this=<optimized out>) at ../src/runtime/current_thread.h:200
#18 my_malloc (size=size@entry=57400) at ../src/service/mem_hook.cpp:297
#19 0x0000000006600c58 in butil::FlatMap<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bvar::VarEntry, butil::DefaultHasher<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, butil::DefaultEqualTo<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, false>::init (this=this@entry=0x7f537ec54b48, nbucket=nbucket@entry=1024, load_factor=load_factor@entry=80) at ../src/butil/containers/flat_map_inl.h:337
#20 0x00000000065fd360 in bvar::VarMapWithLock::VarMapWithLock (this=0x7f537ec54b48) at ../src/bvar/variable.cpp:82
#21 bvar::init_var_maps () at ../src/bvar/variable.cpp:99
#22 0x00007f538077c20b in __pthread_once_slow () from /lib64/libpthread.so.0
#23 0x00000000065fd8c1 in bvar::get_var_maps () at ../src/bvar/variable.cpp:115
#24 bvar::get_var_map (name=...) at ../src/bvar/variable.cpp:120
#25 bvar::Variable::expose_impl (this=this@entry=0x86b6d20 <starrocks::g_publish_latency+384>, prefix=..., name=..., display_filter=bvar::DISPLAY_ON_ALL) at ../src/bvar/variable.cpp:157
#26 0x0000000003205b03 in bvar::detail::WindowBase<bvar::IntRecorder, (bvar::SeriesFrequency)1>::expose_impl (this=0x86b6d20 <starrocks::g_publish_latency+384>, prefix=..., name=..., display_filter=<optimized out>) at /home/disk5/sr-deps/thirdparty-re2/installed/include/bvar/window.h:147
#27 0x00000000065f56a8 in bvar::Variable::expose_as (display_filter=bvar::DISPLAY_ON_ALL, name=..., prefix=..., this=0x86b6d20 <starrocks::g_publish_latency+384>) at ../src/bvar/variable.h:153
#28 bvar::LatencyRecorder::expose (this=this@entry=0x86b6ba0 <starrocks::g_publish_latency>, prefix1=..., prefix2=...) at ../src/bvar/latency_recorder.cpp:210
#29 0x000000000321046d in bvar::LatencyRecorder::LatencyRecorder (prefix2=..., prefix1=..., this=0x86b6ba0 <starrocks::g_publish_latency>) at /home/disk5/sr-deps/thirdparty-re2/installed/include/bvar/latency_recorder.h:89
#30 __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at ../src/agent/publish_version.cpp:36
#31 _GLOBAL__sub_I__ZN9starrocks17g_publish_latencyE () at ../src/agent/publish_version.cpp:208
#32 0x00000000085523bd in __libc_csu_init ()
#33 0x00007f53803ca4e5 in __libc_start_main () from /lib64/libc.so.6
#34 0x00000000031cd029 in _start ()
```

To better illustrate, Here is a small example to reproduce this problem

```cpp
#include <iostream>

class MemTracker;

class ExecEnv {
public:
    ExecEnv();
    static ExecEnv* get_instance() {
        static ExecEnv exec_env;
        return &exec_env;
    }
    MemTracker* mem_tracker() { return _mem_tracker; }

private:
    MemTracker* _mem_tracker;
};

class MemTracker {
public:
    int64_t value = 0;
    void update(size_t size) { value += size; }
};

void* operator new(size_t size) {
    std::cout << "Allocating " << size << " bytes of memory." << std::endl;
    ExecEnv::get_instance()->mem_tracker()->update(size);
    return alloca(size);
}

ExecEnv::ExecEnv() : _mem_tracker(new MemTracker()) {}

int64_t* data;

int main() {
    data = new int64_t[1];
    return 0;
}
```

Here is the stack

```
#0  0x00007fcfb1ac3387 in raise () from /lib64/libc.so.6
>>> bt 30
#0  0x00007fcfb1ac3387 in raise () from /lib64/libc.so.6
#1  0x00007fcfb1ac4a78 in abort () from /lib64/libc.so.6
#2  0x00007fcfb210a63c in __gnu_cxx::__verbose_terminate_handler () at ../../../../libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x00007fcfb2115886 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
#4  0x00007fcfb2114969 in __cxa_call_terminate (ue_header=ue_header@entry=0x1e3ec80) at ../../../../libstdc++-v3/libsupc++/eh_call.cc:54
#5  0x00007fcfb21152a1 in __cxxabiv1::__gxx_personality_v0 (version=<optimized out>, actions=6, exception_class=5138137972254386944, ue_header=0x1e3ec80, context=<optimized out>) at ../../../../libstdc++-v3/libsupc++/eh_personality.cc:685
#6  0x00007fcfb1e6a8e3 in ?? () from /lib64/libgcc_s.so.1
#7  0x00007fcfb1e6ac7b in _Unwind_RaiseException () from /lib64/libgcc_s.so.1
#8  0x00007fcfb2115b78 in __cxxabiv1::__cxa_throw (obj=obj@entry=0x1e3eca0, tinfo=0x7fcfb2430ae0 <typeinfo for __gnu_cxx::recursive_init_error>, dest=0x7fcfb2115e30 <__gnu_cxx::recursive_init_error::~recursive_init_error()>) at ../../../../libstdc++-v3/libsupc++/eh_throw.cc:90
#9  0x00007fcfb210a24c in __cxxabiv1::throw_recursive_init_exception () at ../../../../libstdc++-v3/libsupc++/guard.cc:219
#10 __cxxabiv1::acquire (g=0x204470 <guard variable for ExecEnv::get_instance()::exec_env>) at ../../../../libstdc++-v3/libsupc++/guard.cc:236
#11 __cxxabiv1::__cxa_guard_acquire (g=0x204470 <guard variable for ExecEnv::get_instance()::exec_env>) at ../../../../libstdc++-v3/libsupc++/guard.cc:345
#12 0x0000000000201ef9 in ExecEnv::get_instance () at main.cpp:9
#13 0x0000000000201dde in operator new (size=8) at main.cpp:26
#14 0x0000000000201e49 in ExecEnv::ExecEnv (this=0x204468 <ExecEnv::get_instance()::exec_env>) at main.cpp:30
#15 0x0000000000201f12 in ExecEnv::get_instance () at main.cpp:9
#16 0x0000000000201dde in operator new (size=8) at main.cpp:26
#17 0x0000000000201e77 in main () at main.cpp:35
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
