### PR TITLE
[BugFix] Fix FE host redundant bug when restart FE node in k8s cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/NetUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/NetUtils.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.common.util;
 
+import com.google.common.base.Strings;
 import com.starrocks.common.Pair;
 import org.apache.commons.validator.routines.InetAddressValidator;
 
@@ -89,11 +90,11 @@ public class NetUtils {
         } else {
             // ipOrFqdn is fqdn
             ip = InetAddress.getByName(host).getHostAddress();
-            if (null == ip || ip.equals("")) {
+            if (Strings.isNullOrEmpty(ip)) {
                 throw new UnknownHostException("got a wrong ip");
             }
             fqdn = host;
         }
-        return new Pair<String, String>(ip, fqdn);
+        return new Pair<>(ip, fqdn);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/ha/BDBHATest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/ha/BDBHATest.java
@@ -61,15 +61,15 @@ public class BDBHATest {
         BDBEnvironment environment = journal.getBdbEnvironment();
 
         // add two followers
-        GlobalStateMgr.getCurrentState().addFrontend(FrontendNodeType.FOLLOWER, "host1", 9010);
+        GlobalStateMgr.getCurrentState().addFrontend(FrontendNodeType.FOLLOWER, "192.168.2.3", 9010);
         Assert.assertEquals(1,
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());
-        GlobalStateMgr.getCurrentState().addFrontend(FrontendNodeType.FOLLOWER, "host2", 9010);
+        GlobalStateMgr.getCurrentState().addFrontend(FrontendNodeType.FOLLOWER, "192.168.2.4", 9010);
         Assert.assertEquals(1,
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());
 
         // one joined successfully
-        new Frontend(FrontendNodeType.FOLLOWER, "node1", "host2", 9010)
+        new Frontend(FrontendNodeType.FOLLOWER, "node1", "192.168.2.4", 9010)
                 .handleHbResponse(new FrontendHbResponse("n1", 8030, 9050,
                                 1000, System.currentTimeMillis(), System.currentTimeMillis(), "v1"),
                         false);
@@ -77,7 +77,7 @@ public class BDBHATest {
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());
 
         // the other one is dropped
-        GlobalStateMgr.getCurrentState().dropFrontend(FrontendNodeType.FOLLOWER, "host1", 9010);
+        GlobalStateMgr.getCurrentState().dropFrontend(FrontendNodeType.FOLLOWER, "192.168.2.3", 9010);
 
         Assert.assertEquals(0,
                 environment.getReplicatedEnvironment().getRepMutableConfig().getElectableGroupSizeOverride());

--- a/fe/fe-core/src/test/java/com/starrocks/server/NodeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/NodeMgrTest.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.system.Frontend;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.UnknownHostException;
+
+public class NodeMgrTest {
+
+    @Test(expected = UnknownHostException.class)
+    public void testCheckFeExistByIpOrFqdnException() throws UnknownHostException {
+        NodeMgr nodeMgr = new NodeMgr(false, GlobalStateMgr.getCurrentState());
+        nodeMgr.checkFeExistByIpOrFqdn("not-exist-host.com");
+    }
+
+    @Test
+    public void testCheckFeExistByIpOrFqdn() throws UnknownHostException {
+        NodeMgr nodeMgr = new NodeMgr(false, GlobalStateMgr.getCurrentState());
+        nodeMgr.replayAddFrontend(new Frontend(FrontendNodeType.FOLLOWER, "node1", "localhost", 9010));
+        Assert.assertTrue(nodeMgr.checkFeExistByIpOrFqdn("localhost"));
+        Assert.assertTrue(nodeMgr.checkFeExistByIpOrFqdn("127.0.0.1"));
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18834
If a pod in k8s is deleted, a new pod with the same FQDN will be added to the cluster and the manager will call `Alter system add Follower/Observer ...` to StarRocks(The manager cannot judge whether the node is restarted or newly added, so it call this command every time. But for the restart, this command will fail because the node is already in the cluster). But the function getFeByHost() will return null when the specified FQDN cannot be resolved to ip, in this case, the FE with the same FQDN will be added to cluster.
To fix this bug, I write a new function to judge whether the specified FQDN is already in the cluster, if the FQDN cannot be resolved, an exception will be thrown.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
