### PR TITLE
[BugFix] fix rowset leak when cumulative compaction single rowset (backport #19665)

### DIFF
--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -335,10 +335,14 @@ Status Compaction::modify_rowsets() {
         return Status::InternalError("Process is going to quit. The compaction will stop.");
     }
 
+    std::vector<RowsetSharedPtr> to_replace;
     std::unique_lock wrlock(_tablet->get_header_lock());
-    _tablet->modify_rowsets({_output_rowset}, _input_rowsets);
+    _tablet->modify_rowsets({_output_rowset}, _input_rowsets, &to_replace);
     _tablet->save_meta();
     Rowset::close_rowsets(_input_rowsets);
+    for (auto& rs : to_replace) {
+        StorageEngine::instance()->add_unused_rowset(rs);
+    }
 
     return Status::OK();
 }

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -152,4 +152,25 @@ void CompactionTask::_failure_callback() {
     LOG(WARNING) << "compaction task:" << _task_info.task_id << ", tablet:" << _task_info.tablet_id << " failed.";
 }
 
+void CompactionTask::_commit_compaction() {
+    std::unique_lock wrlock(_tablet->get_header_lock());
+    std::stringstream input_stream_info;
+    for (int i = 0; i < 5 && i < _input_rowsets.size(); ++i) {
+        input_stream_info << _input_rowsets[i]->version() << ";";
+    }
+    if (_input_rowsets.size() > 5) {
+        input_stream_info << ".." << (*_input_rowsets.rbegin())->version();
+    }
+    std::vector<RowsetSharedPtr> to_replace;
+    _tablet->modify_rowsets({_output_rowset}, _input_rowsets, &to_replace);
+    _tablet->save_meta();
+    Rowset::close_rowsets(_input_rowsets);
+    for (auto& rs : to_replace) {
+        StorageEngine::instance()->add_unused_rowset(rs);
+    }
+    LOG(INFO) << "commit compaction. output version:" << _task_info.output_version
+              << ", output rowset version:" << _output_rowset->version()
+              << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size();
+}
+
 } // namespace starrocks

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -240,22 +240,7 @@ protected:
         return Status::OK();
     }
 
-    void _commit_compaction() {
-        std::unique_lock wrlock(_tablet->get_header_lock());
-        std::stringstream input_stream_info;
-        for (int i = 0; i < 5 && i < _input_rowsets.size(); ++i) {
-            input_stream_info << _input_rowsets[i]->version() << ";";
-        }
-        if (_input_rowsets.size() > 5) {
-            input_stream_info << ".." << (*_input_rowsets.rbegin())->version();
-        }
-        _tablet->modify_rowsets({_output_rowset}, _input_rowsets);
-        _tablet->save_meta();
-        Rowset::close_rowsets(_input_rowsets);
-        LOG(INFO) << "commit compaction. output version:" << _task_info.output_version
-                  << ", output rowset version:" << _output_rowset->version()
-                  << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size();
-    }
+    void _commit_compaction();
 
     void _success_callback();
 

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1383,7 +1383,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
         }
         VLOG(3) << "rowsets_to_delete size is:" << rowsets_to_delete.size()
                 << " version is:" << max_rowset->end_version();
-        new_tablet->modify_rowsets(std::vector<RowsetSharedPtr>(), rowsets_to_delete);
+        new_tablet->modify_rowsets(std::vector<RowsetSharedPtr>(), rowsets_to_delete, nullptr);
         new_tablet->set_cumulative_layer_point(-1);
         new_tablet->save_meta();
         for (auto& rowset : rowsets_to_delete) {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -239,7 +239,7 @@ Status Tablet::add_rowset(const RowsetSharedPtr& rowset, bool need_persist) {
             rowsets_to_delete.push_back(it.second);
         }
     }
-    modify_rowsets(std::vector<RowsetSharedPtr>(), rowsets_to_delete);
+    modify_rowsets(std::vector<RowsetSharedPtr>(), rowsets_to_delete, nullptr);
 
     if (need_persist) {
         Status res =
@@ -250,7 +250,8 @@ Status Tablet::add_rowset(const RowsetSharedPtr& rowset, bool need_persist) {
     return Status::OK();
 }
 
-void Tablet::modify_rowsets(const std::vector<RowsetSharedPtr>& to_add, const std::vector<RowsetSharedPtr>& to_delete) {
+void Tablet::modify_rowsets(const std::vector<RowsetSharedPtr>& to_add, const std::vector<RowsetSharedPtr>& to_delete,
+                            std::vector<RowsetSharedPtr>* to_replace) {
     CHECK(!_updates) << "updatable tablet should not call modify_rowsets";
     // the compaction process allow to compact the single version, eg: version[4-4].
     // this kind of "single version compaction" has same "input version" and "output version".
@@ -263,6 +264,15 @@ void Tablet::modify_rowsets(const std::vector<RowsetSharedPtr>& to_add, const st
         _rs_version_map.erase(rs->version());
 
         // put compaction rowsets in _stale_rs_version_map.
+        // if this version already exist, replace it with new rowset.
+        if (to_replace != nullptr) {
+            auto search = _stale_rs_version_map.find(rs->version());
+            if (search != _stale_rs_version_map.end()) {
+                if (search->second->rowset_id() != rs->rowset_id()) {
+                    to_replace->push_back(search->second);
+                }
+            }
+        }
         _stale_rs_version_map[rs->version()] = rs;
     }
 

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -110,7 +110,8 @@ public:
 
     // operation in rowsets
     Status add_rowset(const RowsetSharedPtr& rowset, bool need_persist = true);
-    void modify_rowsets(const vector<RowsetSharedPtr>& to_add, const vector<RowsetSharedPtr>& to_delete);
+    void modify_rowsets(const vector<RowsetSharedPtr>& to_add, const vector<RowsetSharedPtr>& to_delete,
+                        std::vector<RowsetSharedPtr>* to_replace);
 
     // _rs_version_map and _inc_rs_version_map should be protected by _meta_lock
     // The caller must call hold _meta_lock when call this two function.


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19664

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Problem happen in this case:
1. There are `rowset_1_<0,9>` and `rowset_2_<10,10>` in one tablet, and `rowset_2_<10,10>` contains multi overlapping segments
2. Cumulative compaction can compact `rowset_2_<10,10>` to `rowset_3_<10,10>` that contains segments without overlapping. 
After this, `_stale_rs_version_map` contains `<10,10> -> rowset_2`
3. Base compaction can compact `rowset_1_<0,9>` and `rowset_3_<10,10>` to `rowset_4_<0,10>`.
And `rowset_2` will be replace by `rowset_3` in `_stale_rs_version_map`, because they have same key `<10,10>`.
After this, `_stale_rs_version_map` contains `<0,9>->rowset_1 & <10,10> -> rowset_3`
4. A few minutes later, `rowset_1 & rowset_3` in `_stale_rs_version_map` will be removed, and segment files can be release. But `rowset_2` is leak.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
