### PR TITLE
[BugFix] fix array_slice on decimal crash

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -1242,7 +1242,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_distinct_any_type(FunctionContext* ctx
 
     phmap::flat_hash_set<uint32_t> sets;
 
-    uint32_t hash[elements->size()]{0};
+    uint32_t hash[elements->size()];
+    memset(hash, 0, elements->size() * sizeof(uint32_t));
     elements->fnv_hash(hash, 0, elements->size());
 
     size_t rows = columns[0]->size();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -556,6 +556,7 @@ public class FunctionSet {
             .add(ARRAYS_OVERLAP)
             .add(ARRAY_AGG)
             .add(ARRAY_CONCAT)
+            .add(ARRAY_SLICE)
             .build();
 
     public FunctionSet() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -468,6 +468,10 @@ public class DecimalV3FunctionAnalyzer {
                 newFn.setArgsType(argumentTypes);
                 return newFn;
             }
+            case FunctionSet.ARRAY_SLICE: {
+                newFn.setRetType(argumentTypes[0]);
+                return newFn;
+            }
             default:
                 return fn;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -626,6 +626,17 @@ public class ArrayTypeTest extends PlanTestBase {
         assertCContains(plan, "array_sortby[([4: d_1, ARRAY<DECIMAL128(26,2)>, false], " +
                 "[8: d_5, ARRAY<DECIMAL64(16,3)>, true]); " +
                 "args: INVALID_TYPE,INVALID_TYPE; result: ARRAY<DECIMAL128(26,2)>;");
+
+        sql = "select array_slice(d_1, 1) from adec;";
+        plan = getVerboseExplain(sql);
+        assertCContains(plan, "array_slice[([4: d_1, ARRAY<DECIMAL128(26,2)>, false], 1); " +
+                "args: INVALID_TYPE,BIGINT; result: ARRAY<DECIMAL128(26,2)>;");
+
+        sql = "select array_slice(d_2, 1, 3) from adec;";
+        plan = getVerboseExplain(sql);
+        assertCContains(plan, "array_slice[([5: d_2, ARRAY<DECIMAL64(4,3)>, true], 1, 3); " +
+                "args: INVALID_TYPE,BIGINT,BIGINT; result: ARRAY<DECIMAL64(4,3)>;");
+
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
![img_v2_c3892627-4ec9-46b4-a5ca-29576120b67g](https://user-images.githubusercontent.com/5609319/228751357-00f6b328-1e65-4cf5-8b2b-3c706d39f7a4.jpg)


reason:
```
|   1:Project                                                                                                                                                                                    |
|   |  output columns:                                                                                                                                                                           |
|   |  15 <-> array_slice[(ARRAY<decimal32(8, 8)>[CAST(1: c1 AS DECIMAL32(8,8))], 1, 1); args: INVALID_TYPE,BIGINT,BIGINT; result: ARRAY<DECIMAL32>; args nullable: true; result nullable: true] |
|   |  cardinality: 1                                                                                                                                                                            |

```
`result: ARRAY<DECIMAL32>`  lose scala and persions

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
