### PR TITLE
[Enhancement] Support higher version of hive metastore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorConstants.java
@@ -1,0 +1,20 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+// Put connector properties here
+public class ConnectorConstants {
+    public static final String HIVE_VERSION = "hive.version";
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveVersionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveVersionUtil.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.connector.hive;
+
+import com.google.common.base.Strings;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * For getting a compatible version of hive
+ * if user specified the version, it will parse it and return the compatible HiveVersion,
+ * otherwise, use DEFAULT_HIVE_VERSION
+ */
+public class HiveVersionUtil {
+    private static final Logger LOG = LogManager.getLogger(HiveVersionUtil.class);
+
+    private static final HiveVersion DEFAULT_HIVE_VERSION = HiveVersion.V2_3;
+
+    public enum HiveVersion {
+        V1_0,   // [1.0.0 - 1.2.2]
+        V2_0,   // [2.0.0 - 2.2.0]
+        V2_3,   // [2.3.0 - 2.3.6]
+        V3_0    // [3.0.0 - 3.1.2]
+    }
+
+    public static HiveVersion getVersion(String version) {
+        if (Strings.isNullOrEmpty(version)) {
+            return DEFAULT_HIVE_VERSION;
+        }
+        String[] parts = version.split("\\.");
+        if (parts.length < 2) {
+            LOG.warn("Invalid hive version: " + version);
+            return DEFAULT_HIVE_VERSION;
+        }
+        try {
+            int major = Integer.parseInt(parts[0]);
+            int minor = Integer.parseInt(parts[1]);
+            if (major == 1) {
+                return HiveVersion.V1_0;
+            } else if (major == 2) {
+                if (minor >= 0 && minor <= 2) {
+                    return HiveVersion.V1_0;
+                } else if (minor >= 3) {
+                    return HiveVersion.V2_3;
+                } else {
+                    LOG.warn("invalid hive version: " + version);
+                    return DEFAULT_HIVE_VERSION;
+                }
+            } else if (major >= 3) {
+                // Hive 3.x is compatible with Hive v2.3 api
+                return HiveVersion.V2_3;
+            } else {
+                LOG.warn("Invalid hive version: " + version);
+                return DEFAULT_HIVE_VERSION;
+            }
+        } catch (NumberFormatException e) {
+            LOG.warn("Invalid hive version: " + version);
+            return DEFAULT_HIVE_VERSION;
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Hive metastore interface is changed by version.
In order to be compatible with Hive 1.x version, we use `get_table()` to get table from Hive. But this API is forbidden in higher version of Hive.  You will receive below error:
```bash
Caused by: org.apache.hadoop.hive.metastore.api.MetaException: Your client does not appear to support insert-only tables. To skip capability checks, please set metastore.client.capability.check to false. This setting can be set globally, or on the client for the current metastore session. Note that this may lead to incorrect results, data loss, undefined behavior, etc. if your client is actually incompatible. You can also specify custom client capabilities via get_table_req API.
```

Considering Hive 1.x is too old, this PR upgrades the metastore API interface to 2.x. But if user still uses Hive 1.x version, user should specify `hive.version=1.x.x` in properties.

**Summary:**
* If user does not specify `hive.version`, we use Hive 2.x API by default.
* If user specify higher Hive version like `hive.version=3.1.3`, we still use Hive 2.x API, because it's compatible.
* If user use Hive 1.x version, they should specify `hive.version` in properties.

**Example**:
```sql
CREATE EXTERNAL CATALOG hive_test
PROPERTIES(
  "type"="hive", 
  "hive.metastore.uris"="thrift://10.1.0.24:9083",
  "hive.version"="1.2.1"
);
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
