### PR TITLE
[BugFix] Set finished state at the end of lake table schema change job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -683,7 +683,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                 if (modifiedColumns.contains(mvColumn.getName())) {
                     LOG.warn("Setting the materialized view {}({}) to invalid because " +
                             "the column {} of the table {} was modified.", mv.getName(), mv.getId(),
-                            table.getName(), mvColumn.getName());
+                            mvColumn.getName(), table.getName());
                     mv.setActive(false);
                     return;
                 }


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The job state should be set to finished after the relevant table metadata is updated, otherwise the table metadata is not correct when job state is finished.

Fix unstable LakeMaterializedViewTest.testModifyRelatedColumnWithMaterializedView UT.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
