### PR TITLE
[BugFix] Report error when creating table with unknown properties

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2375,6 +2375,11 @@ public class LocalMetastore implements ConnectorMetadata {
             // do not create partition for external table
             if (table.isOlapOrLakeTable()) {
                 if (partitionInfo.getType() == PartitionType.UNPARTITIONED) {
+                    if (properties != null && !properties.isEmpty()) {
+                        // here, all properties should be checked
+                        throw new DdlException("Unknown properties: " + properties);
+                    }
+
                     // this is a 1-level partitioned table, use table name as partition name
                     long partitionId = partitionNameToId.get(tableName);
                     Partition partition = createPartition(db, table, partitionId, tableName, version, tabletIdSet);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -235,7 +235,7 @@ public class AlterTableStatementAnalyzer {
                 clause.setNeedTableStable(false);
                 clause.setOpType(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC);
             } else {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown table property: " + properties.keySet());
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
             }
             return null;
         }
@@ -436,7 +436,7 @@ public class AlterTableStatementAnalyzer {
                     clause.getProperties(), PropertyAnalyzer.PROPERTIES_USE_TEMP_PARTITION_NAME, false));
 
             if (clause.getProperties() != null && !clause.getProperties().isEmpty()) {
-                throw new SemanticException("Unknown properties: " + clause.getProperties().keySet());
+                throw new SemanticException("Unknown properties: " + clause.getProperties());
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.ColumnDef;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.DataProperty;
@@ -32,10 +31,8 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TTabletType;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class MultiItemListPartitionDesc extends PartitionDesc {
@@ -43,7 +40,7 @@ public class MultiItemListPartitionDesc extends PartitionDesc {
     private final boolean ifNotExists;
     private final String partitionName;
     private final List<List<String>> multiValues;
-    private final Map<String, String> partitionProperties;
+    private final Map<String, String> properties;
     private DataProperty partitionDataProperty;
     private Short replicationNum;
     private Boolean isInMemory;
@@ -52,23 +49,23 @@ public class MultiItemListPartitionDesc extends PartitionDesc {
     private List<ColumnDef> columnDefList;
 
     public MultiItemListPartitionDesc(boolean ifNotExists, String partitionName, List<List<String>> multiValues,
-                                      Map<String, String> partitionProperties) {
-        this(ifNotExists, partitionName, multiValues, partitionProperties, NodePosition.ZERO);
+                                      Map<String, String> properties) {
+        this(ifNotExists, partitionName, multiValues, properties, NodePosition.ZERO);
     }
 
     public MultiItemListPartitionDesc(boolean ifNotExists, String partitionName, List<List<String>> multiValues,
-                                      Map<String, String> partitionProperties, NodePosition pos) {
+                                      Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.type = PartitionType.LIST;
         this.partitionName = partitionName;
         this.ifNotExists = ifNotExists;
         this.multiValues = multiValues;
-        this.partitionProperties = partitionProperties;
+        this.properties = properties;
     }
 
     @Override
     public Map<String, String> getProperties() {
-        return this.partitionProperties;
+        return this.properties;
     }
 
     @Override
@@ -147,41 +144,43 @@ public class MultiItemListPartitionDesc extends PartitionDesc {
     }
 
     private void analyzeProperties(Map<String, String> tableProperties) throws AnalysisException {
-        // copy one. because ProperAnalyzer will remove entry after analyze
-        Map<String, String> copiedTableProperties = Optional.ofNullable(tableProperties)
-                .map(properties -> Maps.newHashMap(properties))
-                .orElseGet(() -> new HashMap<>());
-        Map<String, String> copiedPartitionProperties = Optional.ofNullable(this.partitionProperties)
-                .map(properties -> Maps.newHashMap(properties))
-                .orElseGet(() -> new HashMap<>());
-
+        Map<String, String> partitionAndTableProperties = Maps.newHashMap();
         // The priority of the partition attribute is higher than that of the table
-        Map<String, String> allProperties = new HashMap<>();
-        copiedTableProperties.forEach((k, v) -> allProperties.put(k, v));
-        copiedPartitionProperties.forEach((k, v) -> allProperties.put(k, v));
+        if (tableProperties != null) {
+            partitionAndTableProperties.putAll(tableProperties);
+        }
+        if (properties != null) {
+            partitionAndTableProperties.putAll(properties);
+        }
 
         // analyze data property
-        this.partitionDataProperty = PropertyAnalyzer.analyzeDataProperty(allProperties,
+        this.partitionDataProperty = PropertyAnalyzer.analyzeDataProperty(partitionAndTableProperties,
                 DataProperty.getInferredDefaultDataProperty());
 
         // analyze replication num
-        this.replicationNum =
-                PropertyAnalyzer.analyzeReplicationNum(allProperties, RunMode.defaultReplicationNum());
+        this.replicationNum = PropertyAnalyzer
+                .analyzeReplicationNum(partitionAndTableProperties, RunMode.defaultReplicationNum());
 
         // analyze version info
-        this.versionInfo = PropertyAnalyzer.analyzeVersionInfo(allProperties);
+        this.versionInfo = PropertyAnalyzer.analyzeVersionInfo(partitionAndTableProperties);
 
         // analyze in memory
-        this.isInMemory =
-                PropertyAnalyzer.analyzeBooleanProp(allProperties, PropertyAnalyzer.PROPERTIES_INMEMORY, false);
+        this.isInMemory = PropertyAnalyzer
+                .analyzeBooleanProp(partitionAndTableProperties, PropertyAnalyzer.PROPERTIES_INMEMORY, false);
 
         // analyze tabletType
-        this.tabletType = PropertyAnalyzer.analyzeTabletType(allProperties);
+        this.tabletType = PropertyAnalyzer.analyzeTabletType(partitionAndTableProperties);
 
-        // check unknown properties
-        if (copiedTableProperties.isEmpty() && !allProperties.isEmpty()) {
-            Joiner.MapJoiner mapJoiner = Joiner.on(", ").withKeyValueSeparator(" = ");
-            throw new AnalysisException("Unknown properties: " + mapJoiner.join(allProperties));
+        if (properties != null) {
+            // check unknown properties
+            Sets.SetView<String> intersection =
+                    Sets.intersection(partitionAndTableProperties.keySet(), properties.keySet());
+            if (!intersection.isEmpty()) {
+                Map<String, String> unknownProperties = Maps.newHashMap();
+                intersection.stream().forEach(x -> unknownProperties.put(x, properties.get(x)));
+                throw new AnalysisException("Unknown properties: " + unknownProperties);
+            }
+
         }
     }
 
@@ -195,9 +194,9 @@ public class MultiItemListPartitionDesc extends PartitionDesc {
                 .collect(Collectors.joining(","));
         sb.append(items);
         sb.append(")");
-        if (this.partitionProperties != null && !this.partitionProperties.isEmpty()) {
+        if (this.properties != null && !this.properties.isEmpty()) {
             sb.append(" (");
-            sb.append(new PrintableMap(this.partitionProperties, "=", true, false));
+            sb.append(new PrintableMap(this.properties, "=", true, false));
             sb.append(")");
         }
         return sb.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
@@ -97,7 +97,7 @@ public class MultiRangePartitionDesc extends PartitionDesc {
         if (firstPartitionColumnType.isDateType()) {
             return buildDateTypePartition(firstPartitionColumnType, properties);
         } else if (firstPartitionColumnType.isIntegerType()) {
-            return buildNumberTypePartition(properties);
+            return buildNumberTypePartition();
         } else {
             throw new AnalysisException("Unsupported batch partition build type:" + firstPartitionColumnType + ".");
         }
@@ -297,8 +297,9 @@ public class MultiRangePartitionDesc extends PartitionDesc {
             PartitionValue upperPartitionValue = new PartitionValue(beginTime.format(outputDateFormat));
             PartitionKeyDesc partitionKeyDesc = new PartitionKeyDesc(Lists.newArrayList(lowerPartitionValue),
                     Lists.newArrayList(upperPartitionValue));
+            // properties is from table, do not use in new SingleRangePartitionDesc.
             SingleRangePartitionDesc singleRangePartitionDesc = new SingleRangePartitionDesc(false,
-                    partitionName, partitionKeyDesc, properties);
+                    partitionName, partitionKeyDesc, null);
             singleRangePartitionDescs.add(singleRangePartitionDesc);
 
             currentLoopNum++;
@@ -309,8 +310,7 @@ public class MultiRangePartitionDesc extends PartitionDesc {
         return singleRangePartitionDescs;
     }
 
-    private List<SingleRangePartitionDesc> buildNumberTypePartition(Map<String, String> properties)
-            throws AnalysisException {
+    private List<SingleRangePartitionDesc> buildNumberTypePartition() throws AnalysisException {
         if (this.getTimeUnit() != null) {
             throw new AnalysisException("Batch build partition EVERY is date type " +
                     "but START or END does not type match.");
@@ -340,8 +340,9 @@ public class MultiRangePartitionDesc extends PartitionDesc {
             PartitionValue upperPartitionValue = new PartitionValue(Long.toString(beginNum));
             PartitionKeyDesc partitionKeyDesc = new PartitionKeyDesc(Lists.newArrayList(lowerPartitionValue),
                     Lists.newArrayList(upperPartitionValue));
+            // properties is from table, do not use in new SingleRangePartitionDesc.
             SingleRangePartitionDesc singleRangePartitionDesc = new SingleRangePartitionDesc(false,
-                    partitionName, partitionKeyDesc, properties);
+                    partitionName, partitionKeyDesc, null);
             singleRangePartitionDescs.add(singleRangePartitionDesc);
 
             currentLoopNum++;

--- a/fe/fe-core/src/test/java/com/starrocks/binlog/BinlogManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/binlog/BinlogManagerTest.java
@@ -46,11 +46,12 @@ public class BinlogManagerTest {
         GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
         String createTableStmtStr = "CREATE TABLE test.binlog_test(k1 int, v1 int) " +
                 "duplicate key(k1) distributed by hash(k1) buckets 2 properties('replication_num' = '1', " +
-                "'binlog_enable' = 'false', 'binlog_ttl' = '100', 'binlog_max_size' = '100');";
+                "'binlog_enable' = 'false', 'binlog_ttl_second' = '100', 'binlog_max_size' = '100');";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.
                 parseStmtWithNewParser(createTableStmtStr, connectContext);
         GlobalStateMgr.getCurrentState().getMetadata().createTable(createTableStmt);
     }
+
     @Test
     public void testTryEnableBinlog() {
         Database db = GlobalStateMgr.getCurrentState().getDb("test");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -267,6 +267,15 @@ public class CreateTableTest {
                                 + "Primary KEY (col1) distributed by hash(col1) buckets 1 \n"
                                 + "properties('replication_num' = '1', 'replicated_storage' = 'FALSE');"));
 
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Unknown properties: {wrong_key=value}",
+                        () -> createTable("create table test.atbl13 (k1 int, k2 int) duplicate key(k1)\n"
+                                + "distributed by hash(k2) buckets 1\n"
+                                + "properties('replication_num' = '1', 'wrong_key' = 'value'); "));
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Unknown properties: {wrong_key=value}",
+                () -> createTable("create table test.atbl14 (k1 int, k2 int, k3 float) duplicate key(k1)\n"
+                        + "partition by range(k1) (partition p1 values less than(\"10\") ('wrong_key' = 'value'))\n"
+                        + "distributed by hash(k2) buckets 1 properties('replication_num' = '1'); "));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -568,7 +568,7 @@ public class PseudoCluster {
                                 "\"write_quorum\" = \"%s\", " +
                                 "\"replication_num\" = \"%d\", " +
                                 "\"storage_medium\" = \"%s\", " +
-                                "\"group_with\" = \"%s\")",
+                                "\"colocate_with\" = \"%s\")",
                     tableName,
                     buckets, quorum, replication,
                     ssd ? "SSD" : "HDD",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -93,7 +93,7 @@ public class AnalyzeAlterTableStatementTest {
         analyzeFail("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\", \"dynamic_partition.enable\" = \"true\");",
                 "Can only set one table property at a time");
         analyzeFail("ALTER TABLE test.t0 SET (\"abc\" = \"2\");",
-                "Unknown table property: [abc]");
+                "Unknown properties: {abc=2}");
         analyzeFail("ALTER TABLE test.t0 SET (\"send_clear_alter_tasks\" = \"FALSE\");",
                 "Property send_clear_alter_tasks should be set to true");
         analyzeFail("ALTER TABLE test.t0 SET (\"storage_format\" = \"V1\");",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewPlanTest.java
@@ -73,7 +73,7 @@ public class MaterializedViewPlanTest extends PlanTestBase {
     public void testSelectFromBinlog() throws Exception {
         String createTableStmtStr = "CREATE TABLE test.binlog_test(k1 int, v1 int, v2 varchar(20)) " +
                 "duplicate key(k1) distributed by hash(k1) buckets 2 properties('replication_num' = '1', " +
-                "'binlog_enable' = 'false', 'binlog_ttl' = '100', 'binlog_max_size' = '100');";
+                "'binlog_enable' = 'false', 'binlog_ttl_second' = '100', 'binlog_max_size' = '100');";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.
                 parseStmtWithNewParser(createTableStmtStr, connectContext);
         GlobalStateMgr.getCurrentState().getMetadata().createTable(createTableStmt);


### PR DESCRIPTION
1. unpartitioned table properties 
create table t1 (k1 int)
distributed by hash(k1) properties ("wrong_key" = "value");

2. partition properties 
create table t1 (k1 int)
partition by range(k1) (partition p1 values less than("10") ("wrong_key" = "value")) 
distributed by hash(k1);

report `Unknown properties: {wrong_key=value}`

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
