### PR TITLE
[BugFix] array_agg supports upgrade to 3.0

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_factory.cpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.cpp
@@ -119,6 +119,12 @@ static const AggregateFunction* get_function(const std::string& name, LogicalTyp
         }
     }
 
+    if (func_version > 5) {
+        if (name == "array_agg") {
+            func_name = "array_agg2";
+        }
+    }
+
     if (binary_type == TFunctionBinaryType::BUILTIN) {
         auto func = AggregateFuncResolver::instance()->get_aggregate_info(func_name, arg_type, return_type,
                                                                           is_window_function, is_null);

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -105,8 +105,8 @@ public:
         return std::make_shared<ExchangePerfAggregateFunction<PerfType>>();
     }
 
-    static AggregateFunctionPtr MakeArrayAggAggregateFunction() {
-        return std::make_shared<ArrayAggAggregateFunction>();
+    static AggregateFunctionPtr MakeArrayAggAggregateFunctionV2() {
+        return std::make_shared<ArrayAggAggregateFunctionV2>();
     }
 
     template <LogicalType LT>

--- a/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
@@ -32,10 +32,24 @@ struct AvgDispatcher {
     }
 };
 
+struct ArrayAggDispatcher {
+    template <LogicalType lt>
+    void operator()(AggregateFuncResolver* resolver) {
+        if constexpr (lt_is_aggregate<lt> || lt_is_json<lt>) {
+            auto func = std::make_shared<ArrayAggAggregateFunction<lt>>();
+            using AggState = ArrayAggAggregateState<lt>;
+            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>("array_agg", false,
+                                                                                                   func);
+        }
+    }
+};
+
 void AggregateFuncResolver::register_avg() {
     for (auto type : aggregate_types()) {
         type_dispatch_all(type, AvgDispatcher(), this);
+        type_dispatch_all(type, ArrayAggDispatcher(), this);
     }
+    type_dispatch_all(TYPE_JSON, ArrayAggDispatcher(), this);
     add_decimal_mapping<TYPE_DECIMAL32, TYPE_DECIMAL128, true>("decimal_avg");
     add_decimal_mapping<TYPE_DECIMAL64, TYPE_DECIMAL128, true>("decimal_avg");
     add_decimal_mapping<TYPE_DECIMAL128, TYPE_DECIMAL128, true>("decimal_avg");

--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -72,7 +72,7 @@ void AggregateFuncResolver::register_others() {
     add_array_mapping<TYPE_DATETIME, TYPE_INT>("window_funnel");
     add_array_mapping<TYPE_DATE, TYPE_INT>("window_funnel");
 
-    add_general_mapping_notnull("array_agg", false, AggregateFactory::MakeArrayAggAggregateFunction());
+    add_general_mapping_notnull("array_agg2", false, AggregateFactory::MakeArrayAggAggregateFunctionV2());
 }
 
 } // namespace starrocks

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -2012,7 +2012,7 @@ TEST_F(AggregateTest, test_array_agg) {
         // test update
         array_agg_func->update_batch_single_state(local_ctx.get(), int_column->size(), raw_columns.data(),
                                                   state->state());
-        auto agg_state = (ArrayAggAggregateState*)(state->state());
+        auto agg_state = (ArrayAggAggregateStateV2*)(state->state());
         ASSERT_EQ(agg_state->data_columns->size(), 2);
         // data_columns in state are nullable
         ASSERT_EQ(strcmp((*agg_state->data_columns)[0]->debug_string().c_str(),

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -1748,7 +1748,7 @@ TEST_F(AggregateTest, test_array_agg) {
     local_ctx->set_nulls_first(nulls_first);
     local_ctx->set_runtime_state(runtime_state.get());
 
-    const AggregateFunction* array_agg_func = get_aggregate_function("array_agg", TYPE_BIGINT, TYPE_ARRAY, false);
+    const AggregateFunction* array_agg_func = get_aggregate_function("array_agg2", TYPE_BIGINT, TYPE_ARRAY, false);
     auto state = ManagedAggrState::create(local_ctx.get(), array_agg_func);
 
     // nullable columns input
@@ -1780,7 +1780,7 @@ TEST_F(AggregateTest, test_array_agg) {
         // test update
         array_agg_func->update_batch_single_state(local_ctx.get(), int_column->size(), raw_columns.data(),
                                                   state->state());
-        auto agg_state = (ArrayAggAggregateState*)(state->state());
+        auto agg_state = (ArrayAggAggregateStateV2*)(state->state());
         ASSERT_EQ(agg_state->data_columns->size(), 2);
         // data_columns in state are nullable
         ASSERT_EQ((*agg_state->data_columns)[0]->debug_string(), char_column->debug_string());
@@ -1847,7 +1847,7 @@ TEST_F(AggregateTest, test_array_agg) {
         // test update
         array_agg_func->update_batch_single_state(local_ctx.get(), int_column->size(), raw_columns.data(),
                                                   state->state());
-        auto agg_state = (ArrayAggAggregateState*)(state->state());
+        auto agg_state = (ArrayAggAggregateStateV2*)(state->state());
         ASSERT_EQ(agg_state->data_columns->size(), 2);
         // data_columns in state are nullable
         ASSERT_EQ((*agg_state->data_columns)[0]->debug_string(), char_column->debug_string());
@@ -1898,7 +1898,7 @@ TEST_F(AggregateTest, test_array_agg) {
         // test update
         array_agg_func->update_batch_single_state(local_ctx.get(), int_column->size(), raw_columns.data(),
                                                   state->state());
-        auto agg_state = (ArrayAggAggregateState*)(state->state());
+        auto agg_state = (ArrayAggAggregateStateV2*)(state->state());
         ASSERT_EQ(agg_state->data_columns->size(), 2);
         // data_columns in state are nullable
         ASSERT_EQ(strcmp((*agg_state->data_columns)[0]->debug_string().c_str(),
@@ -1953,7 +1953,7 @@ TEST_F(AggregateTest, test_array_agg) {
         // test update
         array_agg_func->update_batch_single_state(local_ctx.get(), int_column->size(), raw_columns.data(),
                                                   state->state());
-        auto agg_state = (ArrayAggAggregateState*)(state->state());
+        auto agg_state = (ArrayAggAggregateStateV2*)(state->state());
         ASSERT_EQ(agg_state->data_columns->size(), 2);
         // data_columns in state are nullable
         ASSERT_EQ(strcmp((*agg_state->data_columns)[0]->debug_string().c_str(), "[NULL, NULL]"), 0);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksTest/issues/2111

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

array_agg() supports upgreading to 3.0 version via func_version. BE supports the old-version array_agg() and new version, so it can execute the plan from 2.5 FE and 3.0 FE.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
