### PR TITLE
[Enhancement] support stream buffer in shared buffered input stream

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -754,6 +754,7 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
+CONF_Int32(io_coalesce_read_min_stream_size, "4194304");
 CONF_Int32(io_tasks_per_scan_operator, "4");
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -754,6 +754,7 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
+CONF_Bool(io_coalesce_enable_stream_read, "true");
 CONF_Int32(io_coalesce_read_min_stream_size, "4194304");
 CONF_Int32(io_tasks_per_scan_operator, "4");
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -218,7 +218,8 @@ Status HdfsScanner::open_random_access_file() {
         io::SharedBufferedInputStream::CoalesceOptions options = {
                 .max_dist_size = config::io_coalesce_read_max_distance_size,
                 .max_buffer_size = config::io_coalesce_read_max_buffer_size,
-                .min_stream_size = config::io_coalesce_read_min_stream_size};
+                .min_stream_size = config::io_coalesce_read_min_stream_size,
+                .enable_stream_read = config::io_coalesce_enable_stream_read};
         _shared_buffered_input_stream->set_coalesce_options(options);
         input_stream = _shared_buffered_input_stream;
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -217,7 +217,8 @@ Status HdfsScanner::open_random_access_file() {
                 std::make_shared<io::SharedBufferedInputStream>(input_stream, filename, file_size);
         io::SharedBufferedInputStream::CoalesceOptions options = {
                 .max_dist_size = config::io_coalesce_read_max_distance_size,
-                .max_buffer_size = config::io_coalesce_read_max_buffer_size};
+                .max_buffer_size = config::io_coalesce_read_max_buffer_size,
+                .min_stream_size = config::io_coalesce_read_min_stream_size};
         _shared_buffered_input_stream->set_coalesce_options(options);
         input_stream = _shared_buffered_input_stream;
 

--- a/be/src/formats/orc/orc_input_stream.cpp
+++ b/be/src/formats/orc/orc_input_stream.cpp
@@ -105,6 +105,7 @@ void ORCHdfsFileStream::setIORanges(std::vector<IORange>& io_ranges) {
         bs_io_ranges.emplace_back(io::SharedBufferedInputStream::IORange{.offset = static_cast<int64_t>(r.offset),
                                                                          .size = static_cast<int64_t>(r.size)});
     }
+    _sb_stream->set_can_use_stream_buffer(true);
     Status st = _sb_stream->set_io_ranges(bs_io_ranges);
     if (!st.ok()) {
         auto msg = strings::Substitute("Failed to setIORanges $0: $1", _file->filename(), st.to_string());

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -473,6 +473,7 @@ Status FileReader::_init_group_readers() {
     // 2. collect io ranges of every row group reader.
     // 3. set io ranges to the stream.
     if (config::parquet_coalesce_read_enable && _sb_stream != nullptr) {
+        _sb_stream->set_can_use_stream_buffer(true);
         std::vector<io::SharedBufferedInputStream::IORange> ranges;
         for (auto& r : _row_group_readers) {
             int64_t end_offset = 0;

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -33,18 +33,6 @@ void SharedBufferedInputStream::SharedBuffer::align(int64_t align_size, int64_t 
     }
 }
 
-void SharedBufferedInputStream::SharedBuffer::align(int64_t align_size, int64_t file_size) {
-    if (align_size != 0) {
-        offset = raw_offset / align_size * align_size;
-        int64_t end = (raw_offset + raw_size + align_size - 1) / align_size * align_size;
-        size = end - offset;
-    } else {
-        offset = raw_offset;
-        size = raw_size;
-    }
-    size = std::min(size, file_size);
-}
-
 Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& ranges) {
     if (ranges.size() == 0) {
         return Status::OK();

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -121,16 +121,24 @@ Status SharedBufferedInputStream::_read_stream_buffer(SharedBuffer& sb, size_t o
         int64_t old_size = sb.buffer.size();
         int64_t tail_size = old_size - adv;
 
+        DCHECK(adv >= 0) << ", sb.stream_offset = " << sb.stream_offset << ", offset = " << offset;
+        // total buffer is skipped.
+        if (tail_size < 0) tail_size = 0;
+
         // move tail data to head.
-        if (adv > 0) {
+        if (adv > 0 && tail_size > 0) {
             uint8_t* data = sb.buffer.data();
             std::memmove(data, data + adv, tail_size);
-            sb.stream_offset = offset;
         }
+
+        // reset stream offset.
+        sb.stream_offset = offset;
 
         // resize buffer.
         int64_t new_size = std::max((int64_t)count, _options.min_stream_size);
         new_size = std::min(new_size, sb.size + sb.offset - sb.stream_offset);
+        DCHECK(new_size >= count) << ", sb.stream_offset = " << sb.stream_offset << ", sb.offset = " << sb.offset
+                                  << ", sb.size = " << sb.size << ", new_size = " << new_size << ", count = " << count;
         sb.buffer.resize(new_size);
 
         // load data to buf.
@@ -142,6 +150,9 @@ Status SharedBufferedInputStream::_read_stream_buffer(SharedBuffer& sb, size_t o
             RETURN_IF_ERROR(_stream->read_at_fully(offset + tail_size, sb.buffer.data() + tail_size, read_size));
         }
     }
+    DCHECK((offset + count) <= (sb.stream_offset + sb.buffer.size()))
+            << ", sb.stream_offset = " << sb.stream_offset << ", offset = " << offset << ", count = " << count
+            << ", buffer_size = " << sb.buffer.size();
     return Status::OK();
 }
 

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -58,8 +58,10 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
     std::vector<IORange> small_ranges;
     for (const IORange& r : check) {
         if (r.size > _options.max_buffer_size) {
-            SharedBuffer sb = SharedBuffer{.raw_offset = r.offset, .raw_size = r.size, .ref_count = 1};
+            SharedBuffer sb = SharedBuffer{
+                    .raw_offset = r.offset, .raw_size = r.size, .ref_count = 1, .use_stream = _can_use_stream_buffer};
             sb.align(_align_size, _file_size);
+            sb.stream_offset = sb.offset;
             _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));
         } else {
             small_ranges.emplace_back(r);
@@ -73,8 +75,10 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
             int64_t end = (small_ranges[to].offset + small_ranges[to].size);
             SharedBuffer sb = SharedBuffer{.raw_offset = small_ranges[from].offset,
                                            .raw_size = end - small_ranges[from].offset,
-                                           .ref_count = ref_count};
+                                           .ref_count = ref_count,
+                                           .use_stream = false};
             sb.align(_align_size, _file_size);
+            sb.stream_offset = sb.offset;
             _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));
         };
 
@@ -110,9 +114,47 @@ StatusOr<SharedBufferedInputStream::SharedBuffer*> SharedBufferedInputStream::_f
     return &sb;
 }
 
+Status SharedBufferedInputStream::_read_stream_buffer(SharedBuffer& sb, size_t offset, size_t count) {
+    DCHECK(offset >= sb.stream_offset);
+    if ((offset + count) > (sb.stream_offset + sb.buffer.size())) {
+        int64_t adv = offset - sb.stream_offset;
+        int64_t old_size = sb.buffer.size();
+        int64_t tail_size = old_size - adv;
+
+        // move tail data to head.
+        if (adv > 0) {
+            uint8_t* data = sb.buffer.data();
+            std::memmove(data, data + adv, tail_size);
+            sb.stream_offset = offset;
+        }
+
+        // resize buffer.
+        int64_t new_size = std::max((int64_t)count, _options.min_stream_size);
+        new_size = std::min(new_size, sb.size + sb.offset - sb.stream_offset);
+        sb.buffer.resize(new_size);
+
+        // load data to buf.
+        {
+            SCOPED_RAW_TIMER(&_shared_io_timer);
+            _shared_io_count += 1;
+            size_t read_size = new_size - tail_size;
+            _shared_io_bytes += read_size;
+            RETURN_IF_ERROR(_stream->read_at_fully(offset + tail_size, sb.buffer.data() + tail_size, read_size));
+        }
+    }
+    return Status::OK();
+}
+
 Status SharedBufferedInputStream::_get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes) {
     ASSIGN_OR_RETURN(auto ret, _find_shared_buffer(offset, nbytes));
     SharedBuffer& sb = *ret;
+
+    if (sb.use_stream) {
+        _read_stream_buffer(sb, offset, nbytes);
+        *buffer = sb.buffer.data() + offset - sb.stream_offset;
+        return Status::OK();
+    }
+
     if (sb.buffer.capacity() == 0) {
         SCOPED_RAW_TIMER(&_shared_io_timer);
         _shared_io_count += 1;

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -33,6 +33,18 @@ void SharedBufferedInputStream::SharedBuffer::align(int64_t align_size, int64_t 
     }
 }
 
+void SharedBufferedInputStream::SharedBuffer::align(int64_t align_size, int64_t file_size) {
+    if (align_size != 0) {
+        offset = raw_offset / align_size * align_size;
+        int64_t end = (raw_offset + raw_size + align_size - 1) / align_size * align_size;
+        size = end - offset;
+    } else {
+        offset = raw_offset;
+        size = raw_size;
+    }
+    size = std::min(size, file_size);
+}
+
 Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& ranges) {
     if (ranges.size() == 0) {
         return Status::OK();

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -58,8 +58,10 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
     std::vector<IORange> small_ranges;
     for (const IORange& r : check) {
         if (r.size > _options.max_buffer_size) {
-            SharedBuffer sb = SharedBuffer{
-                    .raw_offset = r.offset, .raw_size = r.size, .ref_count = 1, .use_stream = _can_use_stream_buffer};
+            SharedBuffer sb = SharedBuffer{.raw_offset = r.offset,
+                                           .raw_size = r.size,
+                                           .ref_count = 1,
+                                           .use_stream = _can_use_stream_buffer && _options.enable_stream_read};
             sb.align(_align_size, _file_size);
             sb.stream_offset = sb.offset;
             _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -35,6 +35,7 @@ public:
         int64_t max_dist_size = 1 * MB;
         int64_t max_buffer_size = 8 * MB;
         int64_t min_stream_size = 4 * MB;
+        bool enable_stream_read = true;
     };
 
     SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename,

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -34,6 +34,7 @@ public:
         static constexpr int64_t MB = 1024 * 1024;
         int64_t max_dist_size = 1 * MB;
         int64_t max_buffer_size = 8 * MB;
+        int64_t min_stream_size = 4 * MB;
     };
 
     SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename,
@@ -54,6 +55,7 @@ public:
     }
 
     Status set_io_ranges(const std::vector<IORange>& ranges);
+    void set_can_use_stream_buffer(bool v) { _can_use_stream_buffer = v; }
     void release_to_offset(int64_t offset);
     void release();
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
@@ -78,6 +80,11 @@ private:
         int64_t offset;
         int64_t size;
         int64_t ref_count;
+
+        // if use stream buffer
+        bool use_stream;
+        int64_t stream_offset;
+
         std::vector<uint8_t> buffer;
         void align(int64_t align_size, int64_t file_size);
     };
@@ -97,6 +104,7 @@ private:
     int64_t _direct_io_bytes = 0;
     int64_t _direct_io_timer = 0;
     int64_t _align_size = 0;
+    bool _can_use_stream_buffer = false;
 };
 
 } // namespace starrocks::io


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For large size column, we use `StreamBuffer` instead of `SharedBuffer`. The difference between two is:
- SteamBuffer only needs to read ahead a fixed amount of data like 4MB
- and SharedBuffer will read all data at once, which is more likely to incur OOM.(because you really don't how large a column will take)

According to my observation, a tpch-100g lineitem table, field `l_quantity` takes 12MB, but actually there are 12 pages in there, which means actually we only need 1MB at a time. 

There is a tradeoff between memory and io counter.

```
l_orderkey:       INT32 UNCOMPRESSED DO:0 FPO:132106132 SZ:6293200/6293200/1.00 VC:1736593 ENC:PLAIN_DICTIONARY,PLAIN,BIT_PACKED,RLE
l_partkey:        INT32 UNCOMPRESSED DO:0 FPO:138399332 SZ:6946713/6946713/1.00 VC:1736593 ENC:PLAIN,BIT_PACKED,RLE
l_suppkey:        INT32 UNCOMPRESSED DO:0 FPO:145346045 SZ:6946713/6946713/1.00 VC:1736593 ENC:PLAIN,BIT_PACKED,RLE
l_linenumber:     INT32 UNCOMPRESSED DO:0 FPO:152292758 SZ:655068/655068/1.00 VC:1736593 ENC:PLAIN_DICTIONARY,BIT_PACKED,RLE
l_quantity:       FIXED_LEN_BYTE_ARRAY UNCOMPRESSED DO:0 FPO:152947826 SZ:12156809/12156809/1.00 VC:1736593 ENC:PLAIN,BIT_PACKED,RLE
l_extendedprice:  FIXED_LEN_BYTE_ARRAY UNCOMPRESSED DO:0 FPO:165104635 SZ:12156809/12156809/1.00 VC:1736593 ENC:PLAIN,BIT_PACKED,RLE
l_discount:       FIXED_LEN_BYTE_ARRAY UNCOMPRESSED DO:0 FPO:177261444 SZ:12156809/12156809/1.00 VC:1736593 ENC:PLAIN,BIT_PACKED,RLE
l_tax:            FIXED_LEN_BYTE_ARRAY UNCOMPRESSED DO:0 FPO:189418253 SZ:12156809/12156809/1.00 VC:1736593 ENC:PLAIN,BIT_PACKED,RLE
``` 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
