### PR TITLE
[BugFix] Null-safe-equals operator <=> incorrect behavior for null equals non-null (backport #16238)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -37,6 +37,14 @@ public abstract class ScalarOperator implements Cloneable {
         return true;
     }
 
+    public boolean isConstantNull() {
+        if (!(this instanceof ConstantOperator)) {
+            return false;
+        }
+        ConstantOperator constant = this.cast();
+        return constant.isNull();
+    }
+
     public abstract boolean isNullable();
 
     public OperatorType getOpType() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -105,7 +105,8 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
         Type type2 = rightChild.getType();
 
         // For a query like: select 'a' <=> NULL, we should cast Constant Null to the type of the other side
-        if (predicate.getBinaryType() == BinaryPredicateOperator.BinaryType.EQ_FOR_NULL) {
+        if (predicate.getBinaryType() == BinaryPredicateOperator.BinaryType.EQ_FOR_NULL &&
+                (leftChild.isConstantNull() || rightChild.isConstantNull())) {
             if (leftChild.isConstantNull()) {
                 predicate.setChild(0, ConstantOperator.createNull(type2));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -16,6 +16,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -102,6 +103,17 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
         ScalarOperator rightChild = predicate.getChild(1);
         Type type1 = leftChild.getType();
         Type type2 = rightChild.getType();
+
+        // For a query like: select 'a' <=> NULL, we should cast Constant Null to the type of the other side
+        if (predicate.getBinaryType() == BinaryPredicateOperator.BinaryType.EQ_FOR_NULL) {
+            if (leftChild.isConstantNull()) {
+                predicate.setChild(0, ConstantOperator.createNull(type2));
+            }
+            if (rightChild.isConstantNull()) {
+                predicate.setChild(1, ConstantOperator.createNull(type1));
+            }
+            return predicate;
+        }
 
         if (type1.matchesType(type2)) {
             return predicate;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
@@ -105,6 +105,28 @@ public class ImplicitCastRuleTest {
     }
 
     @Test
+    public void testEqualForNullBinaryPredicate() {
+        BinaryPredicateOperator[] ops = new BinaryPredicateOperator[] {
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
+                        ConstantOperator.createVarchar("a"),
+                        ConstantOperator.createNull(Type.DOUBLE)),
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
+                        ConstantOperator.createNull(Type.DOUBLE),
+                        ConstantOperator.createVarchar("a")),
+        };
+        for (BinaryPredicateOperator op : ops) {
+            ImplicitCastRule rule = new ImplicitCastRule();
+            ScalarOperator result = rule.apply(op, null);
+
+            assertTrue(result.getChild(0) instanceof ConstantOperator);
+            assertTrue(result.getChild(1) instanceof ConstantOperator);
+
+            assertEquals(PrimitiveType.VARCHAR, result.getChild(0).getType().getPrimitiveType());
+            assertEquals(PrimitiveType.VARCHAR, result.getChild(1).getType().getPrimitiveType());
+        }
+    }
+
+    @Test
     public void testCompoundPredicate() {
         CompoundPredicateOperator op =
                 new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRuleTest.java
@@ -12,6 +12,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
@@ -21,6 +22,7 @@ import mockit.Expectations;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -105,7 +107,7 @@ public class ImplicitCastRuleTest {
     }
 
     @Test
-    public void testEqualForNullBinaryPredicate() {
+    public void testEqualForNullBinaryPredicateWithConstNull() {
         BinaryPredicateOperator[] ops = new BinaryPredicateOperator[] {
                 new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
                         ConstantOperator.createVarchar("a"),
@@ -123,6 +125,35 @@ public class ImplicitCastRuleTest {
 
             assertEquals(PrimitiveType.VARCHAR, result.getChild(0).getType().getPrimitiveType());
             assertEquals(PrimitiveType.VARCHAR, result.getChild(1).getType().getPrimitiveType());
+        }
+    }
+
+    @Test
+    public void testEqualForNullBinaryPredicateWithoutConstNull() {
+        BinaryPredicateOperator[] ops = new BinaryPredicateOperator[] {
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
+                        ConstantOperator.createDate(LocalDateTime.of(2022, Month.JANUARY, 01, 0, 0, 0)),
+                        new ColumnRefOperator(1, Type.DATE, "date_col", true)
+                ),
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
+                        new ColumnRefOperator(1, Type.DATE, "date_col", true),
+                        ConstantOperator.createInt(20220111)
+                ),
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
+                        ConstantOperator.createVarchar("2022-01-01"),
+                        new ColumnRefOperator(1, Type.DATE, "date_col", true)
+                ),
+                new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.EQ_FOR_NULL,
+                        new ColumnRefOperator(1, Type.DATE, "date_col", true),
+                        ConstantOperator.createVarchar("2022-01-01")
+                ),
+        };
+        for (BinaryPredicateOperator op : ops) {
+            ImplicitCastRule rule = new ImplicitCastRule();
+            ScalarOperator result = rule.apply(op, null);
+
+            assertEquals(PrimitiveType.DATE, result.getChild(0).getType().getPrimitiveType());
+            assertEquals(PrimitiveType.DATE, result.getChild(1).getType().getPrimitiveType());
         }
     }
 


### PR DESCRIPTION
cherry-pick #16238
cherry-pick #16495