### PR TITLE
[Enhancement]Array_agg support decimal v3

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -173,9 +173,6 @@ public class FunctionAnalyzer {
             if (fnParams.isDistinct()) {
                 throw new SemanticException("array_agg does not support DISTINCT");
             }
-            if (arg.getType().isDecimalV3()) {
-                throw new SemanticException("array_agg does not support DecimalV3");
-            }
         }
 
         if (fnName.getFunction().equals(FunctionSet.ARRAYS_OVERLAP)) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -240,6 +240,9 @@ public class AnalyzeExprTest {
         analyzeSuccess("select array_agg(a order by b) from (select null as a, null as b " +
                 "union all select v1 as a, v3 as b from t0)A;");
         analyzeSuccess("select array_agg(v1 order by v1),array_sortby(array_agg(v1),array_agg(v2)) from t0;");
+        analyzeSuccess("select array_agg(tj) from tall");
+        analyzeSuccess("select array_agg(tj order by ta) from tall group by tc");
+
 
         analyzeFail("select array_agg(null order by);");
         analyzeFail("select array_agg(null,'a');");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -185,4 +185,31 @@ public class DecimalTypeTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "PREDICATES: 4: c_1_3 <= 1000");
     }
+
+
+    @Test
+    public void testArrayAggDecimal() throws Exception {
+        int stage = connectContext.getSessionVariable().getNewPlannerAggStage();
+        connectContext.getSessionVariable().setNewPlanerAggStage(2);
+        try {
+            String sql = "select array_agg(c_0_0) from tab0";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "array_agg[([16: array_agg, STRUCT<ARRAY<decimal128(26, 2)>>, true]); " +
+                    "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
+            assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
+                    "args: DECIMAL128; result: STRUCT<ARRAY<decimal128(26, 2)>>;");
+        } finally {
+            connectContext.getSessionVariable().setNewPlanerAggStage(stage);
+        }
+
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+        try {
+            String sql = "select array_agg(c_0_0) from tab0";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
+                    "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
+        } finally {
+            connectContext.getSessionVariable().setNewPlanerAggStage(stage);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -185,31 +185,4 @@ public class DecimalTypeTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "PREDICATES: 4: c_1_3 <= 1000");
     }
-
-
-    @Test
-    public void testArrayAggDecimal() throws Exception {
-        int stage = connectContext.getSessionVariable().getNewPlannerAggStage();
-        connectContext.getSessionVariable().setNewPlanerAggStage(2);
-        try {
-            String sql = "select array_agg(c_0_0) from tab0";
-            String plan = getVerboseExplain(sql);
-            assertContains(plan, "array_agg[([16: array_agg, STRUCT<ARRAY<decimal128(26, 2)>>, true]); " +
-                    "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
-            assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
-                    "args: DECIMAL128; result: STRUCT<ARRAY<decimal128(26, 2)>>;");
-        } finally {
-            connectContext.getSessionVariable().setNewPlanerAggStage(stage);
-        }
-
-        connectContext.getSessionVariable().setNewPlanerAggStage(0);
-        try {
-            String sql = "select array_agg(c_0_0) from tab0";
-            String plan = getVerboseExplain(sql);
-            assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
-                    "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
-        } finally {
-            connectContext.getSessionVariable().setNewPlanerAggStage(stage);
-        }
-    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
array_agg support decimal v3.
Supporting array_agg(decimal v3) is not cherry-pick to branch-3.0

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
