### PR TITLE
[Enhancement] Add FE tablet schedule to information_schema

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -123,6 +123,7 @@ set(EXEC_FILES
     schema_scanner/schema_be_tablets_scanner.cpp
     schema_scanner/schema_be_txns_scanner.cpp
     schema_scanner/schema_be_configs_scanner.cpp
+    schema_scanner/schema_fe_tablet_schedules_scanner.cpp
     schema_scanner/schema_helper.cpp
     jdbc_scanner.cpp
     sorting/compare_column.cpp

--- a/be/src/exec/pipeline/scan/olap_schema_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_schema_scan_context.cpp
@@ -90,6 +90,12 @@ Status OlapSchemaScanContext::_prepare_params(RuntimeState* state) {
     if (_tnode.schema_scan_node.__isset.txn_id) {
         _param->txn_id = _tnode.schema_scan_node.txn_id;
     }
+    if (_tnode.schema_scan_node.__isset.type) {
+        _param->type = _obj_pool.add(new std::string(_tnode.schema_scan_node.type));
+    }
+    if (_tnode.schema_scan_node.__isset.state) {
+        _param->state = _obj_pool.add(new std::string(_tnode.schema_scan_node.state));
+    }
 
     return Status::OK();
 }

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -23,6 +23,7 @@
 #include "exec/schema_scanner/schema_collations_scanner.h"
 #include "exec/schema_scanner/schema_columns_scanner.h"
 #include "exec/schema_scanner/schema_dummy_scanner.h"
+#include "exec/schema_scanner/schema_fe_tablet_schedules_scanner.h"
 #include "exec/schema_scanner/schema_load_tracking_logs_scanner.h"
 #include "exec/schema_scanner/schema_loads_scanner.h"
 #include "exec/schema_scanner/schema_materialized_views_scanner.h"
@@ -132,6 +133,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaBeTxnsScanner>();
     case TSchemaTableType::SCH_BE_CONFIGS:
         return std::make_unique<SchemaBeConfigsScanner>();
+    case TSchemaTableType::SCH_FE_TABLET_SCHEDULES:
+        return std::make_unique<SchemaFeTabletSchedulesScanner>();
     default:
         return std::make_unique<SchemaDummyScanner>();
     }

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -57,6 +57,8 @@ struct SchemaScannerParam {
     int64_t partition_id{-1};
     int64_t tablet_id{-1};
     int64_t txn_id{-1};
+    const std::string* type{nullptr};
+    const std::string* state{nullptr};
 
     RuntimeProfile::Counter* _rpc_timer = nullptr;
     RuntimeProfile::Counter* _fill_chunk_timer = nullptr;

--- a/be/src/exec/schema_scanner/schema_fe_tablet_schedules_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_fe_tablet_schedules_scanner.cpp
@@ -1,0 +1,177 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_fe_tablet_schedules_scanner.h"
+
+#include "exec/schema_scanner/schema_helper.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/string_value.h"
+#include "storage/tablet.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaFeTabletSchedulesScanner::_s_columns[] = {
+        {"TABLE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"PARTITION_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"TABLET_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"TYPE", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"PRIORITY", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"TABLET_STATUS", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"CREATE_TIME", TYPE_DOUBLE, sizeof(double), false},
+        {"SCHEDULE_TIME", TYPE_DOUBLE, sizeof(double), false},
+        {"FINISH_TIME", TYPE_DOUBLE, sizeof(double), false},
+        {"CLONE_SRC", TYPE_BIGINT, sizeof(int64_t), false},
+        {"CLONE_DEST", TYPE_BIGINT, sizeof(int64_t), false},
+        {"CLONE_BYTES", TYPE_BIGINT, sizeof(int64_t), false},
+        {"CLONE_DURATION", TYPE_DOUBLE, sizeof(double), false},
+        {"MSG", TYPE_VARCHAR, sizeof(StringValue), false},
+};
+
+SchemaFeTabletSchedulesScanner::SchemaFeTabletSchedulesScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaFeTabletSchedulesScanner::~SchemaFeTabletSchedulesScanner() = default;
+
+Status SchemaFeTabletSchedulesScanner::start(RuntimeState* state) {
+    _cur_idx = 0;
+    TGetTabletScheduleRequest request;
+    TGetTabletScheduleResponse response;
+    if (_param->table_id != -1) {
+        request.__set_table_id(_param->table_id);
+    }
+    if (_param->partition_id != -1) {
+        request.__set_partition_id(_param->partition_id);
+    }
+    if (_param->tablet_id != -1) {
+        request.__set_tablet_id(_param->tablet_id);
+    }
+    if (_param->type != nullptr) {
+        request.__set_type(*_param->type);
+    }
+    if (_param->state != nullptr) {
+        request.__set_state(*_param->state);
+    }
+    if (_param->limit > 0) {
+        request.__set_limit(_param->limit);
+    }
+    if (nullptr != _param->ip && 0 != _param->port) {
+        RETURN_IF_ERROR(SchemaHelper::get_tablet_schedules(*(_param->ip), _param->port, request, &response));
+        _infos.swap(response.tablet_schedules);
+    } else {
+        return Status::InternalError("IP or port doesn't exists");
+    }
+    return Status::OK();
+}
+
+Status SchemaFeTabletSchedulesScanner::fill_chunk(ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 15) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.table_id);
+                break;
+            }
+            case 2: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.partition_id);
+                break;
+            }
+            case 3: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.tablet_id);
+                break;
+            }
+            case 4: {
+                Slice v = Slice(info.type);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 5: {
+                Slice v = Slice(info.priority);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 6: {
+                Slice v = Slice(info.state);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 7: {
+                Slice v = Slice(info.tablet_status);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 8: {
+                fill_column_with_slot<TYPE_DOUBLE>(column.get(), (void*)&info.create_time);
+                break;
+            }
+            case 9: {
+                fill_column_with_slot<TYPE_DOUBLE>(column.get(), (void*)&info.schedule_time);
+                break;
+            }
+            case 10: {
+                fill_column_with_slot<TYPE_DOUBLE>(column.get(), (void*)&info.finish_time);
+                break;
+            }
+            case 11: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.clone_src);
+                break;
+            }
+            case 12: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.clone_dest);
+                break;
+            }
+            case 13: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.clone_bytes);
+                break;
+            }
+            case 14: {
+                fill_column_with_slot<TYPE_DOUBLE>(column.get(), (void*)&info.clone_duration);
+                break;
+            }
+            case 15: {
+                Slice v = Slice(info.error_msg);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaFeTabletSchedulesScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_fe_tablet_schedules_scanner.h
+++ b/be/src/exec/schema_scanner/schema_fe_tablet_schedules_scanner.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "exec/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+class SchemaFeTabletSchedulesScanner : public SchemaScanner {
+public:
+    SchemaFeTabletSchedulesScanner();
+    ~SchemaFeTabletSchedulesScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<TTabletSchedule> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_helper.cpp
+++ b/be/src/exec/schema_scanner/schema_helper.cpp
@@ -141,6 +141,15 @@ Status SchemaHelper::get_loads(const std::string& ip, const int32_t port, const 
             timeout_ms);
 }
 
+Status SchemaHelper::get_tablet_schedules(const std::string& ip, const int32_t port,
+                                          const TGetTabletScheduleRequest& request,
+                                          TGetTabletScheduleResponse* response) {
+    return ThriftRpcHelper::rpc<FrontendServiceClient>(ip, port,
+                                                       [&request, &response](FrontendServiceConnection& client) {
+                                                           client->getTabletSchedule(*response, request);
+                                                       });
+}
+
 void fill_data_column_with_null(Column* data_column) {
     auto* nullable_column = down_cast<NullableColumn*>(data_column);
     nullable_column->append_nulls(1);

--- a/be/src/exec/schema_scanner/schema_helper.h
+++ b/be/src/exec/schema_scanner/schema_helper.h
@@ -70,6 +70,9 @@ public:
 
     static Status get_tables_config(const std::string& ip, const int32_t port,
                                     const TGetTablesConfigRequest& var_params, TGetTablesConfigResponse* var_result);
+
+    static Status get_tablet_schedules(const std::string& ip, const int32_t port,
+                                       const TGetTabletScheduleRequest& request, TGetTabletScheduleResponse* response);
 };
 
 template <LogicalType SlotType>

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -62,8 +62,21 @@ public class SchemaTable extends Table {
         return name.startsWith("be_");
     }
 
+    public static boolean isFeSchemaTable(String name) {
+        // currently, it only stands for single FE leader, because only FE leader has related info
+        return name.startsWith("fe_");
+    }
+
     public boolean isBeSchemaTable() {
         return SchemaTable.isBeSchemaTable(getName());
+    }
+
+    public boolean isFeSchemaTable() {
+        return SchemaTable.isFeSchemaTable(getName());
+    }
+
+    public boolean requireOperatePrivilege() {
+        return isBeSchemaTable() || isFeSchemaTable();
     }
 
     @Override
@@ -661,6 +674,27 @@ public class SchemaTable extends Table {
                                     .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .column("VALUE", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .build()))
+                    .put("fe_tablet_schedules", new SchemaTable(
+                            SystemId.FE_SCHEDULES_ID,
+                            "fe_tablet_schedules",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("TABLE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("PARTITION_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("PRIORITY", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("TABLET_STATUS", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DOUBLE))
+                                    .column("SCHEDULE_TIME", ScalarType.createType(PrimitiveType.DOUBLE))
+                                    .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DOUBLE))
+                                    .column("CLONE_SRC", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("CLONE_DEST", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("CLONE_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("CLONE_DURATION", ScalarType.createType(PrimitiveType.DOUBLE))
+                                    .column("MSG", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .build()))
                     .build();
 
     public static class Builder {
@@ -759,8 +793,8 @@ public class SchemaTable extends Table {
                 TSchemaTableType.SCH_BE_METRICS),
         SCH_BE_TXNS("BE_TXNS", "BE_TXNS",
                 TSchemaTableType.SCH_BE_TXNS),
-
-        SCH_BE_CONFIGS("BE_CONFIGS", "BE_CONFIGS", TSchemaTableType.SCH_BE_CONFIGS);
+        SCH_BE_CONFIGS("BE_CONFIGS", "BE_CONFIGS", TSchemaTableType.SCH_BE_CONFIGS),
+        SCH_FE_TABLET_SCHEDULES("FE_TABLET_SCHEDULES", "FE_TABLET_SCHEDULES", TSchemaTableType.SCH_FE_TABLET_SCHEDULES);
 
         private final String description;
         private final String tableName;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -68,6 +68,7 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.thrift.TTabletSchedule;
 import com.starrocks.thrift.TTaskType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1177,6 +1178,26 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         result.add(String.valueOf(committedVersion));
         result.add(String.valueOf(0));
         result.add(Strings.nullToEmpty(errMsg));
+        return result;
+    }
+
+    public TTabletSchedule toTabletScheduleThrift() {
+        TTabletSchedule result = new TTabletSchedule();
+        result.setTablet_id(tblId);
+        result.setPartition_id(partitionId);
+        result.setTablet_id(tabletId);
+        result.setType(type.name());
+        result.setPriority(dynamicPriority != null ? dynamicPriority.name() : "");
+        result.setState(state != null ? state.name() : "");
+        result.setTablet_status(tabletStatus != null ? tabletStatus.name() : "");
+        result.setCreate_time(createTime / 1000.0);
+        result.setSchedule_time(lastSchedTime / 1000.0);
+        result.setFinish_time(finishedTime / 1000.0);
+        result.setClone_src(srcReplica == null ? -1 : srcReplica.getBackendId());
+        result.setClone_dest(destBackendId);
+        result.setClone_bytes(copySize);
+        result.setClone_duration(copyTimeMs / 1000.0);
+        result.setError_msg(errMsg);
         return result;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -76,6 +76,8 @@ import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.task.CloneTask;
 import com.starrocks.task.DropReplicaTask;
 import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TGetTabletScheduleRequest;
+import com.starrocks.thrift.TGetTabletScheduleResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -339,7 +341,7 @@ public class TabletScheduler extends LeaderDaemon {
      * 4. every pending task should have a max scheduled time, if schedule fails too many times, it should be removed.
      * 5. every running task should have a timeout, to avoid running forever.
      * 6. every running task should also have a max failure time,if clone task fails too many times,
-     *    it should be removed.
+     * it should be removed.
      */
     @Override
     protected void runAfterCatalogReady() {
@@ -562,6 +564,7 @@ public class TabletScheduler extends LeaderDaemon {
 
     /**
      * Only for test.
+     *
      * @param tabletCtx
      */
     private synchronized void addToPendingTablets(TabletSchedCtx tabletCtx) {
@@ -1594,6 +1597,50 @@ public class TabletScheduler extends LeaderDaemon {
     public synchronized long getBalanceTabletsNumber() {
         return pendingTablets.stream().filter(t -> t.getType() == Type.BALANCE).count()
                 + runningTablets.values().stream().filter(t -> t.getType() == Type.BALANCE).count();
+    }
+
+    public TGetTabletScheduleResponse getTabletSchedule(TGetTabletScheduleRequest request) {
+        long tableId = request.isSetTable_id() ? request.table_id : -1;
+        long partitionId = request.isSetPartition_id() ? request.partition_id : -1;
+        long tabletId = request.isSetTablet_id() ? request.tablet_id : -1;
+        String type = request.isSetType() ? request.type : null;
+        String state = request.isSetState() ? request.state : null;
+        long limit = request.isSetLimit() ? request.limit : -1;
+        List<TabletSchedCtx> tabletCtxs;
+        synchronized (this) {
+            Stream<TabletSchedCtx> all;
+            if (TabletSchedCtx.State.PENDING.name().equals(state)) {
+                all = pendingTablets.stream();
+            } else if (TabletSchedCtx.State.RUNNING.name().equals(state)) {
+                all = runningTablets.values().stream();
+            } else if (TabletSchedCtx.State.FINISHED.name().equals(state)) {
+                all = schedHistory.stream();
+            } else {
+                // running first, then history, then pending
+                all = Stream.concat(Stream.concat(runningTablets.values().stream(), schedHistory.stream()),
+                        pendingTablets.stream());
+                if (state != null) {
+                    all = all.filter(t -> t.getState().name().equals(state));
+                }
+            }
+            if (type != null) {
+                all = all.filter(t -> t.getType().name().equals(type));
+            }
+            if (tabletId != -1) {
+                all = all.filter(t -> t.getTabletId() == tabletId);
+            } else if (partitionId != -1) {
+                all = all.filter(t -> t.getPartitionId() == partitionId);
+            } else if (tableId != -1) {
+                all = all.filter(t -> t.getTblId() == tableId);
+            }
+            if (limit > 0) {
+                all = all.limit((int) limit);
+            }
+            tabletCtxs = all.collect(Collectors.toList());
+        }
+        TGetTabletScheduleResponse response = new TGetTabletScheduleResponse();
+        response.setTablet_schedules(tabletCtxs.stream().map(t -> t.toTabletScheduleThrift()).collect(Collectors.toList()));
+        return response;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
@@ -73,9 +73,9 @@ public class SystemId {
     public static final long BE_METRICS_ID = 27L;
 
     public static final long BE_TXNS_ID = 28L;
-    
+
     public static final long BE_CONFIGS_ID = 29L;
-    
+
     public static final long PARTITIONS_ID = 30L;
 
     public static final long COLUMN_PRIVILEGES_ID = 31L;
@@ -83,4 +83,6 @@ public class SystemId {
     public static final long LOADS_ID = 32L;
 
     public static final long LOAD_TRACKING_LOGS_ID = 33L;
+
+    public static final long FE_SCHEDULES_ID = 34L;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -73,6 +73,8 @@ public class SchemaScanNode extends ScanNode {
     private Long partitionId = null;
     private Long tabletId = null;
     private Long txnId = null;
+    private String type = null;
+    private String state = null;
     private List<TScanRangeLocations> beScanRanges = null;
 
     public void setSchemaDb(String schemaDb) {
@@ -181,6 +183,20 @@ public class SchemaScanNode extends ScanNode {
         if (label != null) {
             msg.schema_scan_node.setLabel(label);
         }
+        if (txnId != null) {
+            msg.schema_scan_node.setTxn_id(txnId);
+        }
+        if (type != null) {
+            msg.schema_scan_node.setType(type);
+        }
+        if (state != null) {
+            msg.schema_scan_node.setState(state);
+        }
+        // setting limit for the scanner may cause query to return less rows than expected
+        // but this is for the purpose of protect FE resource usage, so it's acceptable
+        if (getLimit() > 0) {
+            msg.schema_scan_node.setLimit(getLimit());
+        }
     }
 
     public void setBeId(long beId) {
@@ -201,6 +217,14 @@ public class SchemaScanNode extends ScanNode {
 
     public void setTxnId(long txnId) {
         this.txnId = txnId;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setState(String state) {
+        this.state = state;
     }
 
     public boolean isBeSchemaTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -161,6 +161,8 @@ import com.starrocks.thrift.TGetTablesInfoRequest;
 import com.starrocks.thrift.TGetTablesInfoResponse;
 import com.starrocks.thrift.TGetTablesParams;
 import com.starrocks.thrift.TGetTablesResult;
+import com.starrocks.thrift.TGetTabletScheduleRequest;
+import com.starrocks.thrift.TGetTabletScheduleResponse;
 import com.starrocks.thrift.TGetTaskInfoResult;
 import com.starrocks.thrift.TGetTaskRunInfoResult;
 import com.starrocks.thrift.TGetTasksParams;
@@ -296,7 +298,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setDbs(dbs);
         return result;
     }
-
 
     @Override
     public TGetTablesResult getTableNames(TGetTablesParams params) throws TException {
@@ -1706,7 +1707,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             return result;
         }
 
-
         Map<String, AddPartitionClause> addPartitionClauseMap;
         try {
             Column firstPartitionColumn = expressionRangePartitionInfo.getPartitionColumns().get(0);
@@ -1778,8 +1778,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     if (bePathsMap.keySet().size() < quorum) {
                         errorStatus.setError_msgs(Lists.newArrayList(
                                 "Tablet lost replicas. Check if any backend is down or not. tablet_id: "
-                                + tablet.getId() + ", backends: " +
-                                Joiner.on(",").join(localTablet.getBackends())));
+                                        + tablet.getId() + ", backends: " +
+                                        Joiner.on(",").join(localTablet.getBackends())));
                         result.setStatus(errorStatus);
                         return result;
                     }
@@ -1875,5 +1875,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             throw e;
         }
         return result;
+    }
+
+    @Override
+    public TGetTabletScheduleResponse getTabletSchedule(TGetTabletScheduleRequest request) throws TException {
+        TGetTabletScheduleResponse response = GlobalStateMgr.getCurrentState().getTabletScheduler().getTabletSchedule(request);
+        LOG.info("getTabletSchedule: {} return {} TabletSchedule", request, response.getTablet_schedulesSize());
+        return response;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -522,7 +522,7 @@ public class PrivilegeCheckerV2 {
                         ErrorReport.reportSemanticException(ErrorCode.ERR_PRIVILEGE_ACCESS_TABLE_DENIED,
                                 context.getQualifiedUser(), tableName);
                     }
-                } else if (table instanceof SchemaTable && ((SchemaTable) table).isBeSchemaTable()) {
+                } else if (table instanceof SchemaTable && ((SchemaTable) table).requireOperatePrivilege()) {
                     checkStmtOperatePrivilege(context);
                 } else if (table.isMaterializedView()) {
                     checkMvAction(context, tableName, PrivilegeType.SELECT);
@@ -1188,7 +1188,6 @@ public class PrivilegeCheckerV2 {
             }
             String dbName = tableName.getDb() == null ? context.getDatabase() : tableName.getDb();
             checkDbAction(context, catalog, dbName, PrivilegeType.CREATE_TABLE);
-
 
             if (statement.getProperties() != null && statement.getProperties().containsKey("resource")) {
                 String resourceProp = statement.getProperties().get("resource");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1136,6 +1136,11 @@ public class PlanFragmentBuilder {
                                     break;
                                 case "JOB_ID":
                                     scanNode.setJobId(constantOperator.getBigint());
+                                case "TYPE":
+                                    scanNode.setType(constantOperator.getVarchar());
+                                    break;
+                                case "STATE":
+                                    scanNode.setState(constantOperator.getVarchar());
                                     break;
                                 default:
                                     break;
@@ -2573,7 +2578,7 @@ public class PlanFragmentBuilder {
                             .collect(Collectors.toList()),
                     physicalTableFunction.getFnResultColRefs().stream().map(ColumnRefOperator::getId)
                             .collect(Collectors.toList())
-                    );
+            );
             tableFunctionNode.computeStatistics(optExpression.getStatistics());
             tableFunctionNode.setLimit(physicalTableFunction.getLimit());
             inputFragment.setPlanRoot(tableFunctionNode);

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/BalanceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/BalanceTest.java
@@ -14,9 +14,12 @@
 
 package com.starrocks.pseudocluster;
 
+import com.starrocks.clone.TabletScheduler;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TGetTabletScheduleRequest;
+import com.starrocks.thrift.TGetTabletScheduleResponse;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -74,6 +77,10 @@ public class BalanceTest {
             }
             cluster.runSql("test", insertSqls[rand.nextInt(numTable)]);
             Thread.sleep(2000);
+            TabletScheduler tabletScheduler = GlobalStateMgr.getCurrentState().getTabletScheduler();
+            TGetTabletScheduleResponse response =
+                    tabletScheduler.getTabletSchedule(new TGetTabletScheduleRequest());
+            System.out.printf("current tablet schedule size: %d\n", response.tablet_schedules.size());
         }
         System.out.println("balance finished");
     }

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -142,7 +142,8 @@ enum TSchemaTableType {
     SCH_BE_TXNS,
     SCH_BE_CONFIGS,
     SCH_LOADS,
-    SCH_LOAD_TRACKING_LOGS
+    SCH_LOAD_TRACKING_LOGS,
+    SCH_FE_TABLET_SCHEDULES
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1142,6 +1142,37 @@ struct TGetTablesInfoResponse {
     1: optional list<TTableInfo> tables_infos
 }
 
+struct TTabletSchedule {
+    1: optional i64 table_id
+    2: optional i64 partition_id
+    3: optional i64 tablet_id
+    4: optional string type
+    5: optional string priority
+    6: optional string state
+    7: optional string tablet_status
+    8: optional double create_time
+    9: optional double schedule_time
+    10: optional double finish_time
+    11: optional i64 clone_src
+    12: optional i64 clone_dest
+    13: optional i64 clone_bytes
+    14: optional double clone_duration
+    15: optional string error_msg
+}
+
+struct TGetTabletScheduleRequest {
+    1: optional i64 table_id
+    2: optional i64 partition_id
+    3: optional i64 tablet_id
+    4: optional string type
+    5: optional string state
+    6: optional i64 limit
+}
+
+struct TGetTabletScheduleResponse {
+    1: optional list<TTabletSchedule> tablet_schedules
+}
+
 struct TUpdateResourceUsageRequest {
     1: optional i64 backend_id 
     2: optional ResourceUsage.TResourceUsage resource_usage
@@ -1251,5 +1282,7 @@ service FrontendService {
     MVMaintenance.TMVReportEpochResponse mvReport(1: MVMaintenance.TMVMaintenanceTasks request)
 
     TAllocateAutoIncrementIdResult allocAutoIncrementId (1:TAllocateAutoIncrementIdParam params)
+
+    TGetTabletScheduleResponse getTabletSchedule(1: TGetTabletScheduleRequest request)
 }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -425,6 +425,9 @@ struct TSchemaScanNode {
   15: optional i64 txn_id
   16: optional i64 job_id
   17: optional string label
+  18: optional string type
+  19: optional string state
+  20: optional i64 limit
 }
 
 // If you find yourself changing this struct, see also TLakeScanNode


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds FE tablet schedule information to information_schema, so as to debug tablet repair/balance problems more easily.  
Note that this information is only available in FE leader, so MySQL client should connect to FE leader to query this table. 

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
