### PR TITLE
[Enhancement] Add mem statistics for rowset (#11057)

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(Storage STATIC
     rowset/segment_iterator.cpp
     rowset/segment_options.cpp
     rowset/rowid_range_option.cpp
+    rowset/rowset_meta.cpp
     task/engine_batch_load_task.cpp
     task/engine_checksum_task.cpp
     task/engine_clone_task.cpp

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -248,8 +248,8 @@ Status DataDir::load() {
     LOG(INFO) << "begin loading rowset from meta";
     auto load_rowset_func = [&dir_rowset_metas](const TabletUid& tablet_uid, RowsetId rowset_id,
                                                 std::string_view meta_str) -> bool {
-        auto rowset_meta = std::make_shared<RowsetMeta>();
-        bool parsed = rowset_meta->init(meta_str);
+        bool parsed = false;
+        auto rowset_meta = std::make_shared<RowsetMeta>(meta_str, &parsed);
         if (!parsed) {
             LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
             // return false will break meta iterator, return true to skip this error

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -63,7 +63,13 @@ std::string BetaRowset::segment_srcrssid_file_path(const std::string& dir, const
 }
 
 BetaRowset::BetaRowset(const TabletSchema* schema, string rowset_path, RowsetMetaSharedPtr rowset_meta)
-        : Rowset(schema, std::move(rowset_path), std::move(rowset_meta)) {}
+        : Rowset(schema, std::move(rowset_path), std::move(rowset_meta)) {
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());
+}
+
+BetaRowset::~BetaRowset() {
+    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());
+}
 
 Status BetaRowset::init() {
     return Status::OK();

--- a/be/src/storage/rowset/beta_rowset.h
+++ b/be/src/storage/rowset/beta_rowset.h
@@ -41,18 +41,15 @@ class KVStore;
 
 class BetaRowset : public Rowset {
 public:
-    static std::shared_ptr<BetaRowset> create(MemTracker* mem_tracker, const TabletSchema* schema,
-                                              std::string rowset_path, RowsetMetaSharedPtr rowset_meta) {
-        auto rowset =
-                std::shared_ptr<BetaRowset>(new BetaRowset(schema, std::move(rowset_path), std::move(rowset_meta)),
-                                            DeleterWithMemTracker<BetaRowset>(mem_tracker));
-        mem_tracker->consume(rowset->mem_usage());
-        return rowset;
+    BetaRowset() = delete;
+    static std::shared_ptr<BetaRowset> create(const TabletSchema* schema, std::string rowset_path,
+                                              RowsetMetaSharedPtr rowset_meta) {
+        return std::make_shared<BetaRowset>(schema, std::move(rowset_path), std::move(rowset_meta));
     }
 
     BetaRowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta);
 
-    ~BetaRowset() override {}
+    ~BetaRowset() override;
 
     // reload this rowset after the underlying segment file is changed
     Status reload();
@@ -117,6 +114,7 @@ protected:
 private:
     friend class RowsetFactory;
     friend class BetaRowsetReader;
+    int64_t _mem_usage() const { return sizeof(BetaRowset) + _rowset_path.length(); }
     std::vector<SegmentSharedPtr> _segments;
 };
 

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -48,12 +48,7 @@
 namespace starrocks {
 
 BetaRowsetWriter::BetaRowsetWriter(const RowsetWriterContext& context)
-        : _context(context),
-          _rowset_meta(nullptr),
-          _num_rows_written(0),
-          _total_row_size(0),
-          _total_data_size(0),
-          _total_index_size(0) {}
+        : _context(context), _num_rows_written(0), _total_row_size(0), _total_data_size(0), _total_index_size(0) {}
 
 Status BetaRowsetWriter::init() {
     DCHECK(!(_context.tablet_schema->contains_format_v1_column() &&
@@ -74,23 +69,27 @@ Status BetaRowsetWriter::init() {
     if (real_data_format != tablet_format) {
         _rowset_schema = _context.tablet_schema->convert_to_format(real_data_format);
     }
+    _rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+    _rowset_meta_pb->set_deprecated_rowset_id(0);
+    _rowset_meta_pb->set_rowset_id(_context.rowset_id.to_string());
+    _rowset_meta_pb->set_partition_id(_context.partition_id);
+    _rowset_meta_pb->set_tablet_id(_context.tablet_id);
+    _rowset_meta_pb->set_tablet_schema_hash(_context.tablet_schema_hash);
+    _rowset_meta_pb->set_rowset_type(BETA_ROWSET);
+    _rowset_meta_pb->set_rowset_state(_context.rowset_state);
+    _rowset_meta_pb->set_segments_overlap_pb(_context.segments_overlap);
 
-    _rowset_meta = std::make_shared<RowsetMeta>();
-    _rowset_meta->set_rowset_id(_context.rowset_id);
-    _rowset_meta->set_partition_id(_context.partition_id);
-    _rowset_meta->set_tablet_id(_context.tablet_id);
-    _rowset_meta->set_tablet_schema_hash(_context.tablet_schema_hash);
-    _rowset_meta->set_rowset_type(_context.rowset_type);
-    _rowset_meta->set_rowset_state(_context.rowset_state);
-    _rowset_meta->set_segments_overlap(_context.segments_overlap);
     if (_context.rowset_state == PREPARED || _context.rowset_state == COMMITTED) {
         _is_pending = true;
-        _rowset_meta->set_txn_id(_context.txn_id);
-        _rowset_meta->set_load_id(_context.load_id);
+        _rowset_meta_pb->set_txn_id(_context.txn_id);
+        PUniqueId* new_load_id = _rowset_meta_pb->mutable_load_id();
+        new_load_id->set_hi(_context.load_id.hi());
+        new_load_id->set_lo(_context.load_id.lo());
     } else {
-        _rowset_meta->set_version(_context.version);
+        _rowset_meta_pb->set_start_version(_context.version.first);
+        _rowset_meta_pb->set_end_version(_context.version.second);
     }
-    _rowset_meta->set_tablet_uid(_context.tablet_uid);
+    *(_rowset_meta_pb->mutable_tablet_uid()) = _context.tablet_uid.to_proto();
 
     _writer_options.storage_format_version = _context.storage_format_version;
     _writer_options.global_dicts = _context.global_dicts != nullptr ? _context.global_dicts : nullptr;
@@ -108,21 +107,21 @@ StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
     if (_num_rows_written > 0 || (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && _num_delfile > 0)) {
         RETURN_IF_ERROR(_fs->sync_dir(_context.rowset_path_prefix));
     }
-    _rowset_meta->set_num_rows(_num_rows_written);
-    _rowset_meta->set_total_row_size(_total_row_size);
-    _rowset_meta->set_total_disk_size(_total_data_size);
-    _rowset_meta->set_data_disk_size(_total_data_size);
-    _rowset_meta->set_index_disk_size(_total_index_size);
+    _rowset_meta_pb->set_num_rows(_num_rows_written);
+    _rowset_meta_pb->set_total_row_size(_total_row_size);
+    _rowset_meta_pb->set_total_disk_size(_total_data_size);
+    _rowset_meta_pb->set_data_disk_size(_total_data_size);
+    _rowset_meta_pb->set_index_disk_size(_total_index_size);
     // TODO write zonemap to meta
-    _rowset_meta->set_empty(_num_rows_written == 0);
-    _rowset_meta->set_creation_time(time(nullptr));
-    _rowset_meta->set_num_segments(_num_segment);
+    _rowset_meta_pb->set_empty(_num_rows_written == 0);
+    _rowset_meta_pb->set_creation_time(time(nullptr));
+    _rowset_meta_pb->set_num_segments(_num_segment);
     // newly created rowset do not have rowset_id yet, use 0 instead
-    _rowset_meta->set_rowset_seg_id(0);
+    _rowset_meta_pb->set_rowset_seg_id(0);
     // updatable tablet require extra processing
     if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
-        _rowset_meta->set_num_delete_files(_num_delfile);
-        _rowset_meta->set_segments_overlap(NONOVERLAPPING);
+        _rowset_meta_pb->set_num_delete_files(_num_delfile);
+        _rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
         // if load only has delete, we can skip the partial update logic
         if (_context.partial_update_tablet_schema && _flush_chunk_state != FlushChunkState::DELETE) {
             DCHECK(_context.referenced_column_ids.size() == _context.partial_update_tablet_schema->columns().size());
@@ -133,21 +132,22 @@ StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
                 _rowset_txn_meta_pb->add_partial_update_column_ids(_context.referenced_column_ids[i]);
                 _rowset_txn_meta_pb->add_partial_update_column_unique_ids(tablet_column.unique_id());
             }
-            _rowset_meta->set_txn_meta(*_rowset_txn_meta_pb);
+            *_rowset_meta_pb->mutable_txn_meta() = *_rowset_txn_meta_pb;
         }
     } else {
         if (_num_segment <= 1) {
-            _rowset_meta->set_segments_overlap(NONOVERLAPPING);
+            _rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
         }
     }
     if (_is_pending) {
-        _rowset_meta->set_rowset_state(COMMITTED);
+        _rowset_meta_pb->set_rowset_state(COMMITTED);
     } else {
-        _rowset_meta->set_rowset_state(VISIBLE);
+        _rowset_meta_pb->set_rowset_state(VISIBLE);
     }
+    auto rowset_meta = std::make_shared<RowsetMeta>(_rowset_meta_pb);
     RowsetSharedPtr rowset;
     RETURN_IF_ERROR(
-            RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_path_prefix, _rowset_meta, &rowset));
+            RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_path_prefix, rowset_meta, &rowset));
     _already_built = true;
     return rowset;
 }
@@ -385,7 +385,7 @@ Status HorizontalBetaRowsetWriter::add_rowset(RowsetSharedPtr rowset) {
     _num_segment += static_cast<int>(rowset->num_segments());
     // TODO update zonemap
     if (rowset->rowset_meta()->has_delete_predicate()) {
-        _rowset_meta->set_delete_predicate(rowset->rowset_meta()->delete_predicate());
+        *_rowset_meta_pb->mutable_delete_predicate() = rowset->rowset_meta()->delete_predicate();
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -56,7 +56,7 @@ protected:
 
     RowsetWriterContext _context;
     std::shared_ptr<FileSystem> _fs;
-    std::shared_ptr<RowsetMeta> _rowset_meta;
+    std::unique_ptr<RowsetMetaPB> _rowset_meta_pb;
     std::unique_ptr<TabletSchema> _rowset_schema;
     std::unique_ptr<RowsetTxnMetaPB> _rowset_txn_meta_pb;
     SegmentWriterOptions _writer_options;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -35,6 +35,8 @@ Rowset::Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSh
           _rowset_meta(std::move(rowset_meta)),
           _refs_by_reader(0) {}
 
+Rowset::~Rowset() = default;
+
 Status Rowset::load() {
     // if the state is ROWSET_UNLOADING it means close() is called
     // and the rowset is already loaded, and the resource is not closed yet.

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -68,7 +68,7 @@ enum RowsetState {
 
 class RowsetStateMachine {
 public:
-    RowsetStateMachine() {}
+    RowsetStateMachine() = default;
 
     Status on_load() {
         switch (_rowset_state) {
@@ -116,7 +116,11 @@ private:
 
 class Rowset : public std::enable_shared_from_this<Rowset> {
 public:
-    virtual ~Rowset() = default;
+    Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta);
+    Rowset(const Rowset&) = delete;
+    const Rowset& operator=(const Rowset&) = delete;
+
+    virtual ~Rowset();
 
     // Open all segment files in this rowset and load necessary metadata.
     //
@@ -150,20 +154,16 @@ public:
     // helper class to access RowsetMeta
     int64_t start_version() const { return rowset_meta()->version().first; }
     int64_t end_version() const { return rowset_meta()->version().second; }
-    size_t index_disk_size() const { return rowset_meta()->index_disk_size(); }
     size_t data_disk_size() const { return rowset_meta()->total_disk_size(); }
     bool empty() const { return rowset_meta()->empty(); }
-    bool zero_num_rows() const { return rowset_meta()->num_rows() == 0; }
     size_t num_rows() const { return rowset_meta()->num_rows(); }
     size_t total_row_size() const { return rowset_meta()->total_row_size(); }
     Version version() const { return rowset_meta()->version(); }
     RowsetId rowset_id() const { return rowset_meta()->rowset_id(); }
-    int64_t creation_time() { return rowset_meta()->creation_time(); }
+    int64_t creation_time() const { return rowset_meta()->creation_time(); }
     PUniqueId load_id() const { return rowset_meta()->load_id(); }
     int64_t txn_id() const { return rowset_meta()->txn_id(); }
     int64_t partition_id() const { return rowset_meta()->partition_id(); }
-    // flag for push delete rowset
-    bool delete_flag() const { return rowset_meta()->delete_flag(); }
     int64_t num_segments() const { return rowset_meta()->num_segments(); }
     uint32_t num_delete_files() const { return rowset_meta()->get_num_delete_files(); }
     bool has_data_files() const { return num_segments() > 0 || num_delete_files() > 0; }
@@ -220,7 +220,7 @@ public:
 
     void set_need_delete_file() { _need_delete_file = true; }
 
-    bool contains_version(Version version) { return rowset_meta()->version().contains(version); }
+    bool contains_version(Version version) const { return rowset_meta()->version().contains(version); }
 
     static bool comparator(const RowsetSharedPtr& left, const RowsetSharedPtr& right) {
         return left->end_version() < right->end_version();
@@ -278,11 +278,6 @@ public:
 
 protected:
     friend class RowsetFactory;
-
-    Rowset(const Rowset&) = delete;
-    const Rowset& operator=(const Rowset&) = delete;
-    // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
-    Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta);
 
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     virtual Status init() = 0;

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -34,7 +34,7 @@ namespace starrocks {
 Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::string& rowset_path,
                                     const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {
     if (rowset_meta->rowset_type() == BETA_ROWSET) {
-        *rowset = BetaRowset::create(ExecEnv::GetInstance()->metadata_mem_tracker(), schema, rowset_path, rowset_meta);
+        *rowset = BetaRowset::create(schema, rowset_path, rowset_meta);
         RETURN_IF_ERROR((*rowset)->init());
         return Status::OK();
     }

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -1,0 +1,37 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+#include "storage/rowset/rowset_meta.h"
+
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
+
+namespace starrocks {
+RowsetMeta::RowsetMeta(std::string_view pb_rowset_meta, bool* parse_ok) {
+    _rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+    *parse_ok = _deserialize_from_pb(pb_rowset_meta);
+    if (*parse_ok) {
+        _init();
+    }
+    _mem_usage = _calc_mem_usage();
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
+}
+
+RowsetMeta::RowsetMeta(std::unique_ptr<RowsetMetaPB>& rowset_meta_pb) {
+    _rowset_meta_pb = std::move(rowset_meta_pb);
+    _init();
+    _mem_usage = _calc_mem_usage();
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
+}
+
+RowsetMeta::RowsetMeta(const RowsetMetaPB& rowset_meta_pb) {
+    _rowset_meta_pb = std::make_unique<RowsetMetaPB>(rowset_meta_pb);
+    _init();
+    _mem_usage = _calc_mem_usage();
+    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
+}
+
+RowsetMeta::~RowsetMeta() {
+    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -40,180 +40,95 @@ using RowsetMetaSharedPtr = std::shared_ptr<RowsetMeta>;
 
 class RowsetMeta {
 public:
-    // for ut
-    RowsetMeta() = default;
+    RowsetMeta() = delete;
 
-    ~RowsetMeta() = default;
+    explicit RowsetMeta(const RowsetMetaPB& rowset_meta_pb);
+    explicit RowsetMeta(std::unique_ptr<RowsetMetaPB>& rowset_meta_pb);
+    RowsetMeta(std::string_view pb_rowset_meta, bool* parse_ok);
 
-    bool init(std::string_view pb_rowset_meta) {
-        bool ret = _deserialize_from_pb(pb_rowset_meta);
-        if (!ret) {
-            return false;
-        }
-        _init();
-        return true;
-    }
-
-    bool init_from_pb(const RowsetMetaPB& rowset_meta_pb) {
-        _rowset_meta_pb = rowset_meta_pb;
-        _init();
-        return true;
-    }
-
-    bool init_from_json(const std::string& json_rowset_meta) {
-        bool ret = json2pb::JsonToProtoMessage(json_rowset_meta, &_rowset_meta_pb);
-        if (!ret) {
-            return false;
-        }
-        _init();
-        return true;
-    }
-
-    bool serialize(std::string* value) { return _serialize_to_pb(value); }
-
-    bool json_rowset_meta(std::string* json_rowset_meta) {
-        json2pb::Pb2JsonOptions json_options;
-        json_options.pretty_json = true;
-        bool ret = json2pb::ProtoMessageToJson(_rowset_meta_pb, json_rowset_meta, json_options);
-        return ret;
-    }
+    ~RowsetMeta();
 
     RowsetId rowset_id() const { return _rowset_id; }
 
-    void set_rowset_id(const RowsetId& rowset_id) {
-        // rowset id is a required field, just set it to 0
-        _rowset_meta_pb.set_deprecated_rowset_id(0);
-        _rowset_id = rowset_id;
-        _rowset_meta_pb.set_rowset_id(rowset_id.to_string());
-    }
+    int64_t tablet_id() const { return _rowset_meta_pb->tablet_id(); }
 
-    int64_t tablet_id() const { return _rowset_meta_pb.tablet_id(); }
+    TabletUid tablet_uid() const { return _rowset_meta_pb->tablet_uid(); }
 
-    void set_tablet_id(int64_t tablet_id) { _rowset_meta_pb.set_tablet_id(tablet_id); }
+    int64_t txn_id() const { return _rowset_meta_pb->txn_id(); }
 
-    TabletUid tablet_uid() const { return _rowset_meta_pb.tablet_uid(); }
+    int32_t tablet_schema_hash() const { return _rowset_meta_pb->tablet_schema_hash(); }
 
-    void set_tablet_uid(const TabletUid& tablet_uid) {
-        *(_rowset_meta_pb.mutable_tablet_uid()) = tablet_uid.to_proto();
-    }
+    RowsetTypePB rowset_type() const { return _rowset_meta_pb->rowset_type(); }
 
-    int64_t txn_id() const { return _rowset_meta_pb.txn_id(); }
+    RowsetStatePB rowset_state() const { return _rowset_meta_pb->rowset_state(); }
 
-    void set_txn_id(int64_t txn_id) { _rowset_meta_pb.set_txn_id(txn_id); }
+    void set_rowset_state(RowsetStatePB rowset_state) { _rowset_meta_pb->set_rowset_state(rowset_state); }
 
-    int32_t tablet_schema_hash() const { return _rowset_meta_pb.tablet_schema_hash(); }
-
-    void set_tablet_schema_hash(int64_t tablet_schema_hash) {
-        _rowset_meta_pb.set_tablet_schema_hash(tablet_schema_hash);
-    }
-
-    RowsetTypePB rowset_type() const { return _rowset_meta_pb.rowset_type(); }
-
-    void set_rowset_type(RowsetTypePB rowset_type) { _rowset_meta_pb.set_rowset_type(rowset_type); }
-
-    RowsetStatePB rowset_state() const { return _rowset_meta_pb.rowset_state(); }
-
-    void set_rowset_state(RowsetStatePB rowset_state) { _rowset_meta_pb.set_rowset_state(rowset_state); }
-
-    Version version() const { return {_rowset_meta_pb.start_version(), _rowset_meta_pb.end_version()}; }
+    Version version() const { return {_rowset_meta_pb->start_version(), _rowset_meta_pb->end_version()}; }
 
     void set_version(Version version) {
-        _rowset_meta_pb.set_start_version(version.first);
-        _rowset_meta_pb.set_end_version(version.second);
+        _rowset_meta_pb->set_start_version(version.first);
+        _rowset_meta_pb->set_end_version(version.second);
     }
 
-    bool has_version() const { return _rowset_meta_pb.has_start_version() && _rowset_meta_pb.has_end_version(); }
+    bool has_version() const { return _rowset_meta_pb->has_start_version() && _rowset_meta_pb->has_end_version(); }
 
-    int64_t start_version() const { return _rowset_meta_pb.start_version(); }
+    int64_t start_version() const { return _rowset_meta_pb->start_version(); }
 
-    void set_start_version(int64_t start_version) { _rowset_meta_pb.set_start_version(start_version); }
+    int64_t end_version() const { return _rowset_meta_pb->end_version(); }
 
-    int64_t end_version() const { return _rowset_meta_pb.end_version(); }
+    int64_t num_rows() const { return _rowset_meta_pb->num_rows(); }
 
-    void set_end_version(int64_t end_version) { _rowset_meta_pb.set_end_version(end_version); }
+    int64_t total_row_size() { return _rowset_meta_pb->total_row_size(); }
 
-    int64_t num_rows() const { return _rowset_meta_pb.num_rows(); }
+    size_t total_disk_size() const { return _rowset_meta_pb->total_disk_size(); }
 
-    void set_num_rows(int64_t num_rows) { _rowset_meta_pb.set_num_rows(num_rows); }
+    size_t data_disk_size() const { return _rowset_meta_pb->data_disk_size(); }
 
-    int64_t total_row_size() { return _rowset_meta_pb.total_row_size(); }
+    size_t index_disk_size() const { return _rowset_meta_pb->index_disk_size(); }
 
-    void set_total_row_size(int64_t total_row_size) { _rowset_meta_pb.set_total_row_size(total_row_size); }
+    bool has_delete_predicate() const { return _rowset_meta_pb->has_delete_predicate(); }
 
-    size_t total_disk_size() const { return _rowset_meta_pb.total_disk_size(); }
+    const DeletePredicatePB& delete_predicate() const { return _rowset_meta_pb->delete_predicate(); }
 
-    void set_total_disk_size(size_t total_disk_size) { _rowset_meta_pb.set_total_disk_size(total_disk_size); }
-
-    size_t data_disk_size() const { return _rowset_meta_pb.data_disk_size(); }
-
-    void set_data_disk_size(size_t data_disk_size) { _rowset_meta_pb.set_data_disk_size(data_disk_size); }
-
-    size_t index_disk_size() const { return _rowset_meta_pb.index_disk_size(); }
-
-    void set_index_disk_size(size_t index_disk_size) { _rowset_meta_pb.set_index_disk_size(index_disk_size); }
-
-    bool has_delete_predicate() const { return _rowset_meta_pb.has_delete_predicate(); }
-
-    const DeletePredicatePB& delete_predicate() const { return _rowset_meta_pb.delete_predicate(); }
-
-    DeletePredicatePB* mutable_delete_predicate() { return _rowset_meta_pb.mutable_delete_predicate(); }
+    DeletePredicatePB* mutable_delete_predicate() { return _rowset_meta_pb->mutable_delete_predicate(); }
 
     void set_delete_predicate(const DeletePredicatePB& delete_predicate) {
-        *_rowset_meta_pb.mutable_delete_predicate() = delete_predicate;
+        *_rowset_meta_pb->mutable_delete_predicate() = delete_predicate;
     }
-
-    const RowsetTxnMetaPB& txn_meta() const { return _rowset_meta_pb.txn_meta(); }
-
-    RowsetTxnMetaPB* mutable_txn_meta() { return _rowset_meta_pb.mutable_txn_meta(); }
 
     // return semgent_footer position and size if rowset is partial_rowset
     const FooterPointerPB* partial_rowset_footer(size_t segment_id) const {
-        if (!_rowset_meta_pb.has_txn_meta()) {
+        if (!_rowset_meta_pb->has_txn_meta()) {
             return nullptr;
         }
-        return &_rowset_meta_pb.txn_meta().partial_rowset_footers(segment_id);
+        return &_rowset_meta_pb->txn_meta().partial_rowset_footers(segment_id);
     }
 
-    void set_txn_meta(const RowsetTxnMetaPB& txn_meta) { *_rowset_meta_pb.mutable_txn_meta() = txn_meta; }
+    void clear_txn_meta() { _rowset_meta_pb->clear_txn_meta(); }
 
-    void clear_txn_meta() { _rowset_meta_pb.clear_txn_meta(); }
+    bool empty() const { return _rowset_meta_pb->empty(); }
 
-    bool empty() const { return _rowset_meta_pb.empty(); }
+    PUniqueId load_id() const { return _rowset_meta_pb->load_id(); }
 
-    void set_empty(bool empty) { _rowset_meta_pb.set_empty(empty); }
+    int64_t creation_time() const { return _rowset_meta_pb->creation_time(); }
 
-    PUniqueId load_id() const { return _rowset_meta_pb.load_id(); }
+    void set_creation_time(int64_t creation_time) { return _rowset_meta_pb->set_creation_time(creation_time); }
 
-    void set_load_id(const PUniqueId& load_id) {
-        PUniqueId* new_load_id = _rowset_meta_pb.mutable_load_id();
-        new_load_id->set_hi(load_id.hi());
-        new_load_id->set_lo(load_id.lo());
-    }
+    int64_t partition_id() const { return _rowset_meta_pb->partition_id(); }
 
-    bool delete_flag() const { return _rowset_meta_pb.delete_flag(); }
+    int64_t num_segments() const { return _rowset_meta_pb->num_segments(); }
 
-    int64_t creation_time() const { return _rowset_meta_pb.creation_time(); }
+    void to_rowset_pb(RowsetMetaPB* rs_meta_pb) const { *rs_meta_pb = *_rowset_meta_pb; }
 
-    void set_creation_time(int64_t creation_time) { return _rowset_meta_pb.set_creation_time(creation_time); }
-
-    int64_t partition_id() const { return _rowset_meta_pb.partition_id(); }
-
-    void set_partition_id(int64_t partition_id) { return _rowset_meta_pb.set_partition_id(partition_id); }
-
-    int64_t num_segments() const { return _rowset_meta_pb.num_segments(); }
-
-    void set_num_segments(int64_t num_segments) { _rowset_meta_pb.set_num_segments(num_segments); }
-
-    void to_rowset_pb(RowsetMetaPB* rs_meta_pb) const { *rs_meta_pb = _rowset_meta_pb; }
-
-    RowsetMetaPB to_rowset_pb() {
+    RowsetMetaPB to_rowset_pb() const {
         RowsetMetaPB meta_pb;
         to_rowset_pb(&meta_pb);
         return meta_pb;
     }
 
     bool is_singleton_delta() const {
-        return has_version() && _rowset_meta_pb.start_version() == _rowset_meta_pb.end_version();
+        return has_version() && _rowset_meta_pb->start_version() == _rowset_meta_pb->end_version();
     }
 
     // Some time, we may check if this rowset is in rowset meta manager's meta by using RowsetMetaManager::check_rowset_meta.
@@ -225,11 +140,7 @@ public:
 
     bool is_remove_from_rowset_meta() const { return _is_removed_from_rowset_meta; }
 
-    SegmentsOverlapPB segments_overlap() const { return _rowset_meta_pb.segments_overlap_pb(); }
-
-    void set_segments_overlap(SegmentsOverlapPB segments_overlap) {
-        _rowset_meta_pb.set_segments_overlap_pb(segments_overlap);
-    }
+    SegmentsOverlapPB segments_overlap() const { return _rowset_meta_pb->segments_overlap_pb(); }
 
     // return true if segments in this rowset has overlapping data.
     // this is not same as `segments_overlap()` method.
@@ -259,47 +170,52 @@ public:
         return score;
     }
 
-    int64_t mem_usage() const { return sizeof(RowsetMeta) + _rowset_meta_pb.SpaceUsedLong() - sizeof(_rowset_meta_pb); }
+    int64_t mem_usage() const { return _mem_usage; }
 
-    uint32_t get_rowset_seg_id() const { return _rowset_meta_pb.rowset_seg_id(); }
+    uint32_t get_rowset_seg_id() const { return _rowset_meta_pb->rowset_seg_id(); }
 
-    void set_rowset_seg_id(uint32_t id) { _rowset_meta_pb.set_rowset_seg_id(id); }
+    void set_rowset_seg_id(uint32_t id) { _rowset_meta_pb->set_rowset_seg_id(id); }
 
-    uint32_t get_num_delete_files() const { return _rowset_meta_pb.num_delete_files(); }
+    uint32_t get_num_delete_files() const { return _rowset_meta_pb->num_delete_files(); }
 
-    void set_num_delete_files(uint32_t num_delete_files) { _rowset_meta_pb.set_num_delete_files(num_delete_files); }
-
-    const RowsetMetaPB& get_meta_pb() const { return _rowset_meta_pb; }
+    const RowsetMetaPB& get_meta_pb() const { return *_rowset_meta_pb; }
 
 private:
     bool _deserialize_from_pb(std::string_view value) {
-        return _rowset_meta_pb.ParseFromArray(value.data(), value.size());
-    }
-
-    bool _serialize_to_pb(std::string* value) {
-        if (value == nullptr) {
-            return false;
-        }
-        return _rowset_meta_pb.SerializeToString(value);
+        return _rowset_meta_pb->ParseFromArray(value.data(), value.size());
     }
 
     void _init() {
-        if (_rowset_meta_pb.deprecated_rowset_id() > 0) {
-            _rowset_id.init(_rowset_meta_pb.deprecated_rowset_id());
+        if (_rowset_meta_pb->deprecated_rowset_id() > 0) {
+            _rowset_id.init(_rowset_meta_pb->deprecated_rowset_id());
         } else {
-            _rowset_id.init(_rowset_meta_pb.rowset_id());
+            _rowset_id.init(_rowset_meta_pb->rowset_id());
         }
+    }
+
+    int64_t _calc_mem_usage() const {
+        int64_t size = sizeof(RowsetMeta);
+        if (_rowset_meta_pb != nullptr) {
+            size += static_cast<int64_t>(_rowset_meta_pb->SpaceUsedLong());
+        }
+        return size;
     }
 
     friend bool operator==(const RowsetMeta& a, const RowsetMeta& b) {
         if (a._rowset_id != b._rowset_id) return false;
         if (a._is_removed_from_rowset_meta != b._is_removed_from_rowset_meta) return false;
-        return google::protobuf::util::MessageDifferencer::Equals(a._rowset_meta_pb, b._rowset_meta_pb);
+        return google::protobuf::util::MessageDifferencer::Equals(*a._rowset_meta_pb, *b._rowset_meta_pb);
     }
 
     friend bool operator!=(const RowsetMeta& a, const RowsetMeta& b) { return !(a == b); }
 
-    RowsetMetaPB _rowset_meta_pb;
+    // RowsetMeta may be modifyed after create,
+    // so it may be not inconsistent at construct and destruct using `_rowset_meta_pb->SpaceUsedLong`,
+    // So we add one item to record the mem usage. This method will have a certain deviation,
+    // but it can ensure that the statistical error will not accumulate.
+    int64_t _mem_usage = 0;
+
+    std::unique_ptr<RowsetMetaPB> _rowset_meta_pb;
     RowsetId _rowset_id;
     bool _is_removed_from_rowset_meta = false;
 };

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -237,8 +237,7 @@ Status SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb, const 
                                           TabletSchema& tablet_schema, const RowsetId& rowset_id,
                                           RowsetMetaPB* new_rs_meta_pb) {
     // TODO use factory to obtain RowsetMeta when SnapshotManager::convert_rowset_ids supports beta rowset
-    RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
-    rowset_meta->init_from_pb(rs_meta_pb);
+    auto rowset_meta = std::make_shared<RowsetMeta>(rs_meta_pb);
     RowsetSharedPtr org_rowset;
     if (!RowsetFactory::create_rowset(&tablet_schema, new_path, rowset_meta, &org_rowset).ok()) {
         return Status::RuntimeError("fail to create rowset");

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -818,8 +818,8 @@ void StorageEngine::_clean_unused_rowset_metas() {
     std::vector<RowsetMetaSharedPtr> invalid_rowset_metas;
     auto clean_rowset_func = [this, &invalid_rowset_metas](const TabletUid& tablet_uid, RowsetId rowset_id,
                                                            std::string_view meta_str) -> bool {
-        auto rowset_meta = std::make_shared<RowsetMeta>();
-        bool parsed = rowset_meta->init(meta_str);
+        bool parsed = false;
+        auto rowset_meta = std::make_shared<RowsetMeta>(meta_str, &parsed);
         if (!parsed) {
             LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
             // return false will break meta iterator, return true to skip this error

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -482,16 +482,14 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
 
     // init _rs_metas
     for (auto& it : tablet_meta_pb.rs_metas()) {
-        RowsetMetaSharedPtr rs_meta(new RowsetMeta());
-        rs_meta->init_from_pb(it);
+        auto rs_meta = std::make_shared<RowsetMeta>(it);
         if (rs_meta->has_delete_predicate()) {
             add_delete_predicate(rs_meta->delete_predicate(), rs_meta->version().first);
         }
         _rs_metas.push_back(std::move(rs_meta));
     }
     for (auto& it : tablet_meta_pb.inc_rs_metas()) {
-        RowsetMetaSharedPtr rs_meta(new RowsetMeta());
-        rs_meta->init_from_pb(it);
+        auto rs_meta = std::make_shared<RowsetMeta>(it);
         _inc_rs_metas.push_back(std::move(rs_meta));
     }
 

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -228,14 +228,6 @@ private:
 
     Status _save_meta(DataDir* data_dir);
 
-    static int64_t calc_mem_usage_of_rs_metas(const std::vector<RowsetMetaSharedPtr>& rs_metas) {
-        int64_t mem_usage = 0;
-        for (const auto& rs_meta : rs_metas) {
-            mem_usage += rs_meta->mem_usage();
-        }
-        return mem_usage;
-    }
-
     // _del_pred_array is ignored to compare.
     friend bool operator==(const TabletMeta& a, const TabletMeta& b);
     friend bool operator!=(const TabletMeta& a, const TabletMeta& b);

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -788,8 +788,9 @@ Status TabletMetaManager::rowset_iterate(DataDir* store, TTabletId tablet_id, co
 
     return store->get_meta()->iterate(META_COLUMN_FAMILY_INDEX, prefix,
                                       [&](std::string_view key, std::string_view value) -> bool {
-                                          RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
-                                          CHECK(rowset_meta->init(value)) << "Corrupted rowset meta";
+                                          bool parse_ok = false;
+                                          auto rowset_meta = std::make_shared<RowsetMeta>(value, &parse_ok);
+                                          CHECK(parse_ok) << "Corrupted rowset meta";
                                           return func(std::move(rowset_meta));
                                       });
 }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -141,8 +141,9 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
     _pending_commits.clear();
     RETURN_IF_ERROR(TabletMetaManager::pending_rowset_iterate(
             _tablet.data_dir(), _tablet.tablet_id(), [&](int64_t version, std::string_view rowset_meta_data) -> bool {
-                RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
-                CHECK(rowset_meta->init(rowset_meta_data)) << "Corrupted rowset meta";
+                bool parse_ok = false;
+                auto rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_data, &parse_ok);
+                CHECK(parse_ok) << "Corrupted rowset meta";
                 RowsetSharedPtr rowset;
                 st = RowsetFactory::create_rowset(&_tablet.tablet_schema(), _tablet.schema_hash_path(), rowset_meta,
                                                   &rowset);
@@ -2601,10 +2602,7 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta) {
         for (const auto& rowset_meta_pb : snapshot_meta.rowset_metas()) {
             RETURN_IF_ERROR(check_rowset_files(rowset_meta_pb));
             RowsetSharedPtr rowset;
-            auto rowset_meta = std::make_shared<RowsetMeta>();
-            if (!rowset_meta->init_from_pb(rowset_meta_pb)) {
-                return Status::InternalError("rowset meta init from pb failed");
-            }
+            auto rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
             if (rowset_meta->tablet_id() != _tablet.tablet_id()) {
                 return Status::InternalError("mismatched tablet id");
             }
@@ -2670,10 +2668,7 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta) {
 
         uint32_t new_next_rowset_id = _next_rowset_id;
         for (const auto& rowset_meta_pb : snapshot_meta.rowset_metas()) {
-            RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-            if (!rowset_meta->init_from_pb(rowset_meta_pb)) {
-                return Status::InternalError("fail to init rowset meta");
-            }
+            auto rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
             const auto new_id = rowset_meta_pb.rowset_seg_id() + _next_rowset_id;
             new_next_rowset_id =
                     std::max<uint32_t>(new_next_rowset_id, new_id + std::max(1L, rowset_meta_pb.num_segments()));

--- a/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
+++ b/be/test/storage/base_and_cumulative_compaction_policy_test.cpp
@@ -17,6 +17,7 @@
 
 namespace starrocks {
 
+// NOLINTNEXTLINE
 TEST(BaseAndCumulativeCompactionPolicyTest, test_need_compaction) {
     TabletSharedPtr tablet = std::make_shared<Tablet>();
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
@@ -28,26 +29,32 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_need_compaction) {
     std::vector<RowsetSharedPtr> rowsets;
     auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
+    RowsetId id;
+    id.init(2, 3, 0, 0);
     int64_t base_time = UnixSeconds() - 100 * 60;
-    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
-    base_rowset_meta->set_start_version(0);
-    base_rowset_meta->set_end_version(9);
-    base_rowset_meta->set_creation_time(base_time);
-    base_rowset_meta->set_segments_overlap(NONOVERLAPPING);
-    base_rowset_meta->set_num_segments(1);
-    base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
-    base_rowset_meta->set_empty(false);
+    auto base_rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+    base_rowset_meta_pb->set_rowset_id(id.to_string());
+    base_rowset_meta_pb->set_start_version(0);
+    base_rowset_meta_pb->set_end_version(9);
+    base_rowset_meta_pb->set_creation_time(base_time);
+    base_rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+    base_rowset_meta_pb->set_num_segments(1);
+    base_rowset_meta_pb->set_total_disk_size(100 * 1024 * 1024);
+    base_rowset_meta_pb->set_empty(false);
+    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>(base_rowset_meta_pb);
     RowsetSharedPtr base_rowset = std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
     for (int i = 1; i <= 10; i++) {
-        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-        rowset_meta->set_start_version(i * 10);
-        rowset_meta->set_end_version((i + 1) * 10 - 1);
-        rowset_meta->set_creation_time(base_time + i);
-        rowset_meta->set_segments_overlap(NONOVERLAPPING);
-        rowset_meta->set_num_segments(1);
-        rowset_meta->set_total_disk_size(1024 * 1024);
+        auto rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+        rowset_meta_pb->set_rowset_id(id.to_string());
+        rowset_meta_pb->set_start_version(i * 10);
+        rowset_meta_pb->set_end_version((i + 1) * 10 - 1);
+        rowset_meta_pb->set_creation_time(base_time + i);
+        rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+        rowset_meta_pb->set_num_segments(1);
+        rowset_meta_pb->set_total_disk_size(1024 * 1024);
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
         RowsetSharedPtr rowset =
                 std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[1].insert(rowset.get());
@@ -55,13 +62,15 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_need_compaction) {
     }
 
     for (int i = 110; i < 120; i++) {
-        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-        rowset_meta->set_start_version(i);
-        rowset_meta->set_end_version(i);
-        rowset_meta->set_creation_time(base_time + i);
-        rowset_meta->set_segments_overlap(NONOVERLAPPING);
-        rowset_meta->set_num_segments(1);
-        rowset_meta->set_total_disk_size(1024 * 1024);
+        auto rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+        rowset_meta_pb->set_rowset_id(id.to_string());
+        rowset_meta_pb->set_start_version(i);
+        rowset_meta_pb->set_end_version(i);
+        rowset_meta_pb->set_creation_time(base_time + i);
+        rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+        rowset_meta_pb->set_num_segments(1);
+        rowset_meta_pb->set_total_disk_size(1024 * 1024);
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
         RowsetSharedPtr rowset =
                 std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[0].insert(rowset.get());
@@ -71,6 +80,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_need_compaction) {
     ASSERT_TRUE(policy.need_compaction());
 }
 
+// NOLINTNEXTLINE
 TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_with_recent_rowsets) {
     TabletSharedPtr tablet = std::make_shared<Tablet>();
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
@@ -83,29 +93,35 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
     auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
-    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
-    base_rowset_meta->set_start_version(0);
-    base_rowset_meta->set_end_version(9);
-    base_rowset_meta->set_creation_time(base_time);
-    base_rowset_meta->set_segments_overlap(NONOVERLAPPING);
-    base_rowset_meta->set_num_segments(1);
-    base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
-    base_rowset_meta->set_empty(false);
+    RowsetId id;
+    id.init(2, 3, 0, 0);
+    auto base_rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+    base_rowset_meta_pb->set_rowset_id(id.to_string());
+    base_rowset_meta_pb->set_start_version(0);
+    base_rowset_meta_pb->set_end_version(9);
+    base_rowset_meta_pb->set_creation_time(base_time);
+    base_rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+    base_rowset_meta_pb->set_num_segments(1);
+    base_rowset_meta_pb->set_total_disk_size(100 * 1024 * 1024);
+    base_rowset_meta_pb->set_empty(false);
+    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>(base_rowset_meta_pb);
     RowsetSharedPtr base_rowset = std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
     for (int i = 10; i <= 14; i++) {
-        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-        rowset_meta->set_start_version(i);
-        rowset_meta->set_end_version(i);
+        auto rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+        rowset_meta_pb->set_rowset_id(id.to_string());
+        rowset_meta_pb->set_start_version(i);
+        rowset_meta_pb->set_end_version(i);
         if (i == 14) {
-            rowset_meta->set_creation_time(UnixSeconds());
+            rowset_meta_pb->set_creation_time(UnixSeconds());
         } else {
-            rowset_meta->set_creation_time(base_time + i);
+            rowset_meta_pb->set_creation_time(base_time + i);
         }
-        rowset_meta->set_segments_overlap(NONOVERLAPPING);
-        rowset_meta->set_num_segments(1);
-        rowset_meta->set_total_disk_size(1024 * 1024);
+        rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+        rowset_meta_pb->set_num_segments(1);
+        rowset_meta_pb->set_total_disk_size(1024 * 1024);
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
         RowsetSharedPtr rowset =
                 std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[0].insert(rowset.get());
@@ -117,6 +133,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
     ASSERT_EQ(cumulative_task, nullptr);
 }
 
+// NOLINTNEXTLINE
 TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_with_missed_versions) {
     TabletSharedPtr tablet = std::make_shared<Tablet>();
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
@@ -129,14 +146,18 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
     auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
-    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
-    base_rowset_meta->set_start_version(0);
-    base_rowset_meta->set_end_version(9);
-    base_rowset_meta->set_creation_time(base_time);
-    base_rowset_meta->set_segments_overlap(NONOVERLAPPING);
-    base_rowset_meta->set_num_segments(1);
-    base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
-    base_rowset_meta->set_empty(false);
+    RowsetId id;
+    id.init(2, 3, 0, 0);
+    auto base_rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+    base_rowset_meta_pb->set_rowset_id(id.to_string());
+    base_rowset_meta_pb->set_start_version(0);
+    base_rowset_meta_pb->set_end_version(9);
+    base_rowset_meta_pb->set_creation_time(base_time);
+    base_rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+    base_rowset_meta_pb->set_num_segments(1);
+    base_rowset_meta_pb->set_total_disk_size(100 * 1024 * 1024);
+    base_rowset_meta_pb->set_empty(false);
+    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>(base_rowset_meta_pb);
     RowsetSharedPtr base_rowset = std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
@@ -145,13 +166,15 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
             // version 14 is missed
             continue;
         }
-        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-        rowset_meta->set_start_version(i);
-        rowset_meta->set_end_version(i);
-        rowset_meta->set_creation_time(base_time + i);
-        rowset_meta->set_segments_overlap(NONOVERLAPPING);
-        rowset_meta->set_num_segments(1);
-        rowset_meta->set_total_disk_size(1024 * 1024);
+        auto rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+        rowset_meta_pb->set_rowset_id(id.to_string());
+        rowset_meta_pb->set_start_version(i);
+        rowset_meta_pb->set_end_version(i);
+        rowset_meta_pb->set_creation_time(base_time + i);
+        rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+        rowset_meta_pb->set_num_segments(1);
+        rowset_meta_pb->set_total_disk_size(1024 * 1024);
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
         RowsetSharedPtr rowset =
                 std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[0].insert(rowset.get());
@@ -163,6 +186,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_cumulative_compaction_wi
     ASSERT_EQ(cumulative_task, nullptr);
 }
 
+// NOLINTNEXTLINE
 TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_empty_base_rowset) {
     TabletSharedPtr tablet = std::make_shared<Tablet>();
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
@@ -175,23 +199,29 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_emp
     auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
-    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
-    base_rowset_meta->set_start_version(0);
-    base_rowset_meta->set_end_version(9);
-    base_rowset_meta->set_creation_time(base_time);
-    base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
-    base_rowset_meta->set_empty(true);
+    RowsetId id;
+    id.init(2, 3, 0, 0);
+    auto base_rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+    base_rowset_meta_pb->set_rowset_id(id.to_string());
+    base_rowset_meta_pb->set_start_version(0);
+    base_rowset_meta_pb->set_end_version(9);
+    base_rowset_meta_pb->set_creation_time(base_time);
+    base_rowset_meta_pb->set_total_disk_size(100 * 1024 * 1024);
+    base_rowset_meta_pb->set_empty(true);
+    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>(base_rowset_meta_pb);
     RowsetSharedPtr base_rowset = std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
     for (int i = 1; i <= 1; i++) {
-        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-        rowset_meta->set_start_version(i * 10);
-        rowset_meta->set_end_version((i + 1) * 10 - 1);
-        rowset_meta->set_creation_time(base_time + i);
-        rowset_meta->set_segments_overlap(NONOVERLAPPING);
-        rowset_meta->set_num_segments(1);
-        rowset_meta->set_total_disk_size(1024 * 1024);
+        auto rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+        rowset_meta_pb->set_rowset_id(id.to_string());
+        rowset_meta_pb->set_start_version(i * 10);
+        rowset_meta_pb->set_end_version((i + 1) * 10 - 1);
+        rowset_meta_pb->set_creation_time(base_time + i);
+        rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+        rowset_meta_pb->set_num_segments(1);
+        rowset_meta_pb->set_total_disk_size(1024 * 1024);
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
         RowsetSharedPtr rowset =
                 std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[1].insert(rowset.get());
@@ -203,6 +233,7 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_emp
     ASSERT_EQ(base_task, nullptr);
 }
 
+// NOLINTNEXTLINE
 TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_missed_versions) {
     TabletSharedPtr tablet = std::make_shared<Tablet>();
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
@@ -215,12 +246,16 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_mis
     auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
     int64_t base_time = UnixSeconds() - 100 * 60;
-    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
-    base_rowset_meta->set_start_version(0);
-    base_rowset_meta->set_end_version(9);
-    base_rowset_meta->set_creation_time(base_time);
-    base_rowset_meta->set_total_disk_size(100 * 1024 * 1024);
-    base_rowset_meta->set_empty(true);
+    RowsetId id;
+    id.init(2, 3, 0, 0);
+    auto base_rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+    base_rowset_meta_pb->set_rowset_id(id.to_string());
+    base_rowset_meta_pb->set_start_version(0);
+    base_rowset_meta_pb->set_end_version(9);
+    base_rowset_meta_pb->set_creation_time(base_time);
+    base_rowset_meta_pb->set_total_disk_size(100 * 1024 * 1024);
+    base_rowset_meta_pb->set_empty(true);
+    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>(base_rowset_meta_pb);
     RowsetSharedPtr base_rowset = std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     compaction_context->rowset_levels[2].insert(base_rowset.get());
     rowsets.emplace_back(std::move(base_rowset));
@@ -228,13 +263,15 @@ TEST(BaseAndCumulativeCompactionPolicyTest, test_create_base_compaction_with_mis
         if (i == 5) {
             continue;
         }
-        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-        rowset_meta->set_start_version(i * 10);
-        rowset_meta->set_end_version((i + 1) * 10 - 1);
-        rowset_meta->set_creation_time(base_time + i);
-        rowset_meta->set_segments_overlap(NONOVERLAPPING);
-        rowset_meta->set_num_segments(1);
-        rowset_meta->set_total_disk_size(1024 * 1024);
+        auto rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+        rowset_meta_pb->set_rowset_id(id.to_string());
+        rowset_meta_pb->set_start_version(i * 10);
+        rowset_meta_pb->set_end_version((i + 1) * 10 - 1);
+        rowset_meta_pb->set_creation_time(base_time + i);
+        rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
+        rowset_meta_pb->set_num_segments(1);
+        rowset_meta_pb->set_total_disk_size(1024 * 1024);
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
         RowsetSharedPtr rowset =
                 std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         compaction_context->rowset_levels[1].insert(rowset.get());

--- a/be/test/storage/compaction_context_test.cpp
+++ b/be/test/storage/compaction_context_test.cpp
@@ -14,31 +14,40 @@
 
 namespace starrocks {
 
+// NOLINTNEXTLINE
 TEST(CompactionContextTest, test_rowset_comparator) {
     std::set<Rowset*, RowsetComparator> sorted_rowsets_set;
+    RowsetId id;
+    id.init(2, 3, 0, 0);
 
     std::vector<RowsetSharedPtr> rowsets;
     auto tablet_schema = TabletSchemaHelper::create_tablet_schema();
 
-    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>();
-    base_rowset_meta->set_start_version(0);
-    base_rowset_meta->set_end_version(9);
+    auto base_rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+    base_rowset_meta_pb->set_rowset_id(id.to_string());
+    base_rowset_meta_pb->set_start_version(0);
+    base_rowset_meta_pb->set_end_version(9);
+    RowsetMetaSharedPtr base_rowset_meta = std::make_shared<RowsetMeta>(base_rowset_meta_pb);
     RowsetSharedPtr base_rowset = std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset_0", base_rowset_meta);
     rowsets.emplace_back(std::move(base_rowset));
 
     for (int i = 1; i <= 10; i++) {
-        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-        rowset_meta->set_start_version(i * 10);
-        rowset_meta->set_end_version((i + 1) * 10 - 1);
+        auto rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+        rowset_meta_pb->set_rowset_id(id.to_string());
+        rowset_meta_pb->set_start_version(i * 10);
+        rowset_meta_pb->set_end_version((i + 1) * 10 - 1);
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
         RowsetSharedPtr rowset =
                 std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         rowsets.emplace_back(std::move(rowset));
     }
 
     for (int i = 110; i < 120; i++) {
-        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
-        rowset_meta->set_start_version(i);
-        rowset_meta->set_end_version(i);
+        auto rowset_meta_pb = std::make_unique<RowsetMetaPB>();
+        rowset_meta_pb->set_rowset_id(id.to_string());
+        rowset_meta_pb->set_start_version(i);
+        rowset_meta_pb->set_end_version(i);
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
         RowsetSharedPtr rowset =
                 std::make_shared<BetaRowset>(tablet_schema.get(), "./rowset" + std::to_string(i), rowset_meta);
         rowsets.emplace_back(std::move(rowset));

--- a/be/test/storage/version_graph_test.cpp
+++ b/be/test/storage/version_graph_test.cpp
@@ -6,29 +6,44 @@
 
 namespace starrocks::vectorized {
 
+// NOLINTNEXTLINE
 TEST(VersionGraphTest, capture) {
     VersionGraph graph;
+    RowsetId id;
+    id.init(2, 3, 0, 0);
 
     std::vector<RowsetMetaSharedPtr> rs_meta;
     for (int i = 0; i < 10; i++) {
-        rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-        rs_meta.back()->set_start_version(i);
-        rs_meta.back()->set_end_version(i);
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(i);
+        rs_meta_pb->set_end_version(i);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
     }
 
     for (int i = 0; i < 10; i = i + 2) {
-        rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-        rs_meta.back()->set_start_version(i);
-        rs_meta.back()->set_end_version(i + 1);
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(i);
+        rs_meta_pb->set_end_version(i + 1);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
     }
 
-    rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-    rs_meta.back()->set_start_version(0);
-    rs_meta.back()->set_end_version(5);
+    {
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(0);
+        rs_meta_pb->set_end_version(5);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
+    }
 
-    rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-    rs_meta.back()->set_start_version(11);
-    rs_meta.back()->set_end_version(11);
+    {
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(11);
+        rs_meta_pb->set_end_version(11);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
+    }
 
     int64_t max_version = -1;
     graph.construct_version_graph(rs_meta, &max_version);
@@ -202,24 +217,35 @@ TEST(VersionGraphTest, capture) {
     EXPECT_EQ(max_version, -1);
 }
 
+// NOLINTNEXTLINE
 TEST(VersionGraphTest, multi_edge) {
     VersionGraph graph;
+    RowsetId id;
+    id.init(2, 3, 0, 0);
 
     std::vector<RowsetMetaSharedPtr> rs_meta;
-    rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-    rs_meta.back()->set_start_version(0);
-    rs_meta.back()->set_end_version(5);
+    {
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(0);
+        rs_meta_pb->set_end_version(5);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
+    }
 
     for (int i = 0; i < 10; i = i + 2) {
-        rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-        rs_meta.back()->set_start_version(i);
-        rs_meta.back()->set_end_version(i + 1);
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(i);
+        rs_meta_pb->set_end_version(i + 1);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
     }
 
     for (int i = 0; i < 10; i++) {
-        rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-        rs_meta.back()->set_start_version(i);
-        rs_meta.back()->set_end_version(i);
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(i);
+        rs_meta_pb->set_end_version(i);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
     }
 
     int64_t max_version = -1;
@@ -238,24 +264,35 @@ TEST(VersionGraphTest, multi_edge) {
     }
 }
 
+// NOLINTNEXTLINE
 TEST(VersionGraphTest, remove_version) {
     VersionGraph graph;
+    RowsetId id;
+    id.init(2, 3, 0, 0);
 
     std::vector<RowsetMetaSharedPtr> rs_meta;
-    rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-    rs_meta.back()->set_start_version(0);
-    rs_meta.back()->set_end_version(5);
+    {
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(0);
+        rs_meta_pb->set_end_version(5);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
+    }
 
     for (int i = 0; i < 10; i = i + 2) {
-        rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-        rs_meta.back()->set_start_version(i);
-        rs_meta.back()->set_end_version(i + 1);
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(i);
+        rs_meta_pb->set_end_version(i + 1);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
     }
 
     for (int i = 0; i < 10; i++) {
-        rs_meta.emplace_back(std::make_shared<RowsetMeta>());
-        rs_meta.back()->set_start_version(i);
-        rs_meta.back()->set_end_version(i);
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        rs_meta_pb->set_rowset_id(id.to_string());
+        rs_meta_pb->set_start_version(i);
+        rs_meta_pb->set_end_version(i);
+        rs_meta.emplace_back(std::make_shared<RowsetMeta>(rs_meta_pb));
     }
 
     int64_t max_version = -1;


### PR DESCRIPTION
Currently it is too hard to troubleshoot metadata memory problem, and more detailed statistics are required. Add mem statistics for segment for rowset metadata.

RowsetMeta may be modifyed after create, so it may be not inconsistent at construct and destruct using `_rowset_meta_pb->SpaceUsedLong`, So we add one item to record the mem usage. This method will have a certain deviation, but it can ensure that the statistical error will not accumulate.

Remove the default constructor of `RowsetMeta` for easy mem statistics.

