### PR TITLE
[Enhancement] let map_apply remove duplicated keys of map

### DIFF
--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -621,4 +621,35 @@ Status MapColumn::unfold_const_children(const starrocks::TypeDescriptor& type) {
     return Status::OK();
 }
 
+// keep the last identical key
+void MapColumn::remove_duplicated_keys() {
+    Filter filter(_keys->size(), 1);
+
+    bool has_duplicated_keys = false;
+    UInt32Column::Ptr new_offsets = UInt32Column::create();
+    auto& offsets_vec = new_offsets->get_data();
+    offsets_vec.push_back(0);
+
+    uint32_t new_offset = 0;
+    for (auto i = 0; i < _offsets->size() - 1; ++i) {
+        for (auto j = _offsets->get_data()[i]; j < _offsets->get_data()[i + 1]; ++j) {
+            for (auto k = j + 1; k < _offsets->get_data()[i + 1]; ++k) {
+                if (_keys->equals(j, *_keys, k)) {
+                    filter[j] = 0;
+                    has_duplicated_keys = true;
+                    break;
+                }
+            }
+            new_offset += filter[j];
+        }
+        offsets_vec.push_back(new_offset);
+    }
+    if (has_duplicated_keys) {
+        auto new_keys_size = _keys->filter(filter);
+        auto new_values_size = _values->filter(filter);
+        DCHECK(new_keys_size == new_values_size);
+        _offsets.swap(new_offsets);
+    }
+}
+
 } // namespace starrocks

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -631,7 +631,8 @@ void MapColumn::remove_duplicated_keys() {
     offsets_vec.push_back(0);
 
     uint32_t new_offset = 0;
-    for (auto i = 0; i < _offsets->size() - 1; ++i) {
+    size_t size = this->size();
+    for (auto i = 0; i < size; ++i) {
         for (auto j = _offsets->get_data()[i]; j < _offsets->get_data()[i + 1]; ++j) {
             for (auto k = j + 1; k < _offsets->get_data()[i + 1]; ++k) {
                 if (_keys->equals(j, *_keys, k)) {

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -187,6 +187,8 @@ public:
 
     Status unfold_const_children(const starrocks::TypeDescriptor& type) override;
 
+    void remove_duplicated_keys();
+
 private:
     // Keys must be NullableColumn to facilitate handling nested types.
     ColumnPtr _keys;

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -57,6 +57,8 @@ public:
         return _arguments_ids.size();
     }
 
+    Expr* get_lambda_expr() const { return _children[0]; }
+
     void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
 
 private:

--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -31,15 +31,24 @@
 #include "runtime/user_function_cache.h"
 #include "storage/chunk_helper.h"
 
-
 namespace starrocks {
 
-MapApplyExpr::MapApplyExpr(const TExprNode& node) : Expr(node, false) {
-    _maybe_duplicated_keys = down_cast<MapExpr*>(_children[0])->maybe_duplicated_keys();
-}
+MapApplyExpr::MapApplyExpr(const TExprNode& node) : Expr(node, false) {}
 
 // for tests
 MapApplyExpr::MapApplyExpr(TypeDescriptor type) : Expr(std::move(type), false), _maybe_duplicated_keys(true) {}
+
+Status MapApplyExpr::prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) {
+    RETURN_IF_ERROR(Expr::prepare(state, context));
+    if (_children.size() < 2) {
+        return Status::InternalError("map expression's children size should not less than 2.");
+    }
+    auto lambda_func = down_cast<LambdaFunction*>(_children[0]);
+    auto map_expr = down_cast<MapExpr*>(lambda_func->get_lambda_expr());
+    _maybe_duplicated_keys = map_expr->maybe_duplicated_keys();
+    lambda_func->get_lambda_arguments_ids(&_arguments_ids);
+    return Status::OK();
+}
 
 StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* chunk) {
     std::vector<ColumnPtr> input_columns;
@@ -92,12 +101,10 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
     } else {
         auto cur_chunk = std::make_shared<Chunk>();
         // put all arguments into the new chunk
-        std::vector<SlotId> arguments_ids;
-        auto lambda_func = dynamic_cast<LambdaFunction*>(_children[0]);
-        int argument_num = lambda_func->get_lambda_arguments_ids(&arguments_ids);
+        int argument_num = _arguments_ids.size();
         DCHECK(argument_num == input_columns.size());
         for (int i = 0; i < argument_num; ++i) {
-            cur_chunk->append_column(input_columns[i], arguments_ids[i]); // column ref
+            cur_chunk->append_column(input_columns[i], _arguments_ids[i]); // column ref
         }
         // put captured columns into the new chunk aligning with the first map's offsets
         std::vector<SlotId> slot_ids;

--- a/be/src/exprs/map_apply_expr.h
+++ b/be/src/exprs/map_apply_expr.h
@@ -32,10 +32,13 @@ public:
     // for tests
     explicit MapApplyExpr(TypeDescriptor type);
 
+    Status prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) override;
+
     Expr* clone(ObjectPool* pool) const override { return pool->add(new MapApplyExpr(*this)); }
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 private:
     bool _maybe_duplicated_keys;
+    std::vector<SlotId> _arguments_ids;
 };
 } // namespace starrocks

--- a/be/src/exprs/map_apply_expr.h
+++ b/be/src/exprs/map_apply_expr.h
@@ -19,9 +19,7 @@
 
 #include "common/global_types.h"
 #include "common/object_pool.h"
-#include "exprs/column_ref.h"
 #include "exprs/expr.h"
-#include "glog/logging.h"
 
 namespace starrocks {
 
@@ -37,5 +35,7 @@ public:
     Expr* clone(ObjectPool* pool) const override { return pool->add(new MapApplyExpr(*this)); }
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
+private:
+    bool _maybe_duplicated_keys;
 };
 } // namespace starrocks

--- a/be/src/exprs/map_apply_expr.h
+++ b/be/src/exprs/map_apply_expr.h
@@ -37,6 +37,7 @@ public:
     Expr* clone(ObjectPool* pool) const override { return pool->add(new MapApplyExpr(*this)); }
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
+
 private:
     bool _maybe_duplicated_keys;
     std::vector<SlotId> _arguments_ids;

--- a/be/src/exprs/map_expr.cpp
+++ b/be/src/exprs/map_expr.cpp
@@ -17,38 +17,26 @@
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/map_column.h"
-#include "common/object_pool.h"
 #include "util/raw_container.h"
 
 namespace starrocks {
 
-// map's key column and value column come from expression of children[0], children[1]
-class MapExpr final : public Expr {
-public:
-    explicit MapExpr(const TExprNode& node) : Expr(node) {}
-
-    MapExpr(const MapExpr&) = default;
-    MapExpr(MapExpr&&) = default;
-
-    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* chunk) override {
-        DCHECK_EQ(2, _children.size());
-        ASSIGN_OR_RETURN(ColumnPtr key_col, _children[0]->evaluate_checked(context, chunk));
-        ASSIGN_OR_RETURN(ColumnPtr value_col, _children[1]->evaluate_checked(context, chunk));
-        size_t num_rows = std::max(key_col->size(), value_col->size());
-        // No optimization for const column now.
-        key_col = ColumnHelper::unfold_const_column(_children[0]->type(), num_rows, key_col);
-        value_col = ColumnHelper::unfold_const_column(_children[1]->type(), num_rows, value_col);
-        key_col = ColumnHelper::cast_to_nullable_column(key_col);
-        value_col = ColumnHelper::cast_to_nullable_column(value_col);
-        // fake offsets, just for creating map column.
-        auto offsets = UInt32Column::create();
-        offsets->append(0);
-        offsets->append(num_rows);
-        return std::make_shared<MapColumn>(std::move(key_col), std::move(value_col), std::move(offsets));
-    }
-
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new MapExpr(*this)); }
-};
+StatusOr<ColumnPtr> MapExpr::evaluate_checked(ExprContext* context, Chunk* chunk) {
+    DCHECK_EQ(2, _children.size());
+    ASSIGN_OR_RETURN(ColumnPtr key_col, _children[0]->evaluate_checked(context, chunk));
+    ASSIGN_OR_RETURN(ColumnPtr value_col, _children[1]->evaluate_checked(context, chunk));
+    size_t num_rows = std::max(key_col->size(), value_col->size());
+    // No optimization for const column now.
+    key_col = ColumnHelper::unfold_const_column(_children[0]->type(), num_rows, key_col);
+    value_col = ColumnHelper::unfold_const_column(_children[1]->type(), num_rows, value_col);
+    key_col = ColumnHelper::cast_to_nullable_column(key_col);
+    value_col = ColumnHelper::cast_to_nullable_column(value_col);
+    // fake offsets, just for creating map column.
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(num_rows);
+    return std::make_shared<MapColumn>(std::move(key_col), std::move(value_col), std::move(offsets));
+}
 
 Expr* MapExprFactory::from_thrift(const TExprNode& node) {
     DCHECK_EQ(TExprNodeType::MAP_EXPR, node.node_type);

--- a/be/src/exprs/map_expr.h
+++ b/be/src/exprs/map_expr.h
@@ -14,9 +14,26 @@
 
 #pragma once
 
+#include "common/object_pool.h"
 #include "exprs/expr.h"
 
 namespace starrocks {
+
+// map's key column and value column come from expression of children[0], children[1]
+class MapExpr final : public Expr {
+public:
+    explicit MapExpr(const TExprNode& node) : Expr(node) {}
+
+    MapExpr(const MapExpr&) = default;
+    MapExpr(MapExpr&&) = default;
+
+    // a naive way to predicate whether there will be duplicated keys
+    bool maybe_duplicated_keys() { return !_children[0]->is_slotref(); }
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* chunk) override;
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new MapExpr(*this)); }
+};
 
 class MapExprFactory {
 public:

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -65,8 +65,10 @@ StatusOr<ColumnPtr> MapFunctions::map_from_arrays(FunctionContext* context, cons
         auto copied_key_elements = keys_data->elements().clone_shared();
         auto copied_value_elements = values_data->elements().clone_shared();
         auto copied_offsets = keys_data->offsets().clone_shared();
-        return MapColumn::create(std::move(copied_key_elements), std::move(copied_value_elements),
-                                 std::static_pointer_cast<UInt32Column>(copied_offsets));
+        auto map_column = MapColumn::create(std::move(copied_key_elements), std::move(copied_value_elements),
+                                            std::static_pointer_cast<UInt32Column>(copied_offsets));
+        map_column->remove_duplicated_keys();
+        return map_column;
     } else {
         // build the null column
         NullColumnPtr null_column;
@@ -117,6 +119,7 @@ StatusOr<ColumnPtr> MapFunctions::map_from_arrays(FunctionContext* context, cons
         }
         auto map_column = MapColumn::create(std::move(map_key_elements), std::move(map_value_elements),
                                             std::static_pointer_cast<UInt32Column>(map_offsets_column));
+        map_column->remove_duplicated_keys();
         return NullableColumn::create(std::move(map_column), std::move(null_column));
     }
 }

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -1204,4 +1204,71 @@ PARALLEL_TEST(MapColumnTest, test_reference_memory_usage) {
 
     ASSERT_EQ(0, column->Column::reference_memory_usage());
 }
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
+    {
+        auto offsets = UInt32Column::create();
+        auto keys_data = Int32Column::create();
+        auto keys_null = NullColumn::create();
+        auto keys = NullableColumn::create(keys_data, keys_null);
+        auto values_data = Int32Column::create();
+        auto values_null = NullColumn::create();
+        auto values = NullableColumn::create(values_data, values_null);
+        auto column = MapColumn::create(keys, values, offsets);
+
+        DatumMap map;
+        map[(int32_t)1] = (int32_t)11;
+        map[(int32_t)22] = (int32_t)22;
+        map[(int32_t)22] = (int32_t)33;
+        column->append_datum(map);
+
+        DatumMap map1;
+        map1[(int32_t)4] = (int32_t)44;
+        map1[(int32_t)4] = (int32_t)55;
+        map1[(int32_t)4] = (int32_t)66;
+        column->append_datum(map1);
+
+        DatumMap map3;
+        map3[(int32_t)3] = Datum();
+        column->append_datum(map3);
+
+        // {} empty
+        column->append_datum(DatumMap());
+
+        column->remove_duplicated_keys();
+
+        ASSERT_EQ("{1:11,22:33}", column->debug_item(0));
+        ASSERT_EQ("{4:66}", column->debug_item(1));
+        ASSERT_EQ("{3:NULL}", column->debug_item(2));
+        ASSERT_EQ("{}", column->debug_item(3));
+    }
+    {
+        auto offsets = UInt32Column::create();
+        auto keys_data = BinaryColumn::create();
+        auto keys_null = NullColumn::create();
+        auto keys = NullableColumn::create(keys_data, keys_null);
+        auto values_data = BinaryColumn::create();
+        auto null_column = NullColumn::create();
+        auto values = NullableColumn::create(values_data, null_column);
+        auto column = MapColumn::create(keys, values, offsets);
+
+        DatumMap map;
+        map[(Slice) "a"] = (Slice) "hello";
+        map[(Slice) "b"] = (Slice) " ";
+        map[(Slice) "a"] = (Slice) "world";
+        column->append_datum(map);
+
+        DatumMap map1;
+        map1[(Slice) "def"] = (Slice) "haha";
+        map1[(Slice) "g h"] = (Slice) "let's dance";
+        column->append_datum(map1);
+
+        column->remove_duplicated_keys();
+
+        ASSERT_EQ("{'a':'world','b':' '}", column->debug_item(0));
+        ASSERT_EQ("{'def':'haha','g h':'let's dance'}", column->debug_item(1));
+    }
+}
+
 } // namespace starrocks

--- a/be/test/exprs/lambda_map_expr_test.cpp
+++ b/be/test/exprs/lambda_map_expr_test.cpp
@@ -250,7 +250,7 @@ TEST_F(MapApplyExprTest, test_map_int_int) {
     // Query:
     //   select map_apply((k,v)->(k is null, v + a), map)
     //
-    // Outputs: "[{0:45,0:56,0:67}, {0:78,0:89}, {0:NULL}, {}, NULL]"
+    // Outputs: "[{0:67}, {0:89}, {0:NULL}, {}, NULL]"
 
     {
         std::unique_ptr<MapApplyExpr> map_apply_expr = create_map_apply_expr(type_map_int_int);
@@ -265,7 +265,7 @@ TEST_F(MapApplyExprTest, test_map_int_int) {
         ColumnPtr result = map_apply_expr->evaluate(&exprContext, &cur_chunk);
 
         EXPECT_TRUE(result->is_nullable());
-        EXPECT_STREQ(result->debug_string().c_str(), "[{0:45,0:56,0:67}, {0:78,0:89}, {0:NULL}, {}, NULL]");
+        EXPECT_STREQ(result->debug_string().c_str(), "[{0:67}, {0:89}, {0:NULL}, {}, NULL]");
 
         Expr::close(expr_ctxs, &_runtime_state);
     }
@@ -352,7 +352,7 @@ TEST_F(MapApplyExprTest, test_map_varchar_int) {
     // Query:
     //   select map_apply((k,v)->(k is null, v + a), map)
     //
-    // Outputs: {0:12,0:23,0:34}, {0:45,0:56,0:67}, {0:78,0:89}, {0:100}, {}
+    // Outputs: {0:34}, {0:67}, {0:89}, {0:100}, {}
     {
         std::unique_ptr<MapApplyExpr> map_apply_expr = create_map_apply_expr(type_map_varchar_int);
 
@@ -366,7 +366,7 @@ TEST_F(MapApplyExprTest, test_map_varchar_int) {
         ColumnPtr result = map_apply_expr->evaluate(&exprContext, &cur_chunk);
 
         EXPECT_FALSE(result->is_nullable());
-        EXPECT_STREQ(result->debug_string().c_str(), "{0:12,0:23,0:34}, {0:45,0:56,0:67}, {0:78,0:89}, {0:100}, {}");
+        EXPECT_STREQ(result->debug_string().c_str(), "{0:34}, {0:67}, {0:89}, {0:100}, {}");
 
         Expr::close(expr_ctxs, &_runtime_state);
     }

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -46,7 +46,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map) {
     {
         // [1,2,3]
         {
-            DatumArray datum{1, 2, 3};
+            DatumArray datum{1, 2, 2};
             input_keys->append_datum(datum);
         }
         // NULL
@@ -101,7 +101,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map) {
     auto result = std::move(ret.value());
     EXPECT_EQ(6, result->size());
 
-    EXPECT_STREQ("{1:'a',2:'b',3:'c'}", result->debug_item(0).c_str());
+    EXPECT_STREQ("{1:'a',2:'c'}", result->debug_item(0).c_str());
     EXPECT_TRUE(result->is_null(1));
     EXPECT_TRUE(result->is_null(2));
     EXPECT_STREQ("{6:'f',7:'g'}", result->debug_item(3).c_str());


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

map's keys should be unique, so here remove duplicated keys in map.
but if the input map's keys are not unique, and the lambda function does not change the keys, the duplicated exists.

```
mysql> select map_apply((k,v)->(k+cap,v), col_map) from ((select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'']) as col_map, 1 as cap))A;
+--------------------------------------------+
| map_apply((k, v) -> (k + cap, v), col_map) |
+--------------------------------------------+
| {2:"ab",4:"cdd",3:null,null:""}            |
+--------------------------------------------+
1 row in set (0.01 sec)

mysql> select map_apply((k,v)->(k,v), col_map) from ((select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'']) as col_map, 1 as cap))A;
+-------------------------------------------+
| map_apply((k, v) -> (k, v), col_map)      |
+-------------------------------------------+
| {1:"ab",3:"cdd",null:null,2:null,null:""} |
+-------------------------------------------+
```

after let `map_from_arrays` remove duplicated keys:

```
mysql> select map_apply((k,v)->(k,v), col_map) from ((select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'']) as col_map, 1 as cap))A;
+--------------------------------------+
| map_apply((k, v) -> (k, v), col_map) |
+--------------------------------------+
| {1:"ab",3:"cdd",2:null,null:""}      |
+--------------------------------------+
1 row in set (0.01 sec)

mysql> (select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'']) as col_map, 1 as cap);
+---------------------------------+------+
| col_map                         | cap  |
+---------------------------------+------+
| {1:"ab",3:"cdd",2:null,null:""} |    1 |
+---------------------------------+------+
1 row in set (0.01 sec)
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
