### PR TITLE
[BugFix] Fix persistent index too large when using a string column in the key definition

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2396,19 +2396,21 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta, bool relo
         _l1_merged_num.emplace_back(-1);
         _has_l1 = true;
     }
-    // if reload, don't update _usage_and_size_by_key_size 
+    // if reload, don't update _usage_and_size_by_key_size
     if (!reload) {
         _usage_and_size_by_key_size.clear();
         for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
             size_t total_size = 0;
             size_t total_usage = 0;
             auto [l0_shard_offset, l0_shard_size] = shard_info;
-            const auto l0_kv_pairs_size = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
-                                                          std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
-                                                          0UL, [](size_t s, const auto& e) { return s + e->size(); });
-            const auto l0_kv_pairs_usage = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
-                                                           std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
-                                                           0UL, [](size_t s, const auto& e) { return s + e->usage(); });
+            const auto l0_kv_pairs_size =
+                    std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                    std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size), 0UL,
+                                    [](size_t s, const auto& e) { return s + e->size(); });
+            const auto l0_kv_pairs_usage =
+                    std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                    std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size), 0UL,
+                                    [](size_t s, const auto& e) { return s + e->usage(); });
             total_size += l0_kv_pairs_size;
             total_usage += l0_kv_pairs_usage;
             if (_has_l1) {
@@ -2417,12 +2419,12 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta, bool relo
                     auto [l1_shard_offset, l1_shard_size] = iter->second;
                     const auto l1_kv_pairs_size =
                             std::accumulate(std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset),
-                                            std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size), 0UL,
-                                            [](size_t s, const auto& e) { return s + e.size; });
+                                            std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size),
+                                            0UL, [](size_t s, const auto& e) { return s + e.size; });
                     const auto l1_kv_pairs_usage =
                             std::accumulate(std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset),
-                                            std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size), 0UL,
-                                            [](size_t s, const auto& e) { return s + e.data_size; });
+                                            std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size),
+                                            0UL, [](size_t s, const auto& e) { return s + e.data_size; });
                     total_size += l1_kv_pairs_size;
                     total_usage += l1_kv_pairs_usage;
                 }

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -57,6 +57,7 @@ constexpr size_t kL0SnapshotSizeMax = 1 * 1024 * 1024;
 constexpr size_t kL0SnapshotSizeMax = 16 * 1024 * 1024;
 #endif
 constexpr size_t kLongKeySize = 64;
+constexpr size_t kMaxKeyLength = 128; // we only support key length is less than or equal to 128 bytes for now
 
 const char* const kIndexFileMagic = "IDX1";
 
@@ -353,6 +354,14 @@ StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::try_create(s
     for (auto& [kv_ptrs, tags] : bucket_kv_ptrs_tags) {
         kv_ptrs.reserve(estimated_entry_per_bucket);
         tags.reserve(estimated_entry_per_bucket);
+    }
+    if (!kv_refs.empty()) {
+        // This scenario should not happen in theory, since the usage and size stats by key size is not exactly
+        // accurate, so we add this code as a defense
+        if (npage == 0) {
+            LOG(ERROR) << "find a empty shard with kvs, key size: " << key_size << ", kv_num: " << kv_refs.size();
+            npage = 1;
+        }
     }
     for (const auto& kv_ref : kv_refs) {
         auto h = IndexHash(kv_ref.hash);
@@ -815,6 +824,8 @@ public:
 
     size_t size() const override { return _map.size(); }
 
+    size_t usage() const override { return (KeySize + kIndexValueSize) * _map.size(); }
+
     size_t capacity() override { return _map.capacity(); }
 
     void reserve(size_t size) override { _map.reserve(size); }
@@ -1209,6 +1220,8 @@ public:
     }
 
     size_t size() const override { return _set.size(); }
+
+    size_t usage() const override { return _total_kv_pairs_usage; }
 
     size_t capacity() override { return _set.capacity(); }
 
@@ -2382,6 +2395,41 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta) {
         _l1_merged_num.emplace_back(-1);
         _has_l1 = true;
     }
+    for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
+        size_t total_size = 0;
+        size_t total_usage = 0;
+        auto [l0_shard_offset, l0_shard_size] = shard_info;
+        const auto l0_kv_pairs_size = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                                      std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
+                                                      0UL, [](size_t s, const auto& e) { return s + e->size(); });
+        const auto l0_kv_pairs_usage = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                                       std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
+                                                       0UL, [](size_t s, const auto& e) { return s + e->usage(); });
+        total_size += l0_kv_pairs_size;
+        total_usage += l0_kv_pairs_usage;
+        if (_has_l1) {
+            auto iter = _l1_vec[0]->_shard_info_by_length.find(key_size);
+            if (iter != _l1_vec[0]->_shard_info_by_length.end()) {
+                auto [l1_shard_offset, l1_shard_size] = iter->second;
+                const auto l1_kv_pairs_size =
+                        std::accumulate(std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset),
+                                        std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size), 0UL,
+                                        [](size_t s, const auto& e) { return s + e.size; });
+                const auto l1_kv_pairs_usage =
+                        std::accumulate(std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset),
+                                        std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size), 0UL,
+                                        [](size_t s, const auto& e) { return s + e.data_size; });
+                total_size += l1_kv_pairs_size;
+                total_usage += l1_kv_pairs_usage;
+            }
+        }
+        if (auto [it, inserted] = _usage_and_size_by_key_size.insert({key_size, {total_usage, total_size}});
+            !inserted) {
+            LOG(WARNING) << "insert usage and size by key size failed, key_size: " << key_size;
+            return Status::InternalError("insert usage and size by key size falied");
+        }
+    }
+
     return Status::OK();
 }
 
@@ -2574,6 +2622,29 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
     // set _dump_snapshot to true
     // In this case, only do flush or dump snapshot, set _dump_snapshot to avoid append wal
     _dump_snapshot = true;
+
+    // clear l1
+    _l1_vec.clear();
+    _usage_and_size_by_key_size.clear();
+    _l1_merged_num.clear();
+    _has_l1 = false;
+    for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
+        auto [l0_shard_offset, l0_shard_size] = shard_info;
+        const auto l0_kv_pairs_size = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                                      std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
+                                                      0LL, [](size_t s, const auto& e) { return s + e->size(); });
+        const auto l0_kv_pairs_usage = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                                       std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
+                                                       0LL, [](size_t s, const auto& e) { return s + e->usage(); });
+        if (auto [_, inserted] = _usage_and_size_by_key_size.insert({key_size, {l0_kv_pairs_usage, l0_kv_pairs_size}});
+            !inserted) {
+            std::string msg = strings::Substitute(
+                    "load persistent index from tablet failed, insert usage and size by key size failed, key_size: $0",
+                    key_size);
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
+    }
 
     // Init PersistentIndexMetaPB
     //   1. reset |version| |key_size|
@@ -2776,18 +2847,68 @@ Status PersistentIndex::_flush_advance_or_append_wal(size_t n, const Slice* keys
     return Status::OK();
 }
 
+Status PersistentIndex::_update_usage_and_size_by_key_length(
+        std::vector<std::pair<int64_t, int64_t>>& add_usage_and_size) {
+    if (_key_size > 0) {
+        auto iter = _usage_and_size_by_key_size.find(_key_size);
+        DCHECK(iter != _usage_and_size_by_key_size.end());
+        if (iter == _usage_and_size_by_key_size.end()) {
+            std::string msg = strings::Substitute("no key_size: $0 usage info", _key_size);
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        } else {
+            iter->second.first = std::max(0L, iter->second.first + add_usage_and_size[_key_size].first);
+            iter->second.second = std::max(0L, iter->second.second + add_usage_and_size[_key_size].second);
+        }
+    } else {
+        for (int key_size = 1; key_size <= kSliceMaxFixLength; key_size++) {
+            if (add_usage_and_size[key_size].second > 0) {
+                auto iter = _usage_and_size_by_key_size.find(key_size);
+                if (iter == _usage_and_size_by_key_size.end()) {
+                    std::string msg = strings::Substitute("no key_size: $0 usage info", key_size);
+                    LOG(WARNING) << msg;
+                    return Status::InternalError(msg);
+                } else {
+                    iter->second.first = std::max(0L, iter->second.first + add_usage_and_size[key_size].first);
+                    iter->second.second = std::max(0L, iter->second.second + add_usage_and_size[key_size].second);
+                }
+            }
+        }
+
+        int64_t slice_usage = 0;
+        int64_t slice_size = 0;
+        for (int key_size = kSliceMaxFixLength + 1; key_size <= kMaxKeyLength; key_size++) {
+            slice_usage += add_usage_and_size[key_size].first;
+            slice_size += add_usage_and_size[key_size].second;
+        }
+        DCHECK(_key_size == 0);
+        auto iter = _usage_and_size_by_key_size.find(_key_size);
+        if (iter == _usage_and_size_by_key_size.end()) {
+            std::string msg = strings::Substitute("no key_size: $0 usage info", _key_size);
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
+        iter->second.first = std::max(0L, iter->second.first + slice_usage);
+        iter->second.second = std::max(0L, iter->second.second + slice_size);
+    }
+    return Status::OK();
+}
+
 Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values) {
     std::map<size_t, KeysInfo> not_founds_by_key_size;
     size_t num_found = 0;
     RETURN_IF_ERROR(_l0->upsert(n, keys, values, old_values, &num_found, not_founds_by_key_size));
     RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() == NullIndexValue) {
             _size++;
             _usage += keys[i].size + kIndexValueSize;
+            add_usage_and_size[keys[i].size].first += keys[i].size + kIndexValueSize;
+            add_usage_and_size[keys[i].size].second++;
         }
     }
-
+    RETURN_IF_ERROR(_update_usage_and_size_by_key_length(add_usage_and_size));
     return _flush_advance_or_append_wal(n, keys, values);
 }
 
@@ -2807,10 +2928,14 @@ Status PersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* va
             RETURN_IF_ERROR(_l1_vec[0]->check_not_exist(n, keys, check_l1_key_size));
         }
     }
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
     _size += n;
     for (size_t i = 0; i < n; i++) {
         _usage += keys[i].size + kIndexValueSize;
+        add_usage_and_size[keys[i].size].first += keys[i].size + kIndexValueSize;
+        add_usage_and_size[keys[i].size].second++;
     }
+    RETURN_IF_ERROR(_update_usage_and_size_by_key_length(add_usage_and_size));
 
     return _flush_advance_or_append_wal(n, keys, values);
 }
@@ -2821,12 +2946,16 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
     RETURN_IF_ERROR(_l0->erase(n, keys, old_values, &num_erased, not_founds_by_key_size));
     _dump_snapshot |= _can_dump_directly();
     RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() != NullIndexValue) {
             _size--;
             _usage -= keys[i].size + kIndexValueSize;
+            add_usage_and_size[keys[i].size].first -= keys[i].size + kIndexValueSize;
+            add_usage_and_size[keys[i].size].second--;
         }
     }
+    RETURN_IF_ERROR(_update_usage_and_size_by_key_length(add_usage_and_size));
 
     return _flush_advance_or_append_wal(n, keys, nullptr);
 }
@@ -3262,8 +3391,16 @@ static Status merge_shard_kvs_with_delete(size_t key_size, std::vector<KVRef>& l
 }
 
 Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer, int l1_start_idx, int l1_end_idx,
-                                                   size_t total_usage, size_t total_size, bool keep_delete) {
+                                                   std::map<uint32_t, std::pair<int64_t, int64_t>>& usage_and_size_stat,
+                                                   bool keep_delete) {
     for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
+        size_t total_usage = 0;
+        size_t total_size = 0;
+        auto iter = usage_and_size_stat.find(key_size);
+        if (iter != usage_and_size_stat.end()) {
+            total_usage = iter->second.first;
+            total_size = iter->second.second;
+        }
         auto [l0_shard_offset, l0_shard_size] = shard_info;
         const auto [nshard, npage_hint] = MutableIndex::estimate_nshard_and_npage(total_usage);
         const auto nbucket = MutableIndex::estimate_nbucket(key_size, total_usage, nshard, npage_hint);
@@ -3372,7 +3509,7 @@ Status PersistentIndex::_merge_compaction() {
     const std::string idx_file_path =
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
     RETURN_IF_ERROR(writer->init(idx_file_path, _version, true));
-    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage, _size, false));
+    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage_and_size_by_key_size, false));
     // _usage should be equal to total_kv_size. But they may be differen because of compatibility problem when we upgrade
     // from old version and _usage maybe not accurate.
     // so we use total_kv_size to correct the _usage.
@@ -3392,14 +3529,48 @@ Status PersistentIndex::_merge_compaction_advance() {
     int merge_l1_end_idx = _l1_vec.size();
     LOG(INFO) << "merge compaction advance, start_idx: " << merge_l1_start_idx << " end_idx: " << merge_l1_end_idx;
     bool keep_delete = (merge_l1_start_idx != 0);
+    /*
     size_t total_usage = _l0->memory_usage();
     size_t total_size = _l0->size();
     for (int i = merge_l1_start_idx; i < merge_l1_end_idx; i++) {
         total_usage += _l1_vec[i]->total_usage();
         total_size += _l1_vec[i]->total_size();
     }
-    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx, total_usage,
-                                               total_size, keep_delete));
+    */
+
+    std::map<uint32_t, std::pair<int64_t, int64_t>> usage_and_size_stat;
+    for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
+        auto [l0_shard_offset, l0_shard_size] = shard_info;
+        const auto l0_kv_pairs_size = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                                      std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
+                                                      0L, [](size_t s, const auto& e) { return s + e->size(); });
+        const auto l0_kv_pairs_usage = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                                       std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
+                                                       0L, [](size_t s, const auto& e) { return s + e->usage(); });
+        usage_and_size_stat.insert({key_size, {l0_kv_pairs_usage, l0_kv_pairs_size}});
+    }
+    for (int i = merge_l1_start_idx; i < merge_l1_end_idx; i++) {
+        for (const auto& [key_size, shard_info] : _l1_vec[i]->_shard_info_by_length) {
+            auto [l1_shard_offset, l1_shard_size] = shard_info;
+            const auto size = std::accumulate(std::next(_l1_vec[i]->_shards.begin(), l1_shard_offset),
+                                              std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size),
+                                              0L, [](size_t s, const auto& e) { return s + e.size; });
+            const auto usage = std::accumulate(std::next(_l1_vec[i]->_shards.begin(), l1_shard_offset),
+                                               std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size),
+                                               0L, [](size_t s, const auto& e) { return s + e.data_size; });
+
+            auto iter = usage_and_size_stat.find(key_size);
+            if (iter == usage_and_size_stat.end()) {
+                usage_and_size_stat.insert({key_size, {usage, size}});
+            } else {
+                iter->second.first += usage;
+                iter->second.second += size;
+            }
+        }
+    }
+
+    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx, usage_and_size_stat,
+                                               keep_delete));
     RETURN_IF_ERROR(writer->finish());
     std::vector<std::unique_ptr<ImmutableIndex>> new_l1_vec;
     std::vector<int> new_l1_merged_num;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2643,7 +2643,8 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
         const auto l0_kv_pairs_usage = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
                                                        std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
                                                        0LL, [](size_t s, const auto& e) { return s + e->usage(); });
-        if (auto [_, inserted] = _usage_and_size_by_key_length.insert({key_size, {l0_kv_pairs_usage, l0_kv_pairs_size}});
+        if (auto [_, inserted] =
+                    _usage_and_size_by_key_length.insert({key_size, {l0_kv_pairs_usage, l0_kv_pairs_size}});
             !inserted) {
             std::string msg = strings::Substitute(
                     "load persistent index from tablet failed, insert usage and size by key size failed, key_size: $0",

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2396,9 +2396,9 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta, bool relo
         _l1_merged_num.emplace_back(-1);
         _has_l1 = true;
     }
-    // if reload, don't update _usage_and_size_by_key_size
+    // if reload, don't update _usage_and_size_by_key_length
     if (!reload) {
-        _usage_and_size_by_key_size.clear();
+        _usage_and_size_by_key_length.clear();
         for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
             size_t total_size = 0;
             size_t total_usage = 0;
@@ -2429,7 +2429,7 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta, bool relo
                     total_usage += l1_kv_pairs_usage;
                 }
             }
-            if (auto [it, inserted] = _usage_and_size_by_key_size.insert({key_size, {total_usage, total_size}});
+            if (auto [it, inserted] = _usage_and_size_by_key_length.insert({key_size, {total_usage, total_size}});
                 !inserted) {
                 LOG(WARNING) << "insert usage and size by key size failed, key_size: " << key_size;
                 return Status::InternalError("insert usage and size by key size falied");
@@ -2632,7 +2632,7 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
 
     // clear l1
     _l1_vec.clear();
-    _usage_and_size_by_key_size.clear();
+    _usage_and_size_by_key_length.clear();
     _l1_merged_num.clear();
     _has_l1 = false;
     for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
@@ -2643,7 +2643,7 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
         const auto l0_kv_pairs_usage = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
                                                        std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
                                                        0LL, [](size_t s, const auto& e) { return s + e->usage(); });
-        if (auto [_, inserted] = _usage_and_size_by_key_size.insert({key_size, {l0_kv_pairs_usage, l0_kv_pairs_size}});
+        if (auto [_, inserted] = _usage_and_size_by_key_length.insert({key_size, {l0_kv_pairs_usage, l0_kv_pairs_size}});
             !inserted) {
             std::string msg = strings::Substitute(
                     "load persistent index from tablet failed, insert usage and size by key size failed, key_size: $0",
@@ -2857,9 +2857,9 @@ Status PersistentIndex::_flush_advance_or_append_wal(size_t n, const Slice* keys
 Status PersistentIndex::_update_usage_and_size_by_key_length(
         std::vector<std::pair<int64_t, int64_t>>& add_usage_and_size) {
     if (_key_size > 0) {
-        auto iter = _usage_and_size_by_key_size.find(_key_size);
-        DCHECK(iter != _usage_and_size_by_key_size.end());
-        if (iter == _usage_and_size_by_key_size.end()) {
+        auto iter = _usage_and_size_by_key_length.find(_key_size);
+        DCHECK(iter != _usage_and_size_by_key_length.end());
+        if (iter == _usage_and_size_by_key_length.end()) {
             std::string msg = strings::Substitute("no key_size: $0 in usage info", _key_size);
             LOG(WARNING) << msg;
             return Status::InternalError(msg);
@@ -2870,8 +2870,8 @@ Status PersistentIndex::_update_usage_and_size_by_key_length(
     } else {
         for (int key_size = 1; key_size <= kSliceMaxFixLength; key_size++) {
             if (add_usage_and_size[key_size].second > 0) {
-                auto iter = _usage_and_size_by_key_size.find(key_size);
-                if (iter == _usage_and_size_by_key_size.end()) {
+                auto iter = _usage_and_size_by_key_length.find(key_size);
+                if (iter == _usage_and_size_by_key_length.end()) {
                     std::string msg = strings::Substitute("no key_size: $0 in usage info", key_size);
                     LOG(WARNING) << msg;
                     return Status::InternalError(msg);
@@ -2889,8 +2889,8 @@ Status PersistentIndex::_update_usage_and_size_by_key_length(
             slice_size += add_usage_and_size[key_size].second;
         }
         DCHECK(_key_size == 0);
-        auto iter = _usage_and_size_by_key_size.find(_key_size);
-        if (iter == _usage_and_size_by_key_size.end()) {
+        auto iter = _usage_and_size_by_key_length.find(_key_size);
+        if (iter == _usage_and_size_by_key_length.end()) {
             std::string msg = strings::Substitute("no key_size: $0 in usage info", _key_size);
             LOG(WARNING) << msg;
             return Status::InternalError(msg);
@@ -3516,7 +3516,7 @@ Status PersistentIndex::_merge_compaction() {
     const std::string idx_file_path =
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
     RETURN_IF_ERROR(writer->init(idx_file_path, _version, true));
-    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage_and_size_by_key_size, false));
+    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage_and_size_by_key_length, false));
     // _usage should be equal to total_kv_size. But they may be differen because of compatibility problem when we upgrade
     // from old version and _usage maybe not accurate.
     // so we use total_kv_size to correct the _usage.

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -56,6 +56,7 @@ struct IndexValue {
 
 static constexpr size_t kIndexValueSize = 8;
 static_assert(sizeof(IndexValue) == kIndexValueSize);
+constexpr static size_t kSliceMaxFixLength = 64;
 
 uint64_t key_index_hash(const void* data, size_t len);
 
@@ -172,6 +173,8 @@ public:
 
     // get the number of entries in the index (including NullIndexValue)
     virtual size_t size() const = 0;
+
+    virtual size_t usage() const = 0;
 
     virtual size_t capacity() = 0;
 
@@ -309,7 +312,6 @@ private:
     void _init_loop_helper();
 
 private:
-    constexpr static size_t kSliceMaxFixLength = 64;
     uint32_t _fixed_key_size = -1;
     uint64_t _offset = 0;
     uint64_t _page_size = 0;
@@ -586,7 +588,8 @@ private:
     Status _flush_l0();
 
     Status _merge_compaction_internal(ImmutableIndexWriter* writer, int l1_start_idx, int l1_end_idx,
-                                      size_t total_usage, size_t total_size, bool keep_delete);
+                                      std::map<uint32_t, std::pair<int64_t, int64_t>>& usage_and_size_stat,
+                                      bool keep_delete);
     Status _merge_compaction_advance();
     // merge l0 and l1 into new l1, then clear l0
     Status _merge_compaction();
@@ -604,6 +607,8 @@ private:
     Status _get_from_immutable_index(size_t n, const Slice* keys, IndexValue* values,
                                      std::map<size_t, KeysInfo>& keys_info_by_key_size);
 
+    Status _update_usage_and_size_by_key_length(std::vector<std::pair<int64_t, int64_t>>& add_usage_and_size);
+
     // index storage directory
     std::string _path;
     size_t _key_size = 0;
@@ -615,6 +620,11 @@ private:
     std::unique_ptr<ShardByLengthMutableIndex> _l0;
     // add all l1 into vector
     std::vector<std::unique_ptr<ImmutableIndex>> _l1_vec;
+    // The usage and size is not exactly accurate after reload persistent index from disk becaues
+    // we ignore the overlap kvs between l0 and l1. The general accuracy can already be used as a
+    // reference to estimate nshard and npages We don't persist the overlap kvs info to reduce the
+    // write cost of PersistentIndexMeta
+    std::map<uint32_t, std::pair<int64_t, int64_t>> _usage_and_size_by_key_size;
     std::vector<int> _l1_merged_num;
     bool _has_l1 = false;
     std::shared_ptr<FileSystem> _fs;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -624,7 +624,7 @@ private:
     // we ignore the overlap kvs between l0 and l1. The general accuracy can already be used as a
     // reference to estimate nshard and npages We don't persist the overlap kvs info to reduce the
     // write cost of PersistentIndexMeta
-    std::map<uint32_t, std::pair<int64_t, int64_t>> _usage_and_size_by_key_size;
+    std::map<uint32_t, std::pair<int64_t, int64_t>> _usage_and_size_by_key_length;
     std::vector<int> _l1_merged_num;
     bool _has_l1 = false;
     std::shared_ptr<FileSystem> _fs;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -594,7 +594,7 @@ private:
     // merge l0 and l1 into new l1, then clear l0
     Status _merge_compaction();
 
-    Status _load(const PersistentIndexMetaPB& index_meta);
+    Status _load(const PersistentIndexMetaPB& index_meta, bool reload = false);
     Status _reload(const PersistentIndexMetaPB& index_meta);
 
     // commit index meta


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/19475

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In merge compaction of persistent index, we will first estimate the shard num and page num according to the kv data size and kv nums for each key length which will determine the file size of l1. The estimated file size will be slightly larger than the real kv data size generally, but the pr(https://github.com/StarRocks/starrocks/pull/15729) use total kv size to estimate the shard num and page num for each key length. So when the key length takes more values, the size of the l1 file will be bigger and the more disk space is wasted.

This pr add the data size and size of each key length in persistent index so we can estimate the reasonable file size.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
