### PR TITLE
[BugFix] CastStringToArray returns const column when input column is constant

### DIFF
--- a/be/src/exprs/cast_expr_array.cpp
+++ b/be/src/exprs/cast_expr_array.cpp
@@ -205,6 +205,10 @@ StatusOr<ColumnPtr> CastStringToArray::evaluate_checked(ExprContext* context, Ch
     if (column->is_nullable() || has_null) {
         res = NullableColumn::create(res, null_column);
     }
+    // Wrap constant column if source column is constant.
+    if (column->is_constant()) {
+        res = ConstColumn::create(res, column->size());
+    }
 
     return res;
 }

--- a/be/src/exprs/cast_expr_array.cpp
+++ b/be/src/exprs/cast_expr_array.cpp
@@ -285,6 +285,10 @@ StatusOr<ColumnPtr> CastJsonToArray::evaluate_checked(ExprContext* context, Chun
         res = NullableColumn::create(res, null_column);
     }
 
+    // Wrap constant column if source column is constant.
+    if (column->is_constant()) {
+        res = ConstColumn::create(res, column->size());
+    }
     return res;
 }
 

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -1971,7 +1971,7 @@ TEST_F(VectorizedCastExprTest, string_to_array) {
 }
 
 // Test string to array with const input
-TEST_F(VectorizedCastExprTest, const_string_to_array) {
+TEST_F(VectorizedCastExprTest, string_to_array_with_const_input) {
     TExprNode cast_expr;
     cast_expr.opcode = TExprOpcode::CAST;
     cast_expr.node_type = TExprNodeType::CAST_EXPR;
@@ -1991,8 +1991,20 @@ TEST_F(VectorizedCastExprTest, const_string_to_array) {
     result = cast_string_to_array_ptr(cast_expr, TYPE_VARCHAR, src);
     DCHECK(result->is_constant());
     DCHECK_EQ(result->size(), 2);
-    const auto v = ColumnHelper::as_column<ConstColumn>(result);
     EXPECT_EQ("CONST: ['a','b']", result->debug_item(0));
+
+    // const string: multi-dims
+    src = ColumnHelper::create_const_column<TYPE_VARCHAR>(R"([[[4]],[[1, 2]]])", 2);
+    result = cast_string_to_array_ptr(cast_expr, TYPE_VARCHAR, src);
+    DCHECK(result->is_constant());
+    DCHECK_EQ(result->size(), 2);
+    EXPECT_EQ("CONST: ['[[4]]','[[1, 2]]']", result->debug_item(0));
+
+    src = ColumnHelper::create_const_column<TYPE_VARCHAR>(R"([[1, 2, 3], [1, 2, 3]])", 2);
+    result = cast_string_to_array_ptr(cast_expr, TYPE_VARCHAR, src);
+    DCHECK(result->is_constant());
+    DCHECK_EQ(result->size(), 2);
+    EXPECT_EQ("CONST: ['[1, 2, 3]','[1, 2, 3]']", result->debug_item(0));
 }
 
 void array_delimeter_split(const Slice& src, std::vector<Slice>& res, std::vector<char>& stack);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
- Fix bugs when CastStringToArray's input is constant column: #19794


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
