### PR TITLE
[Enhancement] Add be_threads info into infomation schema

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -124,6 +124,7 @@ set(EXEC_FILES
     schema_scanner/schema_be_tablets_scanner.cpp
     schema_scanner/schema_be_txns_scanner.cpp
     schema_scanner/schema_be_configs_scanner.cpp
+    schema_scanner/schema_be_threads_scanner.cpp
     schema_scanner/schema_fe_tablet_schedules_scanner.cpp
     schema_scanner/schema_helper.cpp
     jdbc_scanner.cpp

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -86,6 +86,7 @@ void GlobalDriverExecutor::_finalize_driver(DriverRawPtr driver, RuntimeState* r
 }
 
 void GlobalDriverExecutor::_worker_thread() {
+    auto current_thread = Thread::current_thread();
     const int worker_id = _next_id++;
     while (true) {
         if (_num_threads_setter.should_shrink()) {
@@ -96,7 +97,13 @@ void GlobalDriverExecutor::_worker_thread() {
         CurrentThread::current().set_fragment_instance_id({});
         CurrentThread::current().set_pipeline_driver_id(0);
 
+        if (current_thread != nullptr) {
+            current_thread->set_idle(true);
+        }
         auto maybe_driver = this->_driver_queue->take();
+        if (current_thread != nullptr) {
+            current_thread->set_idle(false);
+        }
         if (maybe_driver.status().is_cancelled()) {
             return;
         }
@@ -143,6 +150,9 @@ void GlobalDriverExecutor::_worker_thread() {
 #else
             maybe_state = driver->process(runtime_state, worker_id);
 #endif
+            if (current_thread != nullptr) {
+                current_thread->inc_finished_tasks();
+            }
             Status status = maybe_state.status();
             this->_driver_queue->update_statistics(driver);
 

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -18,6 +18,7 @@
 #include "exec/schema_scanner/schema_be_configs_scanner.h"
 #include "exec/schema_scanner/schema_be_metrics_scanner.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
+#include "exec/schema_scanner/schema_be_threads_scanner.h"
 #include "exec/schema_scanner/schema_be_txns_scanner.h"
 #include "exec/schema_scanner/schema_charsets_scanner.h"
 #include "exec/schema_scanner/schema_collations_scanner.h"
@@ -133,6 +134,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaBeTxnsScanner>();
     case TSchemaTableType::SCH_BE_CONFIGS:
         return std::make_unique<SchemaBeConfigsScanner>();
+    case TSchemaTableType::SCH_BE_THREADS:
+        return std::make_unique<SchemaBeThreadsScanner>();
     case TSchemaTableType::SCH_FE_TABLET_SCHEDULES:
         return std::make_unique<SchemaFeTabletSchedulesScanner>();
     default:

--- a/be/src/exec/schema_scanner/schema_be_threads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_threads_scanner.cpp
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_be_threads_scanner.h"
+
+#include "agent/master_info.h"
+#include "exec/schema_scanner/schema_helper.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/string_value.h"
+#include "types/logical_type.h"
+#include "util/thread.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaBeThreadsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"GROUP", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"NAME", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"PTHREAD_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"TID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"IDLE", TYPE_BOOLEAN, 1, false},
+        {"FINISHED_TASKS", TYPE_BIGINT, sizeof(int64_t), false},
+};
+
+SchemaBeThreadsScanner::SchemaBeThreadsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeThreadsScanner::~SchemaBeThreadsScanner() = default;
+
+Status SchemaBeThreadsScanner::start(RuntimeState* state) {
+    auto o_id = get_backend_id();
+    _be_id = o_id.has_value() ? o_id.value() : -1;
+    _infos.clear();
+    Thread::get_thread_infos(_infos);
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+Status SchemaBeThreadsScanner::fill_chunk(ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 7) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                // group
+                Slice v(info.group);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 3: {
+                // name
+                Slice v(info.name);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 4: {
+                // pthread_id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.pthread_id);
+                break;
+            }
+            case 5: {
+                // os tid
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.tid);
+                break;
+            }
+            case 6: {
+                // idle
+                fill_column_with_slot<TYPE_BOOLEAN>(column.get(), (void*)&info.idle);
+                break;
+            }
+            case 7: {
+                // finished_tasks
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.finished_tasks);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeThreadsScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_be_threads_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_threads_scanner.h
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "exec/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+struct BeThreadInfo {
+    std::string group;
+    std::string name;
+    int64_t pthread_id{0};
+    int64_t tid{0};
+    bool idle{false};
+    int64_t finished_tasks{0};
+};
+
+class SchemaBeThreadsScanner : public SchemaScanner {
+public:
+    SchemaBeThreadsScanner();
+    ~SchemaBeThreadsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<BeThreadInfo> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -43,12 +43,19 @@ void ScanExecutor::change_num_threads(int32_t num_threads) {
 }
 
 void ScanExecutor::worker_thread() {
+    auto current_thread = Thread::current_thread();
     while (true) {
         if (_num_threads_setter.should_shrink()) {
             break;
         }
 
+        if (current_thread != nullptr) {
+            current_thread->set_idle(true);
+        }
         auto maybe_task = _task_queue->take();
+        if (current_thread != nullptr) {
+            current_thread->set_idle(false);
+        }
         if (maybe_task.status().is_cancelled()) {
             return;
         }
@@ -58,6 +65,9 @@ void ScanExecutor::worker_thread() {
         {
             SCOPED_RAW_TIMER(&time_spent_ns);
             task.work_function();
+        }
+        if (current_thread != nullptr) {
+            current_thread->inc_finished_tasks();
         }
         _task_queue->update_statistics(task, time_spent_ns);
     }

--- a/be/src/util/thread.cpp
+++ b/be/src/util/thread.cpp
@@ -47,6 +47,7 @@
 #include <string>
 
 #include "common/logging.h"
+#include "exec/schema_scanner/schema_be_threads_scanner.h"
 #include "gutil/atomicops.h"
 #include "gutil/dynamic_annotations.h"
 #include "gutil/once.h"
@@ -90,6 +91,8 @@ public:
     // already been removed, this is a no-op.
     void remove_thread(const pthread_t& pthread_id, const std::string& category);
 
+    void get_thread_infos(std::vector<BeThreadInfo>& infos);
+
 private:
     // Container class for any details we want to capture about a thread
     // TODO: Add start-time.
@@ -97,17 +100,19 @@ private:
     class ThreadDescriptor {
     public:
         ThreadDescriptor() = default;
-        ThreadDescriptor(std::string category, std::string name, int64_t thread_id)
-                : _name(std::move(name)), _category(std::move(category)), _thread_id(thread_id) {}
+        ThreadDescriptor(std::string category, std::string name, int64_t thread_id, Thread* thread)
+                : _name(std::move(name)), _category(std::move(category)), _thread_id(thread_id), _thread(thread) {}
 
         const std::string& name() const { return _name; }
         const std::string& category() const { return _category; }
         int64_t thread_id() const { return _thread_id; }
+        Thread* thread() const { return _thread; }
 
     private:
         std::string _name;
         std::string _category;
         int64_t _thread_id;
+        Thread* _thread{nullptr};
     };
 
     // A ThreadCategory is a set of threads that are logically related.
@@ -158,7 +163,7 @@ void ThreadMgr::add_thread(const pthread_t& pthread_id, const std::string& name,
     ANNOTATE_IGNORE_READS_AND_WRITES_BEGIN();
     {
         std::lock_guard l(_lock);
-        _thread_categories[category][pthread_id] = ThreadDescriptor(category, name, tid);
+        _thread_categories[category][pthread_id] = ThreadDescriptor(category, name, tid, Thread::current_thread());
         _threads_running_metric++;
         _threads_started_metric++;
     }
@@ -178,6 +183,26 @@ void ThreadMgr::remove_thread(const pthread_t& pthread_id, const std::string& ca
     }
     ANNOTATE_IGNORE_SYNC_END();
     ANNOTATE_IGNORE_READS_AND_WRITES_END();
+}
+
+void ThreadMgr::get_thread_infos(std::vector<BeThreadInfo>& infos) {
+    std::lock_guard l(_lock);
+    for (const auto& category : _thread_categories) {
+        for (const auto& thread : category.second) {
+            BeThreadInfo& info = infos.emplace_back();
+            info.group = thread.second.category();
+            info.name = thread.second.name();
+            info.pthread_id = thread.first;
+            info.tid = thread.second.thread_id();
+            info.idle = thread.second.thread()->idle();
+            info.finished_tasks = thread.second.thread()->finished_tasks();
+        }
+    }
+}
+
+void Thread::get_thread_infos(std::vector<BeThreadInfo>& infos) {
+    GoogleOnceInit(&once, &init_threadmgr);
+    thread_manager->get_thread_infos(infos);
 }
 
 Thread::~Thread() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -698,6 +698,19 @@ public class SchemaTable extends Table {
                                     .column("CLONE_DURATION", ScalarType.createType(PrimitiveType.DOUBLE))
                                     .column("MSG", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .build()))
+                    .put("be_threads", new SchemaTable(
+                            SystemId.BE_THREADS_ID,
+                            "be_threads",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("GROUP", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("PTHREAD_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("IDLE", ScalarType.createType(PrimitiveType.BOOLEAN))
+                                    .column("FINISHED_TASKS", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .build()))
                     .build();
 
     public static class Builder {
@@ -797,7 +810,8 @@ public class SchemaTable extends Table {
         SCH_BE_TXNS("BE_TXNS", "BE_TXNS",
                 TSchemaTableType.SCH_BE_TXNS),
         SCH_BE_CONFIGS("BE_CONFIGS", "BE_CONFIGS", TSchemaTableType.SCH_BE_CONFIGS),
-        SCH_FE_TABLET_SCHEDULES("FE_TABLET_SCHEDULES", "FE_TABLET_SCHEDULES", TSchemaTableType.SCH_FE_TABLET_SCHEDULES);
+        SCH_FE_TABLET_SCHEDULES("FE_TABLET_SCHEDULES", "FE_TABLET_SCHEDULES", TSchemaTableType.SCH_FE_TABLET_SCHEDULES),
+        SCH_BE_THREADS("BE_THREADS", "BE_THREADS", TSchemaTableType.SCH_BE_THREADS);
 
         private final String description;
         private final String tableName;

--- a/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
@@ -85,4 +85,6 @@ public class SystemId {
     public static final long LOAD_TRACKING_LOGS_ID = 33L;
 
     public static final long FE_SCHEDULES_ID = 34L;
+
+    public static final long BE_THREADS_ID = 35L;
 }

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -143,7 +143,8 @@ enum TSchemaTableType {
     SCH_BE_CONFIGS,
     SCH_LOADS,
     SCH_LOAD_TRACKING_LOGS,
-    SCH_FE_TABLET_SCHEDULES
+    SCH_FE_TABLET_SCHEDULES,
+    SCH_BE_THREADS,
 }
 
 enum THdfsCompression {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20445

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds backend's thread information into information schema, currently only threads created in ThreadPool are listed, more threads will be added later.

Example usage:
```
mysql> select * from be_threads;
+-------+-------------+-----------------------------+-----------------+---------+------+----------------+
| BE_ID | GROUP       | NAME                        | PTHREAD_ID      |    TID  | IDLE | FINISHED_TASKS |
+-------+-------------+-----------------------------+-----------------+---------+------+----------------+
| 10004 | pipeline    | pipeline_poller             | 140547443349248 | 2116137 |    1 |              0 |
| 10004 | pipeline    | pipeline_poller             | 140547661559552 | 2116111 |    1 |              0 |
| 10004 | thread pool | compact_pool                | 140542684686080 | 2116704 |    1 |              0 |
| 10004 | thread pool | up_candidates               | 140542701471488 | 2116702 |    1 |             16 |
| 10004 | thread pool | clone                       | 140543154677504 | 2116648 |    1 |              0 |
| 10004 | thread pool | clone                       | 140543163070208 | 2116647 |    1 |              0 |
| 10004 | thread pool | drop_auto_increment_map_dir | 140543171462912 | 2116646 |    1 |              0 |
| 10004 | thread pool | update_tablet_meta_info     | 140543179855616 | 2116645 |    1 |              0 |
| 10004 | thread pool | move_dir                    | 140543188248320 | 2116644 |    1 |              0 |
| 10004 | thread pool | release_snapshot            | 140543196641024 | 2116643 |    1 |              0 |
| 10004 | thread pool | release_snapshot            | 140543205033728 | 2116642 |    1 |              0 |
| 10004 | thread pool | release_snapshot            | 140543213426432 | 2116641 |    1 |              0 |
...

mysql> select be_id, name, idle, count(*), sum(finished_tasks) from be_threads group by be_id, name, idle order by name;
+-------+-----------------------------+------+----------+---------------------+
| be_id | name                        | idle | count(*) | sum(finished_tasks) |
+-------+-----------------------------+------+----------+---------------------+
| 10004 | alter_tablet                |    1 |        3 |                   0 |
| 10004 | check_consistency           |    1 |        1 |                   0 |
| 10004 | clear_transaction           |    1 |        1 |                   0 |
| 10004 | clone                       |    1 |        2 |                   0 |
| 10004 | compact_pool                |    1 |        1 |                   0 |
| 10004 | con_scan_io                 |    1 |      192 |                   0 |
| 10004 | con_wg_scan_io              |    1 |      192 |                   0 |
| 10004 | create_tablet               |    1 |        3 |                   0 |
| 10004 | delta_writer                |    1 |        8 |                   0 |
| 10004 | download                    |    1 |        1 |                   0 |
| 10004 | drop                        |    1 |        3 |                   0 |
| 10004 | drop_auto_increment_map_dir |    1 |        1 |                   0 |
| 10004 | ex_state_report             |    1 |        2 |                   7 |
| 10004 | fragment_mgr                |    1 |       64 |                   0 |
| 10004 | make_snapshot               |    1 |        5 |                   0 |
| 10004 | memtable_flush              |    1 |        2 |                   0 |
| 10004 | meta-flush                  |    1 |        1 |                   0 |
| 10004 | move_dir                    |    1 |        1 |                   0 |
| 10004 | pip_executor                |    1 |       24 |                   0 |
| 10004 | pip_scan_io                 |    1 |       24 |                   0 |
| 10004 | pip_wg_executor             |    1 |       23 |                  69 |
| 10004 | pip_wg_executor             |    0 |        1 |                   3 |
| 10004 | pip_wg_scan_io              |    1 |       24 |                   5 |
| 10004 | pipeline_poller             |    1 |        2 |                   0 |
| 10004 | publish_version             |    1 |        8 |                   0 |
| 10004 | release_snapshot            |    1 |        5 |                   0 |
| 10004 | segment_flush               |    1 |        2 |                   0 |
| 10004 | segment_replicate           |    1 |        2 |                   0 |
| 10004 | storage_medium_migrate      |    1 |        1 |                   0 |
| 10004 | up_candidates               |    1 |        1 |                  16 |
| 10004 | update_tablet_meta_info     |    1 |        1 |                   0 |
| 10004 | upload                      |    1 |        1 |                   0 |
+-------+-----------------------------+------+----------+---------------------+
32 rows in set (0.07 sec)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
