### PR TITLE
[BugFix] Adjust the default value of thrift_rpc_timeout_ms

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -490,7 +490,7 @@ CONF_mInt32(priority_queue_remaining_tasks_increased_frequency, "512");
 CONF_mBool(sync_tablet_meta, "false");
 
 // Default thrift rpc timeout ms.
-CONF_mInt32(thrift_rpc_timeout_ms, "5000");
+CONF_mInt32(thrift_rpc_timeout_ms, "30000");
 
 // txn commit rpc timeout
 CONF_mInt32(txn_commit_rpc_timeout_ms, "20000");

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -1169,8 +1169,8 @@ public class LeaderImpl {
             TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.getCommit_attachment());
             long timeoutMs = request.isSetCommit_timeout_ms() ? request.getCommit_timeout_ms() : 5000;
             // Make publish timeout is less than thrift_rpc_timeout_ms
-            // Otherwise, the publish will be successful but commit timeout in FE
-            // It will results as error like "call frontend service failed"
+            // Otherwise, the publishing will be successful but commit timeout in FE
+            // It will result as error like "call frontend service failed"
             timeoutMs = timeoutMs * 3 / 4;
             boolean ret = GlobalStateMgr.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
                     db, request.getTxn_id(),

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1368,7 +1368,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         long timeoutMs = request.isSetThrift_rpc_timeout_ms() ? request.getThrift_rpc_timeout_ms() : 5000;
         if (!db.tryReadLock(timeoutMs, TimeUnit.MILLISECONDS)) {
-            throw new UserException("get database read lock timeout, database=" + dbName);
+            throw new UserException("get database read lock timeout, database=" + dbName + ", timeoutMs=" + timeoutMs);
         }
         try {
             Table table = db.getTable(request.getTbl());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently the default value is 5 seconds which is too small,
current lock implementation on FE can easily have long lock wait,
increase it to 30s to make stream load run more stably.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
