### PR TITLE
[BugFix] Be crash when init AUTO_INCREMENT map and Delete op lead to id wasting (#19526)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1632,7 +1632,24 @@ Status OlapTableSink::_fill_auto_increment_id_internal(Chunk* chunk, SlotDescrip
     ColumnPtr& data_col = std::dynamic_pointer_cast<NullableColumn>(col)->data_column();
     std::vector<uint8_t> filter(std::dynamic_pointer_cast<NullableColumn>(col)->immutable_null_column_data());
 
+    if (_keys_type == TKeysType::PRIMARY_KEYS) {
+        size_t op_column_id = chunk->num_columns() - 1;
+        ColumnPtr& op_col = chunk->get_column_by_index(op_column_id);
+        const uint8_t* ops = std::dynamic_pointer_cast<NullableColumn>(op_col)->raw_data();
+        size_t row = chunk->num_rows();
+
+        for (size_t i = 0; i < row; ++i) {
+            if (ops[i] == TOpType::DELETE) {
+                filter[i] = 0;
+            }
+        }
+    }
+
     uint32_t null_rows = SIMD::count_nonzero(filter);
+
+    if (null_rows == 0) {
+        return Status::OK();
+    }
 
     switch (slot->type().type) {
     case TYPE_BIGINT: {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19526

## Problem Summary(Required) ：
Problem:
Problem 1:
When a new auto-increment map for a table init in BE, BE may crash because of need_init flag, there will be a race condition, which will lead to wrong id assignment, and eventually crash because the vector is out of bounds.

<img width="754" alt="image" src="https://user-images.githubusercontent.com/111035020/227087986-518bf88a-7919-4e2c-b283-42973c472f25.png">



Problem 2:
When using stream load with partial_update = false and delete flag for some data, the chunk in OlapTableSink::send_chunk contain the data which will be deleted. An auto-increment id will also be allocated for those rows means that delete op will waste the auto-increment id in this case.

Solution:
1. Check if the row has op = delete in OlapTableSink::send_chunk 
2. The need_init is not needed now, we can remove it safely

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
