### PR TITLE
[Refactor] Remove Int32TwoLevelAggHashMapWithOneNumberKey

### DIFF
--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -69,11 +69,6 @@ template <PhmapSeed seed>
 using FixedSize16SliceAggHashMap =
         phmap::flat_hash_map<SliceKey16, AggDataPtr, FixedSizeSliceKeyHash<SliceKey16, seed>>;
 
-// =====================
-// two level agg hash map
-template <PhmapSeed seed>
-using Int32AggTwoLevelHashMap = phmap::parallel_flat_hash_map<int32_t, AggDataPtr, StdHashWithSeed<int32_t, seed>>;
-
 // The SliceAggTwoLevelHashMap will have 2 ^ 4 = 16 sub map,
 // The 16 is same as PartitionedAggregationNode::PARTITION_FANOUT
 static constexpr uint8_t PHMAPN = 4;

--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -55,7 +55,6 @@ DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_null_timestamp, NullTimeStampAgg
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_null_string, NullOneStringAggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice, SerializedKeyAggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice_two_level, SerializedKeyTwoLevelAggHashMap<PhmapSeed1>);
-DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_int32_two_level, Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice_fx4, SerializedKeyFixedSize4AggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice_fx8, SerializedKeyFixedSize8AggHashMap<PhmapSeed1>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase1_slice_fx16, SerializedKeyFixedSize16AggHashMap<PhmapSeed1>);
@@ -85,7 +84,6 @@ DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_null_timestamp, NullTimeStampAgg
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_null_string, NullOneStringAggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice, SerializedKeyAggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_two_level, SerializedKeyTwoLevelAggHashMap<PhmapSeed2>);
-DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_int32_two_level, Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_fx4, SerializedKeyFixedSize4AggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_fx8, SerializedKeyFixedSize8AggHashMap<PhmapSeed2>);
 DEFINE_MAP_TYPE(AggHashMapVariant::Type::phase2_slice_fx16, SerializedKeyFixedSize16AggHashMap<PhmapSeed2>);
@@ -125,7 +123,6 @@ DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_null_timestamp, NullTimeStampAgg
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_null_string, NullOneStringAggHashSet<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice, SerializedKeyAggHashSet<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice_two_level, SerializedTwoLevelKeyAggHashSet<PhmapSeed1>);
-DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_int32_two_level, Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_uint8, UInt8AggHashSetOfOneNumberKey<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_int8, Int8AggHashSetOfOneNumberKey<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_int16, Int16AggHashSetOfOneNumberKey<PhmapSeed2>);
@@ -152,7 +149,6 @@ DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_null_timestamp, NullTimeStampAgg
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_null_string, NullOneStringAggHashSet<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_slice, SerializedKeyAggHashSet<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_slice_two_level, SerializedTwoLevelKeyAggHashSet<PhmapSeed2>);
-DEFINE_SET_TYPE(AggHashSetVariant::Type::phase2_int32_two_level, Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed2>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice_fx4, SerializedKeyAggHashSetFixedSize4<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice_fx8, SerializedKeyAggHashSetFixedSize8<PhmapSeed1>);
 DEFINE_SET_TYPE(AggHashSetVariant::Type::phase1_slice_fx16, SerializedKeyAggHashSetFixedSize16<PhmapSeed1>);

--- a/be/src/exec/aggregate/agg_hash_variant.h
+++ b/be/src/exec/aggregate/agg_hash_variant.h
@@ -56,7 +56,6 @@ namespace starrocks {
     M(phase1_null_timestamp)         \
     M(phase1_null_string)            \
     M(phase1_slice_two_level)        \
-    M(phase1_int32_two_level)        \
     M(phase2_uint8)                  \
     M(phase2_int8)                   \
     M(phase2_int16)                  \
@@ -83,7 +82,6 @@ namespace starrocks {
     M(phase2_null_timestamp)         \
     M(phase2_null_string)            \
     M(phase2_slice_two_level)        \
-    M(phase2_int32_two_level)        \
     M(phase1_slice_fx4)              \
     M(phase1_slice_fx8)              \
     M(phase1_slice_fx16)             \
@@ -154,8 +152,6 @@ template <PhmapSeed seed>
 using SerializedKeyAggHashMap = AggHashMapWithSerializedKey<SliceAggHashMap<seed>>;
 template <PhmapSeed seed>
 using SerializedKeyTwoLevelAggHashMap = AggHashMapWithSerializedKey<SliceAggTwoLevelHashMap<seed>>;
-template <PhmapSeed seed>
-using Int32TwoLevelAggHashMapWithOneNumberKey = AggHashMapWithOneNumberKey<TYPE_INT, Int32AggTwoLevelHashMap<seed>>;
 
 // fixed slice key type.
 template <PhmapSeed seed>
@@ -226,8 +222,6 @@ template <PhmapSeed seed>
 using SerializedKeyAggHashSet = AggHashSetOfSerializedKey<SliceAggHashSet<seed>>;
 template <PhmapSeed seed>
 using SerializedTwoLevelKeyAggHashSet = AggHashSetOfSerializedKey<SliceAggTwoLevelHashSet<seed>>;
-template <PhmapSeed seed>
-using Int32TwoLevelAggHashSetOfOneNumberKey = AggHashSetOfOneNumberKey<TYPE_INT, Int32AggTwoLevelHashSet<seed>>;
 
 // For fixed slice type.
 template <PhmapSeed seed>
@@ -259,9 +253,7 @@ template <typename HashMapOrSetWithKey>
 inline constexpr bool is_combined_fixed_size_key = CombinedFixedSizeKey<HashMapOrSetWithKey>::value;
 
 static_assert(is_combined_fixed_size_key<SerializedKeyFixedSize4AggHashMap<PhmapSeed1>>);
-static_assert(!is_combined_fixed_size_key<Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed1>>);
 static_assert(is_combined_fixed_size_key<SerializedKeyAggHashSetFixedSize4<PhmapSeed1>>);
-static_assert(!is_combined_fixed_size_key<Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed1>>);
 
 // 1) For different group by columns type, size, cardinality, volume, we should choose different
 // hash functions and different hashmaps.
@@ -302,7 +294,6 @@ using AggHashMapWithKeyPtr = std::variant<
         std::unique_ptr<NullTimeStampAggHashMapWithOneNumberKey<PhmapSeed1>>,
         std::unique_ptr<NullOneStringAggHashMap<PhmapSeed1>>, std::unique_ptr<SerializedKeyAggHashMap<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyTwoLevelAggHashMap<PhmapSeed1>>,
-        std::unique_ptr<Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyFixedSize4AggHashMap<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyFixedSize8AggHashMap<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyFixedSize16AggHashMap<PhmapSeed1>>,
@@ -331,7 +322,6 @@ using AggHashMapWithKeyPtr = std::variant<
         std::unique_ptr<NullTimeStampAggHashMapWithOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<NullOneStringAggHashMap<PhmapSeed2>>, std::unique_ptr<SerializedKeyAggHashMap<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyTwoLevelAggHashMap<PhmapSeed2>>,
-        std::unique_ptr<Int32TwoLevelAggHashMapWithOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyFixedSize4AggHashMap<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyFixedSize8AggHashMap<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyFixedSize16AggHashMap<PhmapSeed2>>>;
@@ -362,7 +352,6 @@ using AggHashSetWithKeyPtr = std::variant<
         std::unique_ptr<NullTimeStampAggHashSetOfOneNumberKey<PhmapSeed1>>,
         std::unique_ptr<NullOneStringAggHashSet<PhmapSeed1>>, std::unique_ptr<SerializedKeyAggHashSet<PhmapSeed1>>,
         std::unique_ptr<SerializedTwoLevelKeyAggHashSet<PhmapSeed1>>,
-        std::unique_ptr<Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed1>>,
         std::unique_ptr<UInt8AggHashSetOfOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<Int8AggHashSetOfOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<Int16AggHashSetOfOneNumberKey<PhmapSeed2>>,
@@ -388,7 +377,6 @@ using AggHashSetWithKeyPtr = std::variant<
         std::unique_ptr<NullTimeStampAggHashSetOfOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<NullOneStringAggHashSet<PhmapSeed2>>, std::unique_ptr<SerializedKeyAggHashSet<PhmapSeed2>>,
         std::unique_ptr<SerializedTwoLevelKeyAggHashSet<PhmapSeed2>>,
-        std::unique_ptr<Int32TwoLevelAggHashSetOfOneNumberKey<PhmapSeed2>>,
         std::unique_ptr<SerializedKeyAggHashSetFixedSize4<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyAggHashSetFixedSize8<PhmapSeed1>>,
         std::unique_ptr<SerializedKeyAggHashSetFixedSize16<PhmapSeed1>>,
@@ -424,7 +412,6 @@ struct AggHashMapVariant {
         phase1_null_string,
         phase1_slice,
         phase1_slice_two_level,
-        phase1_int32_two_level,
 
         phase1_slice_fx4,
         phase1_slice_fx8,
@@ -456,7 +443,6 @@ struct AggHashMapVariant {
         phase2_null_string,
         phase2_slice,
         phase2_slice_two_level,
-        phase2_int32_two_level,
 
         phase2_slice_fx4,
         phase2_slice_fx8,
@@ -527,7 +513,6 @@ struct AggHashSetVariant {
         phase1_null_string,
         phase1_slice,
         phase1_slice_two_level,
-        phase1_int32_two_level,
         phase2_uint8,
         phase2_int8,
         phase2_int16,
@@ -554,7 +539,6 @@ struct AggHashSetVariant {
         phase2_null_string,
         phase2_slice,
         phase2_slice_two_level,
-        phase2_int32_two_level,
 
         phase1_slice_fx4,
         phase1_slice_fx8,

--- a/be/src/exec/hash_map.h
+++ b/be/src/exec/hash_map.h
@@ -20,6 +20,5 @@ namespace starrocks {
 
 using AggDataPtr = uint8_t*;
 using Int32AggHashMap = phmap::flat_hash_map<int32_t, AggDataPtr>;
-using Int32AggTwoLevelHashMap = phmap::parallel_flat_hash_map<int32_t, AggDataPtr>;
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The `lazy_emplace_with_hash` definition of parallel_hash_set:

```
    template <class K = key_type, class F>
    iterator lazy_emplace_with_hash(size_t hashval, const key_arg<K>& key, F&& f)
```

The `lazy_emplace_with_hash` definition of raw_hash_set:

```
    template <class K = key_type, class F>
    iterator lazy_emplace_with_hash(const key_arg<K>& key, size_t& hashval, F&& f)
```

The definition of Int32TwoLevelAggHashMapWithOneNumberKey

```
template <PhmapSeed seed>
using Int32TwoLevelAggHashMapWithOneNumberKey = AggHashMapWithOneNumberKey<TYPE_INT, Int32AggTwoLevelHashMap<seed>>;

using Int32AggTwoLevelHashMap = phmap::parallel_flat_hash_map<int32_t, AggDataPtr>;
```

The implementation of AggHashMapWithOneNumberKey:

```
auto iter = this->hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
                    if constexpr (compute_not_founds) {
                        DCHECK(not_founds);
                        (*not_founds)[i] = 1;
                    }
                    AggDataPtr pv = allocate_func(key);
                    ctor(key, pv);
                });
```

This will wrongly convert hash value to key, and convert key to hash value. This Hash table is currently useless, delete it first.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
