### PR TITLE
[BugFix] fix meminfo get in docker

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -71,7 +71,9 @@ void MemInfo::init() {
 
         if (result == StringParser::PARSE_SUCCESS) {
             // Entries in /proc/meminfo are in KB.
-            _s_physical_mem = mem_total_kb * 1024L;
+            if (_s_physical_mem <= 0 || _s_physical_mem > mem_total_kb * 1024L) {
+                _s_physical_mem = mem_total_kb * 1024L;
+            }
         }
 
         break;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20521

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In docker, if memory limit in `/sys/fs/cgroup/memory/memory.limit_in_bytes` is set and smaller than `/proc/meminfo`, it will use memory in `/proc/meminfo` as limit.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [x] 2.3
