### PR TITLE
[Enhancement] Reduce head object requests in lake tablet GC part 2/2

### DIFF
--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -96,49 +96,11 @@ struct RandomAccessFileOptions {
     bool skip_fill_local_cache = false;
 };
 
-class FileMeta {
-public:
-    // REQUIRE: size >= 0
-    FileMeta& with_size(int64_t size) {
-        _size = size;
-        return *this;
-    }
-
-    // REQUIRE: mtime > 0
-    FileMeta& with_modify_time(int64_t mtime) {
-        _mtime = mtime;
-        return *this;
-    }
-
-    FileMeta& with_is_dir(bool is_dir) {
-        _is_dir = is_dir;
-        return *this;
-    }
-
-    bool has_size() const { return _size >= 0; }
-
-    // REQUIRE: size >= 0
-    void set_size(int64_t size) { _size = size; }
-
-    int64_t size() const { return _size; }
-
-    bool has_modify_time() const { return _mtime > 0; }
-
-    // REQUIRE: mtime > 0
-    void set_modify_time(int64_t mtime) { _mtime = mtime; }
-
-    int64_t modify_time() const { return _mtime; }
-
-    bool has_is_dir() const { return _is_dir >= 0; }
-
-    void set_is_dir(bool is_dir) { _is_dir = is_dir; }
-
-    bool is_dir() const { return _is_dir > 0; }
-
-private:
-    int64_t _size = -1;
-    int64_t _mtime = -1;
-    int _is_dir = -1;
+struct DirEntry {
+    std::string_view name;
+    std::optional<int64_t> mtime;
+    std::optional<int64_t> size; // Undefined if "is_dir" is true
+    std::optional<bool> is_dir;
 };
 
 class FileSystem {
@@ -237,12 +199,7 @@ public:
 
     // `iterate_dir2` is similar to `iterate_dir` but in addition to returning the directory entry name, it
     // also returns some file statistics.
-    //
-    // For performance reason, some implementations may leave some fields in FileMeta unfilled, the caller
-    // should always check the value of `FileMeta::has_xxx()` before accessing the corresponding field of
-    // FileMeta.
-    virtual Status iterate_dir2(const std::string& dir,
-                                const std::function<bool(std::string_view, const FileMeta&)>& cb) = 0;
+    virtual Status iterate_dir2(const std::string& dir, const std::function<bool(DirEntry)>& cb) = 0;
 
     // Delete the named file.
     // FIXME: If the named file does not exist, OK or NOT_FOUND is returned, depend on the implementation.

--- a/be/src/fs/fs_broker.cpp
+++ b/be/src/fs/fs_broker.cpp
@@ -405,10 +405,8 @@ Status BrokerFileSystem::iterate_dir(const std::string& dir, const std::function
     return Status::OK();
 }
 
-Status BrokerFileSystem::iterate_dir2(const std::string& dir,
-                                      const std::function<bool(std::string_view, const FileMeta&)>& cb) {
-    FileMeta meta;
-    return iterate_dir(dir, [&](std::string_view name) { return cb(name, meta); });
+Status BrokerFileSystem::iterate_dir2(const std::string& dir, const std::function<bool(DirEntry)>& cb) {
+    return iterate_dir(dir, [&](std::string_view name) { return cb(DirEntry{.name = name}); });
 }
 
 Status BrokerFileSystem::delete_file(const std::string& path) {

--- a/be/src/fs/fs_broker.h
+++ b/be/src/fs/fs_broker.h
@@ -56,8 +56,7 @@ public:
 
     Status iterate_dir(const std::string& dir, const std::function<bool(std::string_view)>& cb) override;
 
-    Status iterate_dir2(const std::string& dir,
-                        const std::function<bool(std::string_view, const FileMeta&)>& cb) override;
+    Status iterate_dir2(const std::string& dir, const std::function<bool(DirEntry)>& cb) override;
 
     Status delete_file(const std::string& path) override;
 

--- a/be/src/fs/fs_memory.h
+++ b/be/src/fs/fs_memory.h
@@ -53,8 +53,7 @@ public:
 
     Status iterate_dir(const std::string& dir, const std::function<bool(std::string_view)>& cb) override;
 
-    Status iterate_dir2(const std::string& dir,
-                        const std::function<bool(std::string_view, const FileMeta&)>& cb) override;
+    Status iterate_dir2(const std::string& dir, const std::function<bool(DirEntry)>& cb) override;
 
     Status delete_file(const std::string& url) override;
 

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -301,9 +301,7 @@ public:
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
         }
-        auto st = (*fs_st)->list_dir(pair.first, false, [&](EntryStat stat) {
-            return cb(stat.name);
-        });
+        auto st = (*fs_st)->list_dir(pair.first, false, [&](EntryStat stat) { return cb(stat.name); });
         return to_status(st);
     }
 

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -60,6 +60,7 @@ using FileSystemPtr = std::unique_ptr<staros::starlet::fslib::FileSystem>;
 using ReadOnlyFilePtr = std::unique_ptr<staros::starlet::fslib::ReadOnlyFile>;
 using WritableFilePtr = std::unique_ptr<staros::starlet::fslib::WritableFile>;
 using Anchor = staros::starlet::fslib::Stream::Anchor;
+using EntryStat = staros::starlet::fslib::EntryStat;
 
 bool is_starlet_uri(std::string_view uri) {
     return HasPrefixString(uri, "staros://");
@@ -300,7 +301,9 @@ public:
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
         }
-        auto st = (*fs_st)->list_dir(pair.first, false, cb);
+        auto st = (*fs_st)->list_dir(pair.first, false, [&](EntryStat stat) {
+            return cb(stat.name);
+        });
         return to_status(st);
     }
 
@@ -310,8 +313,7 @@ public:
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
         }
-        using StarletDirEntry = staros::starlet::fslib::DirEntry;
-        auto st = (*fs_st)->list_dir(pair.first, false, [&](StarletDirEntry e) {
+        auto st = (*fs_st)->list_dir(pair.first, false, [&](EntryStat e) {
             DirEntry entry{.name = e.name,
                            .mtime = std::move(e.mtime),
                            .size = std::move(e.size),
@@ -357,7 +359,7 @@ public:
         }
         // TODO: leave this check to starlet.
         bool dir_empty = true;
-        auto cb = [&dir_empty](std::string_view file) {
+        auto cb = [&dir_empty](EntryStat stat) {
             dir_empty = false;
             // break the iteration
             return false;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -803,27 +803,27 @@ Status SnapshotLoader::_get_existing_files_from_remote_without_broker(const std:
                                                                       std::map<std::string, FileStat>* files) {
     int64_t file_num = 0;
     Status st;
-    st.update(fs->iterate_dir2(remote_path, [&](std::string_view name, const FileMeta& meta) {
-        if (UNLIKELY(!meta.has_is_dir())) {
+    st.update(fs->iterate_dir2(remote_path, [&](DirEntry entry) {
+        if (UNLIKELY(!entry.is_dir.has_value())) {
             st.update(Status::InternalError("Unable to recognize the file type"));
             return false;
         }
         file_num++;
-        if (meta.is_dir()) {
+        if (!entry.is_dir.value()) {
             return true;
         }
-        if (UNLIKELY(!meta.has_size())) {
+        if (UNLIKELY(!entry.size.has_value())) {
             st.update(Status::InternalError("Unable to get file size"));
             return false;
         }
-        size_t pos = name.find_last_of('.');
-        if (pos == std::string::npos || pos == name.size() - 1) {
+        size_t pos = entry.name.find_last_of('.');
+        if (pos == std::string::npos || pos == entry.name.size() - 1) {
             // Not found checksum separator, ignore this file
             return true;
         }
-        std::string name_part(name.data(), name.data() + pos);
-        std::string md5_part(name.data() + pos + 1, name.data() + name.size());
-        FileStat stat = {name_part, md5_part, meta.size()};
+        std::string name_part(entry.name.data(), entry.name.data() + pos);
+        std::string md5_part(entry.name.data() + pos + 1, entry.name.data() + entry.name.size());
+        FileStat stat = {.name = name_part, .md5 = md5_part, .size = entry.size.value()};
         files->emplace(name_part, stat);
         VLOG(2) << "split remote file: " << name_part << ", checksum: " << md5_part;
         return true;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -809,7 +809,7 @@ Status SnapshotLoader::_get_existing_files_from_remote_without_broker(const std:
             return false;
         }
         file_num++;
-        if (!entry.is_dir.value()) {
+        if (entry.is_dir.value()) {
             return true;
         }
         if (UNLIKELY(!entry.size.has_value())) {

--- a/be/test/fs/fs_memory_test.cpp
+++ b/be/test/fs/fs_memory_test.cpp
@@ -462,18 +462,19 @@ TEST_F(MemoryFileSystemTest, test_iterate_dir2) {
     ASSERT_OK(f->append("test"));
     ASSERT_OK(f->close());
 
-    ASSERT_OK(_fs->iterate_dir2("/home", [](std::string_view name, const FileMeta& meta) -> bool {
+    ASSERT_OK(_fs->iterate_dir2("/home", [](DirEntry entry) -> bool {
+        auto name = entry.name;
         if (name == "code") {
-            CHECK(meta.has_is_dir());
-            CHECK(meta.is_dir());
-            CHECK(!meta.has_modify_time());
-            CHECK(!meta.has_size());
+            CHECK(entry.is_dir.has_value());
+            CHECK(entry.is_dir.value());
+            CHECK(!entry.mtime.has_value());
+            CHECK(!entry.size.has_value());
         } else if (name == "gcc") {
-            CHECK(meta.has_is_dir());
-            CHECK(!meta.is_dir());
-            CHECK(!meta.has_modify_time());
-            CHECK(meta.has_size());
-            CHECK_EQ(4, meta.size());
+            CHECK(entry.is_dir.has_value());
+            CHECK(!entry.is_dir.value());
+            CHECK(!entry.mtime.has_value());
+            CHECK(entry.size.has_value());
+            CHECK_EQ(4, entry.size.value());
         } else {
             CHECK(false) << "Unexpected file " << name;
         }

--- a/be/test/fs/fs_posix_test.cpp
+++ b/be/test/fs/fs_posix_test.cpp
@@ -207,19 +207,20 @@ TEST_F(PosixFileSystemTest, iterate_dir2) {
     ASSERT_OK(f->append("test"));
     ASSERT_OK(f->close());
 
-    ASSERT_OK(fs->iterate_dir2("./ut_dir/fs_posix/", [&](std::string_view name, const FileMeta& meta) -> bool {
+    ASSERT_OK(fs->iterate_dir2("./ut_dir/fs_posix/", [&](DirEntry entry) -> bool {
+        auto name = entry.name;
         if (name == "iterate_dir2.d") {
-            CHECK(meta.has_is_dir());
-            CHECK(meta.is_dir());
-            CHECK(meta.has_modify_time());
-            CHECK_GE(meta.modify_time(), now);
+            CHECK(entry.is_dir.has_value());
+            CHECK(entry.is_dir.value());
+            CHECK(entry.mtime.has_value());
+            CHECK_GE(entry.mtime.value(), now);
         } else if (name == "iterate_dir2") {
-            CHECK(meta.has_is_dir());
-            CHECK(!meta.is_dir());
-            CHECK(meta.has_size());
-            CHECK_EQ(4, meta.size());
-            CHECK(meta.has_modify_time());
-            CHECK_GE(meta.modify_time(), now);
+            CHECK(entry.is_dir.has_value());
+            CHECK(!entry.is_dir.value());
+            CHECK(entry.size.has_value());
+            CHECK_EQ(4, entry.size.value());
+            CHECK(entry.mtime.has_value());
+            CHECK_GE(entry.mtime.value(), now);
         } else {
             CHECK(false) << "Unexpected file " << name;
         }

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -184,26 +184,27 @@ TEST_F(S3FileSystemTest, test_directory) {
     EXPECT_OK(fs->create_dir(S3Path("/dirname2/subdir0")));
     CheckIsDirectory(fs.get(), S3Path("/dirname2/subdir0"), true, true);
 
-    EXPECT_OK(fs->iterate_dir2(S3Path("/dirname2/"), [&](std::string_view name, const FileMeta& meta) {
+    EXPECT_OK(fs->iterate_dir2(S3Path("/dirname2/"), [&](DirEntry entry) {
+        auto name = entry.name;
         if (name == "0.dat") {
-            CHECK(meta.has_is_dir());
-            CHECK(!meta.is_dir());
-            CHECK(meta.has_size());
-            CHECK_EQ(/* length of "hello" = */ 5, meta.size());
-            CHECK(meta.has_modify_time());
-            CHECK_GE(meta.modify_time(), now);
+            CHECK(entry.is_dir.has_value());
+            CHECK(!entry.is_dir.value());
+            CHECK(entry.size.has_value());
+            CHECK_EQ(/* length of "hello" = */ 5, entry.size.value());
+            CHECK(entry.mtime.has_value());
+            CHECK_GE(entry.mtime.value(), now);
         } else if (name == "1.dat") {
-            CHECK(meta.has_is_dir());
-            CHECK(!meta.is_dir());
-            CHECK(meta.has_size());
-            CHECK_EQ(/* length of "starrocks" = */ 9, meta.size());
-            CHECK(meta.has_modify_time());
-            CHECK_GE(meta.modify_time(), now);
+            CHECK(entry.is_dir.has_value());
+            CHECK(!entry.is_dir.value());
+            CHECK(entry.size.has_value());
+            CHECK_EQ(/* length of "starrocks" = */ 9, entry.size.value());
+            CHECK(entry.mtime.has_value());
+            CHECK_GE(entry.mtime.value(), now);
         } else if (name == "subdir0") {
-            CHECK(meta.has_is_dir());
-            CHECK(meta.is_dir());
-            CHECK(!meta.has_size());
-            CHECK(!meta.has_modify_time());
+            CHECK(entry.is_dir.has_value());
+            CHECK(entry.is_dir.value());
+            CHECK(!entry.size.has_value());
+            CHECK(!entry.mtime.has_value());
         } else {
             CHECK(false) << "Unexpected file " << name;
         }


### PR DESCRIPTION
This is the last one of the PR stack to reduce head object requests in lake tablet GC:
- Support iterate_dir2() in StarletFileSystem, which may reduce the head object requests in lake tablet GC
- Refactor: update FileSystem::iterate_dir2() interface signature

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
