### PR TITLE
[Enhancement] Rectify some behaviors when auto creating tablet

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -226,15 +226,16 @@ public class CatalogUtils {
         // When POC, the backends is not greater than three most of the time.
         // The bucketNum will be given a small multiplier factor for small backends.
         int bucketNum = 0;
-        if (backendNum <= 3) {
+        if (backendNum <= 12) {
             bucketNum = 2 * backendNum;
-        } else if (backendNum <= 6) {
-            bucketNum = backendNum;
-        } else if (backendNum <= 12) {
-            bucketNum = 12;
+        } else if (backendNum <= 24) {
+            bucketNum = (int) (1.5 * backendNum);
+        } else if (backendNum <= 36) {
+            bucketNum = 36;
         } else {
             bucketNum = Math.min(backendNum, 48);
         }
         return bucketNum;
+
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
@@ -178,7 +178,9 @@ public class DynamicPartitionProperty {
         sb.append(START + ":" + start + ",");
         sb.append(END + ":" + end + ",");
         sb.append(PREFIX + ":" + prefix + ",");
-        sb.append(BUCKETS + ":" + buckets + ",");
+        if (buckets > 0) {
+            sb.append(BUCKETS + ":" + buckets + ",");
+        }
         if (replicationNum != NOT_SET_REPLICATION_NUM) {
             sb.append(REPLICATION_NUM + ":" + replicationNum + ",");
         }
@@ -199,9 +201,11 @@ public class DynamicPartitionProperty {
                 + ",\n\"" + TIME_ZONE + "\" = \"" + tz.getID() + "\""
                 + ",\n\"" + START + "\" = \"" + start + "\""
                 + ",\n\"" + END + "\" = \"" + end + "\""
-                + ",\n\"" + PREFIX + "\" = \"" + prefix + "\""
-                + ",\n\"" + BUCKETS + "\" = \"" + buckets + "\""
-                + ",\n\"" + HISTORY_PARTITION_NUM + "\" = \"" + historyPartitionNum + "\"";
+                + ",\n\"" + PREFIX + "\" = \"" + prefix + "\"";
+        if (buckets > 0) {
+            res += ",\n\"" + BUCKETS + "\" = \"" + buckets + "\"";
+        }
+        res += ",\n\"" + HISTORY_PARTITION_NUM + "\" = \"" + historyPartitionNum + "\"";
         if (replicationNum != NOT_SET_REPLICATION_NUM) {
             res += ",\n\"" + REPLICATION_NUM + "\" = \"" + replicationNum + "\"";
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -253,8 +253,6 @@ public enum ErrorCode {
             "Invalid dynamic partition end %s"),
     ERROR_DYNAMIC_PARTITION_END_EMPTY(5066, new byte[] {'4', '2', '0', '0', '0'},
             "Dynamic partition end is empty"),
-    ERROR_DYNAMIC_PARTITION_BUCKETS_ZERO(5067, new byte[] {'4', '2', '0', '0', '0'},
-            "Dynamic partition buckets must greater than 0"),
     ERROR_DYNAMIC_PARTITION_BUCKETS_FORMAT(5067, new byte[] {'4', '2', '0', '0', '0'},
             "Invalid dynamic partition buckets %s"),
     ERROR_DYNAMIC_PARTITION_BUCKETS_EMPTY(5066, new byte[] {'4', '2', '0', '0', '0'},

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -74,6 +74,10 @@ public class FeConstants {
     // default scheduler interval is 10 seconds
     public static int default_scheduler_interval_millisecond = 10000;
 
+    // Every 3GB, corresponds a new tablet. Assume compression ratio equals to 3,
+    // the raw data of one tablet equals to 10GB approximately
+    public static final long AUTO_DISTRIBUTION_UNIT = 3221225472L;
+
     public static String getNodeNotFoundError(boolean chooseComputeNode) {
         return chooseComputeNode ? COMPUTE_NODE_NOT_FOUND_ERROR : BACKEND_NODE_NOT_FOUND_ERROR;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -128,8 +128,8 @@ public class DynamicPartitionUtil {
             ErrorReport.reportDdlException(ErrorCode.ERROR_DYNAMIC_PARTITION_BUCKETS_EMPTY);
         }
         try {
-            if (Integer.parseInt(buckets) <= 0) {
-                ErrorReport.reportDdlException(ErrorCode.ERROR_DYNAMIC_PARTITION_BUCKETS_ZERO, buckets);
+            if (Integer.parseInt(buckets) < 0) {
+                buckets = "0";
             }
         } catch (NumberFormatException e) {
             ErrorReport.reportDdlException(ErrorCode.ERROR_DYNAMIC_PARTITION_BUCKETS_FORMAT, buckets);
@@ -212,12 +212,10 @@ public class DynamicPartitionUtil {
         String start = properties.get(DynamicPartitionProperty.START);
         String timeZone = properties.get(DynamicPartitionProperty.TIME_ZONE);
         String end = properties.get(DynamicPartitionProperty.END);
-        String buckets = properties.get(DynamicPartitionProperty.BUCKETS);
         String enable = properties.get(DynamicPartitionProperty.ENABLE);
 
         if (!(Strings.isNullOrEmpty(enable) && Strings.isNullOrEmpty(timeUnit) && Strings.isNullOrEmpty(timeZone)
-                && Strings.isNullOrEmpty(prefix) && Strings.isNullOrEmpty(start) && Strings.isNullOrEmpty(end)
-                && Strings.isNullOrEmpty(buckets))) {
+                && Strings.isNullOrEmpty(prefix) && Strings.isNullOrEmpty(start) && Strings.isNullOrEmpty(end))) {
             if (Strings.isNullOrEmpty(enable)) {
                 properties.put(DynamicPartitionProperty.ENABLE, "true");
             }
@@ -232,9 +230,6 @@ public class DynamicPartitionUtil {
             }
             if (Strings.isNullOrEmpty(end)) {
                 throw new DdlException("Must assign dynamic_partition.end properties");
-            }
-            if (Strings.isNullOrEmpty(buckets)) {
-                throw new DdlException("Must assign dynamic_partition.buckets properties");
             }
             if (Strings.isNullOrEmpty(timeZone)) {
                 properties.put(DynamicPartitionProperty.TIME_ZONE, TimeUtils.getSystemTimeZone().getID());
@@ -301,6 +296,11 @@ public class DynamicPartitionUtil {
         }
         if (properties.containsKey(DynamicPartitionProperty.BUCKETS)) {
             String bucketsValue = properties.get(DynamicPartitionProperty.BUCKETS);
+            checkBuckets(bucketsValue);
+            properties.remove(DynamicPartitionProperty.BUCKETS);
+            analyzedProperties.put(DynamicPartitionProperty.BUCKETS, bucketsValue);
+        } else {
+            String bucketsValue = "0";
             checkBuckets(bucketsValue);
             properties.remove(DynamicPartitionProperty.BUCKETS);
             analyzedProperties.put(DynamicPartitionProperty.BUCKETS, bucketsValue);
@@ -434,15 +434,6 @@ public class DynamicPartitionUtil {
             } else {
                 olapTable.setTableProperty(new TableProperty(dynamicPartitionProperties).buildDynamicProperty());
             }
-        }
-    }
-
-    public static void checkAndSetDynamicPartitionBuckets(Map<String, String> properties, int bucketNum) {
-        if (properties == null || properties.isEmpty()) {
-            return;
-        }
-        if (!Strings.isNullOrEmpty(properties.get(DynamicPartitionProperty.ENABLE))) {
-            properties.putIfAbsent(DynamicPartitionProperty.BUCKETS, String.valueOf(bucketNum));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -905,23 +905,6 @@ public class LocalMetastore implements ConnectorMetadata {
         }
     }
 
-    private int calBucketNumAccordingToBackends() {
-        int backendNum = GlobalStateMgr.getCurrentSystemInfo().getBackendIds().size();
-        // When POC, the backends is not greater than three most of the time.
-        // The bucketNum will be given a small multiplier factor for small backends.
-        int bucketNum = 0;
-        if (backendNum <= 3) {
-            bucketNum = 2 * backendNum;
-        } else if (backendNum <= 6) {
-            bucketNum = (int) (1.5 * backendNum);
-        } else if (backendNum <= 12) {
-            bucketNum = 12;
-        } else {
-            bucketNum = Math.min(backendNum, 48);
-        }
-        return bucketNum;
-    }
-
     private int calAvgBucketNumOfRecentPartitions(OlapTable olapTable, int recentPartitionNum) {
         // 1. If the partition is less than recentPartitionNum, use backendNum to speculate the bucketNum
         int bucketNum = 0;
@@ -952,7 +935,7 @@ public class LocalMetastore implements ConnectorMetadata {
         }
         // A tablet will be regarded using the 1GB size
         // And also the number will not be larger than the calBucketNumAccordingToBackends()
-        bucketNum = (int) Math.min(bucketNum, maxDataSize / (1024 * 1024 * 1024L));
+        bucketNum = (int) Math.min(bucketNum, maxDataSize / FeConstants.AUTO_DISTRIBUTION_UNIT);
         if (bucketNum == 0) {
             bucketNum = 1;
         }
@@ -988,7 +971,11 @@ public class LocalMetastore implements ConnectorMetadata {
             }
         } else {
             if (defaultDistributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH
-                    && Config.enable_auto_tablet_distribution) {
+                    && Config.enable_auto_tablet_distribution
+                    && !colocateTableIndex.isColocateTable(olapTable.getId())) {
+                // 1. If enable_auto_tablet_distribution = true, AUTO Tablet Distibution
+                //    also take effect on exist table when adding new partitions
+                // 2. ColocateTable should comply the original tablet num when creating table.
                 HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
                 distributionInfo = new HashDistributionInfo(0, hashDistributionInfo.getDistributionColumns());
             } else {
@@ -1279,7 +1266,7 @@ public class LocalMetastore implements ConnectorMetadata {
             // get distributionInfo
             distributionInfo = getDistributionInfo(olapTable, addPartitionClause);
 
-            if (distributionInfo.getBucketNum() == 0 || Config.enable_auto_tablet_distribution) {
+            if (distributionInfo.getBucketNum() == 0) {
                 int numBucket = calAvgBucketNumOfRecentPartitions(olapTable, 5);
                 distributionInfo.setBucketNum(numBucket);
             }
@@ -2619,7 +2606,7 @@ public class LocalMetastore implements ConnectorMetadata {
         DistributionDesc distributionDesc = stmt.getDistributionDesc();
         Preconditions.checkNotNull(distributionDesc);
         DistributionInfo distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
-        if (distributionInfo.getBucketNum() == 0 || Config.enable_auto_tablet_distribution) {
+        if (distributionInfo.getBucketNum() == 0) {
             int numBucket = CatalogUtils.calBucketNumAccordingToBackends();
             distributionInfo.setBucketNum(numBucket);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -95,6 +95,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.MarkedCountDownLatch;
 import com.starrocks.common.MetaNotFoundException;

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -192,7 +192,7 @@ public class OlapTableFactory implements AbstractTableFactory {
             table = new ExternalOlapTable(db.getId(), tableId, tableName, baseSchema, keysType, partitionInfo,
                     distributionInfo, indexes, properties);
         } else if (stmt.isOlapEngine()) {
-            if (distributionInfo.getBucketNum() == 0 || Config.enable_auto_tablet_distribution) {
+            if (distributionInfo.getBucketNum() == 0) {
                 int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
                 distributionInfo.setBucketNum(bucketNum);
             }
@@ -497,8 +497,6 @@ public class OlapTableFactory implements AbstractTableFactory {
                         }
                         DataProperty dataProperty = PropertyAnalyzer.analyzeDataProperty(properties,
                                 DataProperty.getInferredDefaultDataProperty());
-                        DynamicPartitionUtil
-                                .checkAndSetDynamicPartitionBuckets(properties, distributionDesc.getBuckets());
                         DynamicPartitionUtil.checkAndSetDynamicPartitionProperty(table, properties);
                         if (table.dynamicPartitionExists() && table.getColocateGroup() != null) {
                             HashDistributionInfo info = (HashDistributionInfo) distributionInfo;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -64,7 +64,7 @@ public class CreateTableAutoTabletTest {
         } finally {
             db.readUnlock();
         }
-        Assert.assertEquals(bucketNum, 12);
+        Assert.assertEquals(bucketNum, 20);
     }
 
     private static void checkTableStateToNormal(OlapTable tb) throws InterruptedException {
@@ -111,7 +111,95 @@ public class CreateTableAutoTabletTest {
         } finally {
             db.readUnlock();
         }
-        Assert.assertEquals(bucketNum, 12);
+        Assert.assertEquals(GlobalStateMgr.getCurrentSystemInfo().getBackendIds().size(), 10);
+        Assert.assertEquals(bucketNum, 20);
+    }
+
+    @Test
+    public void test1AutoTabletWithDynamicPartition() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.runSql("db_for_auto_tablets",
+                " CREATE TABLE test_auto_tablets_of_dynamic_partition (" +
+                     "    k1 date," +
+                     "    k2 int(11)," +
+                     "    k3 smallint(6)," +
+                     "    v1 varchar(2048)," +
+                     "    v2 datetime" +
+                     "  ) ENGINE=OLAP" +
+                     "  DUPLICATE KEY(k1, k2, k3) " +
+                     "  PARTITION BY RANGE(k1)" +
+                     "  (PARTITION p20230306 VALUES [('2023-03-06'), ('2023-03-07')))" +
+                     "  DISTRIBUTED BY HASH(k2) BUCKETS 10" +
+                     "  PROPERTIES (" +
+                     "   'replication_num' = '1'," +
+                     "   'dynamic_partition.enable' = 'true'," +
+                     "   'dynamic_partition.time_unit' = 'DAY'," +
+                     "   'dynamic_partition.time_zone' = 'Asia/Shanghai'," +
+                     "   'dynamic_partition.start' = '-3'," +
+                     "   'dynamic_partition.end' = '3'," +
+                     "   'dynamic_partition.prefix' = 'p');");
+        Thread.sleep(1000); // wait for the dynamic partition created
+        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        if (db == null) {
+            return;
+        }
+
+        OlapTable table = (OlapTable) db.getTable("test_auto_tablets_of_dynamic_partition");
+        if (table == null) {
+            return;
+        }
+
+        int bucketNum = 0;
+        db.readLock();
+        try {
+            Partition partition = table.getPartition("p20230308");
+            bucketNum = partition.getDistributionInfo().getBucketNum();
+        } finally {
+            db.readUnlock();
+        }
+        Assert.assertEquals(bucketNum, 20);
+    }
+
+    @Test
+    public void test1AutoTabletWithColocate() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.runSql("db_for_auto_tablets",
+                " CREATE TABLE colocate_partition (" +
+                     "    k1 date," +
+                     "    k2 int(11)," +
+                     "    k3 smallint(6)," +
+                     "    v1 varchar(2048)," +
+                     "    v2 datetime" +
+                     "  ) ENGINE=OLAP" +
+                     "  DUPLICATE KEY(k1, k2, k3) " +
+                     "  PARTITION BY RANGE(k1)" +
+                     "  (PARTITION p20230306 VALUES [('2023-03-06'), ('2023-03-07')))" +
+                     "  DISTRIBUTED BY HASH(k2) BUCKETS 10" +
+                     "  PROPERTIES (" +
+                     "   'replication_num' = '1'," +
+                     "   'colocate_with' = 'g1');");
+        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        if (db == null) {
+            return;
+        }
+
+        OlapTable table = (OlapTable) db.getTable("colocate_partition");
+        if (table == null) {
+            return;
+        }
+
+        cluster.runSql("db_for_auto_tablets", "ALTER TABLE colocate_partition ADD PARTITION p20230312 VALUES [('2023-03-12'), ('2023-03-13'))");
+        checkTableStateToNormal(table);
+
+        int bucketNum = 0;
+        db.readLock();
+        try {
+            Partition partition = table.getPartition("p20230312");
+            bucketNum = partition.getDistributionInfo().getBucketNum();
+        } finally {
+            db.readUnlock();
+        }
+        Assert.assertEquals(bucketNum, 10);
     }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -21,6 +21,8 @@ import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.UtFrameUtils;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -152,8 +154,8 @@ public class CreateTableAutoTabletTest {
         int bucketNum = 0;
         db.readLock();
         try {
-            Partition partition = table.getPartition("p20230308");
-            bucketNum = partition.getDistributionInfo().getBucketNum();
+            List<Partition> partitions = (List<Partition>) table.getRecentPartitions(3);
+            bucketNum = partitions.get(0).getDistributionInfo().getBucketNum();
         } finally {
             db.readUnlock();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DynamicPartitionTableTest.java
@@ -253,7 +253,7 @@ public class DynamicPartitionTableTest {
                 ");");
         Database db = GlobalStateMgr.getCurrentState().getDb("test");
         OlapTable table = (OlapTable) db.getTable("dynamic_partition_buckets");
-        Assert.assertEquals(table.getTableProperty().getDynamicPartitionProperty().getBuckets(), 32);
+        Assert.assertEquals(table.getTableProperty().getDynamicPartitionProperty().getBuckets(), 0);
     }
 
     @Test


### PR DESCRIPTION
1. When the backnum is smaller, try to creating more tablets
```
if (backendNum <= 12) {
    bucketNum = 2 * backendNum;
} else if (backendNum <= 24) {
    bucketNum = (int) (1.5 * backendNum);
} else if (backendNum <= 36) {
    bucketNum = 36;
} else {
    bucketNum = Math.min(backendNum, 48);
}
```

2. Change the behavior when user specify the tablet num (1) If the user has specified the tablet num, StarRocks will comply the number, ignore the Config.enable_auto_tablet_distribution (2) If enable_auto_tablet_distribution = true, AUTO Tablet Distibution
    also take effect on exist table when adding new partitions

3. ColocateTable should comply the original tablet num when creating table. ColocateTable should keep the tablet num is same among partitions. So the auto tablet distribution is not suitable for this case.

4. Remove the dynamic_partition.buckets After the AUTO Tablet Distibution, the dynamic_partition.buckets is not necessary. We can auto determine the number of tablet

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
