### PR TITLE
[BugFix] Fix NPE when setting password without user specified

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -97,6 +97,7 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableFunctionRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UnionRelation;
+import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.ViewRelation;
@@ -286,10 +287,16 @@ public class AstToStringBuilder {
                             + " as " + userVariable.getEvaluatedExpression().getType().toSql() + ")";
                     setVarList.add(setVarSql);
                 } else if (setVar instanceof SetPassVar) {
-                    String tmp = "PASSWORD FOR " +
-                            ((SetPassVar) setVar).getUserIdent().toString() +
-                            " = PASSWORD('***')";
-                    setVarList.add(tmp);
+                    SetPassVar setPassVar = (SetPassVar) setVar;
+                    UserIdentity userIdentity = setPassVar.getUserIdent();
+                    String setPassSql = "";
+                    if (userIdentity == null) {
+                        setPassSql += "PASSWORD";
+                    } else {
+                        setPassSql += "PASSWORD FOR " + userIdentity;
+                    }
+                    setPassSql += " = PASSWORD('***')";
+                    setVarList.add(setPassSql);
                 }
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/SetPasswordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/SetPasswordTest.java
@@ -64,7 +64,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 
-import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.parseSql;
 
 public class SetPasswordTest {
 
@@ -169,10 +169,22 @@ public class SetPasswordTest {
     }
 
     @Test
-    public void testAuditSetPassword() {
+    public void testAuditSetPasswordWithoutUser() {
         String sql = "SET PASSWORD = PASSWORD('testPass'), pipeline_dop = 2";
-        SetStmt setStmt = (SetStmt) analyzeSuccess(sql);
+        SetStmt setStmt = (SetStmt) parseSql(sql);
         String setSql = AstToStringBuilder.toString(setStmt);
+        Assert.assertFalse(setSql.contains("PASSWORD FOR"));
+        Assert.assertTrue(setSql.contains("PASSWORD('***')"));
+        Assert.assertTrue(setSql.contains("`pipeline_dop` = 2"));
+        System.out.println(setSql);
+    }
+
+    @Test
+    public void testAuditSetPassword() {
+        String sql = "SET PASSWORD FOR admin = PASSWORD('testPass'), pipeline_dop = 2";
+        SetStmt setStmt = (SetStmt) parseSql(sql);
+        String setSql = AstToStringBuilder.toString(setStmt);
+        Assert.assertTrue(setSql.contains("PASSWORD FOR"));
         Assert.assertTrue(setSql.contains("PASSWORD('***')"));
         Assert.assertTrue(setSql.contains("`pipeline_dop` = 2"));
         System.out.println(setSql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -268,10 +268,13 @@ public class AnalyzeTestUtil {
         return starRocksAssert;
     }
 
+    public static StatementBase parseSql(String originStmt) {
+        return com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable()).get(0);
+    }
+
     public static StatementBase analyzeSuccess(String originStmt) {
         try {
-            StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(originStmt,
-                    connectContext.getSessionVariable()).get(0);
+            StatementBase statementBase = parseSql(originStmt);
             Analyzer.analyze(statementBase, connectContext);
 
             if (statementBase instanceof QueryStatement) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix the NPE introduced by #15247

Reproduce steps:
1. enable FE conf `enable_collect_query_detail_info=true`
2. Setting password without user specified `SET PASSWORD = PASSWORD('xxxx')`
3. NPE will be thrown with following log
```
java.lang.NullPointerException: null
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitSetStatement(AstToStringBuilder.java:290) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitSetStatement(AstToStringBuilder.java:122) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.SetStmt.accept(SetStmt.java:64) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:55) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:51) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder.toString(AstToStringBuilder.java:119) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.addRunningQueryDetail(ConnectProcessor.java:282) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:350) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:472) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:738) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_332]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_332]
        at java.lang.Thread.run(Thread.java:750) [?:1.8.0_332]
```

The root cause of the problem is that `userIdent` will not be set until the end of the analysis phase if user is not specified in SQL statement, but `addRunningQueryDetail` is called before the analysis phase.

```
    // parse phase, user will be set to NULL
    @Override
    public ParseNode visitSetPassword(StarRocksParser.SetPasswordContext context) {
        NodePosition pos = createPos(context);
        String passwordText;
        StringLiteral stringLiteral = (StringLiteral) visit(context.string());
        if (context.PASSWORD().size() > 1) {
            passwordText = new String(MysqlPassword.makeScrambledPassword(stringLiteral.getStringValue()));
        } else {
            passwordText = stringLiteral.getStringValue();
        }
        if (context.user() != null) {
            return new SetPassVar((UserIdentity) visit(context.user()), passwordText, pos);
        } else {
            return new SetPassVar(null, passwordText, pos);
        }
    }

    // analyze phase
    private static void analyzeSetPassVar(SetPassVar var, ConnectContext session) {
        try {
            UserIdentity userIdentity = var.getUserIdent();
            if (userIdentity == null) {
                userIdentity = session.getCurrentUserIdentity();
            }
            userIdentity.analyze();
            var.setUserIdent(userIdentity);
            var.setPasswdBytes(MysqlPassword.checkPassword(var.getPasswdParam()));

        } catch (AnalysisException e) {
            throw new SemanticException(e.getMessage());
        }
    }
```


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
