### PR TITLE
[Enhancement] failed to fopen tmp_file when the directory occasionally removed

### DIFF
--- a/be/src/util/download_util.cpp
+++ b/be/src/util/download_util.cpp
@@ -16,15 +16,27 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
+#include "common/status.h"
 #include "fmt/format.h"
 #include "http/http_client.h"
 #include "util/defer_op.h"
+#include "util/filesystem_util.h"
 #include "util/md5.h"
+#include "util/path_util.h"
 
 namespace starrocks {
 
 Status DownloadUtil::download(const std::string& url, const std::string& tmp_file, const std::string& target_file,
                               const std::string& expected_checksum) {
+    auto directory = path_util::dir_name(tmp_file);
+    auto create_directory_status = FileSystemUtil::create_directory(directory);
+
+    if (!create_directory_status.ok()) {
+        std::string error_msg = create_directory_status.get_error_msg();
+        LOG(ERROR) << fmt::format("fail to create directory {}, error_msg {}.", directory, error_msg);
+        return create_directory_status;
+    }
+
     auto fp = fopen(tmp_file.c_str(), "w");
     DeferOp defer([&]() {
         if (fp != nullptr) {

--- a/be/src/util/download_util.cpp
+++ b/be/src/util/download_util.cpp
@@ -16,7 +16,6 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
-#include "common/status.h"
 #include "fmt/format.h"
 #include "http/http_client.h"
 #include "util/defer_op.h"
@@ -28,11 +27,11 @@ namespace starrocks {
 
 Status DownloadUtil::download(const std::string& url, const std::string& tmp_file, const std::string& target_file,
                               const std::string& expected_checksum) {
-    auto directory = path_util::dir_name(tmp_file);
-    auto create_directory_status = FileSystemUtil::create_directory(directory);
+    const std::string directory{path_util::dir_name(tmp_file)};
+    Status create_directory_status = FileSystemUtil::create_directory(directory);
 
     if (!create_directory_status.ok()) {
-        std::string error_msg = create_directory_status.get_error_msg();
+        std::string_view error_msg = create_directory_status.get_error_msg();
         LOG(ERROR) << fmt::format("fail to create directory {}, error_msg {}.", directory, error_msg);
         return create_directory_status;
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

prevent the failure of fopen tmp_file when some part of the entire directory occasionally removed

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [X] 3.0
  - [X] 2.5
  - [ ] 2.4
  - [ ] 2.3
