### PR TITLE
[BugFix] append_trailing_char_if_absent return empty string for const empty strings (#13762)

### DIFF
--- a/be/src/exprs/vectorized/string_functions.cpp
+++ b/be/src/exprs/vectorized/string_functions.cpp
@@ -1526,12 +1526,7 @@ ColumnPtr StringFunctions::append_trailing_char_if_absent(FunctionContext* conte
             auto str = src_viewer.value(row);
             auto tailing_char = tailing_viewer.value(row);
 
-            if (str.size == 0) {
-                dst_builder.append(tailing_char);
-                continue;
-            }
-
-            if (str.data[str.size - 1] == tailing_char.data[0]) {
+            if (str.size == 0 || str.data[str.size - 1] == tailing_char.data[0]) {
                 dst_builder.append(str);
                 continue;
             }

--- a/be/test/exprs/vectorized/string_fn_test.cpp
+++ b/be/test/exprs/vectorized/string_fn_test.cpp
@@ -928,7 +928,7 @@ PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentTest) {
 
     ASSERT_EQ("qwer", v->get_data()[0].to_string());
     ASSERT_EQ("qwer", v->get_data()[1].to_string());
-    ASSERT_EQ("r", v->get_data()[2].to_string());
+    ASSERT_EQ("", v->get_data()[2].to_string());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, appendTrailingCharIfAbsentNullTest) {


### PR DESCRIPTION

(cherry picked from commit 27dd3c37801ecaf32de75db94ae5dc8d10d5fb59)
