### PR TITLE
[Enhancement] Column iterator uses its own file to read data

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -804,6 +804,9 @@ CONF_Int32(starlet_port, "9070");
 CONF_Int32(starlet_cache_thread_num, "64");
 // Root dir used for cache if cache enabled.
 CONF_String(starlet_cache_dir, "");
+// Buffer size in starlet fs buffer stream, size <= 0 means not use buffer stream.
+// Only support in S3/HDFS currently.
+CONF_Int32(starlet_fs_stream_buffer_size_bytes, "131072");
 #endif
 
 CONF_Int64(lake_metadata_cache_limit, /*2GB=*/"2147483648");

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -31,6 +31,8 @@
 
 // cachemgr thread pool size
 DECLARE_int32(cachemgr_threadpool_size);
+// buffer size in starlet fs buffer stream, size <= 0 means not use buffer stream.
+DECLARE_int32(fs_stream_buffer_size_bytes);
 
 namespace starrocks {
 
@@ -293,7 +295,9 @@ void init_staros_worker() {
     if (g_starlet.get() != nullptr) {
         return;
     }
+
     FLAGS_cachemgr_threadpool_size = config::starlet_cache_thread_num;
+    FLAGS_fs_stream_buffer_size_bytes = config::starlet_fs_stream_buffer_size_bytes;
 
     staros::starlet::StarletConfig starlet_config;
     starlet_config.rpc_port = config::starlet_port;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We introduce buffer in starlet s3/hdfs file to prefetch some remote data to improve read efficiency for lake table. However, currently all column iterators of a segment use a shared file, which will cause buffer invalidation, so we need to create a separate file for each column iterator.

Test result of buffer:

```
data: 
ssb lineorder 6kw
bucket 1
oss

select count(lo_orderkey) from lineorder;
buffer size     io time
0               15s327ms
128K            1s910ms
256K            1s295ms
512K            995ms
1M              788ms

select count(lo_orderkey), count(lo_linenumber) from lineorder;
buffer size     io time
0               29s897ms
128K            2s901ms
256K            2s214ms
512K            1s629ms
1M              1s17ms

select count(lo_orderkey), count(lo_linenumber), count(lo_custkey), count(lo_partkey) from lineorder;
buffer size     io time
0               70s
128K            18s813ms
256K            14s152ms
512K            11s949ms
1M              8s592ms
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
