### PR TITLE
[BugFix] Fix incorrect time unit for JournalTask#betterCommitBeforeTime

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalTask.java
@@ -33,15 +33,15 @@ public class JournalTask implements Future<Boolean> {
     // JournalWriter will call notify() after log is committed.
     protected CountDownLatch latch;
     // JournalWrite will commit immediately if received a log with betterCommitBeforeTime > now
-    protected long betterCommitBeforeTime;
+    protected long betterCommitBeforeTimeInNano;
 
     public JournalTask(DataOutputBuffer buffer, long maxWaitIntervalMs) {
         this.buffer = buffer;
         this.latch = new CountDownLatch(1);
         if (maxWaitIntervalMs > 0) {
-            this.betterCommitBeforeTime = System.currentTimeMillis() + maxWaitIntervalMs;
+            this.betterCommitBeforeTimeInNano = System.nanoTime() + maxWaitIntervalMs * 1000000;
         } else {
-            this.betterCommitBeforeTime = -1;
+            this.betterCommitBeforeTimeInNano = -1;
         }
     }
 
@@ -55,8 +55,8 @@ public class JournalTask implements Future<Boolean> {
         latch.countDown();
     }
 
-    public long getBetterCommitBeforeTime() {
-        return betterCommitBeforeTime;
+    public long getBetterCommitBeforeTimeInNano() {
+        return betterCommitBeforeTimeInNano;
     }
 
     public long estimatedSizeByte() {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
@@ -177,11 +177,11 @@ public class JournalWriter {
 
     private boolean shouldCommitNow() {
         // 1. check if is an emergency journal
-        if (currentJournal.getBetterCommitBeforeTime() > 0) {
-            long delayMillis = (System.nanoTime() - currentJournal.getBetterCommitBeforeTime()) / 1000000;
-            if (delayMillis >= 0) {
-                LOG.warn("journal expect commit before {} is delayed {} mills, will commit now",
-                        currentJournal.getBetterCommitBeforeTime(), delayMillis);
+        if (currentJournal.getBetterCommitBeforeTimeInNano() > 0) {
+            long delayNanos = System.nanoTime() - currentJournal.getBetterCommitBeforeTimeInNano();
+            if (delayNanos >= 0) {
+                LOG.warn("journal expect commit before {} is delayed {} nanos, will commit now",
+                        currentJournal.getBetterCommitBeforeTimeInNano(), delayNanos);
                 return true;
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/journal/JournalWriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/JournalWriterTest.java
@@ -117,7 +117,7 @@ public class JournalWriterTest {
         JournalTask expectConsumedEntity = new JournalTask(makeBuffer(10), -1);
         journalQueue.add(expectConsumedEntity);
         JournalTask emergency = new JournalTask(makeBuffer(10), -1);
-        emergency.betterCommitBeforeTime = System.currentTimeMillis() - 10;
+        emergency.betterCommitBeforeTimeInNano = System.nanoTime() - 10;
         journalQueue.add(emergency);
         JournalTask expectNotConsumedEntity = new JournalTask(makeBuffer(10), -1);
         journalQueue.add(expectNotConsumedEntity);


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`JournalTask#betterCommitBeforeTime` is assigned a millisecond time, but used as a nano time in `JournalWriter#shouldCommitNow`. This bug has no bad effect currently because `JournalTask` is always constructed with a -1 `maxWaitIntervalMs`, and it causes `betterCommitBeforeTime` is also -1 which means an invalid time. This problem could be fixed by assigning a nano time to `betterCommitBeforeTime`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
