### PR TITLE
[BugFix] fix lake pk index cache ref leak and update delvec cache strategy

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -95,8 +95,6 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
             }
         }
         if (need_del) {
-            // free cache
-            _tablet.tablet_mgr()->erase_metacache(delvec_cache_key(_tablet_meta->id(), delvec_it->second));
             delvec_it = _tablet_meta->mutable_delvec_meta()->mutable_delvecs()->erase(delvec_it);
             delvec_erase_cnt++;
         } else {
@@ -123,8 +121,6 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version) {
     for (auto&& each_delvec : *(_tablet_meta->mutable_delvec_meta()->mutable_delvecs())) {
         auto iter = _delvecs.find(each_delvec.first);
         if (iter != _delvecs.end()) {
-            // erase old version delvec from cache
-            _tablet.tablet_mgr()->erase_metacache(delvec_cache_key(_tablet_meta->id(), each_delvec.second));
             each_delvec.second.set_version(version);
             each_delvec.second.set_offset(iter->second.offset());
             each_delvec.second.set_size(iter->second.size());

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -43,11 +43,12 @@ public:
     }
 
     ~PrimaryKeyTxnLogApplier() override {
-        if (_inited) {
-            _s_schema_change_set.erase(_tablet.id());
-        }
+        // handle failure first, then release lock
         if (_check_meta_version_succ) {
             _builder.handle_failure();
+        }
+        if (_inited) {
+            _s_schema_change_set.erase(_tablet.id());
         }
     }
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -540,6 +540,17 @@ int32_t UpdateManager::_get_condition_column(const TxnLogPB_OpWrite& op_write, c
     return -1;
 }
 
+bool UpdateManager::TEST_check_primary_index_cache_ref(uint32_t tablet_id, uint32_t ref_cnt) {
+    auto index_entry = _index_cache.get(tablet_id);
+    if (index_entry != nullptr) {
+        DeferOp release_index_entry([&] { _index_cache.release(index_entry); });
+        if (index_entry->get_ref() != ref_cnt + 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace lake
 
 } // namespace starrocks

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -488,6 +488,7 @@ Status UpdateManager::check_meta_version(const Tablet& tablet, int64_t base_vers
         auto& index = index_entry->value();
         if (index.data_version() > base_version) {
             // return error, and ignore this publish later
+            _index_cache.release(index_entry);
             LOG(INFO) << "Primary index version is greater than the base version. tablet_id: " << tablet.id()
                       << " index_version: " << index.data_version() << " base_version: " << base_version;
             return Status::AlreadyExist("lake primary publish txn already finish");

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -98,6 +98,9 @@ public:
 
     void expire_cache();
 
+    // check if pk index's cache ref == ref_cnt
+    bool TEST_check_primary_index_cache_ref(uint32_t tablet_id, uint32_t ref_cnt);
+
 private:
     // print memory tracker state
     void _print_memory_stats();

--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -51,6 +51,8 @@ public:
 
         void update_expire_time(int64_t expire_ms) { _expire_ms = expire_ms; }
 
+        uint32_t get_ref() const { return _ref.load(); }
+
     protected:
         friend class DynamicCache<Key, T>;
         typedef typename std::list<Entry*>::const_iterator Handle;

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -137,6 +137,8 @@ public:
     }
 
     void TearDown() override {
+        // check primary index cache's ref
+        EXPECT_TRUE(_update_manager->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
         tablet.delete_txn_log(_txn_id);
         _txn_id++;

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -137,6 +137,8 @@ public:
     }
 
     void TearDown() override {
+        // check primary index cache's ref
+        EXPECT_TRUE(_update_manager->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
         tablet.delete_txn_log(_txn_id);
         _txn_id++;

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -122,6 +122,8 @@ protected:
     }
 
     void TearDown() override {
+        // check primary index cache's ref
+        EXPECT_TRUE(_update_manager->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
         tablet.delete_txn_log(_txn_id);
         _txn_id++;

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -123,6 +123,8 @@ public:
     }
 
     void TearDown() override {
+        // check primary index cache's ref
+        EXPECT_TRUE(_update_manager->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
         tablet.delete_txn_log(_txn_id);
         _txn_id++;


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14853

## Problem Summary(Required) ：
Fix two problem:
1. When lake primary table publish, and `check_meta_version` failed because base version smaller than index version, will miss release pk index's ref.
2. When `~PrimaryKeyTxnLogApplier()`, we should handle failure first to release pk index, then release tablet lock. Or we will meet concurrent update pk index problem.

Refactor:
And also delete the code about proactively clear the delvec cache. delvec cache will be removed by LRU strategy.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
