### PR TITLE
[Bugfix][Cherry-pick] fix rewrite bug after insert new partition data for 3.0 (#20157)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
@@ -16,6 +16,7 @@
 package com.starrocks.sql.optimizer;
 
 import com.starrocks.catalog.Table;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 
@@ -31,6 +32,10 @@ public class MvRewriteContext {
     private final OptExpression queryExpression;
     private final ReplaceColumnRefRewriter queryColumnRefRewriter;
     private final PredicateSplit queryPredicateSplit;
+
+    // mv's partition and distribution related conjunct predicate,
+    // used to prune partitions and buckets of scan mv operator after rewrite
+    private ScalarOperator mvPruneConjunct;
 
     public MvRewriteContext(
             MaterializationContext materializationContext,
@@ -63,5 +68,13 @@ public class MvRewriteContext {
 
     public PredicateSplit getQueryPredicateSplit() {
         return queryPredicateSplit;
+    }
+
+    public ScalarOperator getMvPruneConjunct() {
+        return mvPruneConjunct;
+    }
+
+    public void setMvPruneConjunct(ScalarOperator mvPruneConjunct) {
+        this.mvPruneConjunct = mvPruneConjunct;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
@@ -15,9 +15,11 @@
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
@@ -28,6 +30,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalHudiScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.OptDistributionPruner;
 import com.starrocks.sql.optimizer.rewrite.OptExternalPartitionPruner;
 import com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner;
@@ -35,14 +38,21 @@ import com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner;
 import java.util.List;
 
 public class MVPartitionPruner {
+    private final OptimizerContext optimizerContext;
+    private final MvRewriteContext mvRewriteContext;
 
-    public OptExpression prunePartition(OptimizerContext context, OptExpression queryExpression) {
-        return queryExpression.getOp().accept(new MVPartitionPrunerVisitor(), queryExpression, context);
+    public MVPartitionPruner(OptimizerContext optimizerContext, MvRewriteContext mvRewriteContext) {
+        this.optimizerContext = optimizerContext;
+        this.mvRewriteContext = mvRewriteContext;
     }
 
-    private class MVPartitionPrunerVisitor extends OptExpressionVisitor<OptExpression, OptimizerContext> {
+    public OptExpression prunePartition(OptExpression queryExpression) {
+        return queryExpression.getOp().accept(new MVPartitionPrunerVisitor(), queryExpression, null);
+    }
+
+    private class MVPartitionPrunerVisitor extends OptExpressionVisitor<OptExpression, Void> {
         @Override
-        public OptExpression visitLogicalTableScan(OptExpression optExpression, OptimizerContext context) {
+        public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
             LogicalScanOperator scanOperator = optExpression.getOp().cast();
 
             if (scanOperator instanceof LogicalOlapScanOperator) {
@@ -56,6 +66,18 @@ public class MVPartitionPruner {
                         .setPrunedPartitionPredicates(Lists.newArrayList())
                         .setSelectedPartitionId(Lists.newArrayList())
                         .setSelectedTabletId(Lists.newArrayList());
+
+                // for mv: select c1, c3, c2 from test_base_part where c3 < 2000 and c1 = 1,
+                // which c3 is partition column and c1 is distribution column.
+                // we should add predicate c3 < 2000 and c1 = 1 into scan operator to do pruning
+                boolean isAddMvPrunePredicate = scanOperator.getTable().isMaterializedView()
+                        && scanOperator.getTable().getId() == mvRewriteContext.getMaterializationContext().getMv().getId()
+                        && mvRewriteContext.getMvPruneConjunct() != null;
+                if (isAddMvPrunePredicate) {
+                    ScalarOperator originPredicate = scanOperator.getPredicate();
+                    ScalarOperator newPredicate = Utils.compoundAnd(originPredicate, mvRewriteContext.getMvPruneConjunct());
+                    builder.setPredicate(newPredicate);
+                }
                 LogicalOlapScanOperator copiedOlapScanOperator = builder.build();
 
                 // prune partition
@@ -67,9 +89,19 @@ public class MVPartitionPruner {
                 List<Long> selectedTabletIds = OptDistributionPruner.pruneTabletIds(copiedOlapScanOperator,
                         prunedOlapScanOperator.getSelectedPartitionId());
 
+                ScalarOperator scanPredicate = prunedOlapScanOperator.getPredicate();
+                if (isAddMvPrunePredicate) {
+                    List<ScalarOperator> originConjuncts = Utils.extractConjuncts(scanOperator.getPredicate());
+                    List<ScalarOperator> pruneConjuncts = Utils.extractConjuncts(mvRewriteContext.getMvPruneConjunct());
+                    pruneConjuncts.removeAll(originConjuncts);
+                    List<ScalarOperator> currentConjuncts = Utils.extractConjuncts(prunedOlapScanOperator.getPredicate());
+                    currentConjuncts.removeAll(pruneConjuncts);
+                    scanPredicate = Utils.compoundAnd(currentConjuncts);
+                }
+
                 LogicalOlapScanOperator.Builder rewrittenBuilder = new LogicalOlapScanOperator.Builder();
                 scanOperator = rewrittenBuilder.withOperator(prunedOlapScanOperator)
-                        .setPredicate(MvUtils.canonizePredicate(prunedOlapScanOperator.getPredicate()))
+                        .setPredicate(MvUtils.canonizePredicate(scanPredicate))
                         .setSelectedTabletId(selectedTabletIds)
                         .build();
             } else if (scanOperator instanceof LogicalHiveScanOperator ||
@@ -81,16 +113,16 @@ public class MVPartitionPruner {
                 Operator.Builder builder = OperatorBuilderFactory.build(scanOperator);
                 LogicalScanOperator copiedScanOperator =
                         (LogicalScanOperator) builder.withOperator(scanOperator).build();
-                scanOperator = OptExternalPartitionPruner.prunePartitions(context,
+                scanOperator = OptExternalPartitionPruner.prunePartitions(optimizerContext,
                         copiedScanOperator);
             }
             return OptExpression.create(scanOperator);
         }
 
-        public OptExpression visit(OptExpression optExpression, OptimizerContext context) {
+        public OptExpression visit(OptExpression optExpression, Void context) {
             List<OptExpression> children = Lists.newArrayList();
             for (int i = 0; i < optExpression.arity(); ++i) {
-                children.add(optExpression.inputAt(i).getOp().accept(this, optExpression.inputAt(i), context));
+                children.add(optExpression.inputAt(i).getOp().accept(this, optExpression.inputAt(i), null));
             }
             return OptExpression.create(optExpression.getOp(), children);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -334,6 +334,7 @@ public class MvUtils {
                 new RelationTransformer(columnRefFactory, connectContext).transformWithSelectLimit(query);
         // optimize the sql by rule and disable rule based materialized view rewrite
         OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
+        optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
         optimizerConfig.disableRuleSet(RuleSetType.SINGLE_TABLE_MV_REWRITE);
         Optimizer optimizer = new Optimizer(optimizerConfig);
         OptExpression optimizedPlan = optimizer.optimize(
@@ -396,12 +397,14 @@ public class MvUtils {
         // Ignore aggregation predicates, because aggregation predicates should be rewritten after
         // aggregation functions' rewrite and should not be pushed down into mv scan operator.
         if (operator.getPredicate() != null && !(operator instanceof LogicalAggregationOperator)) {
-            predicates.add(operator.getPredicate());
+            List<ScalarOperator> conjuncts = Utils.extractConjuncts(operator.getPredicate());
+            predicates.addAll(conjuncts);
         }
         if (operator instanceof LogicalJoinOperator) {
             LogicalJoinOperator joinOperator = (LogicalJoinOperator) operator;
             if (joinOperator.getOnPredicate() != null) {
-                predicates.add(joinOperator.getOnPredicate());
+                List<ScalarOperator> conjuncts = Utils.extractConjuncts(joinOperator.getOnPredicate());
+                predicates.addAll(conjuncts);
             }
         }
         for (OptExpression child : root.getInputs()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -101,7 +101,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             MaterializedViewRewriter mvRewriter = getMaterializedViewRewrite(mvRewriteContext);
             OptExpression candidate = mvRewriter.rewrite();
             if (candidate != null) {
-                candidate = postRewriteMV(context, candidate);
+                candidate = postRewriteMV(context, mvRewriteContext, candidate);
                 if (queryExpression.getGroupExpression() != null) {
                     int currentRootGroupId = queryExpression.getGroupExpression().getGroup().getId();
                     mvContext.addMatchedGroup(currentRootGroupId);
@@ -119,12 +119,13 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
      * 2. partition prune
      * 3. bucket prune
      */
-    private OptExpression postRewriteMV(OptimizerContext context, OptExpression candidate) {
+    private OptExpression postRewriteMV(
+            OptimizerContext optimizerContext, MvRewriteContext mvRewriteContext, OptExpression candidate) {
         if (candidate == null) {
             return null;
         }
         candidate = new MVColumnPruner().pruneColumns(candidate);
-        candidate = new MVPartitionPruner().prunePartition(context, candidate);
+        candidate = new MVPartitionPruner(optimizerContext, mvRewriteContext).prunePartition(candidate);
         return candidate;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -1542,8 +1542,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv, query)
                 .contains("0:OlapScanNode\n" +
                         "     TABLE: mv0\n" +
-                        "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 7: empid = 1");
+                        "     PREAGGREGATION: ON\n");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -172,7 +172,12 @@ public class MaterializedViewTestBase extends PlanTestBase {
         }
 
         public MVRewriteChecker contains(String expect) {
-            Assert.assertTrue(this.rewritePlan.contains(expect));
+            boolean contained = this.rewritePlan.contains(expect);
+            if (!contained) {
+                LOG.warn("rewritePlan: \n{}", rewritePlan);
+                LOG.warn("expect: \n{}", expect);
+            }
+            Assert.assertTrue(contained);
             return this;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -154,10 +154,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                 .contains("UNION")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 6: c3 < 2000\n" +
                         "     partitions=1/1\n" +
-                        "     rollup: partial_mv_6\n" +
-                        "     tabletRatio=2/2")
+                        "     rollup: partial_mv_6")
                 .contains("TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
                         "     partitions=1/5\n" +
@@ -170,10 +168,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                 .contains("partial_mv_6")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 6: c3 <= 999, 6: c3 < 2000\n" +
-                        "     partitions=1/1\n" +
-                        "     rollup: partial_mv_6\n" +
-                        "     tabletRatio=2/2");
+                        "     PREDICATES: 6: c3 <= 999");
 
         starRocksAssert.dropMaterializedView("partial_mv_6");
     }
@@ -365,10 +360,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 2000")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 11: c3 < 2000\n" +
                         "     partitions=1/1\n" +
-                        "     rollup: partial_mv_6\n" +
-                        "     tabletRatio=2/2");
+                        "     rollup: partial_mv_6");
 
         // test query delta
         testRewriteOK(
@@ -378,10 +371,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 2000 and t2.c3 > 100;")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 11: c3 <= 1999, 11: c3 >= 101, 11: c3 < 2000\n" +
-                        "     partitions=1/1\n" +
-                        "     rollup: partial_mv_6\n" +
-                        "     tabletRatio=2/2");
+                        "     PREDICATES: 11: c3 <= 1999, 11: c3 >= 101\n" +
+                        "     partitions=1/1");
 
         // test query delta
         testRewriteOK(
@@ -391,10 +382,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 1000;")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 11: c3 <= 999, 11: c3 < 2000\n" +
-                        "     partitions=1/1\n" +
-                        "     rollup: partial_mv_6\n" +
-                        "     tabletRatio=2/2");
+                        "     PREDICATES: 11: c3 <= 999\n" +
+                        "     partitions=1/1");
 
         // test query delta, agg + join
         testRewriteOK(
@@ -404,10 +393,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 1000;")
                 .contains("TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 12: c3 <= 999, 12: c3 < 2000\n" +
-                        "     partitions=1/1\n" +
-                        "     rollup: partial_mv_6\n" +
-                        "     tabletRatio=2/2");
+                        "     PREDICATES: 12: c3 <= 999\n" +
+                        "     partitions=1/1");
 
         // test union all
         // TODO: MV can be rewritten but cannot bingo(because cost?)!
@@ -462,21 +449,15 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                 .contains("UNION")
                 .contains("TABLE: partial_mv_7\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 5: c1 = 1\n" +
                         "     partitions=4/5\n" +
                         "     rollup: partial_mv_7\n" +
                         "     tabletRatio=4/8")
-                .contains("TABLE: test_base_part\n" +
-                        "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: (8: c1 != 1) OR (10: c3 >= 2000)\n" +
-                        "     partitions=5/5\n" +
-                        "     rollup: test_base_part");
+                .contains("TABLE: test_base_part");
 
         // match all
         testRewriteOK("select c1, c3, c2 from test_base_part where c3 < 2000 and c1 = 1")
                 .contains("TABLE: partial_mv_7\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 5: c1 = 1\n" +
                         "     partitions=4/5\n" +
                         "     rollup: partial_mv_7\n" +
                         "     tabletRatio=4/8");
@@ -485,7 +466,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
         testRewriteOK("select c1, c3, c2 from test_base_part where c3 < 1000 and c1 = 1")
                 .contains("TABLE: partial_mv_7\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 6: c3 <= 999, 5: c1 = 1\n" +
+                        "     PREDICATES: 6: c3 <= 999\n" +
                         "     partitions=3/5\n" +
                         "     rollup: partial_mv_7\n" +
                         "     tabletRatio=3/6");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -1768,11 +1768,7 @@ public class MvRewriteOptimizationTest {
                 " select c1, c3, c2 from test_base_part where c3 < 2000 and c1 = 1;");
         String query11 = "select c1, c3, c2 from test_base_part";
         String plan11 = getFragmentPlan(query11);
-        PlanTestBase.assertContains(plan11, "partial_mv_7", "UNION", "TABLE: test_base_part\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: (8: c1 != 1) OR (10: c3 >= 2000)\n" +
-                "     partitions=6/6\n" +
-                "     rollup: test_base_part");
+        PlanTestBase.assertContains(plan11, "partial_mv_7", "UNION", "TABLE: test_base_part");
         dropMv("test", "partial_mv_7");
 
         createAndRefreshMv("test", "partial_mv_8", "create materialized view partial_mv_8" +


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #19817 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix rewrite failure after inserting new partition data. The bug reason is that the mv plan is cached, but the plan may change after ingestion with new partitions data. And the logic of partition predicate calculation for mv rewrite depends on scan node's selected partition id, which may change after ingestion. So it leads to invalid compensation predicate in mv rewrite, which caused an invalid rewritten plan. Fix it by:
1. disable partition prune rules during compile mv plan, which will keep partition predicates in mv plan, to avoid the problem of caching plan
2. remove mv partition predicate compensation logic because it is not necessary after step 1. and it also fixed the problem of redundant partition predicates after partition prune of mv.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
