### PR TITLE
[BugFix] fix to avoid scan op is nullptr when mem_limit is 0

### DIFF
--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -157,18 +157,17 @@ pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::Pipelin
     bool stream_data_source = _data_source_provider->stream_data_source();
     bool is_stream_pipeline = context->is_stream_pipeline();
     int64_t mem_limit = runtime_state()->query_mem_tracker_ptr()->limit() * config::scan_use_query_mem_ratio;
-    if (mem_limit > 0) {
-        // port from olap scan node. to control chunk buffer usage, we can control memory consumption to avoid OOM.
-        size_t max_buffer_capacity = pipeline::ScanOperator::max_buffer_capacity() * dop;
-        size_t default_buffer_capacity = max_buffer_capacity;
-        pipeline::ChunkBufferLimiterPtr buffer_limiter = std::make_unique<pipeline::DynamicChunkBufferLimiter>(
-                max_buffer_capacity, default_buffer_capacity, mem_limit, runtime_state()->chunk_size());
-        scan_op = !stream_data_source ? std::make_shared<pipeline::ConnectorScanOperatorFactory>(
-                                                context->next_operator_id(), this, dop, std::move(buffer_limiter))
-                                      : std::make_shared<pipeline::StreamScanOperatorFactory>(
-                                                context->next_operator_id(), this, dop, std::move(buffer_limiter),
-                                                is_stream_pipeline);
-    }
+
+    // port from olap scan node. to control chunk buffer usage, we can control memory consumption to avoid OOM.
+    size_t max_buffer_capacity = pipeline::ScanOperator::max_buffer_capacity() * dop;
+    size_t default_buffer_capacity = max_buffer_capacity;
+    pipeline::ChunkBufferLimiterPtr buffer_limiter = std::make_unique<pipeline::DynamicChunkBufferLimiter>(
+            max_buffer_capacity, default_buffer_capacity, mem_limit, runtime_state()->chunk_size());
+    scan_op = !stream_data_source
+                      ? std::make_shared<pipeline::ConnectorScanOperatorFactory>(context->next_operator_id(), this, dop,
+                                                                                 std::move(buffer_limiter))
+                      : std::make_shared<pipeline::StreamScanOperatorFactory>(
+                                context->next_operator_id(), this, dop, std::move(buffer_limiter), is_stream_pipeline);
 
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
     this->init_runtime_filter_for_operator(scan_op.get(), context, rc_rf_probe_collector);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
