### PR TITLE
[UT] consolidate BE ut binaries (#15423)

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -39,7 +39,6 @@
 namespace starrocks {
 
 #ifdef BE_TEST
-std::string k_response_str;
 TLoadTxnBeginResult k_stream_load_begin_result;
 TLoadTxnCommitResult k_stream_load_commit_result;
 TLoadTxnRollbackResult k_stream_load_rollback_result;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -30,35 +30,37 @@ set(EXEC_FILES
         ./fs/fs_test.cpp
         ./fs/output_stream_wrapper_test.cpp
         ./exec/column_value_range_test.cpp
-        ./exec/vectorized/agg_hash_map_test.cpp
-        ./exec/vectorized/csv_scanner_test.cpp
-        ./exec/vectorized/chunks_sorter_heap_sort_test.cpp
-        ./exec/vectorized/join_hash_map_test.cpp
-        ./exec/vectorized/json_scanner_test.cpp
-        ./exec/vectorized/json_parser_test.cpp
-        ./exec/vectorized/hdfs_scanner_test.cpp
-        ./exec/vectorized/table_function_node_test.cpp
-        ./exec/vectorized/file_scan_node_test.cpp
-        ./exec/schema_columns_scanner_test.cpp
-        ./exec/tablet_info_test.cpp
-        ./exec/vectorized/analytor_test.cpp
-        ./exec/vectorized/arrow_converter_test.cpp
-        ./exec/vectorized/sorting_test.cpp
-        ./exec/vectorized/chunks_sorter_test.cpp
-        ./exec/vectorized/parquet_scanner_test.cpp
-        ./exec/vectorized/repeat_node_test.cpp
-        ./exec/vectorized/analytor_test.cpp
         ./exec/es/es_query_builder_test.cpp
         ./exec/es/es_scan_reader_test.cpp
         ./exec/es/es_scroll_parser_test.cpp
-        ./exec/vectorized/hdfs_scan_node_test.cpp
-        ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/pipeline_control_flow_test.cpp
+        ./exec/pipeline/pipeline_driver_queue_test.cpp
+        ./exec/pipeline/pipeline_file_scan_node_test.cpp
+        ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/query_context_manger_test.cpp
         ./exec/pipeline/query_context_test.cpp
         ./exec/pipeline/table_function_operator_test.cpp
-        ./exec/pipeline/pipeline_file_scan_node_test.cpp
-        ./exec/pipeline/pipeline_driver_queue_test.cpp
+        ./exec/query_cache/query_cache_test.cpp
+        ./exec/query_cache/transform_operator.cpp
+        ./exec/schema_columns_scanner_test.cpp
+        ./exec/tablet_info_test.cpp
+        ./exec/vectorized/agg_hash_map_test.cpp
+        ./exec/vectorized/analytor_test.cpp
+        ./exec/vectorized/analytor_test.cpp
+        ./exec/vectorized/arrow_converter_test.cpp
+        ./exec/vectorized/chunks_sorter_heap_sort_test.cpp
+        ./exec/vectorized/chunks_sorter_test.cpp
+        ./exec/vectorized/csv_scanner_test.cpp
+        ./exec/vectorized/file_scan_node_test.cpp
+        ./exec/vectorized/hdfs_scanner_test.cpp
+        ./exec/vectorized/hdfs_scan_node_test.cpp
+        ./exec/vectorized/join_hash_map_test.cpp
+        ./exec/vectorized/json_parser_test.cpp
+        ./exec/vectorized/json_scanner_test.cpp
+        ./exec/vectorized/parquet_scanner_test.cpp
+        ./exec/vectorized/repeat_node_test.cpp
+        ./exec/vectorized/sorting_test.cpp
+        ./exec/vectorized/table_function_node_test.cpp
         ./exprs/agg/json_each_test.cpp
         ./exprs/agg/aggregate_test.cpp
         ./exprs/vectorized/arithmetic_expr_test.cpp
@@ -138,8 +140,10 @@ set(EXEC_FILES
         ./formats/parquet/file_reader_test.cpp
         ./geo/geo_types_test.cpp
         ./geo/wkt_parse_test.cpp
+        ./http/http_client_test.cpp
         ./http/http_utils_test.cpp
         ./http/message_body_sink_test.cpp
+        ./http/metrics_action_test.cpp
         ./http/stream_load_test.cpp
         ./http/transaction_stream_load_test.cpp
         ./io/array_input_stream_test.cpp
@@ -153,12 +157,14 @@ set(EXEC_FILES
         ./storage/disjunctive_predicates_test.cpp
         ./storage/utils_test.cpp
         ./storage/del_vector_test.cpp
+        ./storage/delete_handler_test.cpp
         ./storage/file_utils_test.cpp
         ./storage/fs/file_block_manager_test.cpp
         ./storage/tablet_schema_map_test.cpp
         ./storage/hll_test.cpp
         ./storage/key_coder_test.cpp
         ./storage/kv_store_test.cpp
+        ./storage/options_test.cpp
         ./storage/protobuf_file_test.cpp
         ./storage/page_cache_test.cpp
         ./storage/persistent_index_test.cpp
@@ -251,11 +257,14 @@ set(EXEC_FILES
         ./runtime/mem_pool_test.cpp
         ./runtime/raw_value_test.cpp
         ./runtime/result_queue_mgr_test.cpp
+        ./runtime/routine_load_task_executor_test.cpp
+        ./runtime/small_file_mgr_test.cpp
         ./runtime/snapshot_loader_test.cpp
         ./runtime/stream_load_pipe_test.cpp
         ./runtime/string_value_test.cpp
         ./runtime/type_descriptor_test.cpp
         ./runtime/type_descriptor_test.cpp
+        ./runtime/user_function_cache_test.cpp
         ./runtime/vectorized/sorted_chunks_merger_test.cpp
         ./runtime/memory_scratch_sink_test_issue_8676.cpp
         ./runtime/memory_scratch_sink_test.cpp
@@ -345,11 +354,6 @@ add_executable(starrocks_test ${EXEC_FILES})
 TARGET_LINK_LIBRARIES(starrocks_test ${TEST_LINK_LIBS})
 SET_TARGET_PROPERTIES(starrocks_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
-
-add_executable(query_cache_test exec/query_cache/transform_operator.cpp exec/query_cache/query_cache_test.cpp)
-
-TARGET_LINK_LIBRARIES(query_cache_test ${TEST_LINK_LIBS})
-SET_TARGET_PROPERTIES(query_cache_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 # =================================================
 # bytes_test requires tcmalloc which conflicts with sanitizer.
 # Thus we need a standalone binary without sanitizer to test it.
@@ -374,15 +378,6 @@ TARGET_LINK_LIBRARIES(bytes_test
 
 # =================================================
 # test cases must be compiled as a standalone binary
-ADD_BE_TEST(http/metrics_action_test)
-ADD_BE_TEST(http/http_client_test)
-
-ADD_BE_TEST(runtime/routine_load_task_executor_test)
-ADD_BE_TEST(runtime/small_file_mgr_test)
-ADD_BE_TEST(runtime/user_function_cache_test)
-
-ADD_BE_TEST(storage/delete_handler_test)
-ADD_BE_TEST(storage/options_test)
 ADD_BE_TEST(storage/task/engine_storage_migration_task_test)
 
 # you can simply add test case as single binary without adding `main`

--- a/be/test/exec/query_cache/query_cache_test.cpp
+++ b/be/test/exec/query_cache/query_cache_test.cpp
@@ -22,12 +22,12 @@
 #include "gutil/strings/substitute.h"
 
 namespace starrocks::vectorized {
-struct CacheTest : public ::testing::Test {
+struct QueryCacheTest : public ::testing::Test {
     RuntimeState state;
     query_cache::CacheManagerPtr cache_mgr = std::make_shared<query_cache::CacheManager>(10240);
 };
 
-TEST_F(CacheTest, testLaneArbiter) {
+TEST_F(QueryCacheTest, testLaneArbiter) {
     size_t num_lanes = 4;
     auto lane_arbiter = std::make_shared<query_cache::LaneArbiter>(num_lanes);
     ASSERT_FALSE(lane_arbiter->preferred_lane().has_value());
@@ -79,7 +79,7 @@ TEST_F(CacheTest, testLaneArbiter) {
     ASSERT_FALSE(opt_lane.has_value());
 }
 
-TEST_F(CacheTest, testCacheManager) {
+TEST_F(QueryCacheTest, testCacheManager) {
     static constexpr size_t CACHE_CAPACITY = 10240;
     auto cache_mgr = std::make_shared<query_cache::CacheManager>(CACHE_CAPACITY);
 
@@ -538,7 +538,7 @@ void test_framework_force_populate_and_passthrough(query_cache::CacheManagerPtr 
                                      post_passthrough_actions, std::move(validate_func));
 }
 
-TEST_F(CacheTest, testMultilane) {
+TEST_F(QueryCacheTest, testMultilane) {
     Actions actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, false, false),
             Action::cache_miss_and_emit_first_chunk(2, 10, 11, 1, false, false),
@@ -562,7 +562,7 @@ TEST_F(CacheTest, testMultilane) {
                    eq_validator_gen(10000.0));
 }
 
-TEST_F(CacheTest, testOneLane) {
+TEST_F(QueryCacheTest, testOneLane) {
     Actions actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, false, false),
             Action::emit_eof(1),
@@ -572,7 +572,7 @@ TEST_F(CacheTest, testOneLane) {
     test_framework(cache_mgr, 1, 1, state, mul2_func, plus1_func, 0.0, add_func, actions, {}, eq_validator_gen(100.0));
 }
 
-TEST_F(CacheTest, testOneLanePassthroughBeforeEOFSent) {
+TEST_F(QueryCacheTest, testOneLanePassthroughBeforeEOFSent) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, false, false),
     };
@@ -584,7 +584,7 @@ TEST_F(CacheTest, testOneLanePassthroughBeforeEOFSent) {
                    post_passthrough_actions, eq_validator_gen(100.0));
 }
 
-TEST_F(CacheTest, testOneLanePassthroughAfterEOFSent) {
+TEST_F(QueryCacheTest, testOneLanePassthroughAfterEOFSent) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, false, false),
             Action::emit_eof(1),
@@ -598,7 +598,7 @@ TEST_F(CacheTest, testOneLanePassthroughAfterEOFSent) {
                    post_passthrough_actions, eq_validator_gen(100.0));
 }
 
-TEST_F(CacheTest, testOneLaneEmitManyChunks) {
+TEST_F(QueryCacheTest, testOneLaneEmitManyChunks) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, false, false),
             Action::emit_remain_chunk(1, 10, 17, 1, false, false),
@@ -621,7 +621,7 @@ TEST_F(CacheTest, testOneLaneEmitManyChunks) {
                    approx_validator_gen(3.1415926535));
 }
 
-TEST_F(CacheTest, testOneLaneEmitManyChunksPassthroughBeforeEOFSent) {
+TEST_F(QueryCacheTest, testOneLaneEmitManyChunksPassthroughBeforeEOFSent) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, false, false),
             Action::emit_remain_chunk(1, 10, 17, 1, false, false),
@@ -649,7 +649,7 @@ TEST_F(CacheTest, testOneLaneEmitManyChunksPassthroughBeforeEOFSent) {
                    approx_validator_gen(3.1415926535));
 }
 
-TEST_F(CacheTest, testOneLaneEmitManyChunksPassthroughAfterEOFSent) {
+TEST_F(QueryCacheTest, testOneLaneEmitManyChunksPassthroughAfterEOFSent) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, false, false),
             Action::emit_remain_chunk(1, 10, 17, 1, false, false),
@@ -681,7 +681,7 @@ TEST_F(CacheTest, testOneLaneEmitManyChunksPassthroughAfterEOFSent) {
                    approx_validator_gen(3.1415926535));
 }
 
-TEST_F(CacheTest, testMultiLaneEmitManyChunks) {
+TEST_F(QueryCacheTest, testMultiLaneEmitManyChunks) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 2, 10, 1, false, false),
             Action::cache_miss_and_emit_first_chunk(4, 15, 30, 1, false, false),
@@ -758,7 +758,7 @@ TEST_F(CacheTest, testMultiLaneEmitManyChunks) {
                    approx_validator_gen(3.1415926535));
 }
 
-TEST_F(CacheTest, testMultiLaneEmitManyChunksPassthrough1) {
+TEST_F(QueryCacheTest, testMultiLaneEmitManyChunksPassthrough1) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 2, 10, 1, false, false),
             Action::cache_miss_and_emit_first_chunk(4, 15, 30, 1, false, false),
@@ -808,7 +808,7 @@ TEST_F(CacheTest, testMultiLaneEmitManyChunksPassthrough1) {
                    approx_validator_gen(3.1415926535));
 }
 
-TEST_F(CacheTest, testMultiLaneEmitManyChunksPassthrough2) {
+TEST_F(QueryCacheTest, testMultiLaneEmitManyChunksPassthrough2) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 2, 10, 1, false, false),
             Action::cache_miss_and_emit_first_chunk(4, 15, 30, 1, false, false),
@@ -865,7 +865,7 @@ TEST_F(CacheTest, testMultiLaneEmitManyChunksPassthrough2) {
                    eq_validator_gen(10000.0));
 }
 
-TEST_F(CacheTest, testMultiLaneMissingEOF) {
+TEST_F(QueryCacheTest, testMultiLaneMissingEOF) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 2, 10, 1, false, false),
             Action::cache_miss_and_emit_first_chunk(4, 15, 30, 1, false, false),
@@ -895,7 +895,7 @@ TEST_F(CacheTest, testMultiLaneMissingEOF) {
                    eq_validator_gen(10000.0));
 }
 
-TEST_F(CacheTest, testMultiLaneFinishBeforeEOFHandled) {
+TEST_F(QueryCacheTest, testMultiLaneFinishBeforeEOFHandled) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 2, 10, 1, false, false),
             Action::cache_miss_and_emit_first_chunk(4, 15, 30, 1, false, false),
@@ -929,7 +929,7 @@ TEST_F(CacheTest, testMultiLaneFinishBeforeEOFHandled) {
                    eq_validator_gen(10000.0));
 }
 
-TEST_F(CacheTest, testMultiLaneCacheMiss) {
+TEST_F(QueryCacheTest, testMultiLaneCacheMiss) {
     Actions pre_passthrough_actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 33, 1, false, false),
             Action::cache_miss_and_emit_first_chunk(9, 33, 66, 1, false, false),
@@ -949,7 +949,7 @@ TEST_F(CacheTest, testMultiLaneCacheMiss) {
                    eq_validator_gen(4356.0));
 }
 
-TEST_F(CacheTest, testMultiLanePassthroughWithEmptyTabletNotCached) {
+TEST_F(QueryCacheTest, testMultiLanePassthroughWithEmptyTabletNotCached) {
     Actions actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 0, 1, true, false),
             Action::cache_miss_and_emit_first_chunk(2, 0, 100, 1, false, false),
@@ -984,7 +984,7 @@ TEST_F(CacheTest, testMultiLanePassthroughWithEmptyTabletNotCached) {
                                                   probe_actions, {}, eq_validator_gen(9801));
 }
 
-TEST_F(CacheTest, testMultiLanePassthroughWithEmptyTabletCached) {
+TEST_F(QueryCacheTest, testMultiLanePassthroughWithEmptyTabletCached) {
     Actions actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 0, 1, true, false),
             Action::cache_miss_and_emit_first_chunk(3, 0, 0, 1, true, false),
@@ -1019,7 +1019,7 @@ TEST_F(CacheTest, testMultiLanePassthroughWithEmptyTabletCached) {
                                                   probe_actions, {}, eq_validator_gen(9801));
 }
 
-TEST_F(CacheTest, testMultiLanePassthroughWithoutEmptyTablet) {
+TEST_F(QueryCacheTest, testMultiLanePassthroughWithoutEmptyTablet) {
     Actions actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, true, false),
             Action::cache_miss_and_emit_first_chunk(2, 10, 30, 1, false, false),
@@ -1065,7 +1065,7 @@ TEST_F(CacheTest, testMultiLanePassthroughWithoutEmptyTablet) {
                                                   probe_actions, {}, eq_validator_gen(4000000));
 }
 
-TEST_F(CacheTest, testOneTabletPartialHit) {
+TEST_F(QueryCacheTest, testOneTabletPartialHit) {
     Actions actions = {
             Action::cache_miss_and_emit_first_chunk(1, 0, 10, 1, false, false),
             Action::emit_remain_chunk(1, 10, 1000, 1, true, false),
@@ -1119,7 +1119,7 @@ TEST_F(CacheTest, testOneTabletPartialHit) {
                    eq_validator_gen(9801.0));
 }
 
-TEST_F(CacheTest, testPartialHit) {
+TEST_F(QueryCacheTest, testPartialHit) {
     Actions actions = {
             Action::cache_miss_and_emit_first_chunk(4, 34, 35, 1, false, false),
             Action::cache_miss_and_emit_first_chunk(1, 0, 3, 1, false, false),
@@ -1165,7 +1165,7 @@ TEST_F(CacheTest, testPartialHit) {
                    eq_validator_gen(801.0 * 801.0));
 }
 
-TEST_F(CacheTest, testTicketChecker) {
+TEST_F(QueryCacheTest, testTicketChecker) {
     auto test_func1 = [](int64_t id, int n) {
         auto ticket_checker = std::make_shared<query_cache::TicketChecker>();
         for (auto i = 0; i < n; ++i) {
@@ -1196,8 +1196,3 @@ TEST_F(CacheTest, testTicketChecker) {
 }
 
 } // namespace starrocks::vectorized
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -173,8 +173,3 @@ TEST_F(HttpClientTest, post_failed) {
 }
 
 } // namespace starrocks
-
-int main(int argc, char* argv[]) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/be/test/http/metrics_action_test.cpp
+++ b/be/test/http/metrics_action_test.cpp
@@ -96,8 +96,3 @@ TEST_F(MetricsActionTest, prometheus_no_name) {
 }
 
 } // namespace starrocks
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -22,7 +22,14 @@ class mg_connection;
 
 namespace starrocks {
 
-extern std::string k_response_str;
+extern void (*s_injected_send_reply)(HttpRequest*, HttpStatus, const std::string&);
+
+namespace {
+static std::string k_response_str;
+static void inject_send_reply(HttpRequest* request, HttpStatus status, const std::string& content) {
+    k_response_str = content;
+}
+} // namespace
 
 extern TLoadTxnBeginResult k_stream_load_begin_result;
 extern TLoadTxnCommitResult k_stream_load_commit_result;
@@ -34,6 +41,8 @@ class TransactionStreamLoadActionTest : public testing::Test {
 public:
     TransactionStreamLoadActionTest() = default;
     ~TransactionStreamLoadActionTest() override = default;
+    static void SetUpTestSuite() { s_injected_send_reply = inject_send_reply; }
+    static void TearDownTestSuite() { s_injected_send_reply = nullptr; }
     void SetUp() override {
         k_stream_load_begin_result = TLoadTxnBeginResult();
         k_stream_load_commit_result = TLoadTxnCommitResult();

--- a/be/test/runtime/memory_scratch_sink_test.cpp
+++ b/be/test/runtime/memory_scratch_sink_test.cpp
@@ -93,6 +93,7 @@ public:
 
     void SetUp() override {
         config::periodic_counter_update_period_ms = 500;
+        _default_storage_root_path = config::storage_root_path;
         config::storage_root_path = "./data";
 
         system("mkdir -p ./test_run/output/");
@@ -105,6 +106,7 @@ public:
     void TearDown() override {
         _obj_pool.clear();
         system("rm -rf ./test_run");
+        config::storage_root_path = _default_storage_root_path;
     }
 
     std::unique_ptr<vectorized::CSVScanner> create_csv_scanner(const std::vector<TypeDescriptor>& types,
@@ -178,6 +180,7 @@ private:
     TMemoryScratchSink _tsink;
     DescriptorTbl* _desc_tbl = nullptr;
     std::vector<TExpr> _exprs;
+    std::string _default_storage_root_path;
 };
 
 void MemoryScratchSinkTest::init() {

--- a/be/test/runtime/memory_scratch_sink_test_issue_8676.cpp
+++ b/be/test/runtime/memory_scratch_sink_test_issue_8676.cpp
@@ -117,6 +117,7 @@ public:
 
     void SetUp() override {
         config::periodic_counter_update_period_ms = 500;
+        _default_storage_root_path = config::storage_root_path;
         config::storage_root_path = "./data";
 
         system("mkdir -p ./test_run/output/");
@@ -129,6 +130,7 @@ public:
     void TearDown() override {
         _obj_pool.clear();
         system("rm -rf ./test_run");
+        config::storage_root_path = _default_storage_root_path;
     }
 
     std::unique_ptr<vectorized::CSVScanner> create_csv_scanner(const std::vector<TypeDescriptor>& types,
@@ -202,6 +204,7 @@ private:
     TMemoryScratchSink _tsink;
     DescriptorTbl* _desc_tbl = nullptr;
     std::vector<TExpr> _exprs;
+    std::string _default_storage_root_path;
 };
 
 void MemoryScratchSinkIssue8676Test::init() {

--- a/be/test/runtime/routine_load_task_executor_test.cpp
+++ b/be/test/runtime/routine_load_task_executor_test.cpp
@@ -123,9 +123,3 @@ TEST_F(RoutineLoadTaskExecutorTest, exec_task) {
 }
 
 } // namespace starrocks
-
-int main(int argc, char* argv[]) {
-    starrocks::CpuInfo::init();
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/be/test/runtime/small_file_mgr_test.cpp
+++ b/be/test/runtime/small_file_mgr_test.cpp
@@ -139,8 +139,3 @@ TEST_F(SmallFileMgrTest, test_get_file) {
 }
 
 } // namespace starrocks
-
-int main(int argc, char* argv[]) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/be/test/runtime/user_function_cache_test.cpp
+++ b/be/test/runtime/user_function_cache_test.cpp
@@ -149,8 +149,3 @@ TEST_F(UserFunctionCacheTest, download_normal) {
 }
 
 } // namespace starrocks
-
-int main(int argc, char* argv[]) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -197,6 +197,7 @@ public:
         Compaction::init(config::max_compaction_concurrency);
         config::enable_event_based_compaction_framework = false;
 
+        _default_storage_root_path = config::storage_root_path;
         config::storage_root_path = std::filesystem::current_path().string() + "/data_test_base_compaction";
         fs::remove_all(config::storage_root_path);
         ASSERT_TRUE(fs::create_directories(config::storage_root_path).ok());
@@ -224,6 +225,7 @@ public:
         if (fs::path_exist(config::storage_root_path)) {
             ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
         }
+        config::storage_root_path = _default_storage_root_path;
     }
 
 protected:
@@ -234,6 +236,7 @@ protected:
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
     std::unique_ptr<MemTracker> _metadata_mem_tracker;
+    std::string _default_storage_root_path;
 };
 
 TEST_F(BaseCompactionTest, test_init_succeeded) {

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -205,6 +205,7 @@ public:
         config::enable_event_based_compaction_framework = false;
         Compaction::init(config::max_compaction_concurrency);
 
+        _default_storage_root_path = config::storage_root_path;
         config::storage_root_path = std::filesystem::current_path().string() + "/data_test_cumulative_compaction";
         fs::remove_all(config::storage_root_path);
         ASSERT_TRUE(fs::create_directories(config::storage_root_path).ok());
@@ -235,6 +236,7 @@ public:
         if (fs::path_exist(config::storage_root_path)) {
             ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
         }
+        config::storage_root_path = _default_storage_root_path;
     }
 
 protected:
@@ -244,6 +246,7 @@ protected:
     std::unique_ptr<MemTracker> _metadata_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
+    std::string _default_storage_root_path;
 
     int64_t _rowset_id;
     int64_t _version;

--- a/be/test/storage/default_compaction_policy_test.cpp
+++ b/be/test/storage/default_compaction_policy_test.cpp
@@ -213,6 +213,7 @@ public:
         config::min_base_compaction_num_singleton_deltas = 10;
         Compaction::init(config::max_compaction_concurrency);
 
+        _default_storage_root_path = config::storage_root_path;
         config::storage_root_path = std::filesystem::current_path().string() + "/data_test_cumulative_compaction";
         fs::remove_all(config::storage_root_path);
         ASSERT_TRUE(fs::create_directories(config::storage_root_path).ok());
@@ -246,6 +247,7 @@ public:
         if (fs::path_exist(config::storage_root_path)) {
             ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
         }
+        config::storage_root_path = _default_storage_root_path;
     }
 
 protected:
@@ -255,6 +257,7 @@ protected:
     std::unique_ptr<MemTracker> _metadata_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
+    std::string _default_storage_root_path;
 
     int64_t _rowset_id;
     int64_t _version;

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -29,7 +29,7 @@ public:
 
     void SetUp() override {
         std::vector<starrocks::StorePath> paths;
-        starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths);
+        CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
         _test_dir = paths[0].path + "/lake";
         _location_provider = new lake::FixedLocationProvider(_test_dir);
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(1)));

--- a/be/test/storage/options_test.cpp
+++ b/be/test/storage/options_test.cpp
@@ -28,12 +28,12 @@
 
 namespace starrocks {
 
-void set_up() {
+static void set_up() {
     system("rm -rf ./test_run && mkdir -p ./test_run");
     system("mkdir -p ./test_run/data && mkdir -p ./test_run/data.ssd");
 }
 
-void tear_down() {
+static void tear_down() {
     system("rm -rf ./test_run");
 }
 
@@ -41,6 +41,9 @@ class OptionsTest : public testing::Test {
 public:
     OptionsTest() = default;
     ~OptionsTest() override = default;
+
+    static void SetUpTestSuite() { set_up(); }
+    static void TearDownTestSuite() { tear_down(); }
 };
 
 TEST_F(OptionsTest, parse_root_path) {
@@ -87,14 +90,3 @@ TEST_F(OptionsTest, parse_root_path) {
 }
 
 } // namespace starrocks
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-
-    int ret = 0;
-    starrocks::set_up();
-    ret = RUN_ALL_TESTS();
-    starrocks::tear_down();
-
-    return ret;
-}

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -68,6 +68,7 @@ protected:
         config::txn_shard_size = 1;
 
         static int i = 0;
+        _default_storage_root_path = config::storage_root_path;
         config::storage_root_path = std::filesystem::current_path().string() + "/data_test_" + std::to_string(i);
 
         ASSERT_OK(fs::remove_all(config::storage_root_path));
@@ -96,6 +97,7 @@ protected:
             ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
         }
         StoragePageCache::release_global_cache();
+        config::storage_root_path = _default_storage_root_path;
     }
 
     std::shared_ptr<TabletSchema> create_primary_tablet_schema() {
@@ -223,6 +225,7 @@ protected:
 
 private:
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
+    std::string _default_storage_root_path;
 };
 
 static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,

--- a/be/test/storage/size_tiered_compaction_policy_test.cpp
+++ b/be/test/storage/size_tiered_compaction_policy_test.cpp
@@ -239,6 +239,7 @@ public:
         config::base_compaction_interval_seconds_since_last_operation = 86400;
         Compaction::init(config::max_compaction_concurrency);
 
+        _default_storage_root_path = config::storage_root_path;
         config::storage_root_path = std::filesystem::current_path().string() + "/data_test_cumulative_compaction";
         fs::remove_all(config::storage_root_path);
         ASSERT_TRUE(fs::create_directories(config::storage_root_path).ok());
@@ -272,6 +273,7 @@ public:
         if (fs::path_exist(config::storage_root_path)) {
             ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
         }
+        config::storage_root_path = _default_storage_root_path;
     }
 
 protected:
@@ -281,6 +283,7 @@ protected:
     std::unique_ptr<MemTracker> _metadata_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
     std::unique_ptr<MemPool> _mem_pool;
+    std::string _default_storage_root_path;
 
     int64_t _rowset_id;
     int64_t _version;


### PR DESCRIPTION
* merge all unnecessary standalone tests back to `starrocks_test`
* reduce be ut binaries from 12 down to 3, greatly reduce binary link time cost and resource cost.
* rename `CacheTest` in query_cache_test.cpp to `QueryCacheTest` due to name conflict.
* HttpChannel::send_reply, remove dirty hacked binary symbol hidden, replace with function pointer injection in BE_TEST mode
* Test cases should save global var value before running the case and restore the value after case done, avoiding breaking other cases that dependends on the default environment settings. (config::storage_root_path is an example).

(cherry picked from commit 5b1f71d0c0c4ef0990ff6f3cb129d028332e84d8)
Signed-off-by: Kevin Xiaohua Cai <caixiaohua@starrocks.com>

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
