### PR TITLE
[BugFix] Bugfix GroupByCountDistinctDataSkewEliminateRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -150,7 +150,8 @@ public class LogicalAggregationOperator extends LogicalOperator {
         }
         CallOperator call = aggregations.values().stream().iterator().next();
         if (call.isDistinct() && call.getFnName().equalsIgnoreCase(FunctionSet.COUNT) &&
-                call.getChildren().size() == 1 && call.getChild(0).isColumnRef()) {
+                call.getChildren().size() == 1 && call.getChild(0).isColumnRef() &&
+                !groupingKeys.get(0).equals(call.getChild(0))) {
             return true;
         }
         return false;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -284,4 +284,14 @@ public class SelectStmtTest {
                 "  |  <slot 8> : CAST(murmur_hash3_32(CAST(6: cast AS VARCHAR)) % 512 AS SMALLINT)"));
         FeConstants.runningUnitTest = false;
     }
+    @Test
+    public void testGroupByCountDistinctUseTheSameColumn()
+            throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql =
+                "select k3, count(distinct [skew] k3) from db1.tbl1 group by k3";
+        String s = starRocksAssert.query(sql).explainQuery();
+        Assert.assertFalse(s, s.contains("murmur_hash3_32"));
+        FeConstants.runningUnitTest = false;
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/StarRocksTest/issues/1978

for a group-by-count-distinct query,  if the group-by column and the count distinct column use the same column,  do not apply GroupByCountDistinctDataSkewEliminateRule.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
