### PR TITLE
[Enhancement] Get thread dump before acquire database lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -150,37 +150,34 @@ public class Database extends MetaObject implements Writable {
         return sb.toString();
     }
 
-    private void logSlowLockEventIfNeeded(long startMs, String type, Thread formerOwner) {
+    private void logSlowLockEventIfNeeded(long startMs, String type, String threadDump) {
         long endMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
         if (endMs - startMs > Config.slow_lock_threshold_ms &&
                 endMs > lastSlowLockLogTime + Config.slow_lock_log_every_ms) {
             lastSlowLockLogTime = endMs;
             LOG.warn("slow db lock. type: {}, db id: {}, db name: {}, wait time: {}ms, " +
                             "former {}, current stack trace: ", type, id, fullQualifiedName, endMs - startMs,
-                    getOwnerInfo(formerOwner), new Exception());
+                    threadDump, new Exception());
         }
     }
 
-    private void logTryLockFailureEvent(String type) {
-        Thread owner = rwLock.getOwner();
-        if (owner != null) {
-            LOG.warn("try db lock failed. type: {}, current {}", type, getOwnerInfo(owner));
-        }
+    private void logTryLockFailureEvent(String type, String threadDump) {
+        LOG.warn("try db lock failed. type: {}, current {}", type, threadDump);
     }
 
     public void readLock() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
-        Thread formerOwner = rwLock.getOwner();
+        String threadDump = getOwnerInfo(rwLock.getOwner());
         this.rwLock.readLock().lock();
-        logSlowLockEventIfNeeded(startMs, "readLock", formerOwner);
+        logSlowLockEventIfNeeded(startMs, "readLock", threadDump);
     }
 
     // this function make sure lock can only be obtained if the db has not been dropped
     public boolean readLockAndCheckExist() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
-        Thread formerOwner = rwLock.getOwner();
+        String threadDump = getOwnerInfo(rwLock.getOwner());
         this.rwLock.readLock().lock();
-        logSlowLockEventIfNeeded(startMs, "readLock", formerOwner);
+        logSlowLockEventIfNeeded(startMs, "readLock", threadDump);
         if (exist) {
             return true;
         } else {
@@ -192,12 +189,12 @@ public class Database extends MetaObject implements Writable {
     public boolean tryReadLock(long timeout, TimeUnit unit) {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
-            Thread formerOwner = rwLock.getOwner();
+            String threadDump = getOwnerInfo(rwLock.getOwner());
             if (!this.rwLock.readLock().tryLock(timeout, unit)) {
-                logTryLockFailureEvent("readLock");
+                logTryLockFailureEvent("readLock", threadDump);
                 return false;
             }
-            logSlowLockEventIfNeeded(startMs, "tryReadLock", formerOwner);
+            logSlowLockEventIfNeeded(startMs, "tryReadLock", threadDump);
             return true;
         } catch (InterruptedException e) {
             LOG.warn("failed to try read lock at db[" + id + "]", e);
@@ -209,12 +206,12 @@ public class Database extends MetaObject implements Writable {
     public boolean tryReadLockAndCheckExist(long timeout, TimeUnit unit) {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
-            Thread formerOwner = rwLock.getOwner();
+            String threadDump = getOwnerInfo(rwLock.getOwner());
             if (!this.rwLock.readLock().tryLock(timeout, unit)) {
-                logTryLockFailureEvent("readLock");
+                logTryLockFailureEvent("readLock", threadDump);
                 return false;
             }
-            logSlowLockEventIfNeeded(startMs, "tryReadLock", formerOwner);
+            logSlowLockEventIfNeeded(startMs, "tryReadLock", threadDump);
             if (exist) {
                 return true;
             } else {
@@ -234,17 +231,17 @@ public class Database extends MetaObject implements Writable {
 
     public void writeLock() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
-        Thread formerOwner = rwLock.getOwner();
+        String threadDump = getOwnerInfo(rwLock.getOwner());
         this.rwLock.writeLock().lock();
-        logSlowLockEventIfNeeded(startMs, "writeLock", formerOwner);
+        logSlowLockEventIfNeeded(startMs, "writeLock", threadDump);
     }
 
     // this function make sure lock can only be obtained if the db has not been dropped
     public boolean writeLockAndCheckExist() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
-        Thread formerOwner = rwLock.getOwner();
+        String threadDump = getOwnerInfo(rwLock.getOwner());
         this.rwLock.writeLock().lock();
-        logSlowLockEventIfNeeded(startMs, "writeLock", formerOwner);
+        logSlowLockEventIfNeeded(startMs, "writeLock", threadDump);
         if (exist) {
             return true;
         } else {
@@ -256,12 +253,12 @@ public class Database extends MetaObject implements Writable {
     public boolean tryWriteLock(long timeout, TimeUnit unit) {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
-            Thread formerOwner = rwLock.getOwner();
+            String threadDump = getOwnerInfo(rwLock.getOwner());
             if (!this.rwLock.writeLock().tryLock(timeout, unit)) {
-                logTryLockFailureEvent("writeLock");
+                logTryLockFailureEvent("writeLock", threadDump);
                 return false;
             }
-            logSlowLockEventIfNeeded(startMs, "tryWriteLock", formerOwner);
+            logSlowLockEventIfNeeded(startMs, "tryWriteLock", threadDump);
             return true;
         } catch (InterruptedException e) {
             LOG.warn("failed to try write lock at db[" + id + "]", e);
@@ -273,12 +270,12 @@ public class Database extends MetaObject implements Writable {
     public boolean tryWriteLockAndCheckExist(long timeout, TimeUnit unit) {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
-            Thread formerOwner = rwLock.getOwner();
+            String threadDump = getOwnerInfo(rwLock.getOwner());
             if (!this.rwLock.writeLock().tryLock(timeout, unit)) {
-                logTryLockFailureEvent("tryWriteLock");
+                logTryLockFailureEvent("tryWriteLock", threadDump);
                 return false;
             }
-            logSlowLockEventIfNeeded(startMs, "tryWriteLock", formerOwner);
+            logSlowLockEventIfNeeded(startMs, "tryWriteLock", threadDump);
             if (exist) {
                 return true;
             } else {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
bp from https://github.com/StarRocks/starrocks/pull/16748

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
