### PR TITLE
[Enhancement] Support alter session variables in create and alter materialized view command

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -38,6 +38,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.catalog.ColocateTableIndex;
@@ -80,6 +81,7 @@ import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.mv.MVManager;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SetStmtAnalyzer;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
@@ -98,7 +100,10 @@ import com.starrocks.sql.ast.PartitionRenameClause;
 import com.starrocks.sql.ast.RefreshSchemeDesc;
 import com.starrocks.sql.ast.ReplacePartitionClause;
 import com.starrocks.sql.ast.RollupRenameClause;
+import com.starrocks.sql.ast.SetListItem;
+import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SwapTableClause;
+import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncatePartitionClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
@@ -302,22 +307,22 @@ public class Alter {
         int partitionTTL = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)) {
             partitionTTL = PropertyAnalyzer.analyzePartitionTimeToLive(properties);
+            properties.remove(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER);
         }
         int partitionRefreshNumber = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {
             partitionRefreshNumber = PropertyAnalyzer.analyzePartitionRefreshNumber(properties);
+            properties.remove(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER);
         }
         int autoRefreshPartitionsLimit = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)) {
             autoRefreshPartitionsLimit = PropertyAnalyzer.analyzeAutoRefreshPartitionsLimit(properties, materializedView);
+            properties.remove(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT);
         }
         List<TableName> excludedTriggerTables = Lists.newArrayList();
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)) {
             excludedTriggerTables = PropertyAnalyzer.analyzeExcludedTriggerTables(properties, materializedView);
-        }
-
-        if (!properties.isEmpty()) {
-            throw new AnalysisException("Modify failed because unknown properties: " + properties);
+            properties.remove(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES);
         }
 
         boolean isChanged = false;
@@ -345,12 +350,27 @@ public class Alter {
             isChanged = true;
         }
         DynamicPartitionUtil.registerOrRemovePartitionTTLTable(materializedView.getDbId(), materializedView);
+        if (!properties.isEmpty()) {
+            // analyze properties
+            List<SetListItem> setListItems = Lists.newArrayList();
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                SystemVariable variable = new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue()));
+                setListItems.add(variable);
+            }
+            SetStmtAnalyzer.analyze(new SetStmt(setListItems), null);
+
+            // set properties if there are no exceptions
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                materializedView.getTableProperty().modifyTableProperties(entry.getKey(), entry.getValue());
+            }
+            isChanged = true;
+        }
         if (isChanged) {
             ModifyTablePropertyOperationLog log = new ModifyTablePropertyOperationLog(materializedView.getDbId(),
                     materializedView.getId(), propClone);
             GlobalStateMgr.getCurrentState().getEditLog().logAlterMaterializedViewProperties(log);
         }
-        LOG.info("alter materialized view properties {}, id: {}", properties, materializedView.getId());
+        LOG.info("alter materialized view properties {}, id: {}", propClone, materializedView.getId());
     }
 
     private void processChangeRefreshScheme(RefreshSchemeDesc refreshSchemeDesc, MaterializedView materializedView,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1036,4 +1036,20 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
     public void setPlanContext(MvRewriteContext mvRewriteContext) {
         this.mvRewriteContext = mvRewriteContext;
     }
+
+    @Override
+    public Map<String, String> getProperties() {
+        Map<String, String> properties = super.getProperties();
+        // For materialized view, add into session variables into properties.
+        if (super.getTableProperty() != null && super.getTableProperty().getProperties() != null) {
+            for (Map.Entry<String, String> entry : super.getTableProperty().getProperties().entrySet()) {
+                if (entry.getKey().startsWith(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX)) {
+                    String varKey = entry.getKey().substring(
+                            PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX.length());
+                    properties.put(varKey, entry.getValue());
+                }
+            }
+        }
+        return properties;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -158,6 +158,8 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE = "force_external_table_query_rewrite";
 
+    public static final String PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX = "session.";
+
     public static final String PROPERTIES_STORAGE_VOLUME = "storage_volume";
 
     // constraint for rewrite

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -59,8 +59,7 @@ public class TaskBuilder {
         Map<String, String> taskProperties = Maps.newHashMap();
         taskProperties.put(PartitionBasedMaterializedViewRefreshProcessor.MV_ID, String.valueOf(materializedView.getId()));
         taskProperties.put(SessionVariable.ENABLE_INSERT_STRICT, "false");
-        // TODO: filter session properties into task.
-        taskProperties.putAll(materializedView.getTableProperty().getProperties());
+        taskProperties.putAll(materializedView.getProperties());
 
         task.setProperties(taskProperties);
         task.setDefinition(

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -59,6 +59,9 @@ public class TaskBuilder {
         Map<String, String> taskProperties = Maps.newHashMap();
         taskProperties.put(PartitionBasedMaterializedViewRefreshProcessor.MV_ID, String.valueOf(materializedView.getId()));
         taskProperties.put(SessionVariable.ENABLE_INSERT_STRICT, "false");
+        // TODO: filter session properties into task.
+        taskProperties.putAll(materializedView.getTableProperty().getProperties());
+
         task.setProperties(taskProperties);
         task.setDefinition(
                 "insert overwrite " + materializedView.getName() + " " + materializedView.getViewDefineSql());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -131,7 +131,7 @@ public class TaskRun implements Comparable<TaskRun> {
                         ctx.getDatabase());
             }
             MaterializedView materializedView = (MaterializedView) table;
-            newProperties = materializedView.getTableProperty().getProperties();
+            newProperties = materializedView.getProperties();
         } catch (Exception e) {
             LOG.warn("refresh task properties failed:", e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.scheduler;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Database;
@@ -97,7 +98,6 @@ public class TaskRun implements Comparable<TaskRun> {
     public TaskRunProcessor getProcessor() {
         return processor;
     }
-
     public void setProcessor(TaskRunProcessor processor) {
         this.processor = processor;
     }
@@ -129,8 +129,10 @@ public class TaskRun implements Comparable<TaskRun> {
             if (table == null) {
                 LOG.warn("materialized view:{} in database:{} do not exist when refreshing", mvId,
                         ctx.getDatabase());
+                return newProperties;
             }
             MaterializedView materializedView = (MaterializedView) table;
+            Preconditions.checkState(materializedView != null);
             newProperties = materializedView.getProperties();
         } catch (Exception e) {
             LOG.warn("refresh task properties failed:", e);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -16,6 +16,9 @@ package com.starrocks.scheduler;
 
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.load.loadv2.InsertLoadJob;
@@ -107,6 +110,34 @@ public class TaskRun implements Comparable<TaskRun> {
         return this.type;
     }
 
+    public Map<String, String>  refreshTaskProperties(ConnectContext ctx) {
+        Map<String, String> newProperties = Maps.newHashMap();
+        if (task.getSource() != Constants.TaskSource.MV) {
+            return newProperties;
+        }
+
+        try {
+            // NOTE: mvId is set in Task's properties when creating
+            long mvId = Long.parseLong(properties.get(PartitionBasedMaterializedViewRefreshProcessor.MV_ID));
+            Database database = GlobalStateMgr.getCurrentState().getDb(ctx.getDatabase());
+            if (database == null) {
+                LOG.warn("database {} do not exist when refreshing materialized view:{}", ctx.getDatabase(), mvId);
+                return newProperties;
+            }
+
+            Table table = database.getTable(mvId);
+            if (table == null) {
+                LOG.warn("materialized view:{} in database:{} do not exist when refreshing", mvId,
+                        ctx.getDatabase());
+            }
+            MaterializedView materializedView = (MaterializedView) table;
+            newProperties = materializedView.getTableProperty().getProperties();
+        } catch (Exception e) {
+            LOG.warn("refresh task properties failed:", e);
+        }
+        return newProperties;
+    }
+
     public boolean executeTaskRun() throws Exception {
         TaskRunContext taskRunContext = new TaskRunContext();
         taskRunContext.setDefinition(status.getDefinition());
@@ -118,6 +149,9 @@ public class TaskRun implements Comparable<TaskRun> {
         runCtx.setCurrentRoleIds(runCtx.getCurrentUserIdentity());
         runCtx.getState().reset();
         runCtx.setQueryId(UUID.fromString(status.getQueryId()));
+
+        Map<String, String> newProperties = refreshTaskProperties(runCtx);
+        properties.putAll(newProperties);
         Map<String, String> taskRunContextProperties = Maps.newHashMap();
         runCtx.resetSessionVariable();
         if (properties != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2798,7 +2798,15 @@ public class LocalMetastore implements ConnectorMetadata {
                 // analyze properties
                 List<SetListItem> setListItems = Lists.newArrayList();
                 for (Map.Entry<String, String> entry : properties.entrySet()) {
-                    SystemVariable variable = new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue()));
+                    if (!entry.getKey().startsWith(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX)) {
+                        throw new AnalysisException("Analyze materialized properties failed " +
+                                "because unknown properties: " + properties +
+                                ", please add `session.` prefix if you want add session variables for mv(" +
+                                "eg, \"session.query_timeout\"=\"30000000\").");
+                    }
+                    String varKey = entry.getKey().substring(
+                            PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX.length());
+                    SystemVariable variable = new SystemVariable(varKey, new StringLiteral(entry.getValue()));
                     setListItems.add(variable);
                 }
                 SetStmtAnalyzer.analyze(new SetStmt(setListItems), null);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -16,11 +16,14 @@ package com.starrocks.analysis;
 
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.RefreshSchemeDesc;
+import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -32,11 +35,23 @@ import static org.junit.Assert.assertTrue;
 
 public class AlterMaterializedViewTest {
     private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    private static GlobalStateMgr currentState;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         AnalyzeTestUtil.init();
         connectContext = AnalyzeTestUtil.getConnectContext();
+        starRocksAssert = AnalyzeTestUtil.getStarRocksAssert();
+        currentState = GlobalStateMgr.getCurrentState();
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv1\n" +
+                "                DISTRIBUTED BY HASH(v1) BUCKETS 10\n" +
+                "                PROPERTIES(\n" +
+                "                    \"replication_num\" = \"1\"\n" +
+                "                )\n" +
+                "                as  select v1, count(v2) as count_c2, sum(v3) as sum_c3\n" +
+                "                from t0 group by v1;\n");
     }
 
     @Test
@@ -105,5 +120,22 @@ public class AlterMaterializedViewTest {
     public void testAlterAsyncRefreshLowercase() throws Exception {
         String alterMvSql = "alter materialized view mv1 refresh async start ('2222-05-23') every (interval 1 day)";
         UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+    }
+
+    @Test
+    public void testAlterMVProperties() throws Exception {
+        {
+            String alterMvSql = "alter materialized view mv1 set (\"session.query_timeout\" = \"10000\")";
+            AlterMaterializedViewStmt stmt =
+                    (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+            currentState.alterMaterializedView(stmt);
+        }
+
+        {
+            String alterMvSql = "alter materialized view mv1 set (\"query_timeout\" = \"10000\")";
+            AlterMaterializedViewStmt stmt =
+                    (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+            Assert.assertThrows(DdlException.class, () -> currentState.alterMaterializedView(stmt));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -2033,6 +2033,45 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
+    public void testCreateMVWithSessionProperties1() {
+        String sql = "create materialized view mv_with_property1 " +
+                "partition by ss " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"session.query_timeout\" = \"10000\"" +
+                ") " +
+                "as select tbl1.k1 ss, k2 from tbl1;";
+
+        try {
+            CreateMaterializedViewStatement stmt =
+                    (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            currentState.createMaterializedView(stmt);
+            Table mv1 = testDb.getTable("mv_with_property1");
+            Assert.assertTrue(mv1 instanceof MaterializedView);
+        } catch (Exception e) {
+            Assert.fail();;
+        }
+    }
+
+    @Test
+    public void testCreateMVWithSessionProperties2() {
+        String sql = "create materialized view mv_with_property1 " +
+                "partition by ss " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"query_timeout\" = \"10000\"" +
+                ") " +
+                "as select tbl1.k1 ss, k2 from tbl1;";
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
+            Assert.assertEquals("Analyze materialized properties failed because unknown propertie", e.getMessage());
+        }
+    }
+
+    @Test
     public void testNoDuplicateKey() {
         String sql = "create materialized view mv1 " +
                 "partition by s1 " +
@@ -2481,7 +2520,6 @@ public class CreateMaterializedViewTest {
         } catch (Exception e) {
             Assert.fail();
         }
-
     }
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
- Support alter session variables in create and alter materialized view command
- The task-run will refresh the mv's session variables when it processes in the following.


### Alter Materialized View With Session Variables

```
CREATE MATERIALIZED VIEW mv1
                DISTRIBUTED BY HASH(c1) BUCKETS 10
                PROPERTIES(
                    "replication_num" = "1"
                )
                as  select c1, count(c2) as count_c2, sum(c3) as sum_c3
                from t1 group by c1;
ALTER MATERIALIZED VIEW mv1 SET ("session.query_timeout" = "40000");
```

### Create Materialized View With Session Variables
```
CREATE MATERIALIZED VIEW mv2
                DISTRIBUTED BY HASH(c1) BUCKETS 10
                PROPERTIES(
                    "replication_num" = "1",
                    "session.query_timeout" = "40000"

                )
                as  select c1, count(c2) as count_c2, sum(c3) as sum_c3
                from t1 group by c1;

```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
