### PR TITLE
[BugFix] Fix call LakeTabletsChannel::add_chunk() after abort() caused segment fault

### DIFF
--- a/be/test/exec/parquet_scanner_test.cpp
+++ b/be/test/exec/parquet_scanner_test.cpp
@@ -221,7 +221,8 @@ class ParquetScannerTest : public ::testing::Test {
                 {"col_json_json_string", TypeDescriptor::create_json_type()},
                 {"issue_17693_c0", TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(TYPE_VARCHAR))},
                 {"issue_17822_c0", TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(TYPE_VARCHAR))},
-                {"nested_array_c0", TypeDescriptor::create_array_type(TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(TYPE_VARCHAR)))}};
+                {"nested_array_c0", TypeDescriptor::create_array_type(TypeDescriptor::create_array_type(
+                                            TypeDescriptor::from_logical_type(TYPE_VARCHAR)))}};
         SlotTypeDescInfoArray slot_infos;
         slot_infos.reserve(column_names.size());
         for (auto& name : column_names) {
@@ -335,9 +336,9 @@ class ParquetScannerTest : public ::testing::Test {
                                          test_exec_dir + "/test_data/parquet_data/issue_17693_2.parquet"};
         _issue_17822_file_names =
                 std::vector<std::string>{test_exec_dir + "/test_data/parquet_data/issue_17822.parquet"};
-        _nested_array_file_names = 
+        _nested_array_file_names =
                 std::vector<std::string>{test_exec_dir + "/test_data/parquet_data/nested_array_test1.parquet",
-                                        test_exec_dir + "/test_data/parquet_data/nested_array_test2.parquet"};
+                                         test_exec_dir + "/test_data/parquet_data/nested_array_test2.parquet"};
     }
 
 private:

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -494,7 +494,7 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
     }
 }
 
-TEST_F(LakeTabletsChannelTest, test_cancel) {
+TEST_F(LakeTabletsChannelTest, test_abort) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);
 
@@ -503,15 +503,16 @@ TEST_F(LakeTabletsChannelTest, test_cancel) {
     constexpr int kChunkSize = 128;
     constexpr int kChunkSizePerTablet = kChunkSize / 4;
     auto chunk = generate_data(kChunkSize);
-    std::atomic<bool> started{false};
+    std::atomic<int> write_count{0};
+    std::atomic<bool> stopped{false};
     auto t0 = std::thread([&]() {
-        PTabletWriterAddChunkRequest add_chunk_request;
-        PTabletWriterAddBatchResult add_chunk_response;
-        add_chunk_request.set_index_id(kIndexId);
-        add_chunk_request.set_sender_id(0);
-        add_chunk_request.set_eos(false);
         int64_t packet_seq = 0;
         while (true) {
+            PTabletWriterAddChunkRequest add_chunk_request;
+            PTabletWriterAddBatchResult add_chunk_response;
+            add_chunk_request.set_index_id(kIndexId);
+            add_chunk_request.set_sender_id(0);
+            add_chunk_request.set_eos(false);
             add_chunk_request.set_packet_seq(packet_seq++);
 
             for (int i = 0; i < kChunkSize; i++) {
@@ -527,16 +528,27 @@ TEST_F(LakeTabletsChannelTest, test_cancel) {
             if (add_chunk_response.status().status_code() != TStatusCode::OK) {
                 break;
             }
-            started = true;
+            write_count.fetch_add(1);
         }
+        PTabletWriterAddChunkRequest finish_request;
+        PTabletWriterAddBatchResult finish_response;
+        finish_request.set_index_id(kIndexId);
+        finish_request.set_sender_id(0);
+        finish_request.set_eos(true);
+        finish_request.set_packet_seq(packet_seq++);
+        finish_request.add_partition_ids(10);
+        finish_request.add_partition_ids(11);
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+        ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
+        stopped.store(true);
     });
 
-    while (!started) {
+    while (write_count.load() < 5 && !stopped.load()) {
         std::this_thread::yield();
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-    _tablets_channel->cancel();
+    ASSERT_FALSE(stopped.load());
+    ASSERT_GT(write_count.load(), 0);
+    _tablets_channel->abort();
 
     t0.join();
 
@@ -690,6 +702,61 @@ TEST_F(LakeTabletsChannelTest, test_finish_failed) {
 
     _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
     ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
+}
+
+TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
+    auto open_request = _open_request;
+    open_request.set_num_senders(2);
+
+    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false));
+
+    {
+        constexpr int kChunkSize = 128;
+        constexpr int kChunkSizePerTablet = kChunkSize / 4;
+        auto chunk = generate_data(kChunkSize);
+
+        PTabletWriterAddChunkRequest add_chunk_request;
+        PTabletWriterAddBatchResult add_chunk_response;
+        add_chunk_request.set_index_id(kIndexId);
+        add_chunk_request.set_sender_id(0);
+        add_chunk_request.set_eos(true);
+        add_chunk_request.set_packet_seq(0);
+
+        for (int i = 0; i < kChunkSize; i++) {
+            int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+            add_chunk_request.add_tablet_ids(tablet_id);
+            add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+        }
+
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+
+        _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+        ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+
+        _tablets_channel->abort();
+
+        _tablets_channel->add_chunk(nullptr, add_chunk_request, &add_chunk_response);
+        ASSERT_EQ(TStatusCode::DUPLICATE_RPC_INVOCATION, add_chunk_response.status().status_code());
+    }
+    {
+        PTabletWriterAddChunkRequest finish_request;
+        PTabletWriterAddBatchResult finish_response;
+        finish_request.set_index_id(kIndexId);
+        finish_request.set_sender_id(1);
+        finish_request.set_eos(true);
+        finish_request.set_packet_seq(0);
+
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+        ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
+        ASSERT_GE(finish_response.status().error_msgs_size(), 1);
+        const auto& message = finish_response.status().error_msgs(0);
+        ASSERT_TRUE(message.find("AsyncDeltaWriter has been closed") != std::string::npos) << message;
+
+        PTabletWriterAddBatchResult finish_response2;
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response2);
+        ASSERT_EQ(TStatusCode::DUPLICATE_RPC_INVOCATION, finish_response2.status().status_code());
+    }
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -440,4 +440,15 @@ TEST_F(AsyncDeltaWriterTest, test_close) {
     }
 }
 
+TEST_F(AsyncDeltaWriterTest, test_open_after_close) {
+    auto tablet_id = _tablet_metadata->id();
+    auto delta_writer = AsyncDeltaWriter::create(_tablet_manager.get(), tablet_id, _txn_id, _partition_id, nullptr,
+                                                 _mem_tracker.get());
+    ASSERT_OK(delta_writer->open());
+    delta_writer->close();
+    auto st = delta_writer->open();
+    ASSERT_FALSE(st.ok());
+    ASSERT_EQ("AsyncDeltaWriter has been closed", st.message());
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
- Does not reset the field `_writer` of AsyncDeltaWriterImpl in AsyncDeltaWriterImpl::close() to make it safe to call AsyncDeltaWriterImpl::partition_id() after AsyncDeltaWriterImpl::close() has been invoked.
- Add more checks in LakeTabletsChannel


## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18654 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
