### PR TITLE
[Enhancement] Reduce S3 headObject requests in lake tablet GC

### DIFF
--- a/be/src/fs/fs_broker.cpp
+++ b/be/src/fs/fs_broker.cpp
@@ -405,6 +405,12 @@ Status BrokerFileSystem::iterate_dir(const std::string& dir, const std::function
     return Status::OK();
 }
 
+Status BrokerFileSystem::iterate_dir2(const std::string& dir,
+                                      const std::function<bool(std::string_view, const FileMeta&)>& cb) {
+    FileMeta meta;
+    return iterate_dir(dir, [&](std::string_view name) { return cb(name, meta); });
+}
+
 Status BrokerFileSystem::delete_file(const std::string& path) {
     return _delete_file(path);
 }

--- a/be/src/fs/fs_broker.h
+++ b/be/src/fs/fs_broker.h
@@ -56,6 +56,9 @@ public:
 
     Status iterate_dir(const std::string& dir, const std::function<bool(std::string_view)>& cb) override;
 
+    Status iterate_dir2(const std::string& dir,
+                        const std::function<bool(std::string_view, const FileMeta&)>& cb) override;
+
     Status delete_file(const std::string& path) override;
 
     Status create_dir(const std::string& dirname) override;

--- a/be/src/fs/fs_memory.h
+++ b/be/src/fs/fs_memory.h
@@ -53,6 +53,9 @@ public:
 
     Status iterate_dir(const std::string& dir, const std::function<bool(std::string_view)>& cb) override;
 
+    Status iterate_dir2(const std::string& dir,
+                        const std::function<bool(std::string_view, const FileMeta&)>& cb) override;
+
     Status delete_file(const std::string& url) override;
 
     Status create_dir(const std::string& dirname) override;

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -332,13 +332,14 @@ public:
 
     Status path_exists(const std::string& path) override { return Status::NotSupported("S3FileSystem::path_exists"); }
 
-    Status list_path(const std::string& dir, std::vector<FileStatus>* result) override;
-
     Status get_children(const std::string& dir, std::vector<std::string>* file) override {
         return Status::NotSupported("S3FileSystem::get_children");
     }
 
     Status iterate_dir(const std::string& dir, const std::function<bool(std::string_view)>& cb) override;
+
+    Status iterate_dir2(const std::string& dir,
+                        const std::function<bool(std::string_view, const FileMeta&)>& cb) override;
 
     Status delete_file(const std::string& path) override;
 
@@ -526,7 +527,8 @@ Status S3FileSystem::iterate_dir(const std::string& dir, const std::function<boo
     return directory_exist ? Status::OK() : Status::NotFound(dir);
 }
 
-Status S3FileSystem::list_path(const std::string& dir, std::vector<FileStatus>* file_status) {
+Status S3FileSystem::iterate_dir2(const std::string& dir,
+                                  const std::function<bool(std::string_view, const FileMeta&)>& cb) {
     S3URI uri;
     if (!uri.parse(dir)) {
         return Status::InvalidArgument(fmt::format("Invalid S3 URI {}", dir));
@@ -557,9 +559,11 @@ Status S3FileSystem::list_path(const std::string& dir, std::vector<FileStatus>* 
             const auto& full_name = cp.GetPrefix();
 
             std::string_view name(full_name.data() + uri.key().size(), full_name.size() - uri.key().size() - 1);
-            bool is_dir = true;
-            int64_t file_size = 0;
-            file_status->emplace_back(name, is_dir, file_size);
+            FileMeta stat;
+            stat.set_is_dir(true);
+            if (!cb(name, stat)) {
+                return Status::OK();
+            }
         }
         for (auto&& obj : result.GetContents()) {
             if (obj.GetKey() == uri.key()) {
@@ -568,19 +572,26 @@ Status S3FileSystem::list_path(const std::string& dir, std::vector<FileStatus>* 
             DCHECK(HasPrefixString(obj.GetKey(), uri.key()));
 
             std::string_view obj_key(obj.GetKey());
-            bool is_dir = true;
-            int64_t file_size = 0;
+            FileMeta stat;
+            if (obj.LastModifiedHasBeenSet()) {
+                stat.set_modify_time(obj.GetLastModified().Seconds());
+            }
             if (obj_key.back() == '/') {
                 obj_key = std::string_view(obj_key.data(), obj_key.size() - 1);
+                stat.set_is_dir(true);
             } else {
                 DCHECK(obj.SizeHasBeenSet());
-                is_dir = false;
-                file_size = obj.GetSize();
+                stat.set_is_dir(false);
+                if (obj.SizeHasBeenSet()) {
+                    stat.set_size(obj.GetSize());
+                }
             }
 
             std::string_view name(obj_key.data() + uri.key().size(), obj_key.size() - uri.key().size());
 
-            file_status->emplace_back(name, is_dir, file_size);
+            if (!cb(name, stat)) {
+                return Status::OK();
+            }
         }
     } while (result.GetIsTruncated());
     return directory_exist ? Status::OK() : Status::NotFound(dir);

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -304,6 +304,18 @@ public:
         return to_status(st);
     }
 
+    Status iterate_dir2(const std::string& dir,
+                        const std::function<bool(std::string_view, const FileMeta&)>& cb) override {
+        ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(dir));
+        auto fs_st = get_shard_filesystem(pair.second);
+        if (!fs_st.ok()) {
+            return to_status(fs_st.status());
+        }
+        FileMeta meta;
+        auto st = (*fs_st)->list_dir(pair.first, false, [&](std::string_viw name) { return cb(name, meta); });
+        return to_status(st);
+    }
+
     Status create_dir(const std::string& dirname) override {
         auto st = is_directory(dirname);
         if (st.ok() && st.value()) {

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -27,18 +27,33 @@
 namespace starrocks {
 
 // NOTE: The bucket must be created before running this test.
-constexpr static const char* kBucketName = "starrocks-fs-s3-unit-test";
+constexpr static const char* kBucketName = "starrocks-fs-s3-ut";
 
 class S3FileSystemTest : public testing::Test {
 public:
     S3FileSystemTest() = default;
     ~S3FileSystemTest() override = default;
-    void SetUp() override { Aws::InitAPI(_options); }
-    void TearDown() override { Aws::ShutdownAPI(_options); }
 
-    std::string S3Path(std::string_view path) {
-        return fmt::format("s3://{}.{}{}", kBucketName, config::object_storage_endpoint, path);
+    static void SetUpTestCase() {
+        CHECK(!config::object_storage_access_key_id.empty()) << "Need set object_storage_access_key_id in be_test.conf";
+        CHECK(!config::object_storage_secret_access_key.empty())
+                << "Need set object_storage_secret_access_key in be_test.conf";
+        CHECK(!config::object_storage_endpoint.empty()) << "Need set object_storage_endpoint in be_test.conf";
+
+        Aws::InitAPI(_s_options);
+
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString("s3://"));
+        (void)fs->delete_dir_recursive(S3Path("/"));
     }
+
+    static void TearDownTestCase() {
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString("s3://"));
+        (void)fs->delete_dir_recursive(S3Path("/"));
+
+        Aws::ShutdownAPI(_s_options);
+    }
+
+    static std::string S3Path(std::string_view path) { return fmt::format("s3://{}{}", kBucketName, path); }
 
     void CheckIsDirectory(FileSystem* fs, const std::string& dir_name, bool expected_success,
                           bool expected_is_dir = true) {
@@ -50,11 +65,11 @@ public:
     }
 
 private:
-    Aws::SDKOptions _options;
+    static inline Aws::SDKOptions _s_options;
 };
 
 TEST_F(S3FileSystemTest, test_write_and_read) {
-    auto uri = fmt::format("s3://{}.{}/dir/test-object.png", kBucketName, config::object_storage_endpoint);
+    auto uri = fmt::format("s3://{}/dir/test-object.png", kBucketName);
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString(uri));
     ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(uri));
     EXPECT_OK(wf->append("hello"));
@@ -77,6 +92,7 @@ TEST_F(S3FileSystemTest, test_write_and_read) {
 }
 
 TEST_F(S3FileSystemTest, test_directory) {
+    auto now = ::time(nullptr);
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString("s3://"));
     bool created = false;
 
@@ -151,7 +167,7 @@ TEST_F(S3FileSystemTest, test_directory) {
     //
     {
         ASSIGN_OR_ABORT(auto of, fs->new_writable_file(S3Path("/dirname2/1.dat")));
-        EXPECT_OK(of->append("hello"));
+        EXPECT_OK(of->append("starrocks"));
         EXPECT_OK(of->close());
         CheckIsDirectory(fs.get(), S3Path("/dirname2/1.dat"), true, false);
     }
@@ -167,6 +183,32 @@ TEST_F(S3FileSystemTest, test_directory) {
     //
     EXPECT_OK(fs->create_dir(S3Path("/dirname2/subdir0")));
     CheckIsDirectory(fs.get(), S3Path("/dirname2/subdir0"), true, true);
+
+    EXPECT_OK(fs->iterate_dir2(S3Path("/dirname2/"), [&](std::string_view name, const FileMeta& meta) {
+        if (name == "0.dat") {
+            CHECK(meta.has_is_dir());
+            CHECK(!meta.is_dir());
+            CHECK(meta.has_size());
+            CHECK_EQ(/* length of "hello" = */ 5, meta.size());
+            CHECK(meta.has_modify_time());
+            CHECK_GE(meta.modify_time(), now);
+        } else if (name == "1.dat") {
+            CHECK(meta.has_is_dir());
+            CHECK(!meta.is_dir());
+            CHECK(meta.has_size());
+            CHECK_EQ(/* length of "starrocks" = */ 9, meta.size());
+            CHECK(meta.has_modify_time());
+            CHECK_GE(meta.modify_time(), now);
+        } else if (name == "subdir0") {
+            CHECK(meta.has_is_dir());
+            CHECK(meta.is_dir());
+            CHECK(!meta.has_size());
+            CHECK(!meta.has_modify_time());
+        } else {
+            CHECK(false) << "Unexpected file " << name;
+        }
+        return true;
+    }));
 
     std::vector<std::string> entries;
     auto cb = [&](std::string_view name) -> bool {


### PR DESCRIPTION
Add a new FileSystem interface `iterate_dir2()` for getting the file modification time while traversing the directory to avoid additional `FileSystem::get_file_modified_time()` calls.

In fact, this PR will not have any optimization, because the new interface is not really implemented in the StarletFilesystem,, another PR is needed.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
