### PR TITLE
[BugFix] [Cherry-pick] fix low cardinality dict on mv rewrite for 2.5 (#19325)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -23,6 +23,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -141,6 +142,25 @@ public class Utils {
 
     public static void extractOlapScanOperator(GroupExpression groupExpression, List<LogicalOlapScanOperator> list) {
         extractOperator(groupExpression, list, p -> OperatorType.LOGICAL_OLAP_SCAN.equals(p.getOpType()));
+    }
+
+    public static List<PhysicalOlapScanOperator> extractPhysicalOlapScanOperator(OptExpression root) {
+        List<PhysicalOlapScanOperator> list = Lists.newArrayList();
+        extractOperator(root, list, op -> OperatorType.PHYSICAL_OLAP_SCAN.equals(op.getOpType()));
+        return list;
+    }
+
+    private static <E extends Operator> void extractOperator(OptExpression root, List<E> list,
+                                                             Predicate<Operator> lambda) {
+        if (lambda.test(root.getOp())) {
+            list.add((E) root.getOp());
+            return;
+        }
+
+        List<OptExpression> inputs = root.getInputs();
+        for (OptExpression input : inputs) {
+            extractOperator(input, list, lambda);
+        }
     }
 
     private static <E extends Operator> void extractOperator(GroupExpression root, List<E> list,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -32,7 +32,6 @@ import com.starrocks.sql.optimizer.base.OrderSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.Projection;
-import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDecodeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
@@ -853,9 +852,9 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             return root;
         }
 
-        List<LogicalOlapScanOperator> scanOperators = taskContext.getAllScanOperators();
+        List<PhysicalOlapScanOperator> scanOperators = Utils.extractPhysicalOlapScanOperator(root);
 
-        for (LogicalOlapScanOperator scanOperator : scanOperators) {
+        for (PhysicalOlapScanOperator scanOperator : scanOperators) {
             OlapTable table = (OlapTable) scanOperator.getTable();
             long version = table.getPartitions().stream().map(Partition::getVisibleVersionTime).max(Long::compareTo)
                     .orElse(0L);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
@@ -15,11 +15,8 @@
 package com.starrocks.planner;
 
 import com.google.common.collect.Lists;
-import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.plan.PlanTestBase;
-import com.starrocks.utframe.StarRocksAssert;
-import com.starrocks.utframe.UtFrameUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -28,19 +25,10 @@ public class MaterializedViewSSBTest extends PlanTestBase {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        FeConstants.runningUnitTest = true;
-        Config.enable_experimental_mv = true;
-        UtFrameUtils.createMinStarRocksCluster();
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        MaterializedViewTestBase.setUp();
 
-        connectContext= UtFrameUtils.createDefaultCtx();
-        connectContext.getSessionVariable().setEnablePipelineEngine(true);
-        connectContext.getSessionVariable().setEnableQueryCache(true);
-        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
-        connectContext.getSessionVariable().setEnableOptimizerTraceLog(true);
-        FeConstants.runningUnitTest = true;
-        starRocksAssert = new StarRocksAssert(connectContext);
-        starRocksAssert.withDatabase(MATERIALIZED_DB_NAME)
-                .useDatabase(MATERIALIZED_DB_NAME);
+        starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
 
         // create SSB tables
         // put lineorder last because it depends on other tables for foreign key constraints

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q2-1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q2-1.sql
@@ -21,10 +21,11 @@ ORDER BY
   d_year,
   p_brand;
 [result]
-TOP-N (order by [[22: d_year ASC NULLS FIRST, 39: p_brand ASC NULLS FIRST]])
-    TOP-N (order by [[22: d_year ASC NULLS FIRST, 39: p_brand ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{51: sum=sum(51: sum)}] group by [[22: d_year, 39: p_brand]] having [null]
-            EXCHANGE SHUFFLE[22, 39]
-                AGGREGATE ([LOCAL] aggregate [{51: sum=sum(13: lo_revenue)}] group by [[22: d_year, 39: p_brand]] having [null]
-                    SCAN (columns[64: LO_REVENUE, 80: S_REGION, 84: P_CATEGORY, 85: P_BRAND, 93: d_year] predicate[80: S_REGION = AMERICA AND 84: P_CATEGORY = MFGR#12])
+Decode
+    TOP-N (order by [[22: d_year ASC NULLS FIRST, 109: P_BRAND ASC NULLS FIRST]])
+        TOP-N (order by [[22: d_year ASC NULLS FIRST, 109: P_BRAND ASC NULLS FIRST]])
+            AGGREGATE ([GLOBAL] aggregate [{51: sum=sum(51: sum)}] group by [[22: d_year, 109: P_BRAND]] having [null]
+                EXCHANGE SHUFFLE[22, 109]
+                    AGGREGATE ([LOCAL] aggregate [{51: sum=sum(13: lo_revenue)}] group by [[22: d_year, 109: P_BRAND]] having [null]
+                        SCAN (columns[107: S_REGION, 108: P_CATEGORY, 93: d_year, 109: P_BRAND, 64: LO_REVENUE] predicate[DictMapping(107: S_REGION{80: S_REGION = AMERICA}) AND DictMapping(108: P_CATEGORY{84: P_CATEGORY = MFGR#12})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q2-2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q2-2.sql
@@ -21,10 +21,11 @@ ORDER BY
   d_year,
   p_brand;
 [result]
-TOP-N (order by [[22: d_year ASC NULLS FIRST, 39: p_brand ASC NULLS FIRST]])
-    TOP-N (order by [[22: d_year ASC NULLS FIRST, 39: p_brand ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{51: sum=sum(51: sum)}] group by [[22: d_year, 39: p_brand]] having [null]
-            EXCHANGE SHUFFLE[22, 39]
-                AGGREGATE ([LOCAL] aggregate [{51: sum=sum(13: lo_revenue)}] group by [[22: d_year, 39: p_brand]] having [null]
-                    SCAN (columns[64: LO_REVENUE, 80: S_REGION, 85: P_BRAND, 93: d_year] predicate[80: S_REGION = ASIA AND 85: P_BRAND <= MFGR#2228 AND 85: P_BRAND >= MFGR#2221])
+Decode
+    TOP-N (order by [[22: d_year ASC NULLS FIRST, 108: P_BRAND ASC NULLS FIRST]])
+        TOP-N (order by [[22: d_year ASC NULLS FIRST, 108: P_BRAND ASC NULLS FIRST]])
+            AGGREGATE ([GLOBAL] aggregate [{51: sum=sum(51: sum)}] group by [[22: d_year, 108: P_BRAND]] having [null]
+                EXCHANGE SHUFFLE[22, 108]
+                    AGGREGATE ([LOCAL] aggregate [{51: sum=sum(13: lo_revenue)}] group by [[22: d_year, 108: P_BRAND]] having [null]
+                        SCAN (columns[107: S_REGION, 108: P_BRAND, 93: d_year, 64: LO_REVENUE] predicate[DictMapping(107: S_REGION{80: S_REGION = ASIA}) AND DictMapping(108: P_BRAND{85: P_BRAND <= MFGR#2228}) AND DictMapping(108: P_BRAND{85: P_BRAND >= MFGR#2221})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q2-3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q2-3.sql
@@ -21,10 +21,11 @@ ORDER BY
   d_year,
   p_brand;
 [result]
-TOP-N (order by [[22: d_year ASC NULLS FIRST, 39: p_brand ASC NULLS FIRST]])
-    TOP-N (order by [[22: d_year ASC NULLS FIRST, 39: p_brand ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{51: sum=sum(51: sum)}] group by [[22: d_year, 39: p_brand]] having [null]
-            EXCHANGE SHUFFLE[22, 39]
-                AGGREGATE ([LOCAL] aggregate [{51: sum=sum(13: lo_revenue)}] group by [[22: d_year, 39: p_brand]] having [null]
-                    SCAN (columns[64: LO_REVENUE, 80: S_REGION, 85: P_BRAND, 93: d_year] predicate[80: S_REGION = EUROPE AND 85: P_BRAND = MFGR#2221])
+Decode
+    TOP-N (order by [[22: d_year ASC NULLS FIRST, 108: P_BRAND ASC NULLS FIRST]])
+        TOP-N (order by [[22: d_year ASC NULLS FIRST, 108: P_BRAND ASC NULLS FIRST]])
+            AGGREGATE ([GLOBAL] aggregate [{51: sum=sum(51: sum)}] group by [[22: d_year, 108: P_BRAND]] having [null]
+                EXCHANGE SHUFFLE[22, 108]
+                    AGGREGATE ([LOCAL] aggregate [{51: sum=sum(13: lo_revenue)}] group by [[22: d_year, 108: P_BRAND]] having [null]
+                        SCAN (columns[107: S_REGION, 108: P_BRAND, 93: d_year, 64: LO_REVENUE] predicate[DictMapping(107: S_REGION{80: S_REGION = EUROPE}) AND DictMapping(108: P_BRAND{85: P_BRAND = MFGR#2221})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q3-1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q3-1.sql
@@ -27,8 +27,9 @@ ORDER BY
 [result]
 TOP-N (order by [[37: d_year ASC NULLS FIRST, 50: sum DESC NULLS LAST]])
     TOP-N (order by [[37: d_year ASC NULLS FIRST, 50: sum DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{50: sum=sum(50: sum)}] group by [[5: c_nation, 30: s_nation, 37: d_year]] having [null]
-            EXCHANGE SHUFFLE[5, 30, 37]
-                AGGREGATE ([LOCAL] aggregate [{50: sum=sum(21: lo_revenue)}] group by [[5: c_nation, 30: s_nation, 37: d_year]] having [null]
-                    SCAN (columns[63: LO_REVENUE, 71: C_NATION, 72: C_REGION, 78: S_NATION, 79: S_REGION, 92: d_year] predicate[92: d_year <= 1997 AND 92: d_year >= 1992 AND 72: C_REGION = ASIA AND 79: S_REGION = ASIA])
+        Decode
+            AGGREGATE ([GLOBAL] aggregate [{50: sum=sum(50: sum)}] group by [[106: C_NATION, 108: S_NATION, 37: d_year]] having [null]
+                EXCHANGE SHUFFLE[106, 108, 37]
+                    AGGREGATE ([LOCAL] aggregate [{50: sum=sum(21: lo_revenue)}] group by [[106: C_NATION, 108: S_NATION, 37: d_year]] having [null]
+                        SCAN (columns[106: C_NATION, 107: C_REGION, 92: d_year, 108: S_NATION, 109: S_REGION, 63: LO_REVENUE] predicate[92: d_year <= 1997 AND 92: d_year >= 1992 AND DictMapping(107: C_REGION{72: C_REGION = ASIA}) AND DictMapping(109: S_REGION{79: S_REGION = ASIA})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q3-2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q3-2.sql
@@ -27,8 +27,9 @@ ORDER BY
 [result]
 TOP-N (order by [[37: d_year ASC NULLS FIRST, 50: sum DESC NULLS LAST]])
     TOP-N (order by [[37: d_year ASC NULLS FIRST, 50: sum DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{50: sum=sum(50: sum)}] group by [[4: c_city, 29: s_city, 37: d_year]] having [null]
-            EXCHANGE SHUFFLE[4, 29, 37]
-                AGGREGATE ([LOCAL] aggregate [{50: sum=sum(21: lo_revenue)}] group by [[4: c_city, 29: s_city, 37: d_year]] having [null]
-                    SCAN (columns[63: LO_REVENUE, 70: C_CITY, 71: C_NATION, 77: S_CITY, 78: S_NATION, 92: d_year] predicate[92: d_year <= 1997 AND 92: d_year >= 1992 AND 71: C_NATION = UNITED STATES AND 78: S_NATION = UNITED STATES])
+        Decode
+            AGGREGATE ([GLOBAL] aggregate [{50: sum=sum(50: sum)}] group by [[106: C_CITY, 108: S_CITY, 37: d_year]] having [null]
+                EXCHANGE SHUFFLE[106, 108, 37]
+                    AGGREGATE ([LOCAL] aggregate [{50: sum=sum(21: lo_revenue)}] group by [[106: C_CITY, 108: S_CITY, 37: d_year]] having [null]
+                        SCAN (columns[106: C_CITY, 107: C_NATION, 92: d_year, 108: S_CITY, 109: S_NATION, 63: LO_REVENUE] predicate[92: d_year <= 1997 AND 92: d_year >= 1992 AND DictMapping(107: C_NATION{71: C_NATION = UNITED STATES}) AND DictMapping(109: S_NATION{78: S_NATION = UNITED STATES})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q3-3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q3-3.sql
@@ -29,8 +29,9 @@ ORDER BY
 [result]
 TOP-N (order by [[37: d_year ASC NULLS FIRST, 50: sum DESC NULLS LAST]])
     TOP-N (order by [[37: d_year ASC NULLS FIRST, 50: sum DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{50: sum=sum(50: sum)}] group by [[4: c_city, 29: s_city, 37: d_year]] having [null]
-            EXCHANGE SHUFFLE[4, 29, 37]
-                AGGREGATE ([LOCAL] aggregate [{50: sum=sum(21: lo_revenue)}] group by [[4: c_city, 29: s_city, 37: d_year]] having [null]
-                    SCAN (columns[63: LO_REVENUE, 70: C_CITY, 77: S_CITY, 92: d_year] predicate[92: d_year <= 1997 AND 92: d_year >= 1992 AND 70: C_CITY IN (UNITED KI1, UNITED KI5) AND 77: S_CITY IN (UNITED KI1, UNITED KI5)])
+        Decode
+            AGGREGATE ([GLOBAL] aggregate [{50: sum=sum(50: sum)}] group by [[106: C_CITY, 107: S_CITY, 37: d_year]] having [null]
+                EXCHANGE SHUFFLE[106, 107, 37]
+                    AGGREGATE ([LOCAL] aggregate [{50: sum=sum(21: lo_revenue)}] group by [[106: C_CITY, 107: S_CITY, 37: d_year]] having [null]
+                        SCAN (columns[106: C_CITY, 107: S_CITY, 92: d_year, 63: LO_REVENUE] predicate[92: d_year <= 1997 AND 92: d_year >= 1992 AND DictMapping(106: C_CITY{70: C_CITY IN (UNITED KI1, UNITED KI5)}) AND DictMapping(107: S_CITY{77: S_CITY IN (UNITED KI1, UNITED KI5)})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q3-4.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q3-4.sql
@@ -28,8 +28,9 @@ ORDER BY
 [result]
 TOP-N (order by [[37: d_year ASC NULLS FIRST, 50: sum DESC NULLS LAST]])
     TOP-N (order by [[37: d_year ASC NULLS FIRST, 50: sum DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{50: sum=sum(50: sum)}] group by [[4: c_city, 29: s_city, 37: d_year]] having [null]
-            EXCHANGE SHUFFLE[4, 29, 37]
-                AGGREGATE ([LOCAL] aggregate [{50: sum=sum(21: lo_revenue)}] group by [[4: c_city, 29: s_city, 37: d_year]] having [null]
-                    SCAN (columns[63: LO_REVENUE, 70: C_CITY, 77: S_CITY, 92: d_year, 94: d_yearmonth] predicate[94: d_yearmonth = Dec1997 AND 70: C_CITY IN (UNITED KI1, UNITED KI5) AND 77: S_CITY IN (UNITED KI1, UNITED KI5)])
+        Decode
+            AGGREGATE ([GLOBAL] aggregate [{50: sum=sum(50: sum)}] group by [[106: C_CITY, 107: S_CITY, 37: d_year]] having [null]
+                EXCHANGE SHUFFLE[106, 107, 37]
+                    AGGREGATE ([LOCAL] aggregate [{50: sum=sum(21: lo_revenue)}] group by [[106: C_CITY, 107: S_CITY, 37: d_year]] having [null]
+                        SCAN (columns[106: C_CITY, 107: S_CITY, 92: d_year, 108: d_yearmonth, 63: LO_REVENUE] predicate[DictMapping(108: d_yearmonth{94: d_yearmonth = Dec1997}) AND DictMapping(106: C_CITY{70: C_CITY IN (UNITED KI1, UNITED KI5)}) AND DictMapping(107: S_CITY{77: S_CITY IN (UNITED KI1, UNITED KI5)})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q4-1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q4-1.sql
@@ -25,10 +25,11 @@ ORDER BY
   d_year,
   c_nation;
 [result]
-TOP-N (order by [[5: d_year ASC NULLS FIRST, 22: c_nation ASC NULLS FIRST]])
-    TOP-N (order by [[5: d_year ASC NULLS FIRST, 22: c_nation ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{60: sum=sum(60: sum)}] group by [[5: d_year, 22: c_nation]] having [null]
-            EXCHANGE SHUFFLE[5, 22]
-                AGGREGATE ([LOCAL] aggregate [{60: sum=sum(59: expr)}] group by [[5: d_year, 22: c_nation]] having [null]
-                    SCAN (columns[73: LO_REVENUE, 74: LO_SUPPLYCOST, 81: C_NATION, 82: C_REGION, 89: S_REGION, 92: P_MFGR, 102: d_year] predicate[82: C_REGION = AMERICA AND 89: S_REGION = AMERICA AND 92: P_MFGR IN (MFGR#1, MFGR#2)])
+Decode
+    TOP-N (order by [[5: d_year ASC NULLS FIRST, 115: C_NATION ASC NULLS FIRST]])
+        TOP-N (order by [[5: d_year ASC NULLS FIRST, 115: C_NATION ASC NULLS FIRST]])
+            AGGREGATE ([GLOBAL] aggregate [{60: sum=sum(60: sum)}] group by [[5: d_year, 115: C_NATION]] having [null]
+                EXCHANGE SHUFFLE[5, 115]
+                    AGGREGATE ([LOCAL] aggregate [{60: sum=sum(59: expr)}] group by [[5: d_year, 115: C_NATION]] having [null]
+                        SCAN (columns[115: C_NATION, 116: C_REGION, 117: S_REGION, 102: d_year, 118: P_MFGR, 73: LO_REVENUE, 74: LO_SUPPLYCOST] predicate[DictMapping(116: C_REGION{82: C_REGION = AMERICA}) AND DictMapping(117: S_REGION{89: S_REGION = AMERICA}) AND DictMapping(118: P_MFGR{92: P_MFGR IN (MFGR#1, MFGR#2)})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q4-2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q4-2.sql
@@ -30,10 +30,11 @@ ORDER BY
   s_nation,
   p_category;
 [result]
-TOP-N (order by [[5: d_year ASC NULLS FIRST, 30: s_nation ASC NULLS FIRST, 36: p_category ASC NULLS FIRST]])
-    TOP-N (order by [[5: d_year ASC NULLS FIRST, 30: s_nation ASC NULLS FIRST, 36: p_category ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{60: sum=sum(60: sum)}] group by [[5: d_year, 30: s_nation, 36: p_category]] having [null]
-            EXCHANGE SHUFFLE[5, 30, 36]
-                AGGREGATE ([LOCAL] aggregate [{60: sum=sum(59: expr)}] group by [[5: d_year, 30: s_nation, 36: p_category]] having [null]
-                    SCAN (columns[73: LO_REVENUE, 74: LO_SUPPLYCOST, 82: C_REGION, 88: S_NATION, 89: S_REGION, 92: P_MFGR, 93: P_CATEGORY, 102: d_year] predicate[82: C_REGION = AMERICA AND 89: S_REGION = AMERICA AND 102: d_year IN (1997, 1998) AND 92: P_MFGR IN (MFGR#1, MFGR#2)])
+Decode
+    TOP-N (order by [[5: d_year ASC NULLS FIRST, 116: S_NATION ASC NULLS FIRST, 119: P_CATEGORY ASC NULLS FIRST]])
+        TOP-N (order by [[5: d_year ASC NULLS FIRST, 116: S_NATION ASC NULLS FIRST, 119: P_CATEGORY ASC NULLS FIRST]])
+            AGGREGATE ([GLOBAL] aggregate [{60: sum=sum(60: sum)}] group by [[5: d_year, 116: S_NATION, 119: P_CATEGORY]] having [null]
+                EXCHANGE SHUFFLE[5, 116, 119]
+                    AGGREGATE ([LOCAL] aggregate [{60: sum=sum(59: expr)}] group by [[5: d_year, 116: S_NATION, 119: P_CATEGORY]] having [null]
+                        SCAN (columns[115: C_REGION, 116: S_NATION, 117: S_REGION, 102: d_year, 118: P_MFGR, 119: P_CATEGORY, 73: LO_REVENUE, 74: LO_SUPPLYCOST] predicate[DictMapping(115: C_REGION{82: C_REGION = AMERICA}) AND DictMapping(117: S_REGION{89: S_REGION = AMERICA}) AND 102: d_year IN (1997, 1998) AND DictMapping(118: P_MFGR{92: P_MFGR IN (MFGR#1, MFGR#2)})])
 [end]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q4-3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/ssb/q4-3.sql
@@ -29,10 +29,11 @@ ORDER BY
   s_city,
   p_brand;
 [result]
-TOP-N (order by [[5: d_year ASC NULLS FIRST, 29: s_city ASC NULLS FIRST, 37: p_brand ASC NULLS FIRST]])
-    TOP-N (order by [[5: d_year ASC NULLS FIRST, 29: s_city ASC NULLS FIRST, 37: p_brand ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{60: sum=sum(60: sum)}] group by [[5: d_year, 29: s_city, 37: p_brand]] having [null]
-            EXCHANGE SHUFFLE[5, 29, 37]
-                AGGREGATE ([LOCAL] aggregate [{60: sum=sum(59: expr)}] group by [[5: d_year, 29: s_city, 37: p_brand]] having [null]
-                    SCAN (columns[73: LO_REVENUE, 74: LO_SUPPLYCOST, 82: C_REGION, 87: S_CITY, 88: S_NATION, 93: P_CATEGORY, 94: P_BRAND, 102: d_year] predicate[93: P_CATEGORY = MFGR#14 AND 82: C_REGION = AMERICA AND 88: S_NATION = UNITED STATES AND 102: d_year IN (1997, 1998)])
+Decode
+    TOP-N (order by [[5: d_year ASC NULLS FIRST, 116: S_CITY ASC NULLS FIRST, 119: P_BRAND ASC NULLS FIRST]])
+        TOP-N (order by [[5: d_year ASC NULLS FIRST, 116: S_CITY ASC NULLS FIRST, 119: P_BRAND ASC NULLS FIRST]])
+            AGGREGATE ([GLOBAL] aggregate [{60: sum=sum(60: sum)}] group by [[5: d_year, 116: S_CITY, 119: P_BRAND]] having [null]
+                EXCHANGE SHUFFLE[5, 116, 119]
+                    AGGREGATE ([LOCAL] aggregate [{60: sum=sum(59: expr)}] group by [[5: d_year, 116: S_CITY, 119: P_BRAND]] having [null]
+                        SCAN (columns[115: C_REGION, 116: S_CITY, 117: S_NATION, 102: d_year, 118: P_CATEGORY, 119: P_BRAND, 73: LO_REVENUE, 74: LO_SUPPLYCOST] predicate[DictMapping(118: P_CATEGORY{93: P_CATEGORY = MFGR#14}) AND DictMapping(115: C_REGION{82: C_REGION = AMERICA}) AND DictMapping(117: S_NATION{88: S_NATION = UNITED STATES}) AND 102: d_year IN (1997, 1998)])
 [end]


### PR DESCRIPTION
* fix low cardinality dict on mv rewrite

fix low cardinality dict encode optimization bug for mv rewrite. The reason is that taskContext.getAllScanOperators() info is wrong after mv rewrite. we should collect the new OlapScanOperators in AddDecodeNodeForDictStringRule.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19324 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
fix low cardinality dict on mv rewrite
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
