### PR TITLE
[BugFix] Revert "[Enhancement] protect from dict code out of range (#14798)"

### DIFF
--- a/be/src/formats/parquet/encoding.h
+++ b/be/src/formats/parquet/encoding.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <fmt/format.h>
-
 #include <functional>
 #include <memory>
 
@@ -80,19 +78,6 @@ public:
     // Currently, this function is only used to read dictionary values.
     virtual Status next_batch(size_t count, uint8_t* dst) {
         return Status::NotSupported("next_batch is not supported");
-    }
-
-    template <typename TC, typename TD>
-    Status check_dict_code_out_of_range(const std::vector<TC>& codes, const std::vector<TD>& dict) {
-        size_t size = dict.size();
-        size_t count = codes.size();
-        for (int i = 0; i < count; ++i) {
-            if (codes[i] >= size) {
-                return Status::InternalError(
-                        fmt::format("dict code is out of range. code = {}, size = {}", codes[i], size));
-            }
-        }
-        return Status::OK();
     }
 };
 

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -122,7 +122,6 @@ public:
             data_column = down_cast<FixedLengthColumn<T>*>(dst);
         }
 
-        RETURN_IF_ERROR(check_dict_code_out_of_range(_indexes, _dict));
         size_t cur_size = data_column->size();
         data_column->resize_uninitialized(cur_size + count);
         T* __restrict__ data = data_column->get_data().data() + cur_size;
@@ -186,7 +185,6 @@ public:
 
     Status get_dict_values(const std::vector<int32_t>& dict_codes, Column* column) override {
         std::vector<Slice> slices(dict_codes.size());
-        RETURN_IF_ERROR(check_dict_code_out_of_range(dict_codes, _dict));
         for (size_t i = 0; i < dict_codes.size(); i++) {
             slices[i] = _dict[dict_codes[i]];
         }
@@ -225,7 +223,6 @@ public:
         }
         case VALUE: {
             raw::stl_vector_resize_uninitialized(&_slices, count);
-            RETURN_IF_ERROR(check_dict_code_out_of_range(_indexes, _dict));
             for (int i = 0; i < count; ++i) {
                 _slices[i] = _dict[_indexes[i]];
             }


### PR DESCRIPTION
This reverts commit d641a26ef8643a93618b66fa6ca982ab8eb963a6.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Check out of range of dictDecoder use too much cpu resource.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
