### PR TITLE
[Feature] Support stop FE/BE with rest api

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -59,6 +59,7 @@ using apache::thrift::transport::TProcessor;
 
 namespace starrocks {
 extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_exit_quick;
 
 static int64_t reboot_time = 0;
 
@@ -131,7 +132,7 @@ StatusOr<HeartbeatServer::CmpResult> HeartbeatServer::compare_master_info(const 
     static const char* LOCALHOST = "127.0.0.1";
 
     // reject master's heartbeat when exit
-    if (k_starrocks_exit.load(std::memory_order_relaxed)) {
+    if (k_starrocks_exit.load(std::memory_order_relaxed) || k_starrocks_exit_quick.load(std::memory_order_relaxed)) {
         return Status::InternalError("BE is shutting down");
     }
 

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -73,6 +73,14 @@ DEFINE_bool(cn, false, "start as compute node");
 // After all existing fragments executed, BE will exit.
 std::atomic<bool> k_starrocks_exit = false;
 
+// NOTE: when call `/api/_stop_be` http interface, this flag will be set to true. Then BE will reject
+// all ExecPlanFragments call by returning a fail status(brpc::EINTERNAL).
+// After all existing fragments executed, BE will exit.
+// The difference between k_starrocks_exit and the flag is that
+// k_starrocks_exit not only require waiting for all existing fragment to complete,
+// but also waiting for all threads to exit gracefully.
+std::atomic<bool> k_starrocks_exit_quick = false;
+
 class ReleaseColumnPool {
 public:
     explicit ReleaseColumnPool(double ratio) : _ratio(ratio) {}

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -49,7 +49,8 @@ add_library(Webserver STATIC
   action/runtime_filter_cache_action.cpp
   action/query_cache_action.cpp
   action/pipeline_blocking_drivers_action.cpp
-  action/lake/dump_tablet_metadata_action.cpp)
+  action/lake/dump_tablet_metadata_action.cpp
+  action/stop_be_action.cpp)
 
 # target_link_libraries(Webserver pthread dl Util)
 #ADD_BE_TEST(integer-array-test)

--- a/be/src/http/action/stop_be_action.cpp
+++ b/be/src/http/action/stop_be_action.cpp
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/stop_be_action.h"
+
+#include <sstream>
+#include <string>
+
+#include "http/http_channel.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+#include "util/defer_op.h"
+
+namespace starrocks {
+extern std::atomic<bool> k_starrocks_exit;
+
+std::string StopBeAction::construct_response_message(std::string msg) {
+    std::stringstream ss;
+    ss << "{";
+    ss << "(\"status\": "
+       << "\"" << msg << "\""
+       << ")";
+    ss << "}";
+
+    return ss.str();
+}
+
+void StopBeAction::handle(HttpRequest* req) {
+    LOG(INFO) << "Accept one stop_be request " << req->debug_string();
+
+    DeferOp defer([&]() {
+        if (!k_starrocks_exit.load(std::memory_order_acquire)) {
+            k_starrocks_exit.store(true);
+        }
+    });
+
+    std::string response_msg = construct_response_message("OK");
+    if (k_starrocks_exit.load(std::memory_order_acquire)) {
+        response_msg = construct_response_message("Be is shutting down");
+    }
+
+    HttpChannel::send_reply(req, HttpStatus::OK, response_msg);
+}
+
+} // end namespace starrocks

--- a/be/src/http/action/stop_be_action.cpp
+++ b/be/src/http/action/stop_be_action.cpp
@@ -23,14 +23,13 @@
 #include "util/defer_op.h"
 
 namespace starrocks {
-extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_exit_quick;
 
-std::string StopBeAction::construct_response_message(std::string msg) {
+std::string StopBeAction::construct_response_message(const std::string& msg) {
     std::stringstream ss;
     ss << "{";
-    ss << "(\"status\": "
-       << "\"" << msg << "\""
-       << ")";
+    ss << "\"status\": "
+       << "\"" << msg << "\"";
     ss << "}";
 
     return ss.str();
@@ -40,13 +39,13 @@ void StopBeAction::handle(HttpRequest* req) {
     LOG(INFO) << "Accept one stop_be request " << req->debug_string();
 
     DeferOp defer([&]() {
-        if (!k_starrocks_exit.load(std::memory_order_acquire)) {
-            k_starrocks_exit.store(true);
+        if (!k_starrocks_exit_quick.load(std::memory_order_acquire)) {
+            k_starrocks_exit_quick.store(true);
         }
     });
 
     std::string response_msg = construct_response_message("OK");
-    if (k_starrocks_exit.load(std::memory_order_acquire)) {
+    if (k_starrocks_exit_quick.load(std::memory_order_acquire)) {
         response_msg = construct_response_message("Be is shutting down");
     }
 

--- a/be/src/http/action/stop_be_action.h
+++ b/be/src/http/action/stop_be_action.h
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <string>
+
+#include "http/http_handler.h"
+
+namespace starrocks {
+
+class ExecEnv;
+
+// stop be
+class StopBeAction : public HttpHandler {
+public:
+    explicit StopBeAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+    ~StopBeAction() override = default;
+
+    void handle(HttpRequest* req) override;
+
+private:
+    [[maybe_unused]] ExecEnv* _exec_env;
+
+    std::string construct_response_message(std::string msg);
+};
+
+} // namespace starrocks

--- a/be/src/http/action/stop_be_action.h
+++ b/be/src/http/action/stop_be_action.h
@@ -34,7 +34,7 @@ public:
 private:
     [[maybe_unused]] ExecEnv* _exec_env;
 
-    std::string construct_response_message(std::string msg);
+    std::string construct_response_message(const std::string& msg);
 };
 
 } // namespace starrocks

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -76,6 +76,7 @@
 namespace starrocks {
 
 extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_exit_quick;
 
 using PromiseStatus = std::promise<Status>;
 using PromiseStatusSharedPtr = std::shared_ptr<PromiseStatus>;
@@ -287,7 +288,7 @@ void PInternalServiceImplBase<T>::_exec_plan_fragment(google::protobuf::RpcContr
                                                       google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
-    if (k_starrocks_exit.load(std::memory_order_relaxed)) {
+    if (k_starrocks_exit.load(std::memory_order_relaxed) || k_starrocks_exit_quick.load(std::memory_order_relaxed)) {
         cntl->SetFailed(brpc::EINTERNAL, "BE is shutting down");
         LOG(WARNING) << "reject exec plan fragment because of exit";
         return;

--- a/be/src/service/service.h
+++ b/be/src/service/service.h
@@ -22,6 +22,7 @@ namespace starrocks {
 class ExecEnv;
 
 extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_exit_quick;
 
 void wait_for_fragments_finish(ExecEnv* exec_env, size_t max_loop_cnt_cfg);
 } // namespace starrocks

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -51,6 +51,7 @@
 #include "http/action/restore_tablet_action.h"
 #include "http/action/runtime_filter_cache_action.h"
 #include "http/action/snapshot_action.h"
+#include "http/action/stop_be_action.h"
 #include "http/action/stream_load.h"
 #include "http/action/transaction_stream_load.h"
 #include "http/action/update_config_action.h"
@@ -129,6 +130,11 @@ Status HttpServiceBE::start() {
     auto* health_action = new HealthAction(_env);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/health", health_action);
     _http_handlers.emplace_back(health_action);
+
+    // Register Stop Be action
+    auto* stop_be_action = new StopBeAction(_env);
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/_stop_be", stop_be_action);
+    _http_handlers.emplace_back(stop_be_action);
 
     // register pprof actions
     if (!config::pprof_profile_dir.empty()) {

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -76,7 +76,7 @@ void start_be() {
         exit(1);
     }
 
-    while (!starrocks::k_starrocks_exit.load()) {
+    while (!(starrocks::k_starrocks_exit.load()) && !(starrocks::k_starrocks_exit_quick.load())) {
         sleep(10);
     }
 

--- a/be/src/service/service_cn/starrocks_cn.cpp
+++ b/be/src/service/service_cn/starrocks_cn.cpp
@@ -81,7 +81,7 @@ void start_cn() {
         exit(1);
     }
 
-    while (!starrocks::k_starrocks_exit.load()) {
+    while (!(starrocks::k_starrocks_exit.load()) && !(starrocks::k_starrocks_exit_quick.load())) {
         sleep(10);
     }
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -344,6 +344,11 @@ int main(int argc, char** argv) {
         starrocks::BlockCache::instance()->shutdown();
     }
 
+    if (starrocks::k_starrocks_exit_quick.load()) {
+        LOG(INFO) << "BE is shutting down，will exit quickly";
+        exit(0);
+    }
+
     daemon->stop();
     daemon.reset();
 

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -78,9 +78,12 @@ public class StarRocksFE {
     public static final String STARROCKS_HOME_DIR = System.getenv("STARROCKS_HOME");
     public static final String PID_DIR = System.getenv("PID_DIR");
 
+    public static volatile boolean stopped = false;
+
     public static void main(String[] args) {
         start(STARROCKS_HOME_DIR, PID_DIR, args);
     }
+
 
     // entrance for starrocks frontend
     public static void start(String starRocksDir, String pidDir, String[] args) {
@@ -177,13 +180,16 @@ public class StarRocksFE {
 
             addShutdownHook();
 
-            while (true) {
+            while (!stopped) {
                 Thread.sleep(2000);
             }
+
         } catch (Throwable e) {
             LOG.error("StarRocksFE start failed", e);
             System.exit(-1);
         }
+
+        System.exit(0);
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -179,7 +179,7 @@ public class HttpServer {
         ConnectionAction.registerAction(controller);
         ShowDataAction.registerAction(controller);
         QueryDumpAction.registerAction(controller);
-        // for stop fe
+        // for stop FE
         StopFeAction.registerAction(controller);
 
         // meta service action

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -80,6 +80,7 @@ import com.starrocks.http.rest.ShowDataAction;
 import com.starrocks.http.rest.ShowMetaInfoAction;
 import com.starrocks.http.rest.ShowProcAction;
 import com.starrocks.http.rest.ShowRuntimeInfoAction;
+import com.starrocks.http.rest.StopFeAction;
 import com.starrocks.http.rest.StorageTypeCheckAction;
 import com.starrocks.http.rest.TableQueryPlanAction;
 import com.starrocks.http.rest.TableRowCountAction;
@@ -178,6 +179,8 @@ public class HttpServer {
         ConnectionAction.registerAction(controller);
         ShowDataAction.registerAction(controller);
         QueryDumpAction.registerAction(controller);
+        // for stop fe
+        StopFeAction.registerAction(controller);
 
         // meta service action
         File imageDir = MetaHelper.getLeaderImageDir();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StopFeAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StopFeAction.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.starrocks.StarRocksFE;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import io.netty.handler.codec.http.HttpMethod;
+
+public class StopFeAction extends RestBaseAction {
+    public StopFeAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller)
+            throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, "/api/stop", new StopFeAction(controller));
+    }
+
+    @Override
+    public void execute(BaseRequest request, BaseResponse response) {
+        response.setContentType("application/json");
+
+        RestResult result = new RestResult();
+
+        if (StarRocksFE.stopped) {
+            result.addResultEntry("Message", "FE is shutting down");
+        } else {
+            StarRocksFE.stopped = true;
+            result.addResultEntry("Message", "Stop success");
+        }
+
+        sendResult(request, response, result);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StopFeAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StopFeAction.java
@@ -19,6 +19,12 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.http.UnauthorizedException;
+import com.starrocks.mysql.privilege.PrivPredicate;
+import com.starrocks.privilege.PrivilegeType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.UserIdentity;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class StopFeAction extends RestBaseAction {
@@ -32,9 +38,15 @@ public class StopFeAction extends RestBaseAction {
     }
 
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
-        response.setContentType("application/json");
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws UnauthorizedException {
+        UserIdentity currentUser = ConnectContext.get().getCurrentUserIdentity();
+        if (GlobalStateMgr.getCurrentState().isUsingNewPrivilege()) {
+            checkActionOnSystem(currentUser, PrivilegeType.OPERATE);
+        } else {
+            checkGlobalAuth(currentUser, PrivPredicate.OPERATOR);
+        }
 
+        response.setContentType("application/json");
         RestResult result = new RestResult();
 
         if (StarRocksFE.stopped) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support stop FE/BE with rest api gracefully
In the k8s environment, it may not be allowed to execute the stop_be.sh and stop_fe.sh scripts to make the starrocks process exit. So this pr provides a rest api to stop fe/be gracefully. The effect is equivalent to `stop_be.sh -g` and `stop_fe.sh`

* stop Fe url: /api/stop\
  Return: {"Message":"Stop success","status":"OK"} means success or \
{"Message":"Fe is shutting down","status":"OK"} means there are concurrent requests
* stop Be url: /api/_stop_be\
Return: {"Status":"OK"} means success or
\{"Status":"Be is shutting down"} means there are concurrent requests

The implementation mechanism is setting the flag, so it is necessary to check whether the process has exited exactly after http reply replied . At present, Be exits costs about 1-2 minutes, and Fe is relatively fast in seconds

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
