### PR TITLE
[Enhancement] Improve disk balance speed when added multi backends

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
@@ -89,17 +89,24 @@ public class BackendLoadStatistic {
     }
 
     public static class BeStatComparatorForUsedPercent implements Comparator<BackendLoadStatistic> {
-        private TStorageMedium medium;
+        private final TStorageMedium medium;
+        private final boolean isAscending;
 
         public BeStatComparatorForUsedPercent(TStorageMedium medium) {
             this.medium = medium;
+            this.isAscending = true;
+        }
+
+        public BeStatComparatorForUsedPercent(TStorageMedium medium, boolean isAscending) {
+            this.medium = medium;
+            this.isAscending = isAscending;
         }
 
         @Override
         public int compare(BackendLoadStatistic o1, BackendLoadStatistic o2) {
             double percent1 = o1.getUsedPercent(medium);
             double percent2 = o2.getUsedPercent(medium);
-            return Double.compare(percent1, percent2);
+            return isAscending ? Double.compare(percent1, percent2) : -Double.compare(percent1, percent2);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -1601,7 +1601,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                     if (!table.needSchedule(false)) {
                         continue;
                     }
-                    if (table.isLakeTable()) {
+                    if (table.isCloudNativeTable()) {
                         // replicas are managed by StarOS and cloud storage.
                         continue;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -45,11 +45,13 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * DiskAndTabletLoadReBalancer is responsible for the balancing of disk usage and tablet distribution.
@@ -374,16 +376,34 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
     }
 
     /**
-     * Cluster disk balance is the base for tablet balance, so we balance disk as much as possible
-     * 1. sort be according to used percent in asc order: b1, b2, ... bn
-     * 2. calculate average used percent for all be as avgUsedPercent
-     * 3. init srcBEIndex as n, destBEIndex as 1
-     * 4. copy tablets from srcBE to destBE until
-     * 1) usedPercent of srcBE less than avgUsedPercent, srcBEIndex--
-     * 2) usedPercent of destBE more than avgUsedPercent, destBEIndex++
-     * 5. repeat 4, until srcBEIndex <= destBEIndex
-     * <p>
-     * we prefer to choose tablets in partition that numOfTablet(srcBE) is more than numOfTablet(destBE)
+     * 1. calculate average used percent for all BE as avgUsedPercent
+     * 2. divide BE into two group: one is higher than the avgUsedPercent, another is lower than the avgUsedPercent.
+     * 3. Sort BE in high group by usedPercent in desc order, and BE in low group by usedPercent in asc order.
+     * 4. for every BE in high group the max selected tablet is: highGroupThreshold =
+     *    (Config.tablet_sched_max_balancing_tablets + highGroup.size() - 1) / highGroup.size()
+     *    the max select tablet for backend in low group is: lowGroupThreshold =
+     *    (Config.tablet_sched_max_balancing_tablets + lowGroup.size() - 1) / lowGroup.size();
+     * 5. Choose tablet to migrate from high group to low group.
+     *    1) init the high group index(h) and low group index(l) to 0;
+     *    2) Iterate the tablet in high_group(h) at the granularity of partitions. There are two iterations of partitions,
+     *       the first will make the tablet distribution better, the second will destroy the tablet distribution balance.
+     *       there are some limitations to choose tablet:
+     *       1) it won't make the tablet distribution worse(for the first iteration of partitions).
+     *       2) only choose the tablet on the high load path of high_group(h).
+     *       3) there is no tablet located on the same host of low_group(l).
+     *       4) after migration, the usedPercent of high_group(h) cannot be lower than avgUsedPercent,
+     *          and the usedPercent of low_group(l) cannot be higher than avgUsedPercent.
+     *       5) the tablet must be healthy.
+     *    3) if one tablet is chosen:
+     *          if the number of tablets selected in high_group(h) is bigger than highGroupThreshold, remove h from high group. go
+     *          to the next BE in the high group.
+     *          if the number of tablets selected in low_group(h) is bigger than lowGroupThreshold, remove l from high group. go
+     *          to the next BE in the low group.
+     *          if the number of tablets selected will break the tablet distribution balance for the first iteration or make the
+     *          skew worse for the second iteration, got to the next partition.
+     *    4) After traverse all tablets, if neither the number of tablets selected in high load BE
+     *       nor low load BE exceed the limit, change the group index in succession.
+     *    5) repeat 2), 3), 4) until there is no BE in high group.
      */
     private List<TabletSchedCtx> balanceClusterDisk(ClusterLoadStatistic clusterStat,
                                                     TStorageMedium medium) {
@@ -396,8 +416,6 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
 
         double avgUsedPercent = beStats.stream().mapToDouble(be -> (be.getUsedPercent(medium))).sum() / beStats.size();
 
-        // sort be by disk used percent in asc order
-        beStats.sort(new BackendLoadStatistic.BeStatComparatorForUsedPercent(medium));
         LOG.debug("get backend stats for cluster disk balance. medium: {}, avgUsedPercent: {}, be stats: {}", medium,
                 avgUsedPercent, beStats);
 
@@ -406,145 +424,192 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         // aliveBeIds to check tablet health
         List<Long> aliveBeIds = infoService.getBackendIds(true);
         Map<String, List<Long>> hostGroups = getHostGroups(aliveBeIds);
-        int srcBEIndex = beStats.size() - 1;
-        int destBEIndex = 0;
-        long srcBEUsedCap = beStats.get(srcBEIndex).getTotalUsedCapacityB(medium);
-        long destBEUsedCap = beStats.get(destBEIndex).getTotalUsedCapacityB(medium);
-        // (partition, index) => tabletIds
-        Map<Pair<Long, Long>, Set<Long>> srcBEPartitionTablets =
-                getPartitionTablets(beStats.get(srcBEIndex).getBeId(), medium, -1);
-        Map<Pair<Long, Long>, Set<Long>> destBEPartitionTablets =
-                getPartitionTablets(beStats.get(destBEIndex).getBeId(), medium, -1);
-        boolean srcBEChanged = false;
-        boolean destBEChanged = false;
-        Map<Pair<Long, Long>, PartitionStat> partitionStats = getPartitionStats(medium, false, null, null);
-        OUT:
-        while (srcBEIndex > destBEIndex) {
-            BackendLoadStatistic srcBEStat = beStats.get(srcBEIndex);
-            BackendLoadStatistic destBEStat = beStats.get(destBEIndex);
-            if (srcBEChanged) {
-                srcBEUsedCap = srcBEStat.getTotalUsedCapacityB(medium);
-                srcBEPartitionTablets = getPartitionTablets(srcBEStat.getBeId(), medium, -1);
-            }
-            if (destBEChanged) {
-                destBEUsedCap = destBEStat.getTotalUsedCapacityB(medium);
-                destBEPartitionTablets = getPartitionTablets(destBEStat.getBeId(), medium, -1);
-            }
+        Map<Long, Integer> partitionReplicaCnt = getPartitionReplicaCnt();
 
-            Backend destBackend = infoService.getBackend(destBEStat.getBeId());
-            if (destBackend == null) {
-                destBEIndex++;
-                destBEChanged = true;
-                continue;
-            }
-
-            List<Long> destBeHostGroup = hostGroups.get(destBackend.getHost());
-            int totalBes = beStats.size();
-            List<Long> tablets =
-                    getSourceTablets(partitionStats, srcBEPartitionTablets, destBEPartitionTablets, totalBes);
-            // do not choose selected tablet
-            // do not choose tablet that exists in backends whose host is same with dest be
-            tablets = tablets.stream()
-                    .filter(v -> !selectedTablets.contains(v) && !isTabletExistsInBackends(v, destBeHostGroup))
-                    .collect(Collectors.toList());
-
-            // copy tablets from srcBE high load paths to destBE low load paths
-            Set<Long> srcBEPaths =
-                    srcBEStat.getPathStatisticForMIDAndClazz(BackendLoadStatistic.Classification.HIGH, medium);
-            List<Long> destBEPaths = new ArrayList<>(
-                    destBEStat.getPathStatisticForMIDAndClazz(BackendLoadStatistic.Classification.LOW, medium));
-            if (destBEPaths.size() <= 0) {
-                destBEIndex++;
-                destBEChanged = true;
-                continue;
-            }
-            int destBEPathsIndex = 0;  // round robin to select dest be path
-            long srcBETotalCap = srcBEStat.getTotalCapacityB(medium);
-            long destBETotalCap = destBEStat.getTotalCapacityB(medium);
-            for (Long tabletId : tablets) {
-                TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
-                if (tabletMeta == null) {
-                    continue;
-                }
-                Replica replica = invertedIndex.getReplica(tabletId, srcBEStat.getBeId());
-                if (replica == null || replica.getPathHash() == -1L) {
-                    continue;
-                }
-
-                // only move tablet on high load disk
-                if (!srcBEPaths.contains(replica.getPathHash())) {
-                    continue;
-                }
-
-                // check used percent after move
-                double destBEUsedPercent = (double) (destBEUsedCap + replica.getDataSize()) / destBETotalCap;
-                double srcBEUsedPercent = (double) (srcBEUsedCap - replica.getDataSize()) / srcBETotalCap;
-                if (Math.abs(destBEUsedPercent - avgUsedPercent) > 1e-6 && (destBEUsedPercent > avgUsedPercent)) {
-                    destBEIndex++;
-                    destBEChanged = true;
-                    continue OUT;
-                }
-                if (Math.abs(srcBEUsedPercent - avgUsedPercent) > 1e-6 && (srcBEUsedPercent < avgUsedPercent)) {
-                    srcBEIndex--;
-                    srcBEChanged = true;
-                    continue OUT;
-                }
-
-                // check tablet healthy
-                if (!isTabletHealthy(tabletId, tabletMeta, aliveBeIds)) {
-                    continue;
-                }
-
-                // NOTICE: state has been changed, the tablet must be selected
-                destBEUsedCap += replica.getDataSize();
-                srcBEUsedCap -= replica.getDataSize();
-                Pair<Long, Long> p = Pair.create(tabletMeta.getPartitionId(), tabletMeta.getIndexId());
-                //p: partition <partitionId, indexId>
-                //k: partition same to p
-                srcBEPartitionTablets.compute(p, (k, pTablets) -> {
-                    if (pTablets != null) {
-                        pTablets.remove(tabletId);
-                    }
-                    return pTablets;
-                });
-                destBEPartitionTablets.compute(p, (k, pTablets) -> {
-                    if (pTablets != null) {
-                        pTablets.add(tabletId);
-                        return pTablets;
-                    }
-                    return Sets.newHashSet(tabletId);
-                });
-                // round robin to select dest be path
-                Long destPathHash = destBEPaths.get(destBEPathsIndex);
-                destBEPathsIndex = (destBEPathsIndex + 1) % destBEPaths.size();
-
-                TabletSchedCtx schedCtx = new TabletSchedCtx(TabletSchedCtx.Type.BALANCE,
-                        tabletMeta.getDbId(), tabletMeta.getTableId(), tabletMeta.getPartitionId(),
-                        tabletMeta.getIndexId(), tabletId, System.currentTimeMillis());
-                schedCtx.setOrigPriority(TabletSchedCtx.Priority.LOW);
-                schedCtx.setSrc(replica);
-                schedCtx.setDest(destBEStat.getBeId(), destPathHash);
-                schedCtx.setBalanceType(BalanceType.DISK);
-                selectedTablets.add(tabletId);
-                alternativeTablets.add(schedCtx);
-                if (alternativeTablets.size() >= Config.tablet_sched_max_balancing_tablets) {
-                    break OUT;
-                }
-            }
-
-            // code reach here means that all tablets have moved to destBE, but srcBE and destBE both have not reached the average.
-            // it is not easy to judge whether src or dest should be retained for next round, just random
-            if ((int) (Math.random() * 100) % 2 == 0) {
-                srcBEIndex--;
-                srcBEChanged = true;
+        // divide BE into highGroup and lowGroup
+        ArrayList<BackendLoadStatistic> highGroup = new ArrayList<>();
+        ArrayList<BackendLoadStatistic> lowGroup = new ArrayList<>();
+        for (BackendLoadStatistic beStat : beStats) {
+            if (beStat.getUsedPercent(medium) > avgUsedPercent) {
+                highGroup.add(beStat);
             } else {
-                destBEIndex++;
-                destBEChanged = true;
+                lowGroup.add(beStat);
+            }
+        }
+        if (highGroup.size() <= 0 || lowGroup.size() <= 0) {
+            return alternativeTablets;
+        }
+
+        // sort highGroup in asc order, lowGroup in desc order;
+        highGroup.sort(new BackendLoadStatistic.BeStatComparatorForUsedPercent(medium, false));
+        lowGroup.sort(new BackendLoadStatistic.BeStatComparatorForUsedPercent(medium));
+
+        Map<Long, BackendBalanceState> backendBalanceStates = new HashMap<>();
+        int maxSearchTimes = highGroup.size() + lowGroup.size();
+        int searchTimes = 0;
+        int h = 0;
+        int l = 0;
+        int highGroupThreshold = (Config.tablet_sched_max_balancing_tablets + highGroup.size() - 1) / highGroup.size();
+        int lowGroupThreshold = (Config.tablet_sched_max_balancing_tablets + lowGroup.size() - 1) / lowGroup.size();
+        OUT:
+        while (highGroup.size() > 0 && lowGroup.size() > 0
+                && ++searchTimes <= maxSearchTimes) {
+            h %= highGroup.size();
+            l %= lowGroup.size();
+            BackendLoadStatistic hLoadStatistic = highGroup.get(h);
+            BackendLoadStatistic lLoadStatistic = lowGroup.get(l);
+            // source backend and target backend cannot be on the same host
+            Backend hBackend = infoService.getBackend(hLoadStatistic.getBeId());
+            if (hBackend == null) {
+                LOG.warn("backend: {} dose not exist", hLoadStatistic.getBeId());
+                highGroup.remove(h);
+                continue;
+            }
+            Backend lBackend = infoService.getBackend(lLoadStatistic.getBeId());
+            if (lBackend == null) {
+                LOG.warn("backend: {} dose not exist", lLoadStatistic.getBeId());
+                lowGroup.remove(l);
+                continue;
+            }
+            if (hBackend.getHost().equals(lBackend.getHost())) {
+                h++;
+                continue;
+            }
+
+            BackendBalanceState hState = backendBalanceStates
+                    .computeIfAbsent(hBackend.getId(),
+                            beId -> getBackendBalanceState(beId,
+                                    hLoadStatistic,
+                                    medium,
+                                    partitionReplicaCnt,
+                                    beStats.size(),
+                                    true));
+            BackendBalanceState lState = backendBalanceStates
+                    .computeIfAbsent(lBackend.getId(),
+                            beId -> getBackendBalanceState(beId,
+                                    lLoadStatistic,
+                                    medium,
+                                    partitionReplicaCnt,
+                                    beStats.size(),
+                                    false));
+
+            List<Long> lBeHostGroup = hostGroups.get(lBackend.getHost());
+
+            // tow round:
+            // in the first round, we will migrate the tablet that will make tablet distribution better,
+            // in the second round, we will migrate the tablet that will break the tablet distribution balance.
+            for (int round = 1; round <= 2; round++) {
+                PARTITION:
+                for (Pair<Long, Long> partitionMVId : hState.sortedPartitions) {
+                    Set<Long> hPartitionTablets = hState.partitionTablets.get(partitionMVId);
+                    Set<Long> lPartitionTablets = lState.partitionTablets.computeIfAbsent(partitionMVId,
+                            pmId -> new HashSet<>());
+                    int replicaTotalCnt = partitionReplicaCnt.getOrDefault(partitionMVId.first, 0);
+                    int slotOfHighBE = hPartitionTablets.size() - (replicaTotalCnt / beStats.size());
+                    int slotOfLowBE = ((replicaTotalCnt + beStats.size() - 1) / beStats.size())
+                            - lPartitionTablets.size();
+                    int slotCnt = Math.min(slotOfHighBE, slotOfLowBE);
+                    // slotCnt <= 0 means hat we will make the tablet balance worse,
+                    // ignore this partition for the first round
+                    if (round == 1 && slotCnt <= 0) {
+                        continue;
+                    }
+
+                    int selectedCnt = 0;
+                    List<Long> highLoadPathTablets = hState.getTabletsInHighLoadPath(hPartitionTablets);
+                    for (long tabletId : highLoadPathTablets) {
+                        if (selectedTablets.contains(tabletId)) {
+                            continue;
+                        }
+                        TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
+                        if (tabletMeta == null) {
+                            continue;
+                        }
+                        Replica replica = invertedIndex.getReplica(tabletId, hLoadStatistic.getBeId());
+                        if (replica == null || replica.getPathHash() == -1L || replica.getDataSize() <= 0) {
+                            continue;
+                        }
+
+                        if (isTabletExistsInBackends(tabletId, lBeHostGroup)) {
+                            continue;
+                        }
+
+                        // check used percent after move
+                        double hBEUsedPercent = (double) (hState.usedCapacity - replica.getDataSize())
+                                / hLoadStatistic.getTotalCapacityB(medium);
+                        double lBEUsedPercent = (double) (lState.usedCapacity + replica.getDataSize())
+                                / lLoadStatistic.getTotalCapacityB(medium);
+                        if (lBEUsedPercent > avgUsedPercent && lBEUsedPercent - avgUsedPercent > 1e-6) {
+                            lowGroup.remove(l);
+                            continue OUT;
+                        }
+                        if (hBEUsedPercent < avgUsedPercent && avgUsedPercent - hBEUsedPercent > 1e-6) {
+                            highGroup.remove(h);
+                            continue OUT;
+                        }
+
+                        // check tablet healthy
+                        if (!isTabletHealthy(tabletId, tabletMeta, aliveBeIds)) {
+                            continue;
+                        }
+
+                        // NOTICE: state has been changed, the tablet must be selected
+                        hPartitionTablets.remove(tabletId);
+                        lPartitionTablets.add(tabletId);
+                        hState.tabletSelected++;
+                        lState.tabletSelected++;
+
+                        Long destPathHash = lState.getLowestLoadPath();
+                        lState.addUsedCapacity(destPathHash, replica.getDataSize());
+                        hState.minusUsedCapacity(replica.getPathHash(), replica.getDataSize());
+
+                        TabletSchedCtx schedCtx = new TabletSchedCtx(TabletSchedCtx.Type.BALANCE,
+                                tabletMeta.getDbId(), tabletMeta.getTableId(), tabletMeta.getPartitionId(),
+                                tabletMeta.getIndexId(), tabletId, System.currentTimeMillis());
+                        schedCtx.setOrigPriority(TabletSchedCtx.Priority.LOW);
+                        schedCtx.setSrc(replica);
+                        schedCtx.setDest(lBackend.getId(), destPathHash);
+                        schedCtx.setBalanceType(BalanceType.DISK);
+                        selectedTablets.add(tabletId);
+                        alternativeTablets.add(schedCtx);
+
+                        selectedCnt++;
+
+                        // number of tablets cloned from high load BE exceeds limit
+                        if (hState.tabletSelected >= highGroupThreshold) {
+                            highGroup.remove(h);
+                            continue OUT;
+                        }
+                        // number of tablets cloned to low load BE exceeds limit
+                        if (lState.tabletSelected >= lowGroupThreshold) {
+                            lowGroup.remove(l);
+                            continue OUT;
+                        }
+                        // for round1: the number of selected tablets is bigger than slotCnt,
+                        //             selecting tablet from this partition will break the balance of tablet distribution,
+                        //             so change to next partition
+                        // for round2: In order not to skew the partition too much,
+                        //             we only balance one tablet for a partition,
+                        //             so change to next partition.
+                        if ((round == 1 && selectedCnt >= slotCnt) || round == 2) {
+                            continue PARTITION;
+                        }
+                    }
+                }
+            }
+            // neither the number of tablets select in high load BE nor low load BE exceeds limit,
+            // change group index in succession.
+            if ((h + l) % 2 == 0) {
+                h++;
+            } else {
+                l++;
             }
         }
 
         return alternativeTablets;
     }
+
+
 
     /**
      * Backend disk balance is same with cluster disk balance.
@@ -873,11 +938,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             }
 
             Pair<Long, Long> key = new Pair<>(tabletMeta.getPartitionId(), tabletMeta.getIndexId());
-            if (partitionTablets.containsKey(key)) {
-                partitionTablets.get(key).add(tabletId);
-            } else {
-                partitionTablets.put(key, Sets.newHashSet(tabletId));
-            }
+            partitionTablets.computeIfAbsent(key, k -> Sets.newHashSet()).add(tabletId);
         }
         return partitionTablets;
     }
@@ -1341,26 +1402,6 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         }
     }
 
-    private static class PartitionStat {
-        Long dbId;
-        Long tableId;
-        // skew is (max replica number on be) - (min replica number on be)
-        int skew;
-        int replicaNum;
-
-        public PartitionStat(Long dbId, Long tableId, int skew, int replicaNum) {
-            this.dbId = dbId;
-            this.tableId = tableId;
-            this.skew = skew;
-            this.replicaNum = replicaNum;
-        }
-
-        @Override
-        public String toString() {
-            return "dbId: " + dbId + ", tableId: " + tableId + ", skew: " + skew + ", replicaNum: " + replicaNum;
-        }
-    }
-
     /**
      * Get Map<(partition, index) => PartitionStat>
      * <p>
@@ -1539,6 +1580,98 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         return partitionStats;
     }
 
+    private Map<Long, Integer> getPartitionReplicaCnt() {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        Map<Long, Integer> partitionReplicaCnt = new HashMap<>();
+        List<Long> dbIds = globalStateMgr.getDbIdsIncludeRecycleBin();
+        for (Long dbId : dbIds) {
+            Database db = globalStateMgr.getDbIncludeRecycleBin(dbId);
+            if (db == null) {
+                continue;
+            }
+
+            if (db.isInfoSchemaDb()) {
+                continue;
+            }
+
+            db.readLock();
+            try {
+                for (Table table : globalStateMgr.getTablesIncludeRecycleBin(db)) {
+                    // check table is olap table or colocate table
+                    if (!table.needSchedule(false)) {
+                        continue;
+                    }
+                    if (table.isLakeTable()) {
+                        // replicas are managed by StarOS and cloud storage.
+                        continue;
+                    }
+
+                    OlapTable olapTbl = (OlapTable) table;
+                    for (Partition partition : globalStateMgr.getAllPartitionsIncludeRecycleBin(olapTbl)) {
+                        int replicaTotalCnt = partition.getDistributionInfo().getBucketNum()
+                                * globalStateMgr.getReplicationNumIncludeRecycleBin(olapTbl.getPartitionInfo(),
+                                partition.getId());
+                        partitionReplicaCnt.put(partition.getId(), replicaTotalCnt);
+                    }
+                }
+            } finally {
+                db.readUnlock();
+            }
+        }
+
+        return partitionReplicaCnt;
+    }
+
+    private BackendBalanceState getBackendBalanceState(long backendId,
+                                                       BackendLoadStatistic backendLoadStatistic,
+                                                       TStorageMedium medium,
+                                                       Map<Long, Integer> partitionReplicaCnt,
+                                                       int backendCnt,
+                                                       boolean sortPartition) {
+        Map<Pair<Long, Long>, Set<Long>> partitionTablets = getPartitionTablets(backendId, medium, -1L);
+        List<Pair<Long, Long>> partitions = new ArrayList<>(partitionTablets.keySet());
+        if (sortPartition) {
+            partitions.sort((p1, p2) -> {
+                // skew is (tablet cnt on current BE - average tablet cnt on every BE)
+                // sort partitions by skew in desc order
+                int skew1 = partitionTablets.get(p1).size()
+                        - partitionReplicaCnt.getOrDefault(p1.first, 0) / backendCnt;
+                int skew2 = partitionTablets.get(p2).size()
+                        - partitionReplicaCnt.getOrDefault(p2.first, 0) / backendCnt;
+                return skew2 - skew1;
+            });
+        }
+
+        BackendBalanceState backendBalanceState = new BackendBalanceState(backendId,
+                backendLoadStatistic,
+                invertedIndex,
+                medium,
+                partitionTablets,
+                partitions);
+        backendBalanceState.init();
+        return backendBalanceState;
+    }
+
+    private static class PartitionStat {
+        Long dbId;
+        Long tableId;
+        // skew is (max replica number on be) - (min replica number on be)
+        int skew;
+        int replicaNum;
+
+        public PartitionStat(Long dbId, Long tableId, int skew, int replicaNum) {
+            this.dbId = dbId;
+            this.tableId = tableId;
+            this.skew = skew;
+            this.replicaNum = replicaNum;
+        }
+
+        @Override
+        public String toString() {
+            return "dbId: " + dbId + ", tableId: " + tableId + ", skew: " + skew + ", replicaNum: " + replicaNum;
+        }
+    }
+
     // used to check disk balance when doing tablet distribution balance
     // we check disk balance using 0.9 * Config.balance_load_score_threshold to avoid trigger disk unbalance
     // todo optimization using segment tree
@@ -1628,6 +1761,145 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             destCap.second += size;
 
             init();
+        }
+    }
+
+    public static class BackendBalanceState {
+        long backendId;
+        BackendLoadStatistic statistic;
+        TStorageMedium medium;
+        List<Pair<Long, Long>> sortedPartitions;
+        TabletInvertedIndex tabletInvertedIndex;
+        // <partitionId, mvId> => tablets in that partition
+        Map<Pair<Long, Long>, Set<Long>> partitionTablets;
+        // total data used capacity
+        long usedCapacity;
+        // pathHash => usedCapacity
+        Map<Long, Long> pathUsedCapacity;
+        int tabletSelected = 0;
+        // Min heap of <pathHash, usedPercent>, only used for low load group
+        PriorityQueue<Pair<Long, Double>> pathLoadHeap;
+        // sorted path in desc order, only used for high load group
+        List<Long> sortedPath;
+        // pathHash => index of sortedPath, only used for high load group
+        Map<Long, Integer> pathSortIndex;
+
+        BackendBalanceState(long backendId,
+                            BackendLoadStatistic statistic,
+                            TabletInvertedIndex tabletInvertedIndex,
+                            TStorageMedium medium,
+                            Map<Pair<Long, Long>, Set<Long>> partitionTablets,
+                            List<Pair<Long, Long>> partitions) {
+            this.backendId = backendId;
+            this.statistic = statistic;
+            this.tabletInvertedIndex = tabletInvertedIndex;
+            this.medium = medium;
+            this.partitionTablets = partitionTablets;
+            this.sortedPartitions = partitions;
+        }
+
+        void init() {
+            this.usedCapacity = statistic.getTotalUsedCapacityB(medium);
+            this.pathLoadHeap = new PriorityQueue<>(Pair.comparingBySecond());
+            this.pathUsedCapacity = new HashMap<>();
+            this.sortedPath = new ArrayList<>();
+            this.pathSortIndex = new HashMap<>();
+            for (RootPathLoadStatistic pathStatistic : statistic.getPathStatistics()) {
+                if (pathStatistic.getStorageMedium() != this.medium
+                        || pathStatistic.getDiskState() == DiskInfo.DiskState.OFFLINE
+                        || pathStatistic.getCapacityB() <= 0) {
+                    continue;
+                }
+
+                this.pathLoadHeap.add(new Pair<>(pathStatistic.getPathHash(), pathStatistic.getUsedPercent()));
+                this.pathUsedCapacity.put(pathStatistic.getPathHash(), pathStatistic.getUsedCapacityB());
+                this.sortedPath.add(pathStatistic.getPathHash());
+            }
+            sortedPath.sort((p1, p2) -> {
+                double skew = statistic.getPathStatistic(p1).getUsedPercent()
+                        - statistic.getPathStatistic(p2).getUsedPercent();
+                if (Math.abs(skew) < 1e-6) {
+                    return 0;
+                }
+                return skew > 0 ? -1 : 1;
+            });
+            for (int i = 0; i < sortedPath.size(); i++) {
+                pathSortIndex.put(sortedPath.get(i), i);
+            }
+        }
+
+        // used for low load group
+        public Long getLowestLoadPath() {
+            return this.pathLoadHeap.poll().first;
+        }
+
+        // used for low load group
+        public void addUsedCapacity(long pathHash, long deltaCap) {
+            this.usedCapacity += deltaCap;
+            long newPathUsedCap = this.pathUsedCapacity.compute(pathHash, (path, cap) -> cap + deltaCap);
+            this.pathLoadHeap.add(new Pair<>(pathHash,
+                    (double) newPathUsedCap / statistic.getPathStatistic(pathHash).getCapacityB()));
+        }
+
+        // used for high load group
+        public List<Long> getTabletsInHighLoadPath(Set<Long> tablets) {
+            double avgUsedPercent = pathUsedCapacity.values().stream().mapToLong(Long::longValue).sum()
+                    / (double) statistic.getTotalCapacityB(medium);
+            // find the last high load index, we only choose tablet in the high load paths
+            int lastHighLoadIndex = -1;
+            for (long pathHash : sortedPath) {
+                double usedPercent = pathUsedCapacity.get(pathHash)
+                        / (double) statistic.getPathStatistic(pathHash).getCapacityB();
+                if (usedPercent - avgUsedPercent > -Config.tablet_sched_balance_load_score_threshold) {
+                    lastHighLoadIndex++;
+                } else {
+                    break;
+                }
+            }
+            Preconditions.checkState(lastHighLoadIndex >= 0, "there is no high load path");
+
+            // group the tablet by path, put tablets in sortedPath[i] to tabletGroups[i]
+            ArrayList<Long>[] tabletGroups = new ArrayList[lastHighLoadIndex + 1];
+            for (int i = 0; i < tabletGroups.length; i++) {
+                tabletGroups[i] = new ArrayList<>();
+            }
+            for (long tabletId : tablets) {
+                long pathHash = tabletInvertedIndex.getReplica(tabletId, this.backendId).getPathHash();
+                int sortIndex = pathSortIndex.get(pathHash);
+                if (sortIndex > lastHighLoadIndex) {
+                    continue;
+                }
+
+                tabletGroups[sortIndex].add(tabletId);
+            }
+
+            List<Long> highLoadPathTablets = new ArrayList<>();
+            for (ArrayList<Long> group : tabletGroups) {
+                highLoadPathTablets.addAll(group);
+            }
+            return highLoadPathTablets;
+        }
+
+        // used for high load group
+        public void minusUsedCapacity(long pathHash, long deltaCap) {
+            this.usedCapacity -= deltaCap;
+            long pathUsedCap = this.pathUsedCapacity.compute(pathHash, (path, cap) -> cap - deltaCap);
+            double usedPercent = (double) pathUsedCap / this.statistic.getPathStatistic(pathHash).getCapacityB();
+
+            // adjust the sort order
+            for (int i = this.pathSortIndex.get(pathHash); i < this.sortedPath.size() - 1; i++) {
+                long nextPathHash = this.sortedPath.get(i + 1);
+                double nextUsedPercent = (double) this.pathUsedCapacity.get(nextPathHash)
+                        / this.statistic.getPathStatistic(nextPathHash).getCapacityB();
+                if (usedPercent < nextUsedPercent) {
+                    this.sortedPath.set(i, nextPathHash);
+                    this.sortedPath.set(i + 1, pathHash);
+                    this.pathSortIndex.put(nextPathHash, i);
+                    this.pathSortIndex.put(pathHash, i + 1);
+                } else {
+                    break;
+                }
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1186,6 +1186,8 @@ public class TabletScheduler extends LeaderDaemon {
             sendDeleteReplicaTask(replica.getBackendId(), tabletCtx.getTabletId(), tabletCtx.getSchemaHash());
         }
 
+        invertedIndex.markTabletForceDelete(tabletCtx.getTabletId());
+
         // write edit log
         ReplicaPersistInfo info = ReplicaPersistInfo.createForDelete(tabletCtx.getDbId(),
                 tabletCtx.getTblId(),

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1123,7 +1123,7 @@ public class Config extends ConfigBase {
      * TODO(cmy): remove this config and dynamically adjust it by clone task statistic
      */
     @ConfField(mutable = true, aliases = {"schedule_slot_num_per_path"})
-    public static int tablet_sched_slot_num_per_path = 4;
+    public static int tablet_sched_slot_num_per_path = 16;
 
     // if the number of scheduled tablets in TabletScheduler exceed max_scheduling_tablets
     // skip checking.
@@ -1170,11 +1170,6 @@ public class Config extends ConfigBase {
     public static boolean enable_replicated_storage_as_default_engine = true;
 
     /**
-     * FOR BeLoadBalancer:
-     * the threshold of cluster balance score, if a backend's load score is 10% lower than average score,
-     * this backend will be marked as LOW load, if load score is 10% higher than average score, HIGH load
-     * will be marked.
-     * <p>
      * FOR DiskAndTabletLoadBalancer:
      * upper limit of the difference in disk usage of all backends, exceeding this threshold will cause
      * disk balance

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1123,7 +1123,7 @@ public class Config extends ConfigBase {
      * TODO(cmy): remove this config and dynamically adjust it by clone task statistic
      */
     @ConfField(mutable = true, aliases = {"schedule_slot_num_per_path"})
-    public static int tablet_sched_slot_num_per_path = 16;
+    public static int tablet_sched_slot_num_per_path = 8;
 
     // if the number of scheduled tablets in TabletScheduler exceed max_scheduling_tablets
     // skip checking.

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -18,6 +18,7 @@ package com.starrocks.clone;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
@@ -35,6 +36,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.clone.DiskAndTabletLoadReBalancer.BackendBalanceState;
 import com.starrocks.common.Config;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -45,6 +47,8 @@ import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -570,5 +574,245 @@ public class DiskAndTabletLoadReBalancerTest {
         invertedIndex.addReplica(tabletId, replica);
         LocalTablet tablet1 = new LocalTablet(tabletId, Lists.newArrayList(replica));
         materializedIndex.addTablet(tablet1, tabletMeta, true);
+    }
+
+
+    @Test
+    public void testBalanceParallel(@Mocked GlobalStateMgr globalStateMgr) {
+        // system info
+        long dbId = 10001L;
+        long tableId = 10002L;
+        long partitionId = 10003L;
+        long indexId = 10004L;
+        long tabletDataSize = 200 * 1024 * 1024L;
+        TStorageMedium medium = TStorageMedium.HDD;
+        long beId1 = 1L;
+        long beId2 = 2L;
+        long beId3 = 3L;
+        long beId4 = 4L;
+        long pathHash1 = 1111L;
+        long pathHash2 = 2222L;
+        long pathHash3 = 3333L;
+        long pathHash4 = 4444L;
+
+        SystemInfoService infoService = new SystemInfoService();
+
+        final long highTabletCnt = 10;
+        infoService.addBackend(genBackend(beId1, "host1", 0,
+                highTabletCnt * tabletDataSize, 10 * tabletDataSize, pathHash1));
+
+        infoService.addBackend(genBackend(beId2, "host2", 0,
+                highTabletCnt * tabletDataSize, 10 * tabletDataSize, pathHash2));
+
+        infoService.addBackend(genBackend(beId3, "host3", 10 * tabletDataSize,
+                0, 10 * tabletDataSize, pathHash3));
+
+        infoService.addBackend(genBackend(beId4, "host4", 10 * tabletDataSize,
+                0, 10 * tabletDataSize, pathHash4));
+
+        // tablet inverted index
+        TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
+        MaterializedIndex materializedIndex = new MaterializedIndex(indexId, IndexState.NORMAL);
+        for (int i = 1; i <= highTabletCnt; i++) {
+            addTablet(invertedIndex, materializedIndex, TStorageMedium.HDD, dbId, tableId,
+                    partitionId, indexId, 20000 + i, 30000 + i, beId1, tabletDataSize, pathHash1);
+            addTablet(invertedIndex, materializedIndex, TStorageMedium.HDD, dbId, tableId,
+                    partitionId, indexId, 20000 + highTabletCnt + i, 30000 + highTabletCnt + i,
+                    beId2, tabletDataSize, pathHash2);
+        }
+
+        ClusterLoadStatistic clusterLoadStatistic = new ClusterLoadStatistic(infoService, invertedIndex);
+        clusterLoadStatistic.init();
+
+        PartitionInfo partitionInfo = new PartitionInfo();
+        DataProperty dataProperty = new DataProperty(medium);
+        partitionInfo.addPartition(partitionId, dataProperty, (short) 1, false);
+        DistributionInfo distributionInfo = new HashDistributionInfo(6, Lists.newArrayList());
+        Partition partition = new Partition(partitionId, "partition", materializedIndex, distributionInfo);
+        OlapTable table = new OlapTable(tableId, "table", Lists.newArrayList(), KeysType.AGG_KEYS, partitionInfo,
+                distributionInfo);
+        table.addPartition(partition);
+        Database database = new Database(dbId, "database");
+        database.createTable(table);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.getDbIdsIncludeRecycleBin();
+                result = Lists.newArrayList(dbId);
+                minTimes = 0;
+
+                globalStateMgr.getDbIncludeRecycleBin(dbId);
+                result = database;
+                minTimes = 0;
+
+                globalStateMgr.getTableIncludeRecycleBin((Database) any, anyLong);
+                result = table;
+                minTimes = 0;
+
+                globalStateMgr.getTablesIncludeRecycleBin((Database) any);
+                result = Lists.newArrayList(table);
+                minTimes = 0;
+
+                globalStateMgr.getPartitionIncludeRecycleBin((OlapTable) any, anyLong);
+                result = partition;
+                minTimes = 0;
+
+                globalStateMgr.getAllPartitionsIncludeRecycleBin((OlapTable) any);
+                result = Lists.newArrayList(partition);
+                minTimes = 0;
+
+                globalStateMgr.getReplicationNumIncludeRecycleBin((PartitionInfo) any, anyLong);
+                result = (short) 1;
+                minTimes = 0;
+
+                globalStateMgr.getDataPropertyIncludeRecycleBin((PartitionInfo) any, anyLong);
+                result = dataProperty;
+                minTimes = 0;
+            }
+        };
+
+        Rebalancer rebalancer = new DiskAndTabletLoadReBalancer(infoService, invertedIndex);
+        rebalancer.updateLoadStatistic(clusterLoadStatistic);
+
+        List<TabletSchedCtx> tablets = rebalancer.selectAlternativeTablets();
+        int be1SourceCnt = 0;
+        int be2SourceCnt = 0;
+        for (TabletSchedCtx ctx : tablets) {
+            if (ctx.getSrcBackendId() == beId1) {
+                be1SourceCnt++;
+            }
+
+            if (ctx.getSrcBackendId() == beId2) {
+                be2SourceCnt++;
+            }
+        }
+
+        Assert.assertEquals(4, be1SourceCnt);
+        Assert.assertEquals(4, be2SourceCnt);
+    }
+
+    @Test
+    public void testBackendBalanceState() throws Exception {
+        long tabletDataSize = 200 * 1024 * 1024L;
+        long tabletId1 = 10000L;
+        long tabletId2 = 10001L;
+        long replicaId1 = 11000L;
+        long replicaId2 = 11001L;
+        long pathHash10 = 10L;
+        long pathHash11 = 11L;
+        long pathHash12 = 12L;
+        long pathHash13 = 13L;
+        long pathHash14 = 14L;
+
+        Backend be1 = genBackend(1L, "host1", 2 * tabletDataSize,
+                2 * tabletDataSize, 4 * tabletDataSize, pathHash10);
+        DiskInfo disk10 = genDiskInfo(0, 4 * tabletDataSize,
+                4 * tabletDataSize, "/data10", pathHash10, TStorageMedium.HDD);
+        DiskInfo disk11 = genDiskInfo(tabletDataSize, 3 * tabletDataSize,
+                4 * tabletDataSize, "/data11", pathHash11, TStorageMedium.HDD);
+        DiskInfo disk12 = genDiskInfo(2 * tabletDataSize, 2 * tabletDataSize,
+                4 * tabletDataSize, "/data12", pathHash12, TStorageMedium.HDD);
+        DiskInfo disk13 = genDiskInfo(3 * tabletDataSize, tabletDataSize,
+                4 * tabletDataSize, "/data13", pathHash13, TStorageMedium.HDD);
+        DiskInfo disk14 = genDiskInfo(4 * tabletDataSize, 0,
+                4 * tabletDataSize, "/data14", pathHash14, TStorageMedium.HDD);
+        Map<String, DiskInfo> diskInfoMap1 = Maps.newHashMap();
+        diskInfoMap1.put(disk10.getRootPath(), disk10);
+        diskInfoMap1.put(disk11.getRootPath(), disk11);
+        diskInfoMap1.put(disk12.getRootPath(), disk12);
+        diskInfoMap1.put(disk13.getRootPath(), disk13);
+        diskInfoMap1.put(disk14.getRootPath(), disk14);
+        be1.setDisks(ImmutableMap.copyOf(diskInfoMap1));
+
+        SystemInfoService infoService = new SystemInfoService();
+        infoService.addBackend(be1);
+
+        BackendLoadStatistic backendLoadStatistic = new BackendLoadStatistic(1L,
+                "cluster1",
+                infoService,
+                new TabletInvertedIndex());
+
+        backendLoadStatistic.init();
+        TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
+
+        // add tablet to invertedIndex
+        invertedIndex.addTablet(tabletId1,
+                new TabletMeta(1, 2, 3, 4, -1, TStorageMedium.HDD));
+        Replica replica = new Replica(replicaId1, 1, -1, ReplicaState.NORMAL);
+        replica.setPathHash(pathHash10);
+        invertedIndex.addReplica(tabletId1, replica);
+
+        invertedIndex.addTablet(tabletId2,
+                new TabletMeta(1, 2, 3, 4, -1, TStorageMedium.HDD));
+        replica = new Replica(replicaId2, 1, -1, ReplicaState.NORMAL);
+        replica.setPathHash(pathHash13);
+        invertedIndex.addReplica(tabletId2, replica);
+
+        BackendBalanceState hState = new BackendBalanceState(1L,
+                backendLoadStatistic,
+                invertedIndex,
+                TStorageMedium.HDD,
+                new HashMap<>(),
+                new ArrayList<>());
+
+        hState.init();
+        Assert.assertEquals((Long) pathHash10, hState.sortedPath.get(0));
+        Assert.assertEquals((Long) pathHash11, hState.sortedPath.get(1));
+        Assert.assertEquals((Long) pathHash12, hState.sortedPath.get(2));
+        Assert.assertEquals((Long) pathHash13, hState.sortedPath.get(3));
+        Assert.assertEquals((Long) pathHash14, hState.sortedPath.get(4));
+        Assert.assertEquals((Integer) 0, hState.pathSortIndex.get(pathHash10));
+        Assert.assertEquals((Integer) 1, hState.pathSortIndex.get(pathHash11));
+        Assert.assertEquals((Integer) 2, hState.pathSortIndex.get(pathHash12));
+        Assert.assertEquals((Integer) 3, hState.pathSortIndex.get(pathHash13));
+        Assert.assertEquals((Integer) 4, hState.pathSortIndex.get(pathHash14));
+        Assert.assertEquals(10 * tabletDataSize, hState.usedCapacity);
+
+        List<Long> highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        Assert.assertEquals(1, highLoadPaths.size());
+        Assert.assertEquals((Long) tabletId1, highLoadPaths.get(0));
+
+        // change threshold to 0.3, tabletId2 will be chosen
+        Config.tablet_sched_balance_load_score_threshold = 0.3;
+        highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        Assert.assertEquals(2, highLoadPaths.size());
+        Assert.assertEquals((Long) tabletId1, highLoadPaths.get(0));
+        Assert.assertEquals((Long) tabletId2, highLoadPaths.get(1));
+        // reset
+        Config.tablet_sched_balance_load_score_threshold = 0.1;
+
+        // minus 4 tablets from pathHash10
+        hState.minusUsedCapacity(pathHash10, 4 * tabletDataSize);
+        Assert.assertEquals((Long) pathHash11, hState.sortedPath.get(0));
+        Assert.assertEquals((Long) pathHash12, hState.sortedPath.get(1));
+        Assert.assertEquals((Long) pathHash13, hState.sortedPath.get(2));
+        Assert.assertEquals((Integer) 0, hState.pathSortIndex.get(pathHash11));
+        Assert.assertEquals((Integer) 1, hState.pathSortIndex.get(pathHash12));
+        Assert.assertEquals((Integer) 2, hState.pathSortIndex.get(pathHash13));
+        Assert.assertEquals(6 * tabletDataSize, hState.usedCapacity);
+        // only tabletId2 will be chosen
+        highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        Assert.assertEquals(1, highLoadPaths.size());
+        Assert.assertEquals((Long) tabletId2, highLoadPaths.get(0));
+
+
+        BackendBalanceState lState = new BackendBalanceState(1L,
+                backendLoadStatistic,
+                invertedIndex,
+                TStorageMedium.HDD,
+                new HashMap<>(),
+                new ArrayList<>());
+
+        lState.init();
+
+        // add 2 tablets to the lowest path hash, the lowest path will be pathHash13
+        Long pathHash = lState.getLowestLoadPath();
+        Assert.assertEquals((Long) pathHash14, pathHash);
+        lState.addUsedCapacity(pathHash14, 2 * tabletDataSize);
+        Assert.assertEquals((Long) pathHash13, lState.getLowestLoadPath());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When doing cluster disk balancing, most of the tablets selected are from the same BE, because of the limitation of IO and network, the migration is very slow.
To improve the migration parallelism, we divide the BE into two groups: one is higher than the average disk usage, and another is lower than the average disk usage. When selecting the tablet, we use round robin to change the source BE and target BE once a tablet is chosen.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
