### PR TITLE
[Enhancement] Support Iceberg ScanMetrics for hive/glue catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
+import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.thrift.TIcebergSchema;
 import com.starrocks.thrift.TIcebergSchemaField;
 import org.apache.iceberg.FileFormat;
@@ -33,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.starrocks.connector.ColumnTypeConverter.fromIcebergType;
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.CONNECTOR_ID_GENERATOR;
@@ -44,7 +46,8 @@ public class IcebergApiConverter {
     public static final String PARTITION_NULL_VALUE = "null";
 
     public static IcebergTable toIcebergTable(Table nativeTbl, String catalogName, String remoteDbName,
-                                              String remoteTableName, String nativeCatalogType) {
+                                              String remoteTableName, String nativeCatalogType,
+                                              Optional<IcebergMetricsReporter> metricsReporter) {
         IcebergTable.Builder tableBuilder = IcebergTable.builder()
                 .setId(CONNECTOR_ID_GENERATOR.getNextId().asInt())
                 .setSrTableName(remoteTableName)
@@ -54,7 +57,8 @@ public class IcebergApiConverter {
                 .setRemoteTableName(remoteTableName)
                 .setNativeTable(nativeTbl)
                 .setFullSchema(toFullSchemas(nativeTbl))
-                .setIcebergProperties(toIcebergProps(nativeCatalogType));
+                .setIcebergProperties(toIcebergProps(nativeCatalogType))
+                .setMetricsReporter(metricsReporter);
 
         return tableBuilder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -18,6 +18,7 @@ package com.starrocks.connector.iceberg;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -25,6 +26,7 @@ import org.apache.thrift.TException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Interface for Iceberg catalogs.
@@ -43,6 +45,13 @@ public interface IcebergCatalog {
      * Loads a native Iceberg table based on the information in 'feTable'.
      */
     Table loadTable(TableIdentifier tableIdentifier) throws StarRocksConnectorException;
+
+    /**
+     * Loads a native Iceberg table based on the information in 'feTable',
+     * with scan metrics reporter
+     */
+    Table loadTable(TableIdentifier tableIdentifier, Optional<IcebergMetricsReporter> metricsReporter)
+            throws StarRocksConnectorException;
 
     /**
      * Loads a native Iceberg table based on 'tableId' or 'tableLocation'.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergMetricsReporter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergMetricsReporter.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.cost;
+
+import com.google.common.collect.Lists;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public class IcebergMetricsReporter implements MetricsReporter {
+    private final List<MetricsReport> reports = Lists.newArrayList();
+    private static final Logger LOG = LogManager.getLogger(IcebergMetricsReporter.class);
+
+    @Override
+    public void report(MetricsReport report) {
+        reports.add(report);
+        LOG.debug(String.format("Received metrics report: %s", report));
+    }
+
+    public IcebergScanReportWithCounter lastReport() {
+        if (reports.isEmpty()) {
+            return null;
+        }
+        return new IcebergScanReportWithCounter(reports.size(), (ScanReport) reports.get(reports.size() - 1));
+    }
+
+    public static class IcebergScanReportWithCounter {
+        private final int count;
+        private final ScanReport scanReport;
+        IcebergScanReportWithCounter(int count, ScanReport scanReport) {
+            this.count = count;
+            this.scanReport = scanReport;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public ScanReport getScanReport() {
+            return scanReport;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
+import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.io.IcebergCachingFileIO;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -45,6 +46,7 @@ import org.apache.thrift.TException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.CONNECTOR_ID_GENERATOR;
@@ -78,11 +80,24 @@ public class IcebergHiveCatalog extends BaseMetastoreCatalog implements IcebergC
     }
 
     @Override
+    public Table loadTable(TableIdentifier tableIdentifier, Optional<IcebergMetricsReporter> metricsReporter) {
+        return loadTable(tableIdentifier, null, null, metricsReporter);
+    }
+
+    @Override
     public Table loadTable(TableIdentifier tableId, String tableLocation,
                            Map<String, String> properties) throws StarRocksConnectorException {
+        return loadTable(tableId, tableLocation, properties, Optional.empty());
+    }
+
+    private Table loadTable(TableIdentifier tableId, String tableLocation, Map<String, String> properties,
+                            Optional<IcebergMetricsReporter> metricsReporter) throws StarRocksConnectorException {
         Preconditions.checkState(tableId != null);
         try {
             TableOperations ops = this.newTableOps(tableId);
+            if (metricsReporter.isPresent()) {
+                return new BaseTable(ops, fullTableName(this.name(), tableId), metricsReporter.get());
+            }
             return new BaseTable(ops, fullTableName(this.name(), tableId));
         } catch (Exception e) {
             throw new StarRocksConnectorException(String.format(

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
+import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
@@ -30,6 +31,7 @@ import org.apache.thrift.TException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.CONNECTOR_ID_GENERATOR;
@@ -44,6 +46,12 @@ public class IcebergRESTCatalog extends RESTCatalog implements IcebergCatalog {
     @Override
     public Table loadTable(IcebergTable table) throws StarRocksConnectorException {
         return super.loadTable(TableIdentifier.of(table.getRemoteDbName(), table.getRemoteTableName()));
+    }
+
+    @Override
+    public Table loadTable(TableIdentifier tableId, Optional<IcebergMetricsReporter> metricsReporter)
+        throws StarRocksConnectorException {
+        return super.loadTable(tableId);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergCustomCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergCustomCatalogTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.hive.CachedClientPool;
 import com.starrocks.connector.iceberg.hive.HiveTableOperations;
 import com.starrocks.connector.iceberg.io.IcebergCachingFileIO;
@@ -54,6 +55,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class IcebergCustomCatalogTest {
@@ -154,6 +156,12 @@ public class IcebergCustomCatalogTest {
         @Override
         public Table loadTable(TableIdentifier tableIdentifier) throws StarRocksConnectorException {
             return loadTable(tableIdentifier, null, null);
+        }
+
+        @Override
+        public Table loadTable(TableIdentifier tableIdentifier, Optional<IcebergMetricsReporter> metricsReporter)
+                throws StarRocksConnectorException {
+            return loadTable(tableIdentifier);
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.hive.HiveTableOperations;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import mockit.Expectations;
@@ -30,6 +31,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
 
@@ -110,11 +112,11 @@ public class IcebergMetadataTest {
                                   @Mocked HiveTableOperations hiveTableOperations) {
         new Expectations() {
             {
-                icebergHiveCatalog.loadTable(TableIdentifier.of("db", "tbl"));
+                icebergHiveCatalog.loadTable(TableIdentifier.of("db", "tbl"), (Optional<IcebergMetricsReporter>) any);
                 result = new BaseTable(hiveTableOperations, "tbl");
                 minTimes = 0;
 
-                icebergHiveCatalog.loadTable(TableIdentifier.of("db", "tbl2"));
+                icebergHiveCatalog.loadTable(TableIdentifier.of("db", "tbl2"), (Optional<IcebergMetricsReporter>) any);
                 result = new StarRocksConnectorException("not found");
             }
         };


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Planner profile looks like this:
<img width="1126" alt="截屏2023-03-30 19 51 28" src="https://user-images.githubusercontent.com/28446271/228827577-9fd26101-4ae8-408f-bb80-48c4046049f2.png">
and the scanMetricsReport looks like: it's defined by iceberg.
`- tt / No_1: ScanMetricsResult{totalPlanningDuration=TimerResult{timeUnit=NANOSECONDS, totalDuration=PT0.66060346S, count=1}, resultDataFiles=CounterResult{unit=COUNT, value=154}, resultDeleteFiles=CounterResult{unit=COUNT, value=0}, totalDataManifests=CounterResult{unit=COUNT, value=55}, totalDeleteManifests=CounterResult{unit=COUNT, value=0}, scannedDataManifests=CounterResult{unit=COUNT, value=55}, skippedDataManifests=CounterResult{unit=COUNT, value=0}, totalFileSizeInBytes=CounterResult{unit=BYTES, value=3524280}, totalDeleteFileSizeInBytes=CounterResult{unit=BYTES, value=0}, skippedDataFiles=CounterResult{unit=COUNT, value=0}, skippedDeleteFiles=CounterResult{unit=COUNT, value=0}, scannedDeleteManifests=CounterResult{unit=COUNT, value=0}, skippedDeleteManifests=CounterResult{unit=COUNT, value=0}, indexedDeleteFiles=CounterResult{unit=COUNT, value=0}, equalityDeleteFiles=CounterResult{unit=COUNT, value=0}, positionalDeleteFiles=CounterResult{unit=COUNT, value=0}}`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
