### PR TITLE
[Enhancement] Improve the tablet scheduler logic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -314,10 +314,10 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             throws SchedException {
         TabletScheduler.PathSlot srcBePathSlot = backendsWorkingSlots.get(beId);
         if (srcBePathSlot == null) {
-            throw new SchedException(SchedException.Status.UNRECOVERABLE, "working slots not exist for src be");
+            throw new SchedException(SchedException.Status.UNRECOVERABLE, "working slots not exist for be: " + beId);
         }
         if (srcBePathSlot.takeSlot(pathHash) == -1) {
-            throw new SchedException(SchedException.Status.SCHEDULE_FAILED, "path busy, wait for next round");
+            throw new SchedException(SchedException.Status.SCHEDULE_RETRY, "path busy, wait for next round");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/SchedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/SchedException.java
@@ -38,8 +38,7 @@ public class SchedException extends Exception {
     private static final long serialVersionUID = 4233856721704062083L;
 
     public enum Status {
-        SCHEDULE_FAILED, // failed to schedule the tablet, this should only happen in scheduling pending tablets.
-        RUNNING_FAILED, // failed to running the clone task, this should only happen in handling running tablets.
+        SCHEDULE_RETRY, // there are some resource unavailable or wait for something to happen, retry for the next schedule round
         UNRECOVERABLE, // unable to go on, the tablet should be removed from tablet scheduler.
         FINISHED // schedule is done, remove the tablet from tablet scheduler with status FINISHED
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -596,7 +596,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             }
         }
 
-        throw new SchedException(Status.SCHEDULE_FAILED, "unable to find source slot");
+        throw new SchedException(Status.SCHEDULE_RETRY, "path busy, wait for next round");
     }
 
     /*
@@ -608,7 +608,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             throws SchedException {
         chooseSrcReplica(backendsWorkingSlots);
         if (srcReplica.getBackendId() == destBackendId) {
-            throw new SchedException(Status.SCHEDULE_FAILED, "the chosen source replica is in dest backend");
+            throw new SchedException(Status.UNRECOVERABLE, "the chosen source replica is in dest backend");
         }
     }
 
@@ -658,18 +658,19 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         }
 
         if (chosenReplica == null) {
-            throw new SchedException(Status.SCHEDULE_FAILED, "unable to choose dest replica");
+            throw new SchedException(Status.UNRECOVERABLE, "unable to choose dest replica");
         }
 
         // check if the dest replica has available slot
         PathSlot slot = backendsWorkingSlots.get(chosenReplica.getBackendId());
         if (slot == null) {
-            throw new SchedException(Status.SCHEDULE_FAILED, "backend of dest replica is missing");
+            throw new SchedException(Status.UNRECOVERABLE, "working slots not exist for be: "
+                    + chosenReplica.getBackendId());
         }
 
         long destPathHash = slot.takeSlot(chosenReplica.getPathHash());
         if (destPathHash == -1) {
-            throw new SchedException(Status.SCHEDULE_FAILED, "unable to take slot of dest path");
+            throw new SchedException(Status.SCHEDULE_RETRY, "path busy, wait for next round");
         }
 
         setDest(chosenReplica.getBackendId(), chosenReplica.getPathHash());
@@ -772,13 +773,13 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     public CloneTask createCloneReplicaAndTask() throws SchedException {
         Backend srcBe = infoService.getBackend(srcReplica.getBackendId());
         if (srcBe == null) {
-            throw new SchedException(Status.SCHEDULE_FAILED,
+            throw new SchedException(Status.UNRECOVERABLE,
                     "src backend " + srcReplica.getBackendId() + " does not exist");
         }
 
         Backend destBe = infoService.getBackend(destBackendId);
         if (destBe == null) {
-            throw new SchedException(Status.SCHEDULE_FAILED,
+            throw new SchedException(Status.UNRECOVERABLE,
                     "dest backend " + destBackendId + " does not exist");
         }
 
@@ -821,16 +822,16 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             // double check
             Replica replica = tablet.getReplicaByBackendId(destBackendId);
             if (replica == null) {
-                throw new SchedException(Status.SCHEDULE_FAILED, "dest replica does not exist on BE " + destBackendId);
+                throw new SchedException(Status.UNRECOVERABLE, "dest replica does not exist on BE " + destBackendId);
             }
 
             if (replica.getPathHash() != destPathHash) {
-                throw new SchedException(Status.SCHEDULE_FAILED, "dest replica's path hash is changed. "
+                throw new SchedException(Status.UNRECOVERABLE, "dest replica's path hash is changed. "
                         + "current: " + replica.getPathHash() + ", scheduled: " + destPathHash);
             }
         } else if (type == Type.BALANCE && cloneTask.isLocal()) {
             if (tabletStatus != TabletStatus.HEALTHY) {
-                throw new SchedException(Status.SCHEDULE_FAILED, "tablet " + tabletId + " is not healthy");
+                throw new SchedException(Status.SCHEDULE_RETRY, "tablet " + tabletId + " is not healthy");
             }
         }
 
@@ -899,12 +900,12 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
         // check if clone task success
         if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
-            throw new SchedException(Status.RUNNING_FAILED, request.getTask_status().getError_msgs().get(0));
+            throw new SchedException(Status.UNRECOVERABLE, request.getTask_status().getError_msgs().get(0));
         }
 
         // check tablet info is set
         if (!request.isSetFinish_tablet_infos() || request.getFinish_tablet_infos().isEmpty()) {
-            throw new SchedException(Status.RUNNING_FAILED, "tablet info is not set in task report request");
+            throw new SchedException(Status.UNRECOVERABLE, "tablet info is not set in task report request");
         }
 
         // check task report
@@ -917,7 +918,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     cloneTask.getDbId(), cloneTask.getTableId(), cloneTask.getPartitionId(),
                     cloneTask.getIndexId(), cloneTask.getTabletId(), cloneTask.getBackendId(),
                     dbId, tblId, partitionId, indexId, tablet.getId(), destBackendId);
-            throw new SchedException(Status.RUNNING_FAILED, msg);
+            throw new SchedException(Status.UNRECOVERABLE, msg);
         }
 
         // 1. check the tablet status first
@@ -1024,7 +1025,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             String msg = String.format("the clone replica's version is stale. %d, task visible version: %d",
                     reportedTablet.getVersion(),
                     visibleVersion);
-            throw new SchedException(Status.RUNNING_FAILED, msg);
+            throw new SchedException(Status.UNRECOVERABLE, msg);
         }
 
         // check if replica exist

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -490,7 +490,7 @@ public class TabletScheduler extends LeaderDaemon {
                 tabletCtx.increaseFailedSchedCounter();
                 tabletCtx.setErrMsg(e.getMessage());
 
-                if (e.getStatus() == Status.SCHEDULE_FAILED) {
+                if (e.getStatus() == Status.SCHEDULE_RETRY) {
                     LOG.debug("scheduling for tablet[{}] failed, type: {}, reason: {}",
                             tabletCtx.getTabletId(), tabletCtx.getType().name(), e.getMessage());
                     if (tabletCtx.getType() == Type.BALANCE) {
@@ -874,7 +874,7 @@ public class TabletScheduler extends LeaderDaemon {
                     tabletCtx.getTabletId(), tabletCtx.getTablet().getReplicaInfos(),
                     tabletCtx.getSrcReplica().getBackendId(), tabletCtx.getDestBackendId());
         } catch (SchedException e) {
-            if (e.getStatus() == Status.SCHEDULE_FAILED) {
+            if (e.getStatus() == Status.SCHEDULE_RETRY) {
                 LOG.debug("failed to find version incomplete replica from tablet relocating. " +
                                 "reason: [{}], tablet: [{}], replicas: {} dest:{} try to find a new backend", e.getMessage(),
                         tabletCtx.getTabletId(), tabletCtx.getTablet().getReplicaInfos(),
@@ -925,7 +925,7 @@ public class TabletScheduler extends LeaderDaemon {
             // to remove this tablet from the pendingTablets(consider it as finished)
             throw new SchedException(Status.FINISHED, "redundant replica is deleted");
         }
-        throw new SchedException(Status.SCHEDULE_FAILED, "unable to delete any redundant replicas");
+        throw new SchedException(Status.UNRECOVERABLE, "unable to delete any redundant replicas");
     }
 
     private boolean deleteBackendDropped(TabletSchedCtx tabletCtx, boolean force) throws SchedException {
@@ -1125,7 +1125,7 @@ public class TabletScheduler extends LeaderDaemon {
             deleteReplicaInternal(tabletCtx, replica, "colocate redundant", forceDropBad);
             throw new SchedException(Status.FINISHED, "colocate redundant replica is deleted");
         }
-        throw new SchedException(Status.SCHEDULE_FAILED, "unable to delete any colocate redundant replicas");
+        throw new SchedException(Status.UNRECOVERABLE, "unable to delete any colocate redundant replicas");
     }
 
     private void deleteReplicaInternal(TabletSchedCtx tabletCtx, Replica replica, String reason, boolean force)
@@ -1151,13 +1151,13 @@ public class TabletScheduler extends LeaderDaemon {
             LOG.info("decommission tablet:" + tabletCtx.getTabletId() + " type:" + tabletCtx.getType() + " replica:" +
                     replica.getBackendId() + " reason:" + reason + " watermark:" + nextTxnId + " replicas:" +
                     tabletCtx.getTablet().getReplicaInfos());
-            throw new SchedException(Status.SCHEDULE_FAILED, "set watermark txn " + nextTxnId);
+            throw new SchedException(Status.SCHEDULE_RETRY, "set watermark txn " + nextTxnId);
         } else if (replica.getState() == ReplicaState.DECOMMISSION && replica.getWatermarkTxnId() != -1) {
             long watermarkTxnId = replica.getWatermarkTxnId();
             try {
                 if (!GlobalStateMgr.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(watermarkTxnId,
                         tabletCtx.getDbId(), Lists.newArrayList(tabletCtx.getTblId()))) {
-                    throw new SchedException(Status.SCHEDULE_FAILED,
+                    throw new SchedException(Status.SCHEDULE_RETRY,
                             "wait txn before " + watermarkTxnId + " to be finished");
                 }
             } catch (AnalysisException e) {
@@ -1351,7 +1351,7 @@ public class TabletScheduler extends LeaderDaemon {
         }
 
         if (allFitPaths.isEmpty()) {
-            throw new SchedException(Status.SCHEDULE_FAILED, "unable to find dest path for new replica");
+            throw new SchedException(Status.UNRECOVERABLE, "unable to find dest path for new replica");
         }
 
         // all fit paths has already been sorted by load score in 'allFitPaths' in ascend order.
@@ -1361,7 +1361,7 @@ public class TabletScheduler extends LeaderDaemon {
         if (path != null) {
             return path;
         } else {
-            throw new SchedException(Status.SCHEDULE_FAILED, "unable to find dest path which can be fit in");
+            throw new SchedException(Status.SCHEDULE_RETRY, "path busy, wait for next round");
         }
     }
 
@@ -1453,11 +1453,7 @@ public class TabletScheduler extends LeaderDaemon {
         } catch (SchedException e) {
             tabletCtx.increaseFailedRunningCounter();
             tabletCtx.setErrMsg(e.getMessage());
-            if (e.getStatus() == Status.RUNNING_FAILED) {
-                stat.counterCloneTaskFailed.incrementAndGet();
-                addToRunningTablets(tabletCtx);
-                return false;
-            } else if (e.getStatus() == Status.UNRECOVERABLE) {
+            if (e.getStatus() == Status.UNRECOVERABLE) {
                 // unrecoverable
                 stat.counterTabletScheduledDiscard.incrementAndGet();
                 finalizeTabletCtx(tabletCtx, TabletSchedCtx.State.CANCELLED, e.getMessage());
@@ -1663,7 +1659,7 @@ public class TabletScheduler extends LeaderDaemon {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("path hash is not set.", new Exception());
                 }
-                throw new SchedException(Status.SCHEDULE_FAILED, "path hash is not set");
+                throw new SchedException(Status.UNRECOVERABLE, "path hash is not set");
             }
 
             Slot slot = pathSlots.get(pathHash);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
There are 4 schedule state `SCHEDULE_FAILED, RUNNING_FAILED, UNRECOVERABLE, FINISHED` in the tablet scheduler. For the state: SCHEDULE_FAILED and RUNNING_FAILED, the scheduler will retry schedule that tablet(10 times for balance, endless for repair), but at most cases, retry will fail again, for example: there is no healthy replica or the data on backend is disrupted. 

1. Change the schedule state to UNRECOVERABLE in some cases. 
2. Merge `SCHEDULE_FAILED` and `RUNNING_FAILED` to `SCHEDULE_RETRY`.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
