### PR TITLE
[BugFix]Fix starrocks can not query hive external table when hive decimal type change

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1227,4 +1227,11 @@ int OrcChunkReader::get_column_id_by_slot_name(const std::string& slot_name) con
     return -1;
 }
 
+bool is_implicit_castable(const TypeDescriptor& from) const {
+    if (is_decimal_type()) {
+        return true;
+    }
+    return false;
+}
+
 } // namespace starrocks

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -453,7 +453,7 @@ Status OrcChunkReader::_init_cast_exprs() {
         // For example, if we assume column A is an integer column, but it's stored as string in orc file
         // then min/max of A is almost unusable. Think that there are values ["10", "10000", "100001", "11"]
         // min/max will be "10" and "11", and we expect min/max is 10/100001
-        if (!_broker_load_mode && !starrocks_type.is_implicit_castable(orc_type)) {
+        if (!_broker_load_mode && !is_implicit_castable(starrocks_type, orc_type)) {
             return Status::NotSupported(strings::Substitute("Type mismatch: orc $0 to native $1. file = $2",
                                                             orc_type.debug_string(), starrocks_type.debug_string(),
                                                             _current_file_name));
@@ -1227,8 +1227,8 @@ int OrcChunkReader::get_column_id_by_slot_name(const std::string& slot_name) con
     return -1;
 }
 
-bool is_implicit_castable(const TypeDescriptor& from) const {
-    if (is_decimal_type()) {
+bool OrcChunkReader::is_implicit_castable(TypeDescriptor& starrocks_type, const TypeDescriptor& orc_type) {
+    if (starrocks_type.is_decimal_type() && orc_type.is_decimal_type()) {
         return true;
     }
     return false;

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -136,6 +136,8 @@ public:
     StatusOr<ChunkPtr> get_lazy_chunk();
     ColumnPtr get_row_delete_filter(const std::set<int64_t>& deleted_pos);
 
+    bool is_implicit_castable(TypeDescriptor& starrocks_type, const TypeDescriptor& orc_type);
+
 private:
     ChunkPtr _create_chunk(const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);
     Status _fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -223,13 +223,6 @@ struct TypeDescriptor {
         }
     }
 
-    bool is_implicit_castable(const TypeDescriptor& from) const {
-        if (is_decimal_type()) {
-            return true;
-        }
-        return false;
-    }
-
     bool operator==(const TypeDescriptor& o) const {
         if (type != o.type) {
             return false;

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -225,7 +225,7 @@ struct TypeDescriptor {
 
     bool is_implicit_castable(const TypeDescriptor& from) const {
         if (is_decimal_type()) {
-            return precision == from.precision && scale == from.scale;
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19803

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
when hive decimal schema change, select return result
![image](https://user-images.githubusercontent.com/105328124/226816316-78c5b59b-dbc3-4c06-85ab-cccc90d6d514.png)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
