### PR TITLE
[Refactor]Remove evict cache code for lake branch 2.4

### DIFF
--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -86,9 +86,6 @@ void UpdateConfigAction::handle(HttpRequest* req) {
         _config_callback.emplace("update_memory_limit_percent", [&]() {
             StorageEngine::instance()->update_manager()->update_primary_index_memory_limit(
                     config::update_memory_limit_percent);
-#if defined(USE_STAROS) && !defined(BE_TEST)
-            _exec_env->lake_update_manager()->update_primary_index_memory_limit(config::update_memory_limit_percent);
-#endif
         });
     });
 

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -619,9 +619,6 @@ void* StorageEngine::_update_cache_evict_thread_callback(void* arg) {
             continue;
         }
         _update_manager->evict_cache(memory_urgent_level, memory_high_level);
-#if defined(USE_STAROS) && !defined(BE_TEST)
-        ExecEnv::GetInstance()->lake_update_manager()->evict_cache(memory_urgent_level, memory_high_level);
-#endif
     }
     return nullptr;
 }

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -166,19 +166,19 @@ void UpdateManager::expire_cache() {
 }
 
 void UpdateManager::evict_cache(int64_t memory_urgent_level, int64_t memory_high_level) {
-    int64_t capacity = _update_state_cache.capacity();
-    int64_t size = _update_state_cache.size();
+    int64_t capacity = _index_cache.capacity();
+    int64_t size = _index_cache.size();
     int64_t memory_urgent = capacity * memory_urgent_level / 100;
     int64_t memory_high = capacity * memory_high_level / 100;
 
     if (size > memory_urgent) {
-        _update_state_cache.try_evict(memory_urgent);
+        _index_cache.try_evict(memory_urgent);
     }
 
-    size = _update_state_cache.size();
+    size = _index_cache.size();
     if (size > memory_high) {
         int64_t target_memory = std::max((size * 9 / 10), memory_high);
-        _update_state_cache.try_evict(target_memory);
+        _index_cache.try_evict(target_memory);
     }
     return;
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There are some code for lake table in the pr(https://github.com/StarRocks/starrocks/pull/18392) which is useless in branch 2.4, and this pr remove them.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
