### PR TITLE
[BugFix] support SqlToScalarOperatorTranslator visit lambda functions more than one times (backport #19843)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaArgument.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaArgument.java
@@ -21,11 +21,22 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.thrift.TExprNode;
 
 public class LambdaArgument extends Expr {
     private String name;
     private boolean nullable;
+
+    ColumnRefOperator transformedOp = null;
+
+    public ColumnRefOperator getTransformed() {
+        return transformedOp;
+    }
+
+    public void setTransformed(ColumnRefOperator op) {
+        transformedOp = op;
+    }
 
     public LambdaArgument(String name) {
         this.name = name;
@@ -35,7 +46,7 @@ public class LambdaArgument extends Expr {
         super(rhs);
         name = rhs.getName();
     }
-
+    
     public String getName() {
         return name;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
@@ -20,7 +20,6 @@ import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 
@@ -28,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 
 public class LambdaFunctionExpr extends Expr {
-    private LambdaFunctionOperator transformedOp = null;
     private int commonSubOperatorNum = 0;
     // the arguments are lambda expr, lambda arg1, lambda arg2...
     public LambdaFunctionExpr(List<Expr> arguments) {
@@ -48,14 +46,6 @@ public class LambdaFunctionExpr extends Expr {
 
     public LambdaFunctionExpr(LambdaFunctionExpr rhs) {
         super(rhs);
-    }
-
-    public LambdaFunctionOperator getTransformed() {
-        return transformedOp;
-    }
-
-    public void setTransformed(LambdaFunctionOperator op) {
-        transformedOp = op;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -127,6 +127,7 @@ public class AnalyzeExprTest {
         analyzeSuccess("select array_map(x-> x +  count(v1) over (partition by v1 order by v2),[111]) from tarray");
         analyzeSuccess("select v1, v2, count(v1) over (partition by v1 order by v2) from tarray");
         analyzeSuccess("select v1, v2, count(v1) over (partition by array_sum(array_map(x->x+1, [1])) order by v2) from tarray");
+        analyzeSuccess("with x2 as (select array_map((ss) -> ss * v1, v3) from tarray) select * from x2;");
 
         analyzeFail("select array_map(x,y -> x + y, [], [])"); // should be (x,y)
         analyzeFail("select array_map((x,y,z) -> x + y, [], [])");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/starrocks/pull/19896

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
