### PR TITLE
[BugFix] back quote data identifier in statistic sqls

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -34,7 +34,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             "SELECT $tableId, $partitionId, '$columnName', $dbId," +
                     " '$dbName.$tableName', '$partitionName'," +
                     " COUNT(1), $dataSize, $countDistinctFunction, $countNullFunction, $maxFunction, $minFunction, NOW() "
-                    + "FROM $dbName.$tableName partition $partitionName";
+                    + "FROM `$dbName`.`$tableName` partition `$partitionName`";
 
     private final List<Long> partitionIdList;
 
@@ -93,15 +93,15 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         return Lists.partition(totalQuerySQL, parallelism);
     }
 
-    private String buildCollectFullStatisticSQL(Database database, Table table, Partition partition, String columnNames) {
+    private String buildCollectFullStatisticSQL(Database database, Table table, Partition partition, String columnName) {
         StringBuilder builder = new StringBuilder();
         VelocityContext context = new VelocityContext();
-        Column column = table.getColumn(columnNames);
+        Column column = table.getColumn(columnName);
 
         context.put("dbId", database.getId());
         context.put("tableId", table.getId());
         context.put("partitionId", partition.getId());
-        context.put("columnName", columnNames);
+        context.put("columnName", columnName);
         context.put("dbName", database.getOriginName());
         context.put("tableName", table.getName());
         context.put("partitionName", partition.getName());
@@ -113,10 +113,10 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             context.put("maxFunction", "''");
             context.put("minFunction", "''");
         } else {
-            context.put("countDistinctFunction", "IFNULL(hll_raw(`" + columnNames + "`), hll_empty())");
-            context.put("countNullFunction", "COUNT(1) - COUNT(`" + columnNames + "`)");
-            context.put("maxFunction", "IFNULL(MAX(`" + columnNames + "`), '')");
-            context.put("minFunction", "IFNULL(MIN(`" + columnNames + "`), '')");
+            context.put("countDistinctFunction", "IFNULL(hll_raw(`" + columnName + "`), hll_empty())");
+            context.put("countNullFunction", "COUNT(1) - COUNT(`" + columnName + "`)");
+            context.put("maxFunction", "IFNULL(MAX(`" + columnName + "`), '')");
+            context.put("minFunction", "IFNULL(MIN(`" + columnName + "`), '')");
         }
 
         builder.append(build(context, COLLECT_FULL_STATISTIC_TEMPLATE));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -34,12 +34,12 @@ import static com.starrocks.statistic.StatsConstants.HISTOGRAM_STATISTICS_TABLE_
 public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
     private static final String COLLECT_HISTOGRAM_STATISTIC_TEMPLATE =
             "SELECT $tableId, '$columnName', $dbId, '$dbName.$tableName'," +
-                    " histogram($columnName, cast($bucketNum as int), cast($sampleRatio as double)), " +
+                    " histogram(`$columnName`, cast($bucketNum as int), cast($sampleRatio as double)), " +
                     " $mcv," +
                     " NOW()" +
-                    " FROM (SELECT $columnName FROM $dbName.$tableName where rand() <= $sampleRatio" +
-                    " and $columnName is not null $MCVExclude" +
-                    " ORDER BY $columnName LIMIT $totalRows) t";
+                    " FROM (SELECT `$columnName` FROM `$dbName`.`$tableName` where rand() <= $sampleRatio" +
+                    " and `$columnName` is not null $MCVExclude" +
+                    " ORDER BY `$columnName` LIMIT $totalRows) t";
 
     private static final String COLLECT_MCV_STATISTIC_TEMPLATE =
             "select cast(version as INT), cast(db_id as BIGINT), cast(table_id as BIGINT), " +
@@ -49,7 +49,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                     "$tableId as table_id, " +
                     "`$columnName` as column_key, " +
                     "count(`$columnName`) as column_value " +
-                    "from $dbName.$tableName where `$columnName` is not null " +
+                    "from `$dbName`.`$tableName` where `$columnName` is not null " +
                     "group by `$columnName` " +
                     "order by count(`$columnName`) desc limit $topN ) t";
 
@@ -132,10 +132,10 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
 
         if (!mostCommonValues.isEmpty()) {
             if (column.getType().getPrimitiveType().isDateType() || column.getType().getPrimitiveType().isCharFamily()) {
-                context.put("MCVExclude", " and " + columnName + " not in (\"" +
+                context.put("MCVExclude", " and " + StatisticUtils.quoting(columnName) + " not in (\"" +
                         Joiner.on("\",\"").join(mostCommonValues.keySet()) + "\")");
             } else {
-                context.put("MCVExclude", " and " + columnName + " not in (" +
+                context.put("MCVExclude", " and " + StatisticUtils.quoting(columnName) + " not in (" +
                         Joiner.on(",").join(mostCommonValues.keySet()) + ")");
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
@@ -36,18 +36,18 @@ import java.util.stream.Collectors;
 public class SampleStatisticsCollectJob extends StatisticsCollectJob {
 
     private static final String INSERT_SELECT_METRIC_SAMPLE_TEMPLATE =
-            "SELECT $tableId, '$columnName', $dbId, '$tableName', '$dbName', COUNT(1) * $ratio, "
+            "SELECT $tableId, '$columnName', $dbId, '$dbName.$tableName', '$dbName', COUNT(1) * $ratio, "
                     + "$dataSize * $ratio, 0, 0, '', '', NOW() "
-                    + "FROM (SELECT `$columnName` as column_key FROM $tableName $hints ) as t";
+                    + "FROM (SELECT `$columnName` as column_key FROM `$dbName`.`$tableName` $hints ) as t";
 
     private static final String INSERT_SELECT_TYPE_SAMPLE_TEMPLATE =
-            "SELECT $tableId, '$columnName', $dbId, '$tableName', '$dbName', IFNULL(SUM(t1.count), 0) * $ratio, "
+            "SELECT $tableId, '$columnName', $dbId, '$dbName.$tableName', '$dbName', IFNULL(SUM(t1.count), 0) * $ratio, "
                     + "       $dataSize * $ratio, $countDistinctFunction, "
                     + "       IFNULL(SUM(IF(t1.`column_key` IS NULL, t1.count, 0)), 0) * $ratio, "
                     + "       IFNULL(MAX(t1.`column_key`), ''), IFNULL(MIN(t1.`column_key`), ''), NOW() "
                     + "FROM ( "
                     + "    SELECT t0.`$columnName` as column_key, COUNT(1) as count "
-                    + "    FROM (SELECT `$columnName` FROM $tableName $hints) as t0 "
+                    + "    FROM (SELECT `$columnName` FROM `$dbName`.`$tableName` $hints) as t0 "
                     + "    GROUP BY t0.column_key "
                     + ") as t1";
 
@@ -138,7 +138,7 @@ public class SampleStatisticsCollectJob extends StatisticsCollectJob {
             context.put("tableId", tableId);
             context.put("columnName", name);
             context.put("dbName", db.getFullName());
-            context.put("tableName", db.getOriginName() + "." + table.getName());
+            context.put("tableName", table.getName());
             context.put("dataSize", getDataSize(column, true));
             context.put("ratio", ratio);
             context.put("hints", hintTablets);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -152,9 +152,8 @@ public class StatisticExecutor {
         String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
         String sql = "select cast(" + StatsConstants.STATISTIC_DICT_VERSION + " as Int), " +
                 "cast(" + version + " as bigint), " +
-                "dict_merge(" + "`" + column +
-                "`) as _dict_merge_" + column +
-                " from " + catalogName + "." + db.getOriginName() + "." + table.getName() + " [_META_]";
+                "dict_merge(" +  StatisticUtils.quoting(column) + ") as _dict_merge_" + column +
+                " from " + StatisticUtils.quoting(catalogName, db.getOriginName(), table.getName()) + " [_META_]";
 
 
         ConnectContext context = StatisticUtils.buildConnectContext();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -47,6 +47,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
 
@@ -287,5 +288,17 @@ public class StatisticUtils {
             result = left * right;
         }
         return result;
+    }
+
+    public static String quoting(String ... parts) {
+        StringJoiner joiner = new StringJoiner(".");
+        for (String part : parts) {
+            joiner.add(quoting(part));
+        }
+        return joiner.toString();
+    }
+
+    public static String quoting(String identifier) {
+        return "`" + identifier + "`";
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -128,7 +128,7 @@ public abstract class StatisticsCollectJob {
             if (isSample) {
                 return "IFNULL(SUM(CHAR_LENGTH(`column_key`) * t1.count), 0)";
             } else {
-                return "IFNULL(SUM(CHAR_LENGTH(`" + column.getName() + "`)), 0)";
+                return "IFNULL(SUM(CHAR_LENGTH(" + StatisticUtils.quoting(column.getName()) + ")), 0)";
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -347,8 +347,9 @@ public class StatisticsCollectJobTest extends PlanTestBase {
         String sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectHistogram",
                 db, olapTable, 0.1, 64L, Maps.newHashMap(), "v2");
         Assert.assertEquals(String.format("INSERT INTO histogram_statistics SELECT %d, 'v2', %d, 'test.t0_stats', " +
-                        "histogram(v2, cast(64 as int), cast(0.1 as double)),  NULL, NOW() FROM " +
-                        "(SELECT v2 FROM test.t0_stats where rand() <= 0.1 and v2 is not null  ORDER BY v2 LIMIT 10000000) t",
+                        "histogram(`v2`, cast(64 as int), cast(0.1 as double)),  NULL, NOW() FROM " +
+                        "(SELECT `v2` FROM `test`.`t0_stats` where rand() <= 0.1 and `v2` is not null  " +
+                        "ORDER BY `v2` LIMIT 10000000) t",
                 t0StatsTableId, dbid), sql);
 
         Map<String, String> mostCommonValues = new HashMap<>();
@@ -357,9 +358,9 @@ public class StatisticsCollectJobTest extends PlanTestBase {
         sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectHistogram",
                 db, olapTable, 0.1, 64L, mostCommonValues, "v2");
         Assert.assertEquals(String.format("INSERT INTO histogram_statistics SELECT %s, 'v2', %d, 'test.t0_stats', " +
-                "histogram(v2, cast(64 as int), cast(0.1 as double)),  '[[\"1\",\"10\"],[\"2\",\"20\"]]', NOW() " +
-                "FROM (SELECT v2 FROM test.t0_stats where rand() <= 0.1 and v2 is not null  and v2 not in (1,2) " +
-                "ORDER BY v2 LIMIT 10000000) t", t0StatsTableId, dbid), sql);
+                "histogram(`v2`, cast(64 as int), cast(0.1 as double)),  '[[\"1\",\"10\"],[\"2\",\"20\"]]', NOW() " +
+                "FROM (SELECT `v2` FROM `test`.`t0_stats` where rand() <= 0.1 and `v2` is not null  and `v2` not in (1,2) " +
+                "ORDER BY `v2` LIMIT 10000000) t", t0StatsTableId, dbid), sql);
 
         mostCommonValues.clear();
         mostCommonValues.put("0000-01-01", "10");
@@ -367,9 +368,9 @@ public class StatisticsCollectJobTest extends PlanTestBase {
         sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectHistogram",
                 db, olapTable, 0.1, 64L, mostCommonValues, "v4");
         Assert.assertEquals(String.format("INSERT INTO histogram_statistics SELECT %s, 'v4', %d, 'test.t0_stats', " +
-                "histogram(v4, cast(64 as int), cast(0.1 as double)),  '[[\"0000-01-01\",\"10\"],[\"1991-01-01\",\"20\"]]', " +
-                "NOW() FROM (SELECT v4 FROM test.t0_stats where rand() <= 0.1 and v4 is not null  and v4 not in " +
-                "(\"0000-01-01\",\"1991-01-01\") ORDER BY v4 LIMIT 10000000) t", t0StatsTableId, dbid), sql);
+                "histogram(`v4`, cast(64 as int), cast(0.1 as double)),  '[[\"0000-01-01\",\"10\"],[\"1991-01-01\",\"20\"]]', " +
+                "NOW() FROM (SELECT `v4` FROM `test`.`t0_stats` where rand() <= 0.1 and `v4` is not null  and `v4` not in " +
+                "(\"0000-01-01\",\"1991-01-01\") ORDER BY `v4` LIMIT 10000000) t", t0StatsTableId, dbid), sql);
 
         mostCommonValues.clear();
         mostCommonValues.put("0000-01-01 00:00:00", "10");
@@ -379,17 +380,17 @@ public class StatisticsCollectJobTest extends PlanTestBase {
         Assert.assertEquals("INSERT INTO histogram_statistics SELECT " + t0StatsTableId + ", 'v5', " + dbid +
                 ", 'test" +
                 ".t0_stats', " +
-                "histogram(v5, cast(64 as int), cast(0.1 as double)),  " +
+                "histogram(`v5`, cast(64 as int), cast(0.1 as double)),  " +
                 "'[[\"1991-01-01 00:00:00\",\"20\"],[\"0000-01-01 00:00:00\",\"10\"]]', NOW() FROM " +
-                "(SELECT v5 FROM test.t0_stats where rand() <= 0.1 and v5 is not null  " +
-                "and v5 not in (\"1991-01-01 00:00:00\",\"0000-01-01 00:00:00\") ORDER BY v5 LIMIT 10000000) t", sql);
+                "(SELECT `v5` FROM `test`.`t0_stats` where rand() <= 0.1 and `v5` is not null  " +
+                "and `v5` not in (\"1991-01-01 00:00:00\",\"0000-01-01 00:00:00\") ORDER BY `v5` LIMIT 10000000) t", sql);
 
         sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectMCV",
                 db, olapTable, 100L, "v2");
         Assert.assertEquals("select cast(version as INT), cast(db_id as BIGINT), cast(table_id as BIGINT), " +
                 "cast(column_key as varchar), cast(column_value as varchar) from (select 2 as version, " + dbid +
                 " as db_id, " + t0StatsTableId +
-                " as table_id, `v2` as column_key, count(`v2`) as column_value from test.t0_stats " +
+                " as table_id, `v2` as column_key, count(`v2`) as column_value from `test`.`t0_stats` " +
                 "where `v2` is not null group by `v2` order by count(`v2`) desc limit 100 ) t", sql);
     }
 
@@ -452,9 +453,9 @@ public class StatisticsCollectJobTest extends PlanTestBase {
         Assert.assertEquals(10, StringUtils.countMatches(collectSqlList.toString(), "COUNT(`v1`)"));
         Assert.assertEquals(10, StringUtils.countMatches(collectSqlList.toString(), "COUNT(`v3`)"));
         Assert.assertEquals(10, StringUtils.countMatches(collectSqlList.toString(), "COUNT(`v5`)"));
-        Assert.assertEquals(5, StringUtils.countMatches(collectSqlList.toString(), "partition p0"));
-        Assert.assertEquals(5, StringUtils.countMatches(collectSqlList.toString(), "partition p1"));
-        Assert.assertEquals(5, StringUtils.countMatches(collectSqlList.toString(), "partition p9"));
+        Assert.assertEquals(5, StringUtils.countMatches(collectSqlList.toString(), "partition `p0`"));
+        Assert.assertEquals(5, StringUtils.countMatches(collectSqlList.toString(), "partition `p1`"));
+        Assert.assertEquals(5, StringUtils.countMatches(collectSqlList.toString(), "partition `p9`"));
 
         collectSqlList = collectJob.buildCollectSQLList(15);
         Assert.assertEquals(4, collectSqlList.size());
@@ -534,6 +535,7 @@ public class StatisticsCollectJobTest extends PlanTestBase {
 
         String sql = Deencapsulation.invoke(sampleStatisticsCollectJob, "buildSampleInsertSQL",
                 dbid, olapTable.getId(), Lists.newArrayList("v1", "count"), 100L);
+        assertContains(sql, "`stats`.`tcount`  Tablet(16465)");
         UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
 
         FullStatisticsCollectJob fullStatisticsCollectJob = new FullStatisticsCollectJob(
@@ -546,6 +548,7 @@ public class StatisticsCollectJobTest extends PlanTestBase {
         sql = Deencapsulation.invoke(fullStatisticsCollectJob, "buildCollectFullStatisticSQL",
                 db, olapTable, olapTable.getPartition("tcount"),
                  "count");
+        assertContains(sql, "`stats`.`tcount` partition `tcount`");
         UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When clients create db, table, column contains reserved words, the built in statistic sqls cannot be parsed correctly because of  without back quoting the reserved words. 
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
