### PR TITLE
[Tool] Data generating tool based on query dump

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.dump;
 
 import com.google.common.collect.Lists;
@@ -129,7 +128,10 @@ public class QueryDumpSerializer implements JsonSerializer<QueryDumpInfo> {
         dumpJson.add("column_statistics", tableColumnStatistics);
         // BE number
         ConnectContext ctx = ConnectContext.get();
-        long beNum = ctx.getAliveBackendNumber();
+        long beNum = -1;
+        if (ctx != null) {
+            beNum = ctx.getAliveBackendNumber();
+        }
         dumpJson.addProperty("be_number", beNum);
         // backend core stat
         JsonObject backendCoreStat = new JsonObject();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/generator/CollectLiteralVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/generator/CollectLiteralVisitor.java
@@ -1,0 +1,389 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.dump.generator;
+
+import com.clearspring.analytics.util.Lists;
+import com.starrocks.analysis.AnalyticExpr;
+import com.starrocks.analysis.ArithmeticExpr;
+import com.starrocks.analysis.ArraySliceExpr;
+import com.starrocks.analysis.ArrowExpr;
+import com.starrocks.analysis.BetweenPredicate;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.CaseExpr;
+import com.starrocks.analysis.CastExpr;
+import com.starrocks.analysis.CloneExpr;
+import com.starrocks.analysis.CollectionElementExpr;
+import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.ExistsPredicate;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.GroupByClause;
+import com.starrocks.analysis.GroupingFunctionCallExpr;
+import com.starrocks.analysis.InPredicate;
+import com.starrocks.analysis.InformationFunction;
+import com.starrocks.analysis.IsNullPredicate;
+import com.starrocks.analysis.LikePredicate;
+import com.starrocks.analysis.LimitElement;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.MultiInPredicate;
+import com.starrocks.analysis.OrderByElement;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.SubfieldExpr;
+import com.starrocks.analysis.Subquery;
+import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.analysis.VariableExpr;
+import com.starrocks.connector.parser.trino.PlaceholderExpr;
+import com.starrocks.sql.ast.ArrayExpr;
+import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.CreateViewStmt;
+import com.starrocks.sql.ast.DefaultValueExpr;
+import com.starrocks.sql.ast.ExceptRelation;
+import com.starrocks.sql.ast.FieldReference;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.IntersectRelation;
+import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.LambdaArgument;
+import com.starrocks.sql.ast.LambdaFunctionExpr;
+import com.starrocks.sql.ast.MapExpr;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.TableFunctionRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.UnionRelation;
+import com.starrocks.sql.ast.ValuesRelation;
+import com.starrocks.sql.ast.ViewRelation;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.List;
+
+public class CollectLiteralVisitor extends AstVisitor<Void, CollectLiteralVisitor.Context> {
+    public static final class Context {
+        private final List<LiteralExpr> literalExprs = Lists.newArrayList();
+    }
+
+    private CollectLiteralVisitor() {
+    }
+
+    public static List<LiteralExpr> collect(ParseNode node) {
+        Context context = new Context();
+        new CollectLiteralVisitor().visit(node, context);
+        return context.literalExprs;
+    }
+
+    @Override
+    public Void visit(ParseNode node) {
+        throw new UnsupportedOperationException("missing context");
+    }
+
+    @Override
+    public Void visit(ParseNode node, Context context) {
+        if (node != null) {
+            return super.visit(node, context);
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitNode(ParseNode node, Context context) {
+        throw new UnsupportedOperationException(String.format("Not yet support %s",
+                node != null ? node.getClass().getSimpleName() : null));
+    }
+
+    @Override
+    public Void visitQueryStatement(QueryStatement statement, Context context) {
+        return visit(statement.getQueryRelation(), context);
+    }
+
+    @Override
+    public Void visitCreateViewStatement(CreateViewStmt statement, Context context) {
+        return visit(statement.getQueryStatement(), context);
+    }
+
+    @Override
+    public Void visitInsertStatement(InsertStmt statement, Context context) {
+        return visit(statement.getQueryStatement(), context);
+    }
+
+    @Override
+    public Void visitSelect(SelectRelation node, Context context) {
+        visit(node.getRelation(), context);
+        visit(node.getGroupByClause(), context);
+        visit(node.getHavingClause(), context);
+        visit(node.getWhereClause(), context);
+        if (CollectionUtils.isNotEmpty(node.getOrderBy())) {
+            node.getOrderBy().forEach(sortNode -> visit(sortNode, context));
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitTable(TableRelation node, Context context) {
+        return null;
+    }
+
+    @Override
+    public Void visitJoin(JoinRelation node, Context context) {
+        visit(node.getOnPredicate(), context);
+        visit(node.getLeft(), context);
+        visit(node.getRight(), context);
+        return null;
+    }
+
+    @Override
+    public Void visitSubquery(SubqueryRelation node, Context context) {
+        visit(node.getQueryStatement().getQueryRelation(), context);
+        if (CollectionUtils.isNotEmpty(node.getCteRelations())) {
+            node.getCteRelations().forEach(cte -> visit(cte, context));
+        }
+        if (CollectionUtils.isNotEmpty(node.getOrderBy())) {
+            node.getOrderBy().forEach(orderBy -> visit(orderBy, context));
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitSetOp(SetOperationRelation node, Context context) {
+        if (CollectionUtils.isNotEmpty(node.getRelations())) {
+            node.getRelations().forEach(relation -> visit(relation, context));
+        }
+        if (CollectionUtils.isNotEmpty(node.getCteRelations())) {
+            node.getCteRelations().forEach(relation -> visit(relation, context));
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitUnion(UnionRelation node, Context context) {
+        return visitSetOp(node, context);
+    }
+
+    @Override
+    public Void visitExcept(ExceptRelation node, Context context) {
+        return visitSetOp(node, context);
+    }
+
+    @Override
+    public Void visitIntersect(IntersectRelation node, Context context) {
+        return visitSetOp(node, context);
+    }
+
+    @Override
+    public Void visitValues(ValuesRelation node, Context context) {
+        return null;
+    }
+
+    @Override
+    public Void visitTableFunction(TableFunctionRelation node, Context context) {
+        return null;
+    }
+
+    @Override
+    public Void visitCTE(CTERelation node, Context context) {
+        return visit(node.getCteQueryStatement().getQueryRelation(), context);
+    }
+
+    @Override
+    public Void visitView(ViewRelation node, Context context) {
+        return visit(node.getQueryStatement().getQueryRelation(), context);
+    }
+
+    @Override
+    public Void visitExpression(Expr node, Context context) {
+        node.getChildren().forEach(child -> visit(child, context));
+        return null;
+    }
+
+    @Override
+    public Void visitArithmeticExpr(ArithmeticExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitAnalyticExpr(AnalyticExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitArrayExpr(ArrayExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitMapExpr(MapExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitCollectionElementExpr(CollectionElementExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitArraySliceExpr(ArraySliceExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitArrowExpr(ArrowExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitBetweenPredicate(BetweenPredicate node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitBinaryPredicate(BinaryPredicate node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitCaseWhenExpr(CaseExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitCastExpr(CastExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitCompoundPredicate(CompoundPredicate node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitDefaultValueExpr(DefaultValueExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitExistsPredicate(ExistsPredicate node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitFieldReference(FieldReference node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitFunctionCall(FunctionCallExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitGroupingFunctionCall(GroupingFunctionCallExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitInformationFunction(InformationFunction node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitInPredicate(InPredicate node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitMultiInPredicate(MultiInPredicate node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitIsNullPredicate(IsNullPredicate node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitLikePredicate(LikePredicate node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitLambdaFunctionExpr(LambdaFunctionExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitLambdaArguments(LambdaArgument node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitLiteral(LiteralExpr node, Context context) {
+        context.literalExprs.add(node);
+        return null;
+    }
+
+    @Override
+    public Void visitSlot(SlotRef node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitSubfieldExpr(SubfieldExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitSubquery(Subquery node, Context context) {
+        return visit(node.getQueryStatement().getQueryRelation(), context);
+    }
+
+    @Override
+    public Void visitVariableExpr(VariableExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitTimestampArithmeticExpr(TimestampArithmeticExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitCloneExpr(CloneExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitPlaceholderExpr(PlaceholderExpr node, Context context) {
+        return visitExpression(node, context);
+    }
+
+    @Override
+    public Void visitLimitElement(LimitElement node, Context context) {
+        return null;
+    }
+
+    @Override
+    public Void visitOrderByElement(OrderByElement node, Context context) {
+        return visitExpression(node.getExpr(), context);
+    }
+
+    @Override
+    public Void visitGroupByClause(GroupByClause node, Context context) {
+        if (CollectionUtils.isNotEmpty(node.getGroupingExprs())) {
+            node.getGroupingExprs().forEach(expr -> visit(expr, context));
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/generator/ColumnGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/generator/ColumnGenerator.java
@@ -1,0 +1,673 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.dump.generator;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.ColumnDef;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.sql.ast.PartitionKeyDesc;
+import com.starrocks.sql.ast.SingleRangePartitionDesc;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import org.apache.commons.lang3.tuple.Triple;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+public abstract class ColumnGenerator<Type, GenType> {
+    private static final AtomicLong SEED = new AtomicLong();
+    protected final Random random = new Random(SEED.incrementAndGet());
+    protected final ColumnDef columnDef;
+    protected final ColumnStatistic columnStatistic;
+    protected final List<LiteralExpr> literalExprs;
+    protected final LinkedList<GenType> literals = Lists.newLinkedList();
+    protected Type typeMin;
+    protected Type typeMax;
+    private final long rows;
+    private final Set<GenType> distinctValueSet = Sets.newHashSet();
+    private List<GenType> distinctValueList = null;
+    private boolean isInit = false;
+
+    protected ColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic, List<LiteralExpr> literalExprs,
+                              long rows) {
+        this.columnDef = columnDef;
+        this.columnStatistic = columnStatistic;
+        this.literalExprs = literalExprs;
+        this.rows = rows;
+    }
+
+    /**
+     * This method itself never becomes the bottleneck of performance when generating data
+     * So the simplest way to support concurrent is by adding synchronized modifier
+     */
+    public final synchronized GenType next() throws Exception {
+        if (!isInit) {
+            init();
+            isInit = true;
+        }
+
+        if (nextNull()) {
+            return null;
+        } else if (distinctValueList != null) {
+            return distinctValueList.get(random.nextInt(distinctValueList.size()));
+        } else if (!literals.isEmpty()) {
+            GenType next = literals.pop();
+            distinctValueSet.add(next);
+            return next;
+        } else if (!isStatisticsValid()) {
+            GenType next = nextDefault();
+            distinctValueSet.add(next);
+            int distinctValuesCount;
+            if (rows < 1000) {
+                distinctValuesCount = 16;
+            } else if (rows < 1000000) {
+                distinctValuesCount = 256;
+            } else {
+                distinctValuesCount = 1024;
+            }
+            if (distinctValueSet.size() >= distinctValuesCount) {
+                distinctValueList = Lists.newArrayList(distinctValueSet);
+                distinctValueSet.clear();
+            }
+            return next;
+        } else {
+            GenType next = nextWithStatistics();
+            distinctValueSet.add(next);
+            if (distinctValueSet.size() >= columnStatistic.getDistinctValuesCount()) {
+                distinctValueList = Lists.newArrayList(distinctValueSet);
+                distinctValueSet.clear();
+            }
+            return next;
+        }
+    }
+
+    private void init() {
+        Collections.shuffle(this.literals);
+    }
+
+    private boolean nextNull() {
+        if (columnStatistic != null && columnDef.isAllowNull()) {
+            return random.nextDouble() < columnStatistic.getNullsFraction();
+        } else {
+            return false;
+        }
+    }
+
+    protected abstract GenType nextDefault() throws Exception;
+
+    protected abstract GenType nextWithStatistics() throws Exception;
+
+    protected final boolean isStatisticsValid() {
+        return columnStatistic != null
+                && !Double.isNaN(columnStatistic.getMinValue())
+                && !Double.isInfinite(columnStatistic.getMinValue())
+                && Double.isFinite(columnStatistic.getMinValue())
+                && !Double.isNaN(columnStatistic.getMaxValue())
+                && !Double.isInfinite(columnStatistic.getMaxValue())
+                && Double.isFinite(columnStatistic.getMaxValue());
+    }
+
+    protected final double intervalRandom(Number begin, Number end) {
+        return Math.round(begin.doubleValue() + random.nextDouble() * (end.doubleValue() - begin.doubleValue()));
+    }
+
+    protected final long intervalRandomForLong(Long begin, Long end) {
+        if (begin < end && end - begin <= Integer.MAX_VALUE) {
+            return begin + random.nextInt((int) (end - begin));
+        }
+        return (long) intervalRandom(begin, end);
+    }
+
+    public static ColumnGenerator<?, ?> create(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                               List<LiteralExpr> literalExprs,
+                                               List<SingleRangePartitionDesc> singleRangePartitionDescs, long rows,
+                                               Map<String, Long> partitionRowCounts) throws Exception {
+        if (columnDef.getType().isBoolean()) {
+            return new BooleanColumnGenerator(columnDef, columnStatistic, literalExprs, rows);
+        } else if (columnDef.getType().isIntegerType()) {
+            return new IntegerColumnGenerator(columnDef, columnStatistic, literalExprs, singleRangePartitionDescs, rows,
+                    partitionRowCounts);
+        } else if (columnDef.getType().isLargeIntType()) {
+            return new LargeIntColumnGenerator(columnDef, columnStatistic, literalExprs, rows);
+        } else if (columnDef.getType().isFloatingPointType()) {
+            return new FloatColumnGenerator(columnDef, columnStatistic, literalExprs, rows);
+        } else if (columnDef.getType().isDecimalOfAnyVersion()) {
+            return new DecimalColumnGenerator(columnDef, columnStatistic, literalExprs, rows);
+        } else if (columnDef.getType().isDateType()) {
+            return new TimeColumnGenerator(columnDef, columnStatistic, literalExprs, singleRangePartitionDescs, rows,
+                    partitionRowCounts);
+        } else if (columnDef.getType().isStringType()) {
+            return new StringColumnGenerator(columnDef, columnStatistic, literalExprs, rows);
+        } else if (columnDef.getType().isArrayType()) {
+            return new ArrayColumnGenerator(columnDef, columnStatistic, literalExprs, rows);
+        } else if (columnDef.getType().isJsonType()) {
+            return new JsonColumnGenerator(columnDef, columnStatistic, literalExprs, rows);
+        } else {
+            return new NullColumnGenerator(columnDef, columnStatistic, literalExprs, rows);
+        }
+    }
+
+    private abstract static class PartitionColumnGenerator<GenType> extends ColumnGenerator<Long, GenType> {
+        protected final List<SingleRangePartitionDesc> singleRangePartitionDescs;
+        protected final Map<String, Long> partitionRowNums;
+
+        protected final List<Triple<Long, Long, PartitionKeyDesc.PartitionRangeType>> partitionBoundaries =
+                Lists.newArrayList();
+        private boolean partitionFinished = true;
+        private int partitionIndex = 0;
+        private long partitionRowNum = 0;
+        private long partitionCnt = 0;
+
+        public PartitionColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                        List<LiteralExpr> literalExprs,
+                                        List<SingleRangePartitionDesc> singleRangePartitionDescs, long rows,
+                                        Map<String, Long> partitionRowNums) throws Exception {
+            super(columnDef, columnStatistic, literalExprs, rows);
+
+            this.singleRangePartitionDescs = singleRangePartitionDescs;
+            this.partitionRowNums = partitionRowNums;
+
+            initTypeInfo();
+        }
+
+        protected abstract void initTypeInfo() throws Exception;
+
+        protected final Long nextWithPartitionInfo() {
+            if (singleRangePartitionDescs != null && partitionRowNums != null) {
+                findNextPartitionIdx();
+                if (partitionIndex < singleRangePartitionDescs.size()) {
+                    Triple<Long, Long, PartitionKeyDesc.PartitionRangeType> boundary =
+                            partitionBoundaries.get(partitionIndex);
+                    boolean isFixed = PartitionKeyDesc.PartitionRangeType.FIXED.equals(boundary.getRight());
+                    long next = intervalRandomForLong(boundary.getLeft() + (isFixed ? 0 : 1), boundary.getMiddle());
+                    if (++partitionCnt >= partitionRowNum) {
+                        partitionIndex++;
+                        partitionFinished = true;
+                    }
+                    return next;
+                } else {
+                    return intervalRandomForLong(typeMin, typeMax);
+                }
+            }
+            return null;
+        }
+
+        private void findNextPartitionIdx() {
+            if (partitionIndex >= singleRangePartitionDescs.size()) {
+                return;
+            }
+            if (!partitionFinished) {
+                return;
+            }
+            partitionCnt = 0;
+            while (partitionIndex < singleRangePartitionDescs.size()) {
+                SingleRangePartitionDesc singleRangePartitionDesc = singleRangePartitionDescs.get(partitionIndex);
+
+                Long partitionRowNum = partitionRowNums.get(singleRangePartitionDesc.getPartitionName());
+                if (partitionRowNum != null) {
+                    this.partitionRowNum = partitionRowNum;
+                    break;
+                }
+
+                partitionIndex++;
+            }
+            partitionFinished = false;
+        }
+    }
+
+    private static final class BooleanColumnGenerator extends ColumnGenerator<Boolean, Boolean> {
+
+        public BooleanColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                      List<LiteralExpr> literalExprs,
+                                      long rows) {
+            super(columnDef, columnStatistic, literalExprs, rows);
+        }
+
+        @Override
+        protected Boolean nextDefault() {
+            return random.nextBoolean();
+        }
+
+        @Override
+        protected Boolean nextWithStatistics() {
+            return random.nextBoolean();
+        }
+    }
+
+    private static final class IntegerColumnGenerator extends PartitionColumnGenerator<Long> {
+
+        public IntegerColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                      List<LiteralExpr> literalExprs,
+                                      List<SingleRangePartitionDesc> singleRangePartitionDescs, long rows,
+                                      Map<String, Long> partitionRowNums) throws Exception {
+            super(columnDef, columnStatistic, literalExprs, singleRangePartitionDescs, rows, partitionRowNums);
+        }
+
+        protected void initTypeInfo() {
+            if (singleRangePartitionDescs != null) {
+                typeMin = 19700101L;
+                typeMax = timestampToDate(System.currentTimeMillis());
+                for (SingleRangePartitionDesc singleRangePartitionDesc : this.singleRangePartitionDescs) {
+                    PartitionKeyDesc partitionKeyDesc = singleRangePartitionDesc.getPartitionKeyDesc();
+                    long partitionLower = typeMin;
+                    long partitionUpper = typeMax;
+                    if (partitionKeyDesc.hasLowerValues()) {
+                        Preconditions.checkState(partitionKeyDesc.getLowerValues().size() == 1);
+                        String lowValueStr = partitionKeyDesc.getLowerValues().get(0).getStringValue();
+                        partitionLower = Long.parseLong(lowValueStr);
+                    }
+                    if (partitionKeyDesc.hasUpperValues()) {
+                        Preconditions.checkState(partitionKeyDesc.getUpperValues().size() == 1);
+                        String upperValueStr = partitionKeyDesc.getUpperValues().get(0).getStringValue();
+                        partitionUpper = Long.parseLong(upperValueStr);
+                    }
+
+                    partitionBoundaries.add(
+                            Triple.of(partitionLower, partitionUpper, partitionKeyDesc.getPartitionType()));
+                }
+
+                this.typeMin = partitionBoundaries.stream()
+                        .map(Triple::getLeft)
+                        .mapToLong(v -> v)
+                        .min()
+                        .orElse(typeMin);
+
+                this.typeMax = partitionBoundaries.stream()
+                        .map(Triple::getMiddle)
+                        .mapToLong(v -> v)
+                        .max()
+                        .orElse(typeMax);
+            } else {
+                if (isStatisticsValid()) {
+                    switch (columnDef.getType().getPrimitiveType()) {
+                        case TINYINT:
+                            typeMin = (long) Math.max(-128, columnStatistic.getMinValue());
+                            typeMax = (long) Math.min(127, columnStatistic.getMaxValue());
+                            break;
+                        case SMALLINT:
+                            typeMin = (long) Math.max(-32768, columnStatistic.getMinValue());
+                            typeMax = (long) Math.min(32767, columnStatistic.getMaxValue());
+                            break;
+                        case INT:
+                            typeMin = (long) Math.max(-2147483648, columnStatistic.getMinValue());
+                            typeMax = (long) Math.min(2147483647, columnStatistic.getMaxValue());
+                            break;
+                        case BIGINT:
+                            typeMin = (long) Math.max(-9223372036854775808L, columnStatistic.getMinValue());
+                            typeMax = (long) Math.min(9223372036854775807L, columnStatistic.getMaxValue());
+                            break;
+                        default:
+                            throw new UnsupportedOperationException();
+                    }
+                } else {
+                    switch (columnDef.getType().getPrimitiveType()) {
+                        case TINYINT:
+                            typeMin = -128L;
+                            typeMax = 127L;
+                            break;
+                        case SMALLINT:
+                        case INT:
+                        case BIGINT:
+                        case LARGEINT:
+                            typeMin = -32768L;
+                            typeMax = 32767L;
+                            break;
+                        default:
+                            throw new UnsupportedOperationException();
+                    }
+                }
+            }
+
+            for (LiteralExpr literalExpr : this.literalExprs) {
+                if (literalExpr.getLongValue() > typeMin && literalExpr.getLongValue() < typeMax) {
+                    this.literals.add(literalExpr.getLongValue());
+                }
+            }
+        }
+
+        @Override
+        protected Long nextDefault() {
+            Long next = nextWithPartitionInfo();
+            if (next != null) {
+                return next;
+            }
+            return intervalRandomForLong(typeMin, typeMax);
+        }
+
+        @Override
+        protected Long nextWithStatistics() {
+            return nextDefault();
+        }
+
+        @SuppressWarnings("deprecation")
+        private long timestampToDate(long timestamp) {
+            Date date = new Date(timestamp);
+            return (long) date.getYear() * 10000 + date.getMonth() * 100 + date.getDay();
+        }
+    }
+
+    private static final class LargeIntColumnGenerator extends ColumnGenerator<BigInteger, BigInteger> {
+        public LargeIntColumnGenerator(ColumnDef columnDef,
+                                       ColumnStatistic columnStatistic,
+                                       List<LiteralExpr> literalExprs, long rows) {
+            super(columnDef, columnStatistic, literalExprs, rows);
+
+            // -2^127 + 1
+            typeMin = BigInteger.valueOf(2).pow(127).multiply(BigInteger.valueOf(-1)).add(BigInteger.valueOf(1));
+            // 2^127 - 1
+            typeMax = BigInteger.valueOf(2).pow(127).subtract(BigInteger.valueOf(1));
+
+            if (isStatisticsValid()) {
+                BigInteger statisticsMin = BigDecimal.valueOf(columnStatistic.getMinValue()).toBigInteger();
+                BigInteger statisticsMax = BigDecimal.valueOf(columnStatistic.getMaxValue()).toBigInteger();
+                if (statisticsMin.compareTo(typeMin) > 0) {
+                    typeMin = statisticsMin;
+                }
+                if (statisticsMax.compareTo(typeMax) < 0) {
+                    typeMax = statisticsMax;
+                }
+            } else {
+                typeMin = BigInteger.valueOf(-32768);
+                typeMax = BigInteger.valueOf(32767);
+            }
+
+            for (LiteralExpr literalExpr : this.literalExprs) {
+                BigInteger value = BigDecimal.valueOf(literalExpr.getDoubleValue()).toBigInteger();
+                if (value.compareTo(typeMin) >= 0 && value.compareTo((typeMax)) <= 0) {
+                    this.literals.add(value);
+                }
+            }
+        }
+
+        @Override
+        protected BigInteger nextDefault() {
+            return BigInteger.valueOf((long) intervalRandom(typeMin, typeMax));
+        }
+
+        @Override
+        protected BigInteger nextWithStatistics() {
+            return nextDefault();
+        }
+    }
+
+    private static final class FloatColumnGenerator extends ColumnGenerator<Double, Double> {
+        public FloatColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                    List<LiteralExpr> literalExprs,
+                                    long rows) {
+            super(columnDef, columnStatistic, literalExprs, rows);
+
+            for (LiteralExpr literalExpr : this.literalExprs) {
+                this.literals.add(literalExpr.getDoubleValue());
+            }
+
+            if (isStatisticsValid()) {
+                typeMin = columnStatistic.getMinValue();
+                typeMax = columnStatistic.getMaxValue();
+            } else {
+                typeMin = (double) Short.MIN_VALUE;
+                typeMax = (double) Short.MAX_VALUE;
+            }
+        }
+
+        @Override
+        protected Double nextDefault() {
+            return intervalRandom(typeMin, typeMax);
+        }
+
+        @Override
+        protected Double nextWithStatistics() {
+            return nextDefault();
+        }
+    }
+
+    private static final class DecimalColumnGenerator extends ColumnGenerator<BigDecimal, BigDecimal> {
+
+        private final int precision;
+        private final int scale;
+
+        public DecimalColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                      List<LiteralExpr> literalExprs,
+                                      long rows) {
+            super(columnDef, columnStatistic, literalExprs, rows);
+
+            precision = ((ScalarType) columnDef.getType()).decimalPrecision();
+            scale = ((ScalarType) columnDef.getType()).decimalScale();
+
+            for (LiteralExpr literalExpr : this.literalExprs) {
+                BigDecimal value = BigDecimal.valueOf(literalExpr.getDoubleValue());
+                // For decimal32(1), it can accept 1.2345 but not 123
+                if (value.precision() - value.scale() <= precision) {
+                    literals.add(value.setScale(scale, RoundingMode.HALF_UP));
+                }
+            }
+
+            if (isStatisticsValid()) {
+                typeMin = BigDecimal.valueOf(columnStatistic.getMinValue());
+                typeMax = BigDecimal.valueOf(columnStatistic.getMaxValue());
+            } else {
+                typeMin = BigDecimal.valueOf(Short.MIN_VALUE);
+                typeMax = BigDecimal.valueOf(Short.MAX_VALUE);
+            }
+        }
+
+        @Override
+        protected BigDecimal nextDefault() {
+            BigDecimal next = BigDecimal.valueOf(intervalRandom(typeMin, typeMax));
+            while (next.precision() - next.scale() > precision) {
+                next = next.movePointLeft(1);
+            }
+            return next.setScale(scale, RoundingMode.HALF_UP);
+        }
+
+        @Override
+        protected BigDecimal nextWithStatistics() {
+            return nextDefault();
+        }
+    }
+
+    private static final class StringColumnGenerator extends ColumnGenerator<String, String> {
+
+        private final int maxSize;
+
+        public StringColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                     List<LiteralExpr> literalExprs,
+                                     long rows) {
+            super(columnDef, columnStatistic, literalExprs, rows);
+
+            maxSize = ((ScalarType) columnDef.getType()).getLength();
+
+            for (LiteralExpr literalExpr : this.literalExprs) {
+                String str = literalExpr.getStringValue();
+                str = str.replaceAll("([^\\\\]{2})%", "$1");
+                str = str.replaceAll("^(.?)%", "$1");
+                if (str.length() <= maxSize) {
+                    this.literals.add(str);
+                }
+            }
+        }
+
+        private String getRandomString(int size) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < size; i++) {
+                sb.append((char) (97 + random.nextInt(26)));
+            }
+            return sb.toString();
+        }
+
+        @Override
+        protected String nextDefault() {
+            return getRandomString(random.nextInt(maxSize) + 1);
+        }
+
+        @Override
+        protected String nextWithStatistics() {
+            return getRandomString(random.nextInt(maxSize) + 1);
+        }
+    }
+
+    private static final class TimeColumnGenerator extends PartitionColumnGenerator<String> {
+
+        private DateFormat dateFormat;
+
+        public TimeColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic, List<LiteralExpr> literalExprs,
+                                   List<SingleRangePartitionDesc> singleRangePartitionDescs, long rows,
+                                   Map<String, Long> partitionRowNums) throws Exception {
+            super(columnDef, columnStatistic, literalExprs, singleRangePartitionDescs, rows, partitionRowNums);
+        }
+
+        protected void initTypeInfo() throws Exception {
+            if (this.columnDef.getType().isDate()) {
+                dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            } else {
+                dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            }
+            typeMax = new Date().getTime();
+            if (this.columnDef.getType().isDate()) {
+                typeMin = dateFormat.parse("1970-01-01").getTime();
+            } else {
+                typeMin = dateFormat.parse("1970-01-01 00:00:00").getTime();
+            }
+
+            if (this.singleRangePartitionDescs != null) {
+                for (SingleRangePartitionDesc singleRangePartitionDesc : this.singleRangePartitionDescs) {
+                    PartitionKeyDesc partitionKeyDesc = singleRangePartitionDesc.getPartitionKeyDesc();
+                    long partitionLower = typeMin;
+                    long partitionUpper = typeMax;
+                    if (partitionKeyDesc.hasLowerValues()) {
+                        Preconditions.checkState(partitionKeyDesc.getLowerValues().size() == 1);
+                        String lowValueStr = partitionKeyDesc.getLowerValues().get(0).getStringValue();
+                        partitionLower = dateFormat.parse(lowValueStr).getTime();
+                    }
+                    if (partitionKeyDesc.hasUpperValues()) {
+                        Preconditions.checkState(partitionKeyDesc.getUpperValues().size() == 1);
+                        String upperValueStr = partitionKeyDesc.getUpperValues().get(0).getStringValue();
+                        partitionUpper = dateFormat.parse(upperValueStr).getTime();
+                    }
+
+                    partitionBoundaries.add(
+                            Triple.of(partitionLower, partitionUpper, partitionKeyDesc.getPartitionType()));
+                }
+            }
+
+            this.typeMin = partitionBoundaries.stream()
+                    .map(Triple::getLeft)
+                    .mapToLong(v -> v)
+                    .min()
+                    .orElse(typeMin);
+
+            this.typeMax = partitionBoundaries.stream()
+                    .map(Triple::getMiddle)
+                    .mapToLong(v -> v)
+                    .max()
+                    .orElse(typeMax);
+
+            for (LiteralExpr literalExpr : this.literalExprs) {
+                DateLiteral dateLiteral = (DateLiteral) literalExpr;
+                long timestamp = dateLiteral.toLocalDateTime()
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli();
+                if (timestamp > typeMin && timestamp < typeMax) {
+                    this.literals.add(format(timestamp));
+                }
+            }
+        }
+
+        private String format(long timestamp) {
+            return dateFormat.format(new Date(timestamp));
+        }
+
+        @Override
+        protected String nextDefault() {
+            Long next = nextWithPartitionInfo();
+            if (next != null) {
+                return format(next);
+            }
+            return format(intervalRandomForLong(typeMin, typeMax));
+        }
+
+        @Override
+        protected String nextWithStatistics() {
+            return nextDefault();
+        }
+
+    }
+
+    private static final class ArrayColumnGenerator extends ColumnGenerator<String, String> {
+        public ArrayColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                    List<LiteralExpr> literalExprs, long rows) {
+            super(columnDef, columnStatistic, literalExprs, rows);
+        }
+
+        @Override
+        protected String nextDefault() {
+            return "[]";
+        }
+
+        @Override
+        protected String nextWithStatistics() {
+            return "[]";
+        }
+    }
+
+    private static final class JsonColumnGenerator extends ColumnGenerator<String, String> {
+        public JsonColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic,
+                                   List<LiteralExpr> literalExprs, long rows) {
+            super(columnDef, columnStatistic, literalExprs, rows);
+        }
+
+        @Override
+        protected String nextDefault() {
+            return "{}";
+        }
+
+        @Override
+        protected String nextWithStatistics() {
+            return "{}";
+        }
+    }
+
+    private static final class NullColumnGenerator extends ColumnGenerator<Object, Object> {
+        public NullColumnGenerator(ColumnDef columnDef, ColumnStatistic columnStatistic, List<LiteralExpr> literalExprs,
+                                   long rows) {
+            super(columnDef, columnStatistic, literalExprs, rows);
+        }
+
+        @Override
+        protected Object nextDefault() {
+            return null;
+        }
+
+        @Override
+        protected Object nextWithStatistics() {
+            return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/generator/DataGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/generator/DataGenerator.java
@@ -1,0 +1,468 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.dump.generator;
+
+import com.clearspring.analytics.util.Lists;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.authentication.AuthenticationManager;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.optimizer.dump.MockDumpInfo;
+import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.parser.SqlParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class DataGenerator {
+
+    private static final Option OPTION_MODE = Option.builder("m")
+            .longOpt("mode")
+            .hasArg(true)
+            .argName("count|gen")
+            .desc("Mode, optional value can be 'count' or 'gen'. 'count' mode for printing row info" +
+                    " of all tables. 'gen' mode for generating data based on table schema and column statistics.")
+            .build();
+    private static final Option OPTION_DUMP_PATH = Option.builder("i")
+            .longOpt("path")
+            .hasArg(true)
+            .argName("path")
+            .desc("The path of dump file in json format.")
+            .build();
+    private static final Option OPTION_OUTPUT_DIR = Option.builder("o")
+            .longOpt("output_dir")
+            .hasArg(true)
+            .argName("path")
+            .desc("The directory for generated data and other related files.")
+            .build();
+    private static final Option OPTION_NUM_ROWS = Option.builder("n")
+            .longOpt("num_rows")
+            .hasArg(true)
+            .argName("rows")
+            .desc("The maximum number of rows among all generated tables. " +
+                    "For example, the rows of table t0, t1, t2 are 1000w, 100w, 10w, so t0 is the largest table. " +
+                    "If we specify '-n 100000', so the ratio is 0.01, then t0 will have 10w rows, " +
+                    "and the other tables will decrease proportionally, " +
+                    "which means t1 has 1w rows and t2 has 1k rows. " +
+                    "But if the maximum number of rows among all tables are smaller than this argument, " +
+                    "then it will be simply ignored. " +
+                    "Besides, for general purpose, the minimum number of generated rows is 128.")
+            .build();
+    private static final Option OPTION_MAX_FILE_ROWS = Option.builder()
+            .longOpt("max_file_rows")
+            .hasArg(true)
+            .argName("rows")
+            .desc("The maximum rows of each segmented csv files. If the total number of rows is greater than this, " +
+                    "there will be multiply csv files with a number suffix, like 'xxx.csv-012'. " +
+                    "The default value is 1000000.")
+            .build();
+    private static final Option OPTION_CONCURRENCY = Option.builder("c")
+            .longOpt("concurrency")
+            .hasArg(true)
+            .argName("number")
+            .desc("This argument controls how many tasks can be executed at the same time, " +
+                    "each task is responsible for generating a segmented csv file. The default value is 4.")
+            .build();
+    private static final Option OPTION_HELP = Option.builder("h")
+            .longOpt("help")
+            .hasArg(false)
+            .desc("Print this help document.")
+            .build();
+
+    enum Mode {
+        COUNT,
+        GEN;
+
+        public static Mode of(String str) {
+            for (Mode value : values()) {
+                if (value.toString().toLowerCase().equals(str)) {
+                    return value;
+                }
+            }
+            StringBuilder sb = new StringBuilder();
+            sb.append("mode only can be ");
+            for (Mode value : values()) {
+                sb.append(value.toString().toLowerCase())
+                        .append("|");
+            }
+            sb.setLength(sb.length() - 1);
+            sb.append('.');
+            throw new IllegalArgumentException(sb.toString());
+        }
+    }
+
+    private ExecutorService threadPool;
+    private final ConnectContext session;
+    private final Options options;
+    private final HelpFormatter helpFormatter;
+    private CommandLine commandLine;
+    private Mode mode;
+    private File outputDir;
+    private long expectedRows;
+    private long maxFileRows;
+    private long maxRows;
+    private QueryDumpInfo queryDumpInfo;
+    private final Map<String, Long> queryDumpRowInfos = Maps.newHashMap();
+    private final List<LiteralExpr> literals = Lists.newArrayList();
+    private final List<TableGenerator> tableGenerators = Lists.newArrayList();
+
+    public static void main(String[] args) {
+        DataGenerator dataGenerator = new DataGenerator(args);
+        dataGenerator.process();
+    }
+
+    private DataGenerator(String[] args) {
+        session = new ConnectContext(null);
+        session.setCurrentUserIdentity(UserIdentity.ROOT);
+        session.setQualifiedUser(AuthenticationManager.ROOT_USER);
+        session.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        session.setThreadLocalInfo();
+        session.setDumpInfo(new MockDumpInfo());
+
+        options = new Options();
+        options.addOption(OPTION_MODE);
+        options.addOption(OPTION_DUMP_PATH);
+        options.addOption(OPTION_OUTPUT_DIR);
+        options.addOption(OPTION_NUM_ROWS);
+        options.addOption(OPTION_MAX_FILE_ROWS);
+        options.addOption(OPTION_CONCURRENCY);
+        options.addOption(OPTION_HELP);
+
+        CommandLineParser parser = new DefaultParser();
+        helpFormatter = new HelpFormatter();
+        try {
+            commandLine = parser.parse(options, args, false);
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+            printHelpDoc();
+            System.exit(1);
+        }
+    }
+
+    private void printHelpDoc() {
+        helpFormatter.printHelp("\n    <1>: -m count -i <path>\n" +
+                "    <2>: -m gen -i <path> -o <path> [-n <rows>] [--max_file_rows <rows>] [-c <number>]\n" +
+                "    <3>: -h", options);
+    }
+
+    private void checkRequiredOption(String option) {
+        Preconditions.checkState(commandLine.hasOption(option),
+                String.format("Option '%s' is mandatory", option));
+    }
+
+    private void init() throws Exception {
+        if (commandLine.hasOption(OPTION_HELP.getOpt())) {
+            printHelpDoc();
+            System.exit(0);
+        }
+
+        checkRequiredOption(OPTION_MODE.getOpt());
+        mode = Mode.of(commandLine.getOptionValue(OPTION_MODE.getOpt()));
+
+        checkRequiredOption(OPTION_DUMP_PATH.getOpt());
+        File dumpFile = new File(commandLine.getOptionValue(OPTION_DUMP_PATH.getOpt()));
+        Preconditions.checkState(dumpFile.exists() && dumpFile.isFile(), "dump file not exists");
+        String dumpStr = IOUtils.toString(new FileInputStream(dumpFile), Charset.defaultCharset());
+        queryDumpInfo = GsonUtils.GSON.fromJson(dumpStr, QueryDumpInfo.class);
+
+        if (mode != Mode.GEN) {
+            return;
+        }
+
+        // output dir
+        checkRequiredOption(OPTION_OUTPUT_DIR.getOpt());
+        outputDir = new File(commandLine.getOptionValue(OPTION_OUTPUT_DIR.getOpt()));
+        if (!outputDir.exists()) {
+            boolean res = outputDir.mkdirs();
+            Preconditions.checkState(res);
+        }
+        Preconditions.checkState(outputDir.exists() && outputDir.isDirectory(), "output dir not exists");
+
+        // num rows
+        if (commandLine.hasOption(OPTION_NUM_ROWS.getOpt())) {
+            expectedRows = Long.parseLong(commandLine.getOptionValue(OPTION_NUM_ROWS.getOpt()));
+            Preconditions.checkState(expectedRows > 0, "-n <rows> must be positive");
+        } else {
+            expectedRows = -1;
+        }
+
+        // max file rows
+        if (commandLine.hasOption(OPTION_MAX_FILE_ROWS.getLongOpt())) {
+            maxFileRows = Long.parseLong(commandLine.getOptionValue(OPTION_MAX_FILE_ROWS.getLongOpt()));
+            Preconditions.checkState(expectedRows > 0, "--max_file_rows <rows> must be positive");
+        } else {
+            maxFileRows = 1000000;
+        }
+
+        // concurrency
+        int concurrency;
+        if (commandLine.hasOption(OPTION_CONCURRENCY.getOpt())) {
+            concurrency = Integer.parseInt(commandLine.getOptionValue(OPTION_CONCURRENCY.getOpt()));
+            Preconditions.checkState(concurrency > 0, "-c <concurrency> must be positive");
+            concurrency = Math.min(concurrency, Runtime.getRuntime().availableProcessors());
+        } else {
+            concurrency = 4;
+        }
+        threadPool = Executors.newFixedThreadPool(concurrency);
+
+        File prepareFile = new File(String.format("%s/create_table.sql", outputDir.getAbsolutePath()));
+        if (prepareFile.exists()) {
+            boolean res = prepareFile.delete();
+            Preconditions.checkState(res);
+        }
+
+        // parse query dump from json file
+        String queryStmt = queryDumpInfo.getOriginStmt();
+        Set<String> tableNames = Sets.newHashSet();
+        for (String fullName : queryDumpInfo.getCreateTableStmtMap().keySet()) {
+            String[] segments = fullName.split("\\.");
+            String dbName = segments[0];
+            String tableName = segments[1];
+            queryStmt = queryStmt.replaceAll(String.format("%s\\.", dbName), "");
+            Preconditions.checkState(tableNames.add(tableName), "duplicate table name is not allowed");
+        }
+        IOUtils.write(queryStmt,
+                new FileOutputStream(String.format("%s/query.sql", outputDir.getAbsolutePath())),
+                Charset.defaultCharset());
+    }
+
+    private void process() {
+        try {
+            init();
+            parseRowInfo();
+            if (Mode.COUNT.equals(mode)) {
+                countRows();
+            } else {
+                generateData();
+                generateShell();
+            }
+        } catch (UnsupportedOperationException | IllegalArgumentException | IllegalStateException e1) {
+            System.err.println(e1.getMessage());
+            printHelpDoc();
+            System.exit(1);
+        } catch (Exception e2) {
+            e2.printStackTrace();
+            System.exit(1);
+        } finally {
+            shutdown();
+        }
+    }
+
+    private void shutdown() {
+        if (threadPool != null && !threadPool.isShutdown()) {
+            threadPool.shutdownNow();
+        }
+    }
+
+    private void parseRowInfo() {
+        maxRows = Long.MIN_VALUE;
+        for (Map.Entry<String, String> entry : queryDumpInfo.getCreateTableStmtMap().entrySet()) {
+            String fullTableName = entry.getKey();
+            Map<String, Long> partitionRowCounts = queryDumpInfo.getPartitionRowCountMap().get(fullTableName);
+            long rows;
+            if (partitionRowCounts == null) {
+                rows = 0;
+            } else {
+                rows = partitionRowCounts.values().stream().mapToLong(i -> i).sum();
+            }
+            queryDumpRowInfos.put(fullTableName, rows);
+            maxRows = Math.max(maxRows, rows);
+        }
+    }
+
+    private void countRows() {
+        System.out.println("The number of rows from query dump file for each table are listed down below:");
+        for (Map.Entry<String, String> entry : queryDumpInfo.getCreateTableStmtMap().entrySet()) {
+            String fullTableName = entry.getKey();
+            Long queryDumpRows = queryDumpRowInfos.get(fullTableName);
+            System.out.printf("    %s: original rows=%d%n", fullTableName.split("\\.")[1],
+                    queryDumpRows == null ? 0 : queryDumpRows);
+        }
+    }
+
+    private void generateData() throws Exception {
+        parseLiterals();
+
+        double factor = expectedRows < 0 ? 1 : ((double) expectedRows / Math.max(maxRows, 1));
+        factor = Math.min(1, factor);
+
+        System.out.println("The number of generated rows for each table are listed down below:");
+        for (Map.Entry<String, String> entry : queryDumpInfo.getCreateTableStmtMap().entrySet()) {
+            String fullTableName = entry.getKey();
+            String createTableSql = entry.getValue();
+            CreateTableStmt stmt =
+                    (CreateTableStmt) SqlParser.parse(createTableSql, session.getSessionVariable()).get(0);
+            Map<String, ColumnStatistic> columnStatistics = queryDumpInfo.getTableStatisticsMap().get(fullTableName);
+            Map<String, Long> partitionRowCounts = queryDumpInfo.getPartitionRowCountMap().get(fullTableName);
+            TableGenerator tableGenerator = TableGenerator.create(stmt, partitionRowCounts, columnStatistics,
+                    literals, factor, outputDir, maxFileRows);
+            tableGenerators.add(tableGenerator);
+
+            Long queryDumpRows = queryDumpRowInfos.get(fullTableName);
+            System.out.printf("    %s: original rows=%d, generated rows=%d%n", tableGenerator.getTableName(),
+                    queryDumpRows == null ? 0 : queryDumpRows, tableGenerator.getRows());
+        }
+
+        for (TableGenerator tableGenerator : tableGenerators) {
+            tableGenerator.generate(threadPool);
+        }
+    }
+
+    /**
+     * In order to generate more relevant data, we need to parse the query and extract
+     * all the literal values, and use them as candidates when generating random data.
+     * For example, select v1,v2,v3 from t0 where v1 = 'city'.
+     * the column v1's random generated data must contain 'city', otherwise the query has no output
+     * <p>
+     * For sake of simplicity, we extract all the literals, and put them together to inject to all the
+     * columns only if the type is matched. Continuing with the example above, both v1 and v2 and v3 will
+     * have value 'city', although only v1 is the related column.
+     */
+    private void parseLiterals() {
+        StatementBase statementBase =
+                SqlParser.parse(queryDumpInfo.getOriginStmt(), session.getSessionVariable()).get(0);
+
+        List<LiteralExpr> literals = CollectLiteralVisitor.collect(statementBase);
+        for (LiteralExpr literal : literals) {
+            if (literal instanceof StringLiteral) {
+                try {
+                    DateLiteral dateLiteral = new DateLiteral(literal.getStringValue(), Type.DATETIME);
+                    this.literals.add(dateLiteral);
+                } catch (AnalysisException e1) {
+                    try {
+                        DateLiteral dateLiteral = new DateLiteral(literal.getStringValue(), Type.DATE);
+                        this.literals.add(dateLiteral);
+                    } catch (AnalysisException e2) {
+                        this.literals.add(literal);
+                    }
+                }
+            } else {
+                this.literals.add(literal);
+            }
+        }
+    }
+
+    private void generateShell() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        sb.append("#!/bin/bash\n\n");
+
+        sb.append("set -e\n\n");
+
+        sb.append("function echo_red () {\n" +
+                "    tput setaf 1\n" +
+                "    tput bold\n" +
+                "    echo \"$@\"\n" +
+                "    tput sgr0\n" +
+                "}\n\n");
+        sb.append("function echo_green () {\n" +
+                "    tput setaf 2\n" +
+                "    echo \"$@\"\n" +
+                "    tput sgr0\n" +
+                "}\n\n");
+
+        sb.append("echo_green '============================   Loading Script Start   ============================'\n");
+        sb.append("\n");
+
+        sb.append("# check env\n");
+        String[] printEnvs = {"FE_HOST", "FE_QUERY_PORT", "FE_HTTP_PORT",
+                "FE_USER", "FE_PASSWD", "DATABASE", "DROP_DATABASE_IF_EXIST"};
+        sb.append("echo_green 'All the related env variables are listed down below:'\n");
+        for (String env : printEnvs) {
+            sb.append(String.format("echo_green \"    %s='${%s}'\"\n", env, env));
+        }
+        sb.append("\n");
+        String[] checkEnvs = {"FE_HOST", "FE_QUERY_PORT", "FE_HTTP_PORT", "FE_USER", "DATABASE"};
+        for (String env : checkEnvs) {
+            sb.append(String.format("if [ -z \"${%s}\" ]; then\n", env))
+                    .append(String.format("    echo_red \"    Env '%s' is mandatory\"\n", env))
+                    .append("    exit 1\n")
+                    .append("fi\n");
+        }
+        sb.append("\n");
+
+        sb.append("# create table\n");
+        sb.append("echo_green 'Creating tables:'\n");
+        sb.append("if [ -n \"${DROP_DATABASE_IF_EXIST}\" ]; then\n");
+        sb.append("    MYSQL_PWD=${FE_PASSWD} mysql -h${FE_HOST} -P${FE_QUERY_PORT} -u${FE_USER} " +
+                "-e \"DROP DATABASE IF EXISTS ${DATABASE};\"\n");
+        sb.append("fi\n");
+        sb.append("MYSQL_PWD=${FE_PASSWD} mysql -h${FE_HOST} -P${FE_QUERY_PORT} -u${FE_USER} " +
+                "-e \"CREATE DATABASE IF NOT EXISTS ${DATABASE};\"\n");
+        sb.append(String.format("MYSQL_PWD=${FE_PASSWD} mysql -h${FE_HOST} -P${FE_QUERY_PORT} " +
+                "-u${FE_USER} -D${DATABASE} < %s/create_table.sql\n", outputDir.getAbsolutePath()));
+        sb.append("\n");
+
+        sb.append("# load data\n");
+        sb.append("echo_green 'Loading data from csv files:'\n");
+        for (int i = 0; i < tableGenerators.size(); i++) {
+            TableGenerator tableGenerator = tableGenerators.get(i);
+            sb.append(String.format("csv_files=( $(find %s -maxdepth 1 -name \"%s.csv-*\" | sort) )\n",
+                    outputDir.getAbsolutePath(), tableGenerator.getTableName()));
+            sb.append("total_loaded_rows=0\n");
+            sb.append("for ((i=0; i<${#csv_files[@]}; i++))\n");
+            sb.append("do\n");
+            sb.append("    csv_file=${csv_files[@]:${i}:1}\n");
+            sb.append("    loading_rows=$(wc -l < ${csv_file})\n");
+            sb.append("    ((total_loaded_rows+=loading_rows))\n");
+            sb.append(String.format("    echo_green -en \"\\r    [%d/%d] Loading table: '%s'. " +
+                            "Segment<$((i+1))/${#csv_files[@]}>: '${csv_file##*/}'. " +
+                            "Current loading rows: ${loading_rows}, total loaded rows: ${total_loaded_rows} ...\"\n",
+                    i + 1, tableGenerators.size(), tableGenerator.getTableName()));
+            sb.append(String.format("    stream_load_output=$(curl -s --location-trusted " +
+                            "-u ${FE_USER}:${FE_PASSWD} -T ${csv_file} -H 'column_separator:|' " +
+                            "http://${FE_HOST}:${FE_HTTP_PORT}/api/${DATABASE}/%s/_stream_load)\n",
+                    tableGenerator.getTableName()));
+            sb.append("    if [[ \"${stream_load_output}\" != *\"\\\"Status\\\": \\\"Success\\\"\"* ]]; then\n");
+            sb.append("        echo_red -e \"    Load failed, filePath=${csv_file}, " +
+                    "errorMsg:\\n${stream_load_output}\"\n");
+            sb.append("        exit 1\n");
+            sb.append("    fi\n");
+            sb.append("done\n");
+            sb.append("echo_green\n\n");
+        }
+
+        sb.append("echo_green '============================    Loading Script End    ============================'\n");
+
+        IOUtils.write(sb.toString(),
+                new FileOutputStream(String.format("%s/load_data.sh", outputDir.getAbsolutePath())),
+                Charset.defaultCharset());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/generator/TableGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/generator/TableGenerator.java
@@ -1,0 +1,235 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.dump.generator;
+
+import com.clearspring.analytics.util.Lists;
+import com.google.common.base.Preconditions;
+import com.starrocks.analysis.ColumnDef;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.DecimalLiteral;
+import com.starrocks.analysis.FloatLiteral;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.LargeIntLiteral;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.PartitionDesc;
+import com.starrocks.sql.ast.RangePartitionDesc;
+import com.starrocks.sql.ast.SingleRangePartitionDesc;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+public class TableGenerator {
+
+    private final CreateTableStmt stmt;
+    private final List<LiteralExpr> literals;
+    private final List<ColumnGenerator<?, ?>> columnGenerators = Lists.newArrayList();
+    private final long rows;
+    private final long maxFileRows;
+    private final File outputDir;
+    private final File createTableFile;
+    private final List<File> csvFiles = Lists.newArrayList();
+
+    public static TableGenerator create(CreateTableStmt stmt, Map<String, Long> partitionRowCounts,
+                                        Map<String, ColumnStatistic> columnStatistics, List<LiteralExpr> literals,
+                                        double factor, File outputDir, long maxFileRows) throws Exception {
+        return new TableGenerator(stmt, partitionRowCounts, columnStatistics, literals, factor, outputDir, maxFileRows);
+    }
+
+    private TableGenerator(CreateTableStmt stmt, Map<String, Long> partitionRowCounts,
+                           Map<String, ColumnStatistic> columnStatistics, List<LiteralExpr> literals,
+                           double factor, File outputDir, long maxFileRows) throws Exception {
+        Preconditions.checkState(stmt != null);
+        this.stmt = stmt;
+
+        // For large table, we let the table size shrink with factor proportionally,
+        // but for small table, we set the table size to 128 in order to generate proper output
+        final long minimumRows = 128;
+        if (partitionRowCounts != null) {
+            long rows = partitionRowCounts.values().stream().mapToLong(i -> i).sum();
+            if (rows * factor > minimumRows) {
+                this.rows = (long) (rows * factor);
+                Set<String> partitionNames = partitionRowCounts.keySet();
+                for (String key : partitionNames) {
+                    partitionRowCounts.put(key, (long) (partitionRowCounts.get(key) * factor));
+                }
+            } else {
+                this.rows = minimumRows;
+            }
+        } else {
+            this.rows = minimumRows;
+        }
+
+        this.maxFileRows = maxFileRows;
+
+        this.literals = literals;
+        this.outputDir = outputDir;
+        this.createTableFile = new File(String.format("%s/create_table.sql", outputDir.getAbsolutePath()));
+
+        PartitionDesc partitionDesc = stmt.getPartitionDesc();
+        // partitionName -> partitionDesc
+        List<SingleRangePartitionDesc> singleRangePartitionDescs;
+        String partitionColName;
+        if (partitionDesc != null) {
+            Preconditions.checkState(Objects.equals(PartitionType.RANGE, partitionDesc.getType()),
+                    "only support range partition");
+            RangePartitionDesc rangePartitionDesc = (RangePartitionDesc) partitionDesc;
+            Preconditions.checkState(rangePartitionDesc.getPartitionColNames().size() == 1,
+                    "only support single range partition");
+
+            partitionColName = rangePartitionDesc.getPartitionColNames().get(0);
+            singleRangePartitionDescs = rangePartitionDesc.getSingleRangePartitionDescs();
+        } else {
+            partitionColName = null;
+            singleRangePartitionDescs = null;
+        }
+
+        for (ColumnDef columnDef : stmt.getColumnDefs()) {
+            ColumnStatistic columnStatistic = null;
+            if (columnStatistics != null) {
+                columnStatistic = columnStatistics.get(columnDef.getName());
+            }
+            boolean isPartitionColumn = Objects.equals(columnDef.getName(), partitionColName);
+            ColumnGenerator<?, ?> columnGenerator = ColumnGenerator.create(columnDef,
+                    columnStatistic, getLiteralsByType(columnDef.getType()),
+                    isPartitionColumn ? singleRangePartitionDescs : null,
+                    rows,
+                    isPartitionColumn ? partitionRowCounts : null);
+            columnGenerators.add(columnGenerator);
+        }
+    }
+
+    public long getRows() {
+        return rows;
+    }
+
+    public void generate(ExecutorService threads) throws Exception {
+        String createTableStr = stmt.getOrigStmt().originStmt;
+        createTableStr = createTableStr.replaceAll("\"dynamic_partition\\..*?\"\\s*?=\\s*?\".*?\",?\\s*?\n", "");
+        IOUtils.write(createTableStr + "\n\n", new FileOutputStream(createTableFile, true), Charset.defaultCharset());
+
+        final int taskSize = (int) Math.ceil((double) rows / maxFileRows);
+        String metaFormat = String.format("%%s/%%s.csv-%%0%dd", String.valueOf(taskSize).length());
+        List<Future<Void>> futures = Lists.newArrayList();
+
+        long remainRows = rows;
+        for (int i = 0; i < taskSize; i++) {
+            File csvFile = new File(String.format(metaFormat, outputDir.getAbsolutePath(), stmt.getTableName(), i + 1));
+            csvFiles.add(csvFile);
+            long taskRows = Math.min(remainRows, maxFileRows);
+            futures.add(threads.submit(new GenerateTask(columnGenerators, csvFile, taskRows)));
+            remainRows -= taskRows;
+        }
+
+        for (Future<Void> future : futures) {
+            future.get();
+        }
+
+        check();
+    }
+
+    private void check() throws IOException {
+        long sum = 0;
+        for (File csvFile : csvFiles) {
+            sum += Files.lines(csvFile.toPath()).count();
+        }
+        Preconditions.checkState(sum == rows, "generated row not matehes");
+    }
+
+    private List<LiteralExpr> getLiteralsByType(Type type) {
+        if (type.isDateType()) {
+            return literals.stream()
+                    .filter(literal -> literal instanceof DateLiteral)
+                    .collect(Collectors.toList());
+        } else if (type.isIntegerType() || type.isLargeIntType()) {
+            return literals.stream()
+                    .filter(literal -> literal instanceof IntLiteral || literal instanceof LargeIntLiteral)
+                    .collect(Collectors.toList());
+        } else if (type.isDecimalOfAnyVersion()) {
+            return literals.stream()
+                    .filter(literal -> literal instanceof IntLiteral || literal instanceof LargeIntLiteral
+                            || literal instanceof DecimalLiteral)
+                    .collect(Collectors.toList());
+        } else if (type.isFloatingPointType()) {
+            return literals.stream()
+                    .filter(literal -> literal instanceof IntLiteral || literal instanceof LargeIntLiteral
+                            || literal instanceof DecimalLiteral || literal instanceof FloatLiteral)
+                    .collect(Collectors.toList());
+        } else if (type.isStringType()) {
+            return Lists.newArrayList(literals);
+        } else {
+            return Lists.newArrayList();
+        }
+    }
+
+    public String getTableName() {
+        return stmt.getTableName();
+    }
+
+    private static final class GenerateTask implements Callable<Void> {
+        private final List<ColumnGenerator<?, ?>> columnGenerators;
+        private final File csvFile;
+        private final long rows;
+
+        public GenerateTask(List<ColumnGenerator<?, ?>> columnGenerators, File csvFile, long rows) {
+            this.columnGenerators = columnGenerators;
+            this.csvFile = csvFile;
+            this.rows = rows;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            try (FileOutputStream outputStream = new FileOutputStream(csvFile)) {
+                for (int i = 0; i < rows; i++) {
+                    StringBuilder sb = new StringBuilder();
+                    for (ColumnGenerator<?, ?> columnGenerator : columnGenerators) {
+                        sb.append('|');
+                        Object value = columnGenerator.next();
+                        if (value != null) {
+                            if (value instanceof Double) {
+                                sb.append(String.format("%.3f", value));
+                            } else {
+                                sb.append(value);
+                            }
+                        }
+                    }
+                    sb.append('\n');
+                    outputStream.write(sb.substring(1).getBytes(StandardCharsets.UTF_8));
+
+                    if (i % 100 == 0) {
+                        outputStream.flush();
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Background

For query dump, what do we have now?

1. Get a query dump through http interface, dump info will be stored in a json file.
2. Based on the dump file, we can replay it to generate a plan.

What do we further needed?

1. A data generate tool for generating data based on the query dump's table schema and statistics information.

Why do we need to generate data? Because we need to make sure that the plan can be actually executed and its result is correct.

## Limitation

1. DO NOT support complex column like bitmap, struct.
1. DO NOT support all types of external table.

## How to use & Best practice

Assume env variable `STARROCKS_HOME` is referring to the project's path in your machine

Setup an alias 

```
alias dumputils='java -cp "${STARROCKS_HOME}/output/fe/lib/*" com.starrocks.sql.optimizer.dump.generator.DataGenerator'
```

### Help Info

`dumputils -h`. And here's the help info:

```
usage:
    <1>: -m count -i <path>
    <2>: -m gen -i <path> -o <path> [-n <rows>] [--max_file_rows <rows>]
         [-c <number>]
    <3>: -h
 -c,--concurrency <number>   This argument controls how many tasks can be
                             executed at the same time, each task is
                             responsible for generating a segmented csv
                             file. The default value is 4.
 -h,--help                   Print this help document.
 -i,--path <path>            The path of dump file in json format.
 -m,--mode <count|gen>       Mode, optional value can be 'count' or 'gen'.
                             'count' mode for printing row info of all
                             tables. 'gen' mode for generating data based
                             on table schema and column statistics.
    --max_file_rows <rows>   The maximum rows of each segmented csv files.
                             If the total number of rows is greater than
                             this, there will be multiply csv files with a
                             number suffix, like 'xxx.csv-012'. The
                             default value is 1000000.
 -n,--num_rows <rows>        The maximum number of rows among all
                             generated tables. For example, the rows of
                             table t0, t1, t2 are 1000w, 100w, 10w, so t0
                             is the largest table. If we specify '-n
                             100000', so the ratio is 0.01, then t0 will
                             have 10w rows, and the other tables will
                             decrease proportionally, which means t1 has
                             1w rows and t2 has 1k rows. But if the
                             maximum number of rows among all tables are
                             smaller than this argument, then it will be
                             simply ignored. Besides, for general purpose,
                             the minimum number of generated rows is 128.
 -o,--output_dir <path>      The directory for generated data and other
                             related files.
```

### Get Row info of all tables

```sh
dumputils -m count -i tpcds64.json
```

`tpcds64.json` is a dump file name on my machine. And the output are put down below: 

```
The number of rows from query dump file for each table are listed down below:
    household_demographics: original rows=7200
    customer_demographics: original rows=1920800
    catalog_sales: original rows=1441548
    promotion: original rows=300
    customer: original rows=100000
    store_sales: original rows=2880404
    date_dim: original rows=73049
    income_band: original rows=20
    store_returns: original rows=287514
    store: original rows=12
    catalog_returns: original rows=144067
    item: original rows=18000
    customer_address: original rows=50000
```

### Generate data 

```sh
dumputils -m gen -i tpcds64.json -o output -n 100000 -c 4 --max_file_rows 10000
```

```
The number of generated rows for each table are listed down below:
    household_demographics: original rows=7200, generated rows=249
    customer_demographics: original rows=1920800, generated rows=66685
    catalog_sales: original rows=1441548, generated rows=50046
    promotion: original rows=300, generated rows=128
    customer: original rows=100000, generated rows=3471
    store_sales: original rows=2880404, generated rows=99999
    date_dim: original rows=73049, generated rows=2536
    income_band: original rows=20, generated rows=128
    store_returns: original rows=287514, generated rows=9981
    store: original rows=12, generated rows=128
    catalog_returns: original rows=144067, generated rows=5001
    item: original rows=18000, generated rows=624
    customer_address: original rows=50000, generated rows=1735
```

And here's the generated files in the directory `output` (specified by option `-o`)

```
-rw-rw-r-- 1 hcf hcf    11631 Mar 10 14:52 catalog_sales.csv-6
-rw-rw-r-- 1 hcf hcf    13328 Mar 10 14:52 load_data.sh
-rw-rw-r-- 1 hcf hcf  1486483 Mar 10 14:52 store_returns.csv-1
-rw-rw-r-- 1 hcf hcf    15329 Mar 10 14:52 create_table.sql
-rw-rw-r-- 1 hcf hcf  1624855 Mar 10 14:52 store_sales.csv-08
-rw-rw-r-- 1 hcf hcf  1625544 Mar 10 14:52 store_sales.csv-05
-rw-rw-r-- 1 hcf hcf  1625691 Mar 10 14:52 store_sales.csv-02
-rw-rw-r-- 1 hcf hcf  1625878 Mar 10 14:52 store_sales.csv-01
-rw-rw-r-- 1 hcf hcf  1625931 Mar 10 14:52 store_sales.csv-04
-rw-rw-r-- 1 hcf hcf 16260663 Mar 10 14:51 store_sales.csv-1
-rw-rw-r-- 1 hcf hcf  1626163 Mar 10 14:52 store_sales.csv-07
-rw-rw-r-- 1 hcf hcf  1626190 Mar 10 14:52 store_sales.csv-10
-rw-rw-r-- 1 hcf hcf  1626528 Mar 10 14:52 store_sales.csv-03
-rw-rw-r-- 1 hcf hcf  1626882 Mar 10 14:52 store_sales.csv-06
-rw-rw-r-- 1 hcf hcf  1627001 Mar 10 14:52 store_sales.csv-09
-rw-rw-r-- 1 hcf hcf     1827 Mar 10 14:52 income_band.csv-1
-rw-rw-r-- 1 hcf hcf    18563 Mar 10 14:52 promotion.csv-1
-rw-rw-r-- 1 hcf hcf   200247 Mar 10 14:52 item.csv-1
-rw-rw-r-- 1 hcf hcf  2522311 Mar 10 14:52 catalog_sales.csv-5
-rw-rw-r-- 1 hcf hcf  2522978 Mar 10 14:52 catalog_sales.csv-3
-rw-rw-r-- 1 hcf hcf  2523126 Mar 10 14:52 catalog_sales.csv-1
-rw-rw-r-- 1 hcf hcf  2523386 Mar 10 14:52 catalog_sales.csv-4
-rw-rw-r-- 1 hcf hcf  2523673 Mar 10 14:52 catalog_sales.csv-2
-rw-rw-r-- 1 hcf hcf   269649 Mar 10 14:52 customer_address.csv-1
-rw-rw-r-- 1 hcf hcf     2815 Mar 10 14:52 query.sql
-rw-rw-r-- 1 hcf hcf   362746 Mar 10 14:52 customer_demographics.csv-7
-rw-rw-r-- 1 hcf hcf   373039 Mar 10 14:52 date_dim.csv-1
-rw-rw-r-- 1 hcf hcf    50387 Mar 10 14:52 store.csv-1
-rw-rw-r-- 1 hcf hcf   540546 Mar 10 14:52 customer.csv-1
-rw-rw-r-- 1 hcf hcf   540794 Mar 10 14:52 customer_demographics.csv-1
-rw-rw-r-- 1 hcf hcf   540932 Mar 10 14:52 customer_demographics.csv-5
-rw-rw-r-- 1 hcf hcf   541089 Mar 10 14:52 customer_demographics.csv-4
-rw-rw-r-- 1 hcf hcf   541193 Mar 10 14:52 customer_demographics.csv-3
-rw-rw-r-- 1 hcf hcf   542132 Mar 10 14:52 customer_demographics.csv-2
-rw-rw-r-- 1 hcf hcf   542163 Mar 10 14:52 customer_demographics.csv-6
-rw-rw-r-- 1 hcf hcf     6879 Mar 10 14:52 household_demographics.csv-1
-rw-rw-r-- 1 hcf hcf   948324 Mar 10 14:52 catalog_returns.csv-1
```

Except the csv files, there exists a shell scrip file named `load_data.sh`, you can use it to load data to your test environment.

```
export FE_HOST=127.0.0.1
export FE_QUERY_PORT=8167
export FE_HTTP_PORT=8166
export FE_USER=root
export FE_PASSWD=
export DATABASE=test_query_dump
export DROP_DATABASE_IF_EXIST=yes

bash output/load_data.sh
```

Here's output of the `load_data.sh`

```
============================   Loading Script Start   ============================
All the related env variables are listed down below:
    FE_HOST='127.0.0.1'
    FE_QUERY_PORT='8167'
    FE_HTTP_PORT='8166'
    FE_USER='root'
    FE_PASSWD=''
    DATABASE='test_query_dump'
    DROP_DATABASE_IF_EXIST='yes'
Creating tables:
Loading data from csv files:
    [1/13] Loading table: 'household_demographics'. Segment<1/1>: 'household_demographics.csv-1'. Current loading rows: 249, total loaded rows: 249 ...
    [2/13] Loading table: 'customer_demographics'. Segment<7/7>: 'customer_demographics.csv-7'. Current loading rows: 6685, total loaded rows: 66685 ....
    [3/13] Loading table: 'catalog_sales'. Segment<6/6>: 'catalog_sales.csv-6'. Current loading rows: 46, total loaded rows: 50046 ......
    [4/13] Loading table: 'promotion'. Segment<1/1>: 'promotion.csv-1'. Current loading rows: 128, total loaded rows: 128 ...
    [5/13] Loading table: 'customer'. Segment<1/1>: 'customer.csv-1'. Current loading rows: 3471, total loaded rows: 3471 ...
    [6/13] Loading table: 'store_sales'. Segment<11/11>: 'store_sales.csv-10'. Current loading rows: 9999, total loaded rows: 199998 ...
    [7/13] Loading table: 'date_dim'. Segment<1/1>: 'date_dim.csv-1'. Current loading rows: 2536, total loaded rows: 2536 ...
    [8/13] Loading table: 'income_band'. Segment<1/1>: 'income_band.csv-1'. Current loading rows: 128, total loaded rows: 128 ...
    [9/13] Loading table: 'store_returns'. Segment<1/1>: 'store_returns.csv-1'. Current loading rows: 9981, total loaded rows: 9981 ...
    [10/13] Loading table: 'store'. Segment<1/1>: 'store.csv-1'. Current loading rows: 128, total loaded rows: 128 ...
    [11/13] Loading table: 'catalog_returns'. Segment<1/1>: 'catalog_returns.csv-1'. Current loading rows: 5001, total loaded rows: 5001 ...
    [12/13] Loading table: 'item'. Segment<1/1>: 'item.csv-1'. Current loading rows: 624, total loaded rows: 624 ...
    [13/13] Loading table: 'customer_address'. Segment<1/1>: 'customer_address.csv-1'. Current loading rows: 1735, total loaded rows: 1735 ...
============================    Loading Script End    ============================
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
