### PR TITLE
[Enhancement] Add session variables: max_parallel_scan_instance_num (#19024) (#19233)

### DIFF
--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -80,7 +80,7 @@ public:
     static const std::string _s_average_io_mgr_queue_capacity;
     static const std::string _s_num_scanner_threads_started;
 
-    virtual int io_tasks_per_scan_operator() const { return config::io_tasks_per_scan_operator; }
+    virtual int io_tasks_per_scan_operator() const { return _io_tasks_per_scan_operator; }
 
 protected:
     RuntimeProfile::Counter* _bytes_read_counter; // # bytes read from the scanner
@@ -95,6 +95,7 @@ protected:
     // Aggregated scanner thread counters
     RuntimeProfile::ThreadCounters* _scanner_thread_counters;
     RuntimeProfile::Counter* _num_scanner_threads_started_counter;
+    int32_t _io_tasks_per_scan_operator = config::io_tasks_per_scan_operator;
 };
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -726,6 +726,8 @@ public class OlapScanNode extends ScanNode {
         if (ConnectContext.get() != null) {
             msg.olap_scan_node.setEnable_column_expr_predicate(
                     ConnectContext.get().getSessionVariable().isEnableColumnExprPredicate());
+            msg.olap_scan_node.setMax_parallel_scan_instance_num(
+                    ConnectContext.get().getSessionVariable().getMaxParallelScanInstanceNum());
         }
         msg.olap_scan_node.setDict_string_id_to_int_ids(dictStringIdToIntIds);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -619,6 +619,10 @@ public class ConnectProcessor {
                 ctx.getSessionVariable().setParallelExecInstanceNum(
                         queryOptions.getParallel_exec_instance_num());
             }
+            if (queryOptions.isSetMax_parallel_scan_instance_num()) {
+                ctx.getSessionVariable().setMaxParallelScanInstanceNum(
+                        queryOptions.getMax_parallel_scan_instance_num());
+            }
             if (queryOptions.isSetIs_report_success()) {
                 ctx.getSessionVariable().setReportSuccess(queryOptions.isIs_report_success());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/MasterOpExecutor.java
@@ -132,6 +132,7 @@ public class MasterOpExecutor {
         queryOptions.setQuery_timeout(ctx.getSessionVariable().getQueryTimeoutS());
         queryOptions.setLoad_mem_limit(ctx.getSessionVariable().getLoadMemLimit());
         queryOptions.setParallel_exec_instance_num(ctx.getSessionVariable().getParallelExecInstanceNum());
+        queryOptions.setMax_parallel_scan_instance_num(ctx.getSessionVariable().getMaxParallelScanInstanceNum());
         queryOptions.setIs_report_success(ctx.getSessionVariable().isReportSucc());
         params.setQuery_options(queryOptions);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -84,6 +84,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String DISABLE_COLOCATE_JOIN = "disable_colocate_join";
     public static final String DISABLE_BUCKET_JOIN = "disable_bucket_join";
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
+    public static final String MAX_PARALLEL_SCAN_INSTANCE_NUM = "max_parallel_scan_instance_num";
     public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
     public static final String ENABLE_SPILLING = "enable_spilling";
     // if set to true, some of stmt will be forwarded to master FE to get result
@@ -372,6 +373,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM)
     private int parallelExecInstanceNum = 1;
 
+    @VariableMgr.VarAttr(name = MAX_PARALLEL_SCAN_INSTANCE_NUM)
+    private int maxParallelScanInstanceNum = -1;
+
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
 
@@ -656,6 +660,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return parallelExecInstanceNum;
     }
 
+    public int getMaxParallelScanInstanceNum() {
+        return maxParallelScanInstanceNum;
+    }
+
     // when pipeline engine is enabled
     // in case of pipeline_dop > 0: return pipeline_dop * parallelExecInstanceNum;
     // in case of pipeline_dop <= 0 and avgNumCores < 2: return 1;
@@ -674,6 +682,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setParallelExecInstanceNum(int parallelExecInstanceNum) {
         this.parallelExecInstanceNum = parallelExecInstanceNum;
+    }
+
+    public void setMaxParallelScanInstanceNum(int maxParallelScanInstanceNum) {
+        this.maxParallelScanInstanceNum = maxParallelScanInstanceNum;
     }
 
     public int getExchangeInstanceParallel() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -202,6 +202,8 @@ public class StmtExecutor {
             StringBuilder sb = new StringBuilder();
             sb.append(SessionVariable.PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM).append("=")
                     .append(variables.getParallelExecInstanceNum()).append(",");
+            sb.append(SessionVariable.MAX_PARALLEL_SCAN_INSTANCE_NUM).append("=")
+                    .append(variables.getMaxParallelScanInstanceNum()).append(",");
             sb.append(SessionVariable.PIPELINE_DOP).append("=").append(variables.getPipelineDop()).append(",");
             sb.deleteCharAt(sb.length() - 1);
             summaryProfile.addInfoString(ProfileManager.VARIABLES, sb.toString());

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -168,6 +168,7 @@ struct TQueryOptions {
   //  (if start from a low number, say 80, this id may be used by another param in the new version),
   // start from 1000
   1000: optional i32 parallel_exec_instance_num;
+  1001: optional i32 max_parallel_scan_instance_num;
 }
 
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -344,6 +344,10 @@ struct TOlapScanNode {
   23: optional map<i32, i32> dict_string_id_to_int_ids
   // which columns only be used to filter data in the stage of scan data
   24: optional list<string> unused_output_column_name
+  //25: optional bool sorted_by_keys_per_tablet = false (reserved for 2.3+)
+  //26: optional list<Exprs.TExpr> bucket_exprs (reserved for 2.3+)
+  //27: optional list<string> sort_key_column_names (reserved for v2.3+)
+  28: optional i32 max_parallel_scan_instance_num
 }
 
 struct TJDBCScanNode {


### PR DESCRIPTION
The parallelism number of scan cannot be adjusted manually. The parallelism number of automatically calculated is sometimes very high, taking up a lot of cpu、memory or io resources, but the performance improvement is not obvious. So we add a session variable to limit the maximum parallelism of scan. It's useful for restrict the resource of large scan query.
