### PR TITLE
[Enhancement] Default replication_num based on run mode (#18660)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -583,7 +583,6 @@ public class GlobalStateMgr {
         if (!isCkptGlobalState) {
             RunMode.detectRunMode();
         }
-
         if (RunMode.allowCreateLakeTable()) {
             this.starOSAgent = new StarOSAgent();
         }


### PR DESCRIPTION
- If run mode is shared_nothing, set default replication_num to 3
- If run mode is shared_data, set default replication_num to 1

For table with decoupled compute and storage, if user specify a value of "replication_num" greater than 1, will NOT really create multiple replicas of data. However, the check of "replication_num" on many code paths still takes effect, such as the check of the number of live backends.

For table with decoupled compute and storage, the show create table command will still display the value specified by the user, although the value has no actual effect.


(cherry picked from commit 7925dd670b16393ed76fc5c24647960f30654573)

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
