### PR TITLE
[UT] Fix BinlogManagerTest failure when building with release

### DIFF
--- a/be/test/storage/binlog_manager_test.cpp
+++ b/be/test/storage/binlog_manager_test.cpp
@@ -34,6 +34,7 @@ public:
         CHECK_OK(fs::remove_all(_binlog_file_dir));
         CHECK_OK(fs::create_directories(_binlog_file_dir));
         ASSIGN_OR_ABORT(_fs, FileSystem::CreateSharedFromString(_binlog_file_dir));
+        _next_rowset_uid = 0;
         create_tablet_schema();
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When running `BinlogManagerTest` with release build, the test case `test_ingestion_commit/test_ingestion_abort/test_ingestion_delete` will abort, and the exception is like this

```
BUILD_TYPE=Release ./run-be-ut.sh --test BinlogManagerTest
```

```
*** Aborted at 1678157494 (unix time) try "date -d @1678157494" if you are using GNU date ***
PC: @     0x7ff0396e3387 __GI_raise
*** SIGABRT (@0x329f8) received by PID 207352 (TID 0x7ff03b60d480) from PID 207352; stack trace: ***
    @          0x707a872 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7ff039a8a630 (unknown)
    @     0x7ff0396e3387 __GI_raise
    @     0x7ff0396e4a78 __GI_abort
    @          0x4248a8e starrocks::failure_function()
    @          0x706e1ed google::LogMessage::Fail()
    @          0x707065f google::LogMessage::SendToLog()
    @          0x706dd3e google::LogMessage::Flush()
    @          0x7070c69 google::LogMessageFatal::~LogMessageFatal()
    @          0x3f852e3 starrocks::BinlogManagerTest::create_rowset()
    @          0x3f856c3 starrocks::BinlogManagerTest_test_ingestion_commit_Test::TestBody()
    @          0x8dd9781 testing::internal::HandleExceptionsInMethodIfSupported<>()
    @          0x8dcf836 testing::Test::Run()
    @          0x8dcf9a5 testing::TestInfo::Run()
    @          0x8dcfa95 testing::TestSuite::Run()
    @          0x8dcffe6 testing::internal::UnitTestImpl::RunAllTests()
    @          0x8dd01ee testing::UnitTest::Run()
    @          0x2b09069 main
    @     0x7ff0396cf555 __libc_start_main
    @          0x2d4213f (unknown)
    @                0x0 (unknown)
```

From the core dump, we can know the exception is raised from [RowsetId#init()]( https://github.com/StarRocks/starrocks/blob/main/be/src/storage/olap_common.h#L294). The reason is that `BinlogManagerTest#_next_rowset_uid` is not initialized properly, and using it to create rowset id will break the limitation
<img width="1574" alt="截屏2023-03-07 10 57 01" src="https://user-images.githubusercontent.com/11382970/223308805-6799f94f-5e71-4405-bd32-a8eed8648b44.png">




## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [X] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
