### PR TITLE
[Refactor] change tablet_meta_mem_tracker to metadata_mem_tracker (#10466)

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -183,10 +183,10 @@ void calculate_metrics(void* arg_this) {
 
         LOG(INFO) << fmt::format(
                 "Current memory statistics: process({}), query_pool({}), load({}), "
-                "tablet_meta({}), compaction({}), schema_change({}), column_pool({}), "
+                "metadata({}), compaction({}), schema_change({}), column_pool({}), "
                 "page_cache({}), update({}), chunk_allocator({}), clone({}), consistency({})",
                 mem_metrics->process_mem_bytes.value(), mem_metrics->query_mem_bytes.value(),
-                mem_metrics->load_mem_bytes.value(), mem_metrics->tablet_meta_mem_bytes.value(),
+                mem_metrics->load_mem_bytes.value(), mem_metrics->metadata_mem_bytes.value(),
                 mem_metrics->compaction_mem_bytes.value(), mem_metrics->schema_change_mem_bytes.value(),
                 mem_metrics->column_pool_mem_bytes.value(), mem_metrics->storage_page_cache_mem_bytes.value(),
                 mem_metrics->update_mem_bytes.value(), mem_metrics->chunk_allocator_mem_bytes.value(),

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -268,7 +268,7 @@ Status PhysicalSplitMorselQueue::_init_segment() {
     if (_tablet_seek_ranges.empty()) {
         _segment_scan_range.add(vectorized::Range(0, segment->num_rows()));
     } else {
-        RETURN_IF_ERROR(segment->load_index(StorageEngine::instance()->tablet_meta_mem_tracker()));
+        RETURN_IF_ERROR(segment->load_index(StorageEngine::instance()->metadata_mem_tracker()));
         for (const auto& range : _tablet_seek_ranges) {
             rowid_t lower_rowid = 0;
             rowid_t upper_rowid = segment->num_rows();

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -59,7 +59,7 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id << " schema hash:" << schema_hash;
         return Status::InternalError("no tablet exist");
     }
-    auto tablet_meta = TabletMeta::create(StorageEngine::instance()->tablet_meta_mem_tracker());
+    auto tablet_meta = TabletMeta::create(StorageEngine::instance()->metadata_mem_tracker());
     tablet->generate_tablet_meta_copy(tablet_meta);
     json2pb::Pb2JsonOptions json_options;
     json_options.pretty_json = true;

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -116,7 +116,7 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
             start_mem_tracker = ExecEnv::GetInstance()->load_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "tablet_meta") {
-            start_mem_tracker = ExecEnv::GetInstance()->tablet_meta_mem_tracker();
+            start_mem_tracker = ExecEnv::GetInstance()->metadata_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "query_pool") {
             start_mem_tracker = ExecEnv::GetInstance()->query_pool_mem_tracker();
@@ -155,7 +155,7 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
 
     // Metadata memory statistics use the old memory framework,
     // not in RootMemTrackerTree, so it needs to be added here
-    MemTracker* meta_mem_tracker = ExecEnv::GetInstance()->tablet_meta_mem_tracker();
+    MemTracker* meta_mem_tracker = ExecEnv::GetInstance()->metadata_mem_tracker();
     MemTracker::SimpleItem meta_item{"tablet_meta",
                                      "process",
                                      2,

--- a/be/src/http/web_page_handler.cpp
+++ b/be/src/http/web_page_handler.cpp
@@ -23,7 +23,6 @@
 
 #include <functional>
 
-#include "common/config.h"
 #include "fs/fs.h"
 #include "gutil/stl_util.h"
 #include "gutil/strings/substitute.h"

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -316,7 +316,7 @@ Status ExecEnv::init_mem_tracker() {
     int64_t load_mem_limit = calc_max_load_memory(_mem_tracker->limit());
     _load_mem_tracker = new MemTracker(MemTracker::LOAD, load_mem_limit, "load", _mem_tracker);
     // Metadata statistics memory statistics do not use new mem statistics framework with hook
-    _tablet_meta_mem_tracker = new MemTracker(-1, "tablet_meta", nullptr);
+    _metadata_mem_tracker = new MemTracker(-1, "tablet_meta", nullptr);
 
     int64_t compaction_mem_limit = calc_max_compaction_memory(_mem_tracker->limit());
     _compaction_mem_tracker = new MemTracker(compaction_mem_limit, "compaction", _mem_tracker);
@@ -332,7 +332,7 @@ Status ExecEnv::init_mem_tracker() {
 
     ChunkAllocator::init_instance(_chunk_allocator_mem_tracker, config::chunk_reserved_bytes_limit);
 
-    GlobalTabletSchemaMap::Instance()->set_mem_tracker(_tablet_meta_mem_tracker);
+    GlobalTabletSchemaMap::Instance()->set_mem_tracker(_metadata_mem_tracker);
     SetMemTrackerForColumnPool op(_column_pool_mem_tracker);
     vectorized::ForEach<vectorized::ColumnPoolList>(op);
     _init_storage_page_cache();
@@ -485,9 +485,9 @@ void ExecEnv::_destroy() {
         delete _compaction_mem_tracker;
         _compaction_mem_tracker = nullptr;
     }
-    if (_tablet_meta_mem_tracker) {
-        delete _tablet_meta_mem_tracker;
-        _tablet_meta_mem_tracker = nullptr;
+    if (_metadata_mem_tracker) {
+        delete _metadata_mem_tracker;
+        _metadata_mem_tracker = nullptr;
     }
     if (_load_mem_tracker) {
         delete _load_mem_tracker;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -116,7 +116,7 @@ public:
     MemTracker* process_mem_tracker() { return _mem_tracker; }
     MemTracker* query_pool_mem_tracker() { return _query_pool_mem_tracker; }
     MemTracker* load_mem_tracker() { return _load_mem_tracker; }
-    MemTracker* tablet_meta_mem_tracker() { return _tablet_meta_mem_tracker; }
+    MemTracker* metadata_mem_tracker() { return _metadata_mem_tracker; }
     MemTracker* compaction_mem_tracker() { return _compaction_mem_tracker; }
     MemTracker* schema_change_mem_tracker() { return _schema_change_mem_tracker; }
     MemTracker* column_pool_mem_tracker() { return _column_pool_mem_tracker; }
@@ -198,7 +198,7 @@ private:
     MemTracker* _load_mem_tracker = nullptr;
 
     // The memory for tablet meta
-    MemTracker* _tablet_meta_mem_tracker = nullptr;
+    MemTracker* _metadata_mem_tracker = nullptr;
 
     // The memory used for compaction
     MemTracker* _compaction_mem_tracker = nullptr;

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -231,7 +231,7 @@ int main(int argc, char** argv) {
     starrocks::EngineOptions options;
     options.store_paths = paths;
     options.backend_uid = starrocks::UniqueId::gen_uid();
-    options.tablet_meta_mem_tracker = exec_env->tablet_meta_mem_tracker();
+    options.metadata_mem_tracker = exec_env->metadata_mem_tracker();
     options.schema_change_mem_tracker = exec_env->schema_change_mem_tracker();
     options.compaction_mem_tracker = exec_env->compaction_mem_tracker();
     options.update_mem_tracker = exec_env->update_mem_tracker();

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -49,5 +49,4 @@ StatusOr<TxnLogPtr> Tablet::get_txn_log(int64_t txn_id) {
 Status Tablet::delete_txn_log(int64_t txn_id) {
     return _mgr->delete_txn_log(_group, _id, txn_id);
 }
-
 } // namespace starrocks::lake

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -33,8 +33,8 @@ namespace starrocks {
 class MemTracker;
 
 struct StorePath {
-    StorePath() {}
-    StorePath(std::string path_) : path(std::move(path_)), storage_medium(TStorageMedium::HDD) {}
+    StorePath() = default;
+    explicit StorePath(std::string path_) : path(std::move(path_)), storage_medium(TStorageMedium::HDD) {}
     std::string path;
     TStorageMedium::type storage_medium{TStorageMedium::HDD};
 };
@@ -49,7 +49,7 @@ struct EngineOptions {
     std::vector<StorePath> store_paths;
     // BE's UUID. It will be reset every time BE restarts.
     UniqueId backend_uid{0, 0};
-    MemTracker* tablet_meta_mem_tracker = nullptr;
+    MemTracker* metadata_mem_tracker = nullptr;
     MemTracker* compaction_mem_tracker = nullptr;
     MemTracker* schema_change_mem_tracker = nullptr;
     MemTracker* update_mem_tracker = nullptr;

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -77,7 +77,7 @@ Status BetaRowset::do_load() {
     size_t footer_size_hint = 16 * 1024;
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
-        auto res = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), fs, seg_path, seg_id, _schema,
+        auto res = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs, seg_path, seg_id, _schema,
                                  &footer_size_hint, rowset_meta()->partial_rowset_footer(seg_id));
         if (!res.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
@@ -394,7 +394,7 @@ Status BetaRowset::reload() {
     size_t footer_size_hint = 16 * 1024;
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
-        auto res = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), fs, seg_path, seg_id, _schema,
+        auto res = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs, seg_path, seg_id, _schema,
                                  &footer_size_hint);
         if (!res.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -447,8 +447,8 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
         }
         std::string tmp_segment_file =
                 BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-        auto segment_ptr = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), _fs, tmp_segment_file,
-                                         seg_id, _context.tablet_schema);
+        auto segment_ptr = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), _fs, tmp_segment_file, seg_id,
+                                         _context.tablet_schema);
         if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
             return segment_ptr.status();

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -34,8 +34,7 @@ namespace starrocks {
 Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::string& rowset_path,
                                     const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {
     if (rowset_meta->rowset_type() == BETA_ROWSET) {
-        *rowset =
-                BetaRowset::create(ExecEnv::GetInstance()->metadata_mem_tracker(), schema, rowset_path, rowset_meta);
+        *rowset = BetaRowset::create(ExecEnv::GetInstance()->metadata_mem_tracker(), schema, rowset_path, rowset_meta);
         RETURN_IF_ERROR((*rowset)->init());
         return Status::OK();
     }

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -28,7 +28,6 @@
 #include "rowset_writer_adapter.h"
 #include "storage/rowset/beta_rowset_writer.h"
 #include "storage/rowset/rowset_writer.h"
-#include "storage/type_utils.h"
 
 namespace starrocks {
 
@@ -36,7 +35,7 @@ Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::strin
                                     const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {
     if (rowset_meta->rowset_type() == BETA_ROWSET) {
         *rowset =
-                BetaRowset::create(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), schema, rowset_path, rowset_meta);
+                BetaRowset::create(ExecEnv::GetInstance()->metadata_mem_tracker(), schema, rowset_path, rowset_meta);
         RETURN_IF_ERROR((*rowset)->init());
         return Status::OK();
     }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -448,7 +448,7 @@ Status SegmentIterator::_get_row_ranges_by_keys() {
         return Status::OK();
     }
     DCHECK_EQ(0, _scan_range.span_size());
-    RETURN_IF_ERROR(_segment->load_index(StorageEngine::instance()->tablet_meta_mem_tracker()));
+    RETURN_IF_ERROR(_segment->load_index(StorageEngine::instance()->metadata_mem_tracker()));
     for (const SeekRange& range : _opts.ranges) {
         rowid_t lower_rowid = 0;
         rowid_t upper_rowid = num_rows();
@@ -467,6 +467,7 @@ Status SegmentIterator::_get_row_ranges_by_keys() {
     }
     _opts.stats->rows_key_range_filtered += num_rows() - _scan_range.span_size();
     StarRocksMetrics::instance()->segment_rows_by_short_key.increment(_scan_range.span_size());
+
     return Status::OK();
 }
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -82,7 +82,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _available_storage_medium_type_count(0),
           _is_all_cluster_id_exist(true),
 
-          _tablet_manager(new TabletManager(options.tablet_meta_mem_tracker, config::tablet_map_shard_size)),
+          _tablet_manager(new TabletManager(options.metadata_mem_tracker, config::tablet_map_shard_size)),
           _txn_manager(new TxnManager(config::txn_map_shard_size, config::txn_shard_size, options.store_paths.size())),
           _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
           _memtable_flush_executor(nullptr),

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -180,7 +180,7 @@ public:
 
     bool bg_worker_stopped() { return _bg_worker_stopped.load(std::memory_order_consume); }
 
-    MemTracker* tablet_meta_mem_tracker() { return _options.tablet_meta_mem_tracker; }
+    MemTracker* metadata_mem_tracker() { return _options.metadata_mem_tracker; }
 
     void compaction_check();
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -146,7 +146,7 @@ public:
 
     Status delete_shutdown_tablet_before_clone(int64_t tablet_id);
 
-    MemTracker* tablet_meta_mem_tracker() { return _mem_tracker; }
+    MemTracker* metadata_mem_tracker() { return _mem_tracker; }
 
     // return true if all tablets visited
     bool get_next_batch_tablets(size_t batch_size, std::vector<TabletSharedPtr>* tablets);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2888,8 +2888,8 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
         }
         std::string seg_path =
                 BetaRowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), rssid - iter->first);
-        auto segment = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), fs, seg_path,
-                                     rssid - iter->first, &rowset->schema());
+        auto segment = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs, seg_path, rssid - iter->first,
+                                     &rowset->schema());
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();
             return segment.status();

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -680,7 +680,7 @@ Status EngineCloneTask::_clone_incremental_data(Tablet* tablet, const TabletMeta
     }
 
     // clone_data to tablet
-    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->tablet_meta_mem_tracker(),
+    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->metadata_mem_tracker(),
                                            rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to incremental clone. [tablet=" << tablet->full_name() << " status=" << st << "]";
     return st;
@@ -761,7 +761,7 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
     // 2. local tablet has error in push
     // 3. local tablet cloned rowset from other nodes
     // 4. if cleared alter task info, then push will not write to new tablet, the report info is error
-    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->tablet_meta_mem_tracker(),
+    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->metadata_mem_tracker(),
                                            rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to full clone. tablet=" << tablet->full_name() << ", res=" << st;
     // in previous step, copy all files from CLONE_DIR to tablet dir

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -203,7 +203,7 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("process_mem_bytes", &_memory_metrics->process_mem_bytes);
     registry->register_metric("query_mem_bytes", &_memory_metrics->query_mem_bytes);
     registry->register_metric("load_mem_bytes", &_memory_metrics->load_mem_bytes);
-    registry->register_metric("tablet_meta_mem_bytes", &_memory_metrics->tablet_meta_mem_bytes);
+    registry->register_metric("tablet_meta_mem_bytes", &_memory_metrics->metadata_mem_bytes);
     registry->register_metric("compaction_mem_bytes", &_memory_metrics->compaction_mem_bytes);
     registry->register_metric("schema_change_mem_bytes", &_memory_metrics->schema_change_mem_bytes);
     registry->register_metric("column_pool_mem_bytes", &_memory_metrics->column_pool_mem_bytes);
@@ -266,9 +266,8 @@ void SystemMetrics::_update_memory_metrics() {
     if (ExecEnv::GetInstance()->load_mem_tracker() != nullptr) {
         _memory_metrics->load_mem_bytes.set_value(ExecEnv::GetInstance()->load_mem_tracker()->consumption());
     }
-    if (ExecEnv::GetInstance()->tablet_meta_mem_tracker() != nullptr) {
-        _memory_metrics->tablet_meta_mem_bytes.set_value(
-                ExecEnv::GetInstance()->tablet_meta_mem_tracker()->consumption());
+    if (ExecEnv::GetInstance()->metadata_mem_tracker() != nullptr) {
+        _memory_metrics->metadata_mem_bytes.set_value(ExecEnv::GetInstance()->metadata_mem_tracker()->consumption());
     }
     if (ExecEnv::GetInstance()->compaction_mem_tracker() != nullptr) {
         _memory_metrics->compaction_mem_bytes.set_value(

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -49,7 +49,7 @@ public:
     // Load memory usage
     METRIC_DEFINE_INT_GAUGE(load_mem_bytes, MetricUnit::BYTES);
     // Tablet meta memory usage
-    METRIC_DEFINE_INT_GAUGE(tablet_meta_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(metadata_mem_bytes, MetricUnit::BYTES);
     // Compaction memory usage
     METRIC_DEFINE_INT_GAUGE(compaction_mem_bytes, MetricUnit::BYTES);
     // SchemaChange memory usage

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -179,7 +179,7 @@ public:
         }
 
         TabletSharedPtr tablet =
-                Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta,
+                Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta,
                                                 starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
         tablet->init();
         tablet->calculate_cumulative_point();
@@ -212,10 +212,10 @@ public:
         _schema_hash_path = fmt::format("{}/data/0/12345/1111", config::storage_root_path);
         ASSERT_OK(fs::create_directories(_schema_hash_path));
 
-        _mem_pool.reset(new MemPool());
+        _mem_pool = std::make_unique<MemPool>();
 
-        _compaction_mem_tracker.reset(new MemTracker(-1));
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
     }
 
     void TearDown() override {
@@ -230,12 +230,12 @@ protected:
     std::string _schema_hash_path;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
 };
 
 TEST_F(BaseCompactionTest, test_init_succeeded) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
 }
@@ -247,7 +247,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_LE_1) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet_meta->set_tablet_schema(schema);
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
     tablet->init();
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
@@ -296,7 +296,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_EQ_2) {
         tablet_meta->add_rs_meta(src_rowset->rowset_meta());
     }
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
     tablet->init();
     tablet->calculate_cumulative_point();
 

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -158,7 +158,7 @@ public:
         }
 
         TabletSharedPtr tablet =
-                Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta,
+                Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta,
                                                 starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
         tablet->init();
 
@@ -182,7 +182,7 @@ public:
 
         starrocks::EngineOptions options;
         options.store_paths = paths;
-        options.tablet_meta_mem_tracker = _tablet_meta_mem_tracker.get();
+        options.metadata_mem_tracker = _metadata_mem_tracker.get();
         options.compaction_mem_tracker = _compaction_mem_tracker.get();
         if (k_engine == nullptr) {
             Status s = starrocks::StorageEngine::open(options, &k_engine);
@@ -195,10 +195,10 @@ public:
         _schema_hash_path = fmt::format("{}/data/0/12345/1111", config::storage_root_path);
         ASSERT_OK(fs::create_directories(_schema_hash_path));
 
-        _tablet_meta_mem_tracker.reset(new MemTracker(-1));
-        _mem_pool.reset(new MemPool());
+        _metadata_mem_tracker = std::make_unique<MemTracker>(-1);
+        _mem_pool = std::make_unique<MemPool>();
 
-        _compaction_mem_tracker.reset(new MemTracker(-1));
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
     }
 
     void TearDown() override {
@@ -211,14 +211,14 @@ protected:
     std::unique_ptr<TabletSchema> _tablet_schema;
     RowsetTypePB _rowset_type = BETA_ROWSET;
     std::string _schema_hash_path;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
 };
 
 TEST_F(CumulativeCompactionTest, test_init_succeeded) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
     CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(cumulative_compaction.compact().ok());
 }
@@ -231,7 +231,7 @@ TEST_F(CumulativeCompactionTest, test_candidate_rowsets_empty) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet_meta->set_tablet_schema(schema);
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_tablet_meta_mem_tracker.get(), tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(_metadata_mem_tracker.get(), tablet_meta, nullptr);
     tablet->init();
     CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(cumulative_compaction.compact().ok());

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -42,7 +42,7 @@ using google::protobuf::RepeatedPtrField;
 namespace starrocks {
 
 static StorageEngine* k_engine = nullptr;
-static MemTracker* k_tablet_meta_mem_tracker = nullptr;
+static MemTracker* k_metadata_mem_tracker = nullptr;
 static MemTracker* k_schema_change_mem_tracker = nullptr;
 
 void set_up() {
@@ -59,11 +59,11 @@ void set_up() {
     config::txn_shard_size = 1;
     config::storage_format_version = 2;
 
-    k_tablet_meta_mem_tracker = new MemTracker();
+    k_metadata_mem_tracker = new MemTracker();
     k_schema_change_mem_tracker = new MemTracker();
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.tablet_meta_mem_tracker = k_tablet_meta_mem_tracker;
+    options.metadata_mem_tracker = k_metadata_mem_tracker;
     options.schema_change_mem_tracker = k_schema_change_mem_tracker;
     Status s = starrocks::StorageEngine::open(options, &k_engine);
     ASSERT_TRUE(s.ok()) << s.to_string();
@@ -73,9 +73,9 @@ void tear_down() {
     config::storage_root_path = std::filesystem::current_path().string() + "/data_test";
     fs::remove_all(config::storage_root_path);
     fs::remove_all(string(getenv("STARROCKS_HOME")) + UNUSED_PREFIX);
-    k_tablet_meta_mem_tracker->release(k_tablet_meta_mem_tracker->consumption());
+    k_metadata_mem_tracker->release(k_metadata_mem_tracker->consumption());
     k_schema_change_mem_tracker->release(k_schema_change_mem_tracker->consumption());
-    delete k_tablet_meta_mem_tracker;
+    delete k_metadata_mem_tracker;
     delete k_schema_change_mem_tracker;
 }
 

--- a/be/test/storage/rowset/beta_rowset_test.cpp
+++ b/be/test/storage/rowset/beta_rowset_test.cpp
@@ -61,7 +61,7 @@ protected:
     OlapReaderStatistics _stats;
 
     void SetUp() override {
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
         _schema_change_mem_tracker = std::make_unique<MemTracker>();
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
         config::tablet_map_shard_size = 1;
@@ -79,7 +79,7 @@ protected:
 
         starrocks::EngineOptions options;
         options.store_paths = paths;
-        options.tablet_meta_mem_tracker = _tablet_meta_mem_tracker.get();
+        options.metadata_mem_tracker = _metadata_mem_tracker.get();
         options.schema_change_mem_tracker = _schema_change_mem_tracker.get();
         Status s = starrocks::StorageEngine::open(options, &k_engine);
         ASSERT_TRUE(s.ok()) << s.to_string();
@@ -227,7 +227,7 @@ protected:
     }
 
 private:
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
     std::unique_ptr<MemTracker> _schema_change_mem_tracker = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
 };
@@ -294,7 +294,7 @@ TEST_F(BetaRowsetTest, FinalMergeTest) {
     std::string segment_file =
             BetaRowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), seg_options.fs, segment_file, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), seg_options.fs, segment_file, 0, tablet_schema.get());
     ASSERT_NE(segment->num_rows(), 0);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
@@ -394,7 +394,7 @@ TEST_F(BetaRowsetTest, FinalMergeVerticalTest) {
     std::string segment_file =
             BetaRowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
     auto segment =
-            *Segment::open(_tablet_meta_mem_tracker.get(), seg_options.fs, segment_file, 0, &tablet->tablet_schema());
+            *Segment::open(_metadata_mem_tracker.get(), seg_options.fs, segment_file, 0, &tablet->tablet_schema());
     ASSERT_NE(segment->num_rows(), 0);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -60,7 +60,7 @@ static const std::string TEST_DIR = "/column_reader_writer_test";
 class ColumnReaderWriterTest : public testing::Test {
 public:
     ColumnReaderWriterTest() {
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
 
         TabletSchemaPB schema_pb;
         auto* c0 = schema_pb.add_column();
@@ -77,7 +77,7 @@ public:
         c2->set_name("v2");
         c2->set_type("INT");
 
-        _dummy_segment_schema = TabletSchema::create(_tablet_meta_mem_tracker.get(), schema_pb);
+        _dummy_segment_schema = TabletSchema::create(_metadata_mem_tracker.get(), schema_pb);
     }
 
     ~ColumnReaderWriterTest() override = default;
@@ -89,7 +89,7 @@ protected:
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
         return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema.get(),
-                                         _tablet_meta_mem_tracker.get());
+                                         _metadata_mem_tracker.get());
     }
 
     template <FieldType type, EncodingTypePB encoding, uint32_t version, bool adaptive = true>
@@ -557,7 +557,7 @@ protected:
     }
 
     MemPool _pool;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
     std::shared_ptr<TabletSchema> _dummy_segment_schema;
 };
 

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -26,7 +26,7 @@ public:
         _fs = std::make_shared<MemoryFileSystem>();
         ASSERT_TRUE(_fs->create_dir(kSegmentDir).ok());
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -35,7 +35,7 @@ public:
     const std::string kSegmentDir = "/segment_test";
     std::shared_ptr<MemoryFileSystem> _fs = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
 };
 
 // NOLINTNEXTLINE
@@ -51,7 +51,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
 
     std::vector<Slice> data_strs;
     for (const auto& data : values) {
-        data_strs.push_back(data);
+        data_strs.emplace_back(data);
     }
 
     ColumnPB c1 = create_int_key_pb(1);
@@ -113,7 +113,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     }
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -242,7 +242,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     }
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -41,7 +41,7 @@ protected:
         ASSERT_OK(_fs->create_dir_recursive(kSegmentDir));
 
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -54,7 +54,7 @@ protected:
 
     std::shared_ptr<FileSystem> _fs;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
 };
 
 TEST_F(SegmentRewriterTest, rewrite_test) {
@@ -98,8 +98,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     partial_rowset_footer.set_position(footer_position);
     partial_rowset_footer.set_size(file_size - footer_position);
 
-    auto partial_segment =
-            *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, partial_tablet_schema.get());
+    auto partial_segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, partial_tablet_schema.get());
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
     std::unique_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
@@ -122,7 +121,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, *tablet_schema, read_column_ids, write_columns,
                                        partial_segment->id(), partial_rowset_footer));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, dst_file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, dst_file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -174,7 +173,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     }
     ASSERT_OK(SegmentRewriter::rewrite(file_name, *tablet_schema, read_column_ids, new_write_columns,
                                        partial_segment->id(), partial_rowset_footer));
-    auto rewrite_segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto rewrite_segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
 
     ASSERT_EQ(rewrite_segment->num_rows(), num_rows);
     res = rewrite_segment->new_iterator(schema, seg_options);

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -29,7 +29,6 @@
 #include "column/datum_tuple.h"
 #include "common/logging.h"
 #include "fs/fs_memory.h"
-#include "fs/fs_util.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
@@ -66,7 +65,7 @@ protected:
         _fs = std::make_shared<MemoryFileSystem>();
         ASSERT_TRUE(_fs->create_dir(kSegmentDir).ok());
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -96,7 +95,7 @@ protected:
         uint64_t file_size, index_size, footer_position;
         ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-        *res = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, filename, 0, &query_schema);
+        *res = *Segment::open(_metadata_mem_tracker.get(), _fs, filename, 0, &query_schema);
         ASSERT_EQ(nrows, (*res)->num_rows());
     }
 
@@ -104,7 +103,7 @@ protected:
 
     std::shared_ptr<MemoryFileSystem> _fs = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
 };
 
 TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
@@ -209,7 +208,7 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
     uint64_t footer_position;
     ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -320,7 +319,7 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
 
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -425,7 +424,7 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
     }
 
     ASSERT_OK(writer.finalize_footer(&file_size));
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _fs, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -6,13 +6,13 @@
 
 #include <functional>
 #include <iostream>
+#include <memory>
 
 #include "column/datum_tuple.h"
 #include "fs/fs_memory.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
-#include "storage/chunk_iterator.h"
 #include "storage/empty_iterator.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_factory.h"
@@ -30,8 +30,8 @@ namespace starrocks {
 class RowsetUpdateStateTest : public ::testing::Test {
 public:
     void SetUp() override {
-        _compaction_mem_tracker.reset(new MemTracker(-1));
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
     }
 
     void TearDown() override {
@@ -148,7 +148,7 @@ public:
 protected:
     TabletSharedPtr _tablet;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
 };
 
 static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <memory>
 #include <string>
 #include <thread>
 
@@ -291,8 +292,8 @@ public:
     }
 
     void SetUp() override {
-        _compaction_mem_tracker.reset(new MemTracker(-1));
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
     }
 
     void TearDown() override {
@@ -451,7 +452,7 @@ protected:
     TabletSharedPtr _tablet;
     TabletSharedPtr _tablet2;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
 };
 
 static TabletSharedPtr load_same_tablet_from_store(MemTracker* mem_tracker, const TabletSharedPtr& tablet) {
@@ -763,7 +764,7 @@ void TabletUpdatesTest::test_noncontinous_meta_save_load(bool enable_persistent_
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     _tablet->save_meta();
 
-    auto tablet1 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
 
     ASSERT_EQ(2, tablet1->updates()->num_pending());
     ASSERT_EQ(2, tablet1->updates()->max_version());
@@ -801,7 +802,7 @@ void TabletUpdatesTest::test_save_meta(bool enable_persistent_index) {
 
     _tablet->save_meta();
 
-    auto tablet1 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
     ASSERT_EQ(31, tablet1->updates()->version_history_count());
     ASSERT_EQ(31, tablet1->updates()->max_version());
 
@@ -878,7 +879,7 @@ void TabletUpdatesTest::test_remove_expired_versions(bool enable_persistent_inde
     EXPECT_EQ(-1, read_tablet(_tablet, 2));
     EXPECT_EQ(-1, read_tablet(_tablet, 1));
 
-    auto tablet1 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
     EXPECT_EQ(1, tablet1->updates()->version_history_count());
     EXPECT_EQ(4, tablet1->updates()->max_version());
     EXPECT_EQ(N, read_tablet(tablet1, 4));
@@ -925,7 +926,7 @@ void TabletUpdatesTest::test_apply(bool enable_persistent_index) {
 
     // Ensure the persistent meta is correct.
     auto max_version = rowsets.size() + 1;
-    auto tablet1 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
     // `enable_persistent_index` is not persistent in this case
     // so we reset the `enable_persistent_index` after load
     tablet1->set_enable_persistent_index(enable_persistent_index);
@@ -1009,7 +1010,7 @@ void TabletUpdatesTest::test_concurrent_write_read_and_gc(bool enable_persistent
     EXPECT_EQ(version.load(), _tablet->updates()->max_version());
 
     // Ensure the persistent meta is correct.
-    auto tablet1 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), _tablet);
+    auto tablet1 = load_same_tablet_from_store(_metadata_mem_tracker.get(), _tablet);
     EXPECT_EQ(1, tablet1->updates()->version_history_count());
     EXPECT_EQ(version.load(), tablet1->updates()->max_version());
     EXPECT_EQ(N, read_tablet(tablet1, version.load()));
@@ -1449,7 +1450,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental(bool enable_persistent_in
     ASSERT_EQ(6, tablet1->updates()->version_history_count());
     EXPECT_EQ(10, read_tablet(tablet1, 6));
 
-    auto tablet2 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
     ASSERT_EQ(6, tablet2->updates()->max_version());
     ASSERT_EQ(6, tablet2->updates()->version_history_count());
     EXPECT_EQ(10, read_tablet(tablet2, 6));
@@ -1523,7 +1524,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental_ignore_already_committed_
     ASSERT_EQ(6, tablet1->updates()->version_history_count());
     EXPECT_EQ(10, read_tablet(tablet1, 6));
 
-    auto tablet2 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
     ASSERT_EQ(6, tablet2->updates()->max_version());
     ASSERT_EQ(6, tablet2->updates()->version_history_count());
     EXPECT_EQ(10, read_tablet(tablet2, 6));
@@ -2055,7 +2056,7 @@ void TabletUpdatesTest::test_load_snapshot_full(bool enable_persistent_index) {
     EXPECT_EQ(keys0.size(), read_tablet(tablet1, tablet1->updates()->max_version()));
 
     // Ensure that the tablet state is valid after process restarted.
-    auto tablet2 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
     ASSERT_EQ(11, tablet2->updates()->max_version());
     ASSERT_EQ(1, tablet2->updates()->version_history_count());
     EXPECT_EQ(keys0.size(), read_tablet(tablet2, tablet2->updates()->max_version()));
@@ -2125,7 +2126,7 @@ void TabletUpdatesTest::test_load_snapshot_full_file_not_exist(bool enable_persi
     EXPECT_EQ(keys1.size(), read_tablet(tablet1, tablet1->updates()->max_version()));
 
     // Ensure that the persistent meta is still valid.
-    auto tablet2 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
     ASSERT_EQ(3, tablet2->updates()->max_version());
     ASSERT_EQ(3, tablet2->updates()->version_history_count());
     EXPECT_EQ(keys1.size(), read_tablet(tablet2, tablet2->updates()->max_version()));
@@ -2239,7 +2240,7 @@ void TabletUpdatesTest::test_issue_4193(bool enable_persistent_index) {
     EXPECT_EQ(keys0.size() + keys1.size(), read_tablet(tablet1, tablet1->updates()->max_version()));
 
     // Ensure that the tablet state is valid after process restarted.
-    auto tablet2 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
     ASSERT_EQ(13, tablet2->updates()->max_version());
     EXPECT_EQ(keys0.size() + keys1.size(), read_tablet(tablet2, tablet2->updates()->max_version()));
 }
@@ -2292,7 +2293,7 @@ void TabletUpdatesTest::test_issue_4181(bool enable_persistent_index) {
     EXPECT_EQ(keys0.size(), read_tablet(tablet1, tablet1->updates()->max_version()));
 
     // Ensure that the tablet state is valid after process restarted.
-    auto tablet2 = load_same_tablet_from_store(_tablet_meta_mem_tracker.get(), tablet1);
+    auto tablet2 = load_same_tablet_from_store(_metadata_mem_tracker.get(), tablet1);
     ASSERT_EQ(11, tablet2->updates()->max_version());
     EXPECT_EQ(keys0.size(), read_tablet(tablet2, tablet2->updates()->max_version()));
 }

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -347,14 +347,14 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
-    std::unique_ptr<starrocks::MemTracker> table_meta_mem_tracker = std::make_unique<starrocks::MemTracker>();
+    std::unique_ptr<starrocks::MemTracker> metadata_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> schema_change_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> compaction_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> update_mem_tracker = std::make_unique<starrocks::MemTracker>();
     starrocks::StorageEngine* engine = nullptr;
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.tablet_meta_mem_tracker = table_meta_mem_tracker.get();
+    options.metadata_mem_tracker = metadata_mem_tracker.get();
     options.schema_change_mem_tracker = schema_change_mem_tracker.get();
     options.compaction_mem_tracker = compaction_mem_tracker.get();
     options.update_mem_tracker = update_mem_tracker.get();

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -49,14 +49,14 @@ int main(int argc, char** argv) {
     std::vector<starrocks::StorePath> paths;
     paths.emplace_back(starrocks::config::storage_root_path);
 
-    std::unique_ptr<starrocks::MemTracker> table_meta_mem_tracker = std::make_unique<starrocks::MemTracker>();
+    std::unique_ptr<starrocks::MemTracker> metadata_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> schema_change_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> compaction_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> update_mem_tracker = std::make_unique<starrocks::MemTracker>();
     starrocks::StorageEngine* engine = nullptr;
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.tablet_meta_mem_tracker = table_meta_mem_tracker.get();
+    options.metadata_mem_tracker = metadata_mem_tracker.get();
     options.schema_change_mem_tracker = schema_change_mem_tracker.get();
     options.compaction_mem_tracker = compaction_mem_tracker.get();
     options.update_mem_tracker = update_mem_tracker.get();


### PR DESCRIPTION
In some user clusters, the metadata memory usage is too high, but our current metadata memory statistics are not detailed enough, which makes it difficult to troubleshoot the problem.

Therefore, more fine-grained statistical metadata memory is required. such as detail mem statistics for tablet(tablet_meta, tablet_schema, tablet_struct)/rowset(rowset_meta, rowset_struct)/segment/column/index

But tablet_meta_mem_bytes is ambiguous, so it is changed to metadata_mem_bytes. Currently, StarRocksManager has not collected these metrics, so there will be no compatibility issues. The pr is the first step, change tablet_meta_mem_tracker to metadata_mem_tracker