### PR TITLE
[BugFix] fix NPE when further prune temp partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -318,6 +318,10 @@ public class OptOlapPartitionPruner {
             probeResult = false;
         } else if (((RangePartitionInfo) partitionInfo).getPartitionColumns().size() > 1) {
             probeResult = false;
+        } else if (((RangePartitionInfo) partitionInfo).getIdToRange(true)
+                .containsKey(candidatePartitions.get(0))) {
+            // it's a temp partition list, no need to do the further prune
+            probeResult = false;
         } else if (olapScanOperator.getPredicate() == null) {
             probeResult = false;
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
```
for (long id : candidatePartitions) {
       candidateRanges.add(rangePartitionInfo.getIdToRange(false).get(id));
}
```
NPE is caused by a null value being added in `candidateRanges` when the id is a temp parition id.
When there is a query for temp partition, we donn't need do the further prune process.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
