### PR TITLE
[Enhancement] Add profile about schedule queue and load

### DIFF
--- a/be/src/exec/pipeline/driver_limiter.h
+++ b/be/src/exec/pipeline/driver_limiter.h
@@ -50,6 +50,8 @@ public:
     // `num_drivers` drivers back to the limiter.
     StatusOr<TokenPtr> try_acquire(int num_drivers);
 
+    int num_total_drivers() const { return _num_total_drivers; }
+
 private:
     const int _max_num_drivers;
     std::atomic<int> _num_total_drivers{0};

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -609,33 +609,39 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         int64_t prepare_fragment_ctx_time = 0;
         int64_t prepare_runtime_state_time = 0;
         int64_t prepare_pipeline_driver_time = 0;
+
+        int64_t process_mem_bytes = ExecEnv::GetInstance()->process_mem_tracker()->consumption();
+        size_t num_query_ctxs = ExecEnv::GetInstance()->query_context_mgr()->size();
     } profiler;
 
     DeferOp defer([this, &request, &prepare_success, &profiler]() {
         if (prepare_success) {
             auto fragment_ctx = _query_ctx->fragment_mgr()->get(request.fragment_instance_id());
-            auto* prepare_timer =
-                    ADD_TIMER(fragment_ctx->runtime_state()->runtime_profile(), "FragmentInstancePrepareTime");
+            auto* profile = fragment_ctx->runtime_state()->runtime_profile();
+
+            auto* prepare_timer = ADD_TIMER(profile, "FragmentInstancePrepareTime");
             COUNTER_SET(prepare_timer, profiler.prepare_time);
+
             auto* prepare_query_ctx_timer =
-                    ADD_CHILD_TIMER_THESHOLD(fragment_ctx->runtime_state()->runtime_profile(), "prepare-query-ctx",
-                                             "FragmentInstancePrepareTime", 10_ms);
+                    ADD_CHILD_TIMER_THESHOLD(profile, "prepare-query-ctx", "FragmentInstancePrepareTime", 10_ms);
             COUNTER_SET(prepare_query_ctx_timer, profiler.prepare_query_ctx_time);
 
             auto* prepare_fragment_ctx_timer =
-                    ADD_CHILD_TIMER_THESHOLD(fragment_ctx->runtime_state()->runtime_profile(), "prepare-fragment-ctx",
-                                             "FragmentInstancePrepareTime", 10_ms);
+                    ADD_CHILD_TIMER_THESHOLD(profile, "prepare-fragment-ctx", "FragmentInstancePrepareTime", 10_ms);
             COUNTER_SET(prepare_fragment_ctx_timer, profiler.prepare_fragment_ctx_time);
 
             auto* prepare_runtime_state_timer =
-                    ADD_CHILD_TIMER_THESHOLD(fragment_ctx->runtime_state()->runtime_profile(), "prepare-runtime-state",
-                                             "FragmentInstancePrepareTime", 10_ms);
+                    ADD_CHILD_TIMER_THESHOLD(profile, "prepare-runtime-state", "FragmentInstancePrepareTime", 10_ms);
             COUNTER_SET(prepare_runtime_state_timer, profiler.prepare_runtime_state_time);
 
             auto* prepare_pipeline_driver_timer =
-                    ADD_CHILD_TIMER_THESHOLD(fragment_ctx->runtime_state()->runtime_profile(),
-                                             "prepare-pipeline-driver", "FragmentInstancePrepareTime", 10_ms);
+                    ADD_CHILD_TIMER_THESHOLD(profile, "prepare-pipeline-driver", "FragmentInstancePrepareTime", 10_ms);
             COUNTER_SET(prepare_pipeline_driver_timer, profiler.prepare_runtime_state_time);
+
+            auto* process_mem_counter = ADD_COUNTER(profile, "ProcessMemAtBeginning", TUnit::UNIT);
+            COUNTER_SET(process_mem_counter, profiler.process_mem_bytes);
+            auto* num_query_ctxs_counter = ADD_COUNTER(profile, "ProcessMemAtBeginning", TUnit::UNIT);
+            COUNTER_SET(num_query_ctxs_counter, static_cast<int64_t>(profiler.num_query_ctxs));
         } else {
             _fail_cleanup();
         }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -638,9 +638,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                     ADD_CHILD_TIMER_THESHOLD(profile, "prepare-pipeline-driver", "FragmentInstancePrepareTime", 10_ms);
             COUNTER_SET(prepare_pipeline_driver_timer, profiler.prepare_runtime_state_time);
 
-            auto* process_mem_counter = ADD_COUNTER(profile, "ProcessMemAtBeginning", TUnit::BYTES);
+            auto* process_mem_counter = ADD_COUNTER(profile, "InitialProcessMem", TUnit::BYTES);
             COUNTER_SET(process_mem_counter, profiler.process_mem_bytes);
-            auto* num_query_ctxs_counter = ADD_COUNTER(profile, "NumQueryCtxsAtBeginning", TUnit::UNIT);
+            auto* num_query_ctxs_counter = ADD_COUNTER(profile, "InitialQueryContextCount", TUnit::UNIT);
             COUNTER_SET(num_query_ctxs_counter, static_cast<int64_t>(profiler.num_query_ctxs));
         } else {
             _fail_cleanup();

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -638,9 +638,9 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
                     ADD_CHILD_TIMER_THESHOLD(profile, "prepare-pipeline-driver", "FragmentInstancePrepareTime", 10_ms);
             COUNTER_SET(prepare_pipeline_driver_timer, profiler.prepare_runtime_state_time);
 
-            auto* process_mem_counter = ADD_COUNTER(profile, "ProcessMemAtBeginning", TUnit::UNIT);
+            auto* process_mem_counter = ADD_COUNTER(profile, "ProcessMemAtBeginning", TUnit::BYTES);
             COUNTER_SET(process_mem_counter, profiler.process_mem_bytes);
-            auto* num_query_ctxs_counter = ADD_COUNTER(profile, "ProcessMemAtBeginning", TUnit::UNIT);
+            auto* num_query_ctxs_counter = ADD_COUNTER(profile, "NumQueryCtxsAtBeginning", TUnit::UNIT);
             COUNTER_SET(num_query_ctxs_counter, static_cast<int64_t>(profiler.num_query_ctxs));
         } else {
             _fail_cleanup();

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -611,7 +611,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         int64_t prepare_pipeline_driver_time = 0;
 
         int64_t process_mem_bytes = ExecEnv::GetInstance()->process_mem_tracker()->consumption();
-        size_t num_query_ctxs = ExecEnv::GetInstance()->query_context_mgr()->size();
+        size_t num_process_drivers = ExecEnv::GetInstance()->driver_limiter()->num_total_drivers();
     } profiler;
 
     DeferOp defer([this, &request, &prepare_success, &profiler]() {
@@ -640,8 +640,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
 
             auto* process_mem_counter = ADD_COUNTER(profile, "InitialProcessMem", TUnit::BYTES);
             COUNTER_SET(process_mem_counter, profiler.process_mem_bytes);
-            auto* num_query_ctxs_counter = ADD_COUNTER(profile, "InitialQueryContextCount", TUnit::UNIT);
-            COUNTER_SET(num_query_ctxs_counter, static_cast<int64_t>(profiler.num_query_ctxs));
+            auto* num_process_drivers_counter = ADD_COUNTER(profile, "InitialProcessDriverCount", TUnit::UNIT);
+            COUNTER_SET(num_process_drivers_counter, static_cast<int64_t>(profiler.num_process_drivers));
         } else {
             _fail_cleanup();
         }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -67,6 +67,9 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _output_full_timer = ADD_CHILD_TIMER(_runtime_profile, "OutputFullTime", "PendingTime");
     _pending_finish_timer = ADD_CHILD_TIMER(_runtime_profile, "PendingFinishTime", "PendingTime");
 
+    _peak_driver_queue_size_counter = _runtime_profile->AddHighWaterMarkCounter(
+            "PeakDriverQueueSize", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
+
     DCHECK(_state == DriverState::NOT_READY);
 
     auto* source_op = source_operator();
@@ -185,6 +188,10 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _pending_finish_timer_sw->start();
 
     return Status::OK();
+}
+
+void PipelineDriver::update_peak_driver_queue_size_counter(size_t new_value) {
+    _peak_driver_queue_size_counter->set(new_value);
 }
 
 static inline bool is_multilane(pipeline::OperatorPtr& op) {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -191,7 +191,9 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
 }
 
 void PipelineDriver::update_peak_driver_queue_size_counter(size_t new_value) {
-    _peak_driver_queue_size_counter->set(new_value);
+    if (_peak_driver_queue_size_counter != nullptr) {
+        _peak_driver_queue_size_counter->set(new_value);
+    }
 }
 
 static inline bool is_multilane(pipeline::OperatorPtr& op) {

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -264,6 +264,7 @@ public:
         return _operators.empty() ? nullptr : down_cast<SourceOperator*>(_operators.front().get());
     }
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
+    void update_peak_driver_queue_size_counter(size_t new_value);
     // drivers that waits for runtime filters' readiness must be marked PRECONDITION_NOT_READY and put into
     // PipelineDriverPoller.
     void mark_precondition_not_ready();
@@ -501,6 +502,8 @@ protected:
     MonotonicStopWatch* _input_empty_timer_sw = nullptr;
     MonotonicStopWatch* _output_full_timer_sw = nullptr;
     MonotonicStopWatch* _pending_finish_timer_sw = nullptr;
+
+    RuntimeProfile::HighWaterMarkCounter* _peak_driver_queue_size_counter = nullptr;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -215,6 +215,8 @@ private:
 
     size_t _sum_cpu_limit = 0;
 
+    size_t _num_drivers = 0;
+
     // Cache the minimum entity, used to check should_yield() without lock.
     std::atomic<workgroup::WorkGroupDriverSchedEntity*> _min_wg_entity = nullptr;
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -71,6 +71,8 @@ Status ScanOperator::prepare(RuntimeState* state) {
     _morsels_counter = ADD_COUNTER(_unique_metrics, "MorselsCount", TUnit::UNIT);
     _buffer_unplug_counter = ADD_COUNTER(_unique_metrics, "BufferUnplugCount", TUnit::UNIT);
     _submit_task_counter = ADD_COUNTER(_unique_metrics, "SubmitTaskCount", TUnit::UNIT);
+    _peak_scan_task_queue_size_counter = _unique_metrics->AddHighWaterMarkCounter(
+            "PeakScanTaskQueueSize", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
 
     RETURN_IF_ERROR(do_prepare(state));
 
@@ -341,6 +343,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
     // TODO: consider more factors, such as scan bytes and i/o time.
     task.priority = OlapScanNode::compute_priority(_submit_task_counter->value());
     task.task_group = down_cast<const ScanOperatorFactory*>(_factory)->scan_task_group();
+    task.peak_scan_task_queue_size_counter = _peak_scan_task_queue_size_counter;
     const auto io_task_start_nano = MonotonicNanos();
     task.work_function = [wp = _query_ctx, this, state, chunk_source_index, query_trace_ctx, driver_id,
                           io_task_start_nano]() {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -170,6 +170,7 @@ private:
     RuntimeProfile::Counter* _default_buffer_capacity_counter = nullptr;
     RuntimeProfile::Counter* _buffer_capacity_counter = nullptr;
     RuntimeProfile::HighWaterMarkCounter* _peak_buffer_size_counter = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* _peak_scan_task_queue_size_counter = nullptr;
     // The total number of the original tablets in this fragment instance.
     RuntimeProfile::Counter* _tablets_counter = nullptr;
 };

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -24,6 +24,7 @@
 #include "common/statusor.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "util/blocking_priority_queue.hpp"
+#include "util/runtime_profile.h"
 
 namespace starrocks::workgroup {
 
@@ -58,6 +59,7 @@ public:
     WorkFunction work_function;
     int priority = 0;
     std::shared_ptr<ScanTaskGroup> task_group = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* peak_scan_task_queue_size_counter = nullptr;
 };
 
 /// There are three types of ScanTaskQueue:


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add four profile fields about schedule queue and system load:
- **InitialProcessMem**: The process memory, after a fragment instance is prepared.
- **InitialProcessDriverCount**: The number of drivers in this BE, after a fragment instance is prepared.
- **PeakDriverQueueSize**: The maximum size of driver queue, when a driver is put back to the queue.
- **PeakScanTaskQueueSize**:  The maximum size of scan task queue, when a driver is put back to the queue.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
