### PR TITLE
[BugFix] change default pipeline dop to half of cpu cores

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -83,7 +83,8 @@ public class BackendCoreStat {
     }
 
     public static int getDefaultDOP() {
-        return Math.max(1, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
+        int avgNumOfCores = BackendCoreStat.getAvgNumOfHardwareCoresOfBe();
+        return Math.max(1, avgNumOfCores / 2);
     }
 
     public static int getSinkDefaultDOP() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -200,7 +200,7 @@ public class AggregateTest extends PlanTestBase {
         int originPipelineDop = connectContext.getSessionVariable().getPipelineDop();
         try {
             int cpuCores = 8;
-            int expectedTotalDop = cpuCores;
+            int expectedTotalDop = cpuCores / 2;
             {
                 BackendCoreStat.setDefaultCoresOfBe(cpuCores);
                 Pair<String, ExecPlan> plan = UtFrameUtils.getPlanAndFragment(connectContext, queryStr);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
@@ -70,7 +70,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         PlanFragment fragment0 = plan.getFragments().get(0);
         assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "SCAN SCHEMA");
         Assert.assertEquals(1, fragment0.getParallelExecNum());
-        Assert.assertEquals(numHardwareCores, fragment0.getPipelineDop());
+        Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         PlanFragment fragment1 = plan.getFragments().get(1);
         assertContains(fragment1.getExplainString(TExplainLevel.NORMAL), "MetaScan");
         Assert.assertEquals(1, fragment1.getParallelExecNum());
-        Assert.assertEquals(numHardwareCores, fragment1.getPipelineDop());
+        Assert.assertEquals(numHardwareCores / 2, fragment1.getPipelineDop());
     }
 
     @Test
@@ -93,7 +93,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         PlanFragment fragment0 = plan.getFragments().get(0);
         assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "RESULT SINK");
         Assert.assertEquals(1, fragment0.getParallelExecNum());
-        Assert.assertEquals(numHardwareCores, fragment0.getPipelineDop());
+        Assert.assertEquals(numHardwareCores / 2, fragment0.getPipelineDop());
     }
 
     @Test
@@ -216,7 +216,7 @@ public class PipelineParallelismTest extends PlanTestBase {
         PlanFragment fragment1 = plan.getFragments().get(1);
         assertContains(fragment1.getExplainString(TExplainLevel.NORMAL), "TOP-N");
         Assert.assertEquals(1, fragment1.getParallelExecNum());
-        Assert.assertEquals(numHardwareCores, fragment1.getPipelineDop());
+        Assert.assertEquals(numHardwareCores / 2, fragment1.getPipelineDop());
     }
 
     private void testJoinHelper(int expectedParallelism) throws Exception {
@@ -265,7 +265,7 @@ public class PipelineParallelismTest extends PlanTestBase {
 
             connectContext.getSessionVariable().setPipelineDop(0);
             connectContext.getSessionVariable().setParallelExecInstanceNum(1);
-            testJoinHelper(numHardwareCores);
+            testJoinHelper(numHardwareCores / 2);
 
             connectContext.getSessionVariable().setPipelineDop(4);
             connectContext.getSessionVariable().setParallelExecInstanceNum(8);

--- a/fe/fe-core/src/test/java/com/starrocks/system/BackendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/BackendTest.java
@@ -32,11 +32,11 @@ public class BackendTest {
     public void cpuCoreUpdate() {
         BackendCoreStat.setNumOfHardwareCoresOfBe(1, 8);
         Assert.assertEquals(8, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
-        Assert.assertEquals(8, BackendCoreStat.getDefaultDOP());
+        Assert.assertEquals(4, BackendCoreStat.getDefaultDOP());
 
         BackendCoreStat.setNumOfHardwareCoresOfBe(1, 16);
         Assert.assertEquals(16, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
-        Assert.assertEquals(16, BackendCoreStat.getDefaultDOP());
+        Assert.assertEquals(8, BackendCoreStat.getDefaultDOP());
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

change default dop back to half of cpu cores due to performance degression in some test scenarios

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
