### PR TITLE
[Enhancement] add AssertHoldMutex check and use it 

### DIFF
--- a/be/src/util/assert_mutex.h
+++ b/be/src/util/assert_mutex.h
@@ -1,0 +1,249 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bthread/bthread.h>
+#include <glog/logging.h>
+#include <pthread.h>
+
+#include <optional>
+#include <shared_mutex>
+#include <thread>
+#include <type_traits>
+
+namespace starrocks {
+
+enum AssertHeldState {
+    UNLOCKED = 0,
+    SHARED_LOCK = 1,
+    EXCLUSIVE_LOCK = 2,
+};
+
+template <typename T, typename = std::enable_if_t<std::is_copy_assignable<T>::value, T>>
+class BTlsObject {
+public:
+    explicit BTlsObject() { _create_succ = (bthread_key_create(&_key, delete_handler) == 0); }
+    ~BTlsObject() {
+        if (_create_succ) {
+            void* old = bthread_getspecific(_key);
+            if (old != nullptr) {
+                delete_handler(old);
+                bthread_setspecific(_key, nullptr);
+            }
+            bthread_key_delete(_key);
+        }
+    }
+    template <typename... Args>
+    void set(Args&&... args) {
+        if (_create_succ) {
+            void* old = bthread_getspecific(_key);
+            if (old != nullptr) {
+                ((T*)old)->reset(std::forward<Args>(args)...);
+            } else {
+                auto obj = new T(std::forward<Args>(args)...);
+                int ret = bthread_setspecific(_key, obj);
+                if (ret != 0) {
+                    delete obj;
+                }
+            }
+        }
+    }
+
+    std::optional<T> get() const {
+        if (_create_succ) {
+            void* old = bthread_getspecific(_key);
+            if (old == nullptr) {
+                return {};
+            }
+            return *(T*)old;
+        } else {
+            return {};
+        }
+    }
+
+    void update(std::function<void(T*)> update_func) {
+        if (_create_succ) {
+            void* old = bthread_getspecific(_key);
+            if (old != nullptr) {
+                update_func((T*)old);
+            }
+        }
+    }
+
+    bool create_succ() const { return _create_succ; }
+
+    static void delete_handler(void* p) { delete (T*)p; }
+
+private:
+    bthread_key_t _key;
+    // may create fail because limit, skip check
+    bool _create_succ;
+};
+
+struct AssertHeldInfo {
+    explicit AssertHeldInfo(AssertHeldState s) { reset(s); }
+    void reset(AssertHeldState s) {
+        state = s;
+        shared_lock_cnt = (state == AssertHeldState::SHARED_LOCK) ? 1 : 0;
+        owner = pthread_self();
+    }
+    AssertHeldState state;
+    uint32_t shared_lock_cnt;
+    // can be used to detect deadlock
+    pthread_t owner;
+};
+
+class AssertHeldSharedMutex : public std::shared_mutex {
+public:
+    void lock() {
+        std::shared_mutex::lock();
+        _held_info.set(AssertHeldState::EXCLUSIVE_LOCK);
+    }
+    bool try_lock() {
+        if (std::shared_mutex::try_lock()) {
+            _held_info.set(AssertHeldState::EXCLUSIVE_LOCK);
+            return true;
+        }
+        return false;
+    }
+    void unlock() {
+        std::shared_mutex::unlock();
+        _held_info.set(AssertHeldState::UNLOCKED);
+    }
+
+    // Shared ownership
+
+    void lock_shared() {
+        std::shared_mutex::lock_shared();
+        _inc_shared_lock();
+    }
+
+    bool try_lock_shared() {
+        if (std::shared_mutex::try_lock_shared()) {
+            _inc_shared_lock();
+            return true;
+        }
+        return false;
+    }
+
+    void unlock_shared() {
+        std::shared_mutex::unlock_shared();
+        _dec_shared_lock();
+    }
+    bool assert_held_shared() {
+        if (!_held_info.create_succ()) {
+            // assume check success when create thread local var fail.
+            return true;
+        }
+        auto info = _held_info.get();
+        return info.has_value() && info.value().state == AssertHeldState::SHARED_LOCK;
+    }
+    bool assert_held_exclusive() {
+        if (!_held_info.create_succ()) {
+            // assume check success when create thread local var fail.
+            return true;
+        }
+        auto info = _held_info.get();
+        return info.has_value() && info.value().state == AssertHeldState::EXCLUSIVE_LOCK;
+    }
+
+    int TEST_get_shared_lock_cnt() {
+        if (!_held_info.create_succ()) {
+            return 0;
+        }
+        auto info = _held_info.get();
+        if (!info.has_value() || info.value().state != AssertHeldState::SHARED_LOCK) {
+            return 0;
+        }
+        return info.value().shared_lock_cnt;
+    }
+
+private:
+    // for reentrance
+    void _inc_shared_lock() {
+        auto info = _held_info.get();
+        if (info.has_value()) {
+            _held_info.update([](AssertHeldInfo* info) {
+                info->state = AssertHeldState::SHARED_LOCK;
+                info->shared_lock_cnt++;
+            });
+        } else {
+            _held_info.set(AssertHeldState::SHARED_LOCK);
+        }
+    }
+
+    void _dec_shared_lock() {
+        auto info = _held_info.get();
+        if (info.has_value()) {
+            _held_info.update([](AssertHeldInfo* info) {
+                info->shared_lock_cnt--;
+                if (info->shared_lock_cnt == 0) {
+                    info->state = AssertHeldState::UNLOCKED;
+                }
+            });
+        } else {
+            _held_info.set(AssertHeldState::UNLOCKED);
+        }
+    }
+
+    BTlsObject<AssertHeldInfo> _held_info;
+};
+
+class AssertHeldMutex : public std::mutex {
+public:
+    void lock() {
+        std::mutex::lock();
+        _held_info.set(AssertHeldState::EXCLUSIVE_LOCK);
+    }
+    bool try_lock() {
+        if (std::mutex::try_lock()) {
+            _held_info.set(AssertHeldState::EXCLUSIVE_LOCK);
+            return true;
+        }
+        return false;
+    }
+    void unlock() {
+        std::mutex::unlock();
+        _held_info.set(AssertHeldState::UNLOCKED);
+    }
+    bool assert_held() {
+        if (!_held_info.create_succ()) {
+            // assume check success when create thread local var fail.
+            return true;
+        }
+        auto info = _held_info.get();
+        return info.has_value() && info.value().state == AssertHeldState::EXCLUSIVE_LOCK;
+    }
+
+private:
+    BTlsObject<AssertHeldInfo> _held_info;
+};
+
+#if !defined(BE_TEST) && !defined(NDEBUG)
+#define CHECK_MUTEX_HELD(mutex) DCHECK(mutex.assert_held() == true) << "mutex not held!";
+#define CHECK_MUTEX_HELD_SHARED(mutex) \
+    DCHECK(mutex.assert_held_shared() == true || mutex.assert_held_exclusive() == true) << "mutex not held!";
+#define CHECK_MUTEX_HELD_EXCLUSIVE(mutex) DCHECK(mutex.assert_held_exclusive() == true) << "mutex not held!";
+
+#else
+#define CHECK_MUTEX_HELD(mutex) \
+    {}
+#define CHECK_MUTEX_HELD_SHARED(mutex) \
+    {}
+#define CHECK_MUTEX_HELD_EXCLUSIVE(mutex) \
+    {}
+#endif
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -343,6 +343,7 @@ set(EXEC_FILES
         ./util/system_metrics_test.cpp
         ./util/ratelimit_test.cpp
         ./util/cpu_usage_info_test.cpp
+        ./util/assert_mutex_test.cpp
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
         )

--- a/be/test/util/assert_mutex_test.cpp
+++ b/be/test/util/assert_mutex_test.cpp
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/assert_mutex.h"
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+namespace starrocks {
+
+TEST(TestAssertMutex, TestAssertMutex) {
+    AssertHeldMutex mutex;
+    EXPECT_FALSE(mutex.assert_held());
+    {
+        std::lock_guard<AssertHeldMutex> guard(mutex);
+        EXPECT_TRUE(mutex.assert_held());
+    }
+    EXPECT_FALSE(mutex.assert_held());
+    {
+        std::unique_lock<AssertHeldMutex> guard(mutex);
+        EXPECT_TRUE(mutex.assert_held());
+    }
+    EXPECT_FALSE(mutex.assert_held());
+}
+
+TEST(TestAssertMutex, TestAssertSharedMutex) {
+    AssertHeldSharedMutex mutex;
+    EXPECT_FALSE(mutex.assert_held_shared());
+    EXPECT_FALSE(mutex.assert_held_exclusive());
+    {
+        std::shared_lock<AssertHeldSharedMutex> guard(mutex);
+        EXPECT_TRUE(mutex.assert_held_shared());
+        EXPECT_FALSE(mutex.assert_held_exclusive());
+    }
+    EXPECT_FALSE(mutex.assert_held_shared());
+    EXPECT_FALSE(mutex.assert_held_exclusive());
+    {
+        std::unique_lock<AssertHeldSharedMutex> guard(mutex);
+        EXPECT_FALSE(mutex.assert_held_shared());
+        EXPECT_TRUE(mutex.assert_held_exclusive());
+    }
+    EXPECT_FALSE(mutex.assert_held_shared());
+    EXPECT_FALSE(mutex.assert_held_exclusive());
+}
+
+TEST(TestAssertMutex, TestAssertSharedMutexReentrance) {
+    AssertHeldSharedMutex mutex;
+    EXPECT_FALSE(mutex.assert_held_shared());
+    EXPECT_FALSE(mutex.assert_held_exclusive());
+    {
+        std::shared_lock<AssertHeldSharedMutex> guard(mutex);
+        EXPECT_TRUE(mutex.assert_held_shared());
+        EXPECT_EQ(mutex.TEST_get_shared_lock_cnt(), 1);
+        {
+            std::shared_lock<AssertHeldSharedMutex> guard(mutex);
+            EXPECT_TRUE(mutex.assert_held_shared());
+            EXPECT_EQ(mutex.TEST_get_shared_lock_cnt(), 2);
+            {
+                std::shared_lock<AssertHeldSharedMutex> guard(mutex);
+                EXPECT_TRUE(mutex.assert_held_shared());
+                EXPECT_EQ(mutex.TEST_get_shared_lock_cnt(), 3);
+                {
+                    std::shared_lock<AssertHeldSharedMutex> guard(mutex);
+                    EXPECT_TRUE(mutex.assert_held_shared());
+                    EXPECT_EQ(mutex.TEST_get_shared_lock_cnt(), 4);
+                }
+                EXPECT_TRUE(mutex.assert_held_shared());
+                EXPECT_EQ(mutex.TEST_get_shared_lock_cnt(), 3);
+            }
+            EXPECT_TRUE(mutex.assert_held_shared());
+            EXPECT_EQ(mutex.TEST_get_shared_lock_cnt(), 2);
+        }
+        EXPECT_TRUE(mutex.assert_held_shared());
+        EXPECT_EQ(mutex.TEST_get_shared_lock_cnt(), 1);
+    }
+    EXPECT_FALSE(mutex.assert_held_shared());
+    EXPECT_EQ(mutex.TEST_get_shared_lock_cnt(), 0);
+}
+
+TEST(TestAssertMutex, TestAssertMutexConcurrent) {
+    AssertHeldMutex mutex;
+    std::vector<std::thread> workers;
+    int cnt = 0;
+    for (int i = 0; i < 10; i++) {
+        workers.emplace_back([&]() {
+            std::lock_guard<AssertHeldMutex> guard(mutex);
+            cnt += 1;
+            EXPECT_TRUE(mutex.assert_held());
+        });
+    }
+    for (int i = 0; i < 10; i++) {
+        workers[i].join();
+    }
+    EXPECT_TRUE(cnt == 10);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19266

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add `AssertHeldSharedMutex` and `AssertHeldMutex`, which we can do some self concurrent check at very low cost.

E.g:
```
// At first
void func_a() {
   // do some jobs.
}
void func_A() {
  std::lock_guard(_lock);
  func_a(); // func_a is not thread safe, need to protect by lock
}
// But after many code updates, it may be:
void func_B() {
   // call func_a() without protect
   func_a();
}
```

To prevent this, we can use `AssertHeldMutex`:
```
void func_a() {
   CHECK(_lock.assert_held());
   // do some jobs.
}
void func_A() {
  std::lock_guard(_lock);
  func_a(); // func_a is not thread safe, need to protect by lock
}
void func_B() {
   // call func_a() without protect, check will failed.
   func_a();
}

```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
