### PR TITLE
[Enhancement] Support iceberg metadata two level cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -155,10 +155,6 @@ public class IcebergTable extends Table {
                 .collect(Collectors.toList());
     }
 
-    public String getFileIOMaxTotalBytes() {
-        return icebergProperties.get(IcebergCachingFileIO.FILEIO_CACHE_MAX_TOTAL_BYTES);
-    }
-
     public String getResourceName() {
         return resourceName;
     }
@@ -272,9 +268,9 @@ public class IcebergTable extends Table {
         icebergProperties.put(ICEBERG_CATALOG_TYPE, type.name());
         LOG.info("Iceberg table type is " + type.name());
 
+        // deprecated
         String fileIOCacheMaxTotalBytes = copiedProps.get(IcebergCachingFileIO.FILEIO_CACHE_MAX_TOTAL_BYTES);
         if (!Strings.isNullOrEmpty(fileIOCacheMaxTotalBytes)) {
-            icebergProperties.put(IcebergCachingFileIO.FILEIO_CACHE_MAX_TOTAL_BYTES, fileIOCacheMaxTotalBytes);
             copiedProps.remove(IcebergCachingFileIO.FILEIO_CACHE_MAX_TOTAL_BYTES);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1706,26 +1706,38 @@ public class Config extends ConfigBase {
     /**
      * iceberg metadata cache dir
      */
-    @ConfField
+    @ConfField(mutable = true)
     public static String iceberg_metadata_cache_disk_path = StarRocksFE.STARROCKS_HOME_DIR + "/caches/iceberg";
 
     /**
-     * iceberg metadata cache total size, default 2GB
+     * iceberg metadata memory cache total size, default 512MB
      */
-    @ConfField
-    public static long iceberg_metadata_cache_capacity = 2147483648L;
+    @ConfField(mutable = true)
+    public static long iceberg_metadata_memory_cache_capacity = 536870912L;
+
+    /**
+     * iceberg metadata memory cache expiration time, default 86500s
+     */
+    @ConfField(mutable = true)
+    public static long iceberg_metadata_memory_cache_expiration_seconds = 86500;
+
+    /**
+     * enable iceberg metadata disk cache, default false
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_iceberg_metadata_disk_cache = false;
+
+    /**
+     * iceberg metadata disk cache total size, default 2GB
+     */
+    @ConfField(mutable = true)
+    public static long iceberg_metadata_disk_cache_capacity = 2147483648L;
 
     /**
      * iceberg metadata cache max entry size, default 8MB
      */
-    @ConfField
+    @ConfField(mutable = true)
     public static long iceberg_metadata_cache_max_entry_size = 8388608L;
-
-    /**
-     * iceberg metadata cache expire after access
-     */
-    @ConfField
-    public static long iceberg_metadata_cache_expiration_seconds = 7L * 24L * 60L * 60L;
 
     /**
      * fe will call es api to get es index shard info every es_state_sync_interval_secs

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2596,10 +2596,6 @@ public class GlobalStateMgr {
             sb.append("\nPROPERTIES (\n");
             sb.append("\"database\" = \"").append(icebergTable.getDb()).append("\",\n");
             sb.append("\"table\" = \"").append(icebergTable.getTable()).append("\",\n");
-            String maxTotalBytes = icebergTable.getFileIOMaxTotalBytes();
-            if (!Strings.isNullOrEmpty(maxTotalBytes)) {
-                sb.append("\"fileIO.cache.max-total-bytes\" = \"").append(maxTotalBytes).append("\",\n");
-            }
             sb.append("\"resource\" = \"").append(icebergTable.getResourceName()).append("\"");
             sb.append("\n)");
         } else if (table.getType() == TableType.JDBC) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/18560

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

#18650 
Iceberg may have a lot of matadata files, and in this scenario network io may be critical, we add two level cache so that cache metadata on local disk. 
All iceberg catalogs share this cache, when memory cache is not full, new data will be loaded and cached in memory, when memory cache is full or data  expired, data  retreat to disk.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
