### PR TITLE
[Enhancement] support exchanging >=2GB message via http rpc

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -252,7 +252,7 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(RuntimeState* state, const 
         butil::IOBuf attachment;
         int64_t attachment_physical_bytes = _parent->construct_brpc_attachment(_chunk_request, attachment);
         TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment,
-                                  attachment_physical_bytes};
+                                  attachment_physical_bytes, _brpc_dest_addr};
         RETURN_IF_ERROR(_parent->_buffer->add_request(info));
         _current_request_bytes = 0;
         _chunk_request.reset();
@@ -279,7 +279,7 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(RuntimeState* state, PT
     }
 
     TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment,
-                              attachment_physical_bytes};
+                              attachment_physical_bytes, _brpc_dest_addr};
     RETURN_IF_ERROR(_parent->_buffer->add_request(info));
 
     return Status::OK();

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -251,8 +251,8 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(RuntimeState* state, const 
         }
         butil::IOBuf attachment;
         int64_t attachment_physical_bytes = _parent->construct_brpc_attachment(_chunk_request, attachment);
-        TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(_chunk_request), attachment,
-                                  attachment_physical_bytes, _brpc_dest_addr};
+        TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub,     std::move(_chunk_request), attachment,
+                                  attachment_physical_bytes,   _brpc_dest_addr};
         RETURN_IF_ERROR(_parent->_buffer->add_request(info));
         _current_request_bytes = 0;
         _chunk_request.reset();

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -278,8 +278,8 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(RuntimeState* state, PT
         delta_statistic->to_pb(chunk_request->mutable_query_statistics());
     }
 
-    TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub, std::move(chunk_request), attachment,
-                              attachment_physical_bytes, _brpc_dest_addr};
+    TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub,     std::move(chunk_request), attachment,
+                              attachment_physical_bytes,   _brpc_dest_addr};
     RETURN_IF_ERROR(_parent->_buffer->add_request(info));
 
     return Status::OK();

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -30,9 +30,7 @@ SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFra
           _mem_tracker(fragment_ctx->runtime_state()->instance_mem_tracker()),
           _brpc_timeout_ms(std::min(3600, fragment_ctx->runtime_state()->query_options().query_timeout) * 1000),
           _is_dest_merge(is_dest_merge),
-          _rpc_http_min_size(fragment_ctx->runtime_state()->query_options().__isset.rpc_http_min_size
-                                     ? fragment_ctx->runtime_state()->query_options().rpc_http_min_size
-                                     : ((1L << 31) - (1L << 20))) {
+          _rpc_http_min_size(fragment_ctx->runtime_state()->get_rpc_http_min_size()) {
     for (const auto& dest : destinations) {
         const auto& instance_id = dest.fragment_instance_id;
         // instance_id.lo == -1 indicates that the destination is pseudo for bucket shuffle join.

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -389,7 +389,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
 Status SinkBuffer::_send_rpc(DisposableClosure<PTransmitChunkResult, ClosureContext>* closure,
                              const TransmitChunkInfo& request) {
-    if (UNLIKELY(request.attachment.size() > _rpc_http_min_size)) {
+    if (UNLIKELY(request.attachment.size() + request.params->ByteSizeLong() + sizeof(size_t) * 2 >
+                 _rpc_http_min_size)) {
         butil::IOBuf iobuf;
         butil::IOBufAsZeroCopyOutputStream wrapper(&iobuf);
         request.params->SerializeToZeroCopyStream(&wrapper);

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -29,7 +29,10 @@ SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFra
         : _fragment_ctx(fragment_ctx),
           _mem_tracker(fragment_ctx->runtime_state()->instance_mem_tracker()),
           _brpc_timeout_ms(std::min(3600, fragment_ctx->runtime_state()->query_options().query_timeout) * 1000),
-          _is_dest_merge(is_dest_merge) {
+          _is_dest_merge(is_dest_merge),
+          _rpc_http_min_size(fragment_ctx->runtime_state()->query_options().__isset.rpc_http_min_size
+                                     ? fragment_ctx->runtime_state()->query_options().rpc_http_min_size
+                                     : ((1L << 31) - (1L << 20))) {
     for (const auto& dest : destinations) {
         const auto& instance_id = dest.fragment_instance_id;
         // instance_id.lo == -1 indicates that the destination is pseudo for bucket shuffle join.
@@ -370,15 +373,18 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);
-        closure->cntl.request_attachment().append(request.attachment);
 
         if (bthread_self()) {
-            request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
+            Status st;
+            TRY_CATCH_ALL(st, request.send_rpc(closure, _rpc_http_min_size));
+            RETURN_IF_ERROR(st);
         } else {
             // When the driver worker thread sends request and creates the protobuf request,
             // also use process_mem_tracker to record the memory of the protobuf request.
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
-            request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);
+            Status st;
+            TRY_CATCH_ALL(st, request.send_rpc(closure, _rpc_http_min_size));
+            RETURN_IF_ERROR(st);
         }
 
         return Status::OK();
@@ -386,4 +392,32 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
     return Status::OK();
 }
+
+Status TransmitChunkInfo::send_rpc(DisposableClosure<PTransmitChunkResult, ClosureContext>* closure,
+                                   int64_t rpc_http_min_size) {
+    if (this->attachment.size() > rpc_http_min_size) {
+        butil::IOBuf iobuf;
+        butil::IOBufAsZeroCopyOutputStream wrapper(&iobuf);
+        params->SerializeToZeroCopyStream(&wrapper);
+        // append params to iobuf
+        size_t params_size = iobuf.size();
+        closure->cntl.request_attachment().append(&params_size, sizeof(params_size));
+        closure->cntl.request_attachment().append(iobuf);
+        // append attachment
+        size_t attachment_size = this->attachment.size();
+        closure->cntl.request_attachment().append(&attachment_size, sizeof(attachment_size));
+        closure->cntl.request_attachment().append(this->attachment);
+        LOG(WARNING) << "issue a http prc, attachment's size = " << attachment_size
+                     << " , total size = " << closure->cntl.request_attachment().size();
+        closure->cntl.http_request().set_content_type("application/proto");
+        // create http_stub as needed
+        auto http_stub = BrpcStubCache::create_http_stub(brpc_addr);
+        http_stub->transmit_chunk_via_http(&closure->cntl, NULL, &closure->result, closure);
+    } else {
+        closure->cntl.request_attachment().append(this->attachment);
+        brpc_stub->transmit_chunk(&closure->cntl, this->params.get(), &closure->result, closure);
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -412,8 +412,11 @@ Status SinkBuffer::_send_rpc(DisposableClosure<PTransmitChunkResult, ClosureCont
         }
         closure->cntl.http_request().set_content_type("application/proto");
         // create http_stub as needed
-        auto http_stub = BrpcStubCache::create_http_stub(request.brpc_addr);
-        http_stub->transmit_chunk_via_http(&closure->cntl, NULL, &closure->result, closure);
+        auto res = BrpcStubCache::create_http_stub(request.brpc_addr);
+        if (!res.ok()) {
+            return res.status();
+        }
+        res.value()->transmit_chunk_via_http(&closure->cntl, NULL, &closure->result, closure);
     } else {
         closure->cntl.request_attachment().append(request.attachment);
         request.brpc_stub->transmit_chunk(&closure->cntl, request.params.get(), &closure->result, closure);

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -374,13 +374,13 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
         Status st;
         if (bthread_self()) {
-            TRY_CATCH_ALL(st, request.send_rpc(closure, _rpc_http_min_size));
+            TRY_CATCH_ALL(st, _send_rpc(closure, request));
         } else {
             // When the driver worker thread sends request and creates the protobuf request,
             // also use process_mem_tracker to record the memory of the protobuf request.
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
             // must in the same scope following the above
-            TRY_CATCH_ALL(st, request.send_rpc(closure, _rpc_http_min_size));
+            TRY_CATCH_ALL(st, _send_rpc(closure, request));
         }
         return st;
     }
@@ -389,8 +389,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
 Status SinkBuffer::_send_rpc(DisposableClosure<PTransmitChunkResult, ClosureContext>* closure,
                              const TransmitChunkInfo& request) {
-    if (UNLIKELY(request.attachment.size() + request.params->ByteSizeLong() + sizeof(size_t) * 2 >
-                 _rpc_http_min_size)) {
+    auto expected_iobuf_size = request.attachment.size() + request.params->ByteSizeLong() + sizeof(size_t) * 2;
+    if (UNLIKELY(expected_iobuf_size > _rpc_http_min_size)) {
         butil::IOBuf iobuf;
         butil::IOBufAsZeroCopyOutputStream wrapper(&iobuf);
         request.params->SerializeToZeroCopyStream(&wrapper);
@@ -402,8 +402,14 @@ Status SinkBuffer::_send_rpc(DisposableClosure<PTransmitChunkResult, ClosureCont
         size_t attachment_size = request.attachment.size();
         closure->cntl.request_attachment().append(&attachment_size, sizeof(attachment_size));
         closure->cntl.request_attachment().append(request.attachment);
-        LOG(WARNING) << "issue a http rpc, attachment's size = " << attachment_size
-                     << " , total size = " << closure->cntl.request_attachment().size();
+        if (_rpc_http_min_size == kRpcHttpMinSize) { // logging only in default value
+            LOG(INFO) << "issue a http rpc, attachment's size = " << attachment_size
+                      << " , total size = " << closure->cntl.request_attachment().size();
+        }
+        if (UNLIKELY(expected_iobuf_size != closure->cntl.request_attachment().size())) {
+            LOG(WARNING) << "http rpc expected iobuf size " << expected_iobuf_size << " != "
+                         << " real iobuf size " << closure->cntl.request_attachment().size();
+        }
         closure->cntl.http_request().set_content_type("application/proto");
         // create http_stub as needed
         auto http_stub = BrpcStubCache::create_http_stub(request.brpc_addr);

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -372,20 +372,18 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);
 
+        Status st;
         if (bthread_self()) {
-            Status st;
             TRY_CATCH_ALL(st, request.send_rpc(closure, _rpc_http_min_size));
-            RETURN_IF_ERROR(st);
         } else {
             // When the driver worker thread sends request and creates the protobuf request,
             // also use process_mem_tracker to record the memory of the protobuf request.
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
             // must in the same scope following the above
-            Status st;
             TRY_CATCH_ALL(st, request.send_rpc(closure, _rpc_http_min_size));
-            RETURN_IF_ERROR(st);
         }
-
+        return st;
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -374,13 +374,13 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
         Status st;
         if (bthread_self()) {
-            TRY_CATCH_ALL(st, _send_rpc(closure, request));
+            st = _send_rpc(closure, request);
         } else {
             // When the driver worker thread sends request and creates the protobuf request,
             // also use process_mem_tracker to record the memory of the protobuf request.
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
             // must in the same scope following the above
-            TRY_CATCH_ALL(st, _send_rpc(closure, request));
+            st = _send_rpc(closure, request);
         }
         return st;
     }

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -53,8 +53,6 @@ struct TransmitChunkInfo {
     butil::IOBuf attachment;
     int64_t attachment_physical_bytes;
     const TNetworkAddress brpc_addr;
-    // send by rpc or http
-    Status send_rpc(DisposableClosure<PTransmitChunkResult, ClosureContext>* closure, int64_t rpc_http_min_size);
 };
 
 // TimeTrace is introduced to estimate time more accurately.
@@ -113,6 +111,9 @@ private:
     // Try to send rpc if buffer is not empty and channel is not busy
     // And we need to put this function and other extra works(pre_works) together as an atomic operation
     Status _try_to_send_rpc(const TUniqueId& instance_id, const std::function<void()>& pre_works);
+
+    // send by rpc or http
+    Status _send_rpc(DisposableClosure<PTransmitChunkResult, ClosureContext>* closure, const TransmitChunkInfo& params);
 
     // Roughly estimate network time which is defined as the time between sending a and receiving a packet,
     // and the processing time of both sides are excluded

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -113,7 +113,7 @@ private:
     Status _try_to_send_rpc(const TUniqueId& instance_id, const std::function<void()>& pre_works);
 
     // send by rpc or http
-    Status _send_rpc(DisposableClosure<PTransmitChunkResult, ClosureContext>* closure, const TransmitChunkInfo& params);
+    Status _send_rpc(DisposableClosure<PTransmitChunkResult, ClosureContext>* closure, const TransmitChunkInfo& req);
 
     // Roughly estimate network time which is defined as the time between sending a and receiving a packet,
     // and the processing time of both sides are excluded

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -61,6 +61,9 @@ static void send_rpc_runtime_filter(doris::PBackendService_Stub* stub, RuntimeFi
     rpc_closure->ref();
     rpc_closure->cntl.Reset();
     rpc_closure->cntl.set_timeout_ms(timeout_ms);
+    // as the attachment is empty, the http rpc also can do like the following interface.
+    // create a http rpc stub: http_stub
+    // http_stub->transmit_runtime_filter(&rpc_closure->cntl, &request, &rpc_closure->result, rpc_closure);
     stub->transmit_runtime_filter(&rpc_closure->cntl, &request, &rpc_closure->result, rpc_closure);
     rpc_closure->seq++;
 }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -77,6 +77,8 @@ namespace pipeline {
 class QueryContext;
 }
 
+constexpr int64_t kRpcHttpMinSize = ((1L << 31) - (1L << 20));
+
 // A collection of items that are part of the global state of a
 // query and shared across all execution nodes of that query.
 class RuntimeState {
@@ -352,6 +354,10 @@ public:
     std::shared_ptr<QueryStatisticsRecvr> query_recv();
 
     Status reset_epoch();
+
+    int64_t get_rpc_http_min_size() {
+        return _query_options.__isset.rpc_http_min_size ? _query_options.rpc_http_min_size : kRpcHttpMinSize;
+    }
 
 private:
     // Set per-query state.

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -77,7 +77,7 @@ namespace pipeline {
 class QueryContext;
 }
 
-constexpr int64_t kRpcHttpMinSize = ((1L << 31) - (1L << 20));
+constexpr int64_t kRpcHttpMinSize = ((1L << 31) - (1L << 10));
 
 // A collection of items that are part of the global state of a
 // query and shared across all execution nodes of that query.

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -190,6 +190,39 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
     TRY_CATCH_ALL(st, _exec_env->stream_mgr()->transmit_chunk(*request, &done));
 }
 
+// TODO: try...catch bthread std::bad_alloc exception
+template <typename T>
+void PInternalServiceImplBase<T>::transmit_chunk_via_http(google::protobuf::RpcController* cntl_base,
+                                                          const PHttpRequest* request, PTransmitChunkResult* response,
+                                                          google::protobuf::Closure* done) {
+    auto task = [=]() {
+        auto* cntl = static_cast<brpc::Controller*>(cntl_base);
+        butil::IOBuf& iobuf = cntl->request_attachment();
+        size_t params_size = 0;
+        iobuf.cutn(&params_size, sizeof(params_size));
+        butil::IOBuf params_from;
+        iobuf.cutn(&params_from, params_size);
+        butil::IOBufAsZeroCopyInputStream wrapper(params_from);
+        auto params = std::make_shared<PTransmitChunkParams>();
+        params->ParseFromZeroCopyStream(&wrapper);
+        // the left size
+        size_t attachment_size = 0;
+        iobuf.cutn(&attachment_size, sizeof(attachment_size));
+        if (attachment_size != iobuf.size()) {
+            Status st = Status::InternalError(
+                    fmt::format("{} != {} during deserialization via http", attachment_size, iobuf.size()));
+            st.to_protobuf(response->mutable_status());
+            return;
+        }
+        this->_transmit_chunk(cntl_base, params.get(), response, done);
+    };
+    if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
+        ClosureGuard closure_guard(done);
+        Status::ServiceUnavailable("submit transmit_chunk_via_http task failed")
+                .to_protobuf(response->mutable_status());
+    }
+}
+
 template <typename T>
 void PInternalServiceImplBase<T>::transmit_runtime_filter(google::protobuf::RpcController* cntl_base,
                                                           const PTransmitRuntimeFilterParams* request,

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -187,7 +187,7 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
         }
     }
 
-    TRY_CATCH_ALL(st, _exec_env->stream_mgr()->transmit_chunk(*request, &done));
+    st = _exec_env->stream_mgr()->transmit_chunk(*request, &done);
 }
 
 template <typename T>
@@ -216,9 +216,8 @@ void PInternalServiceImplBase<T>::transmit_chunk_via_http(google::protobuf::RpcC
             }
             return Status::OK();
         };
-        Status st;
-        // catch the exceptions, like the std::bad_alloc caused by deserialization.
-        TRY_CATCH_ALL(st, get_params());
+        // may throw std::bad_alloc exception.
+        Status st = get_params();
         if (!st.ok()) {
             st.to_protobuf(response->mutable_status());
             done->Run();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -190,28 +190,39 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
     TRY_CATCH_ALL(st, _exec_env->stream_mgr()->transmit_chunk(*request, &done));
 }
 
-// TODO: try...catch bthread std::bad_alloc exception
 template <typename T>
 void PInternalServiceImplBase<T>::transmit_chunk_via_http(google::protobuf::RpcController* cntl_base,
                                                           const PHttpRequest* request, PTransmitChunkResult* response,
                                                           google::protobuf::Closure* done) {
     auto task = [=]() {
-        auto* cntl = static_cast<brpc::Controller*>(cntl_base);
-        butil::IOBuf& iobuf = cntl->request_attachment();
-        size_t params_size = 0;
-        iobuf.cutn(&params_size, sizeof(params_size));
-        butil::IOBuf params_from;
-        iobuf.cutn(&params_from, params_size);
-        butil::IOBufAsZeroCopyInputStream wrapper(params_from);
         auto params = std::make_shared<PTransmitChunkParams>();
-        params->ParseFromZeroCopyStream(&wrapper);
-        // the left size
-        size_t attachment_size = 0;
-        iobuf.cutn(&attachment_size, sizeof(attachment_size));
-        if (attachment_size != iobuf.size()) {
-            Status st = Status::InternalError(
-                    fmt::format("{} != {} during deserialization via http", attachment_size, iobuf.size()));
+        auto get_params = [&]() -> Status {
+            auto* cntl = static_cast<brpc::Controller*>(cntl_base);
+            butil::IOBuf& iobuf = cntl->request_attachment();
+            // deserialize PTransmitChunkParams
+            size_t params_size = 0;
+            iobuf.cutn(&params_size, sizeof(params_size));
+            butil::IOBuf params_from;
+            iobuf.cutn(&params_from, params_size);
+            butil::IOBufAsZeroCopyInputStream wrapper(params_from);
+            params->ParseFromZeroCopyStream(&wrapper);
+            // the left size is from chunks' data
+            size_t attachment_size = 0;
+            iobuf.cutn(&attachment_size, sizeof(attachment_size));
+            if (attachment_size != iobuf.size()) {
+                Status st = Status::InternalError(
+                        fmt::format("{} != {} during deserialization via http", attachment_size, iobuf.size()));
+                return st;
+            }
+            return Status::OK();
+        };
+        Status st;
+        // catch the exceptions, like the std::bad_alloc caused by deserialization.
+        TRY_CATCH_ALL(st, get_params());
+        if (!st.ok()) {
             st.to_protobuf(response->mutable_status());
+            done->Run();
+            LOG(WARNING) << "transmit_data via http rpc failed, message=" << st.get_error_msg();
             return;
         }
         this->_transmit_chunk(cntl_base, params.get(), response, done);

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -68,6 +68,10 @@ public:
     void transmit_chunk(::google::protobuf::RpcController* controller, const ::starrocks::PTransmitChunkParams* request,
                         ::starrocks::PTransmitChunkResult* response, ::google::protobuf::Closure* done) override;
 
+    void transmit_chunk_via_http(::google::protobuf::RpcController* controller,
+                                 const ::starrocks::PHttpRequest* request, ::starrocks::PTransmitChunkResult* response,
+                                 ::google::protobuf::Closure* done) override;
+
     void transmit_runtime_filter(::google::protobuf::RpcController* controller,
                                  const ::starrocks::PTransmitRuntimeFilterParams* request,
                                  ::starrocks::PTransmitRuntimeFilterResult* response,

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -85,7 +85,7 @@ public:
     }
 
     // rarely used, so create as needed
-    static std::shared_ptr<doris::PBackendService_Stub> create_http_stub(const TNetworkAddress& taddr) {
+    static std::unique_ptr<doris::PBackendService_Stub> create_http_stub(const TNetworkAddress& taddr) {
         butil::EndPoint endpoint;
         std::string realhost;
         realhost = taddr.hostname;
@@ -111,7 +111,7 @@ public:
         if (channel->Init(endpoint, &options)) {
             return nullptr;
         }
-        return std::make_shared<doris::PBackendService_Stub>(channel.release(),
+        return std::make_unique<doris::PBackendService_Stub>(channel.release(),
                                                              google::protobuf::Service::STUB_OWNS_CHANNEL);
     }
 

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -37,10 +37,10 @@
 #include <memory>
 #include <mutex>
 
+#include "common/statusor.h"
 #include "gen_cpp/Types_types.h" // TNetworkAddress
 #include "gen_cpp/doris_internal_service.pb.h"
 #include "gen_cpp/internal_service.pb.h"
-#include "common/statusor.h"
 #include "service/brpc.h"
 #include "util/network_util.h"
 #include "util/spinlock.h"

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -84,6 +84,7 @@ public:
         return stub;
     }
 
+    // rarely used, so create as needed
     static std::shared_ptr<doris::PBackendService_Stub> create_http_stub(const TNetworkAddress& taddr) {
         butil::EndPoint endpoint;
         std::string realhost;

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -40,6 +40,7 @@
 #include "gen_cpp/Types_types.h" // TNetworkAddress
 #include "gen_cpp/doris_internal_service.pb.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "common/statusor.h"
 #include "service/brpc.h"
 #include "util/network_util.h"
 #include "util/spinlock.h"
@@ -85,20 +86,18 @@ public:
     }
 
     // rarely used, so create as needed
-    static std::unique_ptr<doris::PBackendService_Stub> create_http_stub(const TNetworkAddress& taddr) {
+    static StatusOr<std::unique_ptr<doris::PBackendService_Stub>> create_http_stub(const TNetworkAddress& taddr) {
         butil::EndPoint endpoint;
         std::string realhost;
         realhost = taddr.hostname;
         if (!is_valid_ip(taddr.hostname)) {
             realhost = hostname_to_ip(taddr.hostname);
             if (realhost == "") {
-                LOG(WARNING) << "failed to get ip from host";
-                return nullptr;
+                return Status::RuntimeError("failed to get ip from host " + taddr.hostname);
             }
         }
         if (str2endpoint(realhost.c_str(), taddr.port, &endpoint)) {
-            LOG(WARNING) << "unknown endpoint, host = " << taddr.hostname;
-            return nullptr;
+            return Status::RuntimeError("unknown endpoint, host = " + taddr.hostname);
         }
         // create
         brpc::ChannelOptions options;
@@ -109,7 +108,8 @@ public:
         options.max_retry = 3;
         std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
         if (channel->Init(endpoint, &options)) {
-            return nullptr;
+            return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
+                                        std::to_string(taddr.port));
         }
         return std::make_unique<doris::PBackendService_Stub>(channel.release(),
                                                              google::protobuf::Service::STUB_OWNS_CHANNEL);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -333,6 +333,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String QUERY_CACHE_AGG_CARDINALITY_LIMIT = "query_cache_agg_cardinality_limit";
     public static final String TRANSMISSION_ENCODE_LEVEL = "transmission_encode_level";
+    public static final String RPC_HTTP_MIN_SIZE = "rpc_http_min_size";
 
     public static final String NESTED_MV_REWRITE_MAX_LEVEL = "nested_mv_rewrite_max_level";
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE = "enable_materialized_view_rewrite";
@@ -753,6 +754,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = TRANSMISSION_COMPRESSION_TYPE)
     private String transmissionCompressionType = "NO_COMPRESSION";
+
+    @VariableMgr.VarAttr(name = RPC_HTTP_MIN_SIZE)
+    private long rpcHttpMinSize = ((1L << 31) - (1L << 20));
 
     @VariableMgr.VarAttr(name = TRANSMISSION_ENCODE_LEVEL)
     private int transmissionEncodeLevel = 7;
@@ -1952,6 +1956,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
 
         tResult.setTransmission_encode_level(transmissionEncodeLevel);
+        tResult.setRpc_http_min_size(rpcHttpMinSize);
 
         TCompressionType loadCompressionType = CompressionUtils.findTCompressionByName(loadTransmissionCompressionType);
         if (loadCompressionType != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -755,7 +755,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TRANSMISSION_COMPRESSION_TYPE)
     private String transmissionCompressionType = "NO_COMPRESSION";
 
-    // if a packet's size is larger than RPC_HTTP_MIN_SIZE, it will use RPC via http.
+    // if a packet's size is larger than RPC_HTTP_MIN_SIZE, it will use RPC via http, as the std rpc has 2GB size limit.
+    // the setting size is a bit smaller than 2GB, as the pre-computed serialization size of packets may not accurate.
+    // no need to change it in general.
     @VariableMgr.VarAttr(name = RPC_HTTP_MIN_SIZE, flag = VariableMgr.INVISIBLE)
     private long rpcHttpMinSize = ((1L << 31) - (1L << 20));
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -759,7 +759,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // the setting size is a bit smaller than 2GB, as the pre-computed serialization size of packets may not accurate.
     // no need to change it in general.
     @VariableMgr.VarAttr(name = RPC_HTTP_MIN_SIZE, flag = VariableMgr.INVISIBLE)
-    private long rpcHttpMinSize = ((1L << 31) - (1L << 20));
+    private long rpcHttpMinSize = ((1L << 31) - (1L << 10));
 
     @VariableMgr.VarAttr(name = TRANSMISSION_ENCODE_LEVEL)
     private int transmissionEncodeLevel = 7;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -755,7 +755,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TRANSMISSION_COMPRESSION_TYPE)
     private String transmissionCompressionType = "NO_COMPRESSION";
 
-    @VariableMgr.VarAttr(name = RPC_HTTP_MIN_SIZE)
+    // if a packet's size is larger than RPC_HTTP_MIN_SIZE, it will use RPC via http.
+    @VariableMgr.VarAttr(name = RPC_HTTP_MIN_SIZE, flag = VariableMgr.INVISIBLE)
     private long rpcHttpMinSize = ((1L << 31) - (1L << 20));
 
     @VariableMgr.VarAttr(name = TRANSMISSION_ENCODE_LEVEL)

--- a/gensrc/proto/doris_internal_service.proto
+++ b/gensrc/proto/doris_internal_service.proto
@@ -59,6 +59,7 @@ service PBackendService {
 
     // Transmit vectorized data between backends
     rpc transmit_chunk(starrocks.PTransmitChunkParams) returns (starrocks.PTransmitChunkResult);
+    rpc transmit_chunk_via_http(starrocks.PHttpRequest) returns (starrocks.PTransmitChunkResult);
     rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_chunks(starrocks.PTabletWriterAddChunksRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_segment(starrocks.PTabletWriterAddSegmentRequest) returns (starrocks.PTabletWriterAddSegmentResult);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -63,6 +63,9 @@ message PTransmitDataParams {
     optional PQueryStatistics query_statistics = 8;
 };
 
+message PHttpRequest {
+};
+
 // Transmit vectorized data chunks between Backends.
 // Try to batch enough chunk in one request to reduce each RPC call overhead.
 message PTransmitChunkParams {
@@ -525,6 +528,7 @@ service PInternalService {
 
     // Transmit vectorized data between backends.
     rpc transmit_chunk(PTransmitChunkParams) returns (PTransmitChunkResult);
+    rpc transmit_chunk_via_http(PHttpRequest) returns (PTransmitChunkResult);
     rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_chunks(starrocks.PTabletWriterAddChunksRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_segment(starrocks.PTabletWriterAddSegmentRequest) returns (starrocks.PTabletWriterAddSegmentResult);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -180,6 +180,7 @@ struct TQueryOptions {
   74: optional double spill_mem_limit_threshold;
   75: optional i64 spill_operator_min_bytes;
   76: optional TSpillMode spill_mode;
+  77: optional i64 rpc_http_min_size;
 
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/15316

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

if sending meg's size > `rpc_http_min_size`, it will use HTTP RPC, otherwise using the std baidu_rpc.

HTTP RPC can directly send a request proto with requiring the attachment should be empty. However when the attachment is not empty, the request proto should be put into attachment explicitly.


## Results

before this PR, RPC error when the RPC msg's size > 2GB
after this PR, the large msg transmit successfully via HTTP RPC.

```
// force the standard RPC failed due to the large size of the attachment.

mysql> select host_name() as h, length( group_concat(concat(l_shipinstruct,l_comment)))/1024/1024/1024 as siz from lineitem group by h;
ERROR 1064 (HY000): transmit chunk rpc failed:29ea49f3-c1a8-11ed-896b-00163e132524


// force RPC via HTTP, works fine.

mysql> select host_name() as h, length( group_concat(concat(l_shipinstruct,l_comment)))/1024/1024/1024 as siz from lineitem group by h;
+-------------------------+----------------------+
| h                       | siz                  |
+-------------------------+----------------------+
| iZ8vbgtsjtof0smhp0fd7lZ | -0.45599549543112516 |
| iZ8vbgtsjtof0smhp0fd7kZ |  -0.4556004209443927 |
| iZ8vbgtsjtof0smhp0fd7mZ | -0.45604985300451517 |
+-------------------------+----------------------+
3 rows in set (53.45 sec)
```

test on tpcds-100g,[ the performance seems no differ if using http rpc.](https://starrocks.feishu.cn/sheets/shtcnRkmYLglImO2lTHABonJlx7)
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
