### PR TITLE
[Enhancement] Support opening preaggregation when the case when/if contains a constant zero. (#19474)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -165,6 +165,32 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
         return isNull;
     }
 
+    public boolean isZero() {
+        boolean isZero = false;
+        if (type.isInt()) {
+            Integer val = (Integer) value;
+            isZero = (val.compareTo(0) == 0);
+        } else if (type.isBigint()) {
+            Long val = (Long) value;
+            isZero = (val.compareTo(0L) == 0);
+        } else if (type.isLargeint()) {
+            BigInteger val = (BigInteger) value;
+            isZero = (val.compareTo(BigInteger.ZERO) == 0);
+        } else if (type.isFloat()) {
+            Float val = (Float) value;
+            isZero = (val.compareTo(0.0f) == 0);
+        } else if (type.isDouble()) {
+            Double val = (Double) value;
+            isZero = (val.compareTo(0.0) == 0);
+        } else if (type.isDecimalV3()) {
+            BigDecimal val = (BigDecimal) value;
+            isZero = (val.compareTo(BigDecimal.ZERO) == 0);
+        } else {
+            isZero = false;
+        }
+        return isZero;
+    }
+
     @Override
     public boolean isConstant() {
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -132,6 +132,10 @@ public abstract class ScalarOperator implements Cloneable {
         return this instanceof ConstantOperator && ((ConstantOperator) this).isNull();
     }
 
+    public boolean isConstantZero() {
+        return this instanceof ConstantOperator && ((ConstantOperator) this).isZero();
+    }
+
     public void setHints(List<String> hints) {
         this.hints = hints;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
@@ -25,7 +25,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.task.TaskContext;
@@ -211,13 +210,16 @@ public class PreAggregateTurnOnRule implements TreeRewriteRule {
                     CaseWhenOperator cwo = (CaseWhenOperator) child;
 
                     for (int i = 0; i < cwo.getWhenClauseSize(); i++) {
-                        if (!cwo.getThenClause(i).isColumnRef()) {
+                        if (cwo.getThenClause(i).isColumnRef()) {
+                            conditions.addAll(Utils.extractColumnRef(cwo.getWhenClause(i)));
+                            returns.add((ColumnRefOperator) cwo.getThenClause(i));
+                        } else if (cwo.getThenClause(i).isConstantNull()
+                                || cwo.getThenClause(i).isConstantZero()) {
+                            // If then expr is NULL or Zero, open the preaggregation
+                        } else {
                             scan.setTurnOffReason("The result of THEN isn't value column");
                             return true;
                         }
-
-                        conditions.addAll(Utils.extractColumnRef(cwo.getWhenClause(i)));
-                        returns.add((ColumnRefOperator) cwo.getThenClause(i));
                     }
 
                     if (cwo.hasCase()) {
@@ -225,11 +227,11 @@ public class PreAggregateTurnOnRule implements TreeRewriteRule {
                     }
 
                     if (cwo.hasElse()) {
-                        if (OperatorType.VARIABLE.equals(cwo.getElseClause().getOpType())) {
+                        if (cwo.getElseClause().isColumnRef()) {
                             returns.add((ColumnRefOperator) cwo.getElseClause());
-                        } else if (OperatorType.CONSTANT.equals(cwo.getElseClause().getOpType())
-                                && ((ConstantOperator) cwo.getElseClause()).isNull()) {
-                            // NULL don't effect result, can open PreAggregate
+                        } else if (cwo.getElseClause().isConstantNull()
+                                || cwo.getElseClause().isConstantZero()) {
+                            // If else expr is NULL or Zero, open the preaggregation
                         } else {
                             scan.setTurnOffReason("The result of ELSE isn't value column");
                             return true;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PreAggregationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PreAggregationTest.java
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.meta.BlackListSql;
+import com.starrocks.meta.SqlBlackList;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.DropDbStmt;
+import com.starrocks.sql.ast.ShowCreateDbStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class PreAggregationTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static String DB_NAME = "test";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+
+        starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `test_agg_2` (\n" +
+                "  `k1` int(11) NULL,\n" +
+                "  `k2` int(11) NULL,\n" +
+                "  `k3` int(11) NULL,\n" +
+                "  `v1` int SUM NULL,\n" +
+                "  `v2` bigint SUM NULL,\n" +
+                "  `v3` largeint SUM NULL,\n" +
+                "  `v4` double SUM NULL,\n" +
+                "  `v5` decimal(10, 3) SUM NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(`k1`, `k2`, `k3`)\n" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                " \"replication_num\" = \"1\"\n" +
+                ");");
+    }
+
+    public String getFragmentPlan(String sql) throws Exception {
+        return UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
+                getExplainString(TExplainLevel.NORMAL);
+    }
+
+    public static void assertContains(String text, String... pattern) {
+        for (String s : pattern) {
+            Assert.assertTrue(text, text.contains(s));
+        }
+    }
+
+    @Test
+    public void testPreAggregationCaseWhen() throws Exception {
+        String sql = "select sum(case when k1 = 1 then v1 else +0 end), " +
+                           " sum(case when k1 = 1 then v1 else -0 end), " +
+                           " sum(case when k1 = 1 then v2 else +0 end), " +
+                           " sum(case when k1 = 1 then v2 else -0 end), " +
+                           " sum(case when k1 = 1 then v3 else +0 end), " +
+                           " sum(case when k1 = 1 then v3 else -0 end), " +
+                           " sum(case when k1 = 1 then +0 else v1 end), " +
+                           " sum(case when k1 = 1 then -0 else v1 end), " +
+                           " sum(case when k1 = 1 then +0 else v2 end), " +
+                           " sum(case when k1 = 1 then -0 else v2 end), " +
+                           " sum(case when k1 = 1 then +0 else v3 end), " +
+                           " sum(case when k1 = 1 then -0 else v3 end) from test_agg_2";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:OlapScanNode\n" +
+                "     TABLE: test_agg_2\n" +
+                "     PREAGGREGATION: ON\n");
+
+        sql = "select sum(case when k1 = 1 then v1 else 0.0 end) from test_agg_2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "0:OlapScanNode\n" +
+                "     TABLE: test_agg_2\n" +
+                "     PREAGGREGATION: OFF. Reason: The result of THEN isn't value column\n");
+
+        sql = "select sum(case when k1 = 1 then v4 else +0.0 end), " +
+                    " sum(case when k1 = 1 then v4 else -0.0 end), " +
+                    " sum(case when k1 = 1 then +0.0 else v4 end), " +
+                    " sum(case when k1 = 1 then -0.0 else v4 end) from test_agg_2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "0:OlapScanNode\n" +
+                "     TABLE: test_agg_2\n" +
+                "     PREAGGREGATION: ON\n");
+
+        sql = "select sum(case when k1 = 1 then v5 else +0.0 end), " +
+                    " sum(case when k1 = 1 then v5 else -0.0 end), " +
+                    " sum(case when k1 = 1 then +0.0 else v5 end), " +
+                    " sum(case when k1 = 1 then -0.0 else v5 end) from test_agg_2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "0:OlapScanNode\n" +
+                "     TABLE: test_agg_2\n" +
+                "     PREAGGREGATION: ON\n");
+    }
+}


### PR DESCRIPTION
```
CREATE TABLE IF NOT EXISTS test_agg_2 (
  k1 int(11) NULL,
  k2 int(11) NULL,
  k3 int(11) NULL,
  v1 int SUM NULL,
  v2 bigint SUM NULL
)

select sum(case when k1 = 1 then v1 else 0 end),
       sum(case when k1 = 1 then v2 else 0 end),
       sum(case when k1 = 1 then 0 else v1 end),
       sum(case when k1 = 1 then 0 else v2 end)
from test_agg_2;
```
The case when contains a constant zero. The preaggregation can be opened. Adding an isConstantZero() function to help to address the problem.

I test the performance using catalog_sales.
It contains 19 aggregate key columns, the number of rows is 144992165.
There are 146 rowsets, each has 1 million rows.
```
mysql> desc catalog_sales;
+--------------------------+---------------+------+-------+---------+-------+
| Field                    | Type          | Null | Key   | Default | Extra |
+--------------------------+---------------+------+-------+---------+-------+
| cs_item_sk               | bigint        | YES  | true  | NULL    |       |
| cs_order_number          | bigint        | YES  | true  | NULL    |       |
| cs_sold_date_sk          | bigint        | YES  | true  | NULL    |       |
| cs_sold_time_sk          | bigint        | YES  | true  | NULL    |       |
| cs_ship_date_sk          | bigint        | YES  | true  | NULL    |       |
| cs_bill_customer_sk      | bigint        | YES  | true  | NULL    |       |
| cs_bill_cdemo_sk         | bigint        | YES  | true  | NULL    |       |
| cs_bill_hdemo_sk         | bigint        | YES  | true  | NULL    |       |
| cs_bill_addr_sk          | bigint        | YES  | true  | NULL    |       |
| cs_ship_customer_sk      | bigint        | YES  | true  | NULL    |       |
| cs_ship_cdemo_sk         | bigint        | YES  | true  | NULL    |       |
| cs_ship_hdemo_sk         | bigint        | YES  | true  | NULL    |       |
| cs_ship_addr_sk          | bigint        | YES  | true  | NULL    |       |
| cs_call_center_sk        | bigint        | YES  | true  | NULL    |       |
| cs_catalog_page_sk       | bigint        | YES  | true  | NULL    |       |
| cs_ship_mode_sk          | bigint        | YES  | true  | NULL    |       |
| cs_warehouse_sk          | bigint        | YES  | true  | NULL    |       |
| cs_promo_sk              | bigint        | YES  | true  | NULL    |       |
| cs_quantity              | bigint        | YES  | true  | NULL    |       |
| cs_wholesale_cost        | decimal(38,2) | YES  | false | NULL    |       |
| cs_list_price            | decimal(38,2) | YES  | false | NULL    |       |
| cs_sales_price           | decimal(38,2) | YES  | false | NULL    |       |
| cs_ext_discount_amt      | decimal(38,2) | YES  | false | NULL    |       |
| cs_ext_sales_price       | decimal(38,2) | YES  | false | NULL    |       |
| cs_ext_wholesale_cost    | decimal(38,2) | YES  | false | NULL    |       |
| cs_ext_list_price        | decimal(38,2) | YES  | false | NULL    |       |
| cs_ext_tax               | decimal(38,2) | YES  | false | NULL    |       |
| cs_coupon_amt            | decimal(38,2) | YES  | false | NULL    |       |
| cs_ext_ship_cost         | decimal(38,2) | YES  | false | NULL    |       |
| cs_net_paid              | decimal(38,2) | YES  | false | NULL    |       |
| cs_net_paid_inc_tax      | decimal(38,2) | YES  | false | NULL    |       |
| cs_net_paid_inc_ship     | decimal(38,2) | YES  | false | NULL    |       |
| cs_net_paid_inc_ship_tax | decimal(38,2) | YES  | false | NULL    |       |
| cs_net_profit            | decimal(38,2) | YES  | false | NULL    |       |
+--------------------------+---------------+------+-------+---------+-------+
```

The test query is
```
select sum(case when cs_item_sk > 0 then cs_net_profit else 0.0 end) from catalog_sales;
```
The cold query latency reduce from 80s -> 3.6s
The warm query latency reduce from 10s -> 0.2s
The peak cpu consumption reduce from 9000% -> 700%

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19474

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
