### PR TITLE
[BugFix] replicate_channel cancel method is not thread safe for fast cancel

### DIFF
--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -220,9 +220,6 @@ Status ReplicateToken::submit(std::unique_ptr<SegmentPB> segment, bool eos) {
 }
 
 void ReplicateToken::cancel(const Status& st) {
-    for (auto& channel : _replicate_channels) {
-        channel->cancel();
-    }
     set_status(st);
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
ReplicateChannel cancel method is not thread safe, can not used by fast cancel.
First delete the relevant code to confirm whether the crash comes from this, and then consider the implementation of thread safe method.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
