### PR TITLE
[BugFix] some bug fix for auto increment (#20575)

### DIFF
--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1199,7 +1199,12 @@ Status StorageEngine::get_next_increment_id_interval(int64_t tableid, size_t num
         auto st = _get_remote_next_increment_id_interval(alloc_params, &alloc_result);
 
         if (!st.ok() || alloc_result.status.status_code != TStatusCode::OK) {
-            return Status::InternalError("auto increment allocate failed");
+            std::stringstream err_msg;
+            for (auto& msg : alloc_result.status.error_msgs) {
+                err_msg << msg;
+            }
+
+            return Status::InternalError("auto increment allocate failed, err msg: " + err_msg.str());
         }
 
         if (cur_avaliable_rows > 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -380,6 +380,11 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         Column oriColumn = schemaForFinding.get(modColIndex);
+
+        if (oriColumn.isAutoIncrement()) {
+            throw new DdlException("Can't not modify a AUTO_INCREMENT column");
+        }
+    
         // retain old column name
         modColumn.setName(oriColumn.getName());
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -372,6 +372,7 @@ public class CatalogRecycleBin extends LeaderDaemon implements Writable {
             for (RecycleTableInfo tableInfo : tableToRemove) {
                 Table table = tableInfo.getTable();
                 long tableId = table.getId();
+                GlobalStateMgr.getCurrentState().removeAutoIncrementIdByTableId(tableId, false);
                 removeRecycleMarkers(tableId);
                 nameToTableInfo.remove(tableInfo.dbId, table.getName());
                 idToTableInfo.remove(tableInfo.dbId, tableId);
@@ -407,6 +408,7 @@ public class CatalogRecycleBin extends LeaderDaemon implements Writable {
             if (tableInfo != null) {
                 Runnable runnable = null;
                 Table table = tableInfo.getTable();
+                GlobalStateMgr.getCurrentState().removeAutoIncrementIdByTableId(tableId, true);
                 nameToTableInfo.remove(dbId, table.getName());
                 runnable = table.delete(true);
                 if (!isCheckpointThread() && runnable != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -514,7 +514,6 @@ public class Database extends MetaObject implements Writable {
         }
 
         if (table instanceof OlapTable && table.hasAutoIncrementColumn()) {
-            GlobalStateMgr.getCurrentState().removeAutoIncrementIdByTableId(tableId, isReplay);
             if (!isReplay) {
                 ((OlapTable) table).sendDropAutoIncrementMapTask();
             }
@@ -528,6 +527,7 @@ public class Database extends MetaObject implements Writable {
             Table oldTable = GlobalStateMgr.getCurrentState().getRecycleBin().recycleTable(id, table);
             runnable = (oldTable != null) ? oldTable.delete(isReplay) : null;
         } else {
+            GlobalStateMgr.getCurrentState().removeAutoIncrementIdByTableId(tableId, isReplay);
             runnable = table.delete(isReplay);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4493,6 +4493,11 @@ public class LocalMetastore implements ConnectorMetadata {
             newId = oldId + rows;
         }
 
+        // AUTO_INCREMENT counter overflow
+        if (newId < oldId) {
+            throw new RuntimeException("AUTO_INCREMENT counter overflow");
+        }
+
         return oldId;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -262,9 +262,9 @@ public class InsertPlanner {
                         }
                         if (row.get(idx) instanceof DefaultValueExpr) {
                             if (isAutoIncrement) {
-                                row.set(columnIdx, new NullLiteral());
+                                row.set(idx, new NullLiteral());
                             } else {
-                                row.set(columnIdx, new StringLiteral(targetColumn.calculatedDefaultValue()));
+                                row.set(idx, new StringLiteral(targetColumn.calculatedDefaultValue()));
                             }
                         }
                         row.set(idx, TypeManager.addCastExpr(row.get(idx), targetColumn.getType()));

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -1,0 +1,407 @@
+-- name: test_create_table_abnormal
+CREATE DATABASE test_create_table_abnormal_auto_increment;
+-- result:
+-- !result
+USE test_create_table_abnormal_auto_increment;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+E: (1064, 'Getting syntax error at line 1, column 17. Detail message: AUTO_INCREMENT column id must be NOT NULL.')
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT DEFAULT "100",  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+E: (1064, "Getting syntax error at line 1, column 51. Detail message: Input 'DEFAULT' is not valid at this position.")
+-- !result
+CREATE TABLE t ( id INT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 17 to line 1, column 33. Detail message: The AUTO_INCREMENT column must be BIGINT.')
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL AUTO_INCREMENT, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 53 to line 1, column 74. Detail message: More than one AUTO_INCREMENT column defined in CREATE TABLE Statement.')
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL AUTO_INCREMENT, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 53 to line 1, column 74. Detail message: More than one AUTO_INCREMENT column defined in CREATE TABLE Statement.')
+-- !result
+DROP DATABASE test_create_table_abnormal;
+-- result:
+E: (1064, "Unexpected exception: Can't drop database 'test_create_table_abnormal'; database doesn't exist")
+-- !result
+-- name: test_create_table_normal
+CREATE DATABASE test_create_table_normal_auto_increment;
+-- result:
+-- !result
+USE test_create_table_normal_auto_increment;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL ,  name BIGINT NOT NULL, job1 BIGINT AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL ,  name BIGINT NOT NULL, job1 BIGINT NOT NULL AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT AUTO_INCREMENT, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+-- result:
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+DROP DATABASE test_create_table_normal_auto_increment;
+-- result:
+-- !result
+-- name: test_update
+CREATE DATABASE test_update_auto_increment;
+-- result:
+-- !result
+USE test_update_auto_increment;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t (id,name,job1,job2) values (DEFAULT,0,0,0);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	0	0	0
+-- !result
+UPDATE t SET job2 = 1 WHERE id = 1 AND name = 0;
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	0	0	1
+-- !result
+INSERT INTO t (id,name,job1,job2) values (DEFAULT,1,1,1);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	0	0	1
+2	1	1	1
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t (id,name,job1,job2) values (0,0,DEFAULT,0);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+0	0	1	0
+-- !result
+UPDATE t SET job2 = 1 WHERE id = 0 AND name = 0;
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+0	0	1	1
+-- !result
+INSERT INTO t (id,name,job1,job2) values (1,1,DEFAULT,1);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+0	0	1	1
+1	1	2	1
+-- !result
+UPDATE t SET job1 = 0 WHERE id = 1 AND name = 1;
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+0	0	1	1
+1	1	0	1
+-- !result
+INSERT INTO t (id,name,job1,job2) values (2,2,DEFAULT,2);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+0	0	1	1
+1	1	0	1
+2	2	3	2
+-- !result
+UPDATE t SET job1 = DEFAULT WHERE id = 0 AND name = 0;
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+0	0	4	1
+1	1	0	1
+2	2	3	2
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+DROP DATABASE test_update_auto_increment;
+-- result:
+-- !result
+-- name: test_insert
+CREATE DATABASE test_insert_auto_increment;
+-- result:
+-- !result
+USE test_insert_auto_increment;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t (name,job1,job2) VALUES (1,1,1),(2,2,2);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+-- !result
+INSERT INTO t (id,name,job1,job2) VALUES (DEFAULT,3,3,3),(DEFAULT,4,4,4);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+-- !result
+INSERT INTO t (id,name,job1,job2) VALUES (100,5,5,5);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+100	5	5	5
+-- !result
+INSERT INTO t (id,name,job1,job2) VALUES (101,6,6,6),(DEFAULT,7,7,7);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+100	5	5	5
+101	6	6	6
+5	7	7	7
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t (id,name,job1,job2) VALUES (1,1,1,1),(100000,1,2,2);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY job1;
+-- result:
+1	1	1	1
+100000	1	2	2
+-- !result
+INSERT INTO t (name,job1,job2) VALUES (1,100,100);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY job1;
+-- result:
+100000	1	2	2
+1	1	100	100
+-- !result
+INSERT INTO t (id,name,job1,job2) VALUES (100000,1,100,100);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY job1;
+-- result:
+1	1	100	100
+100000	1	100	100
+-- !result
+INSERT INTO t (id,name,job1,job2) VALUES (100000,1,200,200), (10,10,99,99);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY job1;
+-- result:
+10	10	99	99
+1	1	100	100
+100000	1	200	200
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t (id,name,job2) VALUES (1,1,1),(2,2,2);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+-- !result
+INSERT INTO t (id,name,job1, job2) VALUES (3,3,DEFAULT,3),(4,4,DEFAULT,4);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+-- !result
+INSERT INTO t (id,name,job1, job2) VALUES (5,5,100,5);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+5	5	100	5
+-- !result
+INSERT INTO t (id,name,job1, job2) VALUES (6,6,101,6),(7,7,DEFAULT,7);
+-- result:
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+5	5	100	5
+6	6	101	6
+7	7	5	7
+-- !result
+SELECT * FROM t ORDER BY name;
+-- result:
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+5	5	100	5
+6	6	101	6
+7	7	5	7
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t1 ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+CREATE TABLE t2 ( id BIGINT NOT NULL,  name BIGINT NOT NULL AUTO_INCREMENT, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+CREATE TABLE t3 ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+CREATE TABLE t4 ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL AUTO_INCREMENT) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t1 (id,name,job1,job2) VALUES (DEFAULT,1,1,1);
+-- result:
+-- !result
+INSERT INTO t2 (id,name,job1,job2) VALUES (1,DEFAULT,1,1);
+-- result:
+-- !result
+INSERT INTO t3 (id,name,job1,job2) VALUES (1,1,DEFAULT,1);
+-- result:
+-- !result
+INSERT INTO t4 (id,name,job1,job2) VALUES (1,1,1,DEFAULT);
+-- result:
+-- !result
+INSERT INTO t1 (name,job1,job2) VALUES (1,1,1);
+-- result:
+-- !result
+INSERT INTO t2 (id,job1,job2) VALUES (1,1,1);
+-- result:
+-- !result
+INSERT INTO t3 (id,name,job2) VALUES (1,1,1);
+-- result:
+-- !result
+INSERT INTO t4 (id,name,job1) VALUES (1,1,1);
+-- result:
+-- !result
+DROP TABLE t1;
+-- result:
+-- !result
+DROP TABLE t2;
+-- result:
+-- !result
+DROP TABLE t3;
+-- result:
+-- !result
+DROP TABLE t4;
+-- result:
+-- !result
+DROP DATABASE test_insert_auto_increment;
+-- result:
+-- !result
+-- name: test_schema_change;
+CREATE DATABASE test_schema_change_auto_increment;
+-- result:
+-- !result
+USE test_schema_change_auto_increment;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL AUTO_INCREMENT) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+ALTER TABLE t ADD COLUMN newcol BIGINT AUTO_INCREMENT;
+-- result:
+E: (1064, "Getting syntax error from line 1, column 25 to line 1, column 39. Detail message: Column 'newcol' can not be AUTO_INCREMENT when ADD COLUMN..")
+-- !result
+ALTER TABLE t MODIFY COLUMN job2 BIGINT;
+-- result:
+E: (1064, "Unexpected exception: Can't not modify a AUTO_INCREMENT column")
+-- !result
+ALTER TABLE t MODIFY COLUMN job2 BIGINT AUTO_INCREMENT;
+-- result:
+E: (1064, "Getting syntax error from line 1, column 28 to line 1, column 40. Detail message: Column 'job2' can not be AUTO_INCREMENT when MODIFY COLUMN..")
+-- !result
+ALTER TABLE t DROP COLUMN job2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+DROP DATABASE test_schema_change_auto_increment;
+-- result:
+-- !result

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -1,0 +1,165 @@
+-- name: test_create_table_normal
+CREATE DATABASE test_create_table_normal_auto_increment;
+USE test_create_table_normal_auto_increment;
+
+CREATE TABLE t ( id BIGINT NOT NULL ,  name BIGINT NOT NULL, job1 BIGINT AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+DROP TABLE t;
+
+CREATE TABLE t ( id BIGINT NOT NULL ,  name BIGINT NOT NULL, job1 BIGINT NOT NULL AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+DROP TABLE t;
+
+CREATE TABLE t ( id BIGINT AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+DROP TABLE t;
+
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT AUTO_INCREMENT, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+DROP TABLE t;
+
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+DROP TABLE t;
+
+DROP DATABASE test_create_table_normal_auto_increment;
+
+-- name: test_create_table_abnormal
+CREATE DATABASE test_create_table_abnormal_auto_increment;
+USE test_create_table_abnormal_auto_increment;
+
+CREATE TABLE t ( id BIGINT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT DEFAULT "100",  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+CREATE TABLE t ( id INT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL AUTO_INCREMENT, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL AUTO_INCREMENT, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
+
+DROP DATABASE test_create_table_abnormal;
+
+-- name: test_insert
+CREATE DATABASE test_insert_auto_increment;
+USE test_insert_auto_increment;
+
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+INSERT INTO t (name,job1,job2) VALUES (1,1,1),(2,2,2);
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1,job2) VALUES (DEFAULT,3,3,3),(DEFAULT,4,4,4);
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1,job2) VALUES (100,5,5,5);
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1,job2) VALUES (101,6,6,6),(DEFAULT,7,7,7);
+SELECT * FROM t ORDER BY name;
+
+DROP TABLE t;
+
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+
+INSERT INTO t (id,name,job1,job2) VALUES (1,1,1,1),(100000,1,2,2);
+SELECT * FROM t ORDER BY job1;
+
+INSERT INTO t (name,job1,job2) VALUES (1,100,100);
+SELECT * FROM t ORDER BY job1;
+
+INSERT INTO t (id,name,job1,job2) VALUES (100000,1,100,100);
+SELECT * FROM t ORDER BY job1;
+
+INSERT INTO t (id,name,job1,job2) VALUES (100000,1,200,200), (10,10,99,99);
+SELECT * FROM t ORDER BY job1;
+
+DROP TABLE t;
+
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+
+INSERT INTO t (id,name,job2) VALUES (1,1,1),(2,2,2);
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1, job2) VALUES (3,3,DEFAULT,3),(4,4,DEFAULT,4);
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1, job2) VALUES (5,5,100,5);
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1, job2) VALUES (6,6,101,6),(7,7,DEFAULT,7);
+SELECT * FROM t ORDER BY name;
+
+SELECT * FROM t ORDER BY name;
+
+DROP TABLE t;
+
+CREATE TABLE t1 ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+CREATE TABLE t2 ( id BIGINT NOT NULL,  name BIGINT NOT NULL AUTO_INCREMENT, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+CREATE TABLE t3 ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+CREATE TABLE t4 ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL AUTO_INCREMENT) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+
+INSERT INTO t1 (id,name,job1,job2) VALUES (DEFAULT,1,1,1);
+INSERT INTO t2 (id,name,job1,job2) VALUES (1,DEFAULT,1,1);
+INSERT INTO t3 (id,name,job1,job2) VALUES (1,1,DEFAULT,1);
+INSERT INTO t4 (id,name,job1,job2) VALUES (1,1,1,DEFAULT);
+
+INSERT INTO t1 (name,job1,job2) VALUES (1,1,1);
+INSERT INTO t2 (id,job1,job2) VALUES (1,1,1);
+INSERT INTO t3 (id,name,job2) VALUES (1,1,1);
+INSERT INTO t4 (id,name,job1) VALUES (1,1,1);
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+DROP TABLE t4;
+
+DROP DATABASE test_insert_auto_increment;
+
+-- name: test_update
+CREATE DATABASE test_update_auto_increment;
+USE test_update_auto_increment;
+
+ADMIN SET FRONTEND CONFIG ("auto_increment_cache_size" = "0");
+
+CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+INSERT INTO t (id,name,job1,job2) values (DEFAULT,0,0,0);
+SELECT * FROM t ORDER BY name;
+
+UPDATE t SET job2 = 1 WHERE id = 1 AND name = 0;
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1,job2) values (DEFAULT,1,1,1);
+SELECT * FROM t ORDER BY name;
+
+DROP TABLE t;
+
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL AUTO_INCREMENT, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+
+INSERT INTO t (id,name,job1,job2) values (0,0,DEFAULT,0);
+SELECT * FROM t ORDER BY name;
+
+UPDATE t SET job2 = 1 WHERE id = 0 AND name = 0;
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1,job2) values (1,1,DEFAULT,1);
+SELECT * FROM t ORDER BY name;
+
+UPDATE t SET job1 = 0 WHERE id = 1 AND name = 1;
+SELECT * FROM t ORDER BY name;
+
+INSERT INTO t (id,name,job1,job2) values (2,2,DEFAULT,2);
+SELECT * FROM t ORDER BY name;
+
+UPDATE t SET job1 = DEFAULT WHERE id = 0 AND name = 0;
+SELECT * FROM t ORDER BY name;
+
+DROP TABLE t;
+DROP DATABASE test_update_auto_increment;
+
+-- name: test_schema_change;
+CREATE DATABASE test_schema_change_auto_increment;
+USE test_schema_change_auto_increment;
+
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL AUTO_INCREMENT) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+
+ALTER TABLE t ADD COLUMN newcol BIGINT AUTO_INCREMENT;
+ALTER TABLE t MODIFY COLUMN job2 BIGINT;
+ALTER TABLE t MODIFY COLUMN job2 BIGINT AUTO_INCREMENT;
+ALTER TABLE t DROP COLUMN job2;
+function: wait_alter_table_finish()
+
+DROP TABLE t;
+DROP DATABASE test_schema_change_auto_increment;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20575

## Problem Summary(Required) ：
Problem 1:
Currently, the auto-increment column does not support modifying a column into an AUTO_INCREMENT column. But it is possible that modify an AUTO_INCREMENT column into a normal column. This should be aborted.

Problem 2:
There is no mechanism to handle the overflow of the auto-increment id counter, which will cause be crash.

Problem 3:
The planning for inserting into is not feasible when the auto-increment is not specified and defined before another normal column.

Problem 4:
When we recover a table, the auto-increment id will restart from the beginning, which is a problem.

Solution:
1. Abort the case that we modify an AUTO_INCREMENT column into a normal column.
2. Throw an exception when the id counter is overflowing.
3. Fix the planning problem for the insert statement.
4. remove the auto increment id when truly erasing the table.5. 
5. add some test case for auto increment.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
