### PR TITLE
[Enhancement] optimize refresh external connector table in background

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1715,10 +1715,16 @@ public class Config extends ConfigBase {
     public static int background_refresh_file_metadata_concurrency = 4;
 
     /**
-     * Background refresh hive external table metadata interval in milliseconds.
+     * Background refresh external table metadata interval in milliseconds.
      */
     @ConfField(mutable = true)
     public static int background_refresh_metadata_interval_millis = 600000;
+
+    /**
+     * The duration of background refresh external table metadata since the table last access.
+     */
+    @ConfField(mutable = true)
+    public static long background_refresh_metadata_time_secs_since_last_access_secs = 3600L * 24L;
 
     /**
      * Enable refresh hive partition statistics.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
@@ -40,7 +40,7 @@ public class DeltaLakeInternalMgr {
         this.catalogName = catalogName;
         this.properties = properties;
         this.enableMetastoreCache = Boolean.parseBoolean(properties.getOrDefault("enable_metastore_cache", "false"));
-        this.hmsConf = new CachingHiveMetastoreConf(properties);
+        this.hmsConf = new CachingHiveMetastoreConf(properties, "delta lake");
         this.hdfsEnvironment = hdfsEnvironment;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
@@ -15,8 +15,10 @@
 
 package com.starrocks.connector.hive;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveMetaStoreTable;
 import com.starrocks.catalog.HiveTable;
@@ -59,6 +61,8 @@ public class CacheUpdateProcessor {
     // Record the latest synced event id when processing hive events
     private long lastSyncedEventId = -1;
 
+    private final Map<BasePartitionInfo, Long> partitionUpdatedTimes;
+
     public CacheUpdateProcessor(String catalogName,
                                 IHiveMetastore metastore,
                                 RemoteFileIO remoteFileIO,
@@ -71,6 +75,7 @@ public class CacheUpdateProcessor {
                 ? Optional.of((CachingRemoteFileIO) remoteFileIO) : Optional.empty();
         this.executor = executor;
         this.isRecursive = isRecursive;
+        this.partitionUpdatedTimes = Maps.newHashMap();
         if (enableHmsEventsIncrementalSync) {
             setLastSyncedEventId(metastore.getCurrentEventId());
         }
@@ -85,15 +90,72 @@ public class CacheUpdateProcessor {
         }
     }
 
-    public void refreshTableWithExecutor(Table table, boolean onlyCachedPartitions, ExecutorService executor) {
+    public void refreshTableBackground(Table table, boolean onlyCachedPartitions, ExecutorService executor) {
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
-        metastore.refreshTable(hmsTbl.getDbName(), hmsTbl.getTableName(), onlyCachedPartitions);
-        refreshRemoteFiles(hmsTbl.getTableLocation(), Operator.UPDATE, getExistPaths(hmsTbl), onlyCachedPartitions,
-                executor);
+        List<HivePartitionName> refreshPartitionNames = metastore.refreshTableBackground(
+                hmsTbl.getDbName(), hmsTbl.getTableName(), onlyCachedPartitions);
+
+        if (refreshPartitionNames != null) {
+            Map<BasePartitionInfo, Partition> updatedPartitions = getUpdatedPartitions(hmsTbl, refreshPartitionNames);
+            if (!updatedPartitions.isEmpty()) {
+                // update partition remote files cache
+                List<String> updatedPaths = updatedPartitions.values().stream().map(Partition::getFullPath)
+                        .map(path -> path.endsWith("/") ? path : path + "/")
+                        .collect(Collectors.toList());
+                refreshRemoteFilesBackground(hmsTbl.getTableLocation(), updatedPaths, onlyCachedPartitions, executor);
+
+                LOG.info("{}.{}.{} partitions has updated, updated partition size is {}, " +
+                                "refresh partition and file success", hmsTbl.getCatalogName(), hmsTbl.getDbName(),
+                        hmsTbl.getTableName(), updatedPartitions.size());
+            }
+
+            // update partitionUpdatedTimes
+            updatedPartitions.entrySet().stream().filter(entry -> entry.getValue().getModifiedTime() != 0).
+                    forEach(entry -> partitionUpdatedTimes.put(entry.getKey(), entry.getValue().getModifiedTime()));
+            Map<HivePartitionName, Partition> cachedPartitions = metastore.getAllCachedPartitions();
+            partitionUpdatedTimes.keySet().removeIf(basePartitionInfo -> !cachedPartitions.containsKey(
+                    HivePartitionName.of(basePartitionInfo.dbName, basePartitionInfo.tableName,
+                            basePartitionInfo.partitionName)));
+        }
     }
 
     public Set<HiveTableName> getCachedTableNames() {
         return ((CachingHiveMetastore) metastore).getCachedTableNames();
+    }
+
+    private Map<BasePartitionInfo, Partition> getUpdatedPartitions(HiveMetaStoreTable table,
+                                                                   List<HivePartitionName> refreshPartitionNames) {
+        String dbName = table.getDbName();
+        String tblName = table.getTableName();
+
+        Map<BasePartitionInfo, Partition> toCheckUpdatedPartitionInfoMap = Maps.newHashMap();
+        if (table.isUnPartitioned()) {
+            Partition partition = metastore.getPartition(dbName, tblName, Lists.newArrayList());
+            BasePartitionInfo partitionInfo = new BasePartitionInfo(dbName, tblName, tblName);
+            toCheckUpdatedPartitionInfoMap.put(partitionInfo, partition);
+        } else {
+            Map<HivePartitionName, Partition> partitions = metastore.getCachedPartitions(refreshPartitionNames);
+            for (Map.Entry<HivePartitionName, Partition> partitionEntry : partitions.entrySet()) {
+                Optional<String> partitionName = partitionEntry.getKey().getPartitionNames();
+                partitionName.ifPresent(s -> toCheckUpdatedPartitionInfoMap.put(new BasePartitionInfo(dbName, tblName, s),
+                                partitionEntry.getValue()));
+            }
+        }
+
+        Map<BasePartitionInfo, Partition> updatedPartitions = Maps.newHashMap();
+        for (Map.Entry<BasePartitionInfo, Partition> checkPartition : toCheckUpdatedPartitionInfoMap.entrySet()) {
+            BasePartitionInfo checkPartitionKey = checkPartition.getKey();
+            Partition partition = checkPartition.getValue();
+            if (!partitionUpdatedTimes.containsKey(checkPartitionKey)) {
+                updatedPartitions.put(checkPartitionKey, partition);
+            } else {
+                if (partitionUpdatedTimes.get(checkPartitionKey) != partition.getModifiedTime()) {
+                    updatedPartitions.put(checkPartitionKey, partition);
+                }
+            }
+        }
+
+        return updatedPartitions;
     }
 
     private List<String> getExistPaths(HiveMetaStoreTable table) {
@@ -155,14 +217,26 @@ public class CacheUpdateProcessor {
         }
     }
 
-    private void refreshRemoteFiles(String tableLocation, Operator operator, List<String> existPaths,
-                                    boolean onlyCachedPartitions) {
-        refreshRemoteFiles(tableLocation, operator, existPaths, onlyCachedPartitions, executor);
+    private void refreshRemoteFilesBackground(String tableLocation, List<String> updatePaths,
+                                              boolean onlyCachedPartitions, ExecutorService refreshExecutor) {
+        if (remoteFileIO.isPresent()) {
+            List<RemotePathKey> presentPathKey = updatePaths.stream().map(path -> RemotePathKey.of(path, isRecursive))
+                    .collect(Collectors.toList());
+            if (onlyCachedPartitions) {
+                List<RemotePathKey> cachedPathKey = remoteFileIO.get().getPresentPathKeyInCache(tableLocation,
+                        isRecursive);
+                presentPathKey = cachedPathKey.stream().filter(pathKey -> {
+                    String pathWithSlash = pathKey.getPath().endsWith("/") ? pathKey.getPath() : pathKey.getPath() + "/";
+                    return updatePaths.contains(pathWithSlash);
+                }).collect(Collectors.toList());
+            }
+
+            refreshRemoteFilesImpl(tableLocation, presentPathKey, Lists.newArrayList(), refreshExecutor);
+        }
     }
 
-
     private void refreshRemoteFiles(String tableLocation, Operator operator, List<String> existPaths,
-                                    boolean onlyCachedPartitions, ExecutorService refreshExecutor) {
+                                    boolean onlyCachedPartitions) {
         if (remoteFileIO.isPresent()) {
             List<RemotePathKey> presentPathKey;
             if (onlyCachedPartitions) {
@@ -172,23 +246,37 @@ public class CacheUpdateProcessor {
                         .map(path -> RemotePathKey.of(path, isRecursive))
                         .collect(Collectors.toList());
             }
-            List<Future<?>> futures = Lists.newArrayList();
+            List<RemotePathKey> updateKeys = Lists.newArrayList();
+            List<RemotePathKey> invalidateKeys = Lists.newArrayList();
             presentPathKey.forEach(pathKey -> {
                 String pathWithSlash = pathKey.getPath().endsWith("/") ? pathKey.getPath() : pathKey.getPath() + "/";
                 if (operator == Operator.UPDATE && existPaths.contains(pathWithSlash)) {
-                    futures.add(refreshExecutor.submit(() -> remoteFileIO.get().updateRemoteFiles(pathKey)));
+                    updateKeys.add(pathKey);
                 } else {
-                    futures.add(refreshExecutor.submit(() -> remoteFileIO.get().invalidatePartition(pathKey)));
+                    invalidateKeys.add(pathKey);
                 }
             });
 
-            for (Future<?> future : futures) {
-                try {
-                    future.get();
-                } catch (InterruptedException | ExecutionException e) {
-                    LOG.error("Failed to update remote files on [{}]", tableLocation, e);
-                    throw new StarRocksConnectorException("Failed to update remote files", e);
-                }
+            refreshRemoteFilesImpl(tableLocation, updateKeys, invalidateKeys, executor);
+        }
+    }
+
+    private void refreshRemoteFilesImpl(String tableLocation, List<RemotePathKey> updateKeys,
+                                        List<RemotePathKey> invalidateKeys,
+                                        ExecutorService refreshExecutor) {
+        List<Future<?>> futures = Lists.newArrayList();
+        updateKeys.forEach(pathKey -> futures.add(refreshExecutor.submit(() ->
+                remoteFileIO.get().updateRemoteFiles(pathKey))));
+        invalidateKeys.forEach(pathKey -> futures.add(refreshExecutor.submit(() ->
+                remoteFileIO.get().invalidatePartition(pathKey))));
+
+
+        for (Future<?> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException | ExecutionException e) {
+                LOG.error("Failed to update remote files on [{}]", tableLocation, e);
+                throw new StarRocksConnectorException("Failed to update remote files", e);
             }
         }
     }
@@ -275,6 +363,37 @@ public class CacheUpdateProcessor {
             return null;
         }
         return ((CachingHiveMetastore) metastore).getNextEventResponse(lastSyncedEventId, catalogName, getAllEvents);
+    }
+
+    private static class BasePartitionInfo {
+        private String dbName;
+        private String tableName;
+        private String partitionName;
+
+        public BasePartitionInfo(String dbName, String tableName, String partitionName) {
+            this.dbName = dbName;
+            this.tableName = tableName;
+            this.partitionName = partitionName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BasePartitionInfo)) {
+                return false;
+            }
+            BasePartitionInfo that = (BasePartitionInfo) o;
+            return Objects.equal(dbName, that.dbName) &&
+                    Objects.equal(tableName, that.tableName) &&
+                    Objects.equal(partitionName, that.partitionName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(dbName, tableName, partitionName);
+        }
     }
     
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
@@ -270,7 +270,6 @@ public class CacheUpdateProcessor {
         invalidateKeys.forEach(pathKey -> futures.add(refreshExecutor.submit(() ->
                 remoteFileIO.get().invalidatePartition(pathKey))));
 
-
         for (Future<?> future : futures) {
             try {
                 future.get();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -22,6 +22,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.starrocks.catalog.Database;
@@ -36,6 +37,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,6 +65,8 @@ public class CachingHiveMetastore implements IHiveMetastore {
     public static final long NEVER_REFRESH = -1;
     private final boolean enableListNameCache;
     protected final IHiveMetastore metastore;
+
+    private Map<HiveTableName, Long> lastAccessTimeMap;
 
     protected LoadingCache<String, List<String>> databaseNamesCache;
     protected LoadingCache<String, List<String>> tableNamesCache;
@@ -96,6 +102,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
                                    long refreshIntervalSec, long maxSize, boolean enableListNamesCache) {
         this.metastore = metastore;
         this.enableListNameCache = enableListNamesCache;
+        this.lastAccessTimeMap = Maps.newConcurrentMap();
 
         databaseNamesCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
                 .build(asyncReloading(CacheLoader.from(this::loadAllDatabaseNames), executor));
@@ -176,7 +183,19 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     public Set<HiveTableName> getCachedTableNames() {
-        return partitionKeysCache.asMap().keySet();
+        return partitionCache.asMap().keySet().stream().map(hivePartitionName ->
+                HiveTableName.of(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName())).collect(
+                Collectors.toSet());
+    }
+
+    @Override
+    public Map<HivePartitionName, Partition> getCachedPartitions(List<HivePartitionName> hivePartitionName) {
+        return partitionCache.getAllPresent(hivePartitionName);
+    }
+
+    @Override
+    public Map<HivePartitionName, Partition> getAllCachedPartitions() {
+        return Maps.newHashMap(partitionCache.asMap());
     }
 
     private List<String> loadAllTableNames(String dbName) {
@@ -184,7 +203,10 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     public List<String> getPartitionKeys(String dbName, String tableName) {
-        return get(partitionKeysCache, HiveTableName.of(dbName, tableName));
+        HiveTableName hiveTableName = HiveTableName.of(dbName, tableName);
+        // update last access time
+        lastAccessTimeMap.put(hiveTableName, System.currentTimeMillis());
+        return get(partitionKeysCache, hiveTableName);
     }
 
     private List<String> loadPartitionKeys(HiveTableName hiveTableName) {
@@ -308,7 +330,9 @@ public class CachingHiveMetastore implements IHiveMetastore {
         ));
     }
 
-    public synchronized void refreshTable(String hiveDbName, String hiveTblName, boolean onlyCachedPartitions) {
+    @Override
+    public synchronized List<HivePartitionName> refreshTable(String hiveDbName, String hiveTblName,
+                                                             boolean onlyCachedPartitions) {
         HiveTableName hiveTableName = HiveTableName.of(hiveDbName, hiveTblName);
         Table updatedTable = loadTable(hiveTableName);
         tableCache.put(hiveTableName, updatedTable);
@@ -319,6 +343,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
         }
 
         HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) updatedTable;
+        List<HivePartitionName> refreshPartitionNames = Lists.newArrayList();
         if (hmsTable.isUnPartitioned()) {
             HivePartitionName hivePartitionName = HivePartitionName.of(hiveDbName, hiveTblName, Lists.newArrayList());
             Partition updatedPartition = loadPartition(hivePartitionName);
@@ -337,15 +362,35 @@ public class CachingHiveMetastore implements IHiveMetastore {
                         .collect(Collectors.toList());
             }
 
-            refreshPartitions(presentPartitionNames, updatedPartitionKeys, this::loadPartitionsByNames, partitionCache);
+            refreshPartitionNames = refreshPartitions(presentPartitionNames, updatedPartitionKeys,
+                    this::loadPartitionsByNames, partitionCache);
             if (Config.enable_refresh_hive_partitions_statistics) {
                 refreshPartitions(presentPartitionStatistics, updatedPartitionKeys,
                         this::loadPartitionsStatistics, partitionStatsCache);
             }
         }
+        return refreshPartitionNames;
     }
 
-    private <T> void refreshPartitions(List<HivePartitionName> presentInCache,
+    @Override
+    public List<HivePartitionName> refreshTableBackground(String hiveDbName, String hiveTblName, boolean onlyCachedPartitions) {
+        HiveTableName hiveTableName = HiveTableName.of(hiveDbName, hiveTblName);
+        if (lastAccessTimeMap.containsKey(hiveTableName)) {
+            long lastAccessTime = lastAccessTimeMap.get(hiveTableName);
+            long intervalSec = (System.currentTimeMillis() - lastAccessTime) / 1000;
+            if (intervalSec > Config.background_refresh_metadata_time_secs_since_last_access_secs) {
+                LOG.info("{}.{} skip refresh because of the last access time is {}", hiveDbName, hiveTblName,
+                        LocalDateTime.ofInstant(Instant.ofEpochMilli(lastAccessTime), ZoneId.systemDefault()));
+                return null;
+            }
+        }
+
+        List<HivePartitionName> refreshPartitionNames = refreshTable(hiveDbName, hiveTblName, onlyCachedPartitions);
+        lastAccessTimeMap.keySet().removeIf(tableName -> !getCachedTableNames().contains(tableName));
+        return refreshPartitionNames;
+    }
+
+    private <T> List<HivePartitionName> refreshPartitions(List<HivePartitionName> presentInCache,
                                        List<String> partitionNamesInHMS,
                                        Function<List<HivePartitionName>, Map<HivePartitionName, T>> reload,
                                        LoadingCache<HivePartitionName, T> cache) {
@@ -369,6 +414,7 @@ public class CachingHiveMetastore implements IHiveMetastore {
             }
         }
         cache.invalidateAll(needToInvalidate);
+        return needToRefresh;
     }
 
     public synchronized void refreshPartition(List<HivePartitionName> partitionNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -183,6 +183,8 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     public Set<HiveTableName> getCachedTableNames() {
+        // use partition cache to get all cached table names because partition cache is more accurate,
+        // table cache will be cached when user use `use catalog.db` command.
         return partitionCache.asMap().keySet().stream().map(hivePartitionName ->
                 HiveTableName.of(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName())).collect(
                 Collectors.toSet());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastoreConf.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastoreConf.java
@@ -28,11 +28,12 @@ public class CachingHiveMetastoreConf {
 
     private final boolean enableListNamesCache;
 
-    public CachingHiveMetastoreConf(Map<String, String> conf) {
+    public CachingHiveMetastoreConf(Map<String, String> conf, String catalogType) {
         this.cacheTtlSec = Long.parseLong(conf.getOrDefault("metastore_cache_ttl_sec",
                 String.valueOf(Config.hive_meta_cache_ttl_s)));
         this.cacheRefreshIntervalSec = Long.parseLong(conf.getOrDefault("metastore_cache_refresh_interval_sec",
                 String.valueOf(Config.hive_meta_cache_refresh_interval_s)));
+        String enableListNamesCacheDefaultValue = catalogType.equalsIgnoreCase("hive") ? "true" : "false";
         this.enableListNamesCache = Boolean.parseBoolean(conf.getOrDefault("enable_cache_list_names",
                 "false"));
         this.cacheMaxNum = Long.parseLong(conf.getOrDefault("metastore_cache_max_num", String.valueOf(cacheMaxNum)));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
@@ -104,7 +104,7 @@ public class ConnectorTableMetadataProcessor extends LeaderDaemon {
                     continue;
                 }
                 try {
-                    updateProcessor.refreshTableWithExecutor(table, true, refreshRemoteFileExecutor);
+                    updateProcessor.refreshTableBackground(table, true, refreshRemoteFileExecutor);
                 } catch (Exception e) {
                     LOG.warn("refresh {}.{}.{} meta store info failed, msg : {}", catalogName, dbName,
                             tableName, e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
@@ -96,7 +96,7 @@ public class ConnectorTableMetadataProcessor extends LeaderDaemon {
                 try {
                     table = metadataMgr.getTable(catalogName, dbName, tableName);
                 } catch (Exception e) {
-                    LOG.warn("can't get table of {}.{}.{}，msg: {}", catalogName, dbName, tableName, e);
+                    LOG.warn("can't get table of {}.{}.{}，msg: ", catalogName, dbName, tableName, e);
                     continue;
                 }
                 if (table == null) {
@@ -106,13 +106,13 @@ public class ConnectorTableMetadataProcessor extends LeaderDaemon {
                 try {
                     updateProcessor.refreshTableBackground(table, true, refreshRemoteFileExecutor);
                 } catch (Exception e) {
-                    LOG.warn("refresh {}.{}.{} meta store info failed, msg : {}", catalogName, dbName,
+                    LOG.warn("refresh {}.{}.{} meta store info failed, msg : ", catalogName, dbName,
                             tableName, e);
                     continue;
                 }
                 LOG.info("refresh table {}.{}.{} success", catalogName, dbName, tableName);
             }
-            LOG.info("refresh catalog {} success", catalogName);
+            LOG.info("refresh connector metadata {} finished", catalogName);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -54,7 +54,7 @@ public class HiveConnectorInternalMgr {
         this.properties = properties;
         this.hdfsEnvironment = hdfsEnvironment;
         this.enableMetastoreCache = Boolean.parseBoolean(properties.getOrDefault("enable_metastore_cache", "true"));
-        this.hmsConf = new CachingHiveMetastoreConf(properties);
+        this.hmsConf = new CachingHiveMetastoreConf(properties, "hive");
 
         this.enableRemoteFileCache = Boolean.parseBoolean(properties.getOrDefault("enable_remote_file_cache", "true"));
         this.remoteFileConf = new CachingRemoteFileConf(properties);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.connector.hive;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 
@@ -33,6 +35,14 @@ public interface IHiveMetastore {
 
     List<String> getPartitionKeys(String dbName, String tableName);
 
+    default Map<HivePartitionName, Partition> getCachedPartitions(List<HivePartitionName> hivePartitionNames) {
+        return Maps.newHashMap();
+    }
+
+    default Map<HivePartitionName, Partition> getAllCachedPartitions() {
+        return Maps.newHashMap();
+    }
+
     Partition getPartition(String dbName, String tableName, List<String> partitionValues);
 
     Map<String, Partition> getPartitionsByNames(String dbName, String tableName, List<String> partitionNames);
@@ -41,7 +51,12 @@ public interface IHiveMetastore {
 
     Map<String, HivePartitionStats> getPartitionStatistics(Table table, List<String> partitions);
 
-    default void refreshTable(String hiveDbName, String hiveTblName, boolean onlyCachedPartitions) {
+    default List<HivePartitionName> refreshTable(String hiveDbName, String hiveTblName, boolean onlyCachedPartitions) {
+        return Lists.newArrayList();
+    }
+
+    default List<HivePartitionName> refreshTableBackground(String hiveDbName, String hiveTblName, boolean onlyCachedPartitions) {
+        return Lists.newArrayList();
     }
 
     default void refreshPartition(List<HivePartitionName> partitionNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -51,6 +51,7 @@ public interface IHiveMetastore {
 
     Map<String, HivePartitionStats> getPartitionStatistics(Table table, List<String> partitions);
 
+    // return refreshed partitions in cache for partitioned table, return empty list for unpartitioned table
     default List<HivePartitionName> refreshTable(String hiveDbName, String hiveTblName, boolean onlyCachedPartitions) {
         return Lists.newArrayList();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/Partition.java
@@ -68,7 +68,8 @@ public class Partition implements PartitionInfo {
 
     @Override
     public long getModifiedTime() {
-        return Long.parseLong(parameters.get(TRANSIENT_LAST_DDL_TIME));
+        String ddlTime = parameters.get(TRANSIENT_LAST_DDL_TIME);
+        return Long.parseLong(ddlTime != null ? ddlTime : "0");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
@@ -22,15 +22,12 @@ import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileIO;
-import com.starrocks.connector.hive.CacheUpdateProcessor;
 import com.starrocks.connector.hive.IHiveMetastore;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
-import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 
 import java.util.Map;
-import java.util.Optional;
 
 public class HudiConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
@@ -77,12 +74,6 @@ public class HudiConnector implements Connector {
     }
 
     public void onCreate() {
-        if (!CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog(catalogName) &&
-                internalMgr.isEnableBackgroundRefreshHudiMetadata()) {
-            Optional<CacheUpdateProcessor> updateProcessor = metadataFactory.getCacheUpdateProcessor();
-            updateProcessor.ifPresent(processor -> GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor()
-                    .registerCacheUpdateProcessor(catalogName, updateProcessor.get()));
-        }
     }
 
     public CloudConfiguration getCloudConfiguration() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
@@ -56,7 +56,7 @@ public class HudiConnectorInternalMgr {
         this.properties = properties;
         this.hdfsEnvironment = hdfsEnvironment;
         this.enableMetastoreCache = Boolean.parseBoolean(properties.getOrDefault("enable_metastore_cache", "true"));
-        this.hmsConf = new CachingHiveMetastoreConf(properties);
+        this.hmsConf = new CachingHiveMetastoreConf(properties, "hudi");
 
         this.enableRemoteFileCache = Boolean.parseBoolean(properties.getOrDefault("enable_remote_file_cache", "true"));
         this.remoteFileConf = new CachingRemoteFileConf(properties);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
@@ -86,7 +86,7 @@ public class HiveConnectorTest {
                 result = cachingRemoteFileIO;
 
                 internalMgr.getHiveMetastoreConf();
-                result = new CachingHiveMetastoreConf(properties);
+                result = new CachingHiveMetastoreConf(properties, "hive");
 
                 internalMgr.getRemoteFileConf();
                 result = new CachingRemoteFileConf(properties);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Optimized the background refreshing policy of hive meta information.
1. The table that has not been accessed for a long time  (set by config `background_refresh_metadata_time_secs_since_last_access`)is not refreshed
2. The RemoteFile will not be refreshed if the partition is not updated

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
