### PR TITLE
[Refactor] DateUtils: support parsing year 0000

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -26,23 +26,14 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 
 public class DateUtils {
-    // These are marked as deprecated because they don't support year 0000 parsing
-    @Deprecated
-    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    @Deprecated
-    public static final DateTimeFormatter DATEKEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
-    @Deprecated
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-    @Deprecated
-    public static final DateTimeFormatter MINUTE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
-    @Deprecated
-    public static final DateTimeFormatter HOUR_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHH");
-    @Deprecated
-    public static final DateTimeFormatter YEAR_FORMATTER = DateTimeFormatter.ofPattern("yyyy");
-    @Deprecated
-    public static final DateTimeFormatter QUARTER_FORMATTER = DateTimeFormatter.ofPattern("yyyy'Q'q");
-    @Deprecated
-    public static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd");
+    public static final DateTimeFormatter DATEKEY_FORMATTER = DateTimeFormatter.ofPattern("uuuuMMdd");
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
+    public static final DateTimeFormatter MINUTE_FORMATTER = DateTimeFormatter.ofPattern("uuuuMMddHHmm");
+    public static final DateTimeFormatter HOUR_FORMATTER = DateTimeFormatter.ofPattern("uuuuMMddHH");
+    public static final DateTimeFormatter YEAR_FORMATTER = DateTimeFormatter.ofPattern("uuuu");
+    public static final DateTimeFormatter QUARTER_FORMATTER = DateTimeFormatter.ofPattern("uuuu'Q'q");
+    public static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("uuuuMM");
 
     public static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss");
 


### PR DESCRIPTION
Instead of `yyyy` (year-of-era), which has the concept "1 BC" instead of the year 0, `uuuu` (ISO 8601 year) is used.


## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
I don't even know what this project does, so have no idea about the impact of the changes.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When browsing through usages of date-time formatting APIs, I encountered your repository and wanted to help a bit. Using `yyyy` without an era instead of `uuuu` is a fairly common mistake.