### PR TITLE
[BugFix] improve ease of use

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -413,6 +413,10 @@ public class Util {
     }
 
     public static void validateMetastoreUris(String uris) {
+        if (uris == null) {
+            throw new IllegalArgumentException("Null hive.metastore.uris, " +
+                    "please check your property's key and value of catalog or resource.");
+        }
         URI[] parsedUris = Arrays.stream(uris.split(",")).map(URI::create).toArray(URI[]::new);
         for (URI uri : parsedUris) {
             if (Strings.isNullOrEmpty(uri.getScheme()) || !uri.getScheme().equals("thrift")) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -43,8 +43,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         if (IcebergCatalogType.HIVE_CATALOG == IcebergCatalogType.fromString(properties.get(ICEBERG_CATALOG_TYPE))) {
             catalogType = properties.get(ICEBERG_CATALOG_TYPE);
             metastoreURI = properties.get(ICEBERG_METASTORE_URIS);
-            icebergCatalog = getIcebergHiveCatalog(metastoreURI, properties, hdfsEnvironment);
             Util.validateMetastoreUris(metastoreURI);
+            icebergCatalog = getIcebergHiveCatalog(metastoreURI, properties, hdfsEnvironment);
         } else if (IcebergCatalogType.CUSTOM_CATALOG ==
                 IcebergCatalogType.fromString(properties.get(ICEBERG_CATALOG_TYPE))) {
             catalogType = properties.get(ICEBERG_CATALOG_TYPE);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
@@ -190,10 +190,10 @@ public class IcebergFileStats {
 
     public static Map<Integer, Object> toMap(Map<Integer, Type.PrimitiveType> idToTypeMapping,
                                              Map<Integer, ByteBuffer> idToMetricMap) {
-        if (idToMetricMap == null) {
-            return null;
-        }
         ImmutableMap.Builder<Integer, Object> map = ImmutableMap.builder();
+        if (idToMetricMap == null) {
+            return map.build();
+        }
         idToMetricMap.forEach((id, value) -> {
             // SR on Iceberg only support primitive type now, idToTypeMapping do not contains the corresponding id
             // for complex types like struct, map etc.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
@@ -61,6 +61,7 @@ public class IcebergFileStats {
             this.nullCounts = null;
             this.columnSizes = null;
             corruptedStats = null;
+            hasValidColumnMetrics = false;
         } else {
             this.minValues = new HashMap<>(minValues);
             this.maxValues = new HashMap<>(maxValues);
@@ -190,10 +191,10 @@ public class IcebergFileStats {
 
     public static Map<Integer, Object> toMap(Map<Integer, Type.PrimitiveType> idToTypeMapping,
                                              Map<Integer, ByteBuffer> idToMetricMap) {
-        ImmutableMap.Builder<Integer, Object> map = ImmutableMap.builder();
         if (idToMetricMap == null) {
-            return map.build();
+            return null;
         }
+        ImmutableMap.Builder<Integer, Object> map = ImmutableMap.builder();
         idToMetricMap.forEach((id, value) -> {
             // SR on Iceberg only support primitive type now, idToTypeMapping do not contains the corresponding id
             // for complex types like struct, map etc.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergTableStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergTableStatisticCalculator.java
@@ -170,6 +170,9 @@ public class IcebergTableStatisticCalculator {
             Map<Integer, Object> current,
             Map<Integer, Object> newStats,
             Predicate<Integer> predicate) {
+        if (!icebergFileStats.hasValidColumnMetrics()) {
+            return;
+        }
         for (PartitionField field : partitionFields) {
             int id = field.sourceId();
             if (icebergFileStats.getCorruptedStats().contains(id)) {


### PR DESCRIPTION
First, when user has wrong property key of hive metastore uri, 
they will get null metastoreURI, and getIcebergHiveCatalog use null as key will lead to npe.
Second, when user has wrong property key of hive metastore uri, 
they will get null metastoreURI, and validateMetastoreUris with null string will lead to npe.
Third, when datafile.lowerBounds and so on are null, updatePartitionedStats will encounter npe.



## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [x] 2.4
  - [ ] 2.3
