### PR TITLE
[BugFix] Avoid BE crash when CSV reader try to read complex types

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -180,6 +180,12 @@ void Chunk::append_tuple_column(const ColumnPtr& column, TupleId tuple_id) {
     check_or_die();
 }
 
+void Chunk::append_default() {
+    for (const auto& column : _columns) {
+        column->append_default();
+    }
+}
+
 void Chunk::remove_column_by_index(size_t idx) {
     DCHECK_LT(idx, _columns.size());
     _columns.erase(_columns.begin() + idx);

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -120,6 +120,8 @@ public:
 
     void append_tuple_column(const ColumnPtr& column, TupleId tuple_id);
 
+    void append_default();
+
     void remove_column_by_index(size_t idx);
 
     // Remove multiple columns by their indexes.

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -166,7 +166,7 @@ Status HiveDataSource::_init_partition_values() {
             const ColumnPtr& data_column = const_column->data_column();
             ColumnPtr& chunk_part_column = partition_chunk->get_column_by_slot_id(slot_id);
             if (data_column->is_nullable()) {
-                chunk_part_column->append_nulls(1);
+                chunk_part_column->append_default();
             } else {
                 chunk_part_column->append(*data_column, 0, 1);
             }

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -186,7 +186,8 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(_build_hive_column_name_2_index());
     for (const auto slot : _scanner_params.materialize_slots) {
         DCHECK(slot != nullptr);
-        // We don't care about options.invalid_field_as_null here, converte failed
+        // We don't care about _invalid_field_as_null here, if get converter failed,
+        // we use DefaultValueConverter instead.
         auto converter = csv::get_hive_converter(slot->type(), true);
         DCHECK(converter != nullptr);
         _converters.emplace_back(std::move(converter));

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -187,12 +187,8 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     for (const auto slot : _scanner_params.materialize_slots) {
         DCHECK(slot != nullptr);
         // We don't care about options.invalid_field_as_null here, converte failed
-        auto converter = csv::get_converter(slot->type(), true);
-        if (converter == nullptr && !_invalid_field_as_null) {
-            return Status::NotSupported(strings::Substitute("Unsupported CSV type $0", slot->type().debug_string()));
-        } else if (converter == nullptr) {
-            converter = csv::get_default_value_converter();
-        }
+        auto converter = csv::get_hive_converter(slot->type(), true);
+        DCHECK(converter != nullptr);
         _converters.emplace_back(std::move(converter));
     }
     return Status::OK();

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -14,9 +14,10 @@
 
 #include "exec/hdfs_scanner_text.h"
 
+#include <unordered_map>
+
 #include "column/column_helper.h"
 #include "exec/exec_node.h"
-#include "gen_cpp/Descriptors_types.h"
 #include "gutil/strings/substitute.h"
 #include "util/compression/compression_utils.h"
 #include "util/compression/stream_compression.h"
@@ -182,15 +183,17 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(open_random_access_file());
     RETURN_IF_ERROR(_create_or_reinit_reader());
     SCOPED_RAW_TIMER(&_stats.reader_init_ns);
+    RETURN_IF_ERROR(_build_hive_column_name_2_index());
     for (const auto slot : _scanner_params.materialize_slots) {
-        // TODO slot maybe null?
         DCHECK(slot != nullptr);
-        ConverterPtr conv = csv::get_converter(slot->type(), true);
-        RETURN_IF_ERROR(_get_hive_column_index(slot->col_name()));
-        if (conv == nullptr) {
-            return Status::InternalError(strings::Substitute("Unsupported CSV type $0", slot->type().debug_string()));
+        // We don't care about options.invalid_field_as_null here, converte failed
+        auto converter = csv::get_converter(slot->type(), true);
+        if (converter == nullptr && !_invalid_field_as_null) {
+            return Status::NotSupported(strings::Substitute("Unsupported CSV type $0", slot->type().debug_string()));
+        } else if (converter == nullptr) {
+            converter = csv::get_default_value_converter();
         }
-        _converters.emplace_back(std::move(conv));
+        _converters.emplace_back(std::move(converter));
     }
     return Status::OK();
 }
@@ -222,9 +225,6 @@ Status HdfsTextScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
 
 Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
     DCHECK_EQ(0, chunk->get()->num_rows());
-    Status status;
-    CSVReader::Record record;
-    CSVReader::Fields fields;
 
     int num_columns = chunk->get()->num_columns();
     _column_raw_ptrs.resize(num_columns);
@@ -238,10 +238,11 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
     options.array_hive_collection_delimiter = _collection_delimiter;
     options.array_hive_mapkey_delimiter = _mapkey_delimiter;
     options.array_hive_nested_level = 1;
-    options.invalid_field_as_null = true;
+    options.invalid_field_as_null = _invalid_field_as_null;
 
-    for (size_t num_rows = chunk->get()->num_rows(); num_rows < chunk_size; /**/) {
-        status = down_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&record);
+    for (size_t num_rows = chunk->get()->num_rows(); num_rows < chunk_size; num_rows++) {
+        CSVReader::Record record{};
+        Status status = down_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&record);
         if (status.is_end_of_file()) {
             if (_current_range_index == _scanner_params.scan_ranges.size() - 1) {
                 break;
@@ -253,80 +254,70 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
             RETURN_IF_ERROR(_create_or_reinit_reader());
             continue;
         } else if (!status.ok()) {
-            LOG(WARNING) << "Status is not ok: " << status.to_string();
+            LOG(WARNING) << strings::Substitute("Parse csv file $0 failed: $1", _file->filename(), status.get_error_msg());
             return status;
         }
 
-        fields.clear();
+        bool validate_res = validate_utf8(record.data, record.size);
+        if (!validate_res && options.invalid_field_as_null) {
+            VLOG_ROW << "Face csv invalidate UTF-8 character line, append default value for this line";
+            chunk->get()->append_default();
+            continue;
+        } else if (!validate_res) {
+            return Status::InternalError("Face csv invalidate UTF-8 character line.");
+        }
+
+        CSVReader::Fields fields{};
         _reader->split_record(record, &fields);
 
-        if (!validate_utf8(record.data, record.size)) {
-            continue;
-        }
+        size_t num_materialize_columns = _scanner_params.materialize_slots.size();
 
-        bool has_error = false;
-        std::string error_msg;
-        int num_materialize_columns = _scanner_params.materialize_slots.size();
-        int field_size = fields.size();
-        if (_scanner_params.hive_column_names->size() != field_size) {
-            VLOG(7) << strings::Substitute("Size mismatch between hive column $0 names and fields $1!",
-                                           _scanner_params.hive_column_names->size(), fields.size());
-        }
+        // Fill materialize columns first, then fill partition column
         for (int j = 0; j < num_materialize_columns; j++) {
-            // TODO slot maybe null?
-            const auto slot = _scanner_params.materialize_slots[j];
+            const auto& slot = _scanner_params.materialize_slots[j];
             DCHECK(slot != nullptr);
 
-            std::string col_name = _scanner_params.materialize_slots[j]->col_name();
-            if (!_scanner_params.case_sensitive) {
-                std::transform(col_name.begin(), col_name.end(), col_name.begin(), ::tolower);
-            }
-            int index = _scanner_params.materialize_index_in_chunk[j];
-            int column_field_index = _columns_index[_scanner_params.materialize_slots[j]->col_name()];
-            Column* column = _column_raw_ptrs[index];
-            if (column_field_index < field_size) {
-                const Slice& field = fields[column_field_index];
+            const std::string formatted_slot_name =
+                    _scanner_params.case_sensitive ? slot->col_name() : boost::to_lower_copy(slot->col_name());
+
+            size_t chunk_index = _scanner_params.materialize_index_in_chunk[j];
+            size_t csv_index = _formatted_hive_column_name_2_index[formatted_slot_name];
+            Column* column = _column_raw_ptrs[chunk_index];
+            if (csv_index < fields.size()) {
+                const Slice& field = fields[csv_index];
                 options.type_desc = &(_scanner_params.materialize_slots[j]->type());
                 if (!_converters[j]->read_string(column, field, options)) {
-                    LOG(WARNING) << "Converter encountered an error for field " << field.to_string() << ", index "
-                                 << index << ", column " << _scanner_params.materialize_slots[j]->debug_string();
-                    error_msg = strings::Substitute("CSV parse column [$0] failed, more details please see be log.",
-                                                    _scanner_params.materialize_slots[j]->debug_string());
-                    chunk->get()->set_num_rows(num_rows);
-                    has_error = true;
-                    break;
+                    return Status::InternalError(
+                            strings::Substitute("CSV converter encountered an error for field: $0, column name is: $1",
+                                                field.to_string(), formatted_slot_name));
                 }
             } else {
                 // The size of hive_column_names may be larger than fields when new columns are added.
                 // The default value should be filled when querying the extra columns that
                 // do not exist in the text file.
-                // hive only support null column
-                // TODO: support not null
-                column->append_nulls(1);
+                column->append_default();
             }
         }
-        num_rows += !has_error;
-        if (!has_error) {
-            // Partition column not stored in text file, we should append these columns
-            // when we select partition column.
-            int num_part_columns = _scanner_ctx.partition_columns.size();
-            for (int p = 0; p < num_part_columns; ++p) {
-                int index = _scanner_params.partition_index_in_chunk[p];
-                Column* column = _column_raw_ptrs[index];
-                ColumnPtr partition_value = _scanner_ctx.partition_values[p];
-                DCHECK(partition_value->is_constant());
-                auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(partition_value);
-                const ColumnPtr& data_column = const_column->data_column();
-                if (data_column->is_nullable()) {
-                    column->append_nulls(1);
-                } else {
-                    column->append(*data_column, 0, 1);
-                }
+
+        // Start to append partition column
+        for (size_t p = 0; p < _scanner_ctx.partition_columns.size(); ++p) {
+            size_t chunk_index = _scanner_params.partition_index_in_chunk[p];
+            Column* column = _column_raw_ptrs[chunk_index];
+            ColumnPtr partition_value = _scanner_ctx.partition_values[p];
+            DCHECK(partition_value->is_constant());
+            auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(partition_value);
+            const ColumnPtr& data_column = const_column->data_column();
+            if (data_column->is_nullable()) {
+                column->append_default();
+            } else {
+                column->append(*data_column, 0, 1);
             }
-        } else {
-            return Status::InternalError(error_msg);
         }
     }
+
+    // Check chunk's row number for each column
+    chunk->get()->check_or_die();
+
     return chunk->get()->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");
 }
 
@@ -371,18 +362,26 @@ Status HdfsTextScanner::_create_or_reinit_reader() {
     return Status::OK();
 }
 
-Status HdfsTextScanner::_get_hive_column_index(const std::string& column_name) {
+Status HdfsTextScanner::_build_hive_column_name_2_index() {
     const bool case_sensitive = _scanner_params.case_sensitive;
-    for (int i = 0; i < _scanner_params.hive_column_names->size(); i++) {
-        const std::string& name = _scanner_params.hive_column_names->at(i);
-        const bool found = case_sensitive ? name == column_name : 0 == strcasecmp(name.c_str(), column_name.c_str());
 
-        if (found) {
-            _columns_index[column_name] = i;
-            return Status::OK();
+    for (size_t i = 0; i < _scanner_params.hive_column_names->size(); i++) {
+        const std::string formatted_column_name =
+                case_sensitive ? (*_scanner_params.hive_column_names)[i]
+                               : boost::algorithm::to_lower_copy((*_scanner_params.hive_column_names)[i]);
+        _formatted_hive_column_name_2_index.emplace(formatted_column_name, i);
+    }
+
+    // Check materialize_slots's SlotDescirptor is existed in hive table
+    for (const auto slot : _scanner_params.materialize_slots) {
+        const std::string& formatted_slot_name =
+                case_sensitive ? slot->col_name() : boost::algorithm::to_lower_copy(slot->col_name());
+        if (_formatted_hive_column_name_2_index.find(formatted_slot_name) ==
+            _formatted_hive_column_name_2_index.end()) {
+            return Status::InternalError("Can not get index of column name: " + formatted_slot_name);
         }
     }
-    return Status::InvalidArgument("Can not get index of column name " + column_name);
+    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -254,7 +254,8 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
             RETURN_IF_ERROR(_create_or_reinit_reader());
             continue;
         } else if (!status.ok()) {
-            LOG(WARNING) << strings::Substitute("Parse csv file $0 failed: $1", _file->filename(), status.get_error_msg());
+            LOG(WARNING) << strings::Substitute("Parse csv file $0 failed: $1", _file->filename(),
+                                                status.get_error_msg());
             return status;
         }
 

--- a/be/src/exec/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner_text.h
@@ -20,6 +20,8 @@
 
 namespace starrocks {
 
+// This class used by data lake(Hive, Iceberg,... etc), not for broker load.
+// Broker load plz refer to csv_scanner.cpp
 class HdfsTextScanner final : public HdfsScanner {
 public:
     HdfsTextScanner() = default;
@@ -34,18 +36,22 @@ public:
 private:
     // create a reader or re init reader
     Status _create_or_reinit_reader();
-    Status _get_hive_column_index(const std::string& column_name);
+    Status _build_hive_column_name_2_index();
 
     using ConverterPtr = std::unique_ptr<csv::Converter>;
     std::string _record_delimiter;
     std::string _field_delimiter;
     char _collection_delimiter;
     char _mapkey_delimiter;
+    // Always set true in data lake now.
+    // TODO(SmithCruise) use a hive catalog property to control this behavior
+    bool _invalid_field_as_null = true;
     std::vector<Column*> _column_raw_ptrs;
     std::vector<ConverterPtr> _converters;
     std::shared_ptr<CSVReader> _reader = nullptr;
     size_t _current_range_index = 0;
-    std::unordered_map<std::string, int> _columns_index;
+    // The map's value is the position of column name in hive's table(Not in StarRocks' table)
+    std::unordered_map<std::string, int> _formatted_hive_column_name_2_index;
     bool _no_data = false;
 };
 } // namespace starrocks

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(Formats STATIC
         csv/json_converter.cpp
         csv/numeric_converter.cpp
         csv/nullable_converter.cpp
+        csv/default_value_converter.cpp
         json/nullable_column.cpp
         json/numeric_column.cpp
         json/binary_column.cpp

--- a/be/src/formats/csv/array_converter.cpp
+++ b/be/src/formats/csv/array_converter.cpp
@@ -62,7 +62,10 @@ bool ArrayConverter::read_string(Column* column, Slice s, const Options& options
     }
     size_t old_size = elements->size();
     Options sub_options = options;
-    sub_options.invalid_field_as_null = false;
+    if (options.array_format_type != ArrayFormatType::kHive) {
+        // For broker load, invalid_field_as_null is always false for array's element
+        sub_options.invalid_field_as_null = false;
+    }
     sub_options.array_hive_nested_level++;
     DCHECK_EQ(old_size, offsets->get_data().back());
     for (const auto& f : fields) {

--- a/be/src/formats/csv/converter.cpp
+++ b/be/src/formats/csv/converter.cpp
@@ -57,8 +57,13 @@ static std::unique_ptr<Converter> get_converter(const TypeDescriptor& t) {
         return std::make_unique<DateConverter>();
     case TYPE_DATETIME:
         return std::make_unique<DatetimeConverter>();
-    case TYPE_ARRAY:
-        return std::make_unique<ArrayConverter>(get_converter(t.children[0], true));
+    case TYPE_ARRAY: {
+        auto c = get_converter(t.children[0], true);
+        if (c == nullptr) {
+            return nullptr;
+        }
+        return std::make_unique<ArrayConverter>(std::move(c));
+    }
     case TYPE_DECIMAL32:
         return std::make_unique<DecimalV3Converter<int32_t>>(t.precision, t.scale);
     case TYPE_DECIMAL64:

--- a/be/src/formats/csv/converter.cpp
+++ b/be/src/formats/csv/converter.cpp
@@ -21,6 +21,7 @@
 #include "formats/csv/datetime_converter.h"
 #include "formats/csv/decimalv2_converter.h"
 #include "formats/csv/decimalv3_converter.h"
+#include "formats/csv/default_value_converter.h"
 #include "formats/csv/float_converter.h"
 #include "formats/csv/json_converter.h"
 #include "formats/csv/nullable_converter.h"
@@ -66,27 +67,7 @@ static std::unique_ptr<Converter> get_converter(const TypeDescriptor& t) {
         return std::make_unique<DecimalV3Converter<int128_t>>(t.precision, t.scale);
     case TYPE_JSON:
         return std::make_unique<JsonConverter>();
-    case TYPE_DECIMAL:
-    case TYPE_UNKNOWN:
-    case TYPE_NULL:
-    case TYPE_BINARY:
-    case TYPE_VARBINARY:
-    case TYPE_STRUCT:
-    case TYPE_MAP:
-    case TYPE_HLL:
-    case TYPE_PERCENTILE:
-    case TYPE_TIME:
-    case TYPE_OBJECT:
-    case TYPE_FUNCTION:
-    case TYPE_UNSIGNED_TINYINT:
-    case TYPE_UNSIGNED_SMALLINT:
-    case TYPE_UNSIGNED_INT:
-    case TYPE_UNSIGNED_BIGINT:
-    case TYPE_DISCRETE_DOUBLE:
-    case TYPE_DATE_V1:
-    case TYPE_DATETIME_V1:
-    case TYPE_NONE:
-    case TYPE_MAX_VALUE:
+    default:
         break;
     }
     return nullptr;
@@ -98,6 +79,10 @@ std::unique_ptr<Converter> get_converter(const TypeDescriptor& type_desc, bool n
         return nullptr;
     }
     return nullable ? std::make_unique<NullableConverter>(std::move(c)) : std::move(c);
+}
+
+std::unique_ptr<Converter> get_default_value_converter() {
+    return std::make_unique<DefaultValueConverter>();
 }
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/converter.h
+++ b/be/src/formats/csv/converter.h
@@ -117,6 +117,7 @@ protected:
 };
 
 std::unique_ptr<Converter> get_converter(const TypeDescriptor& type_desc, bool nullable);
+std::unique_ptr<Converter> get_default_value_converter();
 
 } // namespace csv
 } // namespace starrocks

--- a/be/src/formats/csv/converter.h
+++ b/be/src/formats/csv/converter.h
@@ -117,7 +117,7 @@ protected:
 };
 
 std::unique_ptr<Converter> get_converter(const TypeDescriptor& type_desc, bool nullable);
-std::unique_ptr<Converter> get_default_value_converter();
+std::unique_ptr<Converter> get_hive_converter(const TypeDescriptor& type_desc, bool nullable);
 
 } // namespace csv
 } // namespace starrocks

--- a/be/src/formats/csv/default_value_converter.cpp
+++ b/be/src/formats/csv/default_value_converter.cpp
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/csv/default_value_converter.h"
+
+#include "column/column.h"
+
+namespace starrocks::csv {
+
+bool DefaultValueConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+    if (options.invalid_field_as_null) {
+        column->append_default();
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool DefaultValueConverter::read_string(Column* column, Slice s, const Options& options) const {
+    return read_quoted_string(column, s, options);
+}
+
+Status DefaultValueConverter::write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
+                                                  const Options& options) const {
+    return Status::InternalError("Csv DefaultValueConverter only support for read, not write");
+}
+
+Status DefaultValueConverter::write_string(OutputStream* os, const Column& column, size_t row_num,
+                                           const Options& options) const {
+    return write_quoted_string(os, column, row_num, options);
+}
+} // namespace starrocks::csv

--- a/be/src/formats/csv/default_value_converter.h
+++ b/be/src/formats/csv/default_value_converter.h
@@ -1,0 +1,30 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "formats/csv/converter.h"
+
+namespace starrocks::csv {
+
+class DefaultValueConverter final : public Converter {
+public:
+    Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
+    Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
+                               const Options& options) const override;
+    bool read_string(Column* column, Slice s, const Options& options) const override;
+    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+};
+
+} // namespace starrocks::csv

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -131,6 +131,7 @@ set(EXEC_FILES
         ./formats/csv/json_converter_test.cpp
         ./formats/csv/nullable_converter_test.cpp
         ./formats/csv/numeric_converter_test.cpp
+        ./formats/csv/default_value_converter_test.cpp
         ./formats/json/binary_column_test.cpp
         ./formats/json/numeric_column_test.cpp
         ./formats/json/nullable_column_test.cpp

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -1554,8 +1554,8 @@ TEST_F(HdfsScannerTest, TestCSVWithStructMap) {
         EXPECT_TRUE(status.ok());
         EXPECT_EQ(2, chunk->num_rows());
 
-        EXPECT_EQ("[1, NULL, NULL]", chunk->debug_row(0));
-        EXPECT_EQ("[2, NULL, NULL]", chunk->debug_row(1));
+        EXPECT_EQ("[1, [NULL,NULL], [NULL,NULL,NULL]]", chunk->debug_row(0));
+        EXPECT_EQ("[2, [NULL], [NULL,NULL]]", chunk->debug_row(1));
 
         scanner->close(_runtime_state);
     }

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -1554,8 +1554,8 @@ TEST_F(HdfsScannerTest, TestCSVWithStructMap) {
         EXPECT_TRUE(status.ok());
         EXPECT_EQ(2, chunk->num_rows());
 
-        EXPECT_EQ("[1, [NULL,NULL], [NULL,NULL,NULL]]", chunk->debug_row(0));
-        EXPECT_EQ("[2, [NULL], [NULL,NULL]]", chunk->debug_row(1));
+        EXPECT_EQ("[1, NULL, NULL]", chunk->debug_row(0));
+        EXPECT_EQ("[2, NULL, NULL]", chunk->debug_row(1));
 
         scanner->close(_runtime_state);
     }

--- a/be/test/exec/test_data/csv_scanner/array_struct_map.csv
+++ b/be/test/exec/test_data/csv_scanner/array_struct_map.csv
@@ -1,0 +1,2 @@
+1,struct|struct,map|map|map
+2,struct,map|map

--- a/be/test/exec/test_data/csv_scanner/newly_add_column.csv
+++ b/be/test/exec/test_data/csv_scanner/newly_add_column.csv
@@ -1,0 +1,2 @@
+hello,5,smith
+world,6,cruise

--- a/be/test/formats/csv/default_value_converter_test.cpp
+++ b/be/test/formats/csv/default_value_converter_test.cpp
@@ -20,14 +20,14 @@
 
 namespace starrocks::csv {
 
-TEST(DefaultValueConverterTest, test_array_nested_with_map) {
+TEST(DefaultValueConverterTest, test_hive_array_nested_with_map) {
     // ARRAY<TINYINT>
     TypeDescriptor t(TYPE_ARRAY);
     t.children.emplace_back(TYPE_MAP);
     t.children[0].children.emplace_back(TYPE_INT);
     t.children[0].children.emplace_back(TYPE_INT);
 
-    auto conv = csv::get_converter(t, true);
+    auto conv = csv::get_hive_converter(t, true);
     auto col = ColumnHelper::create_column(t, true);
 
     Converter::Options opts;
@@ -40,4 +40,15 @@ TEST(DefaultValueConverterTest, test_array_nested_with_map) {
     EXPECT_FALSE(conv->read_string(col.get(), "[MAP]", opts));
 }
 
-} // namespace csv
+TEST(DefaultValueConverterTest, test_array_nested_with_map) {
+    // ARRAY<TINYINT>
+    TypeDescriptor t(TYPE_ARRAY);
+    t.children.emplace_back(TYPE_MAP);
+    t.children[0].children.emplace_back(TYPE_INT);
+    t.children[0].children.emplace_back(TYPE_INT);
+
+    auto conv = csv::get_converter(t, true);
+    EXPECT_EQ(nullptr, conv);
+}
+
+} // namespace starrocks::csv

--- a/be/test/formats/csv/default_value_converter_test.cpp
+++ b/be/test/formats/csv/default_value_converter_test.cpp
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "formats/csv/converter.h"
+#include "runtime/types.h"
+
+namespace starrocks::csv {
+
+TEST(DefaultValueConverterTest, test_array_nested_with_map) {
+    // ARRAY<TINYINT>
+    TypeDescriptor t(TYPE_ARRAY);
+    t.children.emplace_back(TYPE_MAP);
+    t.children[0].children.emplace_back(TYPE_INT);
+    t.children[0].children.emplace_back(TYPE_INT);
+
+    auto conv = csv::get_converter(t, true);
+    auto col = ColumnHelper::create_column(t, true);
+
+    Converter::Options opts;
+    opts.invalid_field_as_null = true;
+
+    EXPECT_TRUE(conv->read_string(col.get(), "[MAP]", opts));
+    EXPECT_TRUE(col->get(0).is_null());
+
+    opts.invalid_field_as_null = false;
+    EXPECT_FALSE(conv->read_string(col.get(), "[MAP]", opts));
+}
+
+} // namespace csv


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

In CSV hive table, when a user reads for `ARRAY<STRUCT<...>>` or `ARRAY<MAP<...>>` column type,  it will face an NPE problem.

And in this pr, we set all error parsed column's value as null, not abort the query anymore(The default behavior is the same as Trino/Presto). We will introduce a parameter to control this behavior later.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
