### PR TITLE
[BugFix] Fix bug of _short_circuit_break of HashJoiner

### DIFF
--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -318,6 +318,8 @@ void HashJoiner::reference_hash_table(HashJoiner* src_join_builder) {
     hash_table.set_probe_profile(probe_metrics().search_ht_timer, probe_metrics().output_probe_column_timer,
                                  probe_metrics().output_tuple_column_timer);
 
+    // _hash_table_build_rows is root truth, it used to by _short_circuit_break().
+    _hash_table_build_rows = src_join_builder->_hash_table_build_rows;
     _probe_column_count = src_join_builder->_probe_column_count;
     _build_column_count = src_join_builder->_build_column_count;
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Fix  _short_circuit_break bug introduced by https://github.com/StarRocks/starrocks/pull/20030

daily test: case/system_case/test_dql/test_query_cache/test_query_cache_broadcast_hj_ak_db.py:TestQueryCacheBroadcastHjAkDb.test_query_cache_broadcast_hj_ak_db

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
