### PR TITLE
[BugFix] Passthrough originalStmt to avoid npe for show statements

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
@@ -17,12 +17,19 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.OutFileClause;
 import com.starrocks.analysis.RedirectStatus;
+import com.starrocks.qe.OriginStatement;
 
 public class QueryStatement extends StatementBase {
     private final QueryRelation queryRelation;
 
     // represent the "INTO OUTFILE" clause
     protected OutFileClause outFileClause;
+
+    public QueryStatement(QueryRelation queryRelation, OriginStatement originStatement) {
+        super(queryRelation.getPos());
+        this.queryRelation = queryRelation;
+        this.origStmt = originStatement;
+    }
 
     public QueryStatement(QueryRelation queryRelation) {
         super(queryRelation.getPos());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
@@ -167,7 +167,7 @@ public class ShowColumnStmt extends ShowStmt {
         where = where.substitute(aliasMap);
 
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
-                where, null, null));
+                where, null, null), this.origStmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDbStmt.java
@@ -86,7 +86,7 @@ public class ShowDbStmt extends ShowStmt {
         aliasMap.put(new SlotRef(null, DB_COL), item.getExpr().clone(null));
         where = where.substitute(aliasMap);
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
-                where, null, null));
+                where, null, null), this.origStmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -143,7 +143,7 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
                 whereDbEQ,
                 where);
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
-                finalWhere, null, null));
+                finalWhere, null, null), this.getOrigStmt());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStatusStmt.java
@@ -163,7 +163,7 @@ public class ShowTableStatusStmt extends ShowStmt {
         where = where.substitute(aliasMap);
 
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
-                where, null, null));
+                where, null, null), this.origStmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStmt.java
@@ -107,7 +107,7 @@ public class ShowTableStmt extends ShowStmt {
                 whereDbEQ,
                 where);
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
-                finalWhere, null, null));
+                finalWhere, null, null), this.origStmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowVariablesStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowVariablesStmt.java
@@ -118,7 +118,7 @@ public class ShowVariablesStmt extends ShowStmt {
         where = where.substitute(aliasMap);
 
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(tableName),
-                where, null, null));
+                where, null, null), this.origStmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/StatementBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/StatementBase.java
@@ -63,7 +63,8 @@ public abstract class StatementBase implements ParseNode {
     // True if this QueryStmt is the top level query from an EXPLAIN <query>
     protected boolean isExplain = false;
 
-    private OriginStatement origStmt;
+    // Original statement to further usage, eg: enable_sql_blacklist.
+    protected OriginStatement origStmt;
 
     public void setIsExplain(boolean isExplain, ExplainLevel explainLevel) {
         this.isExplain = isExplain;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
@@ -31,11 +31,13 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ShowDbStmt;
+import com.starrocks.sql.ast.ShowTableStmt;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.platform.commons.util.Preconditions;
 
 public class ShowDbStmtTest {
     private ConnectContext ctx;
@@ -108,8 +110,7 @@ public class ShowDbStmtTest {
     }
 
     @Test
-    public void testNormal() throws UserException, AnalysisException {
-        final Analyzer analyzer = AccessTestUtil.fetchBlockAnalyzer();
+    public void testNormal() throws Exception {
         ShowDbStmt stmt = new ShowDbStmt(null);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.assertNull(stmt.getPattern());
@@ -127,6 +128,11 @@ public class ShowDbStmtTest {
         ShowResultSet resultSet = executor.execute();
         ShowResultSetMetaData metaData = resultSet.getMetaData();
         Assert.assertEquals(metaData.getColumn(0).getName(), "Database");
+
+        String sql = "show databases where `database` = 't1'";
+        stmt = (ShowDbStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        Preconditions.notNull(stmt.toSelectStmt().getOrigStmt(), "stmt's original stmt should not be null");
+
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -45,6 +45,7 @@ import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.platform.commons.util.Preconditions;
 
 import java.util.List;
 
@@ -79,6 +80,8 @@ public class ShowMaterializedViewTest {
 
         stmt = (ShowMaterializedViewsStmt) UtFrameUtils.parseStmtWithNewParser(
                 "SHOW MATERIALIZED VIEWS FROM abc where name = 'mv1';", ctx);
+        Preconditions.notNull(stmt.toSelectStmt().getOrigStmt(), "stmt's original stmt should not be null");
+
         Assert.assertEquals("abc", stmt.getDb());
         Assert.assertEquals(
                 "SELECT information_schema.materialized_views.MATERIALIZED_VIEW_ID AS id, " +

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowStatusStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowStatusStmtTest.java
@@ -15,11 +15,11 @@
 
 package com.starrocks.analysis;
 
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.ShowStatusStmt;
 import com.starrocks.sql.parser.SqlParser;
-import com.starrocks.qe.ConnectContext;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTableStmtTest.java
@@ -43,6 +43,7 @@ import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.platform.commons.util.Preconditions;
 
 public class ShowTableStmtTest {
 
@@ -81,6 +82,8 @@ public class ShowTableStmtTest {
 
         String sql = "show full tables where table_type !='VIEW'";
         stmt = (ShowTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        Preconditions.notNull(stmt.toSelectStmt().getOrigStmt(), "stmt's original stmt should not be null");
+
         QueryStatement queryStatement = stmt.toSelectStmt();
         String expect = "SELECT information_schema.tables.TABLE_NAME AS Tables_in_testDb, " +
                 "information_schema.tables.TABLE_TYPE AS Table_type FROM " +


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
- ShowStmt will construct a new QueryStatement, but forget to pass through the original statement.
- Fixes https://github.com/StarRocks/starrocks/issues/20396
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
