### PR TITLE
[Feature] Cleanup the expired and overcapacity binlog

### DIFF
--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -25,17 +25,18 @@ RowsetSharedPtr DupKeyRowsetFetcher::get_rowset(int64_t rowset_id) {
     return _tablet.get_inc_rowset_by_version(Version(rowset_id, rowset_id));
 }
 
-BinlogManager::BinlogManager(int64_t _tablet_id, std::string path, int64_t max_file_size, int32_t max_page_size,
+BinlogManager::BinlogManager(int64_t tablet_id, std::string path, int64_t max_file_size, int32_t max_page_size,
                              CompressionTypePB compression_type, std::shared_ptr<RowsetFetcher> rowset_fetcher)
-        : _tablet_id(_tablet_id),
+        : _tablet_id(tablet_id),
           _path(std::move(path)),
           _max_file_size(max_file_size),
           _max_page_size(max_page_size),
           _compression_type(compression_type),
-          _rowset_fetcher(rowset_fetcher) {}
+          _rowset_fetcher(rowset_fetcher),
+          _unused_binlog_file_ids(UINT64_MAX) {}
 
 BinlogManager::~BinlogManager() {
-    std::lock_guard lock(_meta_lock);
+    std::unique_lock lock(_meta_lock);
     if (_active_binlog_writer != nullptr) {
         _active_binlog_writer->close(true);
         _active_binlog_writer.reset();
@@ -47,9 +48,9 @@ StatusOr<BinlogBuilderParamsPtr> BinlogManager::begin_ingestion(int64_t version)
     DCHECK_EQ(-1, _ingestion_version);
 
     std::shared_lock meta_lock(_meta_lock);
-    if (!_binlog_file_metas.empty()) {
-        BinlogFileMetaPBPtr file_meta = _binlog_file_metas.rbegin()->second;
-        int64_t max_version = file_meta->end_version();
+    if (!_alive_binlog_files.empty()) {
+        BinlogFilePtr binlog_file = _alive_binlog_files.rbegin()->second;
+        int64_t max_version = binlog_file->file_meta()->end_version();
         if (max_version >= version) {
             VLOG(3) << "The version already existed in binlog, tablet: " << _tablet_id
                     << ", max version: " << max_version << ", new version: " << version;
@@ -65,8 +66,8 @@ StatusOr<BinlogBuilderParamsPtr> BinlogManager::begin_ingestion(int64_t version)
     params->compression_type = _compression_type;
     params->start_file_id = _next_file_id;
     if (_active_binlog_writer != nullptr) {
-        params->active_file_meta = _binlog_file_metas.rbegin()->second;
-        params->active_file_writer.swap(_active_binlog_writer);
+        params->active_file_meta = _alive_binlog_files.rbegin()->second->file_meta();
+        params->active_file_writer = _active_binlog_writer;
     }
     return params;
 }
@@ -114,10 +115,11 @@ void BinlogManager::_apply_build_result(BinlogBuildResult* result) {
     std::unique_lock lock(_meta_lock);
     for (auto& meta : result->metas) {
         int128_t lsn = BinlogUtil::get_lsn(meta->start_version(), meta->start_seq_id());
-        auto it = _binlog_file_metas.find(lsn);
-        bool override_meta = it != _binlog_file_metas.end();
+        auto it = _alive_binlog_files.find(lsn);
+        bool override_meta = it != _alive_binlog_files.end();
+        BinlogFilePtr binlog_file = it->second;
         if (override_meta) {
-            BinlogFileMetaPBPtr& old_file_meta = it->second;
+            BinlogFileMetaPBPtr& old_file_meta = binlog_file->file_meta();
             std::unordered_set<int64_t> old_rowsets;
             for (auto rowset_id : old_file_meta->rowsets()) {
                 old_rowsets.emplace(rowset_id);
@@ -125,29 +127,181 @@ void BinlogManager::_apply_build_result(BinlogBuildResult* result) {
 
             for (auto rowset_id : meta->rowsets()) {
                 if (old_rowsets.count(rowset_id) == 0) {
-                    if (_rowset_count_map.count(rowset_id) == 0) {
-                        _total_rowset_disk_size += _rowset_fetcher->get_rowset(rowset_id)->data_disk_size();
+                    if (_alive_rowset_count_map.count(rowset_id) == 0) {
+                        _total_alive_rowset_size += _rowset_fetcher->get_rowset(rowset_id)->data_disk_size();
                     }
-                    _rowset_count_map[rowset_id] += 1;
+                    _alive_rowset_count_map[rowset_id] += 1;
                 }
             }
 
-            _total_binlog_file_disk_size += meta->file_size() - old_file_meta->file_size();
-            _binlog_file_metas[lsn] = meta;
+            _total_alive_binlog_file_size += meta->file_size() - old_file_meta->file_size();
+            binlog_file->update_file_meta(meta);
         } else {
-            _binlog_file_metas[lsn] = meta;
+            _alive_binlog_files[lsn] = std::make_shared<BinlogFile>(meta);
             for (auto rowset_id : meta->rowsets()) {
-                if (_rowset_count_map.count(rowset_id) == 0) {
-                    _total_rowset_disk_size += _rowset_fetcher->get_rowset(rowset_id)->data_disk_size();
+                if (_alive_rowset_count_map.count(rowset_id) == 0) {
+                    _total_alive_rowset_size += _rowset_fetcher->get_rowset(rowset_id)->data_disk_size();
                 }
-                _rowset_count_map[rowset_id] += 1;
+                _alive_rowset_count_map[rowset_id] += 1;
             }
-            _total_binlog_file_disk_size += meta->file_size();
+            _total_alive_binlog_file_size += meta->file_size();
         }
     }
 
     _next_file_id = result->next_file_id;
     _active_binlog_writer = result->active_writer;
+}
+
+void BinlogManager::check_expire_and_capacity(int64_t binlog_ttl_second, int64_t binlog_max_size) {
+    std::unique_lock lock(_meta_lock);
+    _check_wait_reader_binlog_files();
+    _check_alive_binlog_files(binlog_ttl_second, binlog_max_size);
+}
+
+void BinlogManager::_check_wait_reader_binlog_files() {
+    int64_t first_file_id = -1;
+    int64_t last_file_id = -1;
+    int64_t num_files = 0;
+    while (!_wait_reader_binlog_files.empty()) {
+        auto& binlog_file = _wait_reader_binlog_files.front();
+        if (binlog_file->reader_count() > 0) {
+            break;
+        }
+        _wait_reader_binlog_files.pop();
+        auto& file_meta = binlog_file->file_meta();
+        for (int64_t rowset_id : file_meta->rowsets()) {
+            int32_t count = --_wait_reader_rowset_count_map[rowset_id];
+            if (count == 0) {
+                _wait_reader_rowset_count_map.erase(rowset_id);
+            }
+        }
+        _unused_binlog_file_ids.blocking_put(file_meta->id());
+        if (first_file_id == -1) {
+            first_file_id = file_meta->id();
+        }
+        last_file_id = file_meta->id();
+        num_files += 1;
+    }
+    LOG(INFO) << "Check wait reader binlog files, tablet: " << _tablet_id << ", num unused files: " << num_files
+              << ", first_file_id: " << first_file_id << ", last_file_id: " << last_file_id
+              << ", num wait files: " << _wait_reader_binlog_files.size();
+}
+
+void BinlogManager::_check_alive_binlog_files(int64_t binlog_ttl_second, int64_t binlog_max_size) {
+    int64_t now = UnixSeconds();
+    int64_t expiration_time = now - binlog_ttl_second;
+    int64_t active_file_id = _active_binlog_writer != nullptr ? -1 : _active_binlog_writer->file_id();
+    // binlog files should be deleted in the order by the file id, and if there are previous
+    // binlog files waiting for readers, the latter should also wait for the readers
+    bool need_wait_reader = !_wait_reader_binlog_files.empty();
+    int64_t first_file_id = -1;
+    int64_t last_file_id = -1;
+    int64_t num_files = 0;
+    int64_t num_unused_files = 0;
+    for (auto it = _alive_binlog_files.begin(); it != _alive_binlog_files.end();) {
+        auto& binlog_file = it->second;
+        auto& meta = binlog_file->file_meta();
+        // skip to clean up the active file
+        if (meta->id() == active_file_id) {
+            break;
+        }
+        bool expired = meta->end_timestamp_in_us() / 1000000 < expiration_time;
+        bool overcapacity = _total_alive_binlog_file_size + _total_alive_rowset_size > binlog_max_size;
+        if (!expired && !overcapacity) {
+            break;
+        }
+
+        if (binlog_file->reader_count() > 0) {
+            need_wait_reader = true;
+        }
+
+        it = _alive_binlog_files.erase(it);
+        _total_alive_binlog_file_size -= meta->file_size();
+        if (need_wait_reader) {
+            _wait_reader_binlog_files.push(binlog_file);
+        } else {
+            _unused_binlog_file_ids.blocking_put(meta->id());
+        }
+
+        for (int64_t rowset_id : meta->rowsets()) {
+            int32_t count = --_alive_rowset_count_map[rowset_id];
+            if (count == 0) {
+                _alive_rowset_count_map.erase(rowset_id);
+                _total_alive_rowset_size -= _rowset_fetcher->get_rowset(rowset_id)->data_disk_size();
+            }
+            if (need_wait_reader) {
+                _wait_reader_rowset_count_map[rowset_id] += 1;
+            }
+        }
+
+        if (first_file_id == -1) {
+            first_file_id = meta->id();
+        }
+        last_file_id = meta->id();
+        num_files += 1;
+        num_unused_files += need_wait_reader ? 0 : 1;
+
+        VLOG(3) << "Check binlog file is not useful, tablet: " << _tablet_id << ", file_id: " << meta->id()
+                << ", expired: " << expired << ", overcapacity: " << overcapacity
+                << ", need_wait_reader: " << need_wait_reader;
+    }
+
+    LOG(INFO) << "Check binlog expire and capacity, tablet: " << _tablet_id << ", num files: " << num_files
+              << ", first file id: " << first_file_id << ", last file id: " << last_file_id
+              << ", num unused files: " << num_unused_files;
+}
+
+void BinlogManager::delete_unused_binlog() {
+    StatusOr<std::shared_ptr<FileSystem>> status_or;
+    if (!status_or.ok()) {
+        LOG(ERROR) << "Failed to delete unused binlog, tablet: " << _tablet_id << ", " << status_or.status();
+        return;
+    }
+    std::shared_ptr<FileSystem> fs = status_or.value();
+    int64_t file_id;
+    int32_t total_num = 0;
+    int32_t fail_num = 0;
+    while (_unused_binlog_file_ids.try_get(&file_id) == 1) {
+        total_num += 1;
+        std::string file_path = BinlogUtil::binlog_file_path(_path, file_id);
+        // TODO use path gc to clean up binlog files if fail to delete
+        Status st = fs->delete_file(file_path);
+        if (st.ok()) {
+            VLOG(3) << "Delete binlog file, tablet: " << _tablet_id << ", file path: " << file_path;
+        } else {
+            LOG(WARNING) << "Fail to delete binlog file, tablet:  " << _tablet_id << ", file path: " << file_path
+                         << ", " << st;
+            fail_num += 1;
+        }
+    }
+
+    LOG(INFO) << "Delete unused binlog files, tablet: " << _tablet_id << ", total files: " << total_num
+              << ", failed to delete: " << fail_num;
+}
+
+void BinlogManager::delete_all_binlog() {
+    {
+        std::unique_lock lock(_meta_lock);
+        while (!_wait_reader_binlog_files.empty()) {
+            auto& binlog_file = _wait_reader_binlog_files.front();
+            _unused_binlog_file_ids.blocking_put(binlog_file->file_meta()->id());
+            _wait_reader_binlog_files.pop();
+        }
+        for (auto it = _alive_binlog_files.begin(); it != _alive_binlog_files.end(); it++) {
+            _unused_binlog_file_ids.blocking_put(it->second->file_meta()->id());
+        }
+        _alive_binlog_files.clear();
+        _alive_rowset_count_map.clear();
+        _total_alive_binlog_file_size = 0;
+        _total_alive_rowset_size = 0;
+        _wait_reader_rowset_count_map.clear();
+    }
+    delete_unused_binlog();
+}
+
+bool BinlogManager::is_rowset_used(int64_t rowset_id) {
+    std::shared_lock lock(_meta_lock);
+    return _alive_rowset_count_map.count(rowset_id) >= 1 || _wait_reader_rowset_count_map.count(rowset_id) >= 1;
 }
 
 StatusOr<int64_t> BinlogManager::register_reader(std::shared_ptr<BinlogReader> reader) {
@@ -164,38 +318,39 @@ void BinlogManager::unregister_reader(int64_t reader_id) {
     _binlog_readers.erase(reader_id);
 }
 
-StatusOr<BinlogFileMetaPBPtr> BinlogManager::find_binlog_meta(int64_t version, int64_t seq_id) {
+StatusOr<BinlogFileReadHolderPtr> BinlogManager::find_binlog_file(int64_t version, int64_t seq_id) {
     std::shared_lock lock(_meta_lock);
     int128_t lsn = BinlogUtil::get_lsn(version, seq_id);
     // find the first file whose start lsn is greater than the target
-    auto upper = _binlog_file_metas.upper_bound(lsn);
-    if (upper == _binlog_file_metas.begin()) {
+    auto upper = _alive_binlog_files.upper_bound(lsn);
+    if (upper == _alive_binlog_files.begin()) {
         return Status::NotFound(fmt::format("Can't find file meta for version {}, seq_id {}", version, seq_id));
     }
 
-    BinlogFileMetaPBPtr file_meta;
-    if (upper == _binlog_file_metas.end()) {
-        file_meta = _binlog_file_metas.rbegin()->second;
+    BinlogFilePtr binlog_file;
+    if (upper == _alive_binlog_files.end()) {
+        binlog_file = _alive_binlog_files.rbegin()->second;
     } else {
-        file_meta = (--upper)->second;
+        binlog_file = (--upper)->second;
     }
 
-    if (file_meta->end_version() < version) {
+    if (binlog_file->file_meta()->end_version() < version) {
         return Status::NotFound(fmt::format("Can't find file meta for version {}, seq_id {}", version, seq_id));
     }
 
-    return file_meta;
+    return binlog_file->new_read_holder();
 }
 
 BinlogRange BinlogManager::current_binlog_range() {
     std::shared_lock lock(_meta_lock);
-    if (_binlog_file_metas.empty()) {
+    if (_alive_binlog_files.empty()) {
         return {0, 0, -1, -1};
     }
 
-    BinlogFileMetaPBPtr& start = _binlog_file_metas.begin()->second;
-    BinlogFileMetaPBPtr& end = _binlog_file_metas.rbegin()->second;
-    return BinlogRange(start->start_version(), start->start_seq_id(), end->end_version(), end->end_seq_id());
+    BinlogFilePtr& start = _alive_binlog_files.begin()->second;
+    BinlogFilePtr& end = _alive_binlog_files.rbegin()->second;
+    return BinlogRange(start->file_meta()->start_version(), start->file_meta()->start_seq_id(),
+                       end->file_meta()->end_version(), end->file_meta()->end_seq_id());
 }
 
 void BinlogManager::close_active_writer() {

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -117,8 +117,8 @@ void BinlogManager::_apply_build_result(BinlogBuildResult* result) {
         int128_t lsn = BinlogUtil::get_lsn(meta->start_version(), meta->start_seq_id());
         auto it = _alive_binlog_files.find(lsn);
         bool override_meta = it != _alive_binlog_files.end();
-        BinlogFilePtr binlog_file = it->second;
         if (override_meta) {
+            BinlogFilePtr binlog_file = it->second;
             BinlogFileMetaPBPtr& old_file_meta = binlog_file->file_meta();
             std::unordered_set<int64_t> old_rowsets;
             for (auto rowset_id : old_file_meta->rowsets()) {

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -205,7 +205,7 @@ void BinlogManager::_check_wait_reader_binlog_files() {
 void BinlogManager::_check_alive_binlog_files(int64_t current_second, int64_t binlog_ttl_second,
                                               int64_t binlog_max_size) {
     int64_t expiration_time = current_second - binlog_ttl_second;
-    int64_t active_file_id = _active_binlog_writer != nullptr ? -1 : _active_binlog_writer->file_id();
+    int64_t active_file_id = _active_binlog_writer != nullptr ? _active_binlog_writer->file_id() : -1;
     // binlog files should be deleted in the order by the file id, and if there are previous
     // binlog files waiting for readers, the latter should also wait for the readers
     bool need_wait_reader = !_wait_reader_binlog_files.empty();

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -240,8 +240,10 @@ void BinlogManager::_check_alive_binlog_files(int64_t current_second, int64_t bi
         }
 
         for (int64_t rowset_id : meta->rowsets()) {
-            int32_t count = --_alive_rowset_count_map[rowset_id];
-            if (count == 0) {
+            auto rit = _alive_rowset_count_map.find(rowset_id);
+            DCHECK(rit != _alive_rowset_count_map.end());
+            rit->second--;
+            if (rit->second == 0) {
                 _alive_rowset_count_map.erase(rowset_id);
                 _total_alive_rowset_data_size -= _rowset_fetcher->get_rowset(rowset_id)->data_disk_size();
             }

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <map>
+#include <queue>
 #include <unordered_map>
 
 #include "gen_cpp/AgentService_types.h"
@@ -25,6 +26,7 @@
 #include "storage/binlog_builder.h"
 #include "storage/binlog_file_writer.h"
 #include "storage/binlog_reader.h"
+#include "util/blocking_queue.hpp"
 
 namespace starrocks {
 
@@ -123,6 +125,58 @@ private:
     int64_t _end_seq_id;
 };
 
+// Hold a reference to the binlog file for read. Call release() explicitly to
+// dereference the binlog file, or it will be called atomically in destructor
+class BinlogFileReadHolder {
+public:
+    BinlogFileReadHolder(std::shared_ptr<std::atomic<int64_t>> _reader_count, BinlogFileMetaPBPtr file_meta)
+            : _reader_count(_reader_count), _file_meta(file_meta), _released(false) {
+        _reader_count->fetch_add(1);
+    }
+
+    ~BinlogFileReadHolder() { release(); }
+
+    BinlogFileMetaPBPtr& file_meta() { return _file_meta; }
+
+    void release() {
+        bool expect = false;
+        if (_released.compare_exchange_strong(expect, true)) {
+            _reader_count->fetch_sub(1);
+        }
+    }
+
+private:
+    std::shared_ptr<std::atomic<int64_t>> _reader_count;
+    BinlogFileMetaPBPtr _file_meta;
+    std::atomic<bool> _released;
+};
+
+using BinlogFileReadHolderPtr = std::shared_ptr<BinlogFileReadHolder>;
+
+// Representation of a binlog file. It includes the file meta, and a
+// reference count about how many readers are using it
+class BinlogFile {
+public:
+    BinlogFile(BinlogFileMetaPBPtr file_meta) : _file_meta(file_meta) {
+        _reader_count = std::make_shared<std::atomic<int64_t>>();
+    }
+
+    BinlogFileMetaPBPtr& file_meta() { return _file_meta; }
+
+    void update_file_meta(BinlogFileMetaPBPtr& file_meta) { _file_meta = file_meta; }
+
+    BinlogFileReadHolderPtr new_read_holder() {
+        return std::make_shared<BinlogFileReadHolder>(_reader_count, _file_meta);
+    }
+
+    int64_t reader_count() { return _reader_count->load(); }
+
+private:
+    BinlogFileMetaPBPtr _file_meta;
+    std::shared_ptr<std::atomic<int64_t>> _reader_count;
+};
+using BinlogFilePtr = std::shared_ptr<BinlogFile>;
+
 // Manages the binlog metas and files, including generation, deletion and read.
 class BinlogManager {
 public:
@@ -172,6 +226,21 @@ public:
     // Commit the result of pre-commit, and it's visible for reading
     void commit_ingestion(int64_t version);
 
+    // Check expiration and capacity. It should be protected by Tablet#_meta_lock outside
+    // because Tablet#_inc_rs_version_map may be visited. This method only updates metas
+    // of binlog files that should be deleted, but not do the deletion which will be done
+    // in delete_unused_binlog() later, so _meta_lock will not blocked too long.
+    void check_expire_and_capacity(int64_t binlog_ttl_second, int64_t binlog_max_size);
+
+    // Whether the rowset is used by the binlog.
+    bool is_rowset_used(int64_t rowset_id);
+
+    // Delete unused binlog files
+    void delete_unused_binlog();
+
+    // Delete all of data, and only called in Tablet::delete_all_files currently
+    void delete_all_binlog();
+
     // Register the reader, and return a unique id allocated for this reader.
     StatusOr<int64_t> register_reader(std::shared_ptr<BinlogReader> reader);
 
@@ -180,13 +249,13 @@ public:
 
     // Find the binlog file which may contain the change event with given <version, seq_id>.
     // Return Status::NotFound if there is no such file.
-    StatusOr<BinlogFileMetaPBPtr> find_binlog_meta(int64_t version, int64_t seq_id);
+    StatusOr<BinlogFileReadHolderPtr> find_binlog_file(int64_t version, int64_t seq_id);
 
     std::string get_binlog_file_path(int64_t file_id) { return BinlogUtil::binlog_file_path(_path, file_id); }
 
     BinlogRange current_binlog_range();
 
-    // For testing
+    // Following methods are for testing currently
     int64_t next_file_id() { return _next_file_id; }
 
     int64_t ingestion_version() { return _ingestion_version; }
@@ -195,18 +264,20 @@ public:
 
     BinlogFileWriter* active_binlog_writer() { return _active_binlog_writer.get(); }
 
-    std::map<int128_t, BinlogFileMetaPBPtr>& file_metas() { return _binlog_file_metas; }
+    std::map<int128_t, BinlogFilePtr>& alive_binlog_files() { return _alive_binlog_files; }
 
-    std::unordered_map<int64_t, int32_t>& rowset_count_map() { return _rowset_count_map; }
+    std::unordered_map<int64_t, int32_t>& alive_rowset_count_map() { return _alive_rowset_count_map; }
 
-    int64_t total_binlog_file_disk_size() { return _total_binlog_file_disk_size; }
+    int64_t total_useful_binlog_file_size() { return _total_alive_binlog_file_size; }
 
-    int64_t total_rowset_disk_size() { return _total_rowset_disk_size; }
+    int64_t total_rowset_disk_size() { return _total_alive_rowset_size; }
 
     void close_active_writer();
 
 private:
     void _apply_build_result(BinlogBuildResult* result);
+    void _check_wait_reader_binlog_files();
+    void _check_alive_binlog_files(int64_t binlog_ttl_second, int64_t binlog_max_size);
 
     int64_t _tablet_id;
     // binlog storage directory
@@ -227,19 +298,28 @@ private:
 
     // protect following metas' read/write
     std::shared_mutex _meta_lock;
-    // mapping from start LSN(start_version, start_seq_id) of a binlog file to the file meta.
-    // A binlog file with a smaller start LSN also has a smaller file id. The file with the
-    // biggest start LSN is the meta of _active_binlog_writer if it's not null.
-    std::map<int128_t, BinlogFileMetaPBPtr> _binlog_file_metas;
+
+    // Alive binlog files (not expired and overcapacity). Map from start LSN(start_version, start_seq_id)
+    // of a binlog file to the file meta. A binlog file with a smaller start LSN also has a smaller file id.
+    // The file with the biggest start LSN is the meta of _active_binlog_writer if it's not null.
+    std::map<int128_t, BinlogFilePtr> _alive_binlog_files;
+    // Alive rowsets. Map from rowset id to the number of binlog files using it in _alive_binlog_files
+    std::unordered_map<int64_t, int32_t> _alive_rowset_count_map;
+    // Disk size for alive binlog files
+    int64_t _total_alive_binlog_file_size = 0;
+    // Disk size for alive rowsets
+    int64_t _total_alive_rowset_size = 0;
+
     // the binlog file writer that can append data
     BinlogFileWriterPtr _active_binlog_writer;
 
-    // mapping from rowset id to the number of binlog files using it
-    std::unordered_map<int64_t, int32_t> _rowset_count_map;
+    // Binlog files and rowsets that have been expired or overcapacity,
+    // but still used by some readers, and can't be deleted immediately
+    std::queue<BinlogFilePtr> _wait_reader_binlog_files;
+    std::unordered_map<int64_t, int32_t> _wait_reader_rowset_count_map;
 
-    // statistics for disk usage
-    int64_t _total_binlog_file_disk_size = 0;
-    int64_t _total_rowset_disk_size = 0;
+    // unused binlog file ids that can be deleted
+    BlockingQueue<int64_t> _unused_binlog_file_ids;
 
     // Allocate an id for each binlog reader. Protected by _meta_lock
     int64_t _next_reader_id = 0;

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -316,9 +316,9 @@ private:
     // Alive rowsets. Map from rowset id to the number of binlog files using it in _alive_binlog_files
     std::unordered_map<int64_t, int32_t> _alive_rowset_count_map;
     // Disk size for alive binlog files
-    atomic<int64_t> _total_alive_binlog_file_size = 0;
+    std::atomic<int64_t> _total_alive_binlog_file_size = 0;
     // Disk size for alive rowsets
-    atomic<int64_t> _total_alive_rowset_data_size = 0;
+    std::atomic<int64_t> _total_alive_rowset_data_size = 0;
 
     // the binlog file writer that can append data
     BinlogFileWriterPtr _active_binlog_writer;
@@ -328,9 +328,9 @@ private:
     std::deque<BinlogFilePtr> _wait_reader_binlog_files;
     std::unordered_map<int64_t, int32_t> _wait_reader_rowset_count_map;
     // Disk size for wait reader binlog files
-    atomic<int64_t> _total_wait_reader_binlog_file_size = 0;
+    std::atomic<int64_t> _total_wait_reader_binlog_file_size = 0;
     // Disk size for wait reader rowsets
-    atomic<int64_t> _total_wait_reader_rowset_data_size = 0;
+    std::atomic<int64_t> _total_wait_reader_rowset_data_size = 0;
 
     // ids of unused binlog files that can be deleted
     BlockingQueue<int64_t> _unused_binlog_file_ids;

--- a/be/src/storage/binlog_reader.h
+++ b/be/src/storage/binlog_reader.h
@@ -40,6 +40,7 @@ constexpr const char* BINLOG_TIMESTAMP = "_binlog_timestamp";
 
 class Tablet;
 class BinlogManager;
+class BinlogFileReadHolder;
 
 // Read binlog in a tablet. Binlog can be treated as a table with schema. The schema includes the
 // data columns of base table and meta columns of binlog. The name and SQL data type of meta columns
@@ -110,6 +111,7 @@ private:
     Status _seek_binlog_file_reader(int64_t version, int64_t seq_id);
     Status _init_segment_iterator();
     void _release_segment_iterator(bool release_rowset);
+    void _release_binlog_file();
     void _reset();
     void _swap_output_and_data_chunk(Chunk* output_chunk);
     void _append_meta_column(Chunk* output_chunk, int32_t num_rows, int64_t version, int64_t timestamp,
@@ -131,7 +133,7 @@ private:
     int32_t _binlog_timestamp_column_index = -1;
 
     // current binlog file to read
-    BinlogFileMetaPBPtr _file_meta;
+    std::shared_ptr<BinlogFileReadHolder> _binlog_file_holder;
     std::shared_ptr<BinlogFileReader> _binlog_file_reader;
     // owned by _binlog_file_reader
     LogEntryInfo* _log_entry_info = nullptr;

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -209,13 +209,9 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowset
         StorageEngine::instance()->add_unused_rowset(it->second);
         _rs_version_map.erase(it);
     }
-    for (auto& [v, rowset] : _inc_rs_version_map) {
-        StorageEngine::instance()->add_unused_rowset(rowset);
-    }
     for (auto& [v, rowset] : _stale_rs_version_map) {
         StorageEngine::instance()->add_unused_rowset(rowset);
     }
-    _inc_rs_version_map.clear();
     _stale_rs_version_map.clear();
 
     for (auto& rs_meta : rowsets_to_clone) {
@@ -379,13 +375,9 @@ Status Tablet::support_binlog() {
     return Status::InternalError("Not support binlog, keys type: " + KeysType_Name(keys_type()));
 }
 
-bool Tablet::binlog_enable() {
+StatusOr<bool> Tablet::_prepare_binlog_if_needed(const RowsetSharedPtr& rowset, int64_t version) {
     auto config = _tablet_meta->get_binlog_config();
-    return config != nullptr && config->binlog_enable;
-}
-
-StatusOr<bool> Tablet::prepare_binlog_if_needed(const RowsetSharedPtr& rowset, int64_t version) {
-    if (!binlog_enable()) {
+    if (config == nullptr || !config->binlog_enable) {
         return false;
     }
 
@@ -421,13 +413,11 @@ StatusOr<bool> Tablet::prepare_binlog_if_needed(const RowsetSharedPtr& rowset, i
     return true;
 }
 
-void Tablet::commit_binlog(int64_t version) {
-    if (binlog_enable()) {
-        _binlog_manager->commit_ingestion(version);
-    }
+void Tablet::_commit_binlog(int64_t version) {
+    _binlog_manager->commit_ingestion(version);
 }
 
-void Tablet::abort_binlog(const RowsetSharedPtr& rowset, int64_t version) {
+void Tablet::_abort_binlog(const RowsetSharedPtr& rowset, int64_t version) {
     _binlog_manager->delete_ingestion(version);
     rowset->close();
 }
@@ -442,7 +432,7 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset, int64_t version) {
     Status contain_status = _contains_version(rowset_version);
     bool need_binlog = false;
     if (contain_status.ok()) {
-        ASSIGN_OR_RETURN(need_binlog, prepare_binlog_if_needed(rowset, version));
+        ASSIGN_OR_RETURN(need_binlog, _prepare_binlog_if_needed(rowset, version));
     }
 
     // rowset is already set version here, memory is changed, if save failed it maybe a fatal error
@@ -456,7 +446,7 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset, int64_t version) {
     auto st = RowsetMetaManager::save(data_dir()->get_meta(), tablet_uid(), rowset_meta_pb);
     if (!st.ok()) {
         if (need_binlog) {
-            abort_binlog(rowset, version);
+            _abort_binlog(rowset, version);
         }
 
         LOG(WARNING) << "Fail to save committed rowset. "
@@ -478,7 +468,7 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset, int64_t version) {
         // BinlogManager#commit_ingestion needs the data disk size of rowset, and will
         // look up _inc_rs_version_map for the rowset, so should commit binlog after
         // _inc_rs_version_map is updated
-        commit_binlog(version);
+        _commit_binlog(version);
     }
 
     _timestamped_version_tracker.add_version(rowset->version());
@@ -513,17 +503,36 @@ void Tablet::_delete_stale_rowset_by_version(const Version& version) {
     VLOG(3) << "delete stale rowset. tablet=" << full_name() << ", version=" << version;
 }
 
+void Tablet::_delete_unused_binlog() {
+    if (_binlog_manager == nullptr) {
+        return;
+    }
+    {
+        std::shared_lock rdlock(_meta_lock);
+        auto config = _tablet_meta->get_binlog_config();
+        _binlog_manager->check_expire_and_capacity(config->binlog_ttl_second, config->binlog_max_size);
+    }
+    _binlog_manager->delete_unused_binlog();
+}
+
 void Tablet::delete_expired_inc_rowsets() {
+    _delete_unused_binlog();
     int64_t now = UnixSeconds();
     std::vector<Version> expired_versions;
     std::unique_lock wrlock(_meta_lock);
     for (auto& rs_meta : _tablet_meta->all_inc_rs_metas()) {
         int64_t diff = now - rs_meta->creation_time();
-        if (diff >= config::inc_rowset_expired_sec) {
+        bool inc_rowset_expired = diff >= config::inc_rowset_expired_sec;
+        bool binlog_unused = _binlog_manager == nullptr || !_binlog_manager->is_rowset_used(rs_meta->start_version());
+        if (inc_rowset_expired && binlog_unused) {
             Version version(rs_meta->version());
             expired_versions.emplace_back(version);
             VLOG(3) << "find expire incremental rowset. tablet=" << full_name() << ", version=" << version
                     << ", exist_sec=" << diff;
+        } else {
+            VLOG(3) << "incremental rowset still used. tablet=" << full_name() << ", version=" << rs_meta->version()
+                    << ", exist_sec=" << diff << ", inc_rowset_expired: " << inc_rowset_expired
+                    << ", binlog_unused: " << binlog_unused;
         }
     }
 
@@ -890,6 +899,10 @@ void Tablet::calculate_cumulative_point() {
 
 // NOTE: only used when create_table, so it is sure that there is no concurrent reader and writer.
 void Tablet::delete_all_files() {
+    if (_binlog_manager != nullptr) {
+        _binlog_manager->delete_all_binlog();
+    }
+
     // Release resources like memory and disk space.
     // we have to call list_versions first, or else error occurs when
     // removing hash_map item and iterating hash_map concurrently.

--- a/be/test/storage/binlog_manager_test.cpp
+++ b/be/test/storage/binlog_manager_test.cpp
@@ -748,7 +748,6 @@ TEST_F(BinlogManagerTest, test_wait_reader) {
     auto st_5 = binlog_manager->find_binlog_file(file_info_5->rowsets.front().version,
                                                  file_info_5->rowsets.front().start_seq_id);
     ASSERT_OK(st_5.status());
-    BinlogFileReadHolderPtr read_holder_5 = st_5.value();
     auto& param_9 = params[9];
     binlog_manager->check_expire_and_capacity(param_9.binlog_ttl_second, param_9.binlog_ttl_second,
                                               param_9.binlog_max_size);
@@ -763,7 +762,7 @@ TEST_F(BinlogManagerTest, test_wait_reader) {
     verify_wait_reader_binlog_files(binlog_manager.get(), rowset_fetcher.get(), binlog_file_infos, 5, 14);
     ASSERT_EQ(5, binlog_manager->unused_binlog_file_ids().get_size());
 
-    read_holder_5->release();
+    st_5.value().reset();
     auto& param_last = params.back();
     binlog_manager->check_expire_and_capacity(param_last.binlog_ttl_second, param_last.binlog_ttl_second,
                                               param_last.binlog_max_size);

--- a/be/test/storage/binlog_manager_test.cpp
+++ b/be/test/storage/binlog_manager_test.cpp
@@ -146,8 +146,6 @@ TEST_F(BinlogManagerTest, test_ingestion_commit) {
     std::shared_ptr<MockRowsetFetcher> rowset_fetcher = std::make_shared<MockRowsetFetcher>();
     std::shared_ptr<BinlogManager> binlog_manager = std::make_shared<BinlogManager>(
             std::rand(), _binlog_file_dir, max_file_size, max_page_size, compress_type, rowset_fetcher);
-    LsnMap& lsn_map = binlog_manager->alive_binlog_files();
-    RowsetCountMap& rowset_count_map = binlog_manager->alive_rowset_count_map();
     std::map<int64_t, BinlogFileMetaPBPtr> expect_file_metas;
     std::unordered_map<int64_t, std::unordered_set<int64_t>> version_to_file_ids;
     RowsetSharedPtr mock_rowset;
@@ -228,6 +226,9 @@ TEST_F(BinlogManagerTest, test_ingestion_commit) {
         ASSERT_EQ(-1, binlog_manager->ingestion_version());
         ASSERT_TRUE(binlog_manager->build_result() == nullptr);
         ASSERT_EQ(result->active_writer.get(), binlog_manager->active_binlog_writer());
+
+        LsnMap& lsn_map = binlog_manager->alive_binlog_files();
+        RowsetCountMap& rowset_count_map = binlog_manager->alive_rowset_count_map();
         ASSERT_EQ(expect_file_metas.size(), lsn_map.size());
         int64_t expect_binlog_file_size = 0;
         for (auto it : expect_file_metas) {
@@ -240,9 +241,9 @@ TEST_F(BinlogManagerTest, test_ingestion_commit) {
         ASSERT_EQ(expect_binlog_file_size, binlog_manager->total_alive_binlog_file_size());
         ASSERT_EQ(version_to_file_ids.size(), rowset_count_map.size());
         for (auto it : version_to_file_ids) {
-            int64_t file_id = it.first;
-            ASSERT_EQ(1, rowset_count_map.count(file_id));
-            ASSERT_EQ(it.second.size(), rowset_count_map[file_id]);
+            int64_t ver = it.first;
+            ASSERT_EQ(1, rowset_count_map.count(ver));
+            ASSERT_EQ(it.second.size(), rowset_count_map[ver]);
         }
         ASSERT_EQ(rowset_fetcher->total_rowset_data_size(), binlog_manager->total_alive_rowset_data_size());
     }
@@ -255,8 +256,6 @@ TEST_F(BinlogManagerTest, test_ingestion_abort) {
     std::shared_ptr<MockRowsetFetcher> rowset_fetcher = std::make_shared<MockRowsetFetcher>();
     std::shared_ptr<BinlogManager> binlog_manager = std::make_shared<BinlogManager>(
             std::rand(), _binlog_file_dir, max_file_size, max_page_size, compress_type, rowset_fetcher);
-    LsnMap& lsn_map = binlog_manager->alive_binlog_files();
-    RowsetCountMap& rowset_count_map = binlog_manager->alive_rowset_count_map();
     std::map<int64_t, BinlogFileMetaPBPtr> expect_file_metas;
     std::unordered_map<int64_t, std::unordered_set<int64_t>> version_to_file_ids;
     RowsetSharedPtr mock_rowset;
@@ -305,6 +304,9 @@ TEST_F(BinlogManagerTest, test_ingestion_abort) {
     ASSERT_EQ(-1, binlog_manager->ingestion_version());
     ASSERT_TRUE(binlog_manager->build_result() == nullptr);
     ASSERT_EQ(result_2->active_writer.get(), binlog_manager->active_binlog_writer());
+
+    LsnMap& lsn_map = binlog_manager->alive_binlog_files();
+    RowsetCountMap& rowset_count_map = binlog_manager->alive_rowset_count_map();
     ASSERT_EQ(expect_file_metas.size(), lsn_map.size());
     int64_t expect_binlog_file_size = 0;
     for (auto it : expect_file_metas) {
@@ -318,9 +320,9 @@ TEST_F(BinlogManagerTest, test_ingestion_abort) {
 
     ASSERT_EQ(version_to_file_ids.size(), rowset_count_map.size());
     for (auto it : version_to_file_ids) {
-        int64_t fid = it.first;
-        ASSERT_EQ(1, rowset_count_map.count(fid));
-        ASSERT_EQ(it.second.size(), rowset_count_map[fid]);
+        int64_t ver = it.first;
+        ASSERT_EQ(1, rowset_count_map.count(ver));
+        ASSERT_EQ(it.second.size(), rowset_count_map[ver]);
     }
     ASSERT_EQ(rowset_fetcher->total_rowset_data_size(), binlog_manager->total_alive_rowset_data_size());
 }
@@ -332,8 +334,6 @@ TEST_F(BinlogManagerTest, test_ingestion_delete) {
     std::shared_ptr<MockRowsetFetcher> rowset_fetcher = std::make_shared<MockRowsetFetcher>();
     std::shared_ptr<BinlogManager> binlog_manager = std::make_shared<BinlogManager>(
             std::rand(), _binlog_file_dir, max_file_size, max_page_size, compress_type, rowset_fetcher);
-    LsnMap& lsn_map = binlog_manager->alive_binlog_files();
-    RowsetCountMap& rowset_count_map = binlog_manager->alive_rowset_count_map();
     std::map<int64_t, BinlogFileMetaPBPtr> expect_file_metas;
     std::unordered_map<int64_t, std::unordered_set<int64_t>> version_to_file_ids;
     RowsetSharedPtr mock_rowset;
@@ -390,6 +390,8 @@ TEST_F(BinlogManagerTest, test_ingestion_delete) {
     ASSERT_EQ(-1, binlog_manager->ingestion_version());
     ASSERT_TRUE(binlog_manager->build_result() == nullptr);
 
+    LsnMap& lsn_map = binlog_manager->alive_binlog_files();
+    RowsetCountMap& rowset_count_map = binlog_manager->alive_rowset_count_map();
     int64_t expect_binlog_file_size = 0;
     for (auto it : expect_file_metas) {
         BinlogFileMetaPBPtr meta = it.second;
@@ -401,9 +403,9 @@ TEST_F(BinlogManagerTest, test_ingestion_delete) {
     ASSERT_EQ(expect_binlog_file_size, binlog_manager->total_alive_binlog_file_size());
     ASSERT_EQ(version_to_file_ids.size(), rowset_count_map.size());
     for (auto it : version_to_file_ids) {
-        int64_t fid = it.first;
-        ASSERT_EQ(1, rowset_count_map.count(fid));
-        ASSERT_EQ(it.second.size(), rowset_count_map[fid]);
+        int64_t ver = it.first;
+        ASSERT_EQ(1, rowset_count_map.count(ver));
+        ASSERT_EQ(it.second.size(), rowset_count_map[ver]);
     }
     ASSERT_EQ(rowset_fetcher->total_rowset_data_size(), binlog_manager->total_alive_rowset_data_size());
 }
@@ -615,8 +617,6 @@ void verify_wait_reader_binlog_files(BinlogManager* binlog_manager, RowsetFetche
     int32_t index = first_index;
     for (auto& binlog_file : actual_binlog_files) {
         auto& file_info = binlog_file_infos[index];
-        RowsetPartition& first_rowset = file_info->rowsets.front();
-        int128_t lsn = BinlogUtil::get_lsn(first_rowset.version, first_rowset.start_seq_id);
         ASSERT_EQ(file_info->file_id, binlog_file->file_meta()->id());
         expect_total_binlog_file_size += file_info->file_size;
 
@@ -679,6 +679,15 @@ void BinlogManagerTest::test_binlog_expired_and_overcapacity(bool expired, bool 
     bool is_alive = !expired && !overcapacity;
     for (int i = 0; i < params.size(); i += 2) {
         auto& param = params[i];
+        // skip the file if it's timestamp is larger than that of the next file
+        if (expired && i + 1 < params.size()) {
+            int64_t t1 = binlog_file_infos[i]->rowsets.back().timestamp_in_us;
+            int64_t t2 = binlog_file_infos[i + 1]->rowsets.back().timestamp_in_us;
+            if (t1 >= t2) {
+                continue;
+            }
+        }
+
         int64_t current_second = expired ? param.current_second : param.binlog_ttl_second;
         int64_t max_size = overcapacity ? param.binlog_max_size : INT64_MAX;
         binlog_manager->check_expire_and_capacity(current_second, param.binlog_ttl_second, max_size);

--- a/be/test/storage/binlog_reader_test.cpp
+++ b/be/test/storage/binlog_reader_test.cpp
@@ -168,7 +168,7 @@ void BinlogReaderTest::ingestion_rowsets(std::vector<std::vector<RowsetInfo>>& r
         }
         binlog_manager->close_active_writer();
     }
-    ASSERT_EQ(rowsets_per_binlog_file.size(), binlog_manager->file_metas().size());
+    ASSERT_EQ(rowsets_per_binlog_file.size(), binlog_manager->alive_binlog_files().size());
 }
 
 class OutputVerifier {

--- a/be/test/storage/tablet_binlog_test.cpp
+++ b/be/test/storage/tablet_binlog_test.cpp
@@ -128,10 +128,10 @@ TEST_F(TabletBinlogTest, test_generate_binlog) {
     }
 
     BinlogManager* binlog_manager = _tablet->binlog_manager();
-    std::map<int128_t, BinlogFileMetaPBPtr>& lsn_map = binlog_manager->file_metas();
+    std::map<int128_t, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
     std::vector<BinlogFileMetaPBPtr> file_metas;
     for (auto it : lsn_map) {
-        file_metas.push_back(it.second);
+        file_metas.push_back(it.second->file_meta());
     }
     verify_dup_key_multiple_versions(version_infos, _tablet->schema_hash_path(), file_metas);
 }
@@ -159,10 +159,10 @@ TEST_F(TabletBinlogTest, test_publish_out_of_order) {
     }
 
     BinlogManager* binlog_manager = _tablet->binlog_manager();
-    std::map<int128_t, BinlogFileMetaPBPtr>& lsn_map = binlog_manager->file_metas();
+    std::map<int128_t, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
     std::vector<BinlogFileMetaPBPtr> file_metas;
     for (auto it : lsn_map) {
-        file_metas.push_back(it.second);
+        file_metas.push_back(it.second->file_meta());
     }
     verify_dup_key_multiple_versions(version_infos, _tablet->schema_hash_path(), file_metas);
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The feature to support the storage of binlog has several PRs
* Support to write/read binlog file
* Generate binlog when the ingestion is published
* Cleanup the binlog when expired or oversize
* Load binlog when loading tablet
* Read binlog to generate change events

This is the fourth PR. Cleanup the expired and overcapacity binlog.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [ ] 2.2
