### PR TITLE
[Feature] Support query table function directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ fs_brokers/apache_hdfs_broker/src/main/resources/
 fs_brokers/apache_hdfs_broker/src/main/thrift/
 fs_brokers/apache_hdfs_broker/jindosdk-4.6.2
 dependency-reduced-pom.xml
+test/conf/
 tags
 .tags
 .cache

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -296,15 +296,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
 
         // from == null means a statement without from or from dual, add a single row of null values here
         if (from == null) {
-            ArrayList<Expr> row = new ArrayList<>();
-            List<String> columnNames = new ArrayList<>();
-            row.add(NullLiteral.create(Type.NULL));
-            columnNames.add("");
-            List<ArrayList<Expr>> rows = new ArrayList<>();
-            rows.add(row);
-            ValuesRelation valuesRelation = new ValuesRelation(rows, columnNames);
-            valuesRelation.setNullValues(true);
-            from = valuesRelation;
+            from = ValuesRelation.newDualRelation();
         }
 
         SelectRelation resultSelectRelation = new SelectRelation(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -79,6 +79,7 @@ import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.MapExpr;
+import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -701,6 +702,30 @@ public class AstToStringBuilder {
                 if (node.getColumnOutputNames() != null) {
                     sqlBuilder.append("(");
                     sqlBuilder.append(Joiner.on(",").join(node.getColumnOutputNames()));
+                    sqlBuilder.append(")");
+                }
+            }
+
+            return sqlBuilder.toString();
+        }
+
+        @Override
+        public String visitNormalizedTableFunction(NormalizedTableFunctionRelation node, Void scope) {
+            StringBuilder sqlBuilder = new StringBuilder();
+            sqlBuilder.append("TABLE(");
+
+            TableFunctionRelation tableFunction = (TableFunctionRelation) node.getRight();
+            sqlBuilder.append(tableFunction.getFunctionName());
+            sqlBuilder.append("(");
+            sqlBuilder.append(tableFunction.getChildExpressions().stream().map(this::visit).collect(Collectors.joining(",")));
+            sqlBuilder.append(")");
+            sqlBuilder.append(")"); // TABLE(
+
+            if (tableFunction.getAlias() != null) {
+                sqlBuilder.append(" ").append(tableFunction.getAlias().getTbl());
+                if (tableFunction.getColumnOutputNames() != null) {
+                    sqlBuilder.append("(");
+                    sqlBuilder.append(Joiner.on(",").join(tableFunction.getColumnOutputNames()));
                     sqlBuilder.append(")");
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -49,6 +49,7 @@ import com.starrocks.sql.ast.ExceptRelation;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -778,6 +779,14 @@ public class QueryAnalyzer {
             Scope outputScope = new Scope(RelationId.of(node), new RelationFields(fields.build()));
             node.setScope(outputScope);
             return outputScope;
+        }
+
+        @Override
+        public Scope visitNormalizedTableFunction(NormalizedTableFunctionRelation node, Scope scope) {
+            Scope ignored = visitJoin(node, scope);
+            // Only the scope of the table function is visible outside.
+            node.setScope(node.getRight().getScope());
+            return node.getScope();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -227,8 +227,8 @@ public class SetStmtAnalyzer {
                 SelectList selectList = new SelectList(Lists.newArrayList(
                         new SelectListItem(var.getUnevaluatedExpression(), null)), false);
 
-                ArrayList<Expr> row = Lists.newArrayList(NullLiteral.create(Type.NULL));
-                List<ArrayList<Expr>> rows = new ArrayList<>();
+                List<Expr> row = Lists.newArrayList(NullLiteral.create(Type.NULL));
+                List<List<Expr>> rows = new ArrayList<>();
                 rows.add(row);
                 ValuesRelation valuesRelation = new ValuesRelation(rows, Lists.newArrayList(""));
                 valuesRelation.setNullValues(true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -920,6 +920,10 @@ public abstract class AstVisitor<R, C> {
         return visitRelation(node, context);
     }
 
+    public R visitNormalizedTableFunction(NormalizedTableFunctionRelation node, C context) {
+        return visitRelation(node, context);
+    }
+
     public R visitCTE(CTERelation node, C context) {
         return visitRelation(node, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/NormalizedTableFunctionRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/NormalizedTableFunctionRelation.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.analysis.JoinOperator;
+
+/**
+ * {@link NormalizedTableFunctionRelation} is a special {@link JoinRelation} converted from TABLE(table_function(...)).
+ *
+ * <p>
+ * The main difference between {@link NormalizedTableFunctionRelation} and {@link TableFunctionRelation} is that
+ * {@link TableFunctionRelation} can only appear on the right side of a lateral join, while
+ * {@link NormalizedTableFunctionRelation} can appear anywhere a regular table can appear:
+ * <code>
+ *     SELECT * FROM TABLE(my_table_function(...));
+ *     SELECT * FROM t0, TABLE(my_table_function(...));
+ *     SELECT * FROM t0 LEFT JOIN TABLE(my_table_function(...)) t1(x, y) ON ...;
+ *     SELECT * FROM TABLE(my_table_function(...)) t1(x, y) LEFT JOIN t0 ON ...;
+ * </code>
+ */
+public class NormalizedTableFunctionRelation extends JoinRelation {
+    public NormalizedTableFunctionRelation(TableFunctionRelation tableFunctionRelation) {
+        super(JoinOperator.CROSS_JOIN, ValuesRelation.newDualRelation(), tableFunctionRelation, null, true);
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitNormalizedTableFunction(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/Relation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/Relation.java
@@ -67,6 +67,10 @@ public abstract class Relation implements ParseNode {
         return explicitColumnNames;
     }
 
+    public boolean isDualRelation() {
+        return false;
+    }
+
     @Override
     public NodePosition getPos() {
         return pos;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableFunctionRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableFunctionRelation.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.FunctionParams;
 import com.starrocks.catalog.TableFunction;
@@ -39,8 +40,8 @@ public class TableFunctionRelation extends Relation {
     private TableFunction tableFunction;
     private List<Expr> childExpressions;
 
-    public TableFunctionRelation(String functionName, FunctionParams functionParams) {
-        this(functionName, functionParams, NodePosition.ZERO);
+    public TableFunctionRelation(FunctionCallExpr functionCallExpr) {
+        this(functionCallExpr.getFnName().toString().toLowerCase(), functionCallExpr.getParams(), functionCallExpr.getPos());
     }
 
     public TableFunctionRelation(String functionName, FunctionParams functionParams, NodePosition pos) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ValueList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ValueList.java
@@ -19,23 +19,23 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.sql.parser.NodePosition;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class ValueList implements ParseNode {
-    private final ArrayList<Expr> row;
+    private final List<Expr> row;
 
     private final NodePosition pos;
 
-    public ValueList(ArrayList<Expr> row) {
+    public ValueList(List<Expr> row) {
         this(row, NodePosition.ZERO);
     }
 
-    public ValueList(ArrayList<Expr> row, NodePosition pos) {
+    public ValueList(List<Expr> row, NodePosition pos) {
         this.pos = pos;
         this.row = row;
     }
 
-    public ArrayList<Expr> getRow() {
+    public List<Expr> getRow() {
         return row;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -232,6 +232,7 @@ import com.starrocks.sql.ast.ModifyPartitionClause;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.MultiRangePartitionDesc;
+import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionNames;
@@ -1614,7 +1615,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         QueryStatement queryStatement;
         if (context.VALUES() != null) {
             List<ValueList> rowValues = visit(context.expressionsWithDefault(), ValueList.class);
-            List<ArrayList<Expr>> rows = rowValues.stream().map(ValueList::getRow).collect(toList());
+            List<List<Expr>> rows = rowValues.stream().map(ValueList::getRow).collect(toList());
 
             List<String> colNames = new ArrayList<>();
             for (int i = 0; i < rows.get(0).size(); ++i) {
@@ -1644,14 +1645,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         List<ColumnAssignment> assignments = visit(context.assignmentList().assignment(), ColumnAssignment.class);
         List<Relation> fromRelations = null;
         if (context.fromClause() instanceof StarRocksParser.DualContext) {
-            ArrayList<Expr> row = new ArrayList<>();
-            List<String> columnNames = new ArrayList<>();
-            row.add(NullLiteral.create(Type.NULL));
-            columnNames.add("");
-            List<ArrayList<Expr>> rows = new ArrayList<>();
-            rows.add(row);
-            ValuesRelation valuesRelation = new ValuesRelation(rows, columnNames, createPos(context.fromClause()));
-            valuesRelation.setNullValues(true);
+            ValuesRelation valuesRelation = ValuesRelation.newDualRelation(createPos(context.fromClause()));
             fromRelations = Lists.newArrayList(valuesRelation);
         } else {
             StarRocksParser.FromContext fromContext = (StarRocksParser.FromContext) context.fromClause();
@@ -3533,15 +3527,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
           This can share the same logic as select sum(1) from table
          */
         if (from == null) {
-            ArrayList<Expr> row = new ArrayList<>();
-            List<String> columnNames = new ArrayList<>();
-            row.add(NullLiteral.create(Type.NULL));
-            columnNames.add("");
-            List<ArrayList<Expr>> rows = new ArrayList<>();
-            rows.add(row);
-            ValuesRelation valuesRelation = new ValuesRelation(rows, columnNames, NodePosition.ZERO);
-            valuesRelation.setNullValues(true);
-            from = valuesRelation;
+            from = ValuesRelation.newDualRelation();
         }
 
         boolean isDistinct = context.setQuantifier() != null && context.setQuantifier().DISTINCT() != null;
@@ -3898,7 +3884,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitInlineTable(StarRocksParser.InlineTableContext context) {
         List<ValueList> rowValues = visit(context.rowConstructor(), ValueList.class);
-        List<ArrayList<Expr>> rows = rowValues.stream().map(ValueList::getRow).collect(toList());
+        List<List<Expr>> rows = rowValues.stream().map(ValueList::getRow).collect(toList());
 
         List<String> colNames = getColumnNames(context.columnAliases());
         if (colNames == null) {
@@ -3920,18 +3906,35 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitTableFunction(StarRocksParser.TableFunctionContext context) {
-        TableFunctionRelation tableFunctionRelation = new TableFunctionRelation(
-                getQualifiedName(context.qualifiedName()).toString(),
-                new FunctionParams(false, visit(context.expressionList().expression(), Expr.class)),
-                createPos(context));
+        FunctionCallExpr functionCallExpr = (FunctionCallExpr) visit(context.tableFunctionCall());
+        TableFunctionRelation tableFunctionRelation = new TableFunctionRelation(functionCallExpr);
 
         if (context.alias != null) {
             Identifier identifier = (Identifier) visit(context.alias);
             tableFunctionRelation.setAlias(new TableName(null, identifier.getValue()));
         }
         tableFunctionRelation.setColumnOutputNames(getColumnNames(context.columnAliases()));
-
         return tableFunctionRelation;
+    }
+
+    @Override
+    public ParseNode visitTableFunctionTable(StarRocksParser.TableFunctionTableContext context) {
+        TableFunctionRelation relation = new TableFunctionRelation((FunctionCallExpr) visit(context.tableFunctionCall()));
+
+        if (context.alias != null) {
+            Identifier identifier = (Identifier) visit(context.alias);
+            relation.setAlias(new TableName(null, identifier.getValue()));
+        }
+        relation.setColumnOutputNames(getColumnNames(context.columnAliases()));
+
+        return new NormalizedTableFunctionRelation(relation);
+    }
+
+    @Override
+    public ParseNode visitTableFunctionCall(StarRocksParser.TableFunctionCallContext context) {
+        QualifiedName functionName = getQualifiedName(context.qualifiedName());
+        List<Expr> parameters = visit(context.expressionList().expression(), Expr.class);
+        return new FunctionCallExpr(FunctionName.createFnName(functionName.toString().toLowerCase()), parameters);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1629,9 +1629,13 @@ relationPrimary
     | '(' VALUES rowConstructor (',' rowConstructor)* ')'
         (AS? alias=identifier columnAliases?)?                                          #inlineTable
     | subquery (AS? alias=identifier columnAliases?)?                                   #subqueryWithAlias
-    | qualifiedName '(' expressionList ')'
-        (AS? alias=identifier columnAliases?)?                                          #tableFunction
+    | tableFunctionCall (AS? alias=identifier columnAliases?)?                          #tableFunction
+    | TABLE '(' tableFunctionCall ')' (AS? alias=identifier columnAliases?)?            #tableFunctionTable
     | '(' relations ')'                                                                 #parenthesizedRelation
+    ;
+
+tableFunctionCall
+    : qualifiedName '(' expressionList ')'
     ;
 
 joinRelation

--- a/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleQueryAnalyzer.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleQueryAnalyzer.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.ast.ExceptRelation;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -367,6 +368,14 @@ public class SimpleQueryAnalyzer {
 
             Scope outputScope = new Scope(RelationId.of(node), new RelationFields(fields.build()));
             node.setScope(outputScope);
+            return null;
+        }
+
+        @Override
+        public Void visitNormalizedTableFunction(NormalizedTableFunctionRelation node, Void scope) {
+            visitJoin(node, scope);
+            // Only the scope of the table function is visible outside.
+            node.setScope(node.getRight().getScope());
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
@@ -1,0 +1,227 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.Test;
+
+public class TableFunctionTest extends PlanTestBase {
+    @Test
+    public void testSql0() throws Exception {
+        String sql = "SELECT * FROM TABLE(unnest(ARRAY<INT>[1, 2, 3]))";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:2: unnest\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  2:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : ARRAY<int(11)>[1,2,3]\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL");
+    }
+
+    @Test
+    public void testSql1() throws Exception {
+        String sql = "SELECT x FROM TABLE(unnest(ARRAY<INT>[1, 2, 3])) t(x)";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:2: x\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  2:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : ARRAY<int(11)>[1,2,3]\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL");
+    }
+
+    @Test
+    public void testSql2() throws Exception {
+        String sql = "SELECT * FROM TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, 2, 3])) t1(x)";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:2: x | 5: x\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  7:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  \n" +
+                "  |----6:EXCHANGE\n" +
+                "  |    \n" +
+                "  2:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : ARRAY<int(11)>[1]\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL\n" +
+                "\n" +
+                "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 06\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  5:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  \n" +
+                "  4:Project\n" +
+                "  |  <slot 6> : ARRAY<int(11)>[1,2,3]\n" +
+                "  |  \n" +
+                "  3:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL");
+    }
+
+    @Test
+    public void testSql3() throws Exception {
+        String sql = "SELECT * FROM TABLE(unnest(ARRAY<INT>[1])) t0(x) JOIN TABLE(unnest(ARRAY<INT>[1, 2, 3])) t1(x)" +
+                " ON t0.x=t1 .x";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:2: x | 5: x\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  9:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: x = 5: x\n" +
+                "  |  \n" +
+                "  |----8:EXCHANGE\n" +
+                "  |    \n" +
+                "  3:SELECT\n" +
+                "  |  predicates: 2: x IS NOT NULL\n" +
+                "  |  \n" +
+                "  2:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : ARRAY<int(11)>[1]\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL\n" +
+                "\n" +
+                "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 08\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  7:SELECT\n" +
+                "  |  predicates: 5: x IS NOT NULL\n" +
+                "  |  \n" +
+                "  6:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  \n" +
+                "  5:Project\n" +
+                "  |  <slot 6> : ARRAY<int(11)>[1,2,3]\n" +
+                "  |  \n" +
+                "  4:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL");
+    }
+
+    @Test
+    public void testSql4() throws Exception {
+        String sql = "SELECT * FROM TABLE(unnest(ARRAY<INT>[1])) t0(x) LEFT JOIN TABLE(unnest(ARRAY<INT>[1, 2, 3])) t1(x)" +
+                " ON t0.x=t1 .x";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:2: x | 5: x\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  7:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: x = 5: x\n" +
+                "  |  \n" +
+                "  |----6:EXCHANGE\n" +
+                "  |    \n" +
+                "  2:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : ARRAY<int(11)>[1]\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL\n" +
+                "\n" +
+                "PLAN FRAGMENT 1\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 06\n" +
+                "    UNPARTITIONED\n" +
+                "\n" +
+                "  5:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  \n" +
+                "  4:Project\n" +
+                "  |  <slot 6> : ARRAY<int(11)>[1,2,3]\n" +
+                "  |  \n" +
+                "  3:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL");
+    }
+}

--- a/test/sql/test_table_function/R/test_unnest
+++ b/test/sql/test_table_function/R/test_unnest
@@ -1,0 +1,86 @@
+-- name: test_select
+select * from TABLE(unnest(ARRAY<INT>[1, NULL, 10]));
+-- result:
+1
+None
+10
+-- !result
+-- name: test_alias
+select x from TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t(x);
+-- result:
+1
+None
+10
+-- !result
+-- name: test_cross_join4
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[NULL, NULL])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- result:
+None	1
+None	None
+None	10
+None	1
+None	None
+None	10
+-- !result
+-- name: test_cross_join3
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- result:
+E: (1064, 'Unexpected exception: null')
+-- !result
+-- name: test_cross_join
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- result:
+1	1
+1	None
+1	10
+-- !result
+-- name: test_cross_join2
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[10, NULL, 100])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- result:
+10	1
+10	None
+10	10
+None	1
+None	None
+None	10
+100	1
+100	None
+100	10
+-- !result
+-- name: test_cross_join_conditional2
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1, 2, NULL])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) where t0.x=t1.x;
+-- result:
+1	1
+-- !result
+-- name: test_cross_join_conditional
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) where t0.x=t1.x;
+-- result:
+1	1
+-- !result
+-- name: test_left_join
+select * from TABLE(unnest(ARRAY<INT>[1])) t0(x) LEFT JOIN TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) on t0.x=t1.x;
+-- result:
+1	1
+-- !result
+-- name: test_subquery
+select x + 1 from (select * from TABLE(unnest(ARRAY<INT>[1], ARRAY<INT>[2, 3])) t(x, y)) t0;
+-- result:
+2
+None
+-- !result
+-- name: test_right_join
+select * from TABLE(unnest(ARRAY<INT>[1])) t0(x) RIGHT JOIN TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) on t0.x=t1.x;
+-- result:
+None	10
+1	1
+None	None
+-- !result
+-- name: test_view
+create view v_unnest_subquery as select x + y from (select * from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[2, 3])) t1(x)) t2(x, y);
+-- result:
+-- !result
+select * from v_unnest_subquery;
+-- result:
+3
+4
+-- !result

--- a/test/sql/test_table_function/R/test_unnest
+++ b/test/sql/test_table_function/R/test_unnest
@@ -1,16 +1,7 @@
--- name: test_select
-select * from TABLE(unnest(ARRAY<INT>[1, NULL, 10]));
+-- name: test_cross_join_conditional2
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1, 2, NULL])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) where t0.x=t1.x;
 -- result:
-1
-None
-10
--- !result
--- name: test_alias
-select x from TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t(x);
--- result:
-1
-None
-10
+1	1
 -- !result
 -- name: test_cross_join4
 select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[NULL, NULL])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
@@ -21,18 +12,6 @@ None	10
 None	1
 None	None
 None	10
--- !result
--- name: test_cross_join3
-select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
--- result:
-E: (1064, 'Unexpected exception: null')
--- !result
--- name: test_cross_join
-select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
--- result:
-1	1
-1	None
-1	10
 -- !result
 -- name: test_cross_join2
 select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[10, NULL, 100])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
@@ -47,18 +26,34 @@ None	10
 100	None
 100	10
 -- !result
--- name: test_cross_join_conditional2
-select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1, 2, NULL])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) where t0.x=t1.x;
+-- name: test_alias
+select x from TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t(x);
 -- result:
-1	1
--- !result
--- name: test_cross_join_conditional
-select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) where t0.x=t1.x;
--- result:
-1	1
+1
+None
+10
 -- !result
 -- name: test_left_join
 select * from TABLE(unnest(ARRAY<INT>[1])) t0(x) LEFT JOIN TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) on t0.x=t1.x;
+-- result:
+1	1
+-- !result
+-- name: test_select
+select * from TABLE(unnest(ARRAY<INT>[1, NULL, 10]));
+-- result:
+1
+None
+10
+-- !result
+-- name: test_cross_join
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- result:
+1	1
+1	None
+1	10
+-- !result
+-- name: test_cross_join_conditional
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) where t0.x=t1.x;
 -- result:
 1	1
 -- !result
@@ -71,9 +66,9 @@ None
 -- name: test_right_join
 select * from TABLE(unnest(ARRAY<INT>[1])) t0(x) RIGHT JOIN TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) on t0.x=t1.x;
 -- result:
+None	None
 None	10
 1	1
-None	None
 -- !result
 -- name: test_view
 create view v_unnest_subquery as select x + y from (select * from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[2, 3])) t1(x)) t2(x, y);

--- a/test/sql/test_table_function/T/test_unnest
+++ b/test/sql/test_table_function/T/test_unnest
@@ -6,8 +6,6 @@ select x from TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t(x);
 select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
 -- name: test_cross_join2
 select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[10, NULL, 100])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
--- name: test_cross_join3
-select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
 -- name: test_cross_join4
 select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[NULL, NULL])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
 -- name: test_cross_join_conditional

--- a/test/sql/test_table_function/T/test_unnest
+++ b/test/sql/test_table_function/T/test_unnest
@@ -1,0 +1,25 @@
+-- name: test_select
+select * from TABLE(unnest(ARRAY<INT>[1, NULL, 10]));
+-- name: test_alias
+select x from TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t(x);
+-- name: test_cross_join
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- name: test_cross_join2
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[10, NULL, 100])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- name: test_cross_join3
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- name: test_cross_join4
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[NULL, NULL])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x);
+-- name: test_cross_join_conditional
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) where t0.x=t1.x;
+-- name: test_cross_join_conditional2
+select t0.x, t1.x from TABLE(unnest(ARRAY<INT>[1, 2, NULL])) t0(x), TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) where t0.x=t1.x;
+-- name: test_left_join
+select * from TABLE(unnest(ARRAY<INT>[1])) t0(x) LEFT JOIN TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) on t0.x=t1.x;
+-- name: test_right_join
+select * from TABLE(unnest(ARRAY<INT>[1])) t0(x) RIGHT JOIN TABLE(unnest(ARRAY<INT>[1, NULL, 10])) t1(x) on t0.x=t1.x;
+-- name: test_subquery
+select x + 1 from (select * from TABLE(unnest(ARRAY<INT>[1], ARRAY<INT>[2, 3])) t(x, y)) t0;
+-- name: test_view
+create view v_unnest_subquery as select x + y from (select * from TABLE(unnest(ARRAY<INT>[1])) t0(x), TABLE(unnest(ARRAY<INT>[2, 3])) t1(x)) t2(x, y);
+select * from v_unnest_subquery;


### PR DESCRIPTION
Now we can query table functions like normal tables:
```
> select * from TABLE(unnest(ARRAY<INT>[1,2])) t(x); // select
+------+
| x    |
+------+
|    1 |
|    2 |
+------+
2 rows in set (0.02 sec)

> select * from t0; // t0 is a normal table
+------+
| c0   |
+------+
|    1 |
+------+
1 row in set (0.10 sec)

> select * from t0, TABLE(unnest(ARRAY<INT>[1, 2])); // cross join
+------+--------+
| c0   | unnest |
+------+--------+
|    1 |      1 |
|    1 |      2 |
+------+--------+
2 rows in set (0.03 sec)

> select * from t0 left join TABLE(unnest(ARRAY<INT>[1, 2])) t1(x) on t0.c0=t1.x; // left join
+------+------+
| c0   | x    |
+------+------+
|    1 |    1 |
+------+------+
1 row in set (0.06 sec)

> select * from t0 right join TABLE(unnest(ARRAY<INT>[1, 2])) t1(x) on t0.c0=t1.x; // right join
+------+------+
| c0   | x    |
+------+------+
|    1 |    1 |
| NULL |    2 |
+------+------+
2 rows in set (0.04 sec)
```
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
