### PR TITLE
[BugFix] Fix TOP-N filter may cause wrong result when using with lowcardinality optimize

### DIFF
--- a/be/src/storage/olap_runtime_range_pruner.hpp
+++ b/be/src/storage/olap_runtime_range_pruner.hpp
@@ -67,13 +67,13 @@ struct RuntimeColumnPredicateBuilder {
             if constexpr (ltype == TYPE_VARCHAR) {
                 auto cid = parser->column_id(*slot);
                 if (auto iter = global_dictmaps->find(cid); iter != global_dictmaps->end()) {
-                    _build_minmax_range<RangeType, value_type, LowCardDictType, GlobalDictCodeDecoder>(range, rf,
-                                                                                                       iter->second);
+                    build_minmax_range<RangeType, value_type, LowCardDictType, GlobalDictCodeDecoder>(range, rf,
+                                                                                                      iter->second);
                 } else {
-                    _build_minmax_range<RangeType, value_type, mapping_type, DummyDecoder>(range, rf, nullptr);
+                    build_minmax_range<RangeType, value_type, mapping_type, DummyDecoder>(range, rf, nullptr);
                 }
             } else {
-                _build_minmax_range<RangeType, value_type, mapping_type, DummyDecoder>(range, rf, nullptr);
+                build_minmax_range<RangeType, value_type, mapping_type, DummyDecoder>(range, rf, nullptr);
             }
 
             std::vector<TCondition> filters;
@@ -95,12 +95,12 @@ struct RuntimeColumnPredicateBuilder {
         }
     }
 
-private:
     template <class InputType>
     struct DummyDecoder {
         DummyDecoder(std::nullptr_t) {}
         auto decode(InputType input) const { return input; }
     };
+
     template <class InputType>
     struct GlobalDictCodeDecoder {
         GlobalDictCodeDecoder(const GlobalDictMap* dict_map) : _dict_map(dict_map) {}
@@ -140,7 +140,7 @@ private:
     };
 
     template <class Range, class value_type, LogicalType mapping_type, template <class> class Decoder, class... Args>
-    void _build_minmax_range(Range& range, const JoinRuntimeFilter* rf, Args&&... args) {
+    static void build_minmax_range(Range& range, const JoinRuntimeFilter* rf, Args&&... args) {
         const RuntimeBloomFilter<mapping_type>* filter = down_cast<const RuntimeBloomFilter<mapping_type>*>(rf);
         using DecoderType = Decoder<typename RunTimeTypeTraits<mapping_type>::CppType>;
         DecoderType decoder(std::forward<Args>(args)...);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18683

## Problem Summary(Required) ：
```
if we have multi-scanners execute one-by-one, if a scanner has finished building a runtime filter, the rest of the runtime filters will be normalized in normalize_join_runtime_filter. which will cause a down_cast error (RuntimeFilter Type is LowcardinalityType but cast as varchar type)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
