### PR TITLE
[BugFix] Fix ASAN crash when push null chunk to accumulator

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -95,7 +95,9 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
     } else {
         _has_last_chunk = false;
         ASSIGN_OR_RETURN(res, _aggregator->pull_eos_chunk());
-        _accumulator.push(std::move(res));
+        if (res != nullptr && !res->is_empty()) {
+            _accumulator.push(std::move(res));
+        }
         _accumulator.finalize();
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
ChunkPipelineAccumulator couldn't accept null chunk

## Problem Summary(Required) ：
```
*** Aborted at 1678349072 (unix time) try "date -d @1678349072" if you are using GNU date ***
PC: @          0xd192fb9 __gnu_cxx::__normal_iterator<>::__normal_iterator()
*** SIGSEGV (@0x8) received by PID 3788772 (TID 0x7f53297cb640) from PID 8; stack trace: ***
    @         0x16e5bc0a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f548ab33520 (unknown)
    @          0xd192fb9 __gnu_cxx::__normal_iterator<>::__normal_iterator()
    @          0xd18e368 std::vector<>::end()
    @          0xd18dabb std::vector<>::empty()
    @          0xd1883c9 starrocks::Chunk::check_or_die()
    @         0x1477fc0f starrocks::ChunkPipelineAccumulator::push()
    @          0xf35c44d starrocks::pipeline::SortedAggregateStreamingSinkOperator::set_finishing()
    @          0xf262724 starrocks::pipeline::PipelineDriver::_mark_operator_finishing()
    @          0xf25cee1 starrocks::pipeline::PipelineDriver::process()
    @          0xf21abb5 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
