### PR TITLE
[BugFix] fix that display hive metastore api profile with mutiple tables in query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class RemoteFileOperations {
+    public static final String HMS_PARTITIONS_REMOTE_FILES = "HMS.PARTITIONS.getRemoteFiles";
     protected CachingRemoteFileIO remoteFileIO;
     private final ExecutorService executor;
     private final boolean isRecursive;
@@ -68,7 +69,7 @@ public class RemoteFileOperations {
         List<Future<Map<RemotePathKey, List<RemoteFileDesc>>>> futures = Lists.newArrayList();
         List<Map<RemotePathKey, List<RemoteFileDesc>>> result = Lists.newArrayList();
 
-        PlannerProfile.addCustomProperties("HMS.PARTITIONS.getRemoteFiles", String.format("%s partitions", cacheMissSize));
+        PlannerProfile.addCustomProperties(HMS_PARTITIONS_REMOTE_FILES, String.format("%s", cacheMissSize));
 
         try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getRemoteFiles")) {
             for (Partition partition : partitions) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -219,7 +219,8 @@ public class HiveMetaClient {
     public List<Partition> getPartitionsByNames(String dbName, String tblName, List<String> partitionNames) {
         int size = partitionNames.size();
         List<Partition> partitions;
-        PlannerProfile.addCustomProperties("HMS.PARTITIONS.getPartitionsByNames", String.format("%s partitions", size));
+        PlannerProfile.addCustomProperties("HMS.PARTITIONS.getPartitionsByNames." + tblName,
+                String.format("%s partitions", size));
 
         try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getPartitionsByNames")) {
             RecyclableClient client = null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/PlannerProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/PlannerProfile.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.starrocks.connector.RemoteFileOperations.HMS_PARTITIONS_REMOTE_FILES;
 import static com.starrocks.connector.hive.HiveMetastoreOperations.BACKGROUND_THREAD_NAME_PREFIX;
 
 /**
@@ -145,7 +146,13 @@ public class PlannerProfile {
         if (ctx != null) {
             p = ctx.getPlannerProfile();
         }
-        p.customProperties.put(name, value);
+        if (name.equals(HMS_PARTITIONS_REMOTE_FILES) && p.customProperties.containsKey(HMS_PARTITIONS_REMOTE_FILES)) {
+            int currentSize = Integer.parseInt(p.customProperties.get(HMS_PARTITIONS_REMOTE_FILES));
+            int addedSize = Integer.parseInt(value);
+            p.customProperties.put(name, String.valueOf(currentSize + addedSize));
+        } else {
+            p.customProperties.put(name, value);
+        }
 
         String threadName = Thread.currentThread().getName();
         if (threadName.startsWith(BACKGROUND_THREAD_NAME_PREFIX)) {


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
The current profile will only show the profile of one hive/hudi table in the query


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
