### PR TITLE
[BugFix] Cancel fragment instance not query when close external scanner

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -235,6 +235,12 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
     _update_profile_by_level(query_ctx, fragment_ctx, done);
     auto params = ExecStateReporter::create_report_exec_status_params(query_ctx, fragment_ctx, status, done);
     auto fe_addr = fragment_ctx->fe_addr();
+    if (fe_addr.hostname.empty()) {
+        // query executed by external connectors, like spark and flink connector,
+        // does not need to report exec state to FE, so return if fe addr is empty.
+        return;
+    }
+
     auto exec_env = fragment_ctx->runtime_state()->exec_env();
     auto fragment_id = fragment_ctx->fragment_instance_id();
 

--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -116,8 +116,7 @@ Status ExternalScanContextMgr::clear_scan_context(const std::string& context_id)
         // cancel pipeline
         auto fragment_instance_id = context->fragment_instance_id;
         if (auto query_ctx = _exec_env->query_context_mgr()->get(context->query_id); query_ctx != nullptr) {
-            if (auto fragment_ctx = query_ctx->fragment_mgr()->get(fragment_instance_id);
-                fragment_ctx != nullptr) {
+            if (auto fragment_ctx = query_ctx->fragment_mgr()->get(fragment_instance_id); fragment_ctx != nullptr) {
                 std::stringstream msg;
                 msg << "FragmentContext(id=" << print_id(fragment_instance_id) << ") cancelled by close_scanner";
                 fragment_ctx->cancel(Status::Cancelled(msg.str()));

--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -114,7 +114,7 @@ Status ExternalScanContextMgr::clear_scan_context(const std::string& context_id)
     }
     if (context != nullptr) {
         // cancel pipeline
-        auto fragment_instance_id = context->fragment_instance_id;
+        const auto& fragment_instance_id = context->fragment_instance_id;
         if (auto query_ctx = _exec_env->query_context_mgr()->get(context->query_id); query_ctx != nullptr) {
             if (auto fragment_ctx = query_ctx->fragment_mgr()->get(fragment_instance_id); fragment_ctx != nullptr) {
                 std::stringstream msg;

--- a/be/src/runtime/external_scan_context_mgr.cpp
+++ b/be/src/runtime/external_scan_context_mgr.cpp
@@ -107,19 +107,26 @@ Status ExternalScanContextMgr::clear_scan_context(const std::string& context_id)
             context = iter->second;
             if (context == nullptr) {
                 _active_contexts.erase(context_id);
-                Status::OK();
+                return Status::OK();
             }
             iter = _active_contexts.erase(iter);
         }
     }
     if (context != nullptr) {
         // cancel pipeline
+        auto fragment_instance_id = context->fragment_instance_id;
         if (auto query_ctx = _exec_env->query_context_mgr()->get(context->query_id); query_ctx != nullptr) {
-            query_ctx->cancel(Status::Cancelled("user cancelled"));
+            if (auto fragment_ctx = query_ctx->fragment_mgr()->get(fragment_instance_id);
+                fragment_ctx != nullptr) {
+                std::stringstream msg;
+                msg << "FragmentContext(id=" << print_id(fragment_instance_id) << ") cancelled by close_scanner";
+                fragment_ctx->cancel(Status::Cancelled(msg.str()));
+            }
         }
         // clear the fragment instance's related result queue
-        _exec_env->result_queue_mgr()->cancel(context->fragment_instance_id);
-        LOG(INFO) << "close scan context: context id [ " << context_id << " ]";
+        _exec_env->result_queue_mgr()->cancel(fragment_instance_id);
+        LOG(INFO) << "close scan context: context id [ " << context_id << " ], fragment instance id [ "
+                  << print_id(fragment_instance_id) << " ]";
     }
     return Status::OK();
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If cancel query, other fragment instances (scanners) will be cancelled, and spark connector will report SocketTimeoutException when get next data from BE.

Query executed by external connectors does not need to report exec state
to FE.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
