### PR TITLE
[BugFix]Fix decommission backend bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -874,7 +874,7 @@ public class TabletScheduler extends LeaderDaemon {
                     tabletCtx.getTabletId(), tabletCtx.getTablet().getReplicaInfos(),
                     tabletCtx.getSrcReplica().getBackendId(), tabletCtx.getDestBackendId());
         } catch (SchedException e) {
-            if (e.getStatus() == Status.SCHEDULE_RETRY) {
+            if (e.getStatus() == Status.SCHEDULE_RETRY || e.getStatus() == Status.UNRECOVERABLE) {
                 LOG.debug("failed to find version incomplete replica from tablet relocating. " +
                                 "reason: [{}], tablet: [{}], replicas: {} dest:{} try to find a new backend", e.getMessage(),
                         tabletCtx.getTabletId(), tabletCtx.getTablet().getReplicaInfos(),

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
@@ -19,7 +19,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Random;

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
@@ -45,8 +45,6 @@ public class DecommissionTest {
         PseudoCluster.getInstance().shutdown(false);
     }
 
-    //TODO: this ut will fail when the system load is high.
-    @Ignore
     @Test
     public void testDecommission() throws Exception {
         PseudoCluster cluster = PseudoCluster.getInstance();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Introduced by #19635
handleReplicaRelocating will try to fix the version incomplete replica first, if no version incomplete replica, it will go to the handleReplicaMissing logic. This PR #19635 changed the exception to UNRECOVERABLE if there is no version incomplete replica, it's ok for the process of VERSION_INCOMPLETE, but for the REPLICA_RELOCATING, it won't go to the handleReplicaMissing logic, because this exception is not caught.
Catch the UNRECOVERABLE exception when process the replica relocation schedule.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
