### PR TITLE
[BugFix] streamload crash for table with auto increment column and without op column (#20431)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1683,7 +1683,7 @@ Status OlapTableSink::_fill_auto_increment_id_internal(Chunk* chunk, SlotDescrip
     if (_keys_type == TKeysType::PRIMARY_KEYS && _output_tuple_desc->slots().back()->col_name() == "__op") {
         size_t op_column_id = chunk->num_columns() - 1;
         ColumnPtr& op_col = chunk->get_column_by_index(op_column_id);
-        const uint8_t* ops = std::dynamic_pointer_cast<NullableColumn>(op_col)->raw_data();
+        auto* ops = reinterpret_cast<const uint8_t*>(op_col->raw_data());
         size_t row = chunk->num_rows();
 
         for (size_t i = 0; i < row; ++i) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20431

## Problem Summary(Required) ：
Problem:
This problem is introduced by commit 12b61a4dc896821. The op column's type is different in specified case and not specified case. So the nullable column type cast may be fail when we do not specify op column.

Solution:
raw_data() can be called by the base type class Column and we do not cast the derive type.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
