### PR TITLE
[Enhancement] Support persistent the extra messages in TaskRunStatus for MVs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -730,6 +730,7 @@ public class TaskManager {
                 long expireTime = taskRunStatus.getExpireTime();
                 if (currentTimeMs > expireTime) {
                     historyToDelete.add(taskRunStatus.getQueryId());
+                    taskRunManager.getTaskRunHistory().removeTask(taskRunStatus.getQueryId());
                     iterator.remove();
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -48,7 +48,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -545,6 +544,7 @@ public class TaskManager {
                 return;
             }
         }
+        LOG.info("replayCreateTaskRun:" + status);
 
         switch (status.getState()) {
             case PENDING:
@@ -577,6 +577,7 @@ public class TaskManager {
         Constants.TaskRunState fromStatus = statusChange.getFromStatus();
         Constants.TaskRunState toStatus = statusChange.getToStatus();
         Long taskId = statusChange.getTaskId();
+        LOG.info("replayUpdateTaskRun:" + statusChange);
         if (fromStatus == Constants.TaskRunState.PENDING) {
             Queue<TaskRun> taskRunQueue = taskRunManager.getPendingTaskRunMap().get(taskId);
             if (taskRunQueue == null) {
@@ -625,20 +626,32 @@ public class TaskManager {
             }
         } else if (fromStatus == Constants.TaskRunState.RUNNING &&
                 (toStatus == Constants.TaskRunState.SUCCESS || toStatus == Constants.TaskRunState.FAILED)) {
+            // NOTE: TaskRuns before the fe restart will be replayed in `replayCreateTaskRun` which
+            // will not be rerun because `InsertOverwriteJobRunner.replayStateChange` will replay, so
+            // the taskRun's may be PENDING/RUNNING/SUCCESS.
             TaskRun runningTaskRun = taskRunManager.getRunningTaskRunMap().remove(taskId);
-            if (runningTaskRun == null) {
-                return;
-            }
-            TaskRunStatus status = runningTaskRun.getStatus();
-            if (status.getQueryId().equals(statusChange.getQueryId())) {
-                if (toStatus == Constants.TaskRunState.FAILED) {
-                    status.setErrorMessage(statusChange.getErrorMessage());
-                    status.setErrorCode(statusChange.getErrorCode());
+            if (runningTaskRun != null) {
+                TaskRunStatus status = runningTaskRun.getStatus();
+                if (status.getQueryId().equals(statusChange.getQueryId())) {
+                    if (toStatus == Constants.TaskRunState.FAILED) {
+                        status.setErrorMessage(statusChange.getErrorMessage());
+                        status.setErrorCode(statusChange.getErrorCode());
+                    }
+                    status.setState(toStatus);
+                    status.setProgress(100);
+                    status.setFinishTime(statusChange.getFinishTime());
+                    status.setExtraMessage(statusChange.getExtraMessage());
+                    taskRunManager.getTaskRunHistory().addHistory(status);
                 }
-                status.setState(toStatus);
-                status.setProgress(100);
-                status.setFinishTime(statusChange.getFinishTime());
-                taskRunManager.getTaskRunHistory().addHistory(status);
+            } else {
+                // Find the task status from history map.
+                String queryId = statusChange.getQueryId();
+                TaskRunStatus status = taskRunManager.getTaskRunHistory().getTask(queryId);
+                if (status == null) {
+                    return;
+                }
+                // Do update extra message from change status.
+                status.setExtraMessage(statusChange.getExtraMessage());
             }
         } else {
             LOG.warn("Illegal TaskRun queryId:{} status transform from {} to {}",
@@ -710,7 +723,7 @@ public class TaskManager {
         }
         try {
             // only SUCCESS and FAILED in taskRunHistory
-            Deque<TaskRunStatus> taskRunHistory = taskRunManager.getTaskRunHistory().getAllHistory();
+            List<TaskRunStatus> taskRunHistory = taskRunManager.getTaskRunHistory().getAllHistory();
             Iterator<TaskRunStatus> iterator = taskRunHistory.iterator();
             while (iterator.hasNext()) {
                 TaskRunStatus taskRunStatus = iterator.next();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunHistory.java
@@ -40,6 +40,13 @@ public class TaskRunHistory {
         return historyTaskRunMap.get(queryId);
     }
 
+    public void removeTask(String queryId) {
+        if (queryId == null) {
+            return;
+        }
+        historyTaskRunMap.remove(queryId);
+    }
+
     // Reserve historyTaskRunMap values to keep the last insert at the first.
     public List<TaskRunStatus> getAllHistory() {
         List<TaskRunStatus> historyRunStatus =

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunHistory.java
@@ -15,20 +15,36 @@
 
 package com.starrocks.scheduler;
 
-import com.google.common.collect.Queues;
+import com.google.common.collect.Maps;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 
-import java.util.Deque;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class TaskRunHistory {
-
-    private final Deque<TaskRunStatus> historyDeque = Queues.newLinkedBlockingDeque();
+    // Thread-Safe history map: QueryId -> TaskRunStatus
+    // The same task-id may contain multi history task run status, so use query_id instead.
+    private final Map<String, TaskRunStatus> historyTaskRunMap =
+            Collections.synchronizedMap(Maps.newLinkedHashMap());
 
     public void addHistory(TaskRunStatus status) {
-        historyDeque.addFirst(status);
+        historyTaskRunMap.put(status.getQueryId(), status);
     }
 
-    public Deque<TaskRunStatus> getAllHistory() {
-        return historyDeque;
+    public TaskRunStatus getTask(String queryId) {
+        if (queryId == null) {
+            return null;
+        }
+        return historyTaskRunMap.get(queryId);
+    }
+
+    // Reserve historyTaskRunMap values to keep the last insert at the first.
+    public List<TaskRunStatus> getAllHistory() {
+        List<TaskRunStatus> historyRunStatus =
+                historyTaskRunMap.values().stream().collect(Collectors.toList());
+        Collections.reverse(historyRunStatus);
+        return historyRunStatus;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -237,6 +237,18 @@ public class TaskRunStatus implements Writable {
             return "";
         }
     }
+    public void setExtraMessage(String extraMessage) {
+        if (extraMessage == null) {
+            return;
+        }
+
+        if (source == Constants.TaskSource.MV) {
+            this.mvTaskRunExtraMessage =
+                    GsonUtils.GSON.fromJson(extraMessage, MVTaskRunExtraMessage.class);
+        } else {
+            // do nothing
+        }
+    }
 
     public static TaskRunStatus read(DataInput in) throws IOException {
         String json = Text.readString(in);
@@ -267,6 +279,7 @@ public class TaskRunStatus implements Writable {
                 ", expireTime=" + expireTime +
                 ", priority=" + priority +
                 ", mergeRedundant=" + mergeRedundant +
+                ", extraMessage=" + getExtraMessage() +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatusChange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatusChange.java
@@ -48,6 +48,8 @@ public class TaskRunStatusChange implements Writable {
     @SerializedName("errorMessage")
     private String errorMessage;
 
+    @SerializedName("extraMessage")
+    private String extraMessage;
 
     public TaskRunStatusChange(long taskId, TaskRunStatus status,
                                Constants.TaskRunState fromStatus,
@@ -61,6 +63,7 @@ public class TaskRunStatusChange implements Writable {
             errorCode = status.getErrorCode();
             errorMessage = status.getErrorMessage();
         }
+        this.extraMessage = status.getExtraMessage();
     }
 
     public long getTaskId() {
@@ -119,6 +122,14 @@ public class TaskRunStatusChange implements Writable {
         this.finishTime = finishTime;
     }
 
+    public String getExtraMessage() {
+        return extraMessage;
+    }
+
+    public void setExtraMessage(String extraMessage) {
+        this.extraMessage = extraMessage;
+    }
+
     public static TaskRunStatusChange read(DataInput in) throws IOException {
         String json = Text.readString(in);
         return GsonUtils.GSON.fromJson(json, TaskRunStatusChange.class);
@@ -130,4 +141,17 @@ public class TaskRunStatusChange implements Writable {
         Text.writeString(out, json);
     }
 
+    @Override
+    public String toString() {
+        return "TaskRunStatus{" +
+                "queryId='" + queryId + '\'' +
+                ", taskId='" + taskId + '\'' +
+                ", finishTime=" + finishTime +
+                ", fromStatus=" + fromStatus +
+                ", toStatus=" + toStatus +
+                ", errorCode=" + errorCode +
+                ", errorMessage='" + errorMessage + '\'' +
+                ", extraMessage=" + getExtraMessage() +
+                '}';
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
- `TaskRunStatus` only persistent the create info, `extraMessage` will be lost after FE restarts, so need to persistent `extraMessage` into the TaskRunStatusChange log and replay it into the history map.
- Change history deque to LinkedHashMap to be easy to find the task by taskId.

```
    public void logTaskRunCreateStatus(TaskRunStatus status) {
        logEdit(OperationType.OP_CREATE_TASK_RUN, status);
    }

    public void logUpdateTaskRun(TaskRunStatusChange statusChange) {
        logEdit(OperationType.OP_UPDATE_TASK_RUN, statusChange);
    }

```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
