### PR TITLE
[BugFix] Fix ClassCastException when query from information_schema.load_tracking_logs with job_id

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1137,6 +1137,7 @@ public class PlanFragmentBuilder {
                                     break;
                                 case "JOB_ID":
                                     scanNode.setJobId(constantOperator.getBigint());
+                                    break;
                                 case "TYPE":
                                     scanNode.setType(constantOperator.getVarchar());
                                     break;


### PR DESCRIPTION
## What type of PR is this：
- BugFix

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20481 

## Problem Summary(Required) ：

That same error occurs when query information_schema.loads and information_schema.load_tracking_logs.

The switch-case statement seems a typo-error, losing "break" statement in last PR.

Have tested it in our test environment.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
-  bugfix for the main branch
