### PR TITLE
[BugFix] Fix automatic partition creation crash when olap table sink write fail

### DIFF
--- a/be/src/exec/pipeline/olap_table_sink_operator.h
+++ b/be/src/exec/pipeline/olap_table_sink_operator.h
@@ -71,6 +71,7 @@ private:
     bool _is_finished = false;
     mutable bool _is_open_done = false;
     int32_t _sender_id;
+    bool _is_cancelled = false;
 
     // STREAM MV
     bool _is_epoch_finished = false;

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -207,6 +207,7 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
     request.set_miss_auto_increment_column(_parent->_miss_auto_increment_column);
     request.set_abort_delete(_parent->_abort_delete);
     request.set_is_incremental(incremental_open);
+    request.set_sender_id(_parent->_sender_id);
     for (auto& tablet : tablets) {
         auto ptablet = request.add_tablets();
         ptablet->CopyFrom(tablet);
@@ -243,8 +244,8 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
     request.release_id();
     request.release_schema();
 
-    VLOG(2) << "NodeChannel[" << _load_info << "] send open request to [" << _node_info->host << ":"
-            << _node_info->brpc_port << "]";
+    VLOG(2) << "NodeChannel[" << _load_info << "] send open request [incremental: " << incremental_open << "] to ["
+            << _node_info->host << ":" << _node_info->brpc_port << "]";
 }
 
 void NodeChannel::try_incremental_open() {
@@ -1603,9 +1604,6 @@ Status OlapTableSink::try_close(RuntimeState* state) {
 }
 
 Status OlapTableSink::_fill_auto_increment_id(Chunk* chunk) {
-    if (_has_automatic_partition) {
-        return Status::OK();
-    }
     if (_auto_increment_slot_id == -1) {
         return Status::OK();
     }

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -86,7 +86,7 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
     int64_t index_id = request.index_id();
     bool is_lake_tablet = request.has_is_lake_tablet() && request.is_lake_tablet();
 
-    Status st;
+    Status st = Status::OK();
     {
         // We will `bthread::execution_queue_join()` in the destructor of AsyncDeltaWriter,
         // it will block the bthread, so we put its destructor outside the lock.
@@ -112,28 +112,35 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
                 _tablets_channels.insert({index_id, std::move(channel)});
             }
         } else if (request.is_incremental()) {
-            // although shared_ptr's use_count is approximate in multithreaded environment
-            // but we protect shared_ptr ref by _lock
-            size_t i = 0;
-            while (it->second.use_count() != 1) {
-                bthread_usleep(10000); // 10ms
-                auto t1 = std::chrono::steady_clock::now();
-                if (std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000 >
-                    request.timeout_ms()) {
-                    LOG(INFO) << "LoadChannel txn_id: " << request.txn_id() << " load_id: " << print_id(request.id())
-                              << " wait other sender finish write " << request.timeout_ms() << "ms timeout still has "
-                              << it->second.use_count() << " sender";
-                    break;
-                }
+            auto local_tablets_channel = down_cast<LocalTabletsChannel*>(it->second.get());
+            if (local_tablets_channel) {
+                size_t i = 0;
+                while (local_tablets_channel->num_ref_senders() != 0) {
+                    bthread_usleep(10000); // 10ms
+                    auto t1 = std::chrono::steady_clock::now();
+                    if (std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000 >
+                        request.timeout_ms()) {
+                        std::stringstream ss;
+                        ss << "LoadChannel txn_id: " << request.txn_id() << " load_id: " << print_id(request.id())
+                           << " wait other sender finish write " << request.timeout_ms() << "ms timeout still has "
+                           << local_tablets_channel->num_ref_senders() << " sender";
+                        LOG(INFO) << ss.str();
+                        st = Status::InternalError(ss.str());
+                        break;
+                    }
 
-                if (++i % 6000 == 0) {
-                    LOG(INFO) << "LoadChannel txn_id: " << request.txn_id() << " load_id: " << print_id(request.id())
-                              << " wait other sender finish write already "
-                              << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000
-                              << "ms still has " << it->second.use_count() << " sender";
+                    if (++i % 60000 == 0) {
+                        LOG(INFO) << "LoadChannel txn_id: " << request.txn_id()
+                                  << " load_id: " << print_id(request.id())
+                                  << " wait other sender finish write already "
+                                  << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000
+                                  << "ms still has " << local_tablets_channel->num_ref_senders() << " sender";
+                    }
+                }
+                if (st.ok()) {
+                    st = local_tablets_channel->incremental_open(request, _schema);
                 }
             }
-            st = it->second->incremental_open(request, _schema);
         }
     }
     LOG_IF(WARNING, !st.ok()) << "Fail to open index " << index_id << " of load " << _load_id << ": " << st.to_string();
@@ -245,6 +252,7 @@ void LoadChannel::abort(int64_t index_id, const std::vector<int64_t>& tablet_ids
     if (channel != nullptr) {
         auto local_tablets_channel = down_cast<LocalTabletsChannel*>(channel.get());
         if (local_tablets_channel != nullptr) {
+            local_tablets_channel->incr_num_ref_senders();
             local_tablets_channel->abort(tablet_ids);
         }
     }
@@ -263,7 +271,15 @@ void LoadChannel::remove_tablets_channel(int64_t index_id) {
 std::shared_ptr<TabletsChannel> LoadChannel::get_tablets_channel(int64_t index_id) {
     std::lock_guard l(_lock);
     auto it = _tablets_channels.find(index_id);
-    return (it != _tablets_channels.end()) ? it->second : nullptr;
+    if (it != _tablets_channels.end()) {
+        auto local_tablets_channel = down_cast<LocalTabletsChannel*>(it->second.get());
+        if (local_tablets_channel) {
+            local_tablets_channel->incr_num_ref_senders();
+        }
+        return it->second;
+    } else {
+        return nullptr;
+    }
 }
 
 Status LoadChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -549,7 +549,7 @@ void DeltaWriter::abort(bool with_log) {
     }
 
     VLOG(1) << "Aborted delta writer. tablet_id: " << _tablet->tablet_id() << " txn_id: " << _opt.txn_id
-            << " load_id: " << print_id(_opt.load_id);
+            << " load_id: " << print_id(_opt.load_id) << " partition_id: " << partition_id();
 }
 
 int64_t DeltaWriter::partition_id() const {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -169,6 +169,7 @@ message PTabletWriterOpenRequest {
     // before data load, the all current partitions will be opened
     // When the data load in progress, the partition created by automatic partition needs incremental open
     optional bool is_incremental = 29 [default = false];
+    optional int32 sender_id = 30;
 };
 
 message PTabletWriterOpenResult {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. when OlapTableSinkOperator setCancelled, it will close OlapTableSink, so we don't need resend automatic chunk
2. _fill_auto_increment_id need execute in resend automatic_partition_chunk
3. using atomic reference of LocalTabletsChannel to replace SharedPtr use_count()

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
