### PR TITLE
[BugFix] Fix spill compilation error

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -21,6 +21,7 @@
 #include "exec/pipeline/query_context.h"
 #include "exec/sorting/sorting.h"
 #include "exec/spill/spiller.h"
+#include "exec/spill/spiller.hpp"
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
I encountered compilation errors in my environment caused by link error.
```
ld: error: undefined symbol: starrocks::Status starrocks::spill::Spiller::trigger_restore<starrocks::spill::IOTaskExecutor&, starrocks::spill::MemTrackerGuard const&>(starrocks::RuntimeState*, starrocks::spill::IOTaskExecutor&, starrocks::spill::MemTrackerGuard const&)
>>> referenced by spiller.h:156 (/home/disk2/code/starrocks/be/src/exec/spill/spiller.h:156)
>>>               spillable_aggregate_blocking_sink_operator.cpp.o:(std::_Function_handler<starrocks::Status (), starrocks::Status starrocks::spill::Spiller::set_flush_all_call_back<starrocks::spill::IOTaskExecutor&, starrocks::spill::MemTrackerGuard>(std::function<starrocks::Status ()>, starrocks::RuntimeState*, starrocks::spill::IOTaskExecutor&, starrocks::spill::MemTrackerGuard)::'lambda'()>::_M_invoke(std::_Any_data const&)) in archive ../output/tmp/RELEASE/libExec.a
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
