### PR TITLE
[Enhancement] Support [skew] hints in group-by-multi-column-count-distinct-one-column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -137,13 +137,19 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
             return false;
         }
 
-        if (agg.getLimit() >= 0) {
-            return false;
-        }
 
         List<CallOperator> distinctAggOperatorList = agg.getAggregations().values().stream()
                 .filter(CallOperator::isDistinct).collect(Collectors.toList());
         boolean hasMultiColumns = distinctAggOperatorList.stream().anyMatch(f -> f.getChildren().size() > 1);
+
+        if (agg.hasSkew() && distinctAggOperatorList.size() > 1 && !hasMultiColumns &&
+                !agg.getGroupingKeys().isEmpty()) {
+            return true;
+        }
+
+        if (agg.getLimit() >= 0) {
+            return false;
+        }
 
         if (!hasMultiColumns && agg.getGroupingKeys().size() > 1) {
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -284,6 +284,35 @@ public class SelectStmtTest {
                 "  |  <slot 8> : CAST(murmur_hash3_32(CAST(6: cast AS VARCHAR)) % 512 AS SMALLINT)"));
         FeConstants.runningUnitTest = false;
     }
+
+    @Test
+    public void testGroupByMultiColumnCountDistinctWithSkewHint() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql =
+                "select cast(k1 as int), k3, count(distinct [skew] cast(k2 as int)) from db1.tbl1 group by cast(k1 as int), k3";
+        String s = starRocksAssert.query(sql).explainQuery();
+        Assert.assertTrue(s, s.contains("  3:Project\n" +
+                "  |  <slot 3> : 3: k3\n" +
+                "  |  <slot 5> : 5: cast\n" +
+                "  |  <slot 6> : 6: cast\n" +
+                "  |  <slot 8> : CAST(murmur_hash3_32(CAST(6: cast AS VARCHAR)) % 512 AS SMALLINT)"));
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testGroupByMultiColumnMultiCountDistinctWithSkewHint() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql =
+                "select k1, k3, count(distinct [skew] k2), count(distinct k4) from db1.tbl1 group by k1, k3";
+        String s = starRocksAssert.query(sql).explainQuery();
+        Assert.assertTrue(s, s.contains("  4:Project\n" +
+                "  |  <slot 7> : 7: k1\n" +
+                "  |  <slot 8> : 8: k2\n" +
+                "  |  <slot 9> : 9: k3\n" +
+                "  |  <slot 13> : CAST(murmur_hash3_32(8: k2) % 512 AS SMALLINT)"));
+        FeConstants.runningUnitTest = false;
+    }
+
     @Test
     public void testGroupByCountDistinctUseTheSameColumn()
             throws Exception {


### PR DESCRIPTION
# What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Two enhancements:
1.  GroupByCountDistinctDataSkewRule supports multi-group-by-column, for an example: 
```sql
select a, b, count(distinct[skew] c) from t group by a ,b; 
```
2. Make RewriteMultiDistinctByCTERule instead of RewriteMultiDistinctRule take effects when given skew hints, for an example:
```sql
select a, count(distinct a), count(distinct b) from t group by b
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
