### PR TITLE
[BugFix] DecodeNode report "All slotIds should be remapped" when query cache enabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
@@ -27,6 +27,7 @@ import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
 
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -96,9 +97,12 @@ public class DecodeNode extends PlanNode {
     @Override
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
         TNormalDecodeNode decodeNode = new TNormalDecodeNode();
-        List<Integer> fromDictIds = dictIdToStringIds.keySet().stream().sorted(Integer::compareTo)
+        List<Pair<SlotId, SlotId>> dictIdAndStrIdPairs = dictIdToStringIds.entrySet().stream().map(
+                e -> Pair.create(normalizer.remapSlotId(new SlotId(e.getKey())), new SlotId(e.getValue()))
+        ).sorted(Comparator.comparing(p -> p.first.asInt())).collect(Collectors.toList());
+        List<Integer> fromDictIds = dictIdAndStrIdPairs.stream().map(p -> p.first.asInt())
                 .collect(Collectors.toList());
-        List<Integer> toStringIds = fromDictIds.stream().map(dictIdToStringIds::get)
+        List<Integer> toStringIds = dictIdAndStrIdPairs.stream().map(p -> normalizer.remapSlotId(p.second).asInt())
                 .collect(Collectors.toList());
         decodeNode.setFrom_dict_ids(fromDictIds);
         decodeNode.setTo_string_ids(toStringIds);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/19540
daily case: https://github.com/StarRocks/StarRocksTest/pull/2021
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
