### PR TITLE
[Enhancement] to_date function implement in FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -202,6 +202,13 @@ public class ScalarOperatorFunctions {
         }
     }
 
+    @ConstantFunction(name = "to_date", argTypes = {DATETIME}, returnType = DATE)
+    public static ConstantOperator toDate(ConstantOperator date) {
+        LocalDate ld = LocalDate.of(date.getDatetime().getYear(),
+                date.getDatetime().getMonthValue(), date.getDatetime().getDayOfMonth());
+        return ConstantOperator.createDate(ld.atTime(0, 0, 0));
+    }
+
     @ConstantFunction(name = "str_to_date", argTypes = {VARCHAR, VARCHAR}, returnType = DATETIME)
     public static ConstantOperator dateParse(ConstantOperator date, ConstantOperator fmtLiteral) {
         DateTimeFormatterBuilder builder = DateUtils.unixDatetimeFormatBuilder(fmtLiteral.getVarchar(), false);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -332,6 +332,22 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void to_date() {
+        LocalDateTime dateTime = LocalDateTime.of(LocalDate.of(2013,05,17), LocalTime.of(0, 0, 0));
+        assertEquals(dateTime, ScalarOperatorFunctions
+                .toDate(ConstantOperator.createDatetime(LocalDateTime.of(2013,05,17,12,35,10))).getDatetime());
+
+        assertEquals(dateTime, ScalarOperatorFunctions
+                .toDate(ConstantOperator.createDatetime(LocalDateTime.of(2013,05,17,12,35,10, 123))).getDatetime());
+
+        assertEquals(dateTime, ScalarOperatorFunctions
+                .toDate(ConstantOperator.createDatetime(LocalDateTime.of(2013,5,17,12,35,10))).getDatetime());
+
+        assertEquals(dateTime, ScalarOperatorFunctions
+                .toDate(ConstantOperator.createDatetime(LocalDateTime.of(2013,05,17,12,35,10, 00001))).getDatetime());
+    }
+
+    @Test
     public void dateParse() {
         assertEquals("2013-05-10T00:00", ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("2013,05,10"), ConstantOperator.createVarchar("%Y,%m,%d"))


### PR DESCRIPTION
## What type of PR is this：
- [ ] Enhancement

## Which issues of this PR fixes ：
implement to_date function in FE

## Problem Summary(Required) ：
when user use to_date function in where clause compare with partition field；it will result in a full table scan

## Checklist:

- [ ] I have added test cases for  my new feature

