### PR TITLE
[BugFix] Fix absence of modulo function resolution in GroupByCountDistinctDataSkewEliminateRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctDataSkewEliminateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctDataSkewEliminateRule.java
@@ -85,8 +85,11 @@ public class GroupByCountDistinctDataSkewEliminateRule extends TransformationRul
         // for an example, when bucketNum=8; the remainder will be
         // -3, -2, -1, 0, 1, 2, 3, 4, NULL
         ConstantOperator bucketConstOp = new ConstantOperator(bucketNum / 2, Type.INT);
+        Function modFunc = Expr.getBuiltinFunction(FunctionSet.MOD,
+                new Type[] {callHashFuncOp.getType(), bucketConstOp.getType()},
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         CallOperator modBucketOp =
-                new CallOperator(FunctionSet.MOD, Type.INT, Arrays.asList(callHashFuncOp, bucketConstOp));
+                new CallOperator(FunctionSet.MOD, Type.INT, Arrays.asList(callHashFuncOp, bucketConstOp), modFunc);
         ScalarOperator op = new CastOperator(type, modBucketOp, true);
         ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
         return rewriter.rewrite(op, Collections.singletonList(new ReduceCastRule()));


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/starrocks/issues/19731
daily case https://github.com/StarRocks/StarRocksTest/pull/2035
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In GroupByCountDistinctDataSkewEliminateRule,  CallOperator(murmur_hash3_32(column)%bucketNum) missing Function signature, which caused low-cardinality optimization return "Unknown error".
![img_v2_117bb7cf-e7d2-44bd-99d5-e30e3bd2159g](https://user-images.githubusercontent.com/1721321/225908570-328c489d-8365-45b8-a712-15150714e397.jpg)
![img_v2_117bb7cf-e7d2-44bd-99d5-e30e3bd2159g](https://user-images.githubusercontent.com/1721321/225908615-67d46bf4-cca6-4a4b-af6b-357e14aca908.jpg)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
