### PR TITLE
[BugFix] Avoid BE crash when apache-orc throw orc::ParseError exception

### DIFF
--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -465,8 +465,8 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         }
         {
             SCOPED_RAW_TIMER(&_stats.column_read_ns);
-            _orc_reader->lazy_seek_to(position.row_in_stripe);
-            _orc_reader->lazy_read_next(read_num_values);
+            RETURN_IF_ERROR(_orc_reader->lazy_seek_to(position.row_in_stripe));
+            RETURN_IF_ERROR(_orc_reader->lazy_read_next(read_num_values));
         }
         {
             SCOPED_RAW_TIMER(&_stats.column_convert_ns);

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -664,12 +664,30 @@ StatusOr<ChunkPtr> OrcChunkReader::get_lazy_chunk() {
     return _cast_chunk(&ptr, _lazy_load_ctx->lazy_load_slots, &_lazy_load_ctx->lazy_load_indices);
 }
 
-void OrcChunkReader::lazy_read_next(size_t numValues) {
-    _row_reader->lazyLoadNext(*_batch, numValues);
+Status OrcChunkReader::lazy_read_next(size_t numValues) {
+    try {
+        // It may throw orc::ParseError exception
+        _row_reader->lazyLoadNext(*_batch, numValues);
+    } catch (std::exception& e) {
+        auto s = strings::Substitute("OrcChunkReader::lazy_read_next failed. reason = $0, file = $1",
+                                     e.what(),_current_file_name);
+        LOG(WARNING) << s;
+        return Status::InternalError(s);
+    }
+    return Status::OK();
 }
 
-void OrcChunkReader::lazy_seek_to(size_t rowInStripe) {
-    _row_reader->lazyLoadSeekTo(rowInStripe);
+Status OrcChunkReader::lazy_seek_to(size_t rowInStripe) {
+    try {
+        // It may throw orc::ParseError exception
+        _row_reader->lazyLoadSeekTo(rowInStripe);
+    } catch (std::exception& e) {
+        auto s = strings::Substitute("OrcChunkReader::lazy_seek_to failed. reason = $0, file = $1",
+                                     e.what(),_current_file_name);
+        LOG(WARNING) << s;
+        return Status::InternalError(s);
+    }
+    return Status::OK();
 }
 
 void OrcChunkReader::set_row_reader_filter(std::shared_ptr<orc::RowReaderFilter> filter) {

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -669,8 +669,8 @@ Status OrcChunkReader::lazy_read_next(size_t numValues) {
         // It may throw orc::ParseError exception
         _row_reader->lazyLoadNext(*_batch, numValues);
     } catch (std::exception& e) {
-        auto s = strings::Substitute("OrcChunkReader::lazy_read_next failed. reason = $0, file = $1",
-                                     e.what(),_current_file_name);
+        auto s = strings::Substitute("OrcChunkReader::lazy_read_next failed. reason = $0, file = $1", e.what(),
+                                     _current_file_name);
         LOG(WARNING) << s;
         return Status::InternalError(s);
     }
@@ -682,8 +682,8 @@ Status OrcChunkReader::lazy_seek_to(size_t rowInStripe) {
         // It may throw orc::ParseError exception
         _row_reader->lazyLoadSeekTo(rowInStripe);
     } catch (std::exception& e) {
-        auto s = strings::Substitute("OrcChunkReader::lazy_seek_to failed. reason = $0, file = $1",
-                                     e.what(),_current_file_name);
+        auto s = strings::Substitute("OrcChunkReader::lazy_seek_to failed. reason = $0, file = $1", e.what(),
+                                     _current_file_name);
         LOG(WARNING) << s;
         return Status::InternalError(s);
     }

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -130,8 +130,8 @@ public:
     bool has_lazy_load_context() { return _lazy_load_ctx != nullptr; }
     StatusOr<ChunkPtr> get_chunk();
     StatusOr<ChunkPtr> get_active_chunk();
-    void lazy_read_next(size_t numValues);
-    void lazy_seek_to(uint64_t rowInStripe);
+    Status lazy_read_next(size_t numValues);
+    Status lazy_seek_to(uint64_t rowInStripe);
     void lazy_filter_on_cvb(Filter* filter);
     StatusOr<ChunkPtr> get_lazy_chunk();
     ColumnPtr get_row_delete_filter(const std::set<int64_t>& deleted_pos);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#1974](https://github.com/StarRocks/StarRocksTest/issues/1974)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

apache-orc will throw `orc::ParseError` exception when parse orc fails, we need to catch it every where we use it. Otherwise, it will occur BE crashed.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
