### PR TITLE
[Enhancement] Not fill old version data into local cache in compaction and schema change

### DIFF
--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -124,7 +124,8 @@ StatusOr<SegmentPtr> Tablet::load_segment(std::string_view segment_name, int seg
     }
     ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(location));
-    ASSIGN_OR_RETURN(segment, Segment::open(fs, location, seg_id, std::move(tablet_schema), footer_size_hint));
+    ASSIGN_OR_RETURN(segment, Segment::open(fs, location, seg_id, std::move(tablet_schema), footer_size_hint, nullptr,
+                                            !fill_cache));
     if (fill_cache) {
         _mgr->cache_segment(location, segment);
     }

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -65,8 +65,7 @@ public:
     //
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
-    StatusOr<bool> load(FileSystem* fs, const std::string& filename, const BitmapIndexPB& meta, bool use_page_cache,
-                        bool kept_in_memory);
+    StatusOr<bool> load(const IndexReadOptions& opts, const BitmapIndexPB& meta);
 
     // create a new column iterator. Client should delete returned iterator
     // REQUIRES: the index data has been successfully `load()`ed into memory.
@@ -95,8 +94,7 @@ private:
 
     void _reset();
 
-    Status _do_load(FileSystem* fs, const std::string& filename, const BitmapIndexPB& meta, bool use_page_cache,
-                    bool kept_in_memory);
+    Status _do_load(const IndexReadOptions& opts, const BitmapIndexPB& meta);
 
     OnceFlag _load_once;
     TypeInfoPtr _typeinfo;

--- a/be/src/storage/rowset/bloom_filter_index_reader.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_reader.cpp
@@ -54,10 +54,9 @@ BloomFilterIndexReader::~BloomFilterIndexReader() {
     MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->bloom_filter_index_mem_tracker(), _mem_usage());
 }
 
-StatusOr<bool> BloomFilterIndexReader::load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta,
-                                            bool use_page_cache, bool kept_in_memory) {
+StatusOr<bool> BloomFilterIndexReader::load(const IndexReadOptions& opts, const BloomFilterIndexPB& meta) {
     return success_once(_load_once, [&]() {
-        Status st = _do_load(fs, filename, meta, use_page_cache, kept_in_memory);
+        Status st = _do_load(opts, meta);
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->bloom_filter_index_mem_tracker(),
                                      _mem_usage() - sizeof(BloomFilterIndexReader));
@@ -68,14 +67,13 @@ StatusOr<bool> BloomFilterIndexReader::load(FileSystem* fs, const std::string& f
     });
 }
 
-Status BloomFilterIndexReader::_do_load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta,
-                                        bool use_page_cache, bool kept_in_memory) {
+Status BloomFilterIndexReader::_do_load(const IndexReadOptions& opts, const BloomFilterIndexPB& meta) {
     _typeinfo = get_type_info(TYPE_VARCHAR);
     _algorithm = meta.algorithm();
     _hash_strategy = meta.hash_strategy();
     const IndexedColumnMetaPB& bf_index_meta = meta.bloom_filter();
-    _bloom_filter_reader = std::make_unique<IndexedColumnReader>(fs, filename, bf_index_meta);
-    RETURN_IF_ERROR(_bloom_filter_reader->load(use_page_cache, kept_in_memory));
+    _bloom_filter_reader = std::make_unique<IndexedColumnReader>(opts, bf_index_meta);
+    RETURN_IF_ERROR(_bloom_filter_reader->load());
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/bloom_filter_index_reader.h
+++ b/be/src/storage/rowset/bloom_filter_index_reader.h
@@ -66,8 +66,7 @@ public:
     //
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
-    StatusOr<bool> load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta,
-                        bool use_page_cache, bool kept_in_memory);
+    StatusOr<bool> load(const IndexReadOptions& opts, const BloomFilterIndexPB& meta);
 
     // create a new column iterator.
     // REQUIRES: the index data has been successfully `load()`ed into memory.
@@ -78,8 +77,7 @@ public:
     bool loaded() const { return invoked(_load_once); }
 
 private:
-    Status _do_load(FileSystem* fs, const std::string& filename, const BloomFilterIndexPB& meta, bool use_page_cache,
-                    bool kept_in_memory);
+    Status _do_load(const IndexReadOptions& opts, const BloomFilterIndexPB& meta);
 
     void _reset();
 

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -106,7 +106,7 @@ public:
 
     // Caller should free returned iterator after unused.
     // TODO: StatusOr<std::unique_ptr<ColumnIterator>> new_bitmap_index_iterator()
-    Status new_bitmap_index_iterator(BitmapIndexIterator** iterator);
+    Status new_bitmap_index_iterator(BitmapIndexIterator** iterator, bool skip_fill_local_cache);
 
     // Seek to the first entry in the column.
     Status seek_to_first(OrdinalPageIndexIterator* iter);
@@ -138,7 +138,8 @@ public:
     // page-level zone map filter.
     Status zone_map_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p,
                            const ::starrocks::ColumnPredicate* del_predicate,
-                           std::unordered_set<uint32_t>* del_partial_filtered_pages, SparseRange* row_ranges);
+                           std::unordered_set<uint32_t>* del_partial_filtered_pages, SparseRange* row_ranges,
+                           bool skip_fill_local_cache);
 
     // segment-level zone map filter.
     // Return false to filter out this segment.
@@ -146,9 +147,10 @@ public:
     bool segment_zone_map_filter(const std::vector<const ::starrocks::ColumnPredicate*>& predicates) const;
 
     // prerequisite: at least one predicate in |predicates| support bloom filter.
-    Status bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p, SparseRange* ranges);
+    Status bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p, SparseRange* ranges,
+                        bool skip_fill_local_cache);
 
-    Status load_ordinal_index();
+    Status load_ordinal_index(bool skip_fill_local_cache);
 
     uint32_t num_rows() const { return _segment->num_rows(); }
 
@@ -169,10 +171,10 @@ private:
 
     Status _init(ColumnMetaPB* meta);
 
-    Status _load_zonemap_index();
-    Status _load_ordinal_index();
-    Status _load_bitmap_index();
-    Status _load_bloom_filter_index();
+    Status _load_zonemap_index(bool skip_fill_local_cache);
+    Status _load_ordinal_index(bool skip_fill_local_cache);
+    Status _load_bitmap_index(bool skip_fill_local_cache);
+    Status _load_bloom_filter_index(bool skip_fill_local_cache);
 
     Status _parse_zone_map(const ZoneMapPB& zm, ZoneMapDetail* detail) const;
 

--- a/be/src/storage/rowset/indexed_column_reader.cpp
+++ b/be/src/storage/rowset/indexed_column_reader.cpp
@@ -53,7 +53,7 @@ Status IndexedColumnReader::load() {
     RETURN_IF_ERROR(get_block_compression_codec(_meta.compression(), &_compress_codec));
     _validx_key_coder = get_key_coder(_type_info->type());
 
-    RandomAccessFileOptions file_opts{.skip_fill_local_cache = _opts.skip_fill_local_cache};
+    RandomAccessFileOptions file_opts{.skip_fill_local_cache = _skip_fill_local_cache};
     ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(file_opts, _file_name));
     // read and parse ordinal index page when exists
     if (_meta.has_ordinal_index_meta()) {
@@ -97,15 +97,15 @@ Status IndexedColumnReader::read_page(RandomAccessFile* read_file, const PagePoi
     opts.codec = _compress_codec;
     OlapReaderStatistics tmp_stats;
     opts.stats = &tmp_stats;
-    opts.use_page_cache = _opts.use_page_cache;
-    opts.kept_in_memory = _opts.kept_in_memory;
+    opts.use_page_cache = _use_page_cache;
+    opts.kept_in_memory = _kept_in_memory;
     opts.encoding_type = _encoding_info->encoding();
 
     return PageIO::read_and_decompress_page(opts, handle, body, footer);
 }
 
 Status IndexedColumnReader::new_iterator(std::unique_ptr<IndexedColumnIterator>* iter) {
-    RandomAccessFileOptions file_opts{.skip_fill_local_cache = _opts.skip_fill_local_cache};
+    RandomAccessFileOptions file_opts{.skip_fill_local_cache = _skip_fill_local_cache};
     ASSIGN_OR_RETURN(auto file, _fs->new_random_access_file(file_opts, _file_name));
     iter->reset(new IndexedColumnIterator(this, std::move(file)));
     return Status::OK();

--- a/be/src/storage/rowset/indexed_column_reader.h
+++ b/be/src/storage/rowset/indexed_column_reader.h
@@ -42,6 +42,7 @@
 #include "gen_cpp/segment.pb.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/index_page.h"
+#include "storage/rowset/options.h"
 #include "storage/rowset/page_handle.h"
 #include "storage/rowset/page_pointer.h"
 #include "storage/rowset/parsed_page.h"
@@ -112,10 +113,10 @@ class IndexedColumnReader {
 
 public:
     // Does *NOT* take the ownership of |fs|.
-    IndexedColumnReader(FileSystem* fs, std::string file_name, IndexedColumnMetaPB meta)
-            : _fs(fs), _file_name(std::move(file_name)), _meta(std::move(meta)){};
+    IndexedColumnReader(const IndexReadOptions& opts, IndexedColumnMetaPB meta)
+            : _opts(opts), _fs(opts.fs), _file_name(opts.file_name), _meta(std::move(meta)){};
 
-    Status load(bool use_page_cache, bool kept_in_memory);
+    Status load();
 
     Status new_iterator(std::unique_ptr<IndexedColumnIterator>* iter);
 
@@ -131,9 +132,6 @@ public:
         return size;
     }
 
-    bool use_page_cache() const { return _use_page_cache; }
-    bool kept_in_memory() const { return _kept_in_memory; }
-
 private:
     Status load_index_page(RandomAccessFile* read_file, const PagePointerPB& pp, PageHandle* handle,
                            IndexPageReader* reader);
@@ -142,12 +140,12 @@ private:
     Status read_page(RandomAccessFile* read_file, const PagePointer& pp, PageHandle* handle, Slice* body,
                      PageFooterPB* footer) const;
 
+    const IndexReadOptions& _opts;
+
     FileSystem* _fs;
     std::string _file_name;
     IndexedColumnMetaPB _meta;
 
-    bool _use_page_cache = true;
-    bool _kept_in_memory = false;
     int64_t _num_values = 0;
     // whether this column contains any index page.
     // could be false when the column contains only one data page.

--- a/be/src/storage/rowset/indexed_column_reader.h
+++ b/be/src/storage/rowset/indexed_column_reader.h
@@ -114,7 +114,12 @@ class IndexedColumnReader {
 public:
     // Does *NOT* take the ownership of |fs|.
     IndexedColumnReader(const IndexReadOptions& opts, IndexedColumnMetaPB meta)
-            : _opts(opts), _fs(opts.fs), _file_name(opts.file_name), _meta(std::move(meta)){};
+            : _fs(opts.fs),
+              _file_name(opts.file_name),
+              _meta(std::move(meta)),
+              _use_page_cache(opts.use_page_cache),
+              _kept_in_memory(opts.kept_in_memory),
+              _skip_fill_local_cache(opts.skip_fill_local_cache) {}
 
     Status load();
 
@@ -140,11 +145,13 @@ private:
     Status read_page(RandomAccessFile* read_file, const PagePointer& pp, PageHandle* handle, Slice* body,
                      PageFooterPB* footer) const;
 
-    const IndexReadOptions& _opts;
-
     FileSystem* _fs;
     std::string _file_name;
     IndexedColumnMetaPB _meta;
+
+    bool _use_page_cache = true;
+    bool _kept_in_memory = false;
+    bool _skip_fill_local_cache = false;
 
     int64_t _num_values = 0;
     // whether this column contains any index page.

--- a/be/src/storage/rowset/options.h
+++ b/be/src/storage/rowset/options.h
@@ -40,6 +40,8 @@
 
 namespace starrocks {
 
+class FileSystem;
+
 static const uint32_t DEFAULT_PAGE_SIZE = 1024 * 1024; // default size: 1M
 
 class PageBuilderOptions {
@@ -53,6 +55,16 @@ class PageDecoderOptions {
 public:
     PageHandle* page_handle = nullptr;
     bool enable_direct_copy = false;
+};
+
+class IndexReadOptions {
+public:
+    FileSystem* fs = nullptr;
+    std::string file_name = "";
+    bool use_page_cache = false;
+    bool kept_in_memory = false;
+    // for lake tablet
+    bool skip_fill_local_cache = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -83,10 +83,10 @@ OrdinalIndexReader::~OrdinalIndexReader() {
     MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->ordinal_index_mem_tracker(), _mem_usage());
 }
 
-StatusOr<bool> OrdinalIndexReader::load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta,
-                                        ordinal_t num_values, bool use_page_cache, bool kept_in_memory) {
+StatusOr<bool> OrdinalIndexReader::load(const IndexReadOptions& opts, const OrdinalIndexPB& meta,
+                                        ordinal_t num_values) {
     return success_once(_load_once, [&]() {
-        Status st = _do_load(fs, filename, meta, num_values, use_page_cache, kept_in_memory);
+        Status st = _do_load(opts, meta, num_values);
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->ordinal_index_mem_tracker(),
                                      _mem_usage() - sizeof(OrdinalIndexReader))
@@ -97,8 +97,7 @@ StatusOr<bool> OrdinalIndexReader::load(FileSystem* fs, const std::string& filen
     });
 }
 
-Status OrdinalIndexReader::_do_load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta,
-                                    ordinal_t num_values, bool use_page_cache, bool kept_in_memory) {
+Status OrdinalIndexReader::_do_load(const IndexReadOptions& opts, const OrdinalIndexPB& meta, ordinal_t num_values) {
     if (meta.root_page().is_root_data_page()) {
         // only one data page, no index page
         _num_pages = 1;
@@ -108,22 +107,23 @@ Status OrdinalIndexReader::_do_load(FileSystem* fs, const std::string& filename,
         return Status::OK();
     }
     // need to read index page
-    ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(filename));
+    RandomAccessFileOptions file_opts{.skip_fill_local_cache = opts.skip_fill_local_cache};
+    ASSIGN_OR_RETURN(auto read_file, opts.fs->new_random_access_file(file_opts, opts.file_name));
 
-    PageReadOptions opts;
-    opts.read_file = read_file.get();
-    opts.page_pointer = PagePointer(meta.root_page().root_page());
-    opts.codec = nullptr; // ordinal index page uses NO_COMPRESSION right now
+    PageReadOptions page_opts;
+    page_opts.read_file = read_file.get();
+    page_opts.page_pointer = PagePointer(meta.root_page().root_page());
+    page_opts.codec = nullptr; // ordinal index page uses NO_COMPRESSION right now
     OlapReaderStatistics tmp_stats;
-    opts.stats = &tmp_stats;
-    opts.use_page_cache = use_page_cache;
-    opts.kept_in_memory = kept_in_memory;
+    page_opts.stats = &tmp_stats;
+    page_opts.use_page_cache = opts.use_page_cache;
+    page_opts.kept_in_memory = opts.kept_in_memory;
 
     // read index page
     PageHandle page_handle;
     Slice body;
     PageFooterPB footer;
-    RETURN_IF_ERROR(PageIO::read_and_decompress_page(opts, &page_handle, &body, &footer));
+    RETURN_IF_ERROR(PageIO::read_and_decompress_page(page_opts, &page_handle, &body, &footer));
 
     // parse and save all (ordinal, pp) from index page
     IndexPageReader reader;

--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -43,6 +43,7 @@
 #include "runtime/mem_tracker.h"
 #include "storage/rowset/common.h"
 #include "storage/rowset/index_page.h"
+#include "storage/rowset/options.h"
 #include "storage/rowset/page_pointer.h"
 #include "util/coding.h"
 #include "util/once.h"
@@ -87,8 +88,7 @@ public:
     //
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
-    StatusOr<bool> load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta, ordinal_t num_values,
-                        bool use_page_cache, bool kept_in_memory);
+    StatusOr<bool> load(const IndexReadOptions& opts, const OrdinalIndexPB& meta, ordinal_t num_values);
 
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     OrdinalPageIndexIterator seek_at_or_before(ordinal_t ordinal);
@@ -123,8 +123,7 @@ private:
         return sizeof(OrdinalIndexReader) + _ordinals.size() * sizeof(ordinal_t) + _pages.size() * sizeof(PagePointer);
     }
 
-    Status _do_load(FileSystem* fs, const std::string& filename, const OrdinalIndexPB& meta, ordinal_t num_values,
-                    bool use_page_cache, bool kept_in_memory);
+    Status _do_load(const IndexReadOptions& opts, const OrdinalIndexPB& meta, ordinal_t num_values);
 
     OnceFlag _load_once;
     // valid after load

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -48,7 +48,7 @@ ScalarColumnIterator::~ScalarColumnIterator() = default;
 
 Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
     _opts = opts;
-    RETURN_IF_ERROR(_reader->load_ordinal_index());
+    RETURN_IF_ERROR(_reader->load_ordinal_index(_skip_fill_local_cache()));
     _opts.stats->total_columns_data_page_count += _reader->num_data_pages();
 
     if (_reader->encoding_info()->encoding() != DICT_ENCODING) {
@@ -301,8 +301,8 @@ Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
                                                         const ColumnPredicate* del_predicate, SparseRange* row_ranges) {
     DCHECK(row_ranges->empty());
     if (_reader->has_zone_map()) {
-        RETURN_IF_ERROR(
-                _reader->zone_map_filter(predicates, del_predicate, &_delete_partial_satisfied_pages, row_ranges));
+        RETURN_IF_ERROR(_reader->zone_map_filter(predicates, del_predicate, &_delete_partial_satisfied_pages,
+                                                 row_ranges, _skip_fill_local_cache()));
     } else {
         row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     }
@@ -317,7 +317,7 @@ Status ScalarColumnIterator::get_row_ranges_by_bloom_filter(const std::vector<co
         support = support | pred->support_bloom_filter();
     }
     RETURN_IF(!support, Status::OK());
-    RETURN_IF_ERROR(_reader->bloom_filter(predicates, row_ranges));
+    RETURN_IF_ERROR(_reader->bloom_filter(predicates, row_ranges, _skip_fill_local_cache()));
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -125,6 +125,8 @@ private:
 
     bool _contains_deleted_row(uint32_t page_index) const;
 
+    bool _skip_fill_local_cache() const { return _opts.reader_type != READER_QUERY; }
+
     ColumnReader* _reader;
 
     // 1. The _page represents current page.

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -75,18 +75,19 @@ StatusOr<std::shared_ptr<Segment>> Segment::open(std::shared_ptr<FileSystem> fs,
                                                  const FooterPointerPB* partial_rowset_footer) {
     auto segment = std::make_shared<Segment>(private_type(0), std::move(fs), path, segment_id, tablet_schema);
 
-    RETURN_IF_ERROR(segment->_open(footer_length_hint, partial_rowset_footer));
+    RETURN_IF_ERROR(segment->_open(footer_length_hint, partial_rowset_footer, true));
     return std::move(segment);
 }
 
 StatusOr<std::shared_ptr<Segment>> Segment::open(std::shared_ptr<FileSystem> fs, const std::string& path,
                                                  uint32_t segment_id, std::shared_ptr<const TabletSchema> tablet_schema,
                                                  size_t* footer_length_hint,
-                                                 const FooterPointerPB* partial_rowset_footer) {
+                                                 const FooterPointerPB* partial_rowset_footer,
+                                                 bool skip_fill_local_cache) {
     auto segment =
             std::make_shared<Segment>(private_type(0), std::move(fs), path, segment_id, std::move(tablet_schema));
 
-    RETURN_IF_ERROR(segment->_open(footer_length_hint, partial_rowset_footer));
+    RETURN_IF_ERROR(segment->_open(footer_length_hint, partial_rowset_footer, skip_fill_local_cache));
     return std::move(segment);
 }
 
@@ -200,9 +201,11 @@ Segment::~Segment() {
     MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->short_key_index_mem_tracker(), _short_key_index_mem_usage());
 }
 
-Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer) {
+Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer,
+                      bool skip_fill_local_cache) {
     SegmentFooterPB footer;
-    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(_fname));
+    RandomAccessFileOptions opts{.skip_fill_local_cache = skip_fill_local_cache};
+    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(opts, _fname));
     RETURN_IF_ERROR(Segment::parse_segment_footer(read_file.get(), &footer, footer_length_hint, partial_rowset_footer));
 
     RETURN_IF_ERROR(_create_column_readers(&footer));
@@ -250,11 +253,11 @@ StatusOr<ChunkIteratorPtr> Segment::new_iterator(const Schema& schema, const Seg
     }
 }
 
-Status Segment::load_index() {
-    auto res = success_once(_load_index_once, [this] {
+Status Segment::load_index(bool skip_fill_local_cache) {
+    auto res = success_once(_load_index_once, [&] {
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
 
-        Status st = _load_index();
+        Status st = _load_index(skip_fill_local_cache);
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->short_key_index_mem_tracker(),
                                      _short_key_index_mem_usage());
@@ -266,9 +269,10 @@ Status Segment::load_index() {
     return res.status();
 }
 
-Status Segment::_load_index() {
+Status Segment::_load_index(bool skip_fill_local_cache) {
     // read and parse short key index page
-    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(_fname));
+    RandomAccessFileOptions file_opts{.skip_fill_local_cache = skip_fill_local_cache};
+    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(file_opts, _fname));
 
     PageReadOptions opts;
     opts.use_page_cache = !config::disable_storage_page_cache;
@@ -363,9 +367,9 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator(uint32_t 
     return _column_readers[cid]->new_iterator();
 }
 
-Status Segment::new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** iter) {
+Status Segment::new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** iter, bool skip_fill_local_cache) {
     if (_column_readers[cid] != nullptr && _column_readers[cid]->has_bitmap_index()) {
-        return _column_readers[cid]->new_bitmap_index_iterator(iter);
+        return _column_readers[cid]->new_bitmap_index_iterator(iter, skip_fill_local_cache);
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -93,7 +93,8 @@ public:
                                                    uint32_t segment_id,
                                                    std::shared_ptr<const TabletSchema> tablet_schema,
                                                    size_t* footer_length_hint = nullptr,
-                                                   const FooterPointerPB* partial_rowset_footer = nullptr);
+                                                   const FooterPointerPB* partial_rowset_footer = nullptr,
+                                                   bool skip_fill_local_cache = true);
 
     static Status parse_segment_footer(RandomAccessFile* read_file, SegmentFooterPB* footer, size_t* footer_length_hint,
                                        const FooterPointerPB* partial_rowset_footer);
@@ -114,7 +115,7 @@ public:
     // TODO: remove this method, create `ColumnIterator` via `ColumnReader`.
     StatusOr<std::unique_ptr<ColumnIterator>> new_column_iterator(uint32_t cid);
 
-    Status new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** iter);
+    Status new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** iter, bool skip_fill_local_cache);
 
     size_t num_short_keys() const { return _tablet_schema->num_short_key_columns(); }
 
@@ -156,7 +157,7 @@ public:
 
     // Load and decode short key index.
     // May be called multiple times, subsequent calls will no op.
-    Status load_index();
+    Status load_index(bool skip_fill_local_cache = true);
     bool has_loaded_index() const;
 
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
@@ -189,7 +190,7 @@ private:
         std::shared_ptr<const TabletSchema> _schema;
     };
 
-    Status _load_index();
+    Status _load_index(bool skip_fill_local_cache);
 
     void _reset();
 
@@ -204,7 +205,7 @@ private:
     }
 
     // open segment file and read the minimum amount of necessary information (footer)
-    Status _open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer);
+    Status _open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer, bool skip_fill_local_cache);
     Status _create_column_readers(SegmentFooterPB* footer);
 
     StatusOr<ChunkIteratorPtr> _new_iterator(const Schema& schema, const SegmentReadOptions& read_options);

--- a/be/src/storage/rowset/zone_map_index.h
+++ b/be/src/storage/rowset/zone_map_index.h
@@ -87,8 +87,7 @@ public:
     //
     // Return true if the index data was successfully loaded by the caller, false if
     // the data was loaded by another caller.
-    StatusOr<bool> load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta, bool use_page_cache,
-                        bool kept_in_memory);
+    StatusOr<bool> load(const IndexReadOptions& opts, const ZoneMapIndexPB& meta);
 
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     const std::vector<ZoneMapPB>& page_zone_maps() const { return _page_zone_maps; }
@@ -101,8 +100,7 @@ public:
 private:
     void _reset() { std::vector<ZoneMapPB>{}.swap(_page_zone_maps); }
 
-    Status _do_load(FileSystem* fs, const std::string& filename, const ZoneMapIndexPB& meta, bool use_page_cache,
-                    bool kept_in_memory);
+    Status _do_load(const IndexReadOptions& opts, const ZoneMapIndexPB& meta);
 
     size_t _mem_usage() const;
 

--- a/be/test/storage/rowset/ordinal_page_index_test.cpp
+++ b/be/test/storage/rowset/ordinal_page_index_test.cpp
@@ -87,9 +87,14 @@ TEST_F(OrdinalPageIndexTest, normal) {
         LOG(INFO) << "index page size=" << index_meta.ordinal_index().root_page().root_page().size();
     }
 
+    IndexReadOptions opts;
+    opts.fs = _fs.get();
+    opts.file_name = filename;
+    opts.use_page_cache = true;
+    opts.kept_in_memory = false;
+    opts.skip_fill_local_cache = false;
     OrdinalIndexReader index;
-    ASSIGN_OR_ABORT(auto r,
-                    index.load(_fs.get(), filename, index_meta.ordinal_index(), 16 * 1024 * 4096 + 1, true, false));
+    ASSIGN_OR_ABORT(auto r, index.load(opts, index_meta.ordinal_index(), 16 * 1024 * 4096 + 1));
     ASSERT_TRUE(r);
     ASSERT_EQ(16 * 1024, index.num_data_pages());
     ASSERT_EQ(1, index.get_first_ordinal(0));
@@ -143,8 +148,14 @@ TEST_F(OrdinalPageIndexTest, one_data_page) {
         ASSERT_EQ(data_page_pointer, root_page_pointer);
     }
 
+    IndexReadOptions opts;
+    opts.fs = _fs.get();
+    opts.file_name = "";
+    opts.use_page_cache = true;
+    opts.kept_in_memory = false;
+    opts.skip_fill_local_cache = false;
     OrdinalIndexReader index;
-    ASSIGN_OR_ABORT(auto r, index.load(_fs.get(), "", index_meta.ordinal_index(), num_values, true, false));
+    ASSIGN_OR_ABORT(auto r, index.load(opts, index_meta.ordinal_index(), num_values));
     ASSERT_TRUE(r);
     ASSERT_EQ(1, index.num_data_pages());
     ASSERT_EQ(0, index.get_first_ordinal(0));

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -89,8 +89,14 @@ protected:
             ASSERT_OK(wfile->close());
         }
 
+        IndexReadOptions opts;
+        opts.fs = _fs.get();
+        opts.file_name = filename;
+        opts.use_page_cache = true;
+        opts.kept_in_memory = false;
+        opts.skip_fill_local_cache = false;
         ZoneMapIndexReader column_zone_map;
-        ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false));
+        ASSIGN_OR_ABORT(auto r, column_zone_map.load(opts, index_meta.zone_map_index()));
         ASSERT_TRUE(r);
         ASSERT_EQ(3, column_zone_map.num_pages());
         const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();
@@ -143,8 +149,14 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
         ASSERT_OK(file->close());
     }
 
+    IndexReadOptions opts;
+    opts.fs = _fs.get();
+    opts.file_name = filename;
+    opts.use_page_cache = true;
+    opts.kept_in_memory = false;
+    opts.skip_fill_local_cache = false;
     ZoneMapIndexReader column_zone_map;
-    ASSIGN_OR_ABORT(auto r, column_zone_map.load(_fs.get(), filename, index_meta.zone_map_index(), true, false));
+    ASSIGN_OR_ABORT(auto r, column_zone_map.load(opts, index_meta.zone_map_index()));
     ASSERT_TRUE(r);
     ASSERT_EQ(3, column_zone_map.num_pages());
     const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In lake tablet compaction and schema change, new version will be created,
so the old version data is not necessary to be filled into local cache.

Set skip_fill_local_cache true when reading segment, including footer,
data and all kinds of index.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
