### PR TITLE
[Refactor] split hash-joiner to hash join builder and hash join prober

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -62,6 +62,7 @@ set(EXEC_FILES
     lake_meta_scan_node.cpp
     hash_joiner.cpp
     hash_join_node.cpp
+    hash_join_components.cpp
     join_hash_map.cpp
     topn_node.cpp
     chunks_sorter.cpp

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/hash_join_components.h"
+
+#include "column/vectorized_fwd.h"
+#include "exec/hash_joiner.h"
+
+namespace starrocks {
+
+void HashJoinProber::push_probe_chunk(RuntimeState* state, ChunkPtr&& chunk) {
+    DCHECK(!_probe_chunk);
+    _probe_chunk = std::move(chunk);
+    _current_probe_has_remain = true;
+    _hash_joiner.prepare_probe_key_columns(&_key_columns, _probe_chunk);
+}
+
+StatusOr<ChunkPtr> HashJoinProber::probe_chunk(RuntimeState* state, JoinHashTable* hash_table) {
+    auto chunk = std::make_shared<Chunk>();
+    TRY_CATCH_ALLOC_SCOPE_START()
+    DCHECK(_current_probe_has_remain && _probe_chunk);
+    RETURN_IF_ERROR(hash_table->probe(state, _key_columns, &_probe_chunk, &chunk, &_current_probe_has_remain));
+    if (!_current_probe_has_remain) {
+        _probe_chunk = nullptr;
+    }
+    TRY_CATCH_ALLOC_SCOPE_END()
+    return chunk;
+}
+
+StatusOr<ChunkPtr> HashJoinProber::probe_remain(RuntimeState* state, JoinHashTable* hash_table, bool* has_remain) {
+    auto chunk = std::make_shared<Chunk>();
+    TRY_CATCH_ALLOC_SCOPE_START()
+    RETURN_IF_ERROR(hash_table->probe_remain(state, &chunk, &_current_probe_has_remain));
+    *has_remain = _current_probe_has_remain;
+    TRY_CATCH_ALLOC_SCOPE_END()
+    return chunk;
+}
+
+void HashJoinProber::reset() {
+    _probe_chunk->reset();
+    _current_probe_has_remain = false;
+}
+
+void HashJoinBuilder::create(const HashTableParam& param) {
+    _ht.create(param);
+}
+
+void HashJoinBuilder::close() {
+    _key_columns.clear();
+    _ht.close();
+}
+
+void HashJoinBuilder::reset(const HashTableParam& param) {
+    close();
+    create(param);
+}
+
+void HashJoinBuilder::reset_probe(RuntimeState* state) {
+    _key_columns.clear();
+    _ht.reset_probe_state(state);
+}
+
+Status HashJoinBuilder::append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    if (UNLIKELY(_ht.get_row_count() + chunk->num_rows() >= max_hash_table_element_size)) {
+        return Status::NotSupported(strings::Substitute("row count of right table in hash join > $0", UINT32_MAX));
+    }
+
+    _hash_joiner.prepare_build_key_columns(&_key_columns, chunk);
+    // copy chunk of right table
+    SCOPED_TIMER(_hash_joiner.build_metrics().copy_right_table_chunk_timer);
+    TRY_CATCH_BAD_ALLOC(_ht.append_chunk(state, chunk, _key_columns));
+    return Status::OK();
+}
+
+Status HashJoinBuilder::build(RuntimeState* state) {
+    SCOPED_TIMER(_hash_joiner.build_metrics().build_ht_timer);
+    TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_ht.build(state)));
+    _ready = true;
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/exec/hash_join_components.h
+++ b/be/src/exec/hash_join_components.h
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
+#include "exec/join_hash_map.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+class HashJoiner;
+class HashJoinProber {
+public:
+    HashJoinProber(HashJoiner& hash_joiner) : _hash_joiner(hash_joiner) {}
+
+    bool probe_chunk_empty() const { return _probe_chunk == nullptr; }
+
+    void push_probe_chunk(RuntimeState* state, ChunkPtr&& chunk);
+
+    // probe hash table
+    StatusOr<ChunkPtr> probe_chunk(RuntimeState* state, JoinHashTable* hash_table);
+
+    StatusOr<ChunkPtr> probe_remain(RuntimeState* state, JoinHashTable* hash_table, bool* has_remain);
+
+    void reset();
+
+    HashJoinProber* clone_empty(ObjectPool* pool) { return pool->add(new HashJoinProber(_hash_joiner)); }
+
+private:
+    HashJoiner& _hash_joiner;
+    ChunkPtr _probe_chunk;
+    Columns _key_columns;
+    bool _current_probe_has_remain = false;
+};
+
+class HashJoinBuilder {
+public:
+    static constexpr size_t max_hash_table_element_size = UINT32_MAX;
+
+    HashJoinBuilder(HashJoiner& hash_joiner) : _hash_joiner(hash_joiner) {}
+
+    void create(const HashTableParam& param);
+
+    JoinHashTable& hash_table() { return _ht; }
+
+    void close();
+
+    void reset(const HashTableParam& param);
+
+    Status append_chunk(RuntimeState* state, const ChunkPtr& chunk);
+
+    Status build(RuntimeState* state);
+
+    size_t hash_table_row_count() { return _ht.get_row_count(); }
+
+    void reset_probe(RuntimeState* state);
+
+    HashJoinBuilder* clone_empty(ObjectPool* pool) { return pool->add(new HashJoinBuilder(_hash_joiner)); }
+
+    bool ready() const { return _ready; }
+
+private:
+    HashJoiner& _hash_joiner;
+    JoinHashTable _ht;
+    Columns _key_columns;
+    bool _ready = false;
+};
+
+} // namespace starrocks

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -21,6 +21,8 @@
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
+#include "common/statusor.h"
+#include "exec/hash_join_components.h"
 #include "exprs/column_ref.h"
 #include "exprs/expr.h"
 #include "exprs/runtime_filter_bank.h"
@@ -32,6 +34,26 @@
 #include "util/runtime_profile.h"
 
 namespace starrocks {
+
+void HashJoinProbeMetrics::prepare(RuntimeProfile* runtime_profile) {
+    search_ht_timer = ADD_TIMER(runtime_profile, "SearchHashTableTime");
+    output_build_column_timer = ADD_TIMER(runtime_profile, "OutputBuildColumnTime");
+    output_probe_column_timer = ADD_TIMER(runtime_profile, "OutputProbeColumnTime");
+    output_tuple_column_timer = ADD_TIMER(runtime_profile, "OutputTupleColumnTime");
+    probe_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "ProbeConjunctEvaluateTime");
+    other_join_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "OtherJoinConjunctEvaluateTime");
+    where_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "WhereConjunctEvaluateTime");
+}
+
+void HashJoinBuildMetrics::prepare(RuntimeProfile* runtime_profile) {
+    copy_right_table_chunk_timer = ADD_TIMER(runtime_profile, "CopyRightTableChunkTime");
+    build_ht_timer = ADD_TIMER(runtime_profile, "BuildHashTableTime");
+    build_runtime_filter_timer = ADD_TIMER(runtime_profile, "RuntimeFilterBuildTime");
+    build_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "BuildConjunctEvaluateTime");
+    build_buckets_counter =
+            ADD_COUNTER_SKIP_MERGE(runtime_profile, "BuildBuckets", TUnit::UNIT, TCounterMergeType::SKIP_FIRST_MERGE);
+    runtime_filter_num = ADD_COUNTER(runtime_profile, "RuntimeFilterNum", TUnit::UNIT);
+}
 
 HashJoiner::HashJoiner(const HashJoinerParam& param)
         : _hash_join_node(param._hash_join_node),
@@ -59,6 +81,10 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
     if (param._hash_join_node.__isset.build_runtime_filters_from_planner) {
         _build_runtime_filters_from_planner = param._hash_join_node.build_runtime_filters_from_planner;
     }
+    _hash_join_builder = _pool->add(new HashJoinBuilder(*this));
+    _hash_join_prober = _pool->add(new HashJoinProber(*this));
+    _build_metrics = _pool->add(new HashJoinBuildMetrics());
+    _probe_metrics = _pool->add(new HashJoinProbeMetrics());
 }
 
 Status HashJoiner::prepare_builder(RuntimeState* state, RuntimeProfile* runtime_profile) {
@@ -75,20 +101,15 @@ Status HashJoiner::prepare_builder(RuntimeState* state, RuntimeProfile* runtime_
 
     runtime_profile->add_info_string("DistributionMode", to_string(_hash_join_node.distribution_mode));
     runtime_profile->add_info_string("JoinType", to_string(_join_type));
-    _copy_right_table_chunk_timer = ADD_TIMER(runtime_profile, "CopyRightTableChunkTime");
-    _build_ht_timer = ADD_TIMER(runtime_profile, "BuildHashTableTime");
-    _build_runtime_filter_timer = ADD_TIMER(runtime_profile, "RuntimeFilterBuildTime");
-    _build_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "BuildConjunctEvaluateTime");
-    _build_buckets_counter =
-            ADD_COUNTER_SKIP_MERGE(runtime_profile, "BuildBuckets", TUnit::UNIT, TCounterMergeType::SKIP_FIRST_MERGE);
-    _runtime_filter_num = ADD_COUNTER(runtime_profile, "RuntimeFilterNum", TUnit::UNIT);
 
-    HashTableParam param;
-    _init_hash_table_param(&param);
-    _ht.create(param);
+    _build_metrics->prepare(runtime_profile);
 
-    _probe_column_count = _ht.get_probe_column_count();
-    _build_column_count = _ht.get_build_column_count();
+    _init_hash_table_param(&_hash_table_param);
+    _hash_join_builder->create(hash_table_param());
+    auto& ht = _hash_join_builder->hash_table();
+
+    _probe_column_count = ht.get_probe_column_count();
+    _build_column_count = ht.get_build_column_count();
 
     return Status::OK();
 }
@@ -100,13 +121,7 @@ Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_p
 
     runtime_profile->add_info_string("DistributionMode", to_string(_hash_join_node.distribution_mode));
     runtime_profile->add_info_string("JoinType", to_string(_join_type));
-    _search_ht_timer = ADD_TIMER(runtime_profile, "SearchHashTableTime");
-    _output_build_column_timer = ADD_TIMER(runtime_profile, "OutputBuildColumnTime");
-    _output_probe_column_timer = ADD_TIMER(runtime_profile, "OutputProbeColumnTime");
-    _output_tuple_column_timer = ADD_TIMER(runtime_profile, "OutputTupleColumnTime");
-    _probe_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "ProbeConjunctEvaluateTime");
-    _other_join_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "OtherJoinConjunctEvaluateTime");
-    _where_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "WhereConjunctEvaluateTime");
+    _probe_metrics->prepare(runtime_profile);
 
     return Status::OK();
 }
@@ -119,10 +134,10 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->row_desc = &_row_descriptor;
     param->build_row_desc = &_build_row_descriptor;
     param->probe_row_desc = &_probe_row_descriptor;
-    param->search_ht_timer = _search_ht_timer;
-    param->output_build_column_timer = _output_build_column_timer;
-    param->output_probe_column_timer = _output_probe_column_timer;
-    param->output_tuple_column_timer = _output_tuple_column_timer;
+    param->search_ht_timer = probe_metrics().search_ht_timer;
+    param->output_build_column_timer = probe_metrics().output_build_column_timer;
+    param->output_probe_column_timer = probe_metrics().output_probe_column_timer;
+    param->output_tuple_column_timer = probe_metrics().output_tuple_column_timer;
 
     param->output_slots = _output_slots;
     std::set<SlotId> predicate_slots;
@@ -154,25 +169,43 @@ Status HashJoiner::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk
     if (!chunk || chunk->is_empty()) {
         return Status::OK();
     }
-    if (UNLIKELY(_ht.get_row_count() + chunk->num_rows() >= UINT32_MAX)) {
-        return Status::NotSupported(strings::Substitute("row count of right table in hash join > $0", UINT32_MAX));
+
+    update_build_rows(chunk->num_rows());
+    RETURN_IF_ERROR(_hash_join_builder->append_chunk(state, chunk));
+
+    return Status::OK();
+}
+
+Status HashJoiner::append_chunk_to_spill_buffer(RuntimeState* state, const ChunkPtr& chunk) {
+    update_build_rows(chunk->num_rows());
+    auto io_executor = spill_channel()->io_executor();
+    RETURN_IF_ERROR(spiller()->spill(state, chunk, *io_executor, spill::MemTrackerGuard(tls_mem_tracker)));
+    return Status::OK();
+}
+
+Status HashJoiner::append_spill_task(RuntimeState* state, std::function<StatusOr<ChunkPtr>()>& spill_task) {
+    Status st;
+    while (!spiller()->is_full()) {
+        auto chunk_st = spill_task();
+        if (chunk_st.ok()) {
+            RETURN_IF_ERROR(
+                    spiller()->spill(state, chunk_st.value(), io_executor(), spill::MemTrackerGuard(tls_mem_tracker)));
+        } else if (chunk_st.status().is_end_of_file()) {
+            return Status::OK();
+        } else {
+            return chunk_st.status();
+        }
     }
-    {
-        SCOPED_TIMER(_build_conjunct_evaluate_timer);
-        _prepare_key_columns(_key_columns, chunk, _build_expr_ctxs);
-    }
-    {
-        // copy chunk of right table
-        SCOPED_TIMER(_copy_right_table_chunk_timer);
-        TRY_CATCH_BAD_ALLOC(_ht.append_chunk(state, chunk, _key_columns));
-    }
+    // status
+    _spill_channel->add_spill_task({spill_task});
     return Status::OK();
 }
 
 Status HashJoiner::build_ht(RuntimeState* state) {
     if (_phase == HashJoinPhase::BUILD) {
-        RETURN_IF_ERROR(_build(state));
-        COUNTER_SET(_build_buckets_counter, static_cast<int64_t>(_ht.get_bucket_size()));
+        RETURN_IF_ERROR(_hash_join_builder->build(state));
+        size_t bucket_size = _hash_join_builder->hash_table().get_bucket_size();
+        COUNTER_SET(build_metrics().build_buckets_counter, static_cast<int64_t>(bucket_size));
     }
 
     return Status::OK();
@@ -181,7 +214,7 @@ Status HashJoiner::build_ht(RuntimeState* state) {
 bool HashJoiner::need_input() const {
     // when _buffered_chunk accumulates several chunks to form into a large enough chunk, it is moved into
     // _probe_chunk for probe operations.
-    return _phase == HashJoinPhase::PROBE && _probe_input_chunk == nullptr;
+    return _phase == HashJoinPhase::PROBE && _hash_join_prober->probe_chunk_empty();
 }
 
 bool HashJoiner::has_output() const {
@@ -190,7 +223,7 @@ bool HashJoiner::has_output() const {
     }
 
     if (_phase == HashJoinPhase::PROBE) {
-        return _probe_input_chunk != nullptr;
+        return !_hash_join_prober->probe_chunk_empty();
     }
 
     if (_phase == HashJoinPhase::POST_PROBE) {
@@ -204,11 +237,7 @@ bool HashJoiner::has_output() const {
 
 void HashJoiner::push_chunk(RuntimeState* state, ChunkPtr&& chunk) {
     DCHECK(chunk && !chunk->is_empty());
-    DCHECK(!_probe_input_chunk);
-
-    _probe_input_chunk = std::move(chunk);
-    _ht_has_remain = true;
-    _prepare_probe_key_columns();
+    _hash_join_prober->push_probe_chunk(state, std::move(chunk));
 }
 
 StatusOr<ChunkPtr> HashJoiner::pull_chunk(RuntimeState* state) {
@@ -220,18 +249,11 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
     DCHECK(_phase != HashJoinPhase::BUILD);
 
     auto chunk = std::make_shared<Chunk>();
+    auto& ht = _hash_join_builder->hash_table();
 
-    if (_phase == HashJoinPhase::PROBE || _probe_input_chunk != nullptr) {
-        DCHECK(_ht_has_remain && _probe_input_chunk);
-
-        TRY_CATCH_BAD_ALLOC(
-                RETURN_IF_ERROR(_ht.probe(state, _key_columns, &_probe_input_chunk, &chunk, &_ht_has_remain)));
-        if (!_ht_has_remain) {
-            _probe_input_chunk = nullptr;
-        }
-
+    if (_phase == HashJoinPhase::PROBE || !_hash_join_prober->probe_chunk_empty()) {
+        ASSIGN_OR_RETURN(chunk, _hash_join_prober->probe_chunk(state, &ht));
         RETURN_IF_ERROR(_filter_probe_output_chunk(chunk));
-
         return chunk;
     }
 
@@ -241,8 +263,10 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
             return chunk;
         }
 
-        TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_ht.probe_remain(state, &chunk, &_ht_has_remain)));
-        if (!_ht_has_remain) {
+        bool has_remain = false;
+        ASSIGN_OR_RETURN(chunk, _hash_join_prober->probe_remain(state, &ht, &has_remain));
+
+        if (!has_remain) {
             enter_eos_phase();
         }
 
@@ -255,7 +279,7 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
 }
 
 void HashJoiner::close(RuntimeState* state) {
-    _ht.close();
+    _hash_join_builder->close();
 }
 
 Status HashJoiner::create_runtime_filters(RuntimeState* state) {
@@ -263,15 +287,14 @@ Status HashJoiner::create_runtime_filters(RuntimeState* state) {
         return Status::OK();
     }
 
-    uint64_t runtime_join_filter_pushdown_limit = 1024000;
-    if (state->query_options().__isset.runtime_join_filter_pushdown_limit) {
-        runtime_join_filter_pushdown_limit = state->query_options().runtime_join_filter_pushdown_limit;
-    }
+    uint64_t runtime_join_filter_pushdown_limit = runtime_bloom_filter_row_limit();
+
+    auto& ht = _hash_join_builder->hash_table();
 
     if (_is_push_down) {
         if (_probe_node_type == TPlanNodeType::EXCHANGE_NODE && _build_node_type == TPlanNodeType::EXCHANGE_NODE) {
             _is_push_down = false;
-        } else if (_ht.get_row_count() > runtime_join_filter_pushdown_limit) {
+        } else if (ht.get_row_count() > runtime_join_filter_pushdown_limit) {
             _is_push_down = false;
         }
 
@@ -289,8 +312,11 @@ Status HashJoiner::create_runtime_filters(RuntimeState* state) {
 }
 
 void HashJoiner::reference_hash_table(HashJoiner* src_join_builder) {
-    _ht = src_join_builder->_ht.clone_readable_table();
-    _ht.set_probe_profile(_search_ht_timer, _output_probe_column_timer, _output_tuple_column_timer);
+    auto& hash_table = _hash_join_builder->hash_table();
+
+    hash_table = src_join_builder->_hash_join_builder->hash_table().clone_readable_table();
+    hash_table.set_probe_profile(probe_metrics().search_ht_timer, probe_metrics().output_probe_column_timer,
+                                 probe_metrics().output_tuple_column_timer);
 
     _probe_column_count = src_join_builder->_probe_column_count;
     _build_column_count = src_join_builder->_build_column_count;
@@ -316,11 +342,12 @@ void HashJoiner::decr_prober(RuntimeState* state) {
 }
 
 size_t HashJoiner::avg_keys_perf_bucket() const {
-    size_t used_bucket_count = _ht.get_used_bucket_count();
+    const auto& hash_table = _hash_join_builder->hash_table();
+    size_t used_bucket_count = hash_table.get_used_bucket_count();
     if (used_bucket_count == 0) {
         return 0;
     }
-    size_t count = _ht.get_row_count() / used_bucket_count;
+    size_t count = hash_table.get_row_count() / used_bucket_count;
     return count;
 }
 
@@ -332,10 +359,10 @@ Status HashJoiner::reset_probe(starrocks::RuntimeState* state) {
         return Status::OK();
     }
 
-    _probe_input_chunk.reset();
-    _ht_has_remain = false;
-    _key_columns.resize(0);
-    _ht.reset_probe_state(state);
+    _hash_join_prober->reset();
+
+    _hash_join_builder->reset_probe(state);
+
     return Status::OK();
 }
 
@@ -346,12 +373,6 @@ bool HashJoiner::_has_null(const ColumnPtr& column) {
         return null_column->contain_value(1, null_column->size(), 1);
     }
     return false;
-}
-
-Status HashJoiner::_build(RuntimeState* state) {
-    SCOPED_TIMER(_build_ht_timer);
-    TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_ht.build(state)));
-    return Status::OK();
 }
 
 Status HashJoiner::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filter, bool& filter_all, bool& hit_all) {
@@ -428,7 +449,8 @@ Status HashJoiner::_process_outer_join_with_other_conjunct(ChunkPtr* chunk, size
     RETURN_IF_ERROR(_calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all));
     _process_row_for_other_conjunct(chunk, start_column, column_count, filter_all, hit_all, filter);
 
-    _ht.remove_duplicate_index(&filter);
+    auto& ht = _hash_join_builder->hash_table();
+    ht.remove_duplicate_index(&filter);
     (*chunk)->filter(filter);
 
     return Status::OK();
@@ -441,7 +463,9 @@ Status HashJoiner::_process_semi_join_with_other_conjunct(ChunkPtr* chunk) {
 
     _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
 
-    _ht.remove_duplicate_index(&filter);
+    auto& ht = _hash_join_builder->hash_table();
+    ht.remove_duplicate_index(&filter);
+
     (*chunk)->filter(filter);
 
     return Status::OK();
@@ -453,15 +477,16 @@ Status HashJoiner::_process_right_anti_join_with_other_conjunct(ChunkPtr* chunk)
     Filter filter;
 
     _calc_filter_for_other_conjunct(chunk, filter, filter_all, hit_all);
+    auto& ht = _hash_join_builder->hash_table();
+    ht.remove_duplicate_index(&filter);
 
-    _ht.remove_duplicate_index(&filter);
     (*chunk)->set_num_rows(0);
 
     return Status::OK();
 }
 
 Status HashJoiner::_process_other_conjunct(ChunkPtr* chunk) {
-    SCOPED_TIMER(_other_join_conjunct_evaluate_timer);
+    SCOPED_TIMER(probe_metrics().other_join_conjunct_evaluate_timer);
     switch (_join_type) {
     case TJoinOp::LEFT_OUTER_JOIN:
     case TJoinOp::FULL_OUTER_JOIN:
@@ -483,8 +508,73 @@ Status HashJoiner::_process_other_conjunct(ChunkPtr* chunk) {
 }
 
 Status HashJoiner::_process_where_conjunct(ChunkPtr* chunk) {
-    SCOPED_TIMER(_where_conjunct_evaluate_timer);
+    SCOPED_TIMER(probe_metrics().where_conjunct_evaluate_timer);
     return ExecNode::eval_conjuncts(_conjunct_ctxs, (*chunk).get());
+}
+
+Status HashJoiner::_create_runtime_in_filters(RuntimeState* state) {
+    SCOPED_TIMER(build_metrics().build_runtime_filter_timer);
+    size_t ht_row_count = get_ht_row_count();
+    auto& ht = _hash_join_builder->hash_table();
+
+    if (ht_row_count > 1024) {
+        return Status::OK();
+    }
+
+    if (ht_row_count > 0) {
+        // there is a bug (DSDB-3860) in old planner if probe_expr is not slot-ref, and this fix is workaround.
+        size_t size = _build_expr_ctxs.size();
+        std::vector<bool> to_build(size, true);
+        for (int i = 0; i < size; i++) {
+            ExprContext* expr_ctx = _probe_expr_ctxs[i];
+            to_build[i] = (expr_ctx->root()->is_slotref());
+        }
+
+        for (size_t i = 0; i < size; i++) {
+            if (!to_build[i]) continue;
+            ColumnPtr column = ht.get_key_columns()[i];
+            Expr* probe_expr = _probe_expr_ctxs[i]->root();
+            // create and fill runtime in filter.
+            VectorizedInConstPredicateBuilder builder(state, _pool, probe_expr);
+            builder.set_eq_null(_is_null_safes[i]);
+            builder.use_as_join_runtime_filter();
+            Status st = builder.create();
+            if (!st.ok()) {
+                _runtime_in_filters.push_back(nullptr);
+                continue;
+            }
+            if (probe_expr->type().is_string_type()) {
+                _string_key_columns.emplace_back(column);
+            }
+            builder.add_values(column, kHashJoinKeyColumnOffset);
+            _runtime_in_filters.push_back(builder.get_in_const_predicate());
+        }
+    }
+
+    COUNTER_UPDATE(build_metrics().runtime_filter_num, static_cast<int64_t>(_runtime_in_filters.size()));
+    return Status::OK();
+}
+
+Status HashJoiner::_create_runtime_bloom_filters(RuntimeState* state, int64_t limit) {
+    auto& ht = _hash_join_builder->hash_table();
+    for (auto* rf_desc : _build_runtime_filters) {
+        rf_desc->set_is_pipeline(true);
+        // skip if it does not have consumer.
+        if (!rf_desc->has_consumer()) {
+            _runtime_bloom_filter_build_params.emplace_back();
+            continue;
+        }
+        if (!rf_desc->has_remote_targets() && ht.get_row_count() > limit) {
+            _runtime_bloom_filter_build_params.emplace_back();
+            continue;
+        }
+
+        int expr_order = rf_desc->build_expr_order();
+        ColumnPtr column = ht.get_key_columns()[expr_order];
+        bool eq_null = _is_null_safes[expr_order];
+        _runtime_bloom_filter_build_params.emplace_back(pipeline::RuntimeBloomFilterBuildParam(eq_null, column));
+    }
+    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <memory>
 #include <utility>
 
 #include "column/chunk.h"
@@ -21,12 +22,16 @@
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "exec/exec_node.h"
+#include "exec/hash_join_components.h"
 #include "exec/hash_join_node.h"
 #include "exec/join_hash_map.h"
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/pipeline/runtime_filter_types.h"
+#include "exec/pipeline/spill_process_channel.h"
+#include "exec/spill/spiller.h"
 #include "exprs/in_const_predicate.hpp"
 #include "util/phmap/phmap.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 
@@ -35,6 +40,8 @@ class TPlanNode;
 class DescriptorTbl;
 class RuntimeState;
 class ExprContext;
+class HashJoinProber;
+class HashJoinBuilder;
 
 class ColumnRef;
 class RuntimeFilterBuildDescriptor;
@@ -111,6 +118,29 @@ struct HashJoinerParam {
     const TJoinDistributionMode::type _distribution_mode;
 };
 
+struct HashJoinProbeMetrics {
+    RuntimeProfile::Counter* search_ht_timer = nullptr;
+    RuntimeProfile::Counter* output_probe_column_timer = nullptr;
+    RuntimeProfile::Counter* output_tuple_column_timer = nullptr;
+    RuntimeProfile::Counter* probe_conjunct_evaluate_timer = nullptr;
+    RuntimeProfile::Counter* other_join_conjunct_evaluate_timer = nullptr;
+    RuntimeProfile::Counter* where_conjunct_evaluate_timer = nullptr;
+    RuntimeProfile::Counter* output_build_column_timer = nullptr;
+
+    void prepare(RuntimeProfile* runtime_profile);
+};
+
+struct HashJoinBuildMetrics {
+    RuntimeProfile::Counter* build_ht_timer = nullptr;
+    RuntimeProfile::Counter* copy_right_table_chunk_timer = nullptr;
+    RuntimeProfile::Counter* build_runtime_filter_timer = nullptr;
+    RuntimeProfile::Counter* build_conjunct_evaluate_timer = nullptr;
+    RuntimeProfile::Counter* build_buckets_counter = nullptr;
+    RuntimeProfile::Counter* runtime_filter_num = nullptr;
+
+    void prepare(RuntimeProfile* runtime_profile);
+};
+
 class HashJoiner final : public pipeline::ContextWithDependency {
 public:
     explicit HashJoiner(const HashJoinerParam& param);
@@ -144,9 +174,17 @@ public:
             _phase.compare_exchange_strong(old_phase, HashJoinPhase::EOS);
         }
     }
+
+    void update_build_rows(size_t num_rows) { _hash_table_build_rows += num_rows; }
+
     void enter_eos_phase() { _phase = HashJoinPhase::EOS; }
     // build phase
     Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk);
+
+    Status append_chunk_to_spill_buffer(RuntimeState* state, const ChunkPtr& chunk);
+
+    Status append_spill_task(RuntimeState* state, std::function<StatusOr<ChunkPtr>()>& spill_task);
+
     Status build_ht(RuntimeState* state);
     // probe phase
     void push_chunk(RuntimeState* state, ChunkPtr&& chunk);
@@ -157,7 +195,10 @@ public:
     pipeline::OptRuntimeBloomFilterBuildParams& get_runtime_bloom_filter_build_params() {
         return _runtime_bloom_filter_build_params;
     }
-    size_t get_ht_row_count() { return _ht.get_row_count(); }
+
+    size_t get_ht_row_count() { return _hash_join_builder->hash_table_row_count(); }
+
+    HashJoinBuilder* hash_join_builder() { return _hash_join_builder; }
 
     Status create_runtime_filters(RuntimeState* state);
 
@@ -174,15 +215,54 @@ public:
 
     size_t avg_keys_perf_bucket() const;
 
+    const HashJoinBuildMetrics& build_metrics() { return *_build_metrics; }
+    const HashJoinProbeMetrics& probe_metrics() { return *_probe_metrics; }
+
+    size_t runtime_in_filter_row_limit() const { return 1024; }
+
+    size_t runtime_bloom_filter_row_limit() const {
+        uint64_t runtime_join_filter_pushdown_limit = 1024000;
+        if (_runtime_state->query_options().__isset.runtime_join_filter_pushdown_limit) {
+            runtime_join_filter_pushdown_limit = _runtime_state->query_options().runtime_join_filter_pushdown_limit;
+        }
+        return runtime_join_filter_pushdown_limit;
+    }
+
+    // hash table param.
+    const HashTableParam& hash_table_param() const { return _hash_table_param; }
+
+    void set_spiller(std::shared_ptr<spill::Spiller> spiller) { _spiller = std::move(spiller); }
+    void set_spill_channel(SpillProcessChannelPtr channel) { _spill_channel = std::move(channel); }
+    const auto& spiller() { return _spiller; }
+    const SpillProcessChannelPtr& spill_channel() { return _spill_channel; }
+    auto& io_executor() { return *spill_channel()->io_executor(); }
+    void set_spill_strategy(spill::SpillStrategy strategy) { _spill_strategy = strategy; }
+    spill::SpillStrategy spill_strategy() { return _spill_strategy; }
+
+    void prepare_probe_key_columns(Columns* key_columns, const ChunkPtr& chunk) {
+        SCOPED_TIMER(probe_metrics().probe_conjunct_evaluate_timer);
+        _prepare_key_columns(*key_columns, chunk, _probe_expr_ctxs);
+    }
+
+    void prepare_build_key_columns(Columns* key_columns, const ChunkPtr& chunk) {
+        SCOPED_TIMER(build_metrics().build_conjunct_evaluate_timer);
+        _prepare_key_columns(*key_columns, chunk, _build_expr_ctxs);
+    }
+
+    const std::vector<ExprContext*> probe_expr_ctxs() { return _probe_expr_ctxs; }
+
+    HashJoinProber* new_prober(ObjectPool* pool) { return _hash_join_prober->clone_empty(pool); }
+    HashJoinBuilder* new_builder(ObjectPool* pool) { return _hash_join_builder->clone_empty(pool); }
+
 private:
     static bool _has_null(const ColumnPtr& column);
 
     void _init_hash_table_param(HashTableParam* param);
 
-    void _prepare_key_columns(Columns& key_columns, const ChunkPtr& chunk, const vector<ExprContext*>& expr_ctxs) {
+    Status _prepare_key_columns(Columns& key_columns, const ChunkPtr& chunk, const vector<ExprContext*>& expr_ctxs) {
         key_columns.resize(0);
         for (auto& expr_ctx : expr_ctxs) {
-            ColumnPtr column_ptr = EVALUATE_NULL_IF_ERROR(expr_ctx, expr_ctx->root(), chunk.get());
+            ASSIGN_OR_RETURN(auto column_ptr, expr_ctx->evaluate(chunk.get()));
             if (column_ptr->only_null()) {
                 ColumnPtr column = ColumnHelper::create_column(expr_ctx->root()->type(), true);
                 column->append_nulls(chunk->num_rows());
@@ -195,11 +275,7 @@ private:
                 key_columns.emplace_back(column_ptr);
             }
         }
-    }
-
-    void _prepare_probe_key_columns() {
-        SCOPED_TIMER(_probe_conjunct_evaluate_timer);
-        _prepare_key_columns(_key_columns, _probe_input_chunk, _probe_expr_ctxs);
+        return Status::OK();
     }
 
     bool _need_post_probe() const {
@@ -211,19 +287,21 @@ private:
         if (_phase == HashJoinPhase::EOS) {
             return;
         }
+        size_t row_count = _hash_table_build_rows;
 
         // special cases of short-circuit break.
-        if (_ht.get_row_count() == 0 &&
-            (_join_type == TJoinOp::INNER_JOIN || _join_type == TJoinOp::LEFT_SEMI_JOIN ||
-             _join_type == TJoinOp::RIGHT_SEMI_JOIN || _join_type == TJoinOp::RIGHT_ANTI_JOIN ||
-             _join_type == TJoinOp::RIGHT_OUTER_JOIN)) {
+        if (row_count == 0 && (_join_type == TJoinOp::INNER_JOIN || _join_type == TJoinOp::LEFT_SEMI_JOIN ||
+                               _join_type == TJoinOp::RIGHT_SEMI_JOIN || _join_type == TJoinOp::RIGHT_ANTI_JOIN ||
+                               _join_type == TJoinOp::RIGHT_OUTER_JOIN)) {
             _phase = HashJoinPhase::EOS;
             return;
         }
 
-        if (_ht.get_row_count() > 0) {
-            if (_join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN && _ht.get_key_columns().size() == 1 &&
-                _has_null(_ht.get_key_columns()[0]) && _other_join_conjunct_ctxs.empty()) {
+        auto& ht = _hash_join_builder->hash_table();
+
+        if (row_count > 0) {
+            if (_join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN && ht.get_key_columns().size() == 1 &&
+                _has_null(ht.get_key_columns()[0]) && _other_join_conjunct_ctxs.empty()) {
                 // The current implementation of HashTable will reserve a row for judging the end of the linked list.
                 // When performing expression calculations (such as cast string to int),
                 // it is possible that this reserved row will generate Null,
@@ -236,7 +314,6 @@ private:
     }
 
     Status _build(RuntimeState* state);
-    Status _probe(RuntimeState* state, ScopedTimer<MonotonicStopWatch>& probe_timer, ChunkPtr* chunk, bool& eos);
 
     StatusOr<ChunkPtr> _pull_probe_output_chunk(RuntimeState* state);
 
@@ -277,67 +354,9 @@ private:
         return Status::OK();
     }
 
-    Status _create_runtime_in_filters(RuntimeState* state) {
-        SCOPED_TIMER(_build_runtime_filter_timer);
+    Status _create_runtime_in_filters(RuntimeState* state);
 
-        if (_ht.get_row_count() > 1024) {
-            return Status::OK();
-        }
-
-        if (_ht.get_row_count() > 0) {
-            // there is a bug (DSDB-3860) in old planner if probe_expr is not slot-ref, and this fix is workaround.
-            size_t size = _build_expr_ctxs.size();
-            std::vector<bool> to_build(size, true);
-            for (int i = 0; i < size; i++) {
-                ExprContext* expr_ctx = _probe_expr_ctxs[i];
-                to_build[i] = (expr_ctx->root()->is_slotref());
-            }
-
-            for (size_t i = 0; i < size; i++) {
-                if (!to_build[i]) continue;
-                ColumnPtr column = _ht.get_key_columns()[i];
-                Expr* probe_expr = _probe_expr_ctxs[i]->root();
-                // create and fill runtime in filter.
-                VectorizedInConstPredicateBuilder builder(state, _pool, probe_expr);
-                builder.set_eq_null(_is_null_safes[i]);
-                builder.use_as_join_runtime_filter();
-                Status st = builder.create();
-                if (!st.ok()) {
-                    _runtime_in_filters.push_back(nullptr);
-                    continue;
-                }
-                if (probe_expr->type().is_string_type()) {
-                    _string_key_columns.emplace_back(column);
-                }
-                builder.add_values(column, kHashJoinKeyColumnOffset);
-                _runtime_in_filters.push_back(builder.get_in_const_predicate());
-            }
-        }
-
-        COUNTER_UPDATE(_runtime_filter_num, static_cast<int64_t>(_runtime_in_filters.size()));
-        return Status::OK();
-    }
-
-    Status _create_runtime_bloom_filters(RuntimeState* state, int64_t limit) {
-        for (auto* rf_desc : _build_runtime_filters) {
-            rf_desc->set_is_pipeline(true);
-            // skip if it does not have consumer.
-            if (!rf_desc->has_consumer()) {
-                _runtime_bloom_filter_build_params.emplace_back();
-                continue;
-            }
-            if (!rf_desc->has_remote_targets() && _ht.get_row_count() > limit) {
-                _runtime_bloom_filter_build_params.emplace_back();
-                continue;
-            }
-
-            int expr_order = rf_desc->build_expr_order();
-            ColumnPtr column = _ht.get_key_columns()[expr_order];
-            bool eq_null = _is_null_safes[expr_order];
-            _runtime_bloom_filter_build_params.emplace_back(pipeline::RuntimeBloomFilterBuildParam(eq_null, column));
-        }
-        return Status::OK();
-    }
+    Status _create_runtime_bloom_filters(RuntimeState* state, int64_t limit);
 
 private:
     const THashJoinNode& _hash_join_node;
@@ -348,8 +367,6 @@ private:
     TJoinOp::type _join_type = TJoinOp::INNER_JOIN;
     std::atomic<HashJoinPhase> _phase = HashJoinPhase::BUILD;
     bool _is_closed = false;
-
-    ChunkPtr _probe_input_chunk;
 
     const std::vector<bool>& _is_null_safes;
     // Equal conjuncts in Join On.
@@ -375,9 +392,6 @@ private:
 
     bool _is_push_down = false;
 
-    JoinHashTable _ht;
-
-    Columns _key_columns;
     // lifetime of string-typed key columns must exceed HashJoiner's lifetime, because slices in the hash of runtime
     // in-filter constructed from string-typed key columns reference the memory of this column, and the in-filter's
     // lifetime can last beyond HashJoiner.
@@ -386,7 +400,7 @@ private:
     size_t _build_column_count = 0;
 
     // hash table doesn't have reserved data
-    bool _ht_has_remain = false;
+    // bool _ht_has_remain = false;
     // right table have not output data for right outer join/right semi join/right anti join/full outer join
 
     bool _has_referenced_hash_table = false;
@@ -396,22 +410,18 @@ private:
     std::atomic<size_t> _num_finished_probers = 0;
     std::atomic<size_t> _num_closed_probers = 0;
 
-    // Profile for hash join builder.
-    RuntimeProfile::Counter* _build_ht_timer = nullptr;
-    RuntimeProfile::Counter* _copy_right_table_chunk_timer = nullptr;
-    RuntimeProfile::Counter* _build_runtime_filter_timer = nullptr;
-    RuntimeProfile::Counter* _output_build_column_timer = nullptr;
-    RuntimeProfile::Counter* _build_buckets_counter = nullptr;
-    RuntimeProfile::Counter* _runtime_filter_num = nullptr;
+    HashJoinProber* _hash_join_prober;
+    HashJoinBuilder* _hash_join_builder;
 
-    // Profile for hash join prober.
-    RuntimeProfile::Counter* _search_ht_timer = nullptr;
-    RuntimeProfile::Counter* _output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* _output_tuple_column_timer = nullptr;
-    RuntimeProfile::Counter* _build_conjunct_evaluate_timer = nullptr;
-    RuntimeProfile::Counter* _probe_conjunct_evaluate_timer = nullptr;
-    RuntimeProfile::Counter* _other_join_conjunct_evaluate_timer = nullptr;
-    RuntimeProfile::Counter* _where_conjunct_evaluate_timer = nullptr;
+    HashTableParam _hash_table_param;
+
+    std::shared_ptr<spill::Spiller> _spiller;
+    std::shared_ptr<SpillProcessChannel> _spill_channel;
+    spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
+
+    HashJoinBuildMetrics* _build_metrics;
+    HashJoinProbeMetrics* _probe_metrics;
+    size_t _hash_table_build_rows{};
 };
 
 } // namespace starrocks


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
we will implement hybrid hash join, which has multi-partition, for each partition we could allocate a hash join builder and prober

part-1 for https://github.com/StarRocks/starrocks/pull/19122

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
