### PR TITLE
[Feature] Report and show cache capacity of lake table

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -59,6 +59,7 @@
 #include "runtime/snapshot_loader.h"
 #include "service/backend_options.h"
 #include "storage/data_dir.h"
+#include "storage/lake/starlet_cache_dir.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/olap_common.h"
 #include "storage/snapshot_manager.h"
@@ -623,16 +624,16 @@ void* ReportDiskStateTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         request.__set_backend(BackendOptions::get_localBackend());
 
 #ifdef USE_STAROS
-        std::vector<DataDirInfo> starlet_cache_dir_infos;
+        std::vector<lake::StarletCacheDirInfo> starlet_cache_dir_infos;
         StorageEngine::instance()->get_all_starlet_cache_dir_info(&starlet_cache_dir_infos);
         std::map<std::string, TStarletCache> starlet_caches;
         for (auto& cache_path_info : starlet_cache_dir_infos) {
             TStarletCache cache;
             cache.__set_cache_path(cache_path_info.path);
             cache.__set_storage_medium(cache_path_info.storage_medium);
-            cache.__set_cache_total_capacity(cache_path_info.cache_capacity);
-            cache.__set_cache_used_capacity(cache_path_info.cache_used_capacity);
-            cache.__set_cache_available_capacity(cache_path_info.cache_available);
+            cache.__set_cache_total_capacity(cache_path_info.capacity);
+            cache.__set_cache_used_capacity(cache_path_info.used_capacity);
+            cache.__set_cache_available_capacity(cache_path_info.available);
             starlet_caches[cache_path_info.path] = cache;
         }
         request.__set_starlet_caches(starlet_caches);

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -622,6 +622,22 @@ void* ReportDiskStateTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         request.__set_disks(disks);
         request.__set_backend(BackendOptions::get_localBackend());
 
+#ifdef USE_STAROS
+        std::vector<DataDirInfo> starlet_cache_dir_infos;
+        StorageEngine::instance()->get_all_starlet_cache_dir_info(&starlet_cache_dir_infos);
+        std::map<std::string, TStarletCache> starlet_caches;
+        for (auto& cache_path_info : starlet_cache_dir_infos) {
+            TStarletCache cache;
+            cache.__set_cache_path(cache_path_info.path);
+            cache.__set_storage_medium(cache_path_info.storage_medium);
+            cache.__set_cache_total_capacity(cache_path_info.cache_capacity);
+            cache.__set_cache_used_capacity(cache_path_info.cache_used_capacity);
+            cache.__set_cache_available_capacity(cache_path_info.cache_available);
+            starlet_caches[cache_path_info.path] = cache;
+        }
+        request.__set_starlet_caches(starlet_caches);
+#endif
+
         StarRocksMetrics::instance()->report_disk_requests_total.increment(1);
         TMasterResult result;
         AgentStatus status = report_task(request, &result);

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -272,6 +272,14 @@ int main(int argc, char** argv) {
         }
     }
 
+#ifdef USE_STAROS
+    std::vector<starrocks::StorePath> starlet_cache_paths;
+    auto parse_res = starrocks::parse_conf_store_paths(starrocks::config::starlet_cache_dir, &starlet_cache_paths);
+    if (!parse_res.ok()) {
+        LOG(WARNING) << "parse config starlet cache dir path failed, path=" << starrocks::config::starlet_cache_dir;
+    }
+#endif
+
     // Initilize libcurl here to avoid concurrent initialization.
     auto curl_ret = curl_global_init(CURL_GLOBAL_ALL);
     if (curl_ret != 0) {
@@ -298,6 +306,9 @@ int main(int argc, char** argv) {
     // Init and open storage engine.
     starrocks::EngineOptions options;
     options.store_paths = paths;
+#ifdef USE_STAROS
+    options.starlet_cache_paths = starlet_cache_paths;
+#endif
     options.backend_uid = starrocks::UniqueId::gen_uid();
     options.compaction_mem_tracker = exec_env->compaction_mem_tracker();
     options.update_mem_tracker = exec_env->update_mem_tracker();

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -186,4 +186,5 @@ add_library(Storage STATIC
     binlog_reader.cpp
     lake/update_compaction_state.cpp
     lake/txn_log_applier.cpp
+    lake/starlet_cache_dir.cpp
 )

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -68,6 +68,7 @@ static const char* const kTestFilePath = "/.testfile";
 DataDir::DataDir(const std::string& path, TStorageMedium::type storage_medium, TabletManager* tablet_manager,
                  TxnManager* txn_manager)
         : _path(path),
+          _path_hash(0),
           _available_bytes(0),
           _disk_capacity_bytes(0),
           _storage_medium(storage_medium),
@@ -533,6 +534,15 @@ Status DataDir::update_capacity() {
     _disk_capacity_bytes = space_info.capacity;
     return Status::OK();
 }
+
+#ifdef USE_STAROS
+Status DataDir::update_cache_capacity() {
+    ASSIGN_OR_RETURN(auto space_info, FileSystem::Default()->space(_path));
+    _cache_available_bytes = space_info.available;
+    _cache_capacity_bytes = space_info.capacity;
+    return Status::OK();
+}
+#endif
 
 bool DataDir::capacity_limit_reached(int64_t incoming_data_size) {
     double used_pct = (_disk_capacity_bytes - _available_bytes + incoming_data_size) / (double)_disk_capacity_bytes;

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -73,16 +73,10 @@ DataDir::DataDir(const std::string& path, TStorageMedium::type storage_medium, T
           _disk_capacity_bytes(0),
           _storage_medium(storage_medium),
           _is_used(false),
-#ifdef USE_STAROS
-          _cache_available_bytes(0),
-          _cache_capacity_bytes(0),
-          _cache_used_bytes(0),
-#endif
           _tablet_manager(tablet_manager),
           _txn_manager(txn_manager),
           _cluster_id_mgr(std::make_shared<ClusterIdMgr>(path)),
-          _current_shard(0) {
-}
+          _current_shard(0) {}
 
 DataDir::~DataDir() {
     delete _id_generator;
@@ -540,15 +534,6 @@ Status DataDir::update_capacity() {
     _disk_capacity_bytes = space_info.capacity;
     return Status::OK();
 }
-
-#ifdef USE_STAROS
-Status DataDir::update_cache_capacity() {
-    ASSIGN_OR_RETURN(auto space_info, FileSystem::Default()->space(_path));
-    _cache_available_bytes = space_info.available;
-    _cache_capacity_bytes = space_info.capacity;
-    return Status::OK();
-}
-#endif
 
 bool DataDir::capacity_limit_reached(int64_t incoming_data_size) {
     double used_pct = (_disk_capacity_bytes - _available_bytes + incoming_data_size) / (double)_disk_capacity_bytes;

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -73,10 +73,16 @@ DataDir::DataDir(const std::string& path, TStorageMedium::type storage_medium, T
           _disk_capacity_bytes(0),
           _storage_medium(storage_medium),
           _is_used(false),
+#ifdef USE_STAROS
+          _cache_available_bytes(0),
+          _cache_capacity_bytes(0),
+          _cache_used_bytes(0),
+#endif
           _tablet_manager(tablet_manager),
           _txn_manager(txn_manager),
           _cluster_id_mgr(std::make_shared<ClusterIdMgr>(path)),
-          _current_shard(0) {}
+          _current_shard(0) {
+}
 
 DataDir::~DataDir() {
     delete _id_generator;

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -84,10 +84,6 @@ public:
         info.available = _available_bytes;
         info.is_used = _is_used;
         info.storage_medium = _storage_medium;
-#ifdef USE_STAROS
-        info.cache_capacity = _cache_capacity_bytes;
-        info.cache_available = _cache_available_bytes;
-#endif
         return info;
     }
 
@@ -137,11 +133,6 @@ public:
 
     Status update_capacity();
 
-#ifdef USE_STAROS
-    Status update_cache_capacity();
-    void set_cache_used_bytes(int64_t cache_used_bytes) { _cache_used_bytes = cache_used_bytes; }
-#endif
-
 private:
     Status _init_data_dir();
     Status _init_tmp_dir();
@@ -162,11 +153,6 @@ private:
     int64_t _disk_capacity_bytes;
     TStorageMedium::type _storage_medium;
     bool _is_used;
-#ifdef USE_STAROS
-    int64_t _cache_available_bytes;
-    int64_t _cache_capacity_bytes;
-    int64_t _cache_used_bytes;
-#endif
 
     TabletManager* _tablet_manager;
     TxnManager* _txn_manager;

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -84,6 +84,10 @@ public:
         info.available = _available_bytes;
         info.is_used = _is_used;
         info.storage_medium = _storage_medium;
+#ifdef USE_STAROS
+        info.cache_capacity = _cache_capacity_bytes;
+        info.cache_available = _cache_available_bytes;
+#endif
         return info;
     }
 
@@ -133,6 +137,11 @@ public:
 
     Status update_capacity();
 
+#ifdef USE_STAROS
+    Status update_cache_capacity();
+    void set_cache_used_bytes(int64_t cache_used_bytes) { _cache_used_bytes = cache_used_bytes; }
+#endif
+
 private:
     Status _init_data_dir();
     Status _init_tmp_dir();
@@ -153,6 +162,11 @@ private:
     int64_t _disk_capacity_bytes;
     TStorageMedium::type _storage_medium;
     bool _is_used;
+#ifdef USE_STAROS
+    int64_t _cache_available_bytes;
+    int64_t _cache_capacity_bytes;
+    int64_t _cache_used_bytes;
+#endif
 
     TabletManager* _tablet_manager;
     TxnManager* _txn_manager;

--- a/be/src/storage/lake/starlet_cache_dir.cpp
+++ b/be/src/storage/lake/starlet_cache_dir.cpp
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/starlet_cache_dir.h"
+
+namespace starrocks::lake {
+
+StarletCacheDir::StarletCacheDir(const std::string& path, TStorageMedium::type storage_medium)
+        : _path(path), _storage_medium(storage_medium), _available_bytes(0), _disk_capacity_bytes(0) {}
+
+Status StarletCacheDir::update_capacity() {
+    ASSIGN_OR_RETURN(auto space_info, FileSystem::Default()->space(_path));
+    _available_bytes = space_info.available;
+    _disk_capacity_bytes = space_info.capacity;
+    return Status::OK();
+}
+
+StarletCacheDirInfo StarletCacheDir::get_dir_info() {
+    StarletCacheDirInfo info;
+
+    info.path = _path;
+    info.storage_medium = _storage_medium;
+    info.capacity = _disk_capacity_bytes;
+    info.available = _available_bytes;
+    return info;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/starlet_cache_dir.h
+++ b/be/src/storage/lake/starlet_cache_dir.h
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "common/status.h"
+#include "fs/fs.h"
+#include "gen_cpp/Types_types.h"
+
+namespace starrocks::lake {
+
+struct StarletCacheDirInfo {
+    StarletCacheDirInfo() = default;
+
+    ~StarletCacheDirInfo() = default;
+
+    std::string path;
+    TStorageMedium::type storage_medium; // storage medium: SSD|HDD
+
+    int64_t capacity{1};
+    int64_t available{0};
+    int64_t used_capacity{0};
+};
+
+class StarletCacheDir {
+public:
+    explicit StarletCacheDir(const std::string& path, TStorageMedium::type storage_medium = TStorageMedium::HDD);
+
+    ~StarletCacheDir() = default;
+
+    const std::string& path() const { return _path; }
+
+    Status update_capacity();
+
+    StarletCacheDirInfo get_dir_info();
+
+private:
+    std::string _path;
+    TStorageMedium::type _storage_medium;
+    int64_t _available_bytes;
+    int64_t _disk_capacity_bytes;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -94,6 +94,12 @@ struct DataDirInfo {
     int64_t data_used_capacity{0};
     bool is_used{false};
     TStorageMedium::type storage_medium; // storage medium: SSD|HDD
+
+#ifdef USE_STAROS
+    int64_t cache_capacity{1};
+    int64_t cache_available{0};
+    int64_t cache_used_capacity{0};
+#endif
 };
 
 struct TabletInfo {

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -60,6 +60,9 @@ Status parse_conf_store_paths(const std::string& config_path, std::vector<StoreP
 struct EngineOptions {
     // list paths that tablet will be put into.
     std::vector<StorePath> store_paths;
+#ifdef USE_STAROS
+    std::vector<StorePath> starlet_cache_paths;
+#endif
     // BE's UUID. It will be reset every time BE restarts.
     UniqueId backend_uid{0, 0};
     MemTracker* compaction_mem_tracker = nullptr;

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -57,6 +57,7 @@
 #include "runtime/heartbeat_flags.h"
 #include "storage/cluster_id_mgr.h"
 #include "storage/kv_store.h"
+#include "storage/lake/starlet_cache_dir.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
 #include "storage/options.h"
@@ -117,7 +118,7 @@ public:
     Status get_all_data_dir_info(std::vector<DataDirInfo>* data_dir_infos, bool need_update);
 
 #ifdef USE_STAROS
-    Status get_all_starlet_cache_dir_info(std::vector<DataDirInfo>* cache_dir_infos);
+    Status get_all_starlet_cache_dir_info(std::vector<lake::StarletCacheDirInfo>* cache_dir_infos);
     Status get_starlet_cache_path_used_capacity(const std::string& path, uint64_t* cache_used_capacity);
 #endif
 
@@ -337,7 +338,7 @@ private:
     std::mutex _store_lock;
     std::map<std::string, DataDir*> _store_map;
 #ifdef USE_STAROS
-    std::map<std::string, DataDir*> _starlet_cache_map;
+    std::map<std::string, lake::StarletCacheDir*> _starlet_cache_map;
 #endif
     uint32_t _available_storage_medium_type_count;
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -116,6 +116,11 @@ public:
 
     Status get_all_data_dir_info(std::vector<DataDirInfo>* data_dir_infos, bool need_update);
 
+#ifdef USE_STAROS
+    Status get_all_starlet_cache_dir_info(std::vector<DataDirInfo>* cache_dir_infos);
+    Status get_starlet_cache_path_used_capacity(const std::string& path, uint64_t* cache_used_capacity);
+#endif
+
     // get root path for creating tablet. The returned vector of root path should be random,
     // for avoiding that all the tablet would be deployed one disk.
     std::vector<DataDir*> get_stores_for_create_tablet(TStorageMedium::type storage_medium);
@@ -239,6 +244,10 @@ private:
 
     Status _init_store_map();
 
+#ifdef USE_STAROS
+    Status _init_starlet_cache_map();
+#endif
+
     void _update_storage_medium_type_count();
 
     // Some check methods
@@ -327,6 +336,9 @@ private:
     EngineOptions _options;
     std::mutex _store_lock;
     std::map<std::string, DataDir*> _store_map;
+#ifdef USE_STAROS
+    std::map<std::string, DataDir*> _starlet_cache_map;
+#endif
     uint32_t _available_storage_medium_type_count;
 
     bool _is_all_cluster_id_exist;

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendProcNode.java
@@ -51,16 +51,22 @@ import java.util.List;
 import java.util.Map;
 
 public class BackendProcNode implements ProcNodeInterface {
-    public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add(RunMode.allowCreateLakeTable() ? "CachePath" : "RootPath")
-            .add("DataUsedCapacity").add("OtherUsedCapacity").add("AvailCapacity")
-            .add("TotalCapacity").add("TotalUsedPct").add("State").add("PathHash").add("StorageMedium")
-            .add("TabletNum").add("DataTotalCapacity").add("DataUsedPct").build();
+    public ImmutableList<String> titleNames;
 
     private Backend backend;
 
     public BackendProcNode(Backend backend) {
         this.backend = backend;
+        createTitleNames();
+    }
+
+    private void createTitleNames() {
+        ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
+                .add(RunMode.allowCreateLakeTable() ? "CachePath" : "RootPath")
+                .add("DataUsedCapacity").add("OtherUsedCapacity").add("AvailCapacity")
+                .add("TotalCapacity").add("TotalUsedPct").add("State").add("PathHash").add("StorageMedium")
+                .add("TabletNum").add("DataTotalCapacity").add("DataUsedPct");
+        this.titleNames = builder.build();
     }
 
     @Override
@@ -68,7 +74,7 @@ public class BackendProcNode implements ProcNodeInterface {
         Preconditions.checkNotNull(backend);
 
         BaseProcResult result = new BaseProcResult();
-        result.setNames(TITLE_NAMES);
+        result.setNames(titleNames);
 
         if (RunMode.allowCreateLakeTable()) {
             for (Map.Entry<String, StarletCacheInfo> entry : backend.getStarletCaches().entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendProcNode.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Map;
 
 public class BackendProcNode implements ProcNodeInterface {
-    public ImmutableList<String> titleNames;
+    private ImmutableList<String> titleNames;
 
     private Backend backend;
 
@@ -61,12 +61,20 @@ public class BackendProcNode implements ProcNodeInterface {
     }
 
     private void createTitleNames() {
-        ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
-                .add(RunMode.allowCreateLakeTable() ? "CachePath" : "RootPath")
-                .add("DataUsedCapacity").add("OtherUsedCapacity").add("AvailCapacity")
-                .add("TotalCapacity").add("TotalUsedPct").add("State").add("PathHash").add("StorageMedium")
-                .add("TabletNum").add("DataTotalCapacity").add("DataUsedPct");
-        this.titleNames = builder.build();
+        if (RunMode.allowCreateLakeTable()) {
+            ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
+                    .add("CachePath").add("DataUsedCapacity").add("OtherUsedCapacity").add("AvailCapacity")
+                    .add("TotalCapacity").add("TotalUsedPct").add("StorageMedium")
+                    .add("DataTotalCapacity").add("DataUsedPct");
+            this.titleNames = builder.build();
+
+        } else {
+            ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
+                    .add("RootPath").add("DataUsedCapacity").add("OtherUsedCapacity").add("AvailCapacity")
+                    .add("TotalCapacity").add("TotalUsedPct").add("State").add("PathHash").add("StorageMedium")
+                    .add("TabletNum").add("DataTotalCapacity").add("DataUsedPct");
+            this.titleNames = builder.build();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -73,6 +73,7 @@ public class BackendsProcDir implements ProcDirInterface {
                 .add("DataUsedPct").add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct");
         if (RunMode.allowCreateLakeTable()) {
             builder.add("StarletPort").add("WorkerId");
+            builder.add("CacheUsedCapacity").add("CacheAvailCapacity").add("CacheTotalCapacity");
         }
         TITLE_NAMES = builder.build();
     }
@@ -198,6 +199,21 @@ public class BackendsProcDir implements ProcDirInterface {
                 backendInfo.add(String.valueOf(backend.getStarletPort()));
                 long workerId = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerIdByBackendId(backendId);
                 backendInfo.add(String.valueOf(workerId));
+
+                long cacheUsedB = backend.getCacheUsedCapacityB();
+                Pair<Double, String> cacheUsedCapacity = DebugUtil.getByteUint(cacheUsedB);
+                backendInfo.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(cacheUsedCapacity.first)
+                        + " " + cacheUsedCapacity.second);
+                // available
+                long cacheAvailB = backend.getCacheAvailableCapacityB();
+                Pair<Double, String> cacheAvailCapacity = DebugUtil.getByteUint(cacheAvailB);
+                backendInfo.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(cacheAvailCapacity.first)
+                        + " " + cacheAvailCapacity.second);
+                // total
+                long cacheTotalB = backend.getCacheTotalCapacityB();
+                Pair<Double, String> cacheTotalCapacity = DebugUtil.getByteUint(cacheTotalB);
+                backendInfo.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(cacheTotalCapacity.first)
+                        + " " + cacheTotalCapacity.second);
             }
 
             comparableBackendInfos.add(backendInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -62,8 +62,13 @@ import java.util.concurrent.TimeUnit;
 public class BackendsProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(BackendsProcDir.class);
 
-    public static final ImmutableList<String> TITLE_NAMES;
-    static {
+    private SystemInfoService clusterInfoService;
+
+    public BackendsProcDir(SystemInfoService clusterInfoService) {
+        this.clusterInfoService = clusterInfoService;
+    }
+
+    public static ImmutableList<String> getTitleNames() {
         ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
                 .add("BackendId").add("IP").add("HeartbeatPort")
                 .add("BePort").add("HttpPort").add("BrpcPort").add("LastStartTime").add("LastHeartbeat")
@@ -75,13 +80,7 @@ public class BackendsProcDir implements ProcDirInterface {
             builder.add("StarletPort").add("WorkerId");
             builder.add("CacheUsedCapacity").add("CacheAvailCapacity").add("CacheTotalCapacity");
         }
-        TITLE_NAMES = builder.build();
-    }
-
-    private SystemInfoService clusterInfoService;
-
-    public BackendsProcDir(SystemInfoService clusterInfoService) {
-        this.clusterInfoService = clusterInfoService;
+        return builder.build();
     }
 
     @Override
@@ -89,7 +88,7 @@ public class BackendsProcDir implements ProcDirInterface {
         Preconditions.checkNotNull(clusterInfoService);
 
         BaseProcResult result = new BaseProcResult();
-        result.setNames(TITLE_NAMES);
+        result.setNames(getTitleNames());
 
         final List<List<String>> backendInfos = getClusterBackendInfos();
         for (List<String> backendInfo : backendInfos) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarletCacheInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarletCacheInfo.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import autovalue.shaded.com.google.common.common.collect.Lists;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.thrift.TStorageMedium;
+
+import java.util.List;
+
+public class StarletCacheInfo {
+    private String cachePath;
+
+    private long totalCapacityB;
+    private long usedCapacityB;
+    private long availableCapacityB;
+
+    private TStorageMedium storageMedium;
+
+    private static final long DEFAULT_CAPACITY_B = 1024 * 1024 * 1024 * 1024L; // 1T
+
+    public StarletCacheInfo(String cachePath) {
+        this.cachePath = cachePath;
+        this.totalCapacityB = DEFAULT_CAPACITY_B;
+        this.usedCapacityB = 0;
+        this.availableCapacityB = totalCapacityB;
+        this.storageMedium = TStorageMedium.HDD;
+    }
+
+    public long getUsedCapacityB() {
+        return usedCapacityB;
+    }
+
+    public void setUsedCapacityB(long usedCapacityB) {
+        this.usedCapacityB = usedCapacityB;
+    }
+
+    public long getTotalCapacityB() {
+        return totalCapacityB;
+    }
+
+    public void setTotalCapacityB(long totalCapacityB) {
+        this.totalCapacityB = totalCapacityB;
+    }
+
+    public long getAvailableCapacityB() {
+        return availableCapacityB;
+    }
+
+    public void setAvailableCapacityB(long availableCapacityB) {
+        this.availableCapacityB = availableCapacityB;
+    }
+
+    public long getDataTotalCapacityB() {
+        return usedCapacityB + availableCapacityB;
+    }
+
+    public TStorageMedium getStorageMedium() {
+        return storageMedium;
+    }
+
+    public void setStorageMedium(TStorageMedium storageMedium) {
+        this.storageMedium = storageMedium;
+    }
+
+    public List<String> toBackendProcNodeInfo() {
+        List<String> info = Lists.newArrayList();
+        // path
+        info.add(cachePath);
+
+        // data used
+        Pair<Double, String> dataUsedUnitPair = DebugUtil.getByteUint(usedCapacityB);
+        info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(dataUsedUnitPair.first) + " " + dataUsedUnitPair.second);
+
+        // other used
+        long otherUsedB = totalCapacityB - availableCapacityB - usedCapacityB;
+        Pair<Double, String> otherUsedUnitPair = DebugUtil.getByteUint(otherUsedB);
+        info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(otherUsedUnitPair.first) + " " + otherUsedUnitPair.second);
+
+        // avail
+        Pair<Double, String> availUnitPair = DebugUtil.getByteUint(availableCapacityB);
+        info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(availUnitPair.first) + " " + availUnitPair.second);
+
+        // total
+        Pair<Double, String> totalUnitPair = DebugUtil.getByteUint(totalCapacityB);
+        info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(totalUnitPair.first) + " " + totalUnitPair.second);
+
+        // total used percent
+        double used = 0.0;
+        if (totalCapacityB > 0) {
+            used = (double) (totalCapacityB - availableCapacityB) * 100 / totalCapacityB;
+        }
+        info.add(String.format("%.2f", used) + " %");
+
+        // state
+        info.add(DiskInfo.DiskState.ONLINE.name());
+
+        // path hash
+        info.add("");
+
+        // medium
+        if (storageMedium == null) {
+            info.add("N/A");
+        } else {
+            info.add(storageMedium.name());
+        }
+
+        // tablet num
+        info.add("0");
+
+        // data total
+        long dataTotalB = getDataTotalCapacityB();
+        Pair<Double, String> dataTotalUnitPair = DebugUtil.getByteUint(dataTotalB);
+        info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(dataTotalUnitPair.first) + " " + dataTotalUnitPair.second);
+
+        // data used percent
+        double dataUsed = 0.0;
+        if (dataTotalB > 0) {
+            dataUsed = (double) usedCapacityB * 100 / dataTotalB;
+        }
+        info.add(String.format("%.2f", dataUsed) + " %");
+
+        return info;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarletCacheInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarletCacheInfo.java
@@ -14,8 +14,7 @@
 
 package com.starrocks.lake;
 
-import autovalue.shaded.com.google.common.common.collect.Lists;
-import com.starrocks.catalog.DiskInfo;
+import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.thrift.TStorageMedium;
@@ -106,21 +105,12 @@ public class StarletCacheInfo {
         }
         info.add(String.format("%.2f", used) + " %");
 
-        // state
-        info.add(DiskInfo.DiskState.ONLINE.name());
-
-        // path hash
-        info.add("");
-
         // medium
         if (storageMedium == null) {
             info.add("N/A");
         } else {
             info.add(storageMedium.name());
         }
-
-        // tablet num
-        info.add("0");
 
         // data total
         long dataTotalB = getDataTotalCapacityB();

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -551,7 +551,7 @@ public class ReportHandler extends Daemon {
     }
 
     private static void starletCacheReport(long backendId, Map<String, TStarletCache> starletCaches) {
-        LOG.error("begin to handle starlet cache report from backend {}", backendId);
+        LOG.debug("begin to handle starlet cache report from backend {}", backendId);
         long start = System.currentTimeMillis();
         Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(backendId);
         if (backend == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBackendsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBackendsStmt.java
@@ -34,7 +34,7 @@ public class ShowBackendsStmt extends ShowStmt {
     @Override
     public ShowResultSetMetaData getMetaData() {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
-        for (String title : BackendsProcDir.TITLE_NAMES) {
+        for (String title : BackendsProcDir.getTitleNames()) {
             builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
         }
         return builder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -111,6 +111,10 @@ public class Backend extends ComputeNode {
         return this.disksRef;
     }
 
+    public void setStarletCaches(ImmutableMap<String, StarletCacheInfo> caches) {
+        this.starletCacheRef = caches;
+    }
+
     public ImmutableMap<String, StarletCacheInfo> getStarletCaches() {
         return this.starletCacheRef;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendProcNodeTest.java
@@ -166,8 +166,7 @@ public class BackendProcNodeTest {
         Assert.assertEquals(1, result.getRows().size());
         Assert.assertEquals(
                 Lists.newArrayList("CachePath", "DataUsedCapacity", "OtherUsedCapacity", "AvailCapacity",
-                        "TotalCapacity", "TotalUsedPct", "State", "PathHash", "StorageMedium", "TabletNum",
-                        "DataTotalCapacity", "DataUsedPct"),
+                        "TotalCapacity", "TotalUsedPct", "StorageMedium", "DataTotalCapacity", "DataUsedPct"),
                 result.getColumnNames());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendProcNodeTest.java
@@ -147,7 +147,7 @@ public class BackendProcNodeTest {
     }
 
     @Test
-    public void testResulLake() throws AnalysisException {
+    public void testResultLake() throws AnalysisException {
         new MockUp<RunMode>() {
             @Mock
             public RunMode getCurrentRunMode() {
@@ -163,7 +163,7 @@ public class BackendProcNodeTest {
         Assert.assertNotNull(result);
         Assert.assertTrue(result instanceof BaseProcResult);
 
-        Assert.assertTrue(result.getRows().size() == 1);
+        Assert.assertEquals(1, result.getRows().size());
         Assert.assertEquals(
                 Lists.newArrayList("CachePath", "DataUsedCapacity", "OtherUsedCapacity", "AvailCapacity",
                         "TotalCapacity", "TotalUsedPct", "State", "PathHash", "StorageMedium", "TabletNum",

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendsProcDirTest.java
@@ -38,9 +38,12 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.persist.EditLog;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
@@ -193,8 +196,31 @@ public class BackendsProcDirTest {
         Assert.assertTrue(result instanceof BaseProcResult);
     }
 
+    @Test
+    public void testFetchResultLake() throws AnalysisException {
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        BackendsProcDir dir;
+        ProcResult result;
+
+        dir = new BackendsProcDir(systemInfoService);
+        result = dir.fetchResult();
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result instanceof BaseProcResult);
+
+        Assert.assertEquals(31, result.getColumnNames().size());
+        Assert.assertEquals("CacheUsedCapacity", result.getColumnNames().get(28));
+        Assert.assertEquals("CacheAvailCapacity", result.getColumnNames().get(29));
+        Assert.assertEquals("CacheTotalCapacity", result.getColumnNames().get(30));
+    }
+
     @Test    
     public void testIPTitle() {
-        Assert.assertTrue(BackendsProcDir.TITLE_NAMES.get(1).equals("IP"));
+        Assert.assertEquals("IP", BackendsProcDir.getTitleNames().get(1));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -792,13 +792,17 @@ public class ShowExecutorTest {
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
 
-        Assert.assertEquals(28, resultSet.getMetaData().getColumnCount());
+        Assert.assertEquals(31, resultSet.getMetaData().getColumnCount());
         Assert.assertEquals("BackendId", resultSet.getMetaData().getColumn(0).getName());
         Assert.assertEquals("NumRunningQueries", resultSet.getMetaData().getColumn(23).getName());
         Assert.assertEquals("MemUsedPct", resultSet.getMetaData().getColumn(24).getName());
         Assert.assertEquals("CpuUsedPct", resultSet.getMetaData().getColumn(25).getName());
         Assert.assertEquals("StarletPort", resultSet.getMetaData().getColumn(26).getName());
         Assert.assertEquals("WorkerId", resultSet.getMetaData().getColumn(27).getName());
+        // Starlet Cache
+        Assert.assertEquals("CacheUsedCapacity", resultSet.getMetaData().getColumn(28).getName());
+        Assert.assertEquals("CacheAvailCapacity", resultSet.getMetaData().getColumn(29).getName());
+        Assert.assertEquals("CacheTotalCapacity", resultSet.getMetaData().getColumn(30).getName());
 
         Assert.assertTrue(resultSet.next());
         Assert.assertEquals("1", resultSet.getString(0));

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -101,6 +101,14 @@ struct TDisk {
     7: optional Types.TStorageMedium storage_medium
 }
 
+struct TStarletCache {
+    1: optional string cache_path
+    2: optional Types.TSize cache_total_capacity
+    3: optional Types.TSize cache_used_capacity
+    4: optional Types.TSize cache_available_capacity
+    5: optional Types.TStorageMedium storage_medium
+}
+
 struct TPluginInfo {
     1: required string plugin_name
     2: required i32 type
@@ -120,6 +128,8 @@ struct TReportRequest {
     // active workgroup on this backend
     9: optional list<WorkGroup.TWorkGroup> active_workgroups
     10: optional ResourceUsage.TResourceUsage resource_usage
+    // starlet cache
+    11: optional map<string, TStarletCache> starlet_caches // string cache_path
 }
 
 struct TMasterResult {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #18832 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Report and show cache capacity of lake table.
The effect would be looked like:
```
MySQL [(none)]> show proc "/backends/10004";
+---------------------------------+------------------+-------------------+---------------+---------------+--------------+---------------+-------------------+-------------+
| CachePath                       | DataUsedCapacity | OtherUsedCapacity | AvailCapacity | TotalCapacity | TotalUsedPct | StorageMedium | DataTotalCapacity | DataUsedPct |
+---------------------------------+------------------+-------------------+---------------+---------------+--------------+---------------+-------------------+-------------+
| /home/disk2/sr/be/cache         | 27.028 GB        | 351.079 GB        | 1.599 TB      | 1.968 TB      | 18.76 %      | HDD           | 1.626 TB          | 1.62 %      |
+---------------------------------+------------------+-------------------+---------------+---------------+--------------+---------------+-------------------+-------------+
1 row in set (0.00 sec)
MySQL [(none)]> show backends;
+-----------+---------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+-----------+------------------+---------------+---------------+---------+----------------+--------+-------------------+--------------------------------------------------------+-------------------+-------------+----------+-------------------+------------+------------+-------------+----------+-------------------+--------------------+--------------------+
| BackendId | IP            | HeartbeatPort | BePort | HttpPort | BrpcPort | LastStartTime       | LastHeartbeat       | Alive | SystemDecommissioned | ClusterDecommissioned | TabletNum | DataUsedCapacity | AvailCapacity | TotalCapacity | UsedPct | MaxDiskUsedPct | ErrMsg | Version           | Status                                                 | DataTotalCapacity | DataUsedPct | CpuCores | NumRunningQueries | MemUsedPct | CpuUsedPct | StarletPort | WorkerId | CacheUsedCapacity | CacheAvailCapacity | CacheTotalCapacity |
+-----------+---------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+-----------+------------------+---------------+---------------+---------+----------------+--------+-------------------+--------------------------------------------------------+-------------------+-------------+----------+-------------------+------------+------------+-------------+----------+-------------------+--------------------+--------------------+
| 10004     | 172.26.92.212 | 10060         | 9070   | 11040    | 8160     | 2023-03-13 14:26:07 | 2023-03-13 14:30:11 | true  | false                | false                 | 0         | 0.000            | 1.563 TB      | 1.968 TB      | 20.62 % | 20.62 %        |        | UNKNOWN-745f09493 | {"lastSuccessReportTabletsTime":"2023-03-13 14:30:07"} | 1.563 TB          | 0.00 %      | 104      | 0                 | 0.01 %     | 0.0 %      | 8167        | 1        | 64.938 GB         | 1.563 TB           | 1.968 TB           |
+-----------+---------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+-----------+------------------+---------------+---------------+---------+----------------+--------+-------------------+--------------------------------------------------------+-------------------+-------------+----------+-------------------+------------+------------+-------------+----------+-------------------+--------------------+--------------------+
1 row in set (0.00 sec)
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
