### PR TITLE
[Enhancement] Optimize scan range placement of hdfs backend selector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -683,7 +683,7 @@ public class CoordinatorPreprocessor {
                                 int expectedDop = Math.max(1, Math.min(pipelineDop, scanRangeParams.size()));
                                 List<List<TScanRangeParams>> scanRangeParamsPerDriverSeq =
                                         ListUtil.splitBySize(scanRangeParams, expectedDop);
-                                if (fragment.isForceAssignScanRangesPerDriverSeq() && scanRangeParamsPerDriverSeq.size() 
+                                if (fragment.isForceAssignScanRangesPerDriverSeq() && scanRangeParamsPerDriverSeq.size()
                                         != pipelineDop) {
                                     fragment.setPipelineDop(scanRangeParamsPerDriverSeq.size());
                                 }
@@ -1035,13 +1035,15 @@ public class CoordinatorPreprocessor {
                     queryOptions.
                             setEnable_populate_block_cache(
                                     connectContext.getSessionVariable().getEnablePopulateBlockCache());
-                    queryOptions.setHudi_mor_force_jni_reader(connectContext.getSessionVariable().getHudiMORForceJNIReader());
+                    queryOptions.setHudi_mor_force_jni_reader(
+                            connectContext.getSessionVariable().getHudiMORForceJNIReader());
                 }
                 HDFSBackendSelector selector =
                         new HDFSBackendSelector(scanNode, locations, assignment, addressToBackendID, usedBackendIDs,
                                 getSelectorComputeNodes(hasComputeNode),
                                 hasComputeNode,
-                                forceScheduleLocal);
+                                forceScheduleLocal,
+                                connectContext.getSessionVariable().getHDFSBackendSelectorScanRangeShuffle());
                 selector.computeScanRangeAssignment();
             } else {
                 boolean hasColocate = isColocateFragment(scanNode.getFragment().getPlanRoot());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -45,6 +45,7 @@ import com.starrocks.thrift.TScanRangeParams;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -117,7 +118,7 @@ public class HDFSBackendSelector implements BackendSelector {
         public void acceptScanRangeLocations(TScanRangeLocations tScanRangeLocations, PrimitiveSink primitiveSink) {
             THdfsScanRange hdfsScanRange = tScanRangeLocations.scan_range.hdfs_scan_range;
             if (hdfsScanRange.isSetFull_path()) {
-                primitiveSink.putBytes(hdfsScanRange.full_path.getBytes());
+                primitiveSink.putString(hdfsScanRange.full_path, StandardCharsets.UTF_8);
             } else {
                 if (hdfsScanRange.isSetPartition_id() &&
                         predicates.getIdToPartitionKey().containsKey(hdfsScanRange.getPartition_id())) {
@@ -125,7 +126,7 @@ public class HDFSBackendSelector implements BackendSelector {
                     primitiveSink.putInt(partitionKey.hashCode());
                 }
                 if (hdfsScanRange.isSetRelative_path()) {
-                    primitiveSink.putBytes(hdfsScanRange.relative_path.getBytes());
+                    primitiveSink.putString(hdfsScanRange.relative_path, StandardCharsets.UTF_8);
                 }
             }
             if (hdfsScanRange.isSetOffset()) {
@@ -183,7 +184,7 @@ public class HDFSBackendSelector implements BackendSelector {
     class ComputeNodeFunnel implements Funnel<ComputeNode> {
         @Override
         public void funnel(ComputeNode computeNode, PrimitiveSink primitiveSink) {
-            primitiveSink.putBytes(computeNode.getHost().getBytes());
+            primitiveSink.putString(computeNode.getHost(), StandardCharsets.UTF_8);
             primitiveSink.putInt(computeNode.getBePort());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -42,8 +42,9 @@ import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TScanRangeParams;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -65,6 +66,7 @@ import java.util.Set;
  */
 
 public class HDFSBackendSelector implements BackendSelector {
+    public static final Logger LOG = LogManager.getLogger(HDFSBackendSelector.class);
     // be -> assigned scans
     Map<ComputeNode, Long> assignedScansPerComputeNode = Maps.newHashMap();
     // be host -> bes
@@ -114,18 +116,15 @@ public class HDFSBackendSelector implements BackendSelector {
         public void acceptScanRangeLocations(TScanRangeLocations tScanRangeLocations, PrimitiveSink primitiveSink) {
             THdfsScanRange hdfsScanRange = tScanRangeLocations.scan_range.hdfs_scan_range;
             if (hdfsScanRange.isSetFull_path()) {
-                primitiveSink.putBytes(hdfsScanRange.full_path.getBytes(StandardCharsets.UTF_8));
+                primitiveSink.putBytes(hdfsScanRange.full_path.getBytes());
             } else {
-                if (basePath != null) {
-                    primitiveSink.putBytes(basePath.getBytes(StandardCharsets.UTF_8));
-                }
                 if (hdfsScanRange.isSetPartition_id() &&
                         predicates.getIdToPartitionKey().containsKey(hdfsScanRange.getPartition_id())) {
                     PartitionKey partitionKey = predicates.getIdToPartitionKey().get(hdfsScanRange.getPartition_id());
                     primitiveSink.putInt(partitionKey.hashCode());
                 }
                 if (hdfsScanRange.isSetRelative_path()) {
-                    primitiveSink.putBytes(hdfsScanRange.relative_path.getBytes(StandardCharsets.UTF_8));
+                    primitiveSink.putBytes(hdfsScanRange.relative_path.getBytes());
                 }
             }
             if (hdfsScanRange.isSetOffset()) {
@@ -137,12 +136,9 @@ public class HDFSBackendSelector implements BackendSelector {
     private HdfsScanRangeHasher hdfsScanRangeHasher;
 
     public HDFSBackendSelector(ScanNode scanNode, List<TScanRangeLocations> locations,
-                               FragmentScanRangeAssignment assignment,
-                               Map<TNetworkAddress, Long> addressToBackendId,
-                               Set<Long> usedBackendIDs,
-                               ImmutableCollection<ComputeNode> computeNodes,
-                               boolean chooseComputeNode,
-                               boolean forceScheduleLocal) {
+                               FragmentScanRangeAssignment assignment, Map<TNetworkAddress, Long> addressToBackendId,
+                               Set<Long> usedBackendIDs, ImmutableCollection<ComputeNode> computeNodes,
+                               boolean chooseComputeNode, boolean forceScheduleLocal) {
         this.scanNode = scanNode;
         this.locations = locations;
         this.assignment = assignment;
@@ -185,7 +181,7 @@ public class HDFSBackendSelector implements BackendSelector {
     class ComputeNodeFunnel implements Funnel<ComputeNode> {
         @Override
         public void funnel(ComputeNode computeNode, PrimitiveSink primitiveSink) {
-            primitiveSink.putBytes(computeNode.getHost().getBytes(StandardCharsets.UTF_8));
+            primitiveSink.putBytes(computeNode.getHost().getBytes());
             primitiveSink.putInt(computeNode.getBePort());
         }
     }
@@ -205,51 +201,9 @@ public class HDFSBackendSelector implements BackendSelector {
                     new ComputeNodeFunnel(), nodes, kConsistenHashRingVirtualNumber);
         } else {
             hashRing = new RendezvousHashRing(Hashing.murmur3_128(), new TScanRangeLocationsFunnel(),
-                    new ComputeNodeFunnel(),
-                    nodes);
+                    new ComputeNodeFunnel(), nodes);
         }
         return hashRing;
-    }
-
-    // Sort scan ranges, to shuffle them between hosts.
-    // Let's say sc1-h1, sc2-h1, sc3-h2, sc4-h2, then we will sort them as
-    // sc1-h1, sc3-h2, sc2-h1, sc4-h2, so h1, h2 will be interleaved assigned.
-    class ScanRagesSorter {
-        Map<ComputeNode, List<TScanRangeLocations>> map = new HashMap<>();
-
-        public void addScanRange(TScanRangeLocations scanRange, ComputeNode backend) {
-            List<TScanRangeLocations> scanRanges;
-            if (map.containsKey(backend)) {
-                scanRanges = map.get(backend);
-            } else {
-                scanRanges = new ArrayList<>();
-                map.put(backend, scanRanges);
-            }
-            scanRanges.add(scanRange);
-        }
-
-        public List<TScanRangeLocations> sort() {
-            List<TScanRangeLocations> ans = new ArrayList<>();
-            List<List<TScanRangeLocations>> ways = new ArrayList<>(map.values());
-            Collections.sort(ways, (o1, o2) -> o2.size() - o1.size());
-            while (ways.size() > 0) {
-                // shuffle them between hosts.
-                for (int i = 0; i < ways.size(); i++) {
-                    List<TScanRangeLocations> way = ways.get(i);
-                    ans.add(way.remove(way.size() - 1));
-                }
-                // remove empty list.
-                while (ways.size() > 0) {
-                    int last = ways.size() - 1;
-                    if (ways.get(last).size() == 0) {
-                        ways.remove(last);
-                    } else {
-                        break;
-                    }
-                }
-            }
-            return ans;
-        }
     }
 
     private long computeAverageScanRangeBytes() {
@@ -312,15 +266,7 @@ public class HDFSBackendSelector implements BackendSelector {
 
         // use consistent hashing to schedule remote scan ranges
         HashRing hashRing = makeHashRing();
-
-        // sort scan ranges
-        ScanRagesSorter sorter = new ScanRagesSorter();
-        for (TScanRangeLocations scanRange : remoteScanRangeLocations) {
-            List<ComputeNode> backends = hashRing.get(scanRange, 1);
-            sorter.addScanRange(scanRange, backends.get(0));
-        }
-        remoteScanRangeLocations = sorter.sort();
-
+        Collections.shuffle(remoteScanRangeLocations);
         // assign scan ranges.
         for (int i = 0; i < remoteScanRangeLocations.size(); ++i) {
             TScanRangeLocations scanRangeLocations = remoteScanRangeLocations.get(i);
@@ -343,10 +289,10 @@ public class HDFSBackendSelector implements BackendSelector {
         assignedScansPerComputeNode.put(node, assignedScansPerComputeNode.get(node) + addedScans);
 
         // add in assignment
-        Map<Integer, List<TScanRangeParams>> scanRanges = BackendSelector.findOrInsert(
-                assignment, address, new HashMap<>());
-        List<TScanRangeParams> scanRangeParamsList = BackendSelector.findOrInsert(
-                scanRanges, scanNode.getId().asInt(), new ArrayList<TScanRangeParams>());
+        Map<Integer, List<TScanRangeParams>> scanRanges =
+                BackendSelector.findOrInsert(assignment, address, new HashMap<>());
+        List<TScanRangeParams> scanRangeParamsList =
+                BackendSelector.findOrInsert(scanRanges, scanNode.getId().asInt(), new ArrayList<TScanRangeParams>());
         // add scan range params
         TScanRangeParams scanRangeParams = new TScanRangeParams();
         scanRangeParams.scan_range = scanRangeLocations.scan_range;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -380,6 +380,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // control on/off of this bucketization optimization.
     public static final String DISTINCT_COLUMN_BUCKETS = "count_distinct_column_buckets";
     public static final String ENABLE_DISTINCT_COLUMN_BUCKETIZATION = "enable_distinct_column_bucketization";
+    public static final String HDFS_BACKEND_SELECTOR_SCAN_RANGE_SHUFFLE = "hdfs_backend_selector_scan_range_shuffle";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -946,7 +947,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_DISTINCT_COLUMN_BUCKETIZATION)
     private boolean enableDistinctColumnBucketization = true;
-
+    @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_SCAN_RANGE_SHUFFLE)
+    private boolean hdfsBackendSelectorScanRangeShuffle = false;
+    
     public void setFullSortMaxBufferedRows(long v) {
         fullSortMaxBufferedRows = v;
     }
@@ -1818,6 +1821,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setDefaultTableCompression(String compression) {
         this.defaultTableCompressionAlgorithm = compression;
+    }
+
+    public boolean getHDFSBackendSelectorScanRangeShuffle() {
+        return hdfsBackendSelectorScanRangeShuffle;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -947,9 +947,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_DISTINCT_COLUMN_BUCKETIZATION)
     private boolean enableDistinctColumnBucketization = true;
-    @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_SCAN_RANGE_SHUFFLE)
+
+    @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_SCAN_RANGE_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean hdfsBackendSelectorScanRangeShuffle = false;
-    
+
     public void setFullSortMaxBufferedRows(long v) {
         fullSortMaxBufferedRows = v;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -117,7 +117,7 @@ public class HDFSBackendSelectorTest {
 
         HDFSBackendSelector selector =
                 new HDFSBackendSelector(hdfsScanNode, locations, assignment, addressToBackendId, usedBackendIDs,
-                        ImmutableList.copyOf(computeNodes), false, false);
+                        ImmutableList.copyOf(computeNodes), false, false, false);
         selector.computeScanRangeAssignment();
 
         int avg = (scanRangeNumber * scanRangeSize) / hostNumber;
@@ -166,7 +166,7 @@ public class HDFSBackendSelectorTest {
 
         HDFSBackendSelector selector =
                 new HDFSBackendSelector(hdfsScanNode, locations, assignment, addressToBackendId, usedBackendIDs,
-                        ImmutableList.copyOf(computeNodes), true, true);
+                        ImmutableList.copyOf(computeNodes), true, true, false);
         selector.computeScanRangeAssignment();
 
         Map<TNetworkAddress, Long> stats = computeHostReadBytes(assignment, scanNodeId);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Optimzation include:
- take raw string as hash paremeter. no need to decode.
- don't put `basePath` into hasher because all scan range's are the same.
- use simple shuffle instead of `ScanRangeSorter` to avoid data skew(in extreme cases)

CoorPrepareExec time has been reduced from 7746ms -> 1662ms

<img width="308" alt="image" src="https://user-images.githubusercontent.com/1081215/222617889-10628a95-9d53-44b1-a55f-7f436def815a.png">

<img width="382" alt="image" src="https://user-images.githubusercontent.com/1081215/222617821-a1ec6dc4-3b6f-4970-81d6-89af25a2e3a8.png">



## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
