### PR TITLE
[Enhancement] Enhance mv rewrite when mv/query have multi same tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/EquivalenceClasses.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/EquivalenceClasses.java
@@ -19,12 +19,11 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class EquivalenceClasses {
+public class EquivalenceClasses implements Cloneable {
     private final Map<ColumnRefOperator, Set<ColumnRefOperator>> columnToEquivalenceClass;
 
     private List<Set<ColumnRefOperator>> cacheColumnToEquivalenceClass;
@@ -33,9 +32,15 @@ public class EquivalenceClasses {
         columnToEquivalenceClass = Maps.newHashMap();
     }
 
-    public EquivalenceClasses(EquivalenceClasses other) {
-        columnToEquivalenceClass = Maps.newHashMap();
-        columnToEquivalenceClass.putAll(other.columnToEquivalenceClass);
+    @Override
+    public EquivalenceClasses clone() {
+        final EquivalenceClasses ec = new EquivalenceClasses();
+        for (Map.Entry<ColumnRefOperator, Set<ColumnRefOperator>> entry :
+                this.columnToEquivalenceClass.entrySet()) {
+            ec.columnToEquivalenceClass.put(entry.getKey(), Sets.newLinkedHashSet(entry.getValue()));
+        }
+        ec.cacheColumnToEquivalenceClass = null;
+        return ec;
     }
 
     public void addEquivalence(ColumnRefOperator left, ColumnRefOperator right) {
@@ -85,7 +90,7 @@ public class EquivalenceClasses {
             cacheColumnToEquivalenceClass = Lists.newArrayList();
             Set<ColumnRefOperator> visited = Sets.newHashSet();
             for (Set<ColumnRefOperator> columnRefOperators : columnToEquivalenceClass.values()) {
-                if (Collections.disjoint(visited, columnRefOperators)) {
+                if (!visited.containsAll(columnRefOperators)) {
                     visited.addAll(columnRefOperators);
                     cacheColumnToEquivalenceClass.add(columnRefOperators);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnRewriter.java
@@ -56,7 +56,7 @@ public class ColumnRewriter {
         return predicate.accept(visitor, null);
     }
 
-    public ColumnRefOperator rewriteViewToQuery(ColumnRefOperator colRef) {
+    public ColumnRefOperator rewriteViewToQuery(final ColumnRefOperator colRef) {
         if (colRef == null) {
             return null;
         }
@@ -193,7 +193,10 @@ public class ColumnRewriter {
                 if (relationColumns == null) {
                     return result;
                 }
-                result = relationColumns.getOrDefault(columnRef.getName(), columnRef);
+                if (!relationColumns.containsKey(columnRef.getName())) {
+                    return result;
+                }
+                result = relationColumns.get(columnRef.getName());
             }
             if (enableEquivalenceClassesRewrite && equivalenceClasses != null) {
                 Set<ColumnRefOperator> equalities = equivalenceClasses.getEquivalenceClass(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -36,6 +36,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.Pair;
+import com.starrocks.sql.common.PermutationGenerator;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewriteContext;
@@ -127,6 +128,10 @@ public class MaterializedViewRewriter {
             if (!queryTables.containsAll(materializationContext.getIntersectingTables())) {
                 return false;
             }
+            if (!MvUtils.getAllJoinOperators(queryExpression).stream().allMatch(joinOperator ->
+                    joinOperator.isLeftOuterJoin() || joinOperator.isInnerJoin())) {
+                return false;
+            }
         } else {
             return false;
         }
@@ -163,18 +168,79 @@ public class MaterializedViewRewriter {
 
         if (materializationContext.getMvPartialPartitionPredicate() != null) {
             // add latest partition predicate to mv predicate
-            ScalarOperator rewritten = mvColumnRefRewriter.rewrite(materializationContext.getMvPartialPartitionPredicate());
+            ScalarOperator rewritten =
+                    mvColumnRefRewriter.rewrite(materializationContext.getMvPartialPartitionPredicate());
             mvPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(mvPredicate, rewritten));
         }
         final PredicateSplit mvPredicateSplit = PredicateSplit.splitPredicate(mvPredicate);
 
-        Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns = ArrayListMultimap.create();
-        Map<Table, Set<Integer>> compensationRelations = Maps.newHashMap();
         if (matchMode == MatchMode.VIEW_DELTA) {
-            ScalarOperator viewEqualPredicate = mvPredicateSplit.getEqualPredicates();
-            EquivalenceClasses viewEquivalenceClasses = createEquivalenceClasses(viewEqualPredicate);
-            if (!compensateViewDelta(viewEquivalenceClasses, queryExpression, mvExpression,
-                    materializationContext.getQueryRefFactory(), compensationJoinColumns, compensationRelations)) {
+            List<TableScanDesc> mvTableScanDescs = MvUtils.getTableScanDescs(mvExpression);
+            List<TableScanDesc> queryTableScanDescs = MvUtils.getTableScanDescs(queryExpression);
+            // do not support external table now
+            if (queryTableScanDescs.stream().anyMatch(tableScanDesc -> !tableScanDesc.getTable().isNativeTable())) {
+                return null;
+            }
+            if (mvTableScanDescs.stream().anyMatch(tableScanDesc -> !tableScanDesc.getTable().isNativeTable())) {
+                return null;
+            }
+            Map<Table, List<TableScanDesc>> mvTableToTableScanDecs = Maps.newHashMap();
+            for (TableScanDesc mvTableScanDesc : mvTableScanDescs) {
+                mvTableToTableScanDecs.computeIfAbsent(mvTableScanDesc.getTable(), x -> Lists.newArrayList())
+                        .add(mvTableScanDesc);
+            }
+            List<List<TableScanDesc>> mvExtraTableScanDescLists = Lists.newArrayList();
+            for (TableScanDesc mvTableScanDesc : mvTableScanDescs) {
+                if (!queryTableScanDescs.contains(mvTableScanDesc)) {
+                    mvExtraTableScanDescLists.add(mvTableToTableScanDecs.get(mvTableScanDesc.getTable()));
+                }
+            }
+
+            List<Set<TableScanDesc>> mvDistinctScanDescs = Lists.newArrayList();
+            PermutationGenerator generator = new PermutationGenerator(mvExtraTableScanDescLists);
+            while (generator.hasNext()) {
+                List<TableScanDesc> mvExtraTableScanDescs = generator.next();
+                if (mvExtraTableScanDescs.stream().distinct().count() != mvExtraTableScanDescs.size()) {
+                    continue;
+                }
+                Set<TableScanDesc> mvExtraTableScanDescsSet = new HashSet<>(mvExtraTableScanDescs);
+                if (mvDistinctScanDescs.contains(mvExtraTableScanDescsSet)) {
+                    continue;
+                }
+                mvDistinctScanDescs.add(mvExtraTableScanDescsSet);
+
+                OptExpression rewritten = tryRewrite(queryTables, mvTables, matchMode, mvPredicateSplit,
+                        mvColumnRefRewriter, mvTableScanDescs, mvExtraTableScanDescs);
+                if (rewritten != null) {
+                    return rewritten;
+                }
+            }
+        } else {
+            return tryRewrite(queryTables, mvTables, matchMode, mvPredicateSplit, mvColumnRefRewriter,
+                    null, null);
+        }
+        return null;
+    }
+
+    private OptExpression tryRewrite(List<Table> queryTables,
+                                     List<Table> mvTables,
+                                     MatchMode matchMode,
+                                     PredicateSplit mvPredicateSplit,
+                                     ReplaceColumnRefRewriter mvColumnRefRewriter,
+                                     List<TableScanDesc> mvTableScanDescs,
+                                     List<TableScanDesc> mvExtraTableScanDescs) {
+        final OptExpression queryExpression = mvRewriteContext.getQueryExpression();
+        final OptExpression mvExpression = materializationContext.getMvExpression();
+        final ScalarOperator mvEqualPredicate = mvPredicateSplit.getEqualPredicates();
+
+        final Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns = ArrayListMultimap.create();
+        final Map<Table, Set<Integer>> compensationRelations = Maps.newHashMap();
+        final Map<Integer, Integer> expectQueryToMVRelationIds = Maps.newHashMap();
+        if (matchMode == MatchMode.VIEW_DELTA) {
+            EquivalenceClasses viewEquivalenceClasses = createEquivalenceClasses(mvEqualPredicate);
+            if (!compensateViewDelta(viewEquivalenceClasses, mvTableScanDescs, mvExtraTableScanDescs,
+                    materializationContext.getQueryRefFactory(), materializationContext.getMvColumnRefFactory(),
+                    compensationJoinColumns, compensationRelations, expectQueryToMVRelationIds)) {
                 return null;
             }
         }
@@ -183,7 +249,6 @@ public class MaterializedViewRewriter {
                 getRelationIdToColumns(materializationContext.getQueryRefFactory());
         final Map<Integer, Map<String, ColumnRefOperator>> mvRelationIdToColumns =
                 getRelationIdToColumns(materializationContext.getMvColumnRefFactory());
-
         // for query: A1 join A2 join B, mv: A1 join A2 join B
         // there may be two mapping:
         //    1. A1 -> A1, A2 -> A2, B -> B
@@ -191,7 +256,7 @@ public class MaterializedViewRewriter {
         List<BiMap<Integer, Integer>> relationIdMappings = generateRelationIdMap(
                 materializationContext.getQueryRefFactory(),
                 queryTables, queryExpression, materializationContext.getMvColumnRefFactory(),
-                mvTables, mvExpression, matchMode, compensationRelations);
+                mvTables, mvExpression, matchMode, compensationRelations, expectQueryToMVRelationIds);
         if (relationIdMappings.isEmpty()) {
             return null;
         }
@@ -205,7 +270,7 @@ public class MaterializedViewRewriter {
                 .collect(Collectors.toSet());
         final EquivalenceClasses queryEc =
                 createEquivalenceClasses(mvRewriteContext.getQueryPredicateSplit().getEqualPredicates());
-        RewriteContext rewriteContext = new RewriteContext(
+        final RewriteContext rewriteContext = new RewriteContext(
                 queryExpression, mvRewriteContext.getQueryPredicateSplit(), queryEc,
                 queryRelationIdToColumns, materializationContext.getQueryRefFactory(),
                 mvRewriteContext.getQueryColumnRefRewriter(), mvExpression, mvPredicateSplit, mvRelationIdToColumns,
@@ -220,27 +285,47 @@ public class MaterializedViewRewriter {
             mvRewriteContext.setMvPruneConjunct(mvPrunePredicate);
             rewriteContext.setQueryToMvRelationIdMapping(relationIdMapping);
 
+            final ColumnRewriter columnRewriter = new ColumnRewriter(rewriteContext);
             // for view delta, should add compensation join columns to query ec
             if (matchMode == MatchMode.VIEW_DELTA) {
-                EquivalenceClasses newQueryEc = new EquivalenceClasses(queryEc);
-                ColumnRewriter columnRewriter = new ColumnRewriter(rewriteContext);
+                final EquivalenceClasses newQueryEc = queryEc.clone();
                 // convert mv-based compensation join columns into query based after we get relationId mapping
-                for (Map.Entry<ColumnRefOperator, ColumnRefOperator> entry : compensationJoinColumns.entries()) {
-                    ColumnRefOperator newKey = columnRewriter.rewriteViewToQuery(entry.getKey());
-                    ColumnRefOperator newValue = columnRewriter.rewriteViewToQuery(entry.getValue());
-                    if (newKey != null && newValue != null) {
-                        newQueryEc.addEquivalence(newKey, newValue);
+                for (final Map.Entry<ColumnRefOperator, ColumnRefOperator> entry : compensationJoinColumns.entries()) {
+                    final ColumnRefOperator left = entry.getKey();
+                    final ColumnRefOperator right = entry.getValue();
+                    ColumnRefOperator newKey = columnRewriter.rewriteViewToQuery(left);
+                    ColumnRefOperator newValue = columnRewriter.rewriteViewToQuery(right);
+                    if (newKey == null || newValue == null) {
+                        return null;
                     }
+                    newQueryEc.addEquivalence(newKey, newValue);
                 }
                 rewriteContext.setQueryEquivalenceClasses(newQueryEc);
             }
+
+            // construct query based view EC
+            final EquivalenceClasses queryBasedViewEqualPredicate = new EquivalenceClasses();
+            if (mvEqualPredicate != null) {
+                for (ScalarOperator equalPredicate : Utils.extractConjuncts(mvEqualPredicate)) {
+                    Preconditions.checkState(equalPredicate.getChild(0).isColumnRef());
+                    ColumnRefOperator left = (ColumnRefOperator) equalPredicate.getChild(0);
+                    Preconditions.checkState(equalPredicate.getChild(1).isColumnRef());
+                    ColumnRefOperator right = (ColumnRefOperator) equalPredicate.getChild(1);
+                    ColumnRefOperator leftTarget = columnRewriter.rewriteViewToQuery(left);
+                    ColumnRefOperator rightTarget = columnRewriter.rewriteViewToQuery(right);
+                    if (leftTarget == null || rightTarget == null) {
+                        return null;
+                    }
+                    queryBasedViewEqualPredicate.addEquivalence(leftTarget, rightTarget);
+                }
+            }
+            rewriteContext.setQueryBasedViewEquivalenceClasses(queryBasedViewEqualPredicate);
 
             OptExpression rewrittenExpression = tryRewriteForRelationMapping(rewriteContext);
             if (rewrittenExpression != null) {
                 return rewrittenExpression;
             }
         }
-
         return null;
     }
 
@@ -260,35 +345,21 @@ public class MaterializedViewRewriter {
     // return false if it can not be rewritten.
     private boolean compensateViewDelta(
             EquivalenceClasses viewEquivalenceClasses,
-            OptExpression queryExpression,
-            OptExpression mvExpression,
+            List<TableScanDesc> mvTableScanDescs,
+            List<TableScanDesc> mvExtraTableScanDescs,
             ColumnRefFactory queryRefFactory,
+            ColumnRefFactory mvRefFactory,
             Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns,
-            Map<Table, Set<Integer>> compensationRelations) {
+            Map<Table, Set<Integer>> compensationRelations,
+            Map<Integer, Integer> expectQueryToMVRelationIds) {
         // use directed graph to construct foreign key join graph
         MutableGraph<TableScanDesc> mvGraph = GraphBuilder.directed().build();
-        List<TableScanDesc> mvExtraTableScanDescs = Lists.newArrayList();
-
-        List<TableScanDesc> queryTableScanDescs = MvUtils.getTableScanDescs(queryExpression);
-        List<TableScanDesc> mvTableScanDescs = MvUtils.getTableScanDescs(mvExpression);
-        // do not support external table now
-        if (queryTableScanDescs.stream().anyMatch(tableScanDesc -> !tableScanDesc.getTable().isNativeTable())) {
-            return false;
-        }
-        if (mvTableScanDescs.stream().anyMatch(tableScanDesc -> !tableScanDesc.getTable().isNativeTable())) {
-            return false;
-        }
-
+        Map<TableScanDesc, List<ColumnRefOperator>> extraTableColumns = Maps.newHashMap();
         Multimap<String, TableScanDesc> mvNameToTable = ArrayListMultimap.create();
         for (TableScanDesc mvTableScanDesc : mvTableScanDescs) {
             mvGraph.addNode(mvTableScanDesc);
             mvNameToTable.put(mvTableScanDesc.getName(), mvTableScanDesc);
-            // Add extra mv tables to `extraTableScanDescs`
-            if (!queryTableScanDescs.contains(mvTableScanDesc)) {
-                mvExtraTableScanDescs.add(mvTableScanDesc);
-            }
         }
-        Map<TableScanDesc, List<ColumnRefOperator>> extraTableColumns = Maps.newHashMap();
 
         // add edges to directed graph by FK-UK
         for (TableScanDesc mvTableScanDesc : mvGraph.nodes()) {
@@ -312,10 +383,9 @@ public class MaterializedViewRewriter {
                 List<String> parentKeys = columnPairs.stream().map(pair -> pair.second)
                         .map(String::toLowerCase).collect(Collectors.toList());
                 for (TableScanDesc mvParentTableScanDesc : mvParentTableScanDescs) {
-                    List<ColumnRefOperator> tableCompensationColumns = Lists.newArrayList();
                     Multimap<ColumnRefOperator, ColumnRefOperator> constraintCompensationJoinColumns = ArrayListMultimap.create();
                     if (!extraJoinCheck(mvParentTableScanDesc, mvTableScanDesc, columnPairs, childKeys, parentKeys,
-                            viewEquivalenceClasses, tableCompensationColumns, constraintCompensationJoinColumns)) {
+                            viewEquivalenceClasses, constraintCompensationJoinColumns)) {
                         continue;
                     }
 
@@ -323,7 +393,17 @@ public class MaterializedViewRewriter {
                     // to extraColumns.
                     if (mvExtraTableScanDescs.contains(mvParentTableScanDesc)) {
                         compensationJoinColumns.putAll(constraintCompensationJoinColumns);
-                        extraTableColumns.put(mvParentTableScanDesc, tableCompensationColumns);
+                        List<ColumnRefOperator> parentTableCompensationColumns =
+                                constraintCompensationJoinColumns.keys().stream().collect(Collectors.toList());
+                        extraTableColumns.computeIfAbsent(mvParentTableScanDesc, x -> Lists.newArrayList())
+                                .addAll(parentTableCompensationColumns);
+                    }
+                    if (mvExtraTableScanDescs.contains(mvTableScanDesc)) {
+                        compensationJoinColumns.putAll(constraintCompensationJoinColumns);
+                        List<ColumnRefOperator> childTableCompensationColumns =
+                                constraintCompensationJoinColumns.values().stream().collect(Collectors.toList());
+                        extraTableColumns.computeIfAbsent(mvTableScanDesc, k -> Lists.newArrayList())
+                                .addAll(childTableCompensationColumns);
                     }
 
                     // Add an edge (mvTableScanDesc -> mvParentTableScanDesc) into graph
@@ -339,7 +419,8 @@ public class MaterializedViewRewriter {
 
         // should add new tables/columnRefs into query ColumnRefFactory if pass test
         // should collect additional tables and the related columns
-        getCompensationRelations(extraTableColumns, queryRefFactory, compensationRelations);
+        getCompensationRelations(extraTableColumns, queryRefFactory, mvRefFactory,
+                compensationRelations, expectQueryToMVRelationIds);
         return true;
     }
 
@@ -347,7 +428,6 @@ public class MaterializedViewRewriter {
             TableScanDesc parentTableScanDesc, TableScanDesc tableScanDesc,
             List<Pair<String, String>> columnPairs, List<String> childKeys, List<String> parentKeys,
             EquivalenceClasses viewEquivalenceClasses,
-            List<ColumnRefOperator> tableCompensationColumns,
             Multimap<ColumnRefOperator, ColumnRefOperator> constraintCompensationJoinColumns) {
         // now only OlapTable is supported
         Preconditions.checkState(parentTableScanDesc.getTable() instanceof OlapTable);
@@ -395,13 +475,13 @@ public class MaterializedViewRewriter {
                 // there is no join between childTable and parentTable
                 return false;
             }
-            tableCompensationColumns.add(parentColumn);
-            constraintCompensationJoinColumns.put(childColumn, parentColumn);
+            constraintCompensationJoinColumns.put(parentColumn, childColumn);
         }
         return true;
     }
 
-    private boolean graphBasedCheck(MutableGraph<TableScanDesc> graph, List<TableScanDesc> extraTableScanDescs) {
+    private boolean graphBasedCheck(MutableGraph<TableScanDesc> graph,
+                                    List<TableScanDesc> extraTableScanDescs) {
         // remove one in-degree and zero out-degree's node from graph repeatedly
         boolean done;
         do {
@@ -425,10 +505,21 @@ public class MaterializedViewRewriter {
 
     private void getCompensationRelations(Map<TableScanDesc, List<ColumnRefOperator>> extraTableColumns,
                                           ColumnRefFactory queryRefFactory,
-                                          Map<Table, Set<Integer>> compensationRelations) {
+                                          ColumnRefFactory mvRefFactory,
+                                          Map<Table, Set<Integer>> compensationRelations,
+                                          Map<Integer, Integer> expectQueryToMVRelationIds) {
+        // Extra table should always link with MV's relation id.
         for (Map.Entry<TableScanDesc, List<ColumnRefOperator>> entry : extraTableColumns.entrySet()) {
             int relationId = queryRefFactory.getNextRelationId();
-            for (ColumnRefOperator columnRef : entry.getValue()) {
+            List<ColumnRefOperator> columnRefOperators = entry.getValue();
+            int mvRelationId = -1;
+            for (ColumnRefOperator columnRef : columnRefOperators) {
+                if (mvRelationId == -1) {
+                    mvRelationId = mvRefFactory.getRelationId(columnRef.getId());
+                } else {
+                    Preconditions.checkState(mvRelationId == mvRefFactory.getRelationId(columnRef.getId()));
+                }
+
                 OlapTable olapTable = (OlapTable) entry.getKey().getTable();
                 Column column = olapTable.getColumn(columnRef.getName());
                 ColumnRefOperator newColumn =
@@ -439,6 +530,7 @@ public class MaterializedViewRewriter {
             Set<Integer> relationIds =
                     compensationRelations.computeIfAbsent(entry.getKey().getTable(), table -> Sets.newHashSet());
             relationIds.add(relationId);
+            expectQueryToMVRelationIds.put(relationId, mvRelationId);
         }
     }
 
@@ -552,24 +644,6 @@ public class MaterializedViewRewriter {
         }
         OptExpression mvScanOptExpression = OptExpression.create(mvScanBuilder.build());
         deriveLogicalProperty(mvScanOptExpression);
-
-        // construct query based view EC
-        EquivalenceClasses queryBasedViewEqualPredicate = new EquivalenceClasses();
-        if (rewriteContext.getMvPredicateSplit().getEqualPredicates() != null) {
-            ScalarOperator equalPredicates = rewriteContext.getMvPredicateSplit().getEqualPredicates();
-            for (ScalarOperator equalPredicate : Utils.extractConjuncts(equalPredicates)) {
-                Preconditions.checkState(equalPredicate.getChild(0).isColumnRef());
-                ColumnRefOperator left = (ColumnRefOperator) equalPredicate.getChild(0);
-                Preconditions.checkState(equalPredicate.getChild(1).isColumnRef());
-                ColumnRefOperator right = (ColumnRefOperator) equalPredicate.getChild(1);
-                ColumnRefOperator leftTarget = columnRewriter.rewriteViewToQuery(left);
-                ColumnRefOperator rightTarget = columnRewriter.rewriteViewToQuery(right);
-                if (leftTarget != null && rightTarget != null) {
-                    queryBasedViewEqualPredicate.addEquivalence(leftTarget, rightTarget);
-                }
-            }
-        }
-        rewriteContext.setQueryBasedViewEquivalenceClasses(queryBasedViewEqualPredicate);
 
         final PredicateSplit compensationPredicates = getCompensationPredicates(rewriteContext, true);
         if (compensationPredicates == null) {
@@ -855,10 +929,6 @@ public class MaterializedViewRewriter {
             ScalarOperator rewriteScalarOp;
             if (isQueryAgainstView) {
                 if (isViewBased) {
-                    // NOTE: when `isQueryAgainstView` and  `isQueryAgainstView`,
-                    // columnRefMap is still based on MV's column ref factory but MV's EC is based
-                    // on query's column ref factory. So cannot use MV's EC directly which may cause
-                    // wrong mappings, only rewrite with MV's EC after column ref is found in query's relations.
                     rewriteScalarOp = columnRewriter.rewriteViewToQueryWithViewEc(rewritten);
                 } else {
                     rewriteScalarOp = columnRewriter.rewriteViewToQueryWithQueryEc(rewritten);
@@ -1022,7 +1092,8 @@ public class MaterializedViewRewriter {
     private List<BiMap<Integer, Integer>> generateRelationIdMap(
             ColumnRefFactory queryRefFactory, List<Table> queryTables, OptExpression queryExpression,
             ColumnRefFactory mvRefFactory, List<Table> mvTables, OptExpression mvExpression,
-            MatchMode matchMode, Map<Table, Set<Integer>> compensationRelations) {
+            MatchMode matchMode, Map<Table, Set<Integer>> compensationRelations,
+            Map<Integer, Integer> expectQueryToMVRelationIds) {
         Map<Table, Set<Integer>> queryTableToRelationId =
                 getTableToRelationid(queryExpression, queryRefFactory, queryTables);
         if (matchMode == MatchMode.VIEW_DELTA) {
@@ -1098,7 +1169,25 @@ public class MaterializedViewRewriter {
                 result = newResult.build();
             }
         }
-        return result;
+
+        if (expectQueryToMVRelationIds.isEmpty()) {
+            return result;
+        } else {
+            List<BiMap<Integer, Integer>> finalResult = Lists.newArrayList();
+            for (BiMap<Integer, Integer> queryToMVRelations : result) {
+                boolean isExpected = true;
+                for (Map.Entry<Integer, Integer> expect : expectQueryToMVRelationIds.entrySet()) {
+                    if (!queryToMVRelations.get(expect.getKey()).equals(expect.getValue()))  {
+                        isExpected = false;
+                        break;
+                    }
+                }
+                if (isExpected) {
+                    finalResult.add(queryToMVRelations);
+                }
+            }
+            return finalResult;
+        }
     }
 
     public static List<List<Integer>> getPermutationsOfTableIds(List<Integer> tableIds, int n) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Sets;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -40,6 +39,7 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
         executeSqlFile("sql/materialized-view/tpch/ddl_tpch_mv1.sql");
         executeSqlFile("sql/materialized-view/tpch/ddl_tpch_mv2.sql");
         executeSqlFile("sql/materialized-view/tpch/ddl_tpch_mv3.sql");
+       connectContext.getSessionVariable().setEnableMaterializedViewUnionRewrite(false);
     }
 
     @Test
@@ -98,7 +98,6 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
     }
 
     // TODO(lishuming): predicates may be out of order when in parallel.
-    @Ignore
     @Test
     public void testQuery8() {
         runFileUnitTest("materialized-view/tpch/q8");

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q1.sql
@@ -20,7 +20,6 @@ group by
 order by
     l_returnflag,
     l_linestatus;
-
 [result]
 TOP-N (order by [[10: l_returnflag ASC NULLS FIRST, 11: l_linestatus ASC NULLS FIRST]])
     TOP-N (order by [[10: l_returnflag ASC NULLS FIRST, 11: l_linestatus ASC NULLS FIRST]])

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q18.sql
@@ -39,9 +39,9 @@ TOP-N (order by [[13: o_totalprice DESC NULLS LAST, 10: o_orderdate ASC NULLS FI
                 EXCHANGE SHUFFLE[9]
                     SCAN (mv[lineitem_mv] columns[90: c_name, 96: l_orderkey, 98: l_quantity, 105: o_custkey, 106: o_orderdate, 110: o_totalprice] predicate[null])
                 EXCHANGE SHUFFLE[35]
-                    AGGREGATE ([GLOBAL] aggregate [{158: sum=sum(158: sum)}] group by [[137: l_orderkey]] having [158: sum > 315]
+                    AGGREGATE ([GLOBAL] aggregate [{163: sum=sum(163: sum)}] group by [[137: l_orderkey]] having [163: sum > 315]
                         EXCHANGE SHUFFLE[137]
-                            AGGREGATE ([LOCAL] aggregate [{158: sum=sum(141: sum_qty)}] group by [[137: l_orderkey]] having [null]
+                            AGGREGATE ([LOCAL] aggregate [{163: sum=sum(141: sum_qty)}] group by [[137: l_orderkey]] having [null]
                                 SCAN (mv[lineitem_agg_mv1] columns[137: l_orderkey, 141: sum_qty] predicate[null])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q21.sql
@@ -41,9 +41,9 @@ order by
 [result]
 TOP-N (order by [[71: count DESC NULLS LAST, 2: s_name ASC NULLS FIRST]])
     TOP-N (order by [[71: count DESC NULLS LAST, 2: s_name ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{409: count=sum(409: count)}] group by [[157: s_name]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{189: count=sum(189: count)}] group by [[157: s_name]] having [null]
             EXCHANGE SHUFFLE[157]
-                AGGREGATE ([LOCAL] aggregate [{409: count=sum(160: cnt_star)}] group by [[157: s_name]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{189: count=sum(160: cnt_star)}] group by [[157: s_name]] having [null]
                     SCAN (mv[query21_mv] columns[157: s_name, 158: o_orderstatus, 159: n_name, 160: cnt_star] predicate[158: o_orderstatus = F AND 159: n_name = CANADA])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q22.sql
@@ -54,3 +54,4 @@ TOP-N (order by [[29: substring ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[21]
                             SCAN (table[orders] columns[21: o_custkey] predicate[null])
 [end]
+

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q4.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q4.sql
@@ -23,9 +23,9 @@ order by
 [result]
 TOP-N (order by [[6: o_orderpriority ASC NULLS FIRST]])
     TOP-N (order by [[6: o_orderpriority ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{128: count=sum(128: count)}] group by [[53: o_orderpriority]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{119: count=sum(119: count)}] group by [[53: o_orderpriority]] having [null]
             EXCHANGE SHUFFLE[53]
-                AGGREGATE ([LOCAL] aggregate [{128: count=sum(54: order_count)}] group by [[53: o_orderpriority]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{119: count=sum(54: order_count)}] group by [[53: o_orderpriority]] having [null]
                     SCAN (mv[query4_mv] columns[52: o_orderdate, 53: o_orderpriority, 54: order_count] predicate[52: o_orderdate >= 1994-09-01 AND 52: o_orderdate < 1994-12-01 AND 52: o_orderdate >= 1994-01-01 AND 52: o_orderdate < 1995-01-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q5-1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q5-1.sql
@@ -1,6 +1,6 @@
 [sql]
 select
-    count(*)
+    count(1)
 from
     customer,
     orders,
@@ -14,7 +14,7 @@ where
 [result]
 AGGREGATE ([GLOBAL] aggregate [{41: count=count(41: count)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{41: count=count()}] group by [[]] having [null]
+        AGGREGATE ([LOCAL] aggregate [{41: count=count(1)}] group by [[]] having [null]
             SCAN (mv[lineitem_mv] columns[95: c_nationkey, 121: s_nationkey] predicate[121: s_nationkey = 95: c_nationkey])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q5-2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q5-2.sql
@@ -26,6 +26,6 @@ TOP-N (order by [[49: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{49: sum=sum(49: sum)}] group by [[42: n_name]] having [null]
             EXCHANGE SHUFFLE[42]
                 AGGREGATE ([LOCAL] aggregate [{49: sum=sum(48: expr)}] group by [[42: n_name]] having [null]
-                    SCAN (mv[lineitem_mv] columns[103: c_nationkey, 129: s_nationkey, 131: l_saleprice, 135: n_name1] predicate[129: s_nationkey = 103: c_nationkey])
+                    SCAN (mv[lineitem_mv] columns[103: c_nationkey, 129: s_nationkey, 131: l_saleprice, 137: n_name2] predicate[129: s_nationkey = 103: c_nationkey])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q5.sql
@@ -29,6 +29,6 @@ TOP-N (order by [[49: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{49: sum=sum(49: sum)}] group by [[42: n_name]] having [null]
             EXCHANGE SHUFFLE[42]
                 AGGREGATE ([LOCAL] aggregate [{49: sum=sum(48: expr)}] group by [[42: n_name]] having [null]
-                    SCAN (mv[lineitem_mv] columns[103: c_nationkey, 118: o_orderdate, 129: s_nationkey, 131: l_saleprice, 135: n_name1, 139: r_name1] predicate[129: s_nationkey = 103: c_nationkey AND 139: r_name1 = AFRICA AND 118: o_orderdate >= 1995-01-01 AND 118: o_orderdate < 1996-01-01])
+                    SCAN (mv[lineitem_mv] columns[103: c_nationkey, 118: o_orderdate, 129: s_nationkey, 131: l_saleprice, 137: n_name2, 140: r_name2] predicate[129: s_nationkey = 103: c_nationkey AND 140: r_name2 = AFRICA AND 118: o_orderdate >= 1995-01-01 AND 118: o_orderdate < 1996-01-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q7.sql
@@ -41,9 +41,9 @@ order by
 [result]
 TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
     TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{193: sum=sum(193: sum)}] group by [[68: n_name1, 69: n_name2, 70: l_shipyear]] having [null]
+        AGGREGATE ([GLOBAL] aggregate [{243: sum=sum(243: sum)}] group by [[68: n_name1, 69: n_name2, 70: l_shipyear]] having [null]
             EXCHANGE SHUFFLE[68, 69, 70]
-                AGGREGATE ([LOCAL] aggregate [{193: sum=sum(71: sum_saleprice)}] group by [[68: n_name1, 69: n_name2, 70: l_shipyear]] having [null]
+                AGGREGATE ([LOCAL] aggregate [{243: sum=sum(71: sum_saleprice)}] group by [[68: n_name1, 69: n_name2, 70: l_shipyear]] having [null]
                     SCAN (mv[lineitem_mv_agg_mv2] columns[67: l_shipdate, 68: n_name1, 69: n_name2, 70: l_shipyear, 71: sum_saleprice] predicate[67: l_shipdate <= 1996-12-31 AND 67: l_shipdate >= 1995-01-01 AND 67: l_shipdate < 1997-01-01 AND 68: n_name1 = CANADA AND 69: n_name2 = IRAN OR 68: n_name1 = IRAN AND 69: n_name2 = CANADA AND 68: n_name1 IN (CANADA, IRAN) AND 69: n_name2 IN (IRAN, CANADA)])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q8-1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q8-1.sql
@@ -21,6 +21,6 @@ select
           and n1.n_regionkey = r_regionkey
           and s_nationkey = n2.n_nationkey
 [result]
-SCAN (mv[lineitem_mv] columns[144: l_saleprice, 147: o_orderyear, 148: n_name1, 149: n_regionkey1, 151: n_regionkey2] predicate[149: n_regionkey1 = 151: n_regionkey2])
+SCAN (mv[lineitem_mv] columns[144: l_saleprice, 147: o_orderyear, 148: n_name1] predicate[null])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q8.sql
@@ -42,6 +42,6 @@ TOP-N (order by [[61: year ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{65: sum=sum(65: sum), 64: sum=sum(64: sum)}] group by [[61: year]] having [null]
             EXCHANGE SHUFFLE[61]
                 AGGREGATE ([LOCAL] aggregate [{65: sum=sum(62: expr), 64: sum=sum(63: case)}] group by [[61: year]] having [null]
-                    SCAN (mv[lineitem_mv] columns[135: o_orderdate, 144: p_type, 148: l_saleprice, 151: o_orderyear, 152: n_name1, 153: n_regionkey1, 155: n_regionkey2, 156: r_name1] predicate[153: n_regionkey1 = 155: n_regionkey2 AND 156: r_name1 = MIDDLE EAST AND 144: p_type = ECONOMY ANODIZED STEEL AND 135: o_orderdate <= 1996-12-31 AND 135: o_orderdate >= 1995-01-01 AND 135: o_orderdate < 1997-01-01])
+                    SCAN (mv[lineitem_mv] columns[135: o_orderdate, 144: p_type, 148: l_saleprice, 151: o_orderyear, 152: n_name1, 157: r_name2] predicate[135: o_orderdate <= 1996-12-31 AND 144: p_type = ECONOMY ANODIZED STEEL AND 157: r_name2 = MIDDLE EAST AND 135: o_orderdate >= 1995-01-01 AND 135: o_orderdate < 1997-01-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
@@ -34,9 +34,9 @@ order by
 [result]
 TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
     TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{164: sum=sum(164: sum)}] group by [[56: n_name1, 55: o_orderyear]] having [null]
-            EXCHANGE SHUFFLE[56, 55]
-                AGGREGATE ([LOCAL] aggregate [{164: sum=sum(57: sum_amount)}] group by [[56: n_name1, 55: o_orderyear]] having [null]
-                    SCAN (mv[lineitem_mv_agg_mv1] columns[54: p_name, 55: o_orderyear, 56: n_name1, 57: sum_amount] predicate[54: p_name LIKE %peru%])
+        AGGREGATE ([GLOBAL] aggregate [{53: sum=sum(53: sum)}] group by [[48: n_name, 51: year]] having [null]
+            EXCHANGE SHUFFLE[48, 51]
+                AGGREGATE ([LOCAL] aggregate [{53: sum=sum(52: expr)}] group by [[48: n_name, 51: year]] having [null]
+                    SCAN (mv[lineitem_mv] columns[101: c_nationkey, 123: p_name, 127: s_nationkey, 130: l_amount, 132: o_orderyear, 135: n_name2] predicate[127: s_nationkey = 101: c_nationkey AND 123: p_name LIKE %peru%])
 [end]
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
- Do enhancements for queries/mvs that have multi same tables:
  -  Because we cannot decide which tables are needed to compensate into query, so iterate the possible permutations to `tryRewrite`;
- Add `expectQueryToMVRelationIds ` for the missing tables from mv to query, so can reduce the iteration times;
- Shortcut viewDelta rewrite because view-delta only supports inner/left-outer joins; 
- Do deep copy `EquivalenceClasses ` when iterating possible `relationIdMappings `;

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
