### PR TITLE
[Enhancement] Simplify case-when to leverage predicates push-down to storage engine

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -39,6 +39,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.scalar.InvertedCaseWhen;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -514,6 +515,10 @@ public class Utils {
             return null;
         }
         return predicates;
+    }
+
+    public static ScalarOperator pruneTediousPredicate(ScalarOperator predicate) {
+        return InvertedCaseWhen.pruneTedisConjuncts(predicate);
     }
 
     public static <T extends ScalarOperator> List<T> collect(ScalarOperator root, Class<T> clazz) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -39,7 +39,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.scalar.InvertedCaseWhen;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -515,10 +514,6 @@ public class Utils {
             return null;
         }
         return predicates;
-    }
-
-    public static ScalarOperator pruneTediousPredicate(ScalarOperator predicate) {
-        return InvertedCaseWhen.pruneTedisConjuncts(predicate);
     }
 
     public static <T extends ScalarOperator> List<T> collect(ScalarOperator root, Class<T> clazz) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -70,6 +70,7 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
     private static final LocalDateTime MAX_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
     private static final LocalDateTime MIN_DATETIME = LocalDateTime.of(0, 1, 1, 0, 0, 0);
 
+    public static final ConstantOperator NULL = ConstantOperator.createNull(Type.BOOLEAN);
     public static final ConstantOperator TRUE = ConstantOperator.createBoolean(true);
     public static final ConstantOperator FALSE = ConstantOperator.createBoolean(false);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -149,6 +149,15 @@ public abstract class ScalarOperator implements Cloneable {
         return this instanceof ConstantOperator && ((ConstantOperator) this).isZero();
     }
 
+    public boolean isConstantFalse() {
+        return this instanceof ConstantOperator && this.getType() == Type.BOOLEAN &&
+                !((ConstantOperator) this).getBoolean();
+    }
+
+    public boolean isConstantNullOrFalse() {
+        return isConstantNull() || isConstantFalse();
+    }
+
     public void setHints(List<String> hints) {
         this.hints = hints;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -114,6 +114,8 @@ public class ScalarOperatorRewriter {
                 changeNums = context.changeNum();
                 result = applyRuleTopDown(result, rule);
             } while (changeNums != context.changeNum());
+        } else if (rule.isOnlyOnce()) {
+            result = applyRuleOnlyOnce(result, rule);
         }
 
         return result;
@@ -129,6 +131,10 @@ public class ScalarOperatorRewriter {
             context.change();
         }
         return op;
+    }
+
+    private ScalarOperator applyRuleOnlyOnce(ScalarOperator operator, ScalarOperatorRewriteRule rule) {
+        return rule.apply(operator, context);
     }
 
     private ScalarOperator applyRuleTopDown(ScalarOperator operator, ScalarOperatorRewriteRule rule) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/BaseScalarOperatorRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/BaseScalarOperatorRewriteRule.java
@@ -32,6 +32,11 @@ public class BaseScalarOperatorRewriteRule extends ScalarOperatorVisitor<ScalarO
     }
 
     @Override
+    public boolean isOnlyOnce() {
+        return false;
+    }
+
+    @Override
     public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
         return root.accept(this, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/InvertedCaseWhen.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/InvertedCaseWhen.java
@@ -304,15 +304,15 @@ public class InvertedCaseWhen {
             if (!inSet.stream().allMatch(ScalarOperator::isConstantRef)) {
                 return Optional.empty();
             }
+            Optional<InvertedCaseWhen> maybeInvertedCaseWhen = from(predicate.getChild(0));
+            if (!maybeInvertedCaseWhen.isPresent()) {
+                return Optional.empty();
+            }
             // case when ... in (NULL, NULL) is equivalent to NULL
             // case when ... in (NULL, c1) is equivalent to case when ... in (c1)
             inSet.removeIf(ScalarOperator::isConstantNull);
             if (inSet.isEmpty()) {
                 return Optional.of(ConstantOperator.NULL);
-            }
-            Optional<InvertedCaseWhen> maybeInvertedCaseWhen = from(predicate.getChild(0));
-            if (!maybeInvertedCaseWhen.isPresent()) {
-                return Optional.empty();
             }
             InvertedCaseWhen invertedCaseWhen = maybeInvertedCaseWhen.get();
             boolean isNotIn = predicate.isNotIn();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/InvertedCaseWhen.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/InvertedCaseWhen.java
@@ -1,0 +1,477 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class InvertedCaseWhen {
+    private final CaseWhenOperator caseWhen;
+
+    private static class WhenAndOrdinal {
+
+        private final int ordinal;
+        private final ScalarOperator when;
+
+        public WhenAndOrdinal(int ordinal, ScalarOperator when) {
+            this.ordinal = ordinal;
+            this.when = when;
+        }
+
+        public int getOrdinal() {
+            return ordinal;
+        }
+
+        public ScalarOperator getWhen() {
+            return when;
+        }
+    }
+
+    private final Map<ConstantOperator, WhenAndOrdinal> thenMap;
+
+    private static final ConstantOperator CONST_NULL = ConstantOperator.createNull(Type.BOOLEAN);
+    private static final ConstantOperator CONST_TRUE = ConstantOperator.createBoolean(true);
+    private static final ConstantOperator CONST_FALSE = ConstantOperator.createBoolean(false);
+
+    private InvertedCaseWhen(CaseWhenOperator caseWhen, Map<ConstantOperator, ScalarOperator> thenToWhen,
+                             Map<ConstantOperator, Integer> thenToOrdinal) {
+        this.caseWhen = caseWhen;
+        Preconditions.checkArgument(thenToWhen.size() == thenToOrdinal.size());
+        this.thenMap = Maps.newHashMap();
+        thenToOrdinal.forEach((k, v) -> {
+            this.thenMap.put(k, new WhenAndOrdinal(v, thenToWhen.get(k)));
+        });
+    }
+
+    private Optional<ScalarOperator> nullToWhen() {
+        return Optional.ofNullable(this.thenMap.get(CONST_NULL)).map(WhenAndOrdinal::getWhen);
+    }
+
+    // 1. op = { OR(pi)| pi belongs to selected whens} => op OR if(nullWhen, NULL, FALSE)
+    // 2. op = { AND(NOT(pi)| pi belongs to unselected whens} => op AND if(nullWhen, NULL, TRUE)
+    // form 2 can not be reduced, so we do not generate from2, so if case-when has null-value
+    // branches, we do not use unselected whens.
+    private Optional<ScalarOperator> handleNull(ScalarOperator op) {
+        Optional<ScalarOperator> nullWhen = nullToWhen();
+        if (nullWhen.isPresent()) {
+            if (op == CONST_TRUE) {
+                // Theoretical, here should return if(nullWhen, NULL, true), but it is too complex
+                // and can not be pushed down, so do not rewrite the case-when.
+                return Optional.empty();
+            }
+            return Optional.of(Utils.compoundOr(op, ifThenNullOrFalse(nullWhen.get())));
+        } else {
+            // should not generate NULL result
+            // 1. op is Constant, it never generates NULL
+            if (op.isConstantRef()) {
+                return Optional.of(op);
+            }
+            // 2. otherwise, build a new predicate: op AND (op IS NOT NULL)
+            ScalarOperator isNotNull = new IsNullPredicateOperator(true,
+                    caseWhen.hasCase() ? caseWhen.getCaseClause() : op);
+            return Optional.of(Utils.compoundAnd(op, isNotNull));
+        }
+    }
+
+    public static ScalarOperator in(boolean isNotIn, ScalarOperator lhs, List<ScalarOperator> values) {
+        Preconditions.checkArgument(!values.isEmpty());
+        List<ScalarOperator> args = Lists.newArrayList(lhs);
+        args.addAll(values);
+        return new InPredicateOperator(isNotIn, args);
+    }
+
+    public static ScalarOperator in(ScalarOperator lhs, List<ScalarOperator> values) {
+        return in(false, lhs, values);
+    }
+
+    public static ScalarOperator notIn(ScalarOperator lhs, List<ScalarOperator> values) {
+        return in(true, lhs, values);
+    }
+
+    private static class InvertCaseWhenVisitor extends ScalarOperatorVisitor<Optional<InvertedCaseWhen>, Void> {
+        @Override
+        public Optional<InvertedCaseWhen> visit(ScalarOperator scalarOperator, Void context) {
+            return Optional.empty();
+        }
+
+        private Optional<InvertedCaseWhen> handleCaseWhenWithCaseAndConstantWhens(CaseWhenOperator operator) {
+
+            ScalarOperator lhs = operator.getCaseClause();
+            Set<ConstantOperator> uniqueWhens = Sets.newHashSet();
+            Map<ConstantOperator, List<ScalarOperator>> thenToWhenValues = Maps.newHashMap();
+            Map<ConstantOperator, Integer> thenToOrdinal = Maps.newHashMap();
+            for (int i = 0; i < operator.getWhenClauseSize(); ++i) {
+                ConstantOperator then = operator.getThenClause(i).cast();
+                ConstantOperator when = operator.getWhenClause(i).cast();
+                // if when value is NULL or duplicate of preceding when value, it never matches case clause,
+                // so skip it
+                if (when.isConstantNull() || uniqueWhens.contains(when)) {
+                    continue;
+                }
+                if (then.isConstantNull()) {
+                    then = CONST_NULL;
+                }
+                uniqueWhens.add(when);
+                thenToWhenValues.computeIfAbsent(then, (k) -> Lists.newArrayList()).add(when);
+                thenToOrdinal.merge(then, i, Math::max);
+            }
+            Map<ConstantOperator, ScalarOperator> thenToWhen = Maps.newHashMap();
+            thenToWhenValues.forEach((k, v) -> thenToWhen.put(k, in(lhs, v)));
+
+            List<ScalarOperator> allValues = thenToWhenValues.values().stream().flatMap(Collection::stream).collect(
+                    Collectors.toList());
+            // if allValues is empty, the elsePredicate is true constant, for an example
+            // select (case a when NULL then 1 else 2 end) = 2 from t;
+            ScalarOperator elsePredicate = allValues.isEmpty() ? CONST_TRUE : notIn(lhs, allValues);
+
+            elsePredicate = CompoundPredicateOperator.or(elsePredicate, new IsNullPredicateOperator(lhs));
+
+            ConstantOperator alt = (operator.hasElse() && !operator.getElseClause().isConstantNull()) ?
+                    operator.getElseClause().cast() :
+                    CONST_NULL;
+            thenToWhen.put(alt,
+                    CompoundPredicateOperator.or(thenToWhen.getOrDefault(alt, CONST_FALSE), elsePredicate));
+            thenToOrdinal.merge(alt, operator.getWhenClauseSize(), Math::max);
+            return Optional.of(new InvertedCaseWhen(operator, thenToWhen, thenToOrdinal));
+        }
+
+        Optional<InvertedCaseWhen> handleCaseWhen(CaseWhenOperator operator) {
+            List<ScalarOperator> whenClauses = operator.getAllConditionClause();
+            // If case-when has case clause, the first element of whenClauses is case clause, so
+            // remove it, and convert remaining whenClauses into eq predicates.
+            if (operator.hasCase()) {
+                ScalarOperator lhs = operator.getCaseClause();
+                whenClauses = whenClauses.stream().skip(1).map(v -> BinaryPredicateOperator.eq(lhs, v))
+                        .collect(Collectors.toList());
+            }
+            List<ScalarOperator> notWhens =
+                    whenClauses.stream().map(CompoundPredicateOperator::not).collect(Collectors.toList());
+
+            for (int i = 1; i < whenClauses.size(); ++i) {
+                whenClauses.set(i, CompoundPredicateOperator.and(whenClauses.get(i),
+                        CompoundPredicateOperator.and(notWhens.subList(0, i))));
+            }
+            // else predicates means that any when clauses are not matched, for an example:
+            // case c when c1 then v1 when c2 then v2 when c3 then v3 else c4 end
+            // else predicate is (c <> c1 and c <> c2 and c <> c3 and c <> c4) or
+            // (c <> c1 and c <> c2 and c <> c3 and c <> c4) is NULL
+            ScalarOperator elsePredicate = CompoundPredicateOperator.and(notWhens);
+            elsePredicate =
+                    CompoundPredicateOperator.or(elsePredicate, new IsNullPredicateOperator(elsePredicate));
+            whenClauses.add(elsePredicate);
+
+            // if case-when has no else clause, append const null to thenClauses.
+            List<ScalarOperator> thenClauses = operator.getAllValuesClause();
+            if (!operator.hasElse()) {
+                thenClauses.add(CONST_NULL);
+            }
+
+            Preconditions.checkArgument(whenClauses.size() == thenClauses.size());
+            Map<ConstantOperator, List<ScalarOperator>> thenToWhenValues = Maps.newHashMap();
+            Map<ConstantOperator, Integer> thenToOrdinal = Maps.newHashMap();
+            for (int i = 0; i < thenClauses.size(); ++i) {
+                ConstantOperator then = thenClauses.get(i).cast();
+                // NULL is apt to bug, so here use a constNull
+                if (then.isConstantNull()) {
+                    then = CONST_NULL;
+                }
+                ScalarOperator when = whenClauses.get(i);
+                thenToWhenValues.computeIfAbsent(then, (k) -> Lists.newArrayList()).add(when);
+                thenToOrdinal.merge(then, i, Math::max);
+            }
+            Map<ConstantOperator, ScalarOperator> thenToWhen = Maps.newHashMap();
+            thenToWhenValues.forEach(
+                    (then, when) -> thenToWhen.put(then.cast(), CompoundPredicateOperator.or(when)));
+            return Optional.of(new InvertedCaseWhen(operator, thenToWhen, thenToOrdinal));
+        }
+
+        @Override
+        public Optional<InvertedCaseWhen> visitCaseWhenOperator(CaseWhenOperator operator, Void context) {
+            if (!operator.getAllValuesClause().stream().allMatch(ScalarOperator::isConstantRef)) {
+                return visit(operator, context);
+            }
+            if (operator.hasCase() &&
+                    operator.getAllConditionClause().stream().skip(1).allMatch(ScalarOperator::isConstantRef)) {
+                return handleCaseWhenWithCaseAndConstantWhens(operator);
+            } else {
+                return handleCaseWhen(operator);
+            }
+        }
+
+        @Override
+        public Optional<InvertedCaseWhen> visitCall(CallOperator call, Void context) {
+            String fnName = call.getFnName();
+            if (fnName.equalsIgnoreCase(FunctionSet.IF)) {
+                ScalarOperator cond = call.getChild(0);
+                ScalarOperator then = call.getChild(1);
+                ScalarOperator alt = call.getChild(2);
+                if (!then.isConstantRef() || !alt.isConstantRef()) {
+                    return visit(call, context);
+                }
+                CaseWhenOperator caseWhen =
+                        new CaseWhenOperator(call.getType(), null, alt, Lists.newArrayList(cond, then));
+                return caseWhen.accept(this, context);
+            } else if (fnName.equalsIgnoreCase(FunctionSet.NULLIF)) {
+                ScalarOperator child0 = call.getChild(0);
+                ScalarOperator child1 = call.getChild(1);
+                if (!child0.isConstantRef()) {
+                    return visit(call, context);
+                }
+                CaseWhenOperator caseWhen =
+                        new CaseWhenOperator(call.getType(), null, child0,
+                                Lists.newArrayList(BinaryPredicateOperator.eq(child1, child0),
+                                        ConstantOperator.createNull(call.getType())));
+                return caseWhen.accept(this, context);
+            }
+            return visit(call, context);
+        }
+    }
+
+    private static Optional<ScalarOperator> or(List<ScalarOperator> args) {
+        if (args.isEmpty()) {
+            return Optional.empty();
+        } else if (args.size() == 1) {
+            return Optional.of(args.get(0));
+        } else {
+            return Optional.of(CompoundPredicateOperator.or(args));
+        }
+    }
+
+    private static final InvertCaseWhenVisitor INVERT_CASE_WHEN_VISITOR = new InvertCaseWhenVisitor();
+
+    public static Optional<InvertedCaseWhen> from(ScalarOperator op) {
+        return op.accept(INVERT_CASE_WHEN_VISITOR, null);
+    }
+
+    private static ScalarOperator ifThenNullOrFalse(ScalarOperator p) {
+        Function ifFunc = Expr.getBuiltinFunction(FunctionSet.IF, new Type[] {Type.BOOLEAN, Type.BOOLEAN, Type.BOOLEAN},
+                Function.CompareMode.IS_IDENTICAL);
+        Preconditions.checkArgument(ifFunc != null);
+        return new CallOperator(FunctionSet.IF, Type.BOOLEAN, Lists.newArrayList(p, CONST_NULL, CONST_FALSE), ifFunc);
+    }
+
+    private static class SimplifyVisitor extends ScalarOperatorVisitor<Optional<ScalarOperator>, Void> {
+
+        @Override
+        public Optional<ScalarOperator> visit(ScalarOperator scalarOperator, Void context) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<ScalarOperator> visitInPredicate(InPredicateOperator predicate, Void context) {
+            if (predicate.getChildren().stream().skip(1)
+                    .allMatch(child -> !child.isConstantRef() || child.isConstantNull())) {
+                return Optional.empty();
+            }
+            Optional<InvertedCaseWhen> maybeInvertedCaseWhen = from(predicate.getChild(0));
+            if (!maybeInvertedCaseWhen.isPresent()) {
+                return Optional.empty();
+            }
+            InvertedCaseWhen invertedCaseWhen = maybeInvertedCaseWhen.get();
+            Set<ScalarOperator> inSet = predicate.getChildren().stream().skip(1).collect(Collectors.toSet());
+            boolean isNotIn = predicate.isNotIn();
+            Map<ScalarOperator, WhenAndOrdinal> selected = Maps.newHashMap();
+            Map<ScalarOperator, WhenAndOrdinal> unSelected = Maps.newHashMap();
+            invertedCaseWhen.thenMap.entrySet().forEach(e -> {
+                if (!e.getKey().isConstantNull()) {
+                    if (inSet.contains(e.getKey()) ^ isNotIn) {
+                        selected.put(e.getKey(), e.getValue());
+                    } else {
+                        unSelected.put(e.getKey(), e.getValue());
+                    }
+                }
+            });
+            Optional<ScalarOperator> nullWhen = invertedCaseWhen.nullToWhen();
+            if (selected.isEmpty()) {
+                return invertedCaseWhen.handleNull(CONST_FALSE);
+            } else if (unSelected.isEmpty() && !nullWhen.isPresent()) {
+                return Optional.of(CONST_TRUE);
+            }
+            // case-when with case clause can be decomposed into several simple non-overlapping branches,
+            // in practice it is apt to yields simple and efficient simplified predicates.
+            Optional<ScalarOperator> result = Optional.empty();
+            if (invertedCaseWhen.caseWhen.hasCase()) {
+                if (nullWhen.isPresent() || (selected.size() <= unSelected.size())) {
+                    List<ScalarOperator> orArgs = selected.values().stream().map(WhenAndOrdinal::getWhen).collect(
+                            Collectors.toList());
+                    result = or(orArgs);
+                } else {
+                    List<ScalarOperator> orArgs = unSelected.values().stream().map(WhenAndOrdinal::getWhen).collect(
+                            Collectors.toList());
+                    result = or(orArgs).map(CompoundPredicateOperator::not);
+                }
+            } else {
+                // case-when without case clause is apt to yields very complex simplified result, in particular,
+                // when values in in-filter hit then-clauses ranked backward. however, when we build the simplified
+                // predicate, we have two ways:
+                // 1. choose the hit when-clauses: p1,p2,...,pn, then use OR to join them, the result is
+                //  p1 OR p2 OR ... OR pn
+                // 2. choose the missed when-clauses: p1,p2,...,pn, at first use OR to join them, then negate it,
+                //  the result is NOT(p1 OR p2 OR ... OR pn)
+                // for case when q1 then c1 when q2 then c2 ... else pn end, when it converted into InvertedCaseWhen
+                //  thenToWhen records (c1->p1, c2->p2, ..., pn)(lisp style), pi satisfies:
+                //  1. p1 = q1;
+                //  2. pn = ((NOT q1) AND (NOT q2) AND ... AND (NOT qn_1)) OR (q1 AND q2 AND ... AND qn_1) is NULL;
+                //  3. pi = (NOT q1) AND ... AND (NOT qi_1) AND qi.  i < i < n
+                // Because the greater the ordinal of pi is, the more inefficient simplified result is, so when adopt
+                // policy: choose between hit when-clauses and missed when-clauses, who owns the minimum maximum
+                // ordinal wins, if the winner's maximum ordinal is greater than 1, simplification is forbidden.
+                int selectedMaxOrdinal = selected.values().stream()
+                        .map(WhenAndOrdinal::getOrdinal).max(Comparator.comparingInt(v -> v)).orElse(0);
+                int unSelectedMaxOrdinal = unSelected.values().stream()
+                        .map(WhenAndOrdinal::getOrdinal).max(Comparator.comparingInt(v -> v)).orElse(0);
+                if (selectedMaxOrdinal > 1 && unSelectedMaxOrdinal > 1) {
+                    return Optional.empty();
+                }
+                if (selectedMaxOrdinal <= unSelectedMaxOrdinal) {
+                    List<ScalarOperator> orArgs = selected.values().stream().map(WhenAndOrdinal::getWhen).collect(
+                            Collectors.toList());
+                    result = or(orArgs);
+                } else if (!nullWhen.isPresent()) {
+                    List<ScalarOperator> orArgs = unSelected.values().stream().map(WhenAndOrdinal::getWhen).collect(
+                            Collectors.toList());
+                    result = or(orArgs).map(CompoundPredicateOperator::not);
+                } else {
+                    return Optional.empty();
+                }
+            }
+            return result.map(invertedCaseWhen::handleNull).orElse(Optional.empty());
+        }
+
+        @Override
+        public Optional<ScalarOperator> visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
+            BinaryPredicateOperator.BinaryType binaryType = predicate.getBinaryType();
+            if (!binaryType.isEqual() && !binaryType.isNotEqual()) {
+                return Optional.empty();
+            }
+            return in(binaryType.isNotEqual(),
+                    predicate.getChild(0),
+                    Lists.newArrayList(predicate.getChild(1))).accept(this, context);
+        }
+
+        @Override
+        public Optional<ScalarOperator> visitIsNullPredicate(IsNullPredicateOperator predicate, Void context) {
+            Optional<InvertedCaseWhen> maybeInvertedCaseWhen = from(predicate.getChild(0));
+            if (!maybeInvertedCaseWhen.isPresent()) {
+                return Optional.empty();
+            }
+            InvertedCaseWhen invertedCaseWhen = maybeInvertedCaseWhen.get();
+            if (predicate.isNotNull()) {
+                return Optional.of(
+                        invertedCaseWhen.nullToWhen().map(CompoundPredicateOperator::not).orElse(CONST_TRUE));
+            } else {
+                return Optional.of(invertedCaseWhen.nullToWhen().orElse(CONST_FALSE));
+            }
+        }
+    }
+
+    private static final SimplifyVisitor SIMPLIFY_VISITOR = new SimplifyVisitor();
+
+    // Prune tedious predicates introduced by case-when simplification, the tedious predicates are in two forms
+    // as follows:
+    // 1. p OR if(q, NULL, FALSE) => p
+    // 2. p AND p is NOT NULL => p
+    // NOTICE!!! this pruning operations can only be applied to predicates in top-down style, it can not be applied
+    // common expressions, for examples:
+    // 1. select p or if (q, NULL, FALSE) from t;
+    // 2. select * from t where (p and p is NOT NULL) is NULL;
+    private static class TediousPredicatePruner extends ScalarOperatorVisitor<Optional<ScalarOperator>, Void> {
+
+        @Override
+        public Optional<ScalarOperator> visit(ScalarOperator scalarOperator, Void context) {
+            return Optional.empty();
+        }
+
+        public static boolean outputOnlyNullOrFalse(ScalarOperator p) {
+            if (!(p instanceof CallOperator)) {
+                return false;
+            }
+            CallOperator call = (CallOperator) p;
+            if (!call.getFnName().equalsIgnoreCase(FunctionSet.IF)) {
+                return false;
+            }
+            return call.getChildren().stream().skip(1).allMatch(ScalarOperator::isConstantNullOrFalse);
+        }
+
+        @Override
+        public Optional<ScalarOperator> visitCall(CallOperator call, Void context) {
+            if (outputOnlyNullOrFalse(call)) {
+                return Optional.of(CONST_FALSE);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        @Override
+        public Optional<ScalarOperator> visitCompoundPredicate(CompoundPredicateOperator predicate, Void context) {
+            if (predicate.isAnd()) {
+                List<ScalarOperator> conjuncts = predicate.getChildren();
+                if (conjuncts.stream().anyMatch(TediousPredicatePruner::outputOnlyNullOrFalse)) {
+                    return Optional.of(CONST_FALSE);
+                }
+                return Optional.of(Utils.compoundAnd(conjuncts));
+            } else if (predicate.isOr()) {
+                List<ScalarOperator> disjuncts = predicate.getChildren().stream()
+                        .filter(p -> !outputOnlyNullOrFalse(p)).collect(Collectors.toList());
+                if (disjuncts.isEmpty()) {
+                    return Optional.of(CONST_FALSE);
+                } else if (disjuncts.size() > 1) {
+                    return Optional.of(Utils.compoundOr(disjuncts));
+                } else {
+                    List<ScalarOperator> conjuncts = Utils.extractConjuncts(disjuncts.get(0)).stream()
+                            .map(p -> p.accept(this, context).orElse(p)).collect(Collectors.toList());
+                    return Optional.of(Utils.compoundAnd(conjuncts));
+                }
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    public static ScalarOperator pruneTedisConjuncts(ScalarOperator p) {
+        if (p == null) {
+            return p;
+        }
+        return Utils.compoundAnd(Utils.extractConjuncts(p)).accept(new TediousPredicatePruner(), null).orElse(p);
+    }
+
+    public static ScalarOperator simplify(ScalarOperator op) {
+        return op.accept(SIMPLIFY_VISITOR, null).orElse(op);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/OnlyOnceScalarOperatorRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/OnlyOnceScalarOperatorRewriteRule.java
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rewrite.scalar;
 
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
-
-public interface ScalarOperatorRewriteRule {
-    boolean isBottomUp();
-
-    boolean isTopDown();
-
-    boolean isOnlyOnce();
-
-    ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context);
+// OnlyOnceScalarOperatorRewriteRule is not equivalence-transform Rule. non-equivalence transform Rule
+// is used to escalate or degrade predicates to make the predicates simple and applicable to index.
+// it visit the expression tree in top-down style, it finishes as soon as it can not go downwards.
+public class OnlyOnceScalarOperatorRewriteRule extends BaseScalarOperatorRewriteRule {
+    @Override
+    public boolean isOnlyOnce() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/PruneTediousPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/PruneTediousPredicateRule.java
@@ -1,0 +1,107 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class PruneTediousPredicateRule extends OnlyOnceScalarOperatorRewriteRule {
+
+    private PruneTediousPredicateRule() {
+    }
+
+    // Prune tedious predicates introduced by case-when simplification, the tedious predicates are in two forms
+    // as follows:
+    // 1. p OR if(q, NULL, FALSE) => p
+    // 2. p AND p is NOT NULL => p
+    // NOTICE!!! this pruning operations can only be applied to predicates in top-down style, it can not be applied
+    // common expressions, for examples:
+    // 1. select p or if (q, NULL, FALSE) from t;
+    // 2. select * from t where (p and p is NOT NULL) is NULL;
+    private static class Visitor extends ScalarOperatorVisitor<Optional<ScalarOperator>, Void> {
+
+        @Override
+        public Optional<ScalarOperator> visit(ScalarOperator scalarOperator, Void context) {
+            return Optional.empty();
+        }
+
+        public static boolean outputOnlyNullOrFalse(ScalarOperator p) {
+            if (!(p instanceof CallOperator)) {
+                return false;
+            }
+            CallOperator call = (CallOperator) p;
+            if (!call.getFnName().equals(FunctionSet.IF)) {
+                return false;
+            }
+            return call.getChildren().stream().skip(1).allMatch(ScalarOperator::isConstantNullOrFalse);
+        }
+
+        @Override
+        public Optional<ScalarOperator> visitCall(CallOperator call, Void context) {
+            if (outputOnlyNullOrFalse(call)) {
+                return Optional.of(ConstantOperator.FALSE);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        @Override
+        public Optional<ScalarOperator> visitCompoundPredicate(CompoundPredicateOperator predicate, Void context) {
+            if (predicate.isAnd()) {
+                List<ScalarOperator> conjuncts = predicate.getChildren();
+                if (conjuncts.stream().anyMatch(Visitor::outputOnlyNullOrFalse)) {
+                    return Optional.of(ConstantOperator.FALSE);
+                }
+                return Optional.of(Utils.compoundAnd(conjuncts));
+            } else if (predicate.isOr()) {
+                List<ScalarOperator> disjuncts = predicate.getChildren().stream()
+                        .filter(p -> !outputOnlyNullOrFalse(p)).collect(Collectors.toList());
+                if (disjuncts.isEmpty()) {
+                    return Optional.of(ConstantOperator.FALSE);
+                } else if (disjuncts.size() > 1) {
+                    return Optional.of(Utils.compoundOr(disjuncts));
+                } else {
+                    List<ScalarOperator> conjuncts = Utils.extractConjuncts(disjuncts.get(0)).stream()
+                            .map(p -> p.accept(this, context).orElse(p)).collect(Collectors.toList());
+                    return Optional.of(Utils.compoundAnd(conjuncts));
+                }
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    private static final Visitor TEDIOUS_PREDICATE_PRUNER = new Visitor();
+
+    public static final PruneTediousPredicateRule INSTANCE = new PruneTediousPredicateRule();
+
+    @Override
+    public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
+        if (root == null) {
+            return null;
+        }
+        return Utils.compoundAnd(Utils.extractConjuncts(root)).accept(TEDIOUS_PREDICATE_PRUNER, null).orElse(root);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedCaseWhenRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedCaseWhenRule.java
@@ -18,6 +18,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 
 public class SimplifiedCaseWhenRule extends BottomUpScalarOperatorRewriteRule {
+    private SimplifiedCaseWhenRule() {
+    }
+
+    public static final SimplifiedCaseWhenRule INSTANCE = new SimplifiedCaseWhenRule();
+
     @Override
     public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
         return InvertedCaseWhen.simplify(root);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedCaseWhenRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedCaseWhenRule.java
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+
+public class SimplifiedCaseWhenRule extends BottomUpScalarOperatorRewriteRule {
+    @Override
+    public ScalarOperator apply(ScalarOperator root, ScalarOperatorRewriteContext context) {
+        return InvertedCaseWhen.simplify(root);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
+import com.starrocks.sql.optimizer.rewrite.scalar.PruneTediousPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedCaseWhenRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
@@ -80,8 +81,10 @@ public class PushDownPredicateScanRule extends TransformationRule {
         Preconditions.checkState(predicates != null);
 
         // simplify case-when
-        predicates = scalarOperatorRewriter.rewrite(predicates, Lists.newArrayList(new SimplifiedCaseWhenRule()));
-        predicates = Utils.pruneTediousPredicate(predicates);
+        predicates = scalarOperatorRewriter.rewrite(predicates, Lists.newArrayList(
+                SimplifiedCaseWhenRule.INSTANCE,
+                PruneTediousPredicateRule.INSTANCE
+        ));
         predicates = scalarOperatorRewriter.rewrite(predicates,
                 ScalarOperatorRewriter.DEFAULT_REWRITE_SCAN_PREDICATE_RULES);
         predicates = Utils.transTrue2Null(predicates);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
+import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedCaseWhenRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
@@ -77,6 +78,10 @@ public class PushDownPredicateScanRule extends TransformationRule {
         predicates = rangeExtractor.rewriteOnlyColumn(Utils.compoundAnd(Utils.extractConjuncts(predicates)
                 .stream().map(rangeExtractor::rewriteOnlyColumn).collect(Collectors.toList())));
         Preconditions.checkState(predicates != null);
+
+        // simplify case-when
+        predicates = scalarOperatorRewriter.rewrite(predicates, Lists.newArrayList(new SimplifiedCaseWhenRule()));
+        predicates = Utils.pruneTediousPredicate(predicates);
         predicates = scalarOperatorRewriter.rewrite(predicates,
                 ScalarOperatorRewriter.DEFAULT_REWRITE_SCAN_PREDICATE_RULES);
         predicates = Utils.transTrue2Null(predicates);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithCaseWhenTest.java
@@ -1,0 +1,553 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.stream.Stream;
+
+public class SelectStmtWithCaseWhenTest {
+    private static StarRocksAssert starRocksAssert;
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @BeforeClass
+    public static void setUp()
+            throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        String createTblStmtStr = " CREATE TABLE `t0` (\n" +
+                "  `region` varchar(128) NOT NULL COMMENT \"\",\n" +
+                "  `order_date` date NOT NULL COMMENT \"\",\n" +
+                "  `income` decimal(7, 0) NOT NULL COMMENT \"\",\n" +
+                "  `ship_mode` int NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`region`, `order_date`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY RANGE(`order_date`)\n" +
+                "(PARTITION p20220101 VALUES [(\"2022-01-01\"), (\"2022-01-02\")),\n" +
+                "PARTITION p20220102 VALUES [(\"2022-01-02\"), (\"2022-01-03\")),\n" +
+                "PARTITION p20220103 VALUES [(\"2022-01-03\"), (\"2022-01-04\")))\n" +
+                "DISTRIBUTED BY HASH(`region`, `order_date`) BUCKETS 10 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"replicated_storage\" = \"false\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");";
+
+        starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        starRocksAssert.withTable(createTblStmtStr);
+    }
+
+    @Test
+    public void testCaseWhenWithCaseClause() throws Exception {
+        String[][] testCases = new String[][] {
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) = 1",
+                        "Predicates: [1: region, VARCHAR, false] = 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) in (1,2)",
+                        "Predicates: 1: region IN ('China', 'Japan')",
+                        "Predicates: 1: region IN ('Japan', 'China')"
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) <> 1",
+                        "Predicates: [1: region, VARCHAR, false] != 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) <> 2",
+                        "Predicates: [1: region, VARCHAR, false] != 'Japan'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 2 when 'Japan' then 2 else 3 end) <> 2",
+                        "Predicates: 1: region NOT IN ('China', 'Japan')",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 2 when 'China' then 1 else 3 end) = 1",
+                        "0:EMPTYSET",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 2 when 'China' then 1 else 3 end) <> 1",
+                        "  0:OlapScanNode\n" +
+                                "     table: t0, rollup: t0\n" +
+                                "     preAggregation: on\n" +
+                                "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                                "     tabletList=\n" +
+                                "     actualRows=0, avgRowSize=4.0\n" +
+                                "     cardinality: 1",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when NULL then 2 when 'China' then 1 else 3 end) = 3",
+                        "Predicates: [1: region, VARCHAR, false] != 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when NULL then 2 when 'China' then 1 else 3 end) = 1",
+                        "Predicates: [1: region, VARCHAR, false] = 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'USA' then 5 when 'China' then 1 else 3 end) = 3",
+                        "Predicates: 1: region NOT IN ('China', 'USA')",
+                        "Predicates: 1: region NOT IN ('USA', 'China')",
+                },
+                // Q9
+                {"select * from test.t0 where \n" +
+                        "(case region when 'USA' then 5 when 'UK' then 2 when 'China' then 1 end) = 3",
+                        "0:EMPTYSET",
+                },
+                // Q10
+                {"select * from test.t0 where \n" +
+                        "(case region when 'USA' then 1 when 'UK' then 2 when 'China' then 2 end) = 2",
+                        "Predicates: 1: region IN ('UK', 'China')",
+                        "Predicates: 1: region IN ('China', 'UK')",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case region when NULL then 2 when 'China' then 1 else 3 end) <> 1",
+                        "Predicates: [1: region, VARCHAR, false] != 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'UK' then 2 when 'China' then 1 else 3 end) <> 3",
+                        "Predicates: 1: region IN ('UK', 'China')",
+                        "Predicates: 1: region IN ('China', 'UK')",
+                },
+                // Q13
+                {"select * from test.t0 where \n" +
+                        "(case region when 'USA' then 5 when 'UK' then 2 when 'China' then 1 end) <> 3",
+                        "((1: region = 'China') OR (1: region = 'UK')) OR (1: region = 'USA')",
+                        "((1: region = 'UK') OR (1: region = 'China')) OR (1: region = 'USA')",
+                        "((1: region = 'USA') OR (1: region = 'UK')) OR (1: region = 'China')",
+                        "((1: region = 'USA') OR (1: region = 'China')) OR (1: region = 'UK')",
+                        "((1: region = 'China') OR (1: region = 'USA')) OR (1: region = 'UK')",
+                        "((1: region = 'UK') OR (1: region = 'USA')) OR (1: region = 'China')",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'USA' then 1 when 'UK' then 2 when 'China' then 2 end) <> 2",
+                        "[1: region, VARCHAR, false] = 'USA'",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "((case region when 'USA' then 1 when 'UK' then 2 when 'China' then 2 end) <> 2) IS NULL",
+                        "(1: region = 'USA') OR (if(1: region NOT IN ('UK', 'China', 'USA'), NULL, FALSE)) IS NULL",
+                        "(1: region = 'USA') OR (if(1: region NOT IN ('UK', 'USA', 'China'), NULL, FALSE)) IS NULL",
+                        "(1: region = 'USA') OR (if(1: region NOT IN ('USA', 'China', 'UK'), NULL, FALSE)) IS NULL",
+                        "(1: region = 'USA') OR (if(1: region NOT IN ('USA', 'UK', 'China'), NULL, FALSE)) IS NULL",
+                        "(1: region = 'USA') OR (if(1: region NOT IN ('China', 'UK', 'USA'), NULL, FALSE)) IS NULL",
+                        "(1: region = 'USA') OR (if(1: region NOT IN ('China', 'USA', 'UK'), NULL, FALSE)) IS NULL",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) in (1)",
+                        "Predicates: [1: region, VARCHAR, false] = 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) not in (1)",
+                        "Predicates: [1: region, VARCHAR, false] != 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) in (3)",
+                        "Predicates: 1: region NOT IN ('Japan', 'China')",
+                        "Predicates: 1: region NOT IN ('China', 'Japan')",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) not in (3)",
+                        "Predicates: 1: region IN ('Japan', 'China')",
+                        "Predicates: 1: region IN ('China', 'Japan')",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) is null",
+                        "  0:EMPTYSET\n" +
+                                "     cardinality: 1",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 else 3 end) is not null",
+                        "  0:OlapScanNode\n" +
+                                "     table: t0, rollup: t0\n" +
+                                "     preAggregation: on\n" +
+                                "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                                "     tabletList=\n" +
+                                "     actualRows=0, avgRowSize=4.0\n" +
+                                "     cardinality: 1",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 end) is null",
+                        "Predicates: 1: region NOT IN ('Japan', 'China')",
+                        "Predicates: 1: region NOT IN ('China', 'Japan')",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then 2 end) is not null",
+                        "Predicates: 1: region IN ('Japan', 'China')",
+                        "Predicates: 1: region IN ('China', 'Japan')",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then NULL when 'Japan' then 2 end) is null",
+                        "Predicates: (1: region = 'China') OR (1: region NOT IN ('China', 'Japan'))",
+                        "Predicates: (1: region = 'China') OR (1: region NOT IN ('Japan', 'China'))",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case region when 'China' then 1 when 'Japan' then NULL end) is not null",
+                        "Predicates: [1: region, VARCHAR, false] != 'Japan', 1: region IN ('Japan', 'China')",
+                        "Predicates: [1: region, VARCHAR, false] != 'Japan', 1: region IN ('China', 'Japan')",
+                }
+        };
+        int i = 0;
+        for (String[] tc : testCases) {
+            if (i < 0) {
+                ++i;
+                continue;
+            }
+            String sql = tc[0];
+            System.out.printf("Q%d:%s\n", i, sql);
+            String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            Assert.assertTrue(plan, Stream.of(tc).skip(1).anyMatch(plan::contains));
+            ++i;
+        }
+    }
+
+    @Test
+    public void testCaseWhenWithoutCaseClause() throws Exception {
+        String[][] testCases = new String[][] {
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 else 3 end) = 1",
+                        "Predicates: [1: region, VARCHAR, false] = 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 else 3 end) <> 1",
+                        "Predicates: [1: region, VARCHAR, false] != 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region <> 'China' then 1 when region = 'Japan' then 2 else 3 end) <> 2",
+                        "Predicates: (1: region != 'Japan') OR (1: region != 'China')",
+                },
+                //Q3
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 2 when region = 'Japan' then 2 else 3 end) <> 2",
+                        "[1: region, VARCHAR, false] != 'China', " +
+                                "(1: region != 'Japan') OR (1: region = 'China'), " +
+                                "(1: region != 'China') AND ((1: region != 'Japan') OR (1: region = 'China')) " +
+                                "IS NOT NULL",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 2 when region = 'China' then 1 else 3 end) = 1",
+                        "[1: region, VARCHAR, false] = 'China', [1: region, VARCHAR, false] != 'China'",
+                },
+                // Q5
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 2 when region = 'China' then 1 else 3 end) <> 1",
+                        "Predicates: (1: region != 'China') OR (1: region = 'China')",
+                },
+                // Q6
+                {"select * from test.t0 where \n" +
+                        "(case when region is NULL then 2 when region = 'China' then 1 else 3 end) = 3",
+                        "Predicates: [1: region, VARCHAR, false] != 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region = NULL then 2 when region = 'China' then 1 else 3 end) = 1",
+                        "Predicates: [1: region, VARCHAR, false] = 'China'",
+                },
+                // Q8
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'USA' then 5 when region = 'China' then 1 else 3 end) = 3",
+                        "[1: region, VARCHAR, false] != 'USA', (1: region != 'China') OR (1: region = 'USA')",
+                        "(1: region != 'China') OR (1: region = 'USA'), [1: region, VARCHAR, false] != 'USA'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'USA' then 5 when region = 'UK' then 2 \n" +
+                        "when region = 'China' then 1 end) = 3",
+                        "0:EMPTYSET",
+                },
+                // Q10
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'USA' then 1 when region = 'UK' then 2 \n" +
+                        "when region = 'China' then 2 end) = 2",
+                        "Predicates: CASE WHEN 1: region = 'USA' THEN 1 WHEN 1: region = 'UK' " +
+                                "THEN 2 WHEN 1: region = 'China' THEN 2 END = 2",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case when region = NULL then 2 when region = 'China' then 1 else 3 end) <> 1",
+                        "Predicates: [1: region, VARCHAR, false] != 'China'",
+                },
+                //Q12
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'UK' then 2 when region = 'China' then 1 else 3 end) <> 3",
+                        "Predicates: ((1: region = 'China') AND (1: region != 'UK')) OR (1: region = 'UK')",
+                        "Predicates: (1: region = 'UK') OR ((1: region = 'China') AND (1: region != 'UK'))",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'USA' then 5 when region = 'UK' then 2 \n" +
+                        "when region = 'China' then 1 end) <> 3",
+                        " Predicates: CASE WHEN",
+                },
+                // Q14
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'USA' then 1 when region = 'UK' then 2 " +
+                        "when region = 'China' then 2 end) <> 2",
+                        "Predicates: CASE WHEN",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 else 3 end) in (1)",
+                        "Predicates: [1: region, VARCHAR, false] = 'China'",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 else 3 end) not in (1)",
+                        "Predicates: [1: region, VARCHAR, false] != 'China'",
+                },
+                // Q17
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 else 3 end) in (3)",
+                        "Predicates: [1: region, VARCHAR, false] != 'China', " +
+                                "(1: region != 'Japan') OR (1: region = 'China'), " +
+                                "(1: region != 'China') AND ((1: region != 'Japan') " +
+                                "OR (1: region = 'China')) IS NOT NULL",
+                        "Predicates: (1: region != 'Japan') OR (1: region = 'China'), " +
+                                "[1: region, VARCHAR, false] != 'China', " +
+                                "((1: region != 'Japan') OR (1: region = 'China')) " +
+                                "AND (1: region != 'China') IS NOT NULL",
+                },
+                // Q18
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 else 3 end) not in (3)",
+                        "Predicates: ((1: region = 'Japan') AND (1: region != 'China')) OR (1: region = 'China')",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 else 3 end) is null",
+                        "  0:EMPTYSET\n" +
+                                "     cardinality: 1",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 else 3 end) is not null",
+                        "  0:OlapScanNode\n" +
+                                "     table: t0, rollup: t0\n" +
+                                "     preAggregation: on\n" +
+                                "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                                "     tabletList=\n" +
+                                "     actualRows=0, avgRowSize=4.0\n" +
+                                "     cardinality: 1",
+                },
+                // Q21
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 end) is null",
+                        "Predicates: ((1: region != 'China') AND (1: region != 'Japan')) " +
+                                "OR ((1: region != 'China') AND (1: region != 'Japan') IS NULL)",
+                },
+                //Q22
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then 2 end) is not null",
+                        "Predicates: (1: region = 'China') OR (1: region = 'Japan'), " +
+                                "(1: region != 'China') AND (1: region != 'Japan') IS NOT NULL",
+                },
+
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then NULL when region = 'Japan' then 2 end) is null",
+                        " Predicates: (1: region = 'China') OR (((1: region != 'China') AND " +
+                                "(1: region != 'Japan')) OR ((1: region != 'China') AND " +
+                                "(1: region != 'Japan') IS NULL))",
+                },
+                {"select * from test.t0 where \n" +
+                        "(case when region = 'China' then 1 when region = 'Japan' then NULL end) is not null",
+                        "Predicates: (1: region != 'Japan') OR (1: region = 'China'), (1: region = 'China') OR " +
+                                "(1: region = 'Japan'), (1: region != 'China') AND (1: region != 'Japan') IS NOT NULL",
+                }
+        };
+        int i = 0;
+        for (String[] tc : testCases) {
+            if (i != 9) {
+                ++i;
+                continue;
+            }
+            String sql = tc[0];
+            System.out.printf("Q%d: %s\n", i, sql);
+            String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            Assert.assertTrue(plan, Stream.of(tc).skip(1).anyMatch(plan::contains));
+            ++i;
+        }
+    }
+
+    @Test
+    public void testCaseWhenWithManyBranches() throws Exception {
+        String sqlTemp = "select * from test.t0 where (case \n" +
+                "   when ship_mode >= 90 then 'A'\n" +
+                "   when ship_mode >= 80 then 'B'\n" +
+                "   when ship_mode >= 70 then 'C'\n" +
+                "   when ship_mode >= 60 then 'D'\n" +
+                "   else 'E' end)  %s";
+
+        String[][] testCases = new String[][] {
+                // Q0
+                {"= 'A'", "[4: ship_mode, INT, false] >= 90, 4: ship_mode >= 90 IS NOT NULL"},
+                {"= 'B'",
+                        "[4: ship_mode, INT, false] >= 80, [4: ship_mode, INT, false] < 90, " +
+                                "(4: ship_mode >= 80) AND (4: ship_mode < 90) IS NOT NULL"},
+                {"= 'C'", "Predicates: CASE WHEN"},
+                {"= 'D'", "Predicates: CASE WHEN"},
+                {"= 'E'", "Predicates: CASE WHEN"},
+                // Q5
+                {"<> 'A'", "[4: ship_mode, INT, false] < 90, 4: ship_mode < 90 IS NOT NULL"},
+                {"<> 'B'",
+                        "(4: ship_mode < 80) OR (4: ship_mode >= 90), " +
+                                "(4: ship_mode < 80) OR (4: ship_mode >= 90) IS NOT NULL"},
+                {"<> 'C'", "Predicates: CASE WHEN"},
+                {"<> 'D'", "Predicates: CASE WHEN"},
+                {"<> 'E'", "Predicates: CASE WHEN"},
+                // Q10
+                {"in ('A','B')",
+                        "((4: ship_mode >= 80) AND (4: ship_mode < 90)) OR (4: ship_mode >= 90), " +
+                                "((4: ship_mode >= 80) AND (4: ship_mode < 90)) OR (4: ship_mode >= 90) IS NOT NULL",
+                        "(4: ship_mode >= 90) OR ((4: ship_mode >= 80) AND (4: ship_mode < 90)), " +
+                                "(4: ship_mode >= 90) OR ((4: ship_mode >= 80) AND (4: ship_mode < 90)) IS NOT NULL"},
+                {"in ('A','B', 'C')", "Predicates: CASE WHEN"},
+                {"in ('D','E')", "Predicates: CASE WHEN"},
+                {"in ('E')", "Predicates: CASE WHEN"},
+                {"in (NULL)", "0:EMPTYSET"},
+                // Q15
+                {"in ('F')", "0:EMPTYSET"},
+                {"in ('A','B','C','D','E')",
+                        "  0:OlapScanNode\n" +
+                                "     table: t0, rollup: t0\n" +
+                                "     preAggregation: on\n" +
+                                "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                                "     tabletList=\n" +
+                                "     actualRows=0, avgRowSize=4.0\n" +
+                                "     cardinality: 1"},
+                {"in ('A','B','C','D','E','F')",
+                        "  0:OlapScanNode\n" +
+                                "     table: t0, rollup: t0\n" +
+                                "     preAggregation: on\n" +
+                                "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                                "     tabletList=\n" +
+                                "     actualRows=0, avgRowSize=4.0\n" +
+                                "     cardinality: 1"},
+                {"not in ('A','B')",
+                        "(4: ship_mode < 80) OR (4: ship_mode >= 90), [4: ship_mode, INT, false] < 90, " +
+                                "((4: ship_mode < 80) OR (4: ship_mode >= 90)) AND (4: ship_mode < 90) IS NOT NULL",
+                        "[4: ship_mode, INT, false] < 90, (4: ship_mode < 80) OR (4: ship_mode >= 90), " +
+                                "(4: ship_mode < 90) AND ((4: ship_mode < 80) OR (4: ship_mode >= 90)) IS NOT NULL"},
+                // Q19
+                {"not in ('A','B', 'C')", "Predicates: CASE WHEN"},
+                {"not in ('D','E')", "Predicates: CASE WHEN"},
+                {"not in ('E')", "Predicates: CASE WHEN"},
+                {"not in (NULL)", "0:EMPTYSET"},
+                {"not in ('A','B','C','D','E')", "0:EMPTYSET"},
+                {"not in ('A','B','C','D','E','F')", "0:EMPTYSET"},
+                {"is NULL", "0:EMPTYSET"},
+                {"is NOT NULL",
+                        "  0:OlapScanNode\n" +
+                                "     table: t0, rollup: t0\n" +
+                                "     preAggregation: on\n" +
+                                "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                                "     tabletList=\n" +
+                                "     actualRows=0, avgRowSize=4.0\n" +
+                                "     cardinality: 1"},
+        };
+        int i = 0;
+        for (String[] tc : testCases) {
+            String sql = String.format(sqlTemp, tc[0]);
+            System.out.printf("Q%d: %s\n", i, sql);
+            String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            Assert.assertTrue(plan, Stream.of(tc).skip(1).anyMatch(plan::contains));
+            ++i;
+        }
+    }
+
+    @Test
+    public void testIf() throws Exception {
+        String[][] testCases = new String[][] {
+                {"select * from test.t0 where if(region='USA', 1, 0) = 1",
+                        "[1: region, VARCHAR, false] = 'USA', 1: region = 'USA' IS NOT NULL"},
+                //{"select * from test.t0 where (case when region='USA' then 1 else 0 end) = 0", "foobar" },
+                {"select * from test.t0 where if(region='USA', 1, 0) = 0",
+                        "[1: region, VARCHAR, false] != 'USA', 1: region != 'USA' IS NOT NULL"},
+                {"select * from test.t0 where if(region='USA', 1, 0) = 2", "0:EMPTYSET"},
+                {"select * from test.t0 where if(region='USA', 1, 0) <> 1",
+                        "[1: region, VARCHAR, false] != 'USA', 1: region != 'USA' IS NOT NULL"},
+                {"select * from test.t0 where if(region='USA', 1, 0) <> 0",
+                        "[1: region, VARCHAR, false] = 'USA', 1: region = 'USA' IS NOT NULL"},
+                {"select * from test.t0 where if(region='USA', 1, 0) <> 2", "0:OlapScanNode\n" +
+                        "     table: t0, rollup: t0\n" +
+                        "     preAggregation: on\n" +
+                        "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                        "     tabletList=\n" +
+                        "     actualRows=0, avgRowSize=4.0\n" +
+                        "     cardinality: 1"},
+                {"select * from test.t0 where if(region='USA', 1, 0) in (1)",
+                        "[1: region, VARCHAR, false] = 'USA', 1: region = 'USA' IS NOT NULL"},
+                {"select * from test.t0 where if(region='USA', 1, 0) in (1,0)", "  0:OlapScanNode\n" +
+                        "     table: t0, rollup: t0\n" +
+                        "     preAggregation: on\n" +
+                        "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                        "     tabletList=\n" +
+                        "     actualRows=0, avgRowSize=4.0\n" +
+                        "     cardinality: 1\n"},
+                {"select * from test.t0 where if(region='USA', 1, 0) in (2,3)", "0:EMPTYSET"},
+                {"select * from test.t0 where if(region='USA', 1, 0) not in (0)",
+                        "[1: region, VARCHAR, false] = 'USA', 1: region = 'USA' IS NOT NULL"},
+                {"select * from test.t0 where if(region='USA', 1, 0) not in (0,1)", "0:EMPTYSET"},
+                {"select * from test.t0 where if(region='USA', 1, 0) not in (2,3)", "  0:OlapScanNode\n" +
+                        "     table: t0, rollup: t0\n" +
+                        "     preAggregation: on\n" +
+                        "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                        "     tabletList=\n" +
+                        "     actualRows=0, avgRowSize=4.0\n" +
+                        "     cardinality: 1\n"},
+                {"select * from test.t0 where if(region='USA', 1, 0) is NULL", "0:EMPTYSET"},
+                {"select * from test.t0 where if(region='USA', 1, 0) is NOT NULL", "  0:OlapScanNode\n" +
+                        "     table: t0, rollup: t0\n" +
+                        "     preAggregation: on\n" +
+                        "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
+                        "     tabletList=\n" +
+                        "     actualRows=0, avgRowSize=4.0\n" +
+                        "     cardinality: 1\n"},
+                // Q14
+                {"select * from test.t0 where nullif('China', region) = 'China'",
+                        "Predicates: nullif"},
+                // Q15
+                {"select * from test.t0 where nullif('China', region) <> 'China'",
+                        "0:EMPTYSET"},
+                {"select * from test.t0 where nullif('China', region) is NULL",
+                        "[1: region, VARCHAR, false] = 'China'"},
+                {"select * from test.t0 where nullif('China', region) is NOT NULL",
+                        "[1: region, VARCHAR, false] != 'China'"},
+                {"select * from test.t0 where nullif('China', region) = 'USA'", "0:EMPTYSET"},
+                // Q19
+                {"select * from test.t0 where nullif('China', region) <>  'USA'", "Predicates: nullif"},
+        };
+
+        int i = 0;
+        for (String[] tc : testCases) {
+            String sql = tc[0];
+            System.out.printf("Q%d: %s\n", i, sql);
+            String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            Assert.assertTrue(plan, Stream.of(tc).skip(1).anyMatch(plan::contains));
+            ++i;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -302,7 +302,7 @@ public class ExpressionTest extends PlanTestBase {
     public void testCaseWhen() throws Exception {
         String sql = "SELECT v1 FROM t0 WHERE CASE WHEN (v1 IS NOT NULL) THEN NULL END";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("PREDICATES: if(1: v1 IS NOT NULL, NULL, NULL)"));
+        Assert.assertTrue(plan.contains("0:EMPTYSET"));
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/starrocks/issues/19445

Reduce predicates containing case-when  into simple predicates that can be leveraged by storage engine to speedup data access.
Suppor predicates:
1. in-predicates:  case-when-expr  in/not in (constants), 
2. eq-predicates: case-when-expr =/<> constant, 
3. is-null-predicates, case-when-expr is/is not null, 

Case-when-expr in predicates above must output constant values,  some if  and nullif expressions  are also converted into  case-when-expr to adopt this simplification.

Case-when-expr that has case-clause often can be simplified into simple form, while the ones has no case-clause  can not, so for no-case case-when-exprs, only when rhs constant values of predicates hit the top 2 branches of the case-when-expr, the simplification would take place.

Case-when that is absent of else-clause or can output NULL values, are apt to buggy, so in some cases, such case-when are not simplified.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
