### PR TITLE
[Enhancement] Don't set is_catched=true in TRY_CATCH_ALL

### DIFF
--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -389,10 +389,11 @@ private:
         TRY_CATCH_ALLOC_SCOPE_END()             \
     } while (0)
 
+// TRY_CATCH_ALL will not set catched=true, only used for catch unexpected crash,
+// cannot be used to control memory usage.
 #define TRY_CATCH_ALL(result, stmt)                                                      \
     do {                                                                                 \
         try {                                                                            \
-            SCOPED_SET_CATCHED(true);                                                    \
             { result = stmt; }                                                           \
         } catch (std::runtime_error const& e) {                                          \
             result = Status::RuntimeError(fmt::format("Runtime error: {}", e.what()));   \


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

TRY_CATCH_ALL will not set catched=true, only used for catch unexpected crash, cannot be used to control memory usage.

The call link of this function is too long, and this kind of core call process is not suitable for adding pre-allocated memory control

```
    virtual StatusOr<DriverState> process(RuntimeState* runtime_state, int worker_id);
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
