### PR TITLE
[Enhancement] Set the default `block_cache_checksum_enable` to `false` to avoid the checksum overhead

### DIFF
--- a/be/src/block_cache/fb_cachelib.cpp
+++ b/be/src/block_cache/fb_cachelib.cpp
@@ -95,11 +95,6 @@ std::unordered_map<std::string, double> FbCacheLib::cache_stats() {
 Status FbCacheLib::shutdown() {
     if (_cache) {
         _dump_cache_stats();
-        auto res = _cache->shutDown();
-        if (res != Cache::ShutDownStatus::kSuccess) {
-            LOG(WARNING) << "block cache shutdown failed";
-            return Status::InternalError("block cache shutdown failed");
-        }
     }
     return Status::OK();
 }

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -862,7 +862,7 @@ CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
 CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
 CONF_Int64(block_cache_block_size, "1048576");  // 1MB
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
-CONF_Bool(block_cache_checksum_enable, "true");
+CONF_Bool(block_cache_checksum_enable, "false");
 // Maximum number of concurrent inserts we allow globally for block cache.
 // 0 means unlimited.
 CONF_Int64(block_cache_max_concurrent_inserts, "1000000");


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We change the default `block_cache_checksum_enable` to `false` to avoid the checksum overhead because data usually be verified on other levels in many situations.
Also, this PR remove the `shutdown` procedure when block cache stop, because it is only useful for shared memory cache.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
