### PR TITLE
[BugFix] fix wrong column ref in RewriteSumByAssociativeRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
@@ -358,8 +358,8 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
                 ColumnRefOperator newColumnRef;
 
                 if (arg0.isColumnRef()) {
-                    // if arg0 is a ColumnRef and exists in the oldPreAggProjections,
-                    // we don't need to create a new ColumnRef
+                    // if arg0 is a ColumnRef, we don't need to create a new ColumnRef,
+                    // just make sure it occurs in newPreAggProjections
                     newColumnRef = (ColumnRefOperator) arg0;
                     if (!oldPreAggProjections.containsKey(arg0)) {
                         newPreAggProjections.put((ColumnRefOperator) arg0, arg0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
@@ -145,7 +145,7 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
                 "projection in LogicalAggOperator shouldn't be set in logical rewrite phase");
 
         OptExpression newPreAggProjectOpt = OptExpression.create(new LogicalProjectOperator(newPreAggProjections),
-                input.getInputs().get(0).getInputs().get(0).getInputs());
+                input.getInputs().get(0).getInputs());
 
         OptExpression newAggOpt = OptExpression.create(newAggOperator, newPreAggProjectOpt);
 
@@ -357,10 +357,13 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
 
                 ColumnRefOperator newColumnRef;
 
-                if (arg0.isColumnRef() && oldPreAggProjections.containsKey(arg0)) {
+                if (arg0.isColumnRef()) {
                     // if arg0 is a ColumnRef and exists in the oldPreAggProjections,
                     // we don't need to create a new ColumnRef
                     newColumnRef = (ColumnRefOperator) arg0;
+                    if (!oldPreAggProjections.containsKey(arg0)) {
+                        newPreAggProjections.put((ColumnRefOperator) arg0, arg0);
+                    }
                 } else if (commonArguments.containsKey(arg0)) {
                     // if arg0 has been created by the previous rewriting,
                     // we don't need to create a new ColumnRef

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1903,13 +1903,41 @@ public class AggregateTest extends PlanTestBase {
         // for each sum(col + 1), should rewrite to sum(col) + count(col) * 1
         assertContains(plan, "  3:Project\n" +
                 "  |  output columns:\n" +
-                "  |  18 <-> [26: sum, BIGINT, true] + [27: count, BIGINT, true] * 1\n" +
-                "  |  19 <-> [29: sum, BIGINT, true] + [30: count, BIGINT, true] * 1\n" +
-                "  |  20 <-> [32: sum, BIGINT, true] + [33: count, BIGINT, true] * 1\n" +
-                "  |  21 <-> [35: sum, DOUBLE, true] + cast([36: count, BIGINT, true] as DOUBLE) * 1.0\n" +
-                "  |  22 <-> [38: sum, DOUBLE, true] + cast([39: count, BIGINT, true] as DOUBLE) * 1.0\n" +
-                "  |  23 <-> [41: sum, BIGINT, true] + [42: count, BIGINT, true] * 1\n" +
-                "  |  24 <-> [44: sum, DECIMAL128(38,2), true] + cast([45: count, BIGINT, true] as DECIMAL128(18,0)) * 1");
+                "  |  18 <-> [25: sum, BIGINT, true] + [26: count, BIGINT, true] * 1\n" +
+                "  |  19 <-> [27: sum, BIGINT, true] + [28: count, BIGINT, true] * 1\n" +
+                "  |  20 <-> [29: sum, BIGINT, true] + [30: count, BIGINT, true] * 1\n" +
+                "  |  21 <-> [32: sum, DOUBLE, true] + cast([33: count, BIGINT, true] as DOUBLE) * 1.0\n" +
+                "  |  22 <-> [34: sum, DOUBLE, true] + cast([35: count, BIGINT, true] as DOUBLE) * 1.0\n" +
+                "  |  23 <-> [36: sum, BIGINT, true] + [37: count, BIGINT, true] * 1\n" +
+                "  |  24 <-> [38: sum, DECIMAL128(38,2), true] + cast([39: count, BIGINT, true] as DECIMAL128(18,0)) * 1");
+        // if a column can cast to target type safely, we can remove the implicit cast directly.
+        // in this case, t1b is SMALLINT,and need to be cast to BIGINT implicitly before calculate sum,
+        // after we rewrite sum(add(cast t1b as bigint), 1),
+        // there must be no project node between aggregate node and olap scan node
+        sql = "select sum(t1b+1) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  <slot 12> : 13: sum + 14: count * 1\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(2: t1b), count(2: t1b)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+        // apply this rule more than once
+        // 1. sum(add(add(cast t1b as bigint, 1), 1)) => sum(add(cast t1b as bigint, 1)) + count(add(cast t1b as bigint, 1) * 1
+        // 2. sum(add(cast t1b as bigint,1)) => sum(t1b) + count(t1b) * 1
+        // so the final result is sum(t1b) + count(t1b) * 1 + count(add(cast t1b as bigint. 1)) * 1
+        sql = "select sum(t1b+1+1) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  <slot 12> : 16: sum + 17: count * 1 + 15: count * 1\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(2: t1b), count(CAST(2: t1b AS INT) + 1), sum(2: t1b)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
         // 1.2 not null
         sql = "select sum(t1b+1),sum(t1c+1),sum(t1d+1),sum(t1e+1),sum(t1f+1),sum(t1g+1),sum(id_decimal+1)" +
                 " from test_all_type_not_null";
@@ -1918,15 +1946,15 @@ public class AggregateTest extends PlanTestBase {
         // so count() will be a common expression
         assertContains(plan, "  3:Project\n" +
                 "  |  output columns:\n" +
-                "  |  18 <-> [26: sum, BIGINT, true] + [46: multiply, BIGINT, true]\n" +
-                "  |  19 <-> [29: sum, BIGINT, true] + [46: multiply, BIGINT, true]\n" +
-                "  |  20 <-> [32: sum, BIGINT, true] + [46: multiply, BIGINT, true]\n" +
-                "  |  21 <-> [35: sum, DOUBLE, true] + cast([36: count, BIGINT, true] as DOUBLE) * 1.0\n" +
-                "  |  22 <-> [38: sum, DOUBLE, true] + cast([33: count, BIGINT, true] as DOUBLE) * 1.0\n" +
-                "  |  23 <-> [41: sum, BIGINT, true] + [46: multiply, BIGINT, true]\n" +
-                "  |  24 <-> [44: sum, DECIMAL128(38,2), true] + cast([33: count, BIGINT, true] as DECIMAL128(18,0)) * 1\n" +
+                "  |  18 <-> [25: sum, BIGINT, true] + [40: multiply, BIGINT, true]\n" +
+                "  |  19 <-> [27: sum, BIGINT, true] + [40: multiply, BIGINT, true]\n" +
+                "  |  20 <-> [29: sum, BIGINT, true] + [40: multiply, BIGINT, true]\n" +
+                "  |  21 <-> [32: sum, DOUBLE, true] + cast([33: count, BIGINT, true] as DOUBLE) * 1.0\n" +
+                "  |  22 <-> [34: sum, DOUBLE, true] + cast([35: count, BIGINT, true] as DOUBLE) * 1.0\n" +
+                "  |  23 <-> [36: sum, BIGINT, true] + [40: multiply, BIGINT, true]\n" +
+                "  |  24 <-> [38: sum, DECIMAL128(38,2), true] + cast([35: count, BIGINT, true] as DECIMAL128(18,0)) * 1\n" +
                 "  |  common expressions:\n" +
-                "  |  46 <-> [33: count, BIGINT, true] * 1");
+                "  |  40 <-> [35: count, BIGINT, true] * 1");
 
         // 2. aggregate result reuse
         sql = "select sum(t1b), sum(t1b+1), sum(t1b+2) from test_all_type";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1554,13 +1554,13 @@ public class LowCardinalityTest extends PlanTestBase {
         sql = "select max(upper(S_ADDRESS)), min(upper(S_ADDRESS)), max(S_ADDRESS), sum(S_SUPPKEY + 1) from supplier";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
-                "  |  output: count(*), max(19: upper), min(19: upper), max(18: S_ADDRESS), sum(15: S_SUPPKEY)\n" +
+                "  |  output: max(18: upper), min(18: upper), max(17: S_ADDRESS), sum(1: S_SUPPKEY), count(*)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
                 "  1:Project\n" +
-                "  |  <slot 15> : 1: S_SUPPKEY\n" +
-                "  |  <slot 18> : 18: S_ADDRESS\n" +
-                "  |  <slot 19> : DictExpr(18: S_ADDRESS,[upper(<place-holder>)])");
+                "  |  <slot 1> : 1: S_SUPPKEY\n" +
+                "  |  <slot 17> : 17: S_ADDRESS\n" +
+                "  |  <slot 18> : DictExpr(17: S_ADDRESS,[upper(<place-holder>)])");
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/2091

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


in this case , the direct cause is that we miss a column ref slot in ProjectOperator, AggregateOperator need slot 7 and slot 1, but ProjectOperator only provides slot 7.

```sql
mysql> explain SELECT - 32 + SUM( col0 + + 38 ) FROM tab1 AS cor0;
+-----------------------------------------------------------------------------+
| Explain String                                                              |
+-----------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                             |
|  OUTPUT EXPRS:6: expr                                                       |
|   PARTITION: UNPARTITIONED                                                  |
|                                                                             |
|   RESULT SINK                                                               |
|                                                                             |
|   5:EXCHANGE                                                                |
|                                                                             |
| PLAN FRAGMENT 1                                                             |
|  OUTPUT EXPRS:                                                              |
|   PARTITION: RANDOM                                                         |
|                                                                             |
|   STREAM DATA SINK                                                          |
|     EXCHANGE ID: 05                                                         |
|     UNPARTITIONED                                                           |
|                                                                             |
|   4:Project                                                                 |
|   |  <slot 6> : -32 + 8: sum + 9: count * 38                                |
|   |                                                                         |
|   3:AGGREGATE (update finalize)                                             |
|   |  output: count(1: col0), sum(7: col0)                                   |
|   |  group by:                                                              |
|   |  withLocalShuffle: true                                                 |
|   |                                                                         |
|   1:Project                                                                 |
|   |  <slot 7> : 1: col0                                                     |
|   |                                                                         |
|   0:OlapScanNode                                                            |
|      TABLE: tab1                                                            |
|      PREAGGREGATION: ON                                                     |
|      partitions=1/1                                                         |
|      rollup: tab1                                                           |
|      tabletRatio=10/10                                                      |
|      tabletList=35942,35944,35946,35948,35950,35952,35954,35956,35958,35960 |
|      cardinality=3                                                          |
|      avgRowSize=8.0                                                         |
|      numNodes=0                                                             |
+-----------------------------------------------------------------------------+
37 rows in set (0.01 sec)
```

in fact, when we rewrite `sum(col0+38)`, we don't need to create a new column ref because a column ref to col0 already exists,  we just need to ensure that the existed  column ref appears in the project node.

after fix, the plan is:
```sql
mysql> explain SELECT - 32 + SUM( col0 + + 38 ) FROM tab1 AS cor0;
+-----------------------------------------------------------------------------+
| Explain String                                                              |
+-----------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                             |
|  OUTPUT EXPRS:6: expr                                                       |
|   PARTITION: UNPARTITIONED                                                  |
|                                                                             |
|   RESULT SINK                                                               |
|                                                                             |
|   4:EXCHANGE                                                                |
|                                                                             |
| PLAN FRAGMENT 1                                                             |
|  OUTPUT EXPRS:                                                              |
|   PARTITION: RANDOM                                                         |
|                                                                             |
|   STREAM DATA SINK                                                          |
|     EXCHANGE ID: 04                                                         |
|     UNPARTITIONED                                                           |
|                                                                             |
|   3:Project                                                                 |
|   |  <slot 6> : -32 + 7: sum + 8: count * 38                                |
|   |                                                                         |
|   2:AGGREGATE (update finalize)                                             |
|   |  output: sum(1: col0), count(1: col0)                                   |
|   |  group by:                                                              |
|   |  withLocalShuffle: true                                                 |
|   |                                                                         |
|   0:OlapScanNode                                                            |
|      TABLE: tab1                                                            |
|      PREAGGREGATION: ON                                                     |
|      partitions=1/1                                                         |
|      rollup: tab1                                                           |
|      tabletRatio=10/10                                                      |
|      tabletList=10976,10978,10980,10982,10984,10986,10988,10990,10992,10994 |
|      cardinality=1                                                          |
|      avgRowSize=1.0                                                         |
|      numNodes=0                                                             |
+-----------------------------------------------------------------------------+
34 rows in set (0.01 sec)
```
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
