### PR TITLE
[BugFix] support SqlToScalarOperatorTranslator visit lambda functions more than one times

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaArgument.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaArgument.java
@@ -46,8 +46,7 @@ public class LambdaArgument extends Expr {
         super(rhs);
         name = rhs.getName();
     }
-
-
+    
     public String getName() {
         return name;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaArgument.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaArgument.java
@@ -21,11 +21,22 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.thrift.TExprNode;
 
 public class LambdaArgument extends Expr {
     private String name;
     private boolean nullable;
+
+    ColumnRefOperator transformedOp = null;
+
+    public ColumnRefOperator getTransformed() {
+        return transformedOp;
+    }
+
+    public void setTransformed(ColumnRefOperator op) {
+        transformedOp = op;
+    }
 
     public LambdaArgument(String name) {
         this.name = name;
@@ -35,6 +46,7 @@ public class LambdaArgument extends Expr {
         super(rhs);
         name = rhs.getName();
     }
+
 
     public String getName() {
         return name;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
@@ -20,7 +20,6 @@ import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 
 public class LambdaFunctionExpr extends Expr {
-    private LambdaFunctionOperator transformedOp = null;
     private int commonSubOperatorNum = 0;
     // the arguments are lambda expr, lambda arg1, lambda arg2...
     public LambdaFunctionExpr(List<Expr> arguments) {
@@ -54,14 +52,6 @@ public class LambdaFunctionExpr extends Expr {
 
     public LambdaFunctionExpr(LambdaFunctionExpr rhs) {
         super(rhs);
-    }
-
-    public LambdaFunctionOperator getTransformed() {
-        return transformedOp;
-    }
-
-    public void setTransformed(LambdaFunctionOperator op) {
-        transformedOp = op;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -63,7 +63,7 @@ public class PruneScanColumnRule extends TransformationRule {
         // including columns in predicate or some specialized columns defined by scan operator.
         Set<ColumnRefOperator> outputColumns =
                 scanOperator.getColRefToColumnMetaMap().keySet().stream().filter(requiredOutputColumns::contains)
-                        .collect(Collectors.toSet()); //  requiredOutputColumns.cardinality() == outputColumns.size()
+                        .collect(Collectors.toSet());
         outputColumns.addAll(Utils.extractColumnRef(scanOperator.getPredicate()));
 
         if (outputColumns.size() == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -63,7 +63,7 @@ public class PruneScanColumnRule extends TransformationRule {
         // including columns in predicate or some specialized columns defined by scan operator.
         Set<ColumnRefOperator> outputColumns =
                 scanOperator.getColRefToColumnMetaMap().keySet().stream().filter(requiredOutputColumns::contains)
-                        .collect(Collectors.toSet());
+                        .collect(Collectors.toSet()); //  requiredOutputColumns.cardinality() == outputColumns.size()
         outputColumns.addAll(Utils.extractColumnRef(scanOperator.getPredicate()));
 
         if (outputColumns.size() == 0) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -127,6 +127,8 @@ public class AnalyzeExprTest {
         analyzeSuccess("select array_map(x-> x +  count(v1) over (partition by v1 order by v2),[111]) from tarray");
         analyzeSuccess("select v1, v2, count(v1) over (partition by v1 order by v2) from tarray");
         analyzeSuccess("select v1, v2, count(v1) over (partition by array_sum(array_map(x->x+1, [1])) order by v2) from tarray");
+        analyzeSuccess("with x2 as (select array_map((ss) -> ss * v1, v3) from tarray) select * from x2;");
+
 
         analyzeFail("select array_map(x,y -> x + y, [], [])"); // should be (x,y)
         analyzeFail("select array_map((x,y,z) -> x + y, [], [])");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -129,7 +129,6 @@ public class AnalyzeExprTest {
         analyzeSuccess("select v1, v2, count(v1) over (partition by array_sum(array_map(x->x+1, [1])) order by v2) from tarray");
         analyzeSuccess("with x2 as (select array_map((ss) -> ss * v1, v3) from tarray) select * from x2;");
 
-
         analyzeFail("select array_map(x,y -> x + y, [], [])"); // should be (x,y)
         analyzeFail("select array_map((x,y,z) -> x + y, [], [])");
         analyzeFail("select array_map(x -> z,[1])");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/starrocks/issues/19392

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
To avoid the ids of lambda arguments are different after each visit(), previously SqlToScalarOperatorTranslator transform lambda functions only once. so if transform it more than one times, the previously allocated ids for captured columns cannot be recognized later in CTE transform.

now fix that by remembering transformed columnRef in lambda arguments.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
