### PR TITLE
[BugFix] [Cherry-pick][Branch-2.5]Fix not insert null value when refresh mv for external table (#20470)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.IsNullPredicate;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
@@ -676,6 +677,13 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         if (outputPartitionSlot != null) {
             List<Expr> partitionPredicates =
                     MvUtils.convertRange(outputPartitionSlot, sourceTablePartitionRange);
+            // range contains the min value could be null value
+            Optional<Range<PartitionKey>> nullRange = sourceTablePartitionRange.stream().
+                    filter(range -> range.lowerEndpoint().isMinValue()).findAny();
+            if (nullRange.isPresent()) {
+                Expr isNullPredicate = new IsNullPredicate(outputPartitionSlot, false);
+                partitionPredicates.add(isNullPredicate);
+            }
             tableRelation.setPartitionPredicate(Expr.compoundOr(partitionPredicates));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -532,7 +532,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
                 ImmutableList.of(PrimitiveType.DATE)));
 
         List<String> partitionNames = Lists.newArrayList();
-        partitionNames.addAll(ImmutableList.of("l_shipdate=1998-01-01", "l_shipdate=1998-01-02", "l_shipdate=1998-01-03",
+        partitionNames.addAll(ImmutableList.of("l_shipdate=" + HiveMetaClient.PARTITION_NULL_VALUE,
+                "l_shipdate=1998-01-01", "l_shipdate=1998-01-02", "l_shipdate=1998-01-03",
                 "l_shipdate=1998-01-04", "l_shipdate=1998-01-05"));
 
         List<String> partitionColumnNames = ImmutableList.of("l_shipdate");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
@@ -462,7 +462,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         taskRun.executeTaskRun();
 
         Collection<Partition> partitions = materializedView.getPartitions();
-        Assert.assertEquals(5, partitions.size());
+        Assert.assertEquals(6, partitions.size());
         Assert.assertEquals(1, materializedView.getPartition("p19980101").getVisibleVersion());
         Assert.assertEquals(1, materializedView.getPartition("p19980102").getVisibleVersion());
         Assert.assertEquals(1, materializedView.getPartition("p19980103").getVisibleVersion());
@@ -485,7 +485,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
 
-        Assert.assertEquals(5, partitions.size());
+        Assert.assertEquals(6, partitions.size());
         Assert.assertEquals(2, materializedView.getPartition("p19980101").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p19980102").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p19980103").getVisibleVersion());
@@ -601,7 +601,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5");
+        assertPlanContains(execPlan, "partitions=6/6");
 
         MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                 getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
@@ -611,11 +611,10 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
-        System.out.println(execPlan.getExplainString(TExplainLevel.NORMAL));
 
-        assertPlanContains(execPlan, "partitions=1/6");
+        assertPlanContains(execPlan, "partitions=1/7");
         Collection<Partition> partitions = materializedView.getPartitions();
-        Assert.assertEquals(6, partitions.size());
+        Assert.assertEquals(7, partitions.size());
 
         mockedHiveMetadata.dropPartition("partitioned_db", "lineitem_par", "l_shipdate=1998-01-06");
         starRocksAssert.useDatabase("test").dropMaterializedView("hive_parttbl_mv1");
@@ -694,7 +693,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5");
+        assertPlanContains(execPlan, "partitions=6/6");
 
         MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                 getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
@@ -707,7 +706,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         execPlan = mvContext.getExecPlan();
 
         assertPlanContains(execPlan, "l_shipdate >= '1998-01-04', 16: l_shipdate < '1998-01-05'",
-                "partitions=1/5");
+                "partitions=1/6");
 
         mockedHiveMetadata.updateTable("tpch", "orders");
 
@@ -715,7 +714,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5", "partitions=1/1");
+        assertPlanContains(execPlan, "partitions=6/6", "partitions=1/1");
     }
 
     public void testAutoPartitionRefreshWithUnPartitionedHiveTable() throws Exception {
@@ -784,7 +783,9 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5");
+        System.out.println(execPlan.getExplainString(TExplainLevel.NORMAL));
+        assertPlanContains(execPlan, "partitions=6/6", "PARTITION PREDICATES: (16: l_shipdate < '1998-01-06') " +
+                "OR (16: l_shipdate IS NULL)");
 
         MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                 getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
@@ -796,10 +797,10 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
-                "partitions=2/5");
+                "partitions=2/6");
 
         Collection<Partition> partitions = materializedView.getPartitions();
-        Assert.assertEquals(5, partitions.size());
+        Assert.assertEquals(6, partitions.size());
         Assert.assertEquals(2, materializedView.getPartition("p19980101").getVisibleVersion());
         Assert.assertEquals(3, materializedView.getPartition("p19980102").getVisibleVersion());
         Assert.assertEquals(3, materializedView.getPartition("p19980103").getVisibleVersion());
@@ -831,7 +832,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5");
+        assertPlanContains(execPlan, "partitions=6/6");
 
         MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                 getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
@@ -842,7 +843,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5");
+        assertPlanContains(execPlan, "partitions=6/6");
 
         Collection<Partition> partitions = materializedView.getPartitions();
         Assert.assertEquals(1, partitions.size());
@@ -875,7 +876,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5");
+        assertPlanContains(execPlan, "partitions=6/6");
 
         MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                 getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
@@ -887,10 +888,10 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
-                "partitions=2/5");
+                "partitions=2/6");
 
         Collection<Partition> partitions = materializedView.getPartitions();
-        Assert.assertEquals(5, partitions.size());
+        Assert.assertEquals(6, partitions.size());
         Assert.assertEquals(2, materializedView.getPartition("p19980101").getVisibleVersion());
         Assert.assertEquals(3, materializedView.getPartition("p19980102").getVisibleVersion());
         Assert.assertEquals(3, materializedView.getPartition("p19980103").getVisibleVersion());
@@ -924,7 +925,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
 
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5");
+        assertPlanContains(execPlan, "partitions=6/6");
 
         MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                 getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
@@ -936,10 +937,10 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
-                "partitions=2/5");
+                "partitions=2/6");
 
         Collection<Partition> partitions = materializedView.getPartitions();
-        Assert.assertEquals(5, partitions.size());
+        Assert.assertEquals(6, partitions.size());
         Assert.assertEquals(2, materializedView.getPartition("p19980101").getVisibleVersion());
         Assert.assertEquals(3, materializedView.getPartition("p19980102").getVisibleVersion());
         Assert.assertEquals(3, materializedView.getPartition("p19980103").getVisibleVersion());
@@ -1024,7 +1025,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         taskRun.executeTaskRun();
         Collection<Partition> partitions = materializedView.getPartitions();
 
-        Assert.assertEquals(5, partitions.size());
+        Assert.assertEquals(6, partitions.size());
         Assert.assertEquals(2, materializedView.getPartition("p19980101").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p19980102").getVisibleVersion());
         Assert.assertEquals(1, materializedView.getPartition("p19980103").getVisibleVersion());
@@ -1038,7 +1039,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
         Assert.assertTrue(plan.contains("PARTITION PREDICATES: 16: l_shipdate >= '1998-01-01', " +
                 "16: l_shipdate < '1998-01-03'"));
-        Assert.assertTrue(plan.contains("partitions=2/5"));
+        Assert.assertTrue(plan.contains("partitions=2/6"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -13,6 +13,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.Config;
+import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
@@ -1860,7 +1861,7 @@ public class MvRewriteOptimizationTest {
         MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                 getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
-                ImmutableList.of("l_shipdate=1998-01-01"));
+                ImmutableList.of("l_shipdate=" + HiveMetaClient.PARTITION_NULL_VALUE));
 
         query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
                 "where l_shipdate > '1998-01-04'";
@@ -1875,7 +1876,7 @@ public class MvRewriteOptimizationTest {
         query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` ";
         plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "hive_parttbl_mv", "UNION",
-                "PARTITION PREDICATES: (22: l_shipdate < '1998-01-02') OR (22: l_shipdate >= '1998-01-06')");
+                "PARTITION PREDICATES: (22: l_shipdate < '1998-01-01') OR (22: l_shipdate >= '1998-01-06')");
         dropMv("test", "hive_parttbl_mv");
 
         createAndRefreshMv("test", "hive_parttbl_mv_2",
@@ -1900,8 +1901,8 @@ public class MvRewriteOptimizationTest {
                 ImmutableList.of("l_shipdate=1998-01-02"));
         plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "hive_parttbl_mv_2", "l_orderkey > 100", "lineitem_par",
-                "PARTITION PREDICATES: (23: l_shipdate < '1998-01-01') OR (23: l_shipdate >= '1998-01-02'), " +
-                        "(23: l_shipdate < '1998-01-03') OR (23: l_shipdate >= '1998-01-06')",
+                "PARTITION PREDICATES: 23: l_shipdate >= '1998-01-02', (23: l_shipdate < '1998-01-03') OR " +
+                        "(23: l_shipdate >= '1998-01-06')",
                 "NON-PARTITION PREDICATES: 21: l_orderkey > 100");
 
         dropMv("test", "hive_parttbl_mv_2");
@@ -1922,8 +1923,8 @@ public class MvRewriteOptimizationTest {
                         "where l_shipdate > '1998-01-02';");
         query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` ";
         plan = getFragmentPlan(query);
-        PlanTestBase.assertContains(plan, "hive_parttbl_mv_3", "partitions=3/5", "lineitem_par",
-                "partitions=2/5");
+        PlanTestBase.assertContains(plan, "hive_parttbl_mv_3", "partitions=3/6", "lineitem_par",
+                "partitions=2/6");
         dropMv("test", "hive_parttbl_mv_3");
 
         createAndRefreshMv("test", "hive_parttbl_mv_4",
@@ -1941,7 +1942,7 @@ public class MvRewriteOptimizationTest {
                         "where l_shipdate < '1998-01-02' and l_orderkey = 100;");
         query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` ";
         plan = getFragmentPlan(query);
-        PlanTestBase.assertContains(plan, "hive_parttbl_mv_4", "partitions=1/5", "lineitem_par",
+        PlanTestBase.assertContains(plan, "hive_parttbl_mv_4", "partitions=1/6", "lineitem_par",
                 "NON-PARTITION PREDICATES: ((22: l_shipdate >= '1998-01-02') OR (20: l_orderkey != 100)) OR " +
                         "(22: l_shipdate < '1998-01-01')");
         dropMv("test", "hive_parttbl_mv_4");


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
