### PR TITLE
[BugFix] fix shared buffer io coalesce

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -754,8 +754,8 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
+CONF_Int32(io_coalesce_read_min_stream_size, "4194304");
 CONF_Int32(io_tasks_per_scan_operator, "4");
-
 CONF_Bool(scan_node_always_shared_scan, "false");
 CONF_Bool(connector_scan_node_always_shared_scan, "true");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -754,6 +754,7 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
+CONF_Bool(io_coalesce_enable_stream_read, "true");
 CONF_Int32(io_coalesce_read_min_stream_size, "4194304");
 CONF_Int32(io_tasks_per_scan_operator, "4");
 CONF_Bool(scan_node_always_shared_scan, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -754,8 +754,6 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
-CONF_Bool(io_coalesce_enable_stream_read, "true");
-CONF_Int32(io_coalesce_read_min_stream_size, "4194304");
 CONF_Int32(io_tasks_per_scan_operator, "4");
 CONF_Bool(scan_node_always_shared_scan, "false");
 CONF_Bool(connector_scan_node_always_shared_scan, "true");

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -223,6 +223,11 @@ Status HdfsScanner::open_random_access_file() {
     if (_compression_type == CompressionTypePB::NO_COMPRESSION) {
         _shared_buffered_input_stream =
                 std::make_shared<io::SharedBufferedInputStream>(input_stream, filename, file_size);
+        io::SharedBufferedInputStream::CoalesceOptions options = {
+                .max_dist_size = config::io_coalesce_read_max_distance_size,
+                .max_buffer_size = config::io_coalesce_read_max_buffer_size,
+                .min_stream_size = config::io_coalesce_read_min_stream_size};
+        _shared_buffered_input_stream->set_coalesce_options(options);
         input_stream = _shared_buffered_input_stream;
 
         // input_stream = CacheInputStream(input_stream)

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -226,7 +226,8 @@ Status HdfsScanner::open_random_access_file() {
         io::SharedBufferedInputStream::CoalesceOptions options = {
                 .max_dist_size = config::io_coalesce_read_max_distance_size,
                 .max_buffer_size = config::io_coalesce_read_max_buffer_size,
-                .min_stream_size = config::io_coalesce_read_min_stream_size};
+                .min_stream_size = config::io_coalesce_read_min_stream_size,
+                .enable_stream_read = config::io_coalesce_enable_stream_read};
         _shared_buffered_input_stream->set_coalesce_options(options);
         input_stream = _shared_buffered_input_stream;
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -36,14 +36,6 @@ public:
         return nread;
     }
 
-    // StatusOr<int64_t> read_at(int64_t offset, void* data, int64_t size) override {
-    //     SCOPED_RAW_TIMER(&_stats->io_ns);
-    //     _stats->io_count += 1;
-    //     ASSIGN_OR_RETURN(auto nread, _stream->read_at(offset, data, size));
-    //     _stats->bytes_read += nread;
-    //     return nread;
-    // }
-
     Status read_at_fully(int64_t offset, void* data, int64_t size) override {
         SCOPED_RAW_TIMER(&_stats->io_ns);
         _stats->io_count += 1;
@@ -225,9 +217,7 @@ Status HdfsScanner::open_random_access_file() {
                 std::make_shared<io::SharedBufferedInputStream>(input_stream, filename, file_size);
         io::SharedBufferedInputStream::CoalesceOptions options = {
                 .max_dist_size = config::io_coalesce_read_max_distance_size,
-                .max_buffer_size = config::io_coalesce_read_max_buffer_size,
-                .min_stream_size = config::io_coalesce_read_min_stream_size,
-                .enable_stream_read = config::io_coalesce_enable_stream_read};
+                .max_buffer_size = config::io_coalesce_read_max_buffer_size};
         _shared_buffered_input_stream->set_coalesce_options(options);
         input_stream = _shared_buffered_input_stream;
 

--- a/be/src/formats/orc/orc_input_stream.cpp
+++ b/be/src/formats/orc/orc_input_stream.cpp
@@ -105,7 +105,6 @@ void ORCHdfsFileStream::setIORanges(std::vector<IORange>& io_ranges) {
         bs_io_ranges.emplace_back(io::SharedBufferedInputStream::IORange{.offset = static_cast<int64_t>(r.offset),
                                                                          .size = static_cast<int64_t>(r.size)});
     }
-    _sb_stream->set_can_use_stream_buffer(true);
     Status st = _sb_stream->set_io_ranges(bs_io_ranges);
     if (!st.ok()) {
         auto msg = strings::Substitute("Failed to setIORanges $0: $1", _file->filename(), st.to_string());

--- a/be/src/formats/orc/orc_input_stream.cpp
+++ b/be/src/formats/orc/orc_input_stream.cpp
@@ -105,6 +105,7 @@ void ORCHdfsFileStream::setIORanges(std::vector<IORange>& io_ranges) {
         bs_io_ranges.emplace_back(io::SharedBufferedInputStream::IORange{.offset = static_cast<int64_t>(r.offset),
                                                                          .size = static_cast<int64_t>(r.size)});
     }
+    _sb_stream->set_can_use_stream_buffer(true);
     Status st = _sb_stream->set_io_ranges(bs_io_ranges);
     if (!st.ok()) {
         auto msg = strings::Substitute("Failed to setIORanges $0: $1", _file->filename(), st.to_string());

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -464,10 +464,7 @@ Status FileReader::_init_group_readers() {
     // 2. collect io ranges of every row group reader.
     // 3. set io ranges to the stream.
     if (config::parquet_coalesce_read_enable && _sb_stream != nullptr) {
-        io::SharedBufferedInputStream::CoalesceOptions options = {
-                .max_dist_size = config::io_coalesce_read_max_distance_size,
-                .max_buffer_size = config::io_coalesce_read_max_buffer_size};
-        _sb_stream->set_coalesce_options(options);
+        _sb_stream->set_can_use_stream_buffer(true);
         std::vector<io::SharedBufferedInputStream::IORange> ranges;
         for (auto& r : _row_group_readers) {
             int64_t end_offset = 0;

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -464,7 +464,6 @@ Status FileReader::_init_group_readers() {
     // 2. collect io ranges of every row group reader.
     // 3. set io ranges to the stream.
     if (config::parquet_coalesce_read_enable && _sb_stream != nullptr) {
-        _sb_stream->set_can_use_stream_buffer(true);
         std::vector<io::SharedBufferedInputStream::IORange> ranges;
         for (auto& r : _row_group_readers) {
             int64_t end_offset = 0;

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -58,8 +58,10 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
     std::vector<IORange> small_ranges;
     for (const IORange& r : check) {
         if (r.size > _options.max_buffer_size) {
-            SharedBuffer sb = SharedBuffer{
-                    .raw_offset = r.offset, .raw_size = r.size, .ref_count = 1, .use_stream = _can_use_stream_buffer};
+            SharedBuffer sb = SharedBuffer{.raw_offset = r.offset,
+                                           .raw_size = r.size,
+                                           .ref_count = 1,
+                                           .use_stream = _can_use_stream_buffer && _options.enable_stream_read};
             sb.align(_align_size, _file_size);
             sb.stream_offset = sb.offset;
             _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -58,8 +58,10 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
     std::vector<IORange> small_ranges;
     for (const IORange& r : check) {
         if (r.size > _options.max_buffer_size) {
-            SharedBuffer sb = SharedBuffer{.raw_offset = r.offset, .raw_size = r.size, .ref_count = 1};
+            SharedBuffer sb = SharedBuffer{
+                    .raw_offset = r.offset, .raw_size = r.size, .ref_count = 1, .use_stream = _can_use_stream_buffer};
             sb.align(_align_size, _file_size);
+            sb.stream_offset = sb.offset;
             _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));
         } else {
             small_ranges.emplace_back(r);
@@ -73,8 +75,10 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
             int64_t end = (small_ranges[to].offset + small_ranges[to].size);
             SharedBuffer sb = SharedBuffer{.raw_offset = small_ranges[from].offset,
                                            .raw_size = end - small_ranges[from].offset,
-                                           .ref_count = ref_count};
+                                           .ref_count = ref_count,
+                                           .use_stream = false};
             sb.align(_align_size, _file_size);
+            sb.stream_offset = sb.offset;
             _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));
         };
 
@@ -110,7 +114,47 @@ StatusOr<SharedBufferedInputStream::SharedBuffer*> SharedBufferedInputStream::_f
     return &sb;
 }
 
-Status SharedBufferedInputStream::_get_bytes(SharedBuffer& sb, const uint8_t** buffer, size_t offset, size_t* nbytes) {
+Status SharedBufferedInputStream::_read_stream_buffer(SharedBuffer& sb, size_t offset, size_t count) {
+    DCHECK(offset >= sb.stream_offset);
+    if ((offset + count) > (sb.stream_offset + sb.buffer.size())) {
+        int64_t adv = offset - sb.stream_offset;
+        int64_t old_size = sb.buffer.size();
+        int64_t tail_size = old_size - adv;
+
+        // move tail data to head.
+        if (adv > 0) {
+            uint8_t* data = sb.buffer.data();
+            std::memmove(data, data + adv, tail_size);
+            sb.stream_offset = offset;
+        }
+
+        // resize buffer.
+        int64_t new_size = std::max((int64_t)count, _options.min_stream_size);
+        new_size = std::min(new_size, sb.size + sb.offset - sb.stream_offset);
+        sb.buffer.resize(new_size);
+
+        // load data to buf.
+        {
+            SCOPED_RAW_TIMER(&_shared_io_timer);
+            _shared_io_count += 1;
+            size_t read_size = new_size - tail_size;
+            _shared_io_bytes += read_size;
+            RETURN_IF_ERROR(_stream->read_at_fully(offset + tail_size, sb.buffer.data() + tail_size, read_size));
+        }
+    }
+    return Status::OK();
+}
+
+Status SharedBufferedInputStream::_get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes) {
+    ASSIGN_OR_RETURN(auto ret, _find_shared_buffer(offset, nbytes));
+    SharedBuffer& sb = *ret;
+
+    if (sb.use_stream) {
+        _read_stream_buffer(sb, offset, nbytes);
+        *buffer = sb.buffer.data() + offset - sb.stream_offset;
+        return Status::OK();
+    }
+
     if (sb.buffer.capacity() == 0) {
         SCOPED_RAW_TIMER(&_shared_io_timer);
         _shared_io_count += 1;
@@ -145,8 +189,7 @@ Status SharedBufferedInputStream::read_at_fully(int64_t offset, void* out, int64
         return Status::OK();
     }
     const uint8_t* buffer = nullptr;
-    size_t nbytes = count;
-    RETURN_IF_ERROR(_get_bytes(*(st.value()), &buffer, offset, &nbytes));
+    RETURN_IF_ERROR(_get_bytes(&buffer, offset, count));
     strings::memcpy_inlined(out, buffer, count);
     return Status::OK();
 }
@@ -166,8 +209,7 @@ StatusOr<std::string_view> SharedBufferedInputStream::peek(int64_t count) {
     ASSIGN_OR_RETURN(auto ret, _find_shared_buffer(_offset, count));
     if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
     const uint8_t* buf = nullptr;
-    size_t nbytes = count;
-    RETURN_IF_ERROR(_get_bytes(*ret, &buf, _offset, &nbytes));
+    RETURN_IF_ERROR(_get_bytes(&buf, _offset, count));
     return std::string_view((const char*)buf, count);
 }
 

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -54,7 +54,6 @@ public:
     }
 
     Status set_io_ranges(const std::vector<IORange>& ranges);
-    void set_can_use_stream_buffer(bool v) { _can_use_stream_buffer = v; }
     void release_to_offset(int64_t offset);
     void release();
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -35,6 +35,7 @@ public:
         int64_t max_dist_size = 1 * MB;
         int64_t max_buffer_size = 8 * MB;
         int64_t min_stream_size = 4 * MB;
+        bool enable_stream_read = true;
     };
 
     SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename,

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -70,10 +70,13 @@ public:
 private:
     struct SharedBuffer {
     public:
+        int64_t raw_offset;
+        int64_t raw_size;
         int64_t offset;
         int64_t size;
         int64_t ref_count;
         std::vector<uint8_t> buffer;
+        void align(int64_t align_size, int64_t file_size);
     };
     Status _get_bytes(SharedBuffer& sb, const uint8_t** buffer, size_t offset, size_t* nbytes);
     StatusOr<SharedBuffer*> _find_shared_buffer(size_t offset, size_t count);

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -34,8 +34,6 @@ public:
         static constexpr int64_t MB = 1024 * 1024;
         int64_t max_dist_size = 1 * MB;
         int64_t max_buffer_size = 8 * MB;
-        int64_t min_stream_size = 4 * MB;
-        bool enable_stream_read = true;
     };
 
     SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename,
@@ -81,11 +79,6 @@ private:
         int64_t offset;
         int64_t size;
         int64_t ref_count;
-
-        // if use stream buffer
-        bool use_stream;
-        int64_t stream_offset;
-
         std::vector<uint8_t> buffer;
         void align(int64_t align_size, int64_t file_size);
     };
@@ -105,7 +98,6 @@ private:
     int64_t _direct_io_bytes = 0;
     int64_t _direct_io_timer = 0;
     int64_t _align_size = 0;
-    bool _can_use_stream_buffer = false;
 };
 
 } // namespace starrocks::io

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -36,7 +36,7 @@ public:
         int64_t max_buffer_size = 8 * MB;
     };
 
-    SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename, size_t size);
+    SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename, size_t file_size);
     ~SharedBufferedInputStream() override = default;
 
     Status seek(int64_t position) override {
@@ -85,7 +85,7 @@ private:
     std::map<int64_t, SharedBuffer> _map;
     CoalesceOptions _options;
     int64_t _offset = 0;
-    int64_t _size = 0;
+    int64_t _file_size = 0;
     int64_t _shared_io_count = 0;
     int64_t _shared_io_bytes = 0;
     int64_t _shared_io_timer = 0;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Since we move shared buffer under cache input stream, we have to do alignment, and merge consecutive io ranges.

But there is a problem that after alignement, some small io ranges can be merged with large io range(>8M), which will make even large io range and that's very bad for memory consumption.

So in this PR, we separate `raw_offset, raw_size` from `offset, size` (after alignment). And we do io coalsece wrt. raw offset and size, instead of `offset,size`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
