### PR TITLE
[Enhancement] support configurable encoding in query spilling

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -180,6 +180,7 @@ Status SpillableAggregateBlockingSinkOperatorFactory::prepare(RuntimeState* stat
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();
     _spill_options->name = "agg-blocking-spill";
     _spill_options->plan_node_id = _plan_node_id;
+    _spill_options->encode_level = state->spill_encode_level();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -136,7 +136,8 @@ Status SpillablePartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();
     _spill_options->name = "local-sort-spill";
     _spill_options->plan_node_id = _plan_node_id;
-
+    _spill_options->encode_level = state->spill_encode_level();
+    // _spill_options->column_number = _materialized_tuple_desc->slots().size();
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -137,7 +137,6 @@ Status SpillablePartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->name = "local-sort-spill";
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
-    // _spill_options->column_number = _materialized_tuple_desc->slots().size();
     return Status::OK();
 }
 

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -253,6 +253,7 @@ private:
 
 Status OrderedInputStream::init(SerdePtr serde, const SortExecExprs* sort_exprs, const SortDescs* descs) {
     std::vector<starrocks::ChunkProvider> chunk_providers;
+    DCHECK(!_input_blocks.empty());
     for (auto& block : _input_blocks) {
         std::vector<BlockPtr> blocks{block};
         auto stream = std::make_shared<BufferedInputStream>(chunk_buffer_max_size,

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -26,7 +26,9 @@ struct SpilledChunkBuildSchema {
     void set_schema(const ChunkPtr& chunk) { _chunk = chunk->clone_empty(0); }
     bool empty() { return _chunk->num_columns() == 0; }
     ChunkUniquePtr new_chunk() { return _chunk->clone_unique(); }
-
+    size_t column_number() const {
+        return _chunk->num_columns();
+    }
 private:
     ChunkPtr _chunk{new Chunk()};
 };
@@ -35,6 +37,9 @@ struct ChunkBuilder {
     ChunkBuilder() = default;
     ChunkUniquePtr operator()() const { return _spill_chunk_schema->new_chunk(); }
     auto& chunk_schema() { return _spill_chunk_schema; }
+    size_t column_number() const {
+        return _spill_chunk_schema->column_number();
+    }
 
 private:
     std::shared_ptr<SpilledChunkBuildSchema> _spill_chunk_schema;
@@ -90,6 +95,7 @@ struct SpilledOptions {
     size_t min_spilled_size = 1 * 1024 * 1024;
 
     bool read_shared = false;
+    int encode_level = 0;
 
     BlockManager* block_manager = nullptr;
 };

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -26,9 +26,8 @@ struct SpilledChunkBuildSchema {
     void set_schema(const ChunkPtr& chunk) { _chunk = chunk->clone_empty(0); }
     bool empty() { return _chunk->num_columns() == 0; }
     ChunkUniquePtr new_chunk() { return _chunk->clone_unique(); }
-    size_t column_number() const {
-        return _chunk->num_columns();
-    }
+    size_t column_number() const { return _chunk->num_columns(); }
+
 private:
     ChunkPtr _chunk{new Chunk()};
 };
@@ -37,9 +36,7 @@ struct ChunkBuilder {
     ChunkBuilder() = default;
     ChunkUniquePtr operator()() const { return _spill_chunk_schema->new_chunk(); }
     auto& chunk_schema() { return _spill_chunk_schema; }
-    size_t column_number() const {
-        return _spill_chunk_schema->column_number();
-    }
+    size_t column_number() const { return _spill_chunk_schema->column_number(); }
 
 private:
     std::shared_ptr<SpilledChunkBuildSchema> _spill_chunk_schema;

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -34,7 +34,6 @@ public:
         if (_encode_context == nullptr) {
             auto column_number = _parent->chunk_builder().column_number();
             auto encode_level = _parent->options().encode_level;
-            LOG(INFO) << "init encode_context, column_number: " << column_number << ", encode_level:" << encode_level;
             _encode_context = serde::EncodeContext::get_encode_context_shared_ptr(column_number, encode_level);
         }
         return Status::OK();
@@ -182,7 +181,6 @@ StatusOr<ChunkUniquePtr> ColumnarSerde::deserialize(SerdeContext& ctx, BlockRead
 
     const uint8_t* read_cursor = reinterpret_cast<uint8_t*>(serialize_buffer.data());
     if (_encode_context == nullptr) {
-        // @TODO deserialize time
         SCOPED_TIMER(_parent->metrics().deserialize_timer);
         for (auto& column : columns) {
             read_cursor = serde::ColumnArraySerde::deserialize(read_cursor, column.get());

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -20,106 +20,186 @@
 #include "gutil/port.h"
 #include "runtime/runtime_state.h"
 #include "serde/column_array_serde.h"
+#include "serde/encode_context.h"
 
 namespace starrocks::spill {
 
 class ColumnarSerde : public Serde {
 public:
-    ColumnarSerde(ChunkBuilder chunk_builder, const BlockCompressionCodec* compress_codec)
-            : _chunk_builder(std::move(chunk_builder)), _compress_codec(compress_codec) {}
+    ColumnarSerde(Spiller* parent, ChunkBuilder chunk_builder, std::shared_ptr<serde::EncodeContext> encode_context)
+            : Serde(parent), _chunk_builder(std::move(chunk_builder)), _encode_context(std::move(encode_context)) {}
     ~ColumnarSerde() override = default;
+
+    Status prepare() override {
+        if (_encode_context == nullptr) {
+            auto column_number = _parent->chunk_builder().column_number();
+            auto encode_level = _parent->options().encode_level;
+            LOG(INFO) << "init encode_context, column_number: " << column_number << ", encode_level:" << encode_level;
+            _encode_context = serde::EncodeContext::get_encode_context_shared_ptr(column_number, encode_level);
+        }
+        return Status::OK();
+    }
 
     Status serialize(SerdeContext& ctx, const ChunkPtr& chunk, BlockPtr block) override;
     StatusOr<ChunkUniquePtr> deserialize(SerdeContext& ctx, BlockReader* reader) override;
 
 private:
-    size_t serialize_size(const ChunkPtr& chunk) const;
+    size_t _max_serialized_size(const ChunkPtr& chunk) const;
+
+    inline const std::vector<uint32_t>& _get_encode_levels() {
+        DCHECK(_encode_context != nullptr);
+        std::shared_lock l(_mutex);
+        return _encode_context->get_encode_levels();
+    }
+
+    inline void _update_encode_stats(const std::vector<std::pair<uint64_t, uint64_t>>& column_stats) {
+        DCHECK(_encode_context != nullptr);
+        std::unique_lock l(_mutex);
+        for (size_t i = 0; i < column_stats.size(); i++) {
+            _encode_context->update(i, column_stats[i].first, column_stats[i].second);
+        }
+        _encode_context->adjust_encode_levels();
+    }
 
     ChunkBuilder _chunk_builder;
-    const BlockCompressionCodec* _compress_codec = nullptr;
+    // assuming that the chunks processed by the same Spiller are similar,
+    // so we maintain a context for each ColumnarSerde, which may be accessed by multiple threads.
+    // here a std::shared_mutex is used to ensure concurrency safety.
+    std::shared_mutex _mutex;
+    std::shared_ptr<serde::EncodeContext> _encode_context;
 };
 
-size_t ColumnarSerde::serialize_size(const ChunkPtr& chunk) const {
+size_t ColumnarSerde::_max_serialized_size(const ChunkPtr& chunk) const {
     size_t total_size = 0;
-    for (const auto& column : chunk->columns()) {
-        total_size += serde::ColumnArraySerde::max_serialized_size(*column);
+    const auto& columns = chunk->columns();
+    if (_encode_context == nullptr) {
+        for (const auto& column : columns) {
+            total_size += serde::ColumnArraySerde::max_serialized_size(*column);
+        }
+    } else {
+        for (size_t i = 0; i < columns.size(); i++) {
+            total_size +=
+                    serde::ColumnArraySerde::max_serialized_size(*columns[i], _encode_context->get_encode_level(i));
+        }
     }
     return total_size;
 }
 
 Status ColumnarSerde::serialize(SerdeContext& ctx, const ChunkPtr& chunk, BlockPtr block) {
-    // 1. serialize
-    size_t max_size = serialize_size(chunk);
+    size_t max_serialized_size = _max_serialized_size(chunk);
     auto& serialize_buffer = ctx.serialize_buffer;
-    serialize_buffer.resize(max_size);
-    auto* buf = reinterpret_cast<uint8_t*>(serialize_buffer.data());
-    uint8_t* begin = buf;
-    for (const auto& column : chunk->columns()) {
-        buf = serde::ColumnArraySerde::serialize(*column, buf);
+    serialize_buffer.resize(max_serialized_size);
+
+    uint8_t* buf = reinterpret_cast<uint8_t*>(serialize_buffer.data());
+    uint8_t* head = buf;
+
+    const auto& columns = chunk->columns();
+
+    std::unique_ptr<uint8_t[]> meta_buf;
+    size_t meta_len;
+    if (_encode_context == nullptr) {
+        SCOPED_TIMER(_parent->metrics().serialize_timer);
+        for (const auto& column : columns) {
+            buf = serde::ColumnArraySerde::serialize(*column, buf);
+            if (UNLIKELY(buf == nullptr)) {
+                return Status::InternalError("unsupported column occurs in spill serialize phase");
+            }
+        }
+        serialize_buffer.resize(buf - head);
+        // only 8 bytes for serialized size if encoding is disable
+        meta_len = sizeof(size_t);
+        meta_buf.reset(new uint8_t[meta_len]);
+        uint8_t* tmp_buf = meta_buf.get();
+        UNALIGNED_STORE64(tmp_buf, serialize_buffer.size());
+    } else {
+        SCOPED_TIMER(_parent->metrics().serialize_timer);
+        auto encode_levels = _get_encode_levels();
+        std::vector<std::pair<uint64_t, uint64_t>>
+                column_stats; // used to record raw_bytes and encoded_bytes for each column
+        column_stats.reserve(columns.size());
+        int padding_size = 0;
+        for (size_t i = 0; i < columns.size(); i++) {
+            uint8_t* begin = buf;
+            buf = serde::ColumnArraySerde::serialize(*columns[i], buf, false, encode_levels[i]);
+            if (UNLIKELY(buf == nullptr)) {
+                return Status::InternalError("unsupported column occurs in spill serialize phase");
+            }
+            // raw_bytes and encoded_bytes
+            column_stats.emplace_back(columns[i]->byte_size(), buf - begin);
+            if (serde::EncodeContext::enable_encode_integer(encode_levels[i])) {
+                padding_size = serde::EncodeContext::STREAMVBYTE_PADDING_SIZE;
+            }
+        }
+        _update_encode_stats(column_stats);
+
+        serialize_buffer.resize(buf - head + padding_size);
+        // 8 bytes for encoded size, 4 bytes for each column's encode level
+        // @TODO(silverbullet233): encode levels can be further encoded to save space if necessary.
+        meta_len = sizeof(size_t) + columns.size() * sizeof(uint32_t);
+        meta_buf.reset(new uint8_t[meta_len]);
+        // fill encoded size
+        uint8_t* tmp_buf = meta_buf.get();
+        UNALIGNED_STORE64(tmp_buf, serialize_buffer.size());
+        tmp_buf += sizeof(size_t);
+        // fill encode level
+        for (auto encode_level : encode_levels) {
+            UNALIGNED_STORE32(tmp_buf, encode_level);
+            tmp_buf += sizeof(uint32_t);
+        }
     }
-    size_t uncompressed_size = buf - begin;
-    serialize_buffer.resize(uncompressed_size);
-
-    // 2. compress
-    auto& compress_buffer = ctx.compress_buffer;
-    Slice compress_input(serialize_buffer.data(), uncompressed_size);
-    Slice compress_slice;
-
-    int max_compressed_size = _compress_codec->max_compressed_len(uncompressed_size);
-    if (compress_buffer.size() < max_compressed_size) {
-        compress_buffer.resize(max_compressed_size);
-    }
-    compress_slice = Slice(compress_buffer.data(), compress_buffer.size());
-    RETURN_IF_ERROR(_compress_codec->compress(compress_input, &compress_slice));
-    size_t compressed_size = compress_slice.size;
-    compress_buffer.resize(compressed_size);
-
-    // 3. append data to block
-    uint8_t meta_buf[sizeof(size_t) * 2];
-    UNALIGNED_STORE64(meta_buf, compressed_size);
-    UNALIGNED_STORE64(meta_buf + sizeof(size_t), uncompressed_size);
 
     std::vector<Slice> data;
-    data.emplace_back(Slice(meta_buf, sizeof(size_t) * 2));
-    data.emplace_back(compress_slice);
+    data.emplace_back(Slice(meta_buf.get(), meta_len));
+    data.emplace_back(Slice(serialize_buffer.data(), serialize_buffer.size()));
     RETURN_IF_ERROR(block->append(data));
-    TRACE_SPILL_LOG << "serialize chunk to block: " << block->debug_string() << ", compressed size: " << compressed_size
-                    << ", uncompressed size: " << uncompressed_size;
+    COUNTER_UPDATE(_parent->metrics().flush_bytes, meta_len + serialize_buffer.size());
+    TRACE_SPILL_LOG << "serialize chunk to block: " << block->debug_string()
+                    << ", original size: " << chunk->bytes_usage() << ", encoded size: " << serialize_buffer.size();
     return Status::OK();
 }
 
 StatusOr<ChunkUniquePtr> ColumnarSerde::deserialize(SerdeContext& ctx, BlockReader* reader) {
-    size_t compressed_size, uncompressed_size;
-    RETURN_IF_ERROR(reader->read_fully(&compressed_size, sizeof(size_t)));
-    RETURN_IF_ERROR(reader->read_fully(&uncompressed_size, sizeof(size_t)));
-
-    TRACE_SPILL_LOG << "deserialize chunk from block: " << reader->debug_string()
-                    << ", compressed size: " << compressed_size << ", uncompressed size: " << uncompressed_size;
-
-    auto& compress_buffer = ctx.compress_buffer;
-    auto& serialize_buffer = ctx.serialize_buffer;
-    compress_buffer.resize(compressed_size);
-    serialize_buffer.resize(uncompressed_size);
-
-    auto buf = reinterpret_cast<uint8_t*>(compress_buffer.data());
-    RETURN_IF_ERROR(reader->read_fully(buf, compressed_size));
-    // decompress
-    Slice input_slice(compress_buffer.data(), compressed_size);
-    Slice serialize_slice(serialize_buffer.data(), uncompressed_size);
-    RETURN_IF_ERROR(_compress_codec->decompress(input_slice, &serialize_slice));
-
-    // deserialize
+    size_t encoded_size;
+    RETURN_IF_ERROR(reader->read_fully(&encoded_size, sizeof(size_t)));
+    size_t read_bytes = sizeof(size_t) + encoded_size;
+    std::vector<uint32_t> encode_levels;
     auto chunk = _chunk_builder();
-    const uint8_t* read_cursor = reinterpret_cast<uint8_t*>(serialize_buffer.data());
-    for (const auto& column : chunk->columns()) {
-        read_cursor = serde::ColumnArraySerde::deserialize(read_cursor, column.get());
+    auto& columns = chunk->columns();
+    if (_encode_context != nullptr) {
+        // decode encode levels for each column
+        for (size_t i = 0; i < columns.size(); i++) {
+            uint32_t encode_level;
+            RETURN_IF_ERROR(reader->read_fully(&encode_level, sizeof(uint32_t)));
+            encode_levels.push_back(encode_level);
+        }
+        read_bytes += columns.size() * sizeof(uint32_t);
     }
+    auto& serialize_buffer = ctx.serialize_buffer;
+    serialize_buffer.resize(encoded_size);
+
+    auto buf = reinterpret_cast<uint8_t*>(serialize_buffer.data());
+    RETURN_IF_ERROR(reader->read_fully(buf, encoded_size));
+
+    const uint8_t* read_cursor = reinterpret_cast<uint8_t*>(serialize_buffer.data());
+    if (_encode_context == nullptr) {
+        // @TODO deserialize time
+        SCOPED_TIMER(_parent->metrics().deserialize_timer);
+        for (auto& column : columns) {
+            read_cursor = serde::ColumnArraySerde::deserialize(read_cursor, column.get());
+        }
+    } else {
+        SCOPED_TIMER(_parent->metrics().deserialize_timer);
+        for (size_t i = 0; i < columns.size(); i++) {
+            read_cursor = serde::ColumnArraySerde::deserialize(read_cursor, columns[i].get(), false, encode_levels[i]);
+        }
+    }
+    COUNTER_UPDATE(_parent->metrics().restore_bytes, read_bytes);
+    TRACE_SPILL_LOG << "deserialize chunk from block: " << reader->debug_string() << ", encoded size: " << encoded_size
+                    << ", original size: " << chunk->bytes_usage();
     return chunk;
 }
 
-StatusOr<SerdePtr> Serde::create_serde(const ChunkBuilder& chunk_builder, const CompressionTypePB& compress_type) {
-    const BlockCompressionCodec* codec = nullptr;
-    RETURN_IF_ERROR(get_block_compression_codec(compress_type, &codec));
-    return std::make_shared<ColumnarSerde>(chunk_builder, codec);
+StatusOr<SerdePtr> Serde::create_serde(Spiller* parent) {
+    return std::make_shared<ColumnarSerde>(parent, parent->chunk_builder(), nullptr);
 }
 } // namespace starrocks::spill

--- a/be/src/exec/spill/serde.h
+++ b/be/src/exec/spill/serde.h
@@ -30,22 +30,25 @@ enum class SerdeType {
 
 struct SerdeContext {
     std::string serialize_buffer;
-    raw::RawString compress_buffer;
 };
-
+class Spiller;
 // Serde is used to serialize and deserialize spilled data.
 class Serde;
 using SerdePtr = std::shared_ptr<Serde>;
 class Serde {
 public:
+    Serde(Spiller* parent): _parent(parent) {}
     virtual ~Serde() = default;
 
+    virtual Status prepare() = 0;
     // serialize chunk and append the serialized data into block
     virtual Status serialize(SerdeContext& ctx, const ChunkPtr& chunk, BlockPtr block) = 0;
     // deserialize data from block, return the chunk after deserialized
     virtual StatusOr<ChunkUniquePtr> deserialize(SerdeContext& ctx, BlockReader* reader) = 0;
 
-    static StatusOr<SerdePtr> create_serde(const ChunkBuilder& chunk_builder, const CompressionTypePB& compress_type);
+    static StatusOr<SerdePtr> create_serde(Spiller* parent);
+protected:
+    Spiller* _parent = nullptr;
 };
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/serde.h
+++ b/be/src/exec/spill/serde.h
@@ -37,7 +37,7 @@ class Serde;
 using SerdePtr = std::shared_ptr<Serde>;
 class Serde {
 public:
-    Serde(Spiller* parent): _parent(parent) {}
+    Serde(Spiller* parent) : _parent(parent) {}
     virtual ~Serde() = default;
 
     virtual Status prepare() = 0;
@@ -47,6 +47,7 @@ public:
     virtual StatusOr<ChunkUniquePtr> deserialize(SerdeContext& ctx, BlockReader* reader) = 0;
 
     static StatusOr<SerdePtr> create_serde(Spiller* parent);
+
 protected:
     Spiller* _parent = nullptr;
 };

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -52,8 +52,6 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile) {
     restore_bytes = ADD_COUNTER(profile, "SpillRestoreBytes", TUnit::BYTES);
     serialize_timer = ADD_TIMER(profile, "SpillSerializeTimer");
     deserialize_timer = ADD_TIMER(profile, "SpillDeserializeTimer");
-    // log_block_num = ADD_COUNTER(profile, "SpillLogBlockNum");
-    // log_block_container_num = ADD_COUNTER(profile, "SpillLogBlockContainerNum");
 
 }
 

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -52,7 +52,6 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile) {
     restore_bytes = ADD_COUNTER(profile, "SpillRestoreBytes", TUnit::BYTES);
     serialize_timer = ADD_TIMER(profile, "SpillSerializeTimer");
     deserialize_timer = ADD_TIMER(profile, "SpillDeserializeTimer");
-
 }
 
 Status Spiller::prepare(RuntimeState* state) {

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -47,12 +47,20 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile) {
     restore_timer = ADD_TIMER(profile, "SpillRestoreTimer");
     shuffle_timer = ADD_TIMER(profile, "SpillShuffleTimer");
     split_partition_timer = ADD_TIMER(profile, "SplitPartitionTimer");
+
+    flush_bytes = ADD_COUNTER(profile, "SpillFlushBytes", TUnit::BYTES);
+    restore_bytes = ADD_COUNTER(profile, "SpillRestoreBytes", TUnit::BYTES);
+    serialize_timer = ADD_TIMER(profile, "SpillSerializeTimer");
+    deserialize_timer = ADD_TIMER(profile, "SpillDeserializeTimer");
+    // log_block_num = ADD_COUNTER(profile, "SpillLogBlockNum");
+    // log_block_container_num = ADD_COUNTER(profile, "SpillLogBlockContainerNum");
+
 }
 
 Status Spiller::prepare(RuntimeState* state) {
     _chunk_builder.chunk_schema() = std::make_shared<SpilledChunkBuildSchema>();
 
-    ASSIGN_OR_RETURN(_serde, Serde::create_serde(_chunk_builder, _opts.compress_type));
+    ASSIGN_OR_RETURN(_serde, Serde::create_serde(this));
 
     if (_opts.init_partition_nums > 0) {
         _writer = std::make_unique<PartitionedSpillerWriter>(this, state);

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -54,6 +54,13 @@ struct SpillProcessMetrics {
     RuntimeProfile::Counter* restore_rows = nullptr;
     RuntimeProfile::Counter* shuffle_timer = nullptr;
     RuntimeProfile::Counter* split_partition_timer = nullptr;
+
+    RuntimeProfile::Counter* flush_bytes = nullptr;
+    RuntimeProfile::Counter* restore_bytes = nullptr;
+    RuntimeProfile::Counter* serialize_timer = nullptr;
+    RuntimeProfile::Counter* deserialize_timer = nullptr;
+    RuntimeProfile::Counter* log_block_num = nullptr;
+    RuntimeProfile::Counter* log_block_container_num = nullptr;
 };
 
 // major spill interfaces
@@ -144,6 +151,9 @@ public:
 
     const std::shared_ptr<spill::Serde>& serde() { return _serde; }
     BlockManager* block_manager() { return _block_manager; }
+    const ChunkBuilder& chunk_builder() {
+        return _chunk_builder;
+    }
 
 private:
     Status _get_spilled_task_status() {

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -149,9 +149,7 @@ public:
 
     const std::shared_ptr<spill::Serde>& serde() { return _serde; }
     BlockManager* block_manager() { return _block_manager; }
-    const ChunkBuilder& chunk_builder() {
-        return _chunk_builder;
-    }
+    const ChunkBuilder& chunk_builder() { return _chunk_builder; }
 
 private:
     Status _get_spilled_task_status() {

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -59,8 +59,6 @@ struct SpillProcessMetrics {
     RuntimeProfile::Counter* restore_bytes = nullptr;
     RuntimeProfile::Counter* serialize_timer = nullptr;
     RuntimeProfile::Counter* deserialize_timer = nullptr;
-    RuntimeProfile::Counter* log_block_num = nullptr;
-    RuntimeProfile::Counter* log_block_container_num = nullptr;
 };
 
 // major spill interfaces

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -63,7 +63,6 @@ Status Spiller::partitioned_spill(RuntimeState* state, const ChunkPtr& chunk, Sp
     if (_chunk_builder.chunk_schema()->empty()) {
         _chunk_builder.chunk_schema()->set_schema(chunk);
         RETURN_IF_ERROR(_serde->prepare());
-        // @TODO init serde
     }
 
     std::vector<uint32_t> indexs;

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -41,6 +41,7 @@ Status Spiller::spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&&
 
     if (_chunk_builder.chunk_schema()->empty()) {
         _chunk_builder.chunk_schema()->set_schema(chunk);
+        RETURN_IF_ERROR(_serde->prepare());
     }
 
     if (_opts.init_partition_nums > 0) {
@@ -61,6 +62,8 @@ Status Spiller::partitioned_spill(RuntimeState* state, const ChunkPtr& chunk, Sp
 
     if (_chunk_builder.chunk_schema()->empty()) {
         _chunk_builder.chunk_schema()->set_schema(chunk);
+        RETURN_IF_ERROR(_serde->prepare());
+        // @TODO init serde
     }
 
     std::vector<uint32_t> indexs;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -311,6 +311,7 @@ public:
     int64_t spill_operator_min_bytes() const { return _query_options.spill_operator_min_bytes; }
 
     int64_t spill_operator_max_bytes() const { return _query_options.spill_operator_max_bytes; }
+    int32_t spill_encode_level() const { return _query_options.spill_encode_level; }
 
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const { return _tablet_commit_infos; }
 

--- a/be/src/serde/CMakeLists.txt
+++ b/be/src/serde/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/serde")
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/serde")
 
 add_library(Serde STATIC
+        encode_context.cpp
         column_array_serde.cpp
         protobuf_serde.cpp
         )

--- a/be/src/serde/encode_context.cpp
+++ b/be/src/serde/encode_context.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "serde/encode_context.h"
+
+#include "gen_cpp/data.pb.h" // ChunkPB
+
+namespace starrocks::serde {
+
+EncodeContext::EncodeContext(const int col_num, const int encode_level) : _session_encode_level(encode_level) {
+    for (auto i = 0; i < col_num; ++i) {
+        _column_encode_level.emplace_back(_session_encode_level);
+        _raw_bytes.emplace_back(0);
+        _encoded_bytes.emplace_back(0);
+    }
+    DCHECK(_session_encode_level != 0);
+    // the lowest bit is set and other bits are not zero, then enable adjust.
+    if (_session_encode_level & 1 && (_session_encode_level >> 1)) {
+        _enable_adjust = true;
+    }
+}
+
+void EncodeContext::update(const int col_id, uint64_t mem_bytes, uint64_t encode_byte) {
+    DCHECK(_session_encode_level != 0);
+    if (!_enable_adjust) {
+        return;
+    }
+    // decide to encode or not by the encoding ratio of the first EncodeSamplingNum of every _frequency chunks
+    if (_times % _frequency < EncodeSamplingNum) {
+        _raw_bytes[col_id] += mem_bytes;
+        _encoded_bytes[col_id] += encode_byte;
+    }
+}
+
+// if encode ratio < EncodeRatioLimit, encode it, otherwise not.
+void EncodeContext::_adjust(const int col_id) {
+    auto old_level = _column_encode_level[col_id];
+    if (_encoded_bytes[col_id] < _raw_bytes[col_id] * EncodeRatioLimit) {
+        _column_encode_level[col_id] = _session_encode_level;
+    } else {
+        _column_encode_level[col_id] = 0;
+    }
+    if (old_level != _column_encode_level[col_id] || _session_encode_level < -1) {
+        VLOG_ROW << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
+                 << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
+                 << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
+                 << " higher than limit " << EncodeRatioLimit;
+    }
+    _encoded_bytes[col_id] = 0;
+    _raw_bytes[col_id] = 0;
+}
+
+void EncodeContext::set_encode_levels_in_pb(ChunkPB* const res) {
+    res->mutable_encode_level()->Reserve(static_cast<int>(_column_encode_level.size()));
+    for (const auto& level : _column_encode_level) {
+        res->mutable_encode_level()->Add(level);
+    }
+    adjust_encode_levels();
+}
+
+void EncodeContext::adjust_encode_levels() {
+    ++_times;
+    // must adjust after writing the current encode_level
+    if (_enable_adjust && (_times % _frequency == EncodeSamplingNum)) {
+        for (auto col_id = 0; col_id < _column_encode_level.size(); ++col_id) {
+            _adjust(col_id);
+        }
+        _frequency = _frequency > 1000000000 ? _frequency : _frequency * 2;
+    }
+}
+} // namespace starrocks::serde

--- a/be/src/serde/encode_context.h
+++ b/be/src/serde/encode_context.h
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <streamvbyte.h>
+
+#include <string_view>
+#include <vector>
+
+#include "column/chunk.h"
+#include "column/chunk_extra_data.h"
+#include "common/statusor.h"
+
+namespace starrocks {
+class ChunkPB;
+}
+namespace starrocks::serde {
+constexpr double EncodeRatioLimit = 0.9;
+constexpr uint32_t EncodeSamplingNum = 5;
+
+// EncodeContext adaptively adjusts encode_level according to the compression ratio. In detail,
+// for every _frequency chunks, if the compression ratio for the first EncodeSamplingNum chunks is less than
+// EncodeRatioLimit, then encode the rest chunks, otherwise not.
+
+class EncodeContext {
+public:
+    static std::shared_ptr<EncodeContext> get_encode_context_shared_ptr(const int col_num, const int encode_level) {
+        return encode_level == 0 ? nullptr : std::make_shared<EncodeContext>(col_num, encode_level);
+    }
+    EncodeContext(const int col_num, const int encode_level);
+    // update encode_level for each column
+    void update(const int col_id, uint64_t mem_bytes, uint64_t encode_byte);
+
+    int get_encode_level(const int col_id) {
+        DCHECK(_session_encode_level != 0);
+        return _column_encode_level[col_id];
+    }
+
+    const std::vector<uint32_t>& get_encode_levels() const {
+        DCHECK(_session_encode_level != 0);
+        return _column_encode_level;
+    }
+
+    int get_session_encode_level() {
+        DCHECK(_session_encode_level != 0);
+        return _session_encode_level;
+    }
+
+    void set_encode_levels_in_pb(ChunkPB* const res);
+
+    // adjust encode levels for each column,
+    // it must be called once after each chunk is encoded
+    void adjust_encode_levels();
+
+    static constexpr uint16_t STREAMVBYTE_PADDING_SIZE = STREAMVBYTE_PADDING;
+
+    static bool enable_encode_integer(const int encode_level) { return encode_level & ENCODE_INTEGER; }
+
+    static bool enable_encode_string(const int encode_level) { return encode_level & ENCODE_STRING; }
+
+private:
+    static constexpr int ENCODE_INTEGER = 2;
+    static constexpr int ENCODE_STRING = 4;
+
+    // if encode ratio < EncodeRatioLimit, encode it, otherwise not.
+    void _adjust(const int col_id);
+    const int _session_encode_level;
+    uint64_t _times = 0;
+    uint64_t _frequency = 64;
+    bool _enable_adjust = false;
+    std::vector<uint64_t> _raw_bytes, _encoded_bytes;
+    std::vector<uint32_t> _column_encode_level;
+};
+} // namespace starrocks::serde

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -28,64 +28,6 @@
 
 namespace starrocks::serde {
 
-EncodeContext::EncodeContext(const int col_num, const int encode_level) : _session_encode_level(encode_level) {
-    for (auto i = 0; i < col_num; ++i) {
-        _column_encode_level.emplace_back(_session_encode_level);
-        _raw_bytes.emplace_back(0);
-        _encoded_bytes.emplace_back(0);
-    }
-    DCHECK(_session_encode_level != 0);
-    // the lowest bit is set and other bits are not zero, then enable adjust.
-    if (_session_encode_level & 1 && (_session_encode_level >> 1)) {
-        _enable_adjust = true;
-    }
-}
-
-void EncodeContext::update(const int col_id, uint64_t mem_bytes, uint64_t encode_byte) {
-    DCHECK(_session_encode_level != 0);
-    if (!_enable_adjust) {
-        return;
-    }
-    // decide to encode or not by the encoding ratio of the first EncodeSamplingNum of every _frequency chunks
-    if (_times % _frequency < EncodeSamplingNum) {
-        _raw_bytes[col_id] += mem_bytes;
-        _encoded_bytes[col_id] += encode_byte;
-    }
-}
-
-// if encode ratio < EncodeRatioLimit, encode it, otherwise not.
-void EncodeContext::_adjust(const int col_id) {
-    auto old_level = _column_encode_level[col_id];
-    if (_encoded_bytes[col_id] < _raw_bytes[col_id] * EncodeRatioLimit) {
-        _column_encode_level[col_id] = _session_encode_level;
-    } else {
-        _column_encode_level[col_id] = 0;
-    }
-    if (old_level != _column_encode_level[col_id] || _session_encode_level < -1) {
-        VLOG_ROW << "Old encode level " << old_level << " is changed to " << _column_encode_level[col_id]
-                 << " because the first " << EncodeSamplingNum << " of " << _frequency << " in total " << _times
-                 << " chunks' compression ratio is " << _encoded_bytes[col_id] * 1.0 / _raw_bytes[col_id]
-                 << " higher than limit " << EncodeRatioLimit;
-    }
-    _encoded_bytes[col_id] = 0;
-    _raw_bytes[col_id] = 0;
-}
-
-void EncodeContext::set_encode_levels_in_pb(ChunkPB* const res) {
-    res->mutable_encode_level()->Reserve(static_cast<int>(_column_encode_level.size()));
-    for (const auto& level : _column_encode_level) {
-        res->mutable_encode_level()->Add(level);
-    }
-    ++_times;
-    // must adjust after writing the current encode_level
-    if (_enable_adjust && (_times % _frequency == EncodeSamplingNum)) {
-        for (auto col_id = 0; col_id < _column_encode_level.size(); ++col_id) {
-            _adjust(col_id);
-        }
-        _frequency = _frequency > 1000000000 ? _frequency : _frequency * 2;
-    }
-}
-
 int64_t ProtobufChunkSerde::max_serialized_size(const Chunk& chunk, const std::shared_ptr<EncodeContext>& context) {
     int64_t serialized_size = 8; // 4 bytes version plus 4 bytes row number
 

--- a/be/src/serde/protobuf_serde.h
+++ b/be/src/serde/protobuf_serde.h
@@ -23,59 +23,13 @@
 #include "column/chunk_extra_data.h"
 #include "common/statusor.h"
 #include "gen_cpp/data.pb.h" // ChunkPB
+#include "serde/encode_context.h"
 
 namespace starrocks {
 class RowDescriptor;
 }
 
 namespace starrocks::serde {
-constexpr double EncodeRatioLimit = 0.9;
-constexpr uint32_t EncodeSamplingNum = 5;
-
-// EncodeContext adaptively adjusts encode_level according to the compression ratio. In detail,
-// for every _frequency chunks, if the compression ratio for the first EncodeSamplingNum chunks is less than
-// EncodeRatioLimit, then encode the rest chunks, otherwise not.
-
-class EncodeContext {
-public:
-    static std::shared_ptr<EncodeContext> get_encode_context_shared_ptr(const int col_num, const int encode_level) {
-        return encode_level == 0 ? nullptr : std::make_shared<EncodeContext>(col_num, encode_level);
-    }
-    EncodeContext(const int col_num, const int encode_level);
-    // update encode_level for each column
-    void update(const int col_id, uint64_t mem_bytes, uint64_t encode_byte);
-
-    int get_encode_level(const int col_id) {
-        DCHECK(_session_encode_level != 0);
-        return _column_encode_level[col_id];
-    }
-
-    int get_session_encode_level() {
-        DCHECK(_session_encode_level != 0);
-        return _session_encode_level;
-    }
-
-    void set_encode_levels_in_pb(ChunkPB* const res);
-
-    static constexpr uint16_t STREAMVBYTE_PADDING_SIZE = STREAMVBYTE_PADDING;
-
-    static bool enable_encode_integer(const int encode_level) { return encode_level & ENCODE_INTEGER; }
-
-    static bool enable_encode_string(const int encode_level) { return encode_level & ENCODE_STRING; }
-
-private:
-    static constexpr int ENCODE_INTEGER = 2;
-    static constexpr int ENCODE_STRING = 4;
-
-    // if encode ratio < EncodeRatioLimit, encode it, otherwise not.
-    void _adjust(const int col_id);
-    const int _session_encode_level;
-    uint64_t _times = 0;
-    uint64_t _frequency = 64;
-    bool _enable_adjust = false;
-    std::vector<uint64_t> _raw_bytes, _encoded_bytes;
-    std::vector<uint32_t> _column_encode_level;
-};
 
 class ProtobufChunkDeserializer;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -379,6 +379,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String SPILL_MEM_LIMIT_THRESHOLD = "spill_mem_limit_threshold";
     public static final String SPILL_OPERATOR_MIN_BYTES = "spill_operator_min_bytes";
     public static final String SPILL_OPERATOR_MAX_BYTES = "spill_operator_max_bytes";
+    public static final String SPILL_ENCODE_LEVEL = "spill_encode_level";
 
     // full_sort_max_buffered_{rows,bytes} are thresholds that limits input size of partial_sort
     // in full sort.
@@ -689,6 +690,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long spillOperatorMinBytes = 1024L * 1024 * 10;
     @VarAttr(name = SPILL_OPERATOR_MAX_BYTES, flag = VariableMgr.INVISIBLE)
     private long spillOperatorMaxBytes = 1024L * 1024 * 1000;
+    @VarAttr(name = SPILL_ENCODE_LEVEL)
+    private int spillEncodeLevel = 7;
 
     @VariableMgr.VarAttr(name = FORWARD_TO_LEADER, alias = FORWARD_TO_MASTER)
     private boolean forwardToLeader = false;
@@ -1308,6 +1311,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getSpillOperatorMaxBytes() {
         return this.spillOperatorMaxBytes;
+    }
+
+    public int getSpillEncodeLevel() {
+        return this.spillEncodeLevel;
     }
 
     public boolean getForwardToLeader() {
@@ -2000,6 +2007,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             tResult.setSpill_mem_limit_threshold(spillMemLimitThreshold);
             tResult.setSpill_operator_min_bytes(spillOperatorMinBytes);
             tResult.setSpill_operator_max_bytes(spillOperatorMaxBytes);
+            tResult.setSpill_encode_level(spillEncodeLevel);
         }
 
         // Compression Type

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -690,6 +690,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long spillOperatorMinBytes = 1024L * 1024 * 10;
     @VarAttr(name = SPILL_OPERATOR_MAX_BYTES, flag = VariableMgr.INVISIBLE)
     private long spillOperatorMaxBytes = 1024L * 1024 * 1000;
+    // the encoding level of spilled data, the meaning of values is similar to transmission_encode_level,
+    // see more details in the comment above transmissionEncodeLevel
     @VarAttr(name = SPILL_ENCODE_LEVEL)
     private int spillEncodeLevel = 7;
 
@@ -780,6 +782,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = RPC_HTTP_MIN_SIZE, flag = VariableMgr.INVISIBLE)
     private long rpcHttpMinSize = ((1L << 31) - (1L << 10));
 
+    // encode integers/binary per column for exchange, controlled by transmission_encode_level
+    // if transmission_encode_level & 2, intergers are encode by streamvbyte, in order or not;
+    // if transmission_encode_level & 4, binary columns are compressed by lz4
+    // if transmission_encode_level & 1, enable adaptive encoding.
+    // e.g.
+    // if transmission_encode_level = 7, SR will adaptively encode numbers and string columns according to the proper encoding ratio(< 0.9);
+    // if transmission_encode_level = 6, SR will force encoding numbers and string columns.
+    // in short,
+    // for transmission_encode_level,
+    // 2 for encoding integers or types supported by integers,
+    // 4 for encoding string,
+    // json and object columns are left to be supported later.
     @VariableMgr.VarAttr(name = TRANSMISSION_ENCODE_LEVEL)
     private int transmissionEncodeLevel = 7;
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -183,6 +183,8 @@ struct TQueryOptions {
   75: optional double spill_mem_limit_threshold;
   76: optional i64 spill_operator_min_bytes;
   77: optional i64 spill_operator_max_bytes;
+  78: optional i32 spill_encode_level;
+
   85: optional TSpillMode spill_mode;
   
   86: optional i32 io_tasks_per_scan_operator = 4;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Major changes:
1. using the same encoding method as Exchange in query spilling and make the encode level configurable.
2. because EncodeContext can be used in multiple places, separate it from protobuf_serde.h and protobuf_serde.cpp

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
