### PR TITLE
[Enhancement][Cherry-Pick] Support set current catalog by its name (backport #19103)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -102,6 +102,8 @@ import com.starrocks.sql.ast.KillAnalyzeStmt;
 import com.starrocks.sql.ast.KillStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetCatalogStmt;
+import com.starrocks.sql.ast.SetDefaultRoleStmt;
 import com.starrocks.sql.ast.SetRoleStmt;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SetVar;
@@ -461,6 +463,8 @@ public class StmtExecutor {
                 handleUseDbStmt();
             } else if (parsedStmt instanceof UseCatalogStmt) {
                 handleUseCatalogStmt();
+            } else if (parsedStmt instanceof SetCatalogStmt) {
+                handleSetCatalogStmt();
             } else if (parsedStmt instanceof CreateTableAsSelectStmt) {
                 if (execPlanBuildByNewPlanner) {
                     handleCreateTableAsSelectStmt(beginTimeInNanoSecond);
@@ -962,6 +966,30 @@ public class StmtExecutor {
         UseCatalogStmt useCatalogStmt = (UseCatalogStmt) parsedStmt;
         try {
             context.getGlobalStateMgr().changeCatalog(context, useCatalogStmt.getCatalogName());
+        } catch (Exception e) {
+            context.getState().setError(e.getMessage());
+            return;
+        }
+        context.getState().setOk();
+    }
+
+    private void handleSetCatalogStmt() throws AnalysisException {
+        SetCatalogStmt setCatalogStmt = (SetCatalogStmt) parsedStmt;
+        try {
+            String catalogName = setCatalogStmt.getCatalogName();
+            context.getGlobalStateMgr().changeCatalog(context, catalogName);
+        } catch (Exception e) {
+            context.getState().setError(e.getMessage());
+            return;
+        }
+        context.getState().setOk();
+    }
+
+    // Process use warehouse statement
+    private void handleUseWarehouseStmt() throws AnalysisException {
+        UseWarehouseStmt useWarehouseStmt = (UseWarehouseStmt) parsedStmt;
+        try {
+            context.getGlobalStateMgr().changeWarehouse(context, useWarehouseStmt.getWarehouseName());
         } catch (Exception e) {
             context.getState().setError(e.getMessage());
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -103,7 +103,6 @@ import com.starrocks.sql.ast.KillStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetCatalogStmt;
-import com.starrocks.sql.ast.SetDefaultRoleStmt;
 import com.starrocks.sql.ast.SetRoleStmt;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SetVar;
@@ -978,18 +977,6 @@ public class StmtExecutor {
         try {
             String catalogName = setCatalogStmt.getCatalogName();
             context.getGlobalStateMgr().changeCatalog(context, catalogName);
-        } catch (Exception e) {
-            context.getState().setError(e.getMessage());
-            return;
-        }
-        context.getState().setOk();
-    }
-
-    // Process use warehouse statement
-    private void handleUseWarehouseStmt() throws AnalysisException {
-        UseWarehouseStmt useWarehouseStmt = (UseWarehouseStmt) parsedStmt;
-        try {
-            context.getGlobalStateMgr().changeWarehouse(context, useWarehouseStmt.getWarehouseName());
         } catch (Exception e) {
             context.getState().setError(e.getMessage());
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -3143,6 +3143,11 @@ public class GlobalStateMgr {
             ctx.setCurrentCatalog(newCatalogName);
         }
 
+        if (!Strings.isNullOrEmpty(dbName) && metadataMgr.getDb(ctx.getCurrentCatalog(), dbName) == null) {
+            LOG.debug("Unknown catalog {} and db {}", ctx.getCurrentCatalog(), dbName);
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
+
         // Check auth for internal catalog.
         // Here we check the request permission that sent by the mysql client or jdbc.
         // So we didn't check UseDbStmt permission in PrivilegeChecker.
@@ -3158,11 +3163,6 @@ public class GlobalStateMgr {
                             ctx.getQualifiedUser(), dbName);
                 }
             }
-        }
-
-        if (metadataMgr.getDb(ctx.getCurrentCatalog(), dbName) == null) {
-            LOG.debug("Unknown catalog '%s' and db '%s'", ctx.getCurrentCatalog(), dbName);
-            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
 
         ctx.setDatabase(dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -79,6 +79,9 @@ import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.RefreshTableStmt;
 import com.starrocks.sql.ast.RestoreStmt;
 import com.starrocks.sql.ast.ResumeRoutineLoadStmt;
+import com.starrocks.sql.ast.ResumeWarehouseStmt;
+import com.starrocks.sql.ast.SetCatalogStmt;
+import com.starrocks.sql.ast.SetDefaultRoleStmt;
 import com.starrocks.sql.ast.SetRoleStmt;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SetUserPropertyStmt;
@@ -454,6 +457,43 @@ public class Analyzer {
         @Override
         public Void visitShowCatalogsStatement(ShowCatalogsStmt statement, ConnectContext context) {
             CatalogAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitSetCatalogStatement(SetCatalogStmt statement, ConnectContext context) {
+            CatalogAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        // ---------------------------------------- Warehouse Statement -----------------------------------------------------
+        @Override
+        public Void visitCreateWarehouseStatement(CreateWarehouseStmt statement, ConnectContext context) {
+            WarehouseAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitAlterWarehouseStatement(AlterWarehouseStmt statement, ConnectContext context) {
+            WarehouseAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitSuspendWarehouseStatement(SuspendWarehouseStmt statement, ConnectContext context) {
+            WarehouseAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitResumeWarehouseStatement(ResumeWarehouseStmt statement, ConnectContext context) {
+            WarehouseAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitDropWarehouseStatement(DropWarehouseStmt statement, ConnectContext context) {
+            WarehouseAnalyzer.analyze(statement, context);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -79,9 +79,7 @@ import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.RefreshTableStmt;
 import com.starrocks.sql.ast.RestoreStmt;
 import com.starrocks.sql.ast.ResumeRoutineLoadStmt;
-import com.starrocks.sql.ast.ResumeWarehouseStmt;
 import com.starrocks.sql.ast.SetCatalogStmt;
-import com.starrocks.sql.ast.SetDefaultRoleStmt;
 import com.starrocks.sql.ast.SetRoleStmt;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SetUserPropertyStmt;
@@ -463,37 +461,6 @@ public class Analyzer {
         @Override
         public Void visitSetCatalogStatement(SetCatalogStmt statement, ConnectContext context) {
             CatalogAnalyzer.analyze(statement, context);
-            return null;
-        }
-
-        // ---------------------------------------- Warehouse Statement -----------------------------------------------------
-        @Override
-        public Void visitCreateWarehouseStatement(CreateWarehouseStmt statement, ConnectContext context) {
-            WarehouseAnalyzer.analyze(statement, context);
-            return null;
-        }
-
-        @Override
-        public Void visitAlterWarehouseStatement(AlterWarehouseStmt statement, ConnectContext context) {
-            WarehouseAnalyzer.analyze(statement, context);
-            return null;
-        }
-
-        @Override
-        public Void visitSuspendWarehouseStatement(SuspendWarehouseStmt statement, ConnectContext context) {
-            WarehouseAnalyzer.analyze(statement, context);
-            return null;
-        }
-
-        @Override
-        public Void visitResumeWarehouseStatement(ResumeWarehouseStmt statement, ConnectContext context) {
-            WarehouseAnalyzer.analyze(statement, context);
-            return null;
-        }
-
-        @Override
-        public Void visitDropWarehouseStatement(DropWarehouseStmt statement, ConnectContext context) {
-            WarehouseAnalyzer.analyze(statement, context);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -10,6 +10,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.DropCatalogStmt;
+import com.starrocks.sql.ast.SetCatalogStmt;
 import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.ast.StatementBase;
 
@@ -71,6 +72,16 @@ public class CatalogAnalyzer {
                 throw new SemanticException("Can't drop the resource mapping catalog");
             }
 
+            return null;
+        }
+
+        @Override
+        public Void visitSetCatalogStatement(SetCatalogStmt statement, ConnectContext context) {
+            if (Strings.isNullOrEmpty(statement.getCatalogName())) {
+                throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
+            }
+
+            FeNameFormat.checkCatalogName(statement.getCatalogName());
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -81,7 +81,11 @@ public class CatalogAnalyzer {
                 throw new SemanticException("You have an error in your SQL. The correct syntax is: USE 'CATALOG catalog_name'.");
             }
 
-            FeNameFormat.checkCatalogName(statement.getCatalogName());
+            try {
+                FeNameFormat.checkCatalogName(statement.getCatalogName());
+            } catch (AnalysisException e) {
+                throw new SemanticException(e.getMessage());
+            }
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -39,19 +39,8 @@ import com.starrocks.sql.ast.InstallPluginStmt;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RecoverDbStmt;
-import com.starrocks.sql.ast.RecoverPartitionStmt;
-import com.starrocks.sql.ast.RecoverTableStmt;
-import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
-import com.starrocks.sql.ast.RefreshTableStmt;
-import com.starrocks.sql.ast.RestoreStmt;
-import com.starrocks.sql.ast.ResumeRoutineLoadStmt;
-import com.starrocks.sql.ast.RevokeRoleStmt;
-import com.starrocks.sql.ast.SetCatalogStmt;
-import com.starrocks.sql.ast.SetDefaultRoleStmt;
-import com.starrocks.sql.ast.SetListItem;
-import com.starrocks.sql.ast.SetPassVar;
-import com.starrocks.sql.ast.SetStmt;
-import com.starrocks.sql.ast.SetType;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
 import com.starrocks.sql.ast.SetUserPropertyStmt;
 import com.starrocks.sql.ast.ShowAuthenticationStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
@@ -289,104 +278,6 @@ public class PrivilegeCheckerV2 {
                     context, statement.getResourceName(), PrivilegeType.ResourceAction.ALTER)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ALTER");
             }
-            return null;
-        }
-
-        @Override
-        public Void visitShowResourceStatement(ShowResourcesStmt statement, ConnectContext context) {
-            // `show resources` only show resource that user has any privilege on, we will check it in
-            // the execution logic, not here, see `handleShowResources()` for details.
-            return null;
-        }
-
-        // --------------------------------- Resource Group Statement -------------------------------------
-        public Void visitCreateResourceGroupStatement(CreateResourceGroupStmt statement, ConnectContext context) {
-            if (!PrivilegeActions.checkSystemAction(
-                    context, PrivilegeType.CREATE_RESOURCE_GROUP)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                        "CREATE RESOURCE GROUP");
-            }
-            return null;
-        }
-
-        public Void visitDropResourceGroupStatement(DropResourceGroupStmt statement, ConnectContext context) {
-            if (!PrivilegeActions.checkResourceGroupAction(
-                    context, statement.getName(), PrivilegeType.DROP)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "DROP");
-            }
-            return null;
-        }
-
-        public Void visitAlterResourceGroupStatement(AlterResourceGroupStmt statement, ConnectContext context) {
-            if (!PrivilegeActions.checkResourceGroupAction(
-                    context, statement.getName(), PrivilegeType.ALTER)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ALTER");
-            }
-            return null;
-        }
-
-        public Void visitShowResourceGroupStatement(ShowResourceGroupStmt statement, ConnectContext context) {
-            // we don't check privilege for `show resource groups` statement
-            return null;
-        }
-
-        // --------------------------------- Warehouse Statement ------------------------------------------
-        @Override
-        public Void visitUseWarehouseStatement(UseWarehouseStmt statement, ConnectContext context) {
-            return null;
-        }
-
-        // --------------------------------- Catalog Statement --------------------------------------------
-
-        @Override
-        public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
-            // No authorization check for using default_catalog
-            if (CatalogMgr.isInternalCatalog(statement.getCatalogName())) {
-                return null;
-            }
-            if (!PrivilegeActions.checkAnyActionOnCatalog(context, statement.getCatalogName())) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
-                        context.getQualifiedUser(), statement.getCatalogName());
-            }
-            return null;
-        }
-
-        @Override
-        public Void visitSetCatalogStatement(SetCatalogStmt statement, ConnectContext context) {
-            String catalogName = statement.getCatalogName();
-            // No authorization check for using default_catalog
-            if (CatalogMgr.isInternalCatalog(catalogName)) {
-                return null;
-            }
-            if (!PrivilegeActions.checkAnyActionOnCatalog(context, catalogName)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
-                        context.getQualifiedUser(), catalogName);
-            }
-            return null;
-        }
-
-        @Override
-        public Void visitCreateCatalogStatement(CreateCatalogStmt statement, ConnectContext context) {
-            if (!PrivilegeActions.checkSystemAction(context, PrivilegeType.CREATE_EXTERNAL_CATALOG)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
-                        context.getQualifiedUser(), statement.getCatalogName());
-            }
-            return null;
-        }
-
-        @Override
-        public Void visitDropCatalogStatement(DropCatalogStmt statement, ConnectContext context) {
-            if (!PrivilegeActions.checkCatalogAction(context, statement.getName(), PrivilegeType.DROP)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
-                        context.getQualifiedUser(), statement.getName());
-            }
-            return null;
-        }
-
-        @Override
-        public Void visitShowCatalogsStatement(ShowCatalogsStmt statement, ConnectContext context) {
-            // `show catalogs` only show catalog that user has any privilege on, we will check it in
-            // the execution logic, not here, see `handleShowCatalogs()` for details.
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeCheckerV2.java
@@ -39,8 +39,19 @@ import com.starrocks.sql.ast.InstallPluginStmt;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RecoverDbStmt;
-import com.starrocks.sql.ast.SelectRelation;
-import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.RecoverPartitionStmt;
+import com.starrocks.sql.ast.RecoverTableStmt;
+import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
+import com.starrocks.sql.ast.RefreshTableStmt;
+import com.starrocks.sql.ast.RestoreStmt;
+import com.starrocks.sql.ast.ResumeRoutineLoadStmt;
+import com.starrocks.sql.ast.RevokeRoleStmt;
+import com.starrocks.sql.ast.SetCatalogStmt;
+import com.starrocks.sql.ast.SetDefaultRoleStmt;
+import com.starrocks.sql.ast.SetListItem;
+import com.starrocks.sql.ast.SetPassVar;
+import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.SetUserPropertyStmt;
 import com.starrocks.sql.ast.ShowAuthenticationStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
@@ -281,7 +292,105 @@ public class PrivilegeCheckerV2 {
             return null;
         }
 
-        // --------------------------------------- Plugin Statement --------------------------------------------------------
+        @Override
+        public Void visitShowResourceStatement(ShowResourcesStmt statement, ConnectContext context) {
+            // `show resources` only show resource that user has any privilege on, we will check it in
+            // the execution logic, not here, see `handleShowResources()` for details.
+            return null;
+        }
+
+        // --------------------------------- Resource Group Statement -------------------------------------
+        public Void visitCreateResourceGroupStatement(CreateResourceGroupStmt statement, ConnectContext context) {
+            if (!PrivilegeActions.checkSystemAction(
+                    context, PrivilegeType.CREATE_RESOURCE_GROUP)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
+                        "CREATE RESOURCE GROUP");
+            }
+            return null;
+        }
+
+        public Void visitDropResourceGroupStatement(DropResourceGroupStmt statement, ConnectContext context) {
+            if (!PrivilegeActions.checkResourceGroupAction(
+                    context, statement.getName(), PrivilegeType.DROP)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "DROP");
+            }
+            return null;
+        }
+
+        public Void visitAlterResourceGroupStatement(AlterResourceGroupStmt statement, ConnectContext context) {
+            if (!PrivilegeActions.checkResourceGroupAction(
+                    context, statement.getName(), PrivilegeType.ALTER)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ALTER");
+            }
+            return null;
+        }
+
+        public Void visitShowResourceGroupStatement(ShowResourceGroupStmt statement, ConnectContext context) {
+            // we don't check privilege for `show resource groups` statement
+            return null;
+        }
+
+        // --------------------------------- Warehouse Statement ------------------------------------------
+        @Override
+        public Void visitUseWarehouseStatement(UseWarehouseStmt statement, ConnectContext context) {
+            return null;
+        }
+
+        // --------------------------------- Catalog Statement --------------------------------------------
+
+        @Override
+        public Void visitUseCatalogStatement(UseCatalogStmt statement, ConnectContext context) {
+            // No authorization check for using default_catalog
+            if (CatalogMgr.isInternalCatalog(statement.getCatalogName())) {
+                return null;
+            }
+            if (!PrivilegeActions.checkAnyActionOnCatalog(context, statement.getCatalogName())) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
+                        context.getQualifiedUser(), statement.getCatalogName());
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitSetCatalogStatement(SetCatalogStmt statement, ConnectContext context) {
+            String catalogName = statement.getCatalogName();
+            // No authorization check for using default_catalog
+            if (CatalogMgr.isInternalCatalog(catalogName)) {
+                return null;
+            }
+            if (!PrivilegeActions.checkAnyActionOnCatalog(context, catalogName)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
+                        context.getQualifiedUser(), catalogName);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitCreateCatalogStatement(CreateCatalogStmt statement, ConnectContext context) {
+            if (!PrivilegeActions.checkSystemAction(context, PrivilegeType.CREATE_EXTERNAL_CATALOG)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
+                        context.getQualifiedUser(), statement.getCatalogName());
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitDropCatalogStatement(DropCatalogStmt statement, ConnectContext context) {
+            if (!PrivilegeActions.checkCatalogAction(context, statement.getName(), PrivilegeType.DROP)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
+                        context.getQualifiedUser(), statement.getName());
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitShowCatalogsStatement(ShowCatalogsStmt statement, ConnectContext context) {
+            // `show catalogs` only show catalog that user has any privilege on, we will check it in
+            // the execution logic, not here, see `handleShowCatalogs()` for details.
+            return null;
+        }
+
+        // --------------------------------------- Plugin Statement ---------------------------------------
 
         @Override
         public Void visitInstallPluginStatement(InstallPluginStmt statement, ConnectContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -265,6 +265,14 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(statement, context);
     }
 
+    public R visitShowCreateExternalCatalogStatement(ShowCreateExternalCatalogStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
+    public R visitSetCatalogStatement(SetCatalogStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
     // ------------------------------------------- DML Statement -------------------------------------------------------
 
     public R visitInsertStatement(InsertStmt statement, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -265,10 +265,6 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(statement, context);
     }
 
-    public R visitShowCreateExternalCatalogStatement(ShowCreateExternalCatalogStmt statement, C context) {
-        return visitStatement(statement, context);
-    }
-
     public R visitSetCatalogStatement(SetCatalogStmt statement, C context) {
         return visitStatement(statement, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SetCatalogStmt.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.analysis.RedirectStatus;
+
+/*
+  Set catalog specified by catalog name
+
+  syntax:
+      SET CATALOG catalog_name
+ */
+public class SetCatalogStmt extends StatementBase {
+    private final String catalogName;
+
+    public SetCatalogStmt(String catalogName) {
+        this.catalogName = catalogName;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitSetCatalogStatement(this, context);
+    }
+
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        return RedirectStatus.NO_FORWARD;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -247,8 +247,6 @@ import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetCatalogStmt;
-import com.starrocks.sql.ast.SetDefaultRoleStmt;
-import com.starrocks.sql.ast.SetListItem;
 import com.starrocks.sql.ast.SetNamesVar;
 import com.starrocks.sql.ast.SetPassVar;
 import com.starrocks.sql.ast.SetQualifier;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -246,6 +246,9 @@ import com.starrocks.sql.ast.RowDelimiter;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetCatalogStmt;
+import com.starrocks.sql.ast.SetDefaultRoleStmt;
+import com.starrocks.sql.ast.SetListItem;
 import com.starrocks.sql.ast.SetNamesVar;
 import com.starrocks.sql.ast.SetPassVar;
 import com.starrocks.sql.ast.SetQualifier;
@@ -408,6 +411,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         Identifier identifier = (Identifier) visit(context.identifierOrString());
         String catalogName = identifier.getValue();
         return new UseCatalogStmt(catalogName);
+    }
+
+    @Override
+    public ParseNode visitSetCatalogStatement(StarRocksParser.SetCatalogStatementContext context) {
+        Identifier identifier = (Identifier) visit(context.identifierOrString());
+        String catalogName = identifier.getValue();
+        return new SetCatalogStmt(catalogName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -22,6 +22,7 @@ statement
     // Database Statement
     | useDatabaseStatement
     | useCatalogStatement
+    | setCatalogStatement
     | showDatabasesStatement
     | alterDbQuotaStatement
     | createDbStatement
@@ -238,6 +239,10 @@ useDatabaseStatement
 
 useCatalogStatement
     : USE CATALOG identifierOrString
+    ;
+
+setCatalogStatement
+    : SET CATALOG identifierOrString
     ;
 
 showDatabasesStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetCatalogStmtTest.java
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SetCatalogStmtTest {
+    private static ConnectContext ctx;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        StarRocksAssert starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("db1").useDatabase("tbl1");
+        String createCatalog = "create external catalog hive_catalog properties(" +
+                "\"type\" = \"hive\", \"hive.metastore.uris\" = \"thrift://127.0.0.1:3333\")";
+        starRocksAssert.withCatalog(createCatalog);
+        ctx = new ConnectContext(null);
+        ctx.setGlobalStateMgr(AccessTestUtil.fetchAdminCatalog());
+    }
+
+    @Test
+    public void testParserAndAnalyzer() {
+        String sql = "SET CATALOG hive_catalog'";
+        AnalyzeTestUtil.analyzeSuccess(sql);
+
+        String sql_2 = "SET CATALOG default_catalog'";
+        AnalyzeTestUtil.analyzeSuccess(sql_2);
+
+        String sql_3 = "SET xxxx default_catalog'";
+        AnalyzeTestUtil.analyzeFail(sql_3);
+    }
+
+    @Test
+    public void testSetCatalog(@Mocked CatalogMgr catalogMgr) throws Exception {
+        new Expectations() {
+            {
+                catalogMgr.catalogExists("hive_catalog");
+                result = true;
+                minTimes = 0;
+
+                catalogMgr.catalogExists("default_catalog");
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        ctx.setQueryId(UUIDUtil.genUUID());
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        StmtExecutor executor = new StmtExecutor(ctx, "set catalog hive_catalog");
+        executor.execute();
+
+        Assert.assertEquals("hive_catalog", ctx.getCurrentCatalog());
+
+        executor = new StmtExecutor(ctx, "set catalog default_catalog");
+        executor.execute();
+
+        Assert.assertEquals("default_catalog", ctx.getCurrentCatalog());
+
+        executor = new StmtExecutor(ctx, "set xxx default_catalog");
+        executor.execute();
+        Assert.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
+
+        executor = new StmtExecutor(ctx, "set catalog default_catalog xxx");
+        executor.execute();
+        Assert.assertSame(ctx.getState().getStateType(), QueryState.MysqlStateType.ERR);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetCatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetCatalogStmtTest.java
@@ -20,7 +20,6 @@ import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
-import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add sql grammar SET CATALOG catalog_name for changing the current session's catalog.

Note: using this sql would reset the current database.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
