### PR TITLE
[BugFix] Fix be crash in merge_compaction_advance

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3553,10 +3553,10 @@ Status PersistentIndex::_merge_compaction_advance() {
         for (const auto& [key_size, shard_info] : _l1_vec[i]->_shard_info_by_length) {
             auto [l1_shard_offset, l1_shard_size] = shard_info;
             const auto size = std::accumulate(std::next(_l1_vec[i]->_shards.begin(), l1_shard_offset),
-                                              std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size),
+                                              std::next(_l1_vec[i]->_shards.begin(), l1_shard_offset + l1_shard_size),
                                               0L, [](size_t s, const auto& e) { return s + e.size; });
             const auto usage = std::accumulate(std::next(_l1_vec[i]->_shards.begin(), l1_shard_offset),
-                                               std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size),
+                                               std::next(_l1_vec[i]->_shards.begin(), l1_shard_offset + l1_shard_size),
                                                0L, [](size_t s, const auto& e) { return s + e.data_size; });
 
             auto iter = usage_and_size_stat.find(key_size);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In function `PersistentIndex::_merge_compaction_advance`, we will calculate the total kv nums and kv data size of all tmp l1 that need to be merged. And we should get the shard info from each tmp l1 but the code is not.

As the following codes show, we get begin shard from `_l1_vec[i]` but always get the end shard from `_l1_vec[0]` which will cause an unexpected errors and cause be crash.

```
Status PersistentIndex::_merge_compaction_advance() {
        ....
        for (const auto& [key_size, shard_info] : _l1_vec[i]->_shard_info_by_length) {
            auto [l1_shard_offset, l1_shard_size] = shard_info;
            const auto size = std::accumulate(std::next(_l1_vec[i]->_shards.begin(), l1_shard_offset),
                                              std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size), // we should get shard info from _l1_vec[i] but not _l1_vec[0]
                                              0L, [](size_t s, const auto& e) { return s + e.size; });
            const auto usage = std::accumulate(std::next(_l1_vec[i]->_shards.begin(), l1_shard_offset),
                                               std::next(_l1_vec[0]->_shards.begin(), l1_shard_offset + l1_shard_size), // we should get shard info from _l1_vec[i] but not _l1_vec[0]
                                               0L, [](size_t s, const auto& e) { return s + e.data_size; });
}
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
