### PR TITLE
[Enhancement] put `io_task_per_scan_operator` to session variable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -755,9 +755,8 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
-
-CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 CONF_Int32(io_tasks_per_scan_operator, "4");
+
 CONF_Bool(connector_chunk_source_accumulate_chunk_enable, "true");
 CONF_Bool(connector_dynamic_chunk_buffer_limiter_enable, "true");
 CONF_Bool(connector_min_max_predicate_from_runtime_filter_enable, "true");

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -587,10 +587,6 @@ void ConnectorScanNode::_init_counter() {
     _profile.scanner_queue_counter = ADD_COUNTER(_runtime_profile, "ScannerQueueCounter", TUnit::UNIT);
 }
 
-int ConnectorScanNode::io_tasks_per_scan_operator() const {
-    return config::connector_io_tasks_per_scan_operator;
-}
-
 bool ConnectorScanNode::always_shared_scan() const {
     return config::connector_scan_node_always_shared_scan;
 }

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -47,8 +47,6 @@ public:
 
     connector::DataSourceProvider* data_source_provider() { return _data_source_provider.get(); }
     connector::ConnectorType connector_type() { return _connector_type; }
-
-    int io_tasks_per_scan_operator() const override;
     bool always_shared_scan() const override;
 
 private:

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -72,9 +72,9 @@ Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     }
 
     if (_olap_scan_node.__isset.max_parallel_scan_instance_num && _olap_scan_node.max_parallel_scan_instance_num >= 1) {
-        // The parallel scan num will be restricted by the config::io_tasks_per_scan_operator.
+        // The parallel scan num will be restricted by the io_tasks_per_scan_operator.
         _io_tasks_per_scan_operator =
-                std::min(_olap_scan_node.max_parallel_scan_instance_num, config::io_tasks_per_scan_operator);
+                std::min(_olap_scan_node.max_parallel_scan_instance_num, _io_tasks_per_scan_operator);
     }
 
     _estimate_scan_and_output_row_bytes();
@@ -760,7 +760,7 @@ void OlapScanNode::_estimate_scan_and_output_row_bytes() {
 }
 
 size_t OlapScanNode::_scanner_concurrency() const {
-    // The max scan parallel num for pipeline engine is config::io_tasks_per_scan_operator,
+    // The max scan parallel num for pipeline engine is io_tasks_per_scan_operator()
     // But the max scan parallel num of non-pipeline engine is kMaxConcurrency.
     // This functions is only used for non-pipeline engine,
     // so use the min value of concurrency which is calculated and max_parallel_scan_instance_num.

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -50,6 +50,7 @@ const std::string ScanNode::_s_scanner_thread_total_wallclock_time = "ScannerThr
 const string ScanNode::_s_num_scanner_threads_started = "NumScannerThreadsStarted";
 
 Status ScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
+    RETURN_IF_ERROR(ExecNode::init(tnode, state));
     const TQueryOptions& options = state->query_options();
     if (options.__isset.io_tasks_per_scan_operator) {
         _io_tasks_per_scan_operator = options.io_tasks_per_scan_operator;

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -49,6 +49,14 @@ const std::string ScanNode::_s_scanner_thread_total_wallclock_time = "ScannerThr
 
 const string ScanNode::_s_num_scanner_threads_started = "NumScannerThreadsStarted";
 
+Status ScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
+    const TQueryOptions& options = state->query_options();
+    if (options.__isset.io_tasks_per_scan_operator) {
+        _io_tasks_per_scan_operator = options.io_tasks_per_scan_operator;
+    }
+    return Status::OK();
+}
+
 Status ScanNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
 

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -72,6 +72,8 @@ public:
     ScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs) : ExecNode(pool, tnode, descs) {}
     ~ScanNode() override = default;
 
+    Status init(const TPlanNode& tnode, RuntimeState* state) override;
+
     // Set up counters
     Status prepare(RuntimeState* state) override;
 

--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -32,20 +32,20 @@ namespace starrocks {
 struct ArrayAggAggregateState {
     void update(FunctionContext* ctx, const Column& column, size_t index, size_t offset, size_t count) {
         if (UNLIKELY(index >= data_columns->size())) {
-            ctx->set_error(
-                    (std::string(fmt::format("index {} is larger than column size {}.", index, data_columns->size())))
-                            .c_str(),
-                    false);
+            if (ctx != nullptr) {
+                auto s = fmt::format("index {} is larger than column size {}.", index, data_columns->size());
+                ctx->set_error(s.c_str(), false);
+            }
             return;
         }
         (*data_columns)[index]->append(column, offset, count);
     }
     void update_nulls(FunctionContext* ctx, size_t index, size_t count) {
         if (UNLIKELY(index >= data_columns->size())) {
-            ctx->set_error(
-                    std::string(fmt::format("index {} is larger than column size {}.", index, data_columns->size()))
-                            .c_str(),
-                    false);
+            if (ctx != nullptr) {
+                auto s = fmt::format("index {} is larger than column size {}.", index, data_columns->size());
+                ctx->set_error(s.c_str(), false);
+            }
             return;
         }
         DCHECK((*data_columns)[index]->is_nullable());

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -37,6 +37,7 @@ struct ColumnReaderOptions {
     int chunk_size = 0;
     HdfsScanStats* stats = nullptr;
     RandomAccessFile* file = nullptr;
+    io::SharedBufferedInputStream* sb_stream = nullptr;
     tparquet::RowGroup* row_group_meta = nullptr;
     ColumnReaderContext* context = nullptr;
 };

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -160,7 +160,7 @@ Status GroupReader::_init_column_readers() {
     opts.file = _param.file;
     opts.row_group_meta = _row_group_metadata.get();
     opts.context = _obj_pool.add(new ColumnReaderContext);
-
+    opts.sb_stream = _param.sb_stream;
     for (const auto& column : _param.read_cols) {
         RETURN_IF_ERROR(_create_column_reader(column));
     }

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -54,7 +54,6 @@ public:
 
     Status set_io_ranges(const std::vector<IORange>& ranges);
     void release_to_offset(int64_t offset);
-    Status get_bytes(const uint8_t** buffer, size_t offset, size_t* nbytes);
     void release();
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
     void set_align_size(int64_t size) { _align_size = size; }
@@ -76,8 +75,10 @@ private:
         int64_t ref_count;
         std::vector<uint8_t> buffer;
     };
+    Status _get_bytes(SharedBuffer& sb, const uint8_t** buffer, size_t offset, size_t* nbytes);
     StatusOr<SharedBuffer*> _find_shared_buffer(size_t offset, size_t count);
     std::shared_ptr<SeekableInputStream> _stream;
+    std::string _filename;
     std::map<int64_t, SharedBuffer> _map;
     CoalesceOptions _options;
     int64_t _offset = 0;

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -1734,7 +1734,6 @@ TEST_F(AggregateTest, test_exchange_bytes) {
     ASSERT_EQ(data_column_bigint->byte_size() + data_column->byte_size(), result_column->get_data()[0]);
 }
 
-
 TEST_F(AggregateTest, test_array_agg) {
     std::vector<FunctionContext::TypeDesc> arg_types = {
             AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_logical_type(TYPE_VARCHAR)),
@@ -1957,9 +1956,7 @@ TEST_F(AggregateTest, test_array_agg) {
         auto agg_state = (ArrayAggAggregateState*)(state->state());
         ASSERT_EQ(agg_state->data_columns->size(), 2);
         // data_columns in state are nullable
-        ASSERT_EQ(strcmp((*agg_state->data_columns)[0]->debug_string().c_str(),
-                         "[NULL, NULL]"),
-                  0);
+        ASSERT_EQ(strcmp((*agg_state->data_columns)[0]->debug_string().c_str(), "[NULL, NULL]"), 0);
         ASSERT_EQ(strcmp((*agg_state->data_columns)[1]->debug_string().c_str(), "[3, 3]"), 0);
 
         TypeDescriptor type_array_char;
@@ -1978,9 +1975,7 @@ TEST_F(AggregateTest, test_array_agg) {
         type_struct_char_int.field_names.emplace_back("int");
         auto res_struct_col = ColumnHelper::create_column(type_struct_char_int, true);
         array_agg_func->serialize_to_column(local_ctx.get(), state->state(), res_struct_col.get());
-        ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(),
-                         "[{vchar:[NULL,NULL],int:[3,3]}]"),
-                  0);
+        ASSERT_EQ(strcmp(res_struct_col->debug_string().c_str(), "[{vchar:[NULL,NULL],int:[3,3]}]"), 0);
 
         res_struct_col->resize(0);
         array_agg_func->convert_to_serialize_format(local_ctx.get(), columns, int_column->size(), &res_struct_col);

--- a/docs/administration/Configuration.md
+++ b/docs/administration/Configuration.md
@@ -486,7 +486,6 @@ BE static parameters are as follows.
 | compaction_max_memory_limit | -1 | N/A | |
 | compaction_max_memory_limit_percent | 100 | N/A | |
 | compaction_memory_limit_per_worker | 2147483648 | N/A | |
-| connector_io_tasks_per_scan_operator | 16 | N/A | |
 | consistency_max_memory_limit | 10G | N/A | |
 | consistency_max_memory_limit_percent | 20 | N/A | |
 | cumulative_compaction_num_threads_per_disk | 1 | N/A | |

--- a/docs/reference/System_variable.md
+++ b/docs/reference/System_variable.md
@@ -476,3 +476,9 @@ SELECT /*+ SET_VAR
 * sql_dialect
 
   The SQL dialect that is used. For example, you can run the `set sql_dialect = 'trino';` command to set the SQL dialect to Trino, so you can use Trino-specific SQL syntax and functions in your queries.
+
+* io_tasks_per_scan_operator
+
+  The number of io tasks issued by a scan operator simutaneously. Increase this value when accessing remote storage system like HDFS/S3 if latency is high. However the higher this value, the more memory consumption.
+
+  The value is an interger. Default value: 4.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -321,6 +321,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_SCAN_BLOCK_CACHE = "enable_scan_block_cache";
     public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
     public static final String HUDI_MOR_FORCE_JNI_READER = "hudi_mor_force_jni_reader";
+    public static final String IO_TASKS_PER_SCAN_OPERATOR = "io_tasks_per_scan_operator";
 
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
@@ -874,6 +875,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_SCAN_BLOCK_CACHE)
     private boolean useScanBlockCache = false;
 
+    @VariableMgr.VarAttr(name = IO_TASKS_PER_SCAN_OPERATOR)
+    private int ioTasksPerScanOperator = 4;
+
     @VariableMgr.VarAttr(name = ENABLE_POPULATE_BLOCK_CACHE)
     private boolean enablePopulateBlockCache = true;
 
@@ -882,6 +886,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean getUseScanBlockCache() {
         return useScanBlockCache;
+    }
+
+    public int getIoTasksPerScanOperator() {
+        return ioTasksPerScanOperator;
     }
 
     @VarAttr(name = ENABLE_QUERY_CACHE)
@@ -1369,7 +1377,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return transactionVisibleWaitTimeout;
     }
 
-    public boolean isForceScheduleLocal() {
+    public boolean getForceScheduleLocal() {
         return forceScheduleLocal;
     }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -181,7 +181,7 @@ struct TQueryOptions {
   75: optional i64 spill_operator_min_bytes;
   76: optional TSpillMode spill_mode;
   77: optional i64 rpc_http_min_size;
-
+  78: optional i32 io_tasks_per_scan_operator = 4;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Right now this configuration is a static BE conf, which is bad for tuning. 

And we have found the case that, high value of this item is good for accesing remote storage when latency is high, but no ood(and not bad) when latency is ok. However, higher value means more memory consumption, which will incur OOM. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
