### PR TITLE
[Enhancement] Add tablet path info to be_tablets table

### DIFF
--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -26,13 +26,15 @@
 namespace starrocks {
 
 SchemaScanner::ColumnDesc SchemaBeTabletsScanner::_s_columns[] = {
-        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},        {"TABLE_ID", TYPE_BIGINT, sizeof(int64_t), false},
-        {"PARTITION_ID", TYPE_BIGINT, sizeof(int64_t), false}, {"TABLET_ID", TYPE_BIGINT, sizeof(int64_t), false},
-        {"NUM_VERSION", TYPE_BIGINT, sizeof(int64_t), false},  {"MAX_VERSION", TYPE_BIGINT, sizeof(int64_t), false},
-        {"MIN_VERSION", TYPE_BIGINT, sizeof(int64_t), false},  {"NUM_ROWSET", TYPE_BIGINT, sizeof(int64_t), false},
-        {"NUM_ROW", TYPE_BIGINT, sizeof(int64_t), false},      {"DATA_SIZE", TYPE_BIGINT, sizeof(int64_t), false},
-        {"INDEX_MEM", TYPE_BIGINT, sizeof(int64_t), false},    {"CREATE_TIME", TYPE_BIGINT, sizeof(int64_t), false},
-        {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},   {"TYPE", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},         {"TABLE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"PARTITION_ID", TYPE_BIGINT, sizeof(int64_t), false},  {"TABLET_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NUM_VERSION", TYPE_BIGINT, sizeof(int64_t), false},   {"MAX_VERSION", TYPE_BIGINT, sizeof(int64_t), false},
+        {"MIN_VERSION", TYPE_BIGINT, sizeof(int64_t), false},   {"NUM_ROWSET", TYPE_BIGINT, sizeof(int64_t), false},
+        {"NUM_ROW", TYPE_BIGINT, sizeof(int64_t), false},       {"DATA_SIZE", TYPE_BIGINT, sizeof(int64_t), false},
+        {"INDEX_MEM", TYPE_BIGINT, sizeof(int64_t), false},     {"CREATE_TIME", TYPE_BIGINT, sizeof(int64_t), false},
+        {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},    {"TYPE", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"DATA_DIR", TYPE_VARCHAR, sizeof(StringValue), false}, {"SHARD_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"SCHEMA_HASH", TYPE_BIGINT, sizeof(int64_t), false},
 };
 
 SchemaBeTabletsScanner::SchemaBeTabletsScanner()
@@ -89,7 +91,7 @@ Status SchemaBeTabletsScanner::fill_chunk(ChunkPtr* chunk) {
     for (; _cur_idx < _infos.size(); _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
-            if (slot_id < 1 || slot_id > 14) {
+            if (slot_id < 1 || slot_id > 17) {
                 return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
             }
             ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
@@ -164,6 +166,19 @@ Status SchemaBeTabletsScanner::fill_chunk(ChunkPtr* chunk) {
                 // type
                 Slice type = Slice(keys_type_to_string((KeysType)info.type));
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&type);
+                break;
+            }
+            case 15: {
+                Slice type = Slice(info.data_dir);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&type);
+                break;
+            }
+            case 16: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.shard_id);
+                break;
+            }
+            case 17: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.schema_hash);
                 break;
             }
             default:

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.h
@@ -35,6 +35,9 @@ struct TabletBasicInfo {
     int64_t create_time{0};
     int32_t state{0};
     int32_t type{0};
+    std::string data_dir;
+    int64_t shard_id{0};
+    int64_t schema_hash{0};
 };
 
 class SchemaBeTabletsScanner : public SchemaScanner {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1362,6 +1362,9 @@ void Tablet::get_basic_info(TabletBasicInfo& info) {
     info.create_time = _tablet_meta->creation_time();
     info.state = _state;
     info.type = keys_type();
+    info.data_dir = data_dir()->path();
+    info.shard_id = shard_id();
+    info.schema_hash = schema_hash();
     if (_updates != nullptr) {
         _updates->get_basic_info_extra(info);
     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -634,6 +634,9 @@ public class SchemaTable extends Table {
                                     .column("CREATE_TIME", ScalarType.createType(PrimitiveType.BIGINT))
                                     .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("DATA_DIR", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("SHARD_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("SCHEMA_HASH", ScalarType.createType(PrimitiveType.BIGINT))
                                     .build()))
                     .put("be_metrics", new SchemaTable(
                             SystemId.BE_METRICS_ID,


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds more path-related info to be_tablets table, including tablet's data_dir, shard_id and schema_hash, together they can determine a tablet's full path.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
