### PR TITLE
[Refactor] fix peek semantic in `SharedBufferedInputStream` and `CacheInputStream`

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -140,6 +140,9 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
     Slice read_data;
     auto ret = _page_reader->peek(read_size);
     if (ret.ok()) {
+        // peek dos not advance offset.
+        int64_t pos = _page_reader->get_offset();
+        _page_reader->seek_to_offset(pos + read_size);
         read_data = Slice(ret.value().data(), read_size);
     } else {
         read_buffer.reserve(read_size);

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -140,9 +140,9 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
     Slice read_data;
     auto ret = _page_reader->peek(read_size);
     if (ret.ok()) {
+        DCHECK_EQ(ret.value().size, read_size);
         // peek dos not advance offset.
-        int64_t pos = _page_reader->get_offset();
-        _page_reader->seek_to_offset(pos + read_size);
+        _page_reader->skip_bytes(read_size);
         read_data = Slice(ret.value().data(), read_size);
     } else {
         read_buffer.reserve(read_size);

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -139,8 +139,7 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
     // check if we can zero copy read.
     Slice read_data;
     auto ret = _page_reader->peek(read_size);
-    if (ret.ok()) {
-        DCHECK_EQ(ret.value().size, read_size);
+    if (ret.ok() && ret.value().size() == read_size) {
         // peek dos not advance offset.
         _page_reader->skip_bytes(read_size);
         read_data = Slice(ret.value().data(), read_size);

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -78,6 +78,7 @@ Status PageReader::skip_bytes(size_t size) {
         return Status::InternalError("Size to skip exceed page size");
     }
     _offset += size;
+    _stream->skip(size);
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -87,8 +87,6 @@ StatusOr<std::string_view> PageReader::peek(size_t size) {
     }
     _stream->seek(_offset);
     ASSIGN_OR_RETURN(auto ret, _stream->peek(size));
-    // advance `offset` only when succeed.
-    _offset += size;
     return ret;
 }
 

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -48,6 +48,7 @@ public:
     void seek_to_offset(uint64_t offset) {
         _offset = offset;
         _next_header_pos = offset;
+        _stream->seek(offset);
     }
 
     uint64_t get_offset() const { return _offset; }

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -169,7 +169,6 @@ StatusOr<std::string_view> CacheInputStream::peek(int64_t count) {
     if (_enable_populate_cache) {
         _populate_cache_from_zero_copy_buffer(s.data(), _offset, count);
     }
-    _offset += count;
     return s;
 }
 

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -56,6 +56,11 @@ public:
 
     StatusOr<std::string_view> peek(int64_t count) override;
 
+    Status skip(int64_t count) override {
+        _offset += count;
+        return _stream->skip(count);
+    }
+
 private:
     void _populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count);
 

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -177,7 +177,6 @@ StatusOr<std::string_view> SharedBufferedInputStream::peek(int64_t count) {
     const uint8_t* buf = nullptr;
     size_t nbytes = count;
     RETURN_IF_ERROR(get_bytes(&buf, _offset, &nbytes));
-    _offset += count;
     return std::string_view((const char*)buf, count);
 }
 

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -41,7 +41,7 @@ public:
 
     Status seek(int64_t position) override {
         _offset = position;
-        return Status::OK();
+        return _stream->seek(position);
     }
     StatusOr<int64_t> position() override { return _offset; }
     StatusOr<int64_t> read(void* data, int64_t count) override;
@@ -49,7 +49,7 @@ public:
     StatusOr<int64_t> get_size() override;
     Status skip(int64_t count) override {
         _offset += count;
-        return Status::OK();
+        return _stream->skip(count);
     }
 
     Status set_io_ranges(const std::vector<IORange>& ranges);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`peek` interface is not supposed to advance read offset.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
