### PR TITLE
[Enhancement] hive metastore cache max num is configurable by catalog properties

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileConf.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileConf.java
@@ -22,7 +22,7 @@ import java.util.Map;
 public class CachingRemoteFileConf {
     private final long cacheTtlSec;
     private final long cacheRefreshIntervalSec;
-    private final long cacheMaxSize = 100000L;
+    private long cacheMaxSize = 1000000L;
     private final int perQueryCacheMaxSize = 10000;
 
     public CachingRemoteFileConf(Map<String, String> conf) {
@@ -30,6 +30,7 @@ public class CachingRemoteFileConf {
                 String.valueOf(Config.remote_file_cache_ttl_s)));
         this.cacheRefreshIntervalSec = Long.parseLong(conf.getOrDefault("remote_file_cache_refresh_interval_sec",
                 String.valueOf(Config.remote_file_cache_refresh_interval_s)));
+        this.cacheMaxSize = Long.parseLong(conf.getOrDefault("remote_file_cache_max_num", String.valueOf(cacheMaxSize)));
     }
 
     public long getCacheTtlSec() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastoreConf.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastoreConf.java
@@ -22,7 +22,7 @@ import java.util.Map;
 public class CachingHiveMetastoreConf {
     private final long cacheTtlSec;
     private final long cacheRefreshIntervalSec;
-    private final long cacheMaxNum = 100000;
+    private long cacheMaxNum = 1000000;
     private final int perQueryCacheMaxNum = 10000;
     private final int cacheRefreshThreadMaxNum = 20;
 
@@ -35,6 +35,7 @@ public class CachingHiveMetastoreConf {
                 String.valueOf(Config.hive_meta_cache_refresh_interval_s)));
         this.enableListNamesCache = Boolean.parseBoolean(conf.getOrDefault("enable_cache_list_names",
                 "false"));
+        this.cacheMaxNum = Long.parseLong(conf.getOrDefault("metastore_cache_max_num", String.valueOf(cacheMaxNum)));
     }
 
     public long getCacheTtlSec() {


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Some users have large tables with many partitions, so the catalog level cache num is not enough.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
