### PR TITLE
[Enhancement] Print lake read filepath in be.out when BE crashed

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -85,7 +85,8 @@ static void dump_trace_info() {
         // dump query_id and fragment id
         auto query_id = CurrentThread::current().query_id();
         auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
-        char buffer[256] = {};
+        const std::string lake_filename = CurrentThread::current().get_lake_filename();
+        char buffer[512] = {};
 
         // write build version
         int res = get_build_version(buffer, sizeof(buffer));
@@ -97,6 +98,14 @@ static void dump_trace_info() {
         res = sprintf(buffer + res, "fragment_instance:") + res;
         res = print_unique_id(buffer + res, fragment_instance_id) + res;
         res = sprintf(buffer + res, "\n") + res;
+
+        // print for lake filename
+        if (!lake_filename.empty()) {
+            res = sprintf(buffer + res, "lake filename: ") + res;
+            res = sprintf(buffer + res, "%s", lake_filename.c_str()) + res;
+            res = sprintf(buffer + res, "\n") + res;
+        }
+
         wt = write(STDERR_FILENO, buffer, res);
         // dump memory usage
         // copy trackers

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -85,7 +85,7 @@ static void dump_trace_info() {
         // dump query_id and fragment id
         auto query_id = CurrentThread::current().query_id();
         auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
-        const std::string scan_file_path = CurrentThread::current().get_scan_file_path();
+        const std::string custom_coredump_msg = CurrentThread::current().get_custom_coredump_msg();
         const uint32_t MAX_BUFFER_SIZE = 512;
         char buffer[MAX_BUFFER_SIZE] = {};
 
@@ -101,9 +101,9 @@ static void dump_trace_info() {
         res = sprintf(buffer + res, "\n") + res;
 
         // print for lake filename
-        if (!scan_file_path.empty()) {
-            // Avoid buffer overflow, because url's length in not fixed
-            res = snprintf(buffer + res, MAX_BUFFER_SIZE - res, "Scan file path: %s\n", scan_file_path.c_str()) + res;
+        if (!custom_coredump_msg.empty()) {
+            // Avoid buffer overflow, because custom coredump msg's length in not fixed
+            res = snprintf(buffer + res, MAX_BUFFER_SIZE - res, "%s\n", custom_coredump_msg.c_str()) + res;
         }
 
         wt = write(STDERR_FILENO, buffer, res);

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -85,8 +85,9 @@ static void dump_trace_info() {
         // dump query_id and fragment id
         auto query_id = CurrentThread::current().query_id();
         auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
-        const std::string lake_filename = CurrentThread::current().get_lake_filename();
-        char buffer[512] = {};
+        const std::string scan_file_path = CurrentThread::current().get_scan_file_path();
+        const uint32_t MAX_BUFFER_SIZE = 512;
+        char buffer[MAX_BUFFER_SIZE] = {};
 
         // write build version
         int res = get_build_version(buffer, sizeof(buffer));
@@ -100,10 +101,9 @@ static void dump_trace_info() {
         res = sprintf(buffer + res, "\n") + res;
 
         // print for lake filename
-        if (!lake_filename.empty()) {
-            res = sprintf(buffer + res, "lake filename: ") + res;
-            res = sprintf(buffer + res, "%s", lake_filename.c_str()) + res;
-            res = sprintf(buffer + res, "\n") + res;
+        if (!scan_file_path.empty()) {
+            // Avoid buffer overflow, because url's length in not fixed
+            res = snprintf(buffer + res, MAX_BUFFER_SIZE - res, "Scan file path: %s\n", scan_file_path.c_str()) + res;
         }
 
         wt = write(STDERR_FILENO, buffer, res);

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -62,6 +62,8 @@ public:
     void set_read_limit(const uint64_t limit) { _read_limit = limit; }
     Status parse_runtime_filters(RuntimeState* state);
     void update_has_any_predicate();
+    // Called frequently, don't do heavy work
+    virtual const std::string get_custom_coredump_msg() const { return ""; }
 
 protected:
     int64_t _read_limit = -1; // no limit

--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -142,6 +142,10 @@ Status FileDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
     return Status::OK();
 }
 
+const std::string FileDataSource::get_custom_coredump_msg() const {
+    return strings::Substitute("Load file path: $0", _scan_range.ranges[0].path);
+}
+
 int64_t FileDataSource::raw_rows_read() const {
     return _counter.filtered_rows_read + _counter.num_rows_filtered;
 }

--- a/be/src/connector/file_connector.h
+++ b/be/src/connector/file_connector.h
@@ -56,6 +56,7 @@ public:
     Status open(RuntimeState* state) override;
     void close(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
+    const std::string get_custom_coredump_msg() const override;
 
     int64_t raw_rows_read() const override;
     int64_t num_rows_read() const override;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -522,7 +522,8 @@ Status HiveDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
 
 const std::string HiveDataSource::get_custom_coredump_msg() const {
     const std::string path = !_scan_range.relative_path.empty() ? _scan_range.relative_path : _scan_range.full_path;
-    return strings::Substitute("Hive file path: $0, partition id: $1, length: $2, offset: $3", path, _scan_range.partition_id, _scan_range.length, _scan_range.offset);
+    return strings::Substitute("Hive file path: $0, partition id: $1, length: $2, offset: $3", path,
+                               _scan_range.partition_id, _scan_range.length, _scan_range.offset);
 }
 
 int64_t HiveDataSource::raw_rows_read() const {

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -22,7 +22,6 @@
 #include "exec/hdfs_scanner_text.h"
 #include "exec/jni_scanner.h"
 #include "exprs/expr.h"
-#include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
 
 namespace starrocks::connector {

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -22,8 +22,8 @@
 #include "exec/hdfs_scanner_text.h"
 #include "exec/jni_scanner.h"
 #include "exprs/expr.h"
-#include "storage/chunk_helper.h"
 #include "runtime/current_thread.h"
+#include "storage/chunk_helper.h"
 
 namespace starrocks::connector {
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -23,6 +23,7 @@
 #include "exec/jni_scanner.h"
 #include "exprs/expr.h"
 #include "storage/chunk_helper.h"
+#include "runtime/current_thread.h"
 
 namespace starrocks::connector {
 
@@ -423,6 +424,9 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
     FSOptions fsOptions =
             FSOptions(hdfs_scan_node.__isset.cloud_configuration ? &hdfs_scan_node.cloud_configuration : nullptr);
+
+    // Use to print file path in be.out when coredump
+    tls_thread_status.set_lake_filename(native_file_path);
 
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(native_file_path, fsOptions));
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -426,7 +426,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
             FSOptions(hdfs_scan_node.__isset.cloud_configuration ? &hdfs_scan_node.cloud_configuration : nullptr);
 
     // Use to print file path in be.out when coredump
-    tls_thread_status.set_lake_filename(native_file_path);
+    tls_thread_status.set_scan_file_path(native_file_path);
 
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(native_file_path, fsOptions));
 

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -53,6 +53,7 @@ public:
     Status open(RuntimeState* state) override;
     void close(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
+    const std::string get_custom_coredump_msg() const override;
 
     int64_t raw_rows_read() const override;
     int64_t num_rows_read() const override;

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -66,6 +66,10 @@ public:
     void pin_chunk_token(ChunkBufferTokenPtr chunk_token);
     void unpin_chunk_token();
 
+    // Used to print custom error msg in be.out when coredmp
+    // Don't do heavey work, it calls frequently
+    virtual const std::string get_custom_coredump_msg() const { return ""; }
+
 protected:
     // MUST be implemented by different ChunkSource
     virtual Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) = 0;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -190,6 +190,10 @@ Status ConnectorChunkSource::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
+const std::string ConnectorChunkSource::get_custom_coredump_msg() const {
+    return _data_source->get_custom_coredump_msg();
+}
+
 void ConnectorChunkSource::close(RuntimeState* state) {
     if (_closed) return;
     _closed = true;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -88,6 +88,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
+    const std::string get_custom_coredump_msg() const override;
 
 protected:
     virtual bool _reach_eof() { return _limit != -1 && _rows_read >= _limit; }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -355,6 +355,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(this);
 
             auto& chunk_source = _chunk_sources[chunk_source_index];
+            SCOPED_SET_CUSTOM_COREDUMP_MSG(chunk_source->get_custom_coredump_msg());
+
             [[maybe_unused]] std::string category;
             category = fmt::sprintf("chunk_source_%d_0x%x", get_plan_node_id(), query_trace_ctx.id);
             QUERY_TRACE_ASYNC_START("io_task", category, query_trace_ctx);

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -392,10 +392,10 @@ private:
         return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));                                       \
     }
 
-#define TRY_CATCH_BAD_ALLOC(stmt)                    \
-    do {                                             \
-        TRY_CATCH_ALLOC_SCOPE_START() { stmt; }      \
-        TRY_CATCH_ALLOC_SCOPE_END()                  \
+#define TRY_CATCH_BAD_ALLOC(stmt)               \
+    do {                                        \
+        TRY_CATCH_ALLOC_SCOPE_START() { stmt; } \
+        TRY_CATCH_ALLOC_SCOPE_END()             \
     } while (0)
 
 #define TRY_CATCH_ALL(result, stmt)                                                      \

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -367,11 +367,9 @@ private:
         CurrentThread::current().set_fragment_instance_id({});               \
     });
 
-#define SCOPED_SET_CUSTOM_COREDUMP_MSG(custom_coredump_msg)     \
-    CurrentThread::current().set_custom_coredump_msg(custom_coredump_msg);              \
-    auto VARNAME_LINENUM(defer) = DeferOp([] {                               \
-        CurrentThread::current().set_custom_coredump_msg({});                  \
-    });
+#define SCOPED_SET_CUSTOM_COREDUMP_MSG(custom_coredump_msg)                \
+    CurrentThread::current().set_custom_coredump_msg(custom_coredump_msg); \
+    auto VARNAME_LINENUM(defer) = DeferOp([] { CurrentThread::current().set_custom_coredump_msg({}); });
 
 #define TRY_CATCH_ALLOC_SCOPE_START() \
     try {                             \
@@ -394,10 +392,12 @@ private:
         return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));                                       \
     }
 
-#define TRY_CATCH_BAD_ALLOC(stmt)               \
-    do {                                        \
-        TRY_CATCH_ALLOC_SCOPE_START() { stmt; } \
-        TRY_CATCH_ALLOC_SCOPE_END()             \
+#define TRY_CATCH_BAD_ALLOC(stmt)       \
+    do {                                \
+        TRY_CATCH_ALLOC_SCOPE_START() { \
+            stmt;                       \
+        }                               \
+        TRY_CATCH_ALLOC_SCOPE_END()     \
     } while (0)
 
 #define TRY_CATCH_ALL(result, stmt)                                                      \

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -388,13 +388,11 @@ private:
         return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));                                       \
     }
 
-#define TRY_CATCH_BAD_ALLOC(stmt)       \
-    do {                                \
-        TRY_CATCH_ALLOC_SCOPE_START() { \
-            stmt;                       \
-        }                               \
-        TRY_CATCH_ALLOC_SCOPE_END()     \
-    } while (0)
+#define TRY_CATCH_BAD_ALLOC(stmt)               \
+    do {                                        \
+        TRY_CATCH_ALLOC_SCOPE_START() { stmt; } \
+        TRY_CATCH_ALLOC_SCOPE_END()             \
+     } while (0)
 
 #define TRY_CATCH_ALL(result, stmt)                                                      \
     do {                                                                                 \

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -157,9 +157,9 @@ public:
     void set_pipeline_driver_id(int32_t driver_id) { _driver_id = driver_id; }
     int32_t get_driver_id() const { return _driver_id; }
 
-    void set_lake_filename(const std::string filename) { _lake_filename = filename; }
+    void set_scan_file_path(const std::string scan_file_path) { _scan_file_path = scan_file_path; }
 
-    std::string get_lake_filename() const { return _lake_filename; }
+    std::string get_scan_file_path() const { return _scan_file_path; }
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
@@ -261,7 +261,7 @@ private:
     // Store in TLS for diagnose coredump easier
     TUniqueId _query_id;
     TUniqueId _fragment_instance_id;
-    std::string _lake_filename{};
+    std::string _scan_file_path{};
     int32_t _driver_id = 0;
     bool _is_catched = false;
     bool _check = true;

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -392,7 +392,7 @@ private:
     do {                                        \
         TRY_CATCH_ALLOC_SCOPE_START() { stmt; } \
         TRY_CATCH_ALLOC_SCOPE_END()             \
-     } while (0)
+    } while (0)
 
 #define TRY_CATCH_ALL(result, stmt)                                                      \
     do {                                                                                 \

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -392,12 +392,10 @@ private:
         return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));                                       \
     }
 
-#define TRY_CATCH_BAD_ALLOC(stmt)       \
-    do {                                \
-        TRY_CATCH_ALLOC_SCOPE_START() { \
-            stmt;                       \
-        }                               \
-        TRY_CATCH_ALLOC_SCOPE_END()     \
+#define TRY_CATCH_BAD_ALLOC(stmt)                    \
+    do {                                             \
+        TRY_CATCH_ALLOC_SCOPE_START() { stmt; }      \
+        TRY_CATCH_ALLOC_SCOPE_END()                  \
     } while (0)
 
 #define TRY_CATCH_ALL(result, stmt)                                                      \

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -157,6 +157,10 @@ public:
     void set_pipeline_driver_id(int32_t driver_id) { _driver_id = driver_id; }
     int32_t get_driver_id() const { return _driver_id; }
 
+    void set_lake_filename(const std::string filename) { _lake_filename = filename; }
+
+    std::string get_lake_filename() const { return _lake_filename; }
+
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
         mem_tracker_ctx_shift();
@@ -257,6 +261,7 @@ private:
     // Store in TLS for diagnose coredump easier
     TUniqueId _query_id;
     TUniqueId _fragment_instance_id;
+    std::string _lake_filename{};
     int32_t _driver_id = 0;
     bool _is_catched = false;
     bool _check = true;
@@ -383,10 +388,12 @@ private:
         return Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));                                       \
     }
 
-#define TRY_CATCH_BAD_ALLOC(stmt)               \
-    do {                                        \
-        TRY_CATCH_ALLOC_SCOPE_START() { stmt; } \
-        TRY_CATCH_ALLOC_SCOPE_END()             \
+#define TRY_CATCH_BAD_ALLOC(stmt)       \
+    do {                                \
+        TRY_CATCH_ALLOC_SCOPE_START() { \
+            stmt;                       \
+        }                               \
+        TRY_CATCH_ALLOC_SCOPE_END()     \
     } while (0)
 
 #define TRY_CATCH_ALL(result, stmt)                                                      \

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -157,9 +157,9 @@ public:
     void set_pipeline_driver_id(int32_t driver_id) { _driver_id = driver_id; }
     int32_t get_driver_id() const { return _driver_id; }
 
-    void set_scan_file_path(const std::string scan_file_path) { _scan_file_path = scan_file_path; }
+    void set_custom_coredump_msg(const std::string custom_coredump_msg) { _custom_coredump_msg = custom_coredump_msg; }
 
-    std::string get_scan_file_path() const { return _scan_file_path; }
+    const std::string get_custom_coredump_msg() const { return _custom_coredump_msg; }
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
@@ -261,7 +261,7 @@ private:
     // Store in TLS for diagnose coredump easier
     TUniqueId _query_id;
     TUniqueId _fragment_instance_id;
-    std::string _scan_file_path{};
+    std::string _custom_coredump_msg{};
     int32_t _driver_id = 0;
     bool _is_catched = false;
     bool _check = true;
@@ -365,6 +365,12 @@ private:
         CurrentThread::current().set_pipeline_driver_id(0);                  \
         CurrentThread::current().set_query_id({});                           \
         CurrentThread::current().set_fragment_instance_id({});               \
+    });
+
+#define SCOPED_SET_CUSTOM_COREDUMP_MSG(custom_coredump_msg)     \
+    CurrentThread::current().set_custom_coredump_msg(custom_coredump_msg);              \
+    auto VARNAME_LINENUM(defer) = DeferOp([] {                               \
+        CurrentThread::current().set_custom_coredump_msg({});                  \
     });
 
 #define TRY_CATCH_ALLOC_SCOPE_START() \


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When BE crashed, the user is hard to know which file occurs, in this pr, we will print file path in `be.out`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
