### PR TITLE
[BugFix] Init OlapTable AtomicLong variables after deserialized from gson

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -215,10 +215,10 @@ public class OlapTable extends Table {
     protected long binlogTxnId = -1;
 
     // Record the alter, schema change, MV update time
-    public final AtomicLong lastSchemaUpdateTime = new AtomicLong(-1);
+    public AtomicLong lastSchemaUpdateTime = new AtomicLong(-1);
     // Record the start and end time for data load version update phase
-    public final AtomicLong lastVersionUpdateStartTime = new AtomicLong(-1);
-    public final AtomicLong lastVersionUpdateEndTime = new AtomicLong(0);
+    public AtomicLong lastVersionUpdateStartTime = new AtomicLong(-1);
+    public AtomicLong lastVersionUpdateEndTime = new AtomicLong(0);
 
     public OlapTable() {
         this(TableType.OLAP);
@@ -1570,6 +1570,11 @@ public class OlapTable extends Table {
 
         // The table may be restored from another cluster, it should be set to current cluster id.
         clusterId = GlobalStateMgr.getCurrentState().getClusterId();
+
+        lastSchemaUpdateTime = new AtomicLong(-1);
+        // Record the start and end time for data load version update phase
+        lastVersionUpdateStartTime = new AtomicLong(-1);
+        lastVersionUpdateEndTime = new AtomicLong(0);
     }
 
     public OlapTable selectiveCopy(Collection<String> reservedPartitions, boolean resetState, IndexExtState extState) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
@@ -147,6 +147,10 @@ public class LakeTableTest {
             ++expectedTabletId;
         }
 
+        Assert.assertEquals(-1, newLakeTable.lastSchemaUpdateTime.longValue());
+        Assert.assertEquals(-1, newLakeTable.lastVersionUpdateStartTime.longValue());
+        Assert.assertEquals(0, newLakeTable.lastVersionUpdateEndTime.longValue());
+
         Assert.assertNull(table.delete(true));
         Assert.assertNotNull(table.delete(false));
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19274

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
