### PR TITLE
[BugFix] Fix create partition memory leak bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1054,6 +1054,11 @@ public class LocalMetastore implements ConnectorMetadata {
                 Partition partition =
                         createPartition(db, copiedTable, partitionId, partitionName, version, tabletIdSet);
 
+                // createPartition() will set partition's partitionInfo to the copiedTable's partitionInfo,
+                // and this will cause memory leak because every partition will refer to a distinct PartitionInfo Object.
+                // Set the partitionInfo to the olapTable's partitionInfo here.
+                partition.setPartitionInfo(olapTable.getPartitionInfo());
+
                 partitionList.add(partition);
                 tabletIdSetForAll.addAll(tabletIdSet);
                 partitionNameToTabletSet.put(partitionName, tabletIdSet);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
createPartition() will set partition's partitionInfo to the copiedTable's partitionInfo, and this will cause memory leak because every partition will refer to a distinct PartitionInfo Object.
Set the partitionInfo to the olapTable's partitionInfo.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
