### PR TITLE
[BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
@@ -102,8 +102,8 @@ public class ExpressionContext {
         return childrenProperty.get(index).getOutputColumns();
     }
 
-    public LogicalProperty.OneTabletMeta isExecuteInOneTablet(int index) {
-        return childrenProperty.get(index).isExecuteInOneTablet();
+    public LogicalProperty.OneTabletProperty oneTabletProperty(int index) {
+        return childrenProperty.get(index).oneTabletProperty();
     }
 
     public Operator getChildOperator(int index) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
@@ -102,7 +102,7 @@ public class ExpressionContext {
         return childrenProperty.get(index).getOutputColumns();
     }
 
-    public boolean isExecuteInOneTablet(int index) {
+    public LogicalProperty.OneTabletMeta isExecuteInOneTablet(int index) {
         return childrenProperty.get(index).isExecuteInOneTablet();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -176,7 +176,7 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
     public Void visitPhysicalHashAggregate(PhysicalHashAggregateOperator node, ExpressionContext context) {
         // If scan tablet sum less than 1, do one phase local aggregate is enough
         if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 0
-                && context.getRootProperty().isExecuteInOneTablet().self
+                && context.getRootProperty().oneTabletProperty().supportOneTabletOpt
                 && node.isOnePhaseAgg()) {
             requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY));
             return null;
@@ -228,7 +228,7 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
             distributionProperty = new DistributionProperty(DistributionSpec.createGatherDistributionSpec());
         } else {
             // If scan tablet sum less than 1, no distribution property is required
-            if (context.getRootProperty().isExecuteInOneTablet().self) {
+            if (context.getRootProperty().oneTabletProperty().supportOneTabletOpt) {
                 distributionProperty = DistributionProperty.EMPTY;
             } else {
                 distributionProperty = createShuffleAggProperty(partitionColumnRefSet);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer;
 
 import com.google.common.base.Preconditions;
@@ -166,7 +165,8 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
             requiredProperties.add(Lists.newArrayList(gather, gather));
         } else {
             PhysicalPropertySet rightBroadcastProperty =
-                    new PhysicalPropertySet(new DistributionProperty(DistributionSpec.createReplicatedDistributionSpec()));
+                    new PhysicalPropertySet(
+                            new DistributionProperty(DistributionSpec.createReplicatedDistributionSpec()));
             requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY, rightBroadcastProperty));
         }
         return null;
@@ -174,9 +174,9 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
 
     @Override
     public Void visitPhysicalHashAggregate(PhysicalHashAggregateOperator node, ExpressionContext context) {
-        // If scan tablet sum leas than 1, do one phase local aggregate is enough
+        // If scan tablet sum less than 1, do one phase local aggregate is enough
         if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 0
-                && context.getRootProperty().isExecuteInOneTablet()
+                && context.getRootProperty().isExecuteInOneTablet().self
                 && node.isOnePhaseAgg()) {
             requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY));
             return null;
@@ -227,7 +227,12 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
         if (partitionColumnRefSet.isEmpty()) {
             distributionProperty = new DistributionProperty(DistributionSpec.createGatherDistributionSpec());
         } else {
-            distributionProperty = createShuffleAggProperty(partitionColumnRefSet);
+            // If scan tablet sum less than 1, no distribution property is required
+            if (context.getRootProperty().isExecuteInOneTablet().self) {
+                distributionProperty = DistributionProperty.EMPTY;
+            } else {
+                distributionProperty = createShuffleAggProperty(partitionColumnRefSet);
+            }
         }
         requiredProperties.add(Lists.newArrayList(new PhysicalPropertySet(distributionProperty, sortProperty)));
 
@@ -266,7 +271,7 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
     public Void visitPhysicalLimit(PhysicalLimitOperator node, ExpressionContext context) {
         // @todo: check the condition is right?
         //
-        // If scan tablet sum leas than 1, don't need required gather, because work machine always less than 1?
+        // If scan tablet sum less than 1, don't need required gather, because work machine always less than 1?
         // if (context.getRootProperty().isExecuteInOneTablet()) {
         //     requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY));
         //     return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
@@ -84,27 +84,27 @@ public class LogicalProperty implements Property {
     }
 
     public static final class OneTabletMeta {
+        /*
+         * For instance, see the below example
+         *        Agg(group by v1)
+         *             |
+         *             v
+         *      Analytic(partition by b2)
+         *             |
+         *             v
+         *        Scan (bucket: v1, only one tablet)
+         * For Analytic(self=true, asChild=false):
+         *     Can perform one tablet optimization(no exchange needed).
+         *
+         * For Agg(self=false, asChild=false):
+         *     Cannot perform one tablet optimization(exchange needed), because it's child, i.e. Analytic, cannot
+         * offer one tablet guarantee because distribution has been changed.
+         */
         public final boolean self;
         public final boolean asChild;
         public final ColumnRefSet bucketColumns;
 
         private OneTabletMeta(boolean self, boolean asChild, ColumnRefSet bucketColumns) {
-            /*
-             * For instance, see the below example
-             *        Agg(group by v1)
-             *             |
-             *             v
-             *      Analytic(partition by b2)
-             *             |
-             *             v
-             *        Scan (bucket: v1, only one tablet)
-             * For Analytic(self=true, asChild=false):
-             *     Can perform one tablet optimization(no exchange needed).
-             *
-             * For Agg(self=false, asChild=false):
-             *     Cannot perform one tablet optimization(exchange needed), because it's child, i.e. Analytic, cannot
-             * offer one tablet guarantee because distribution has been changed.
-             */
             this.self = self;
             this.asChild = asChild;
             this.bucketColumns = bucketColumns;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.base;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Column;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalExceptOperator;
@@ -32,14 +33,24 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.logical.MockOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import jersey.repackaged.com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class LogicalProperty implements Property {
     // Operator's output columns
     private ColumnRefSet outputColumns;
 
     // The flag for execute upon less than or equal one tablet
-    private boolean isExecuteInOneTablet;
+    private OneTabletMeta isExecuteInOneTablet;
 
     public ColumnRefSet getOutputColumns() {
         return outputColumns;
@@ -49,7 +60,7 @@ public class LogicalProperty implements Property {
         this.outputColumns = outputColumns;
     }
 
-    public boolean isExecuteInOneTablet() {
+    public OneTabletMeta isExecuteInOneTablet() {
         return isExecuteInOneTablet;
     }
 
@@ -72,66 +83,147 @@ public class LogicalProperty implements Property {
         isExecuteInOneTablet = op.accept(new OneTabletExecutorVisitor(), expressionContext);
     }
 
-    static class OneTabletExecutorVisitor extends OperatorVisitor<Boolean, ExpressionContext> {
+    public static final class OneTabletMeta {
+        public final boolean self;
+        public final boolean asChild;
+        public final ColumnRefSet bucketColumns;
+
+        private OneTabletMeta(boolean self, boolean asChild, ColumnRefSet bucketColumns) {
+            /*
+             * For instance, see the below example
+             *        Agg(group by v1)
+             *             |
+             *             v
+             *      Analytic(partition by b2)
+             *             |
+             *             v
+             *        Scan (bucket: v1, only one tablet)
+             * For Analytic(self=true, asChild=false):
+             *     Can perform one tablet optimization(no exchange needed).
+             *
+             * For Agg(self=false, asChild=false):
+             *     Cannot perform one tablet optimization(exchange needed), because it's child, i.e. Analytic, cannot
+             * offer one tablet guarantee because distribution has been changed.
+             */
+            this.self = self;
+            this.asChild = asChild;
+            this.bucketColumns = bucketColumns;
+        }
+
+        private static OneTabletMeta onlySelf(ColumnRefSet bucketColumns) {
+            return new OneTabletMeta(true, false, bucketColumns);
+        }
+
+        private static OneTabletMeta both(ColumnRefSet bucketColumns) {
+            return new OneTabletMeta(true, true, bucketColumns);
+        }
+
+        private static OneTabletMeta neither() {
+            return new OneTabletMeta(false, false, null);
+        }
+    }
+
+    static class OneTabletExecutorVisitor extends OperatorVisitor<OneTabletMeta, ExpressionContext> {
         @Override
-        public Boolean visitOperator(Operator node, ExpressionContext context) {
+        public OneTabletMeta visitOperator(Operator node, ExpressionContext context) {
             Preconditions.checkState(context.arity() != 0);
             return context.isExecuteInOneTablet(0);
         }
 
         @Override
-        public Boolean visitMockOperator(MockOperator node, ExpressionContext context) {
-            return true;
+        public OneTabletMeta visitMockOperator(MockOperator node, ExpressionContext context) {
+            return OneTabletMeta.both(new ColumnRefSet());
         }
 
         @Override
-        public Boolean visitLogicalTableScan(LogicalScanOperator node, ExpressionContext context) {
+        public OneTabletMeta visitLogicalTableScan(LogicalScanOperator node, ExpressionContext context) {
             if (node instanceof LogicalOlapScanOperator) {
-                return ((LogicalOlapScanOperator) node).getSelectedTabletId().size() <= 1;
-            } else {
-                return node instanceof LogicalMysqlScanOperator || node instanceof LogicalJDBCScanOperator;
+                if (((LogicalOlapScanOperator) node).getSelectedTabletId().size() <= 1) {
+                    Set<String> distributionColumnNames = node.getTable().getDistributionColumnNames();
+                    List<ColumnRefOperator> bucketColumns = Lists.newArrayList();
+                    for (Map.Entry<ColumnRefOperator, Column> entry : node.getColRefToColumnMetaMap().entrySet()) {
+                        if (distributionColumnNames.contains(entry.getValue().getName())) {
+                            bucketColumns.add(entry.getKey());
+                        }
+                    }
+                    return OneTabletMeta.both(new ColumnRefSet(bucketColumns));
+                }
+                return OneTabletMeta.neither();
+            } else if (node instanceof LogicalMysqlScanOperator || node instanceof LogicalJDBCScanOperator) {
+                return OneTabletMeta.both(new ColumnRefSet());
             }
+            return OneTabletMeta.neither();
         }
 
         @Override
-        public Boolean visitLogicalValues(LogicalValuesOperator node, ExpressionContext context) {
-            return true;
+        public OneTabletMeta visitLogicalValues(LogicalValuesOperator node, ExpressionContext context) {
+            return OneTabletMeta.both(new ColumnRefSet());
         }
 
         @Override
-        public Boolean visitLogicalJoin(LogicalJoinOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletMeta visitLogicalAnalytic(LogicalWindowOperator node, ExpressionContext context) {
+            OneTabletMeta isExecuteInOneTablet = context.isExecuteInOneTablet(0);
+            if (isExecuteInOneTablet.asChild) {
+                List<Integer> partitionColumnRefSet = new ArrayList<>();
+                node.getPartitionExpressions().forEach(e -> partitionColumnRefSet
+                        .addAll(Arrays.stream(e.getUsedColumns().getColumnIds()).boxed().collect(Collectors.toList())));
+                ColumnRefSet partitionColumns = ColumnRefSet.createByIds(partitionColumnRefSet);
+                if (partitionColumns.isSame(isExecuteInOneTablet.bucketColumns)) {
+                    return isExecuteInOneTablet;
+                }
+                return OneTabletMeta.onlySelf(isExecuteInOneTablet.bucketColumns);
+            }
+            return OneTabletMeta.neither();
         }
 
         @Override
-        public Boolean visitLogicalUnion(LogicalUnionOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletMeta visitLogicalAggregation(LogicalAggregationOperator node,
+                                                     ExpressionContext context) {
+            OneTabletMeta isExecuteInOneTablet = context.isExecuteInOneTablet(0);
+            if (isExecuteInOneTablet.asChild) {
+                ColumnRefSet groupByColumns = new ColumnRefSet(node.getGroupingKeys());
+                if (groupByColumns.isSame(isExecuteInOneTablet.bucketColumns)) {
+                    return isExecuteInOneTablet;
+                }
+                return OneTabletMeta.onlySelf(isExecuteInOneTablet.bucketColumns);
+            }
+            return OneTabletMeta.neither();
         }
 
         @Override
-        public Boolean visitLogicalExcept(LogicalExceptOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletMeta visitLogicalJoin(LogicalJoinOperator node, ExpressionContext context) {
+            return OneTabletMeta.neither();
         }
 
         @Override
-        public Boolean visitLogicalIntersect(LogicalIntersectOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletMeta visitLogicalUnion(LogicalUnionOperator node, ExpressionContext context) {
+            return OneTabletMeta.neither();
         }
 
         @Override
-        public Boolean visitLogicalTableFunction(LogicalTableFunctionOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletMeta visitLogicalExcept(LogicalExceptOperator node, ExpressionContext context) {
+            return OneTabletMeta.neither();
         }
 
         @Override
-        public Boolean visitLogicalCTEAnchor(LogicalCTEAnchorOperator node, ExpressionContext context) {
+        public OneTabletMeta visitLogicalIntersect(LogicalIntersectOperator node, ExpressionContext context) {
+            return OneTabletMeta.neither();
+        }
+
+        @Override
+        public OneTabletMeta visitLogicalTableFunction(LogicalTableFunctionOperator node, ExpressionContext context) {
+            return OneTabletMeta.neither();
+        }
+
+        @Override
+        public OneTabletMeta visitLogicalCTEAnchor(LogicalCTEAnchorOperator node, ExpressionContext context) {
             Preconditions.checkState(context.arity() == 2);
             return context.isExecuteInOneTablet(1);
         }
 
         @Override
-        public Boolean visitLogicalCTEConsume(LogicalCTEConsumeOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletMeta visitLogicalCTEConsume(LogicalCTEConsumeOperator node, ExpressionContext context) {
+            return OneTabletMeta.neither();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -133,7 +133,7 @@ public class SplitAggregateRule extends TransformationRule {
             return false;
         }
         // 4. If scan tablet sum leas than 1, do one phase aggregate is enough
-        if (aggStage == AUTO_MODE && input.getLogicalProperty().isExecuteInOneTablet().self) {
+        if (aggStage == AUTO_MODE && input.getLogicalProperty().oneTabletProperty().supportOneTabletOpt) {
             return false;
         }
         // Default, we could generate two stage aggregate

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.base.Preconditions;
@@ -72,7 +71,6 @@ public class SplitAggregateRule extends TransformationRule {
     private static final int ONE_STAGE = 1;
 
     private static final int TWO_STAGE = 2;
-
 
     public static SplitAggregateRule getInstance() {
         return INSTANCE;
@@ -135,7 +133,7 @@ public class SplitAggregateRule extends TransformationRule {
             return false;
         }
         // 4. If scan tablet sum leas than 1, do one phase aggregate is enough
-        if (aggStage == AUTO_MODE && input.getLogicalProperty().isExecuteInOneTablet()) {
+        if (aggStage == AUTO_MODE && input.getLogicalProperty().isExecuteInOneTablet().self) {
             return false;
         }
         // Default, we could generate two stage aggregate
@@ -644,8 +642,9 @@ public class SplitAggregateRule extends TransformationRule {
             CallOperator callOperator;
             if (!type.isLocal()) {
                 List<ScalarOperator> arguments =
-                        Lists.newArrayList(new ColumnRefOperator(column.getId(), aggregation.getType(), column.getName(),
-                                aggregation.isNullable()));
+                        Lists.newArrayList(
+                                new ColumnRefOperator(column.getId(), aggregation.getType(), column.getName(),
+                                        aggregation.isNullable()));
                 appendConstantColumns(arguments, aggregation);
 
                 callOperator = new CallOperator(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -376,7 +376,8 @@ public class PlanFragmentBuilder {
             // Key columns and value columns cannot be pruned in the non-skip-aggr scan stage.
             // - All the keys columns must be retained to merge and aggregate rows.
             // - Value columns can only be used after merging and aggregating.
-            MaterializedIndexMeta materializedIndexMeta = referenceTable.getIndexMetaByIndexId(node.getSelectedIndexId());
+            MaterializedIndexMeta materializedIndexMeta =
+                    referenceTable.getIndexMetaByIndexId(node.getSelectedIndexId());
             if (materializedIndexMeta.getKeysType().isAggregationFamily() && !node.isPreAggregation()) {
                 return;
             }
@@ -1595,7 +1596,8 @@ public class PlanFragmentBuilder {
                 }
 
                 // Check colocate for the first phase in three/four-phase agg whose second phase is pruned.
-                if (!withLocalShuffle && !node.isUseStreamingPreAgg() && hasColocateOlapScanChildInFragment(aggregationNode)) {
+                if (!withLocalShuffle && !node.isUseStreamingPreAgg() &&
+                        hasColocateOlapScanChildInFragment(aggregationNode)) {
                     aggregationNode.setColocate(true);
                 }
             } else if (node.getType().isGlobal() || (node.getType().isLocal() && !node.isSplit())) {
@@ -1700,7 +1702,7 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
             if (node.isOnePhaseAgg() || node.isMergedLocalAgg() || node.getType().isDistinctGlobal()) {
-                if (optExpr.getLogicalProperty().isExecuteInOneTablet()) {
+                if (optExpr.getLogicalProperty().isExecuteInOneTablet().self) {
                     clearOlapScanNodePartitions(aggregationNode);
                 }
                 // For ScanNode->LocalShuffle->AggNode, we needn't assign scan ranges per driver sequence.
@@ -2355,6 +2357,10 @@ public class PlanFragmentBuilder {
             if (root instanceof SortNode) {
                 SortNode sortNode = (SortNode) root;
                 sortNode.setAnalyticPartitionExprs(analyticEvalNode.getPartitionExprs());
+            }
+
+            if (optExpr.getLogicalProperty().isExecuteInOneTablet().self) {
+                clearOlapScanNodePartitions(analyticEvalNode);
             }
 
             inputFragment.setPlanRoot(analyticEvalNode);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1702,7 +1702,7 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
             if (node.isOnePhaseAgg() || node.isMergedLocalAgg() || node.getType().isDistinctGlobal()) {
-                if (optExpr.getLogicalProperty().isExecuteInOneTablet().self) {
+                if (optExpr.getLogicalProperty().oneTabletProperty().supportOneTabletOpt) {
                     clearOlapScanNodePartitions(aggregationNode);
                 }
                 // For ScanNode->LocalShuffle->AggNode, we needn't assign scan ranges per driver sequence.
@@ -2359,7 +2359,7 @@ public class PlanFragmentBuilder {
                 sortNode.setAnalyticPartitionExprs(analyticEvalNode.getPartitionExprs());
             }
 
-            if (optExpr.getLogicalProperty().isExecuteInOneTablet().self) {
+            if (optExpr.getLogicalProperty().oneTabletProperty().supportOneTabletOpt) {
                 clearOlapScanNodePartitions(analyticEvalNode);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -110,26 +110,26 @@ public class TrinoQueryTest extends TrinoTestBase {
     @Test
     public void testSelectAnalytic() throws Exception {
         String sql = "select sum(v1) over(partition by v2) from t0";
-        assertPlanContains(sql, "3:ANALYTIC\n" +
+        assertPlanContains(sql, "2:ANALYTIC\n" +
                 "  |  functions: [, sum(1: v1), ]\n" +
                 "  |  partition by: 2: v2");
 
         sql = "select sum(v1) over(partition by v2 order by v3) from t0";
-        assertPlanContains(sql, "3:ANALYTIC\n" +
+        assertPlanContains(sql, "2:ANALYTIC\n" +
                 "  |  functions: [, sum(1: v1), ]\n" +
                 "  |  partition by: 2: v2\n" +
                 "  |  order by: 3: v3 ASC\n" +
                 "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
 
         sql = "select lead(v1,1,0) over(partition by v2 order by v3) from t0";
-        assertPlanContains(sql, "3:ANALYTIC\n" +
+        assertPlanContains(sql, "2:ANALYTIC\n" +
                 "  |  functions: [, lead(1: v1, 1, 0), ]\n" +
                 "  |  partition by: 2: v2\n" +
                 "  |  order by: 3: v3 ASC\n" +
                 "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING");
 
         sql = "select lag(v1) over(partition by v2 order by v3) from t0";
-        assertPlanContains(sql, "3:ANALYTIC\n" +
+        assertPlanContains(sql, "2:ANALYTIC\n" +
                 "  |  functions: [, lag(1: v1, 1, NULL), ]\n" +
                 "  |  partition by: 2: v2\n" +
                 "  |  order by: 3: v3 ASC\n" +
@@ -138,35 +138,35 @@ public class TrinoQueryTest extends TrinoTestBase {
         sql =
                 "select first_value(v1) over(partition by v2 order by v3 range between unbounded preceding and unbounded " +
                         "following) from t0";
-        assertPlanContains(sql, "3:ANALYTIC\n" +
+        assertPlanContains(sql, "2:ANALYTIC\n" +
                 "  |  functions: [, first_value(1: v1), ]\n" +
                 "  |  partition by: 2: v2\n" +
                 "  |  order by: 3: v3 ASC\n" +
                 "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
 
         sql = "select last_value(v1) over(partition by v2 order by v3 rows 6 preceding) from t0";
-        assertPlanContains(sql, "3:ANALYTIC\n" +
+        assertPlanContains(sql, "2:ANALYTIC\n" +
                 "  |  functions: [, last_value(1: v1), ]\n" +
                 "  |  partition by: 2: v2\n" +
                 "  |  order by: 3: v3 ASC\n" +
                 "  |  window: ROWS BETWEEN 6 PRECEDING AND CURRENT ROW");
 
         sql = "select row_number() over(partition by v2 order by v3) from t0";
-        assertPlanContains(sql, "3:ANALYTIC\n" +
+        assertPlanContains(sql, "2:ANALYTIC\n" +
                 "  |  functions: [, row_number(), ]\n" +
                 "  |  partition by: 2: v2\n" +
                 "  |  order by: 3: v3 ASC\n" +
                 "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
 
         sql = "select rank() over(partition by v2 order by v3) from t0";
-        assertPlanContains(sql, "3:ANALYTIC\n" +
+        assertPlanContains(sql, "2:ANALYTIC\n" +
                 "  |  functions: [, rank(), ]\n" +
                 "  |  partition by: 2: v2\n" +
                 "  |  order by: 3: v3 ASC\n" +
                 "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
 
         sql = "select dense_rank() over(partition by v2 order by v3) from t0";
-        assertPlanContains(sql, " 3:ANALYTIC\n" +
+        assertPlanContains(sql, " 2:ANALYTIC\n" +
                 "  |  functions: [, dense_rank(), ]\n" +
                 "  |  partition by: 2: v2\n" +
                 "  |  order by: 3: v3 ASC\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rule;
 
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.Memo;
@@ -33,9 +34,13 @@ public class BinderTest {
 
     @Test
     public void testBinder() {
+        OlapTable table1 = new OlapTable();
+        table1.setDefaultDistributionInfo(new HashDistributionInfo());
+        OlapTable table2 = new OlapTable();
+        table2.setDefaultDistributionInfo(new HashDistributionInfo());
         OptExpression expr = OptExpression.create(new LogicalJoinOperator(),
-                new OptExpression(new LogicalOlapScanOperator(new OlapTable())),
-                new OptExpression(new LogicalOlapScanOperator(new OlapTable())));
+                new OptExpression(new LogicalOlapScanOperator(table1)),
+                new OptExpression(new LogicalOlapScanOperator(table2)));
 
         Pattern pattern = Pattern.create(OperatorType.LOGICAL_JOIN)
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF))

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -609,7 +609,7 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select SUM(v2) from (select v2, sum(v1) as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
@@ -617,7 +617,7 @@ public class AggregateTest extends PlanTestBase {
                 "  |  group by: 2: v2\n");
         sql = "select SUM(v2) from (select v2, sum(distinct v2) as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
@@ -652,7 +652,7 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select SUM(x1) from (select v2 as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
@@ -2071,7 +2071,8 @@ public class AggregateTest extends PlanTestBase {
                 "  |  <slot 12> : 14: cast + rand() + 1.0\n" +
                 "  |  common expressions:\n" +
                 "  |  <slot 14> : CAST(2: t1b AS DOUBLE)");
-        sql = "select cast(id_decimal as decimal(38,2)),cast(id_decimal as decimal(37,2)) from test_all_type group by 1, 2";
+        sql =
+                "select cast(id_decimal as decimal(38,2)),cast(id_decimal as decimal(37,2)) from test_all_type group by 1, 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
                 "  |  group by: 11: cast, 12: cast\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -683,10 +683,10 @@ public class ExpressionTest extends PlanTestBase {
         // window functions
         sql = "select count(c1) over (partition by array_sum(array_map(x->x+1, [1]))) from test_array12";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  4:ANALYTIC\n" +
+        Assert.assertTrue(plan.contains("  3:ANALYTIC\n" +
                 "  |  functions: [, count(6: c1), ]\n" +
                 "  |  partition by: 8: array_sum"));
-        Assert.assertTrue(plan.contains("  3:SORT\n" +
+        Assert.assertTrue(plan.contains("  2:SORT\n" +
                 "  |  order by: <slot 8> 8: array_sum ASC\n" +
                 "  |  offset:"));
         Assert.assertTrue(plan.contains("  1:Project\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
@@ -294,6 +294,6 @@ public class GroupingSetTest extends PlanTestBase {
                 "  |  \n" +
                 "  6:Project\n" +
                 "  |  <slot 6> : 6: array_agg\n" +
-                "  |  <slot 9> : array_join(7: array_agg, ','))");
+                "  |  <slot 9> : array_join(7: array_agg, ',')");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
@@ -283,17 +283,17 @@ public class GroupingSetTest extends PlanTestBase {
                 "    ) tev,unnest(x2) \n" +
                 ") tev group by GROUPING SETS((u2, r1)) ";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "6:Project\n" +
+        assertContains(plan, "8:Project\n" +
                 "  |  <slot 10> : 10: unnest\n" +
                 "  |  <slot 11> : datediff(CAST(split(9: array_join, ',')[2] AS DATETIME), CAST(10: unnest AS DATETIME))\n" +
                 "  |  \n" +
-                "  5:TableValueFunction\n" +
+                "  7:TableValueFunction\n" +
                 "  |  tableFunctionName: unnest\n" +
                 "  |  columns: [unnest]\n" +
                 "  |  returnTypes: [BIGINT]\n" +
                 "  |  \n" +
-                "  4:Project\n" +
+                "  6:Project\n" +
                 "  |  <slot 6> : 6: array_agg\n" +
-                "  |  <slot 9> : array_join(7: array_agg, ',')");
+                "  |  <slot 9> : array_join(7: array_agg, ','))");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1093,7 +1093,7 @@ public class LowCardinalityTest extends PlanTestBase {
                 ") t where rm < 10";
         plan = getCostExplain(sql);
 
-        Assert.assertTrue(plan.contains("  3:SORT\n" +
+        Assert.assertTrue(plan.contains("  2:SORT\n" +
                 "  |  order by: [20, INT, false] ASC, [2, INT, false] ASC"));
         Assert.assertTrue(plan.contains("  1:PARTITION-TOP-N\n" +
                 "  |  partition by: [20: L_COMMENT, INT, false] "));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -375,32 +375,32 @@ public class OrderByTest extends PlanTestBase {
 
         sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by v";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "6:SORT\n" +
+        assertContains(plan, "5:SORT\n" +
                 "  |  order by: <slot 8> 8: sum(4: v1) ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  5:Project\n" +
+                "  4:Project\n" +
                 "  |  <slot 4> : 4: v1\n" +
                 "  |  <slot 5> : 5: v2\n" +
                 "  |  <slot 8> : 8: sum(4: v1)\n" +
                 "  |  \n" +
-                "  4:ANALYTIC\n" +
+                "  3:ANALYTIC\n" +
                 "  |  functions: [, sum(4: v1), ]\n" +
                 "  |  partition by: 7: expr");
 
         sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by avg(v1) over(partition by v1 + 1)";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "6:SORT\n" +
+        assertContains(plan, "5:SORT\n" +
                 "  |  order by: <slot 9> 9: avg(4: v1) ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  5:Project\n" +
+                "  4:Project\n" +
                 "  |  <slot 4> : 4: v1\n" +
                 "  |  <slot 5> : 5: v2\n" +
                 "  |  <slot 8> : 8: sum(4: v1)\n" +
                 "  |  <slot 9> : 9: avg(4: v1)\n" +
                 "  |  \n" +
-                "  4:ANALYTIC\n" +
+                "  3:ANALYTIC\n" +
                 "  |  functions: [, sum(4: v1), ], [, avg(4: v1), ]");
 
         sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by 2";
@@ -409,46 +409,36 @@ public class OrderByTest extends PlanTestBase {
 
         sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by 3";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "6:SORT\n" +
+        assertContains(plan, "5:SORT\n" +
                 "  |  order by: <slot 8> 8: sum(4: v1) ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  5:Project\n" +
+                "  4:Project\n" +
                 "  |  <slot 4> : 4: v1\n" +
                 "  |  <slot 5> : 5: v2\n" +
                 "  |  <slot 8> : 8: sum(4: v1)\n" +
                 "  |  \n" +
-                "  4:ANALYTIC\n" +
+                "  3:ANALYTIC\n" +
                 "  |  functions: [, sum(4: v1), ]\n" +
                 "  |  partition by: 7: expr");
 
         sql = "select avg(v1) over(partition by sum(v2) + 1) as v from t0 group by v1 order by v";
         plan = getFragmentPlan(sql);
-        assertContains(plan, " 7:SORT\n" +
+        assertContains(plan, " 6:SORT\n" +
                 "  |  order by: <slot 9> 9: avg(1: v1) ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  6:Project\n" +
+                "  5:Project\n" +
                 "  |  <slot 9> : 9: avg(1: v1)\n" +
                 "  |  \n" +
-                "  5:ANALYTIC\n" +
+                "  4:ANALYTIC\n" +
                 "  |  functions: [, avg(1: v1), ]\n" +
                 "  |  partition by: 8: expr\n" +
                 "  |  \n" +
-                "  4:SORT\n" +
+                "  3:SORT\n" +
                 "  |  order by: <slot 8> 8: expr ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  3:EXCHANGE\n" +
-                "\n" +
-                "PLAN FRAGMENT 2\n" +
-                " OUTPUT EXPRS:\n" +
-                "  PARTITION: RANDOM\n" +
-                "\n" +
-                "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 03\n" +
-                "    HASH_PARTITIONED: 8: expr\n" +
-                "\n" +
                 "  2:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
                 "  |  <slot 8> : 4: sum + 1\n" +
@@ -459,64 +449,44 @@ public class OrderByTest extends PlanTestBase {
 
         sql = "select v1, avg(v1) over(partition by sum(v2) + 1) as v from t0 group by v1 order by 2,1";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "7:SORT\n" +
+        assertContains(plan, "6:SORT\n" +
                 "  |  order by: <slot 9> 9: avg(1: v1) ASC, <slot 1> 1: v1 ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  6:Project\n" +
+                "  5:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
                 "  |  <slot 9> : 9: avg(1: v1)\n" +
                 "  |  \n" +
-                "  5:ANALYTIC\n" +
+                "  4:ANALYTIC\n" +
                 "  |  functions: [, avg(1: v1), ]\n" +
                 "  |  partition by: 8: expr\n" +
                 "  |  \n" +
-                "  4:SORT\n" +
+                "  3:SORT\n" +
                 "  |  order by: <slot 8> 8: expr ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  3:EXCHANGE\n" +
-                "\n" +
-                "PLAN FRAGMENT 2\n" +
-                " OUTPUT EXPRS:\n" +
-                "  PARTITION: RANDOM\n" +
-                "\n" +
-                "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 03\n" +
-                "    HASH_PARTITIONED: 8: expr\n" +
-                "\n" +
                 "  2:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
                 "  |  <slot 8> : 4: sum + 1");
 
         sql = "select avg(v1) over(partition by sum(v2) + 1) as v from t0 group by v1 order by v1";
         plan = getFragmentPlan(sql);
-        assertContains(plan, " 7:SORT\n" +
+        assertContains(plan, " 6:SORT\n" +
                 "  |  order by: <slot 1> 1: v1 ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  6:Project\n" +
+                "  5:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
                 "  |  <slot 9> : 9: avg(1: v1)\n" +
                 "  |  \n" +
-                "  5:ANALYTIC\n" +
+                "  4:ANALYTIC\n" +
                 "  |  functions: [, avg(1: v1), ]\n" +
                 "  |  partition by: 8: expr\n" +
                 "  |  \n" +
-                "  4:SORT\n" +
+                "  3:SORT\n" +
                 "  |  order by: <slot 8> 8: expr ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
-                "  3:EXCHANGE\n" +
-                "\n" +
-                "PLAN FRAGMENT 2\n" +
-                " OUTPUT EXPRS:\n" +
-                "  PARTITION: RANDOM\n" +
-                "\n" +
-                "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 03\n" +
-                "    HASH_PARTITIONED: 8: expr\n" +
-                "\n" +
                 "  2:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
                 "  |  <slot 8> : 4: sum + 1\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -125,21 +125,21 @@ public class StructTypePlanTest extends PlanTestBase {
     @Test
     public void testStructWithWindow() throws Exception {
         String sql = "select sum(c2.b) over(partition by c2.a order by c0) from test";
-        assertPlanContains(sql, " 4:ANALYTIC\n" +
+        assertPlanContains(sql, " 3:ANALYTIC\n" +
                 "  |  functions: [, sum(7: c2.b), ]\n" +
                 "  |  partition by: 9: c2.a\n" +
                 "  |  order by: 1: c0 ASC\n" +
                 "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
 
         sql = "select sum(c0) over(partition by c2.a order by c2.b) from test";
-        assertPlanContains(sql, " 4:ANALYTIC\n" +
+        assertPlanContains(sql, " 3:ANALYTIC\n" +
                 "  |  functions: [, sum(5: c0), ]\n" +
                 "  |  partition by: 9: c2.a\n" +
                 "  |  order by: 10: c2.b ASC\n" +
                 "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
 
         sql = "select sum(c1.b[10].b) over(partition by c2.a order by c2.b) from test";
-        assertPlanContains(sql, "4:ANALYTIC\n" +
+        assertPlanContains(sql, "3:ANALYTIC\n" +
                 "  |  functions: [, sum(6: c1.b[10].b), ]\n" +
                 "  |  partition by: 9: c2.a\n" +
                 "  |  order by: 10: c2.b ASC\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -193,21 +193,23 @@ public class WindowTest extends PlanTestBase {
     public void testWindowPartitionAndSortSameColumn() throws Exception {
         String sql = "SELECT k3, avg(k3) OVER (partition by k3 order by k3) AS sum FROM baseall;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  3:ANALYTIC\n" +
+        assertContains(plan, "  2:ANALYTIC\n" +
                 "  |  functions: [, avg(3: k3), ]\n" +
                 "  |  partition by: 3: k3\n" +
-                "  |  order by: 3: k3 ASC");
-        assertContains(plan, "  2:SORT\n" +
-                "  |  order by: <slot 3> 3: k3 ASC");
+                "  |  order by: 3: k3 ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: <slot 3> 3: k3 ASC\n" +
+                "  |  offset: 0");
     }
 
     @Test
     public void testWindowDuplicatePartition() throws Exception {
         String sql = "select max(v3) over (partition by v2,v2,v2 order by v2,v2) from t0;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:SORT\n"
-                + "  |  order by: <slot 2> 2: v2 ASC\n"
-                + "  |  offset: 0");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: <slot 2> 2: v2 ASC\n" +
+                "  |  offset: 0");
 
     }
 
@@ -275,16 +277,11 @@ public class WindowTest extends PlanTestBase {
         // Normal case.
         sql = "select v1, v2, NTILE(2) over (partition by v1 order by v2) as j1 from t0";
         String plan = getFragmentPlan(sql);
-        assertContains(plan,
-                "  3:ANALYTIC\n" +
-                        "  |  functions: [, ntile(2), ]\n" +
-                        "  |  partition by: 1: v1\n" +
-                        "  |  order by: 2: v2 ASC\n" +
-                        "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
-                        "  |  \n" +
-                        "  2:SORT\n" +
-                        "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC\n" +
-                        "  |  offset: 0");
+        assertContains(plan, "  2:ANALYTIC\n" +
+                "  |  functions: [, ntile(2), ]\n" +
+                "  |  partition by: 1: v1\n" +
+                "  |  order by: 2: v2 ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT RO");
     }
 
     @Test
@@ -669,7 +666,7 @@ public class WindowTest extends PlanTestBase {
                 "(select v1 from t0 where v1 = 1) b " +
                 "where a.v1 = b.v1";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  2:SORT\n" +
+        assertContains(plan, "  1:SORT\n" +
                 "  |  order by: [1, BIGINT, true] ASC, [2, BIGINT, true] DESC\n" +
                 "  |  offset: 0\n" +
                 "  |  cardinality: 1\n" +
@@ -685,7 +682,7 @@ public class WindowTest extends PlanTestBase {
                 "where a.v1 = b.v1";
 
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "3:ANALYTIC\n" +
+        assertContains(plan, "  2:ANALYTIC\n" +
                 "  |  functions: [, sum[([2: v2, BIGINT, true]); args: BIGINT; " +
                 "result: BIGINT; args nullable: true; result nullable: true], ]\n" +
                 "  |  partition by: [3: v3, BIGINT, true]\n" +
@@ -703,7 +700,7 @@ public class WindowTest extends PlanTestBase {
                     "sum(v1/v3) over ([hash] partition by v1,v2 ) " +
                     "from t0";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  2:ANALYTIC\n" +
+            assertContains(plan, "  1:ANALYTIC\n" +
                     "  |  functions: [, sum(1: v1), ], [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
                     "  |  partition by: 1: v1, 2: v2\n" +
                     "  |  useHashBasedPartition");
@@ -716,7 +713,7 @@ public class WindowTest extends PlanTestBase {
             assertContains(plan, "  4:ANALYTIC\n" +
                     "  |  functions: [, sum(1: v1), ]\n" +
                     "  |  partition by: 1: v1, 2: v2");
-            assertContains(plan, "  2:ANALYTIC\n" +
+            assertContains(plan, "  1:ANALYTIC\n" +
                     "  |  functions: [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
                     "  |  partition by: 1: v1, 2: v2\n" +
                     "  |  useHashBasedPartition");
@@ -726,14 +723,67 @@ public class WindowTest extends PlanTestBase {
                     "sum(v1/v3) over ([hash] partition by v1,v2 ) " +
                     "from t0";
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  4:ANALYTIC\n" +
+            assertContains(plan, "  3:ANALYTIC\n" +
                     "  |  functions: [, sum(1: v1), ]\n" +
                     "  |  partition by: 1: v1\n" +
                     "  |  useHashBasedPartition");
-            assertContains(plan, "  2:ANALYTIC\n" +
+            assertContains(plan, "  1:ANALYTIC\n" +
                     "  |  functions: [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
                     "  |  partition by: 1: v1, 2: v2\n" +
                     "  |  useHashBasedPartition");
+        }
+    }
+
+    @Test
+    public void testOneTablet() throws Exception {
+        {
+            String sql = "select v1 from (" +
+                    "select v1, dense_rank() over (partition by v1 order by v3) rk from t0" +
+                    ") temp " +
+                    "where rk = 1 " +
+                    "group by v1";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, dense_rank(), ]\n" +
+                    "  |  partition by: 1: v1\n" +
+                    "  |  order by: 3: v3 ASC\n" +
+                    "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  1:SORT\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
+            assertContains(plan, "  5:AGGREGATE (update finalize)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  4:Project\n" +
+                    "  |  <slot 1> : 1: v1");
+        }
+        {
+            String sql = "select v1 from (" +
+                    "select v1, dense_rank() over (partition by v1, v2 order by v3) rk from t0" +
+                    ") temp " +
+                    "where rk = 1 " +
+                    "group by v1";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, dense_rank(), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  order by: 3: v3 ASC\n" +
+                    "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  1:SORT\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
+            assertContains(plan, "  7:AGGREGATE (merge finalize)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  6:EXCHANGE");
         }
     }
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15-1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15-1.sql
@@ -13,8 +13,10 @@ from
          group by
              l_suppkey) b;
 [result]
-AGGREGATE ([GLOBAL] aggregate [{19: max=max(18: sum)}] group by [[]] having [null]
-    AGGREGATE ([GLOBAL] aggregate [{110: sum=sum(33: sum_disc_price)}] group by [[24: l_suppkey]] having [null]
-        SCAN (mv[lineitem_agg_mv2] columns[24: l_suppkey, 25: l_shipdate, 33: sum_disc_price] predicate[25: l_shipdate >= 1995-07-01 AND 25: l_shipdate < 1995-10-01 AND 25: l_shipdate >= 1995-01-01 AND 25: l_shipdate < 1996-01-01])
+AGGREGATE ([GLOBAL] aggregate [{19: max=max(19: max)}] group by [[]] having [null]
+    EXCHANGE GATHER
+        AGGREGATE ([LOCAL] aggregate [{19: max=max(18: sum)}] group by [[]] having [null]
+            AGGREGATE ([GLOBAL] aggregate [{110: sum=sum(33: sum_disc_price)}] group by [[24: l_suppkey]] having [null]
+                SCAN (mv[lineitem_agg_mv2] columns[24: l_suppkey, 25: l_shipdate, 33: sum_disc_price] predicate[25: l_shipdate >= 1995-07-01 AND 25: l_shipdate < 1995-10-01 AND 25: l_shipdate >= 1995-01-01 AND 25: l_shipdate < 1996-01-01])
 [end]
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19725

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The derivation of `isExecuteInOneTablet` is wrong when it comes to agg or analytic node that changes the data distribution. 

Besides, analytic node can also benefit from one tablet optimization.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
