### PR TITLE
[BugFix] Fix problem of finding partition end when enable hash based partition

### DIFF
--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -74,7 +74,7 @@ Status AnalyticNode::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
     DCHECK(child(0)->row_desc().is_prefix_of(row_desc()));
 
-    _analytor = std::make_shared<Analytor>(_tnode, child(0)->row_desc(), _result_tuple_desc);
+    _analytor = std::make_shared<Analytor>(_tnode, child(0)->row_desc(), _result_tuple_desc, false);
     RETURN_IF_ERROR(_analytor->prepare(state, _pool, runtime_profile()));
 
     return Status::OK();
@@ -321,11 +321,13 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
     OpFactories ops_with_sink = _children[0]->decompose_to_pipeline(context);
     auto* upstream_source_op = context->source_operator(ops_with_sink);
 
+    const bool use_hash_based_partition = _tnode.analytic_node.order_by_exprs.empty() &&
+                                          _tnode.analytic_node.__isset.use_hash_based_partition &&
+                                          _tnode.analytic_node.use_hash_based_partition;
     if (_tnode.analytic_node.partition_exprs.empty()) {
         // analytic's dop must be 1 if with no partition clause
         ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink);
-    } else if (_tnode.analytic_node.order_by_exprs.empty() && _tnode.analytic_node.__isset.use_hash_based_partition &&
-               _tnode.analytic_node.use_hash_based_partition) {
+    } else if (use_hash_based_partition) {
         // analytic has only partition by columns but no order by columns
         auto pseudo_plan_node_id = context->next_pseudo_plan_node_id();
         HashPartitionContextFactoryPtr hash_partition_ctx_factory =
@@ -344,8 +346,8 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
     upstream_source_op = context->source_operator(ops_with_sink);
     auto degree_of_parallelism = upstream_source_op->degree_of_parallelism();
 
-    AnalytorFactoryPtr analytor_factory =
-            std::make_shared<AnalytorFactory>(degree_of_parallelism, _tnode, child(0)->row_desc(), _result_tuple_desc);
+    AnalytorFactoryPtr analytor_factory = std::make_shared<AnalytorFactory>(
+            degree_of_parallelism, _tnode, child(0)->row_desc(), _result_tuple_desc, use_hash_based_partition);
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
 
     ops_with_sink.emplace_back(

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -38,8 +38,11 @@ Status window_init_jvm_context(int64_t fid, const std::string& url, const std::s
                                const std::string& symbol, FunctionContext* context);
 
 Analytor::Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc,
-                   const TupleDescriptor* result_tuple_desc)
-        : _tnode(tnode), _child_row_desc(child_row_desc), _result_tuple_desc(result_tuple_desc) {
+                   const TupleDescriptor* result_tuple_desc, bool use_hash_based_partition)
+        : _tnode(tnode),
+          _child_row_desc(child_row_desc),
+          _result_tuple_desc(result_tuple_desc),
+          _use_hash_based_partition(use_hash_based_partition) {
     if (tnode.analytic_node.__isset.buffered_tuple_id) {
         _buffered_tuple_id = tnode.analytic_node.buffered_tuple_id;
     }
@@ -538,9 +541,14 @@ void Analytor::find_partition_end() {
     _found_partition_end.second = static_cast<int64_t>(_partition_columns[0]->size());
     {
         SCOPED_TIMER(_partition_search_timer);
-        for (auto& column : _partition_columns) {
+        if (_use_hash_based_partition) {
             _found_partition_end.second =
-                    _find_first_not_equal(column.get(), _partition_end, start, _found_partition_end.second);
+                    _find_first_not_equal_for_hash_baed_partition(_partition_end, start, _found_partition_end.second);
+        } else {
+            for (auto& column : _partition_columns) {
+                _found_partition_end.second =
+                        _find_first_not_equal(column.get(), _partition_end, start, _found_partition_end.second);
+            }
         }
     }
 
@@ -758,6 +766,30 @@ int64_t Analytor::_find_first_not_equal(Column* column, int64_t target, int64_t 
     return end - 1;
 }
 
+int64_t Analytor::_find_first_not_equal_for_hash_baed_partition(int64_t target, int64_t start, int64_t end) {
+    auto compare = [this](size_t left, size_t right) {
+        for (auto& column : _partition_columns) {
+            auto res = column->compare_at(left, right, *column, 1);
+            if (res != 0) {
+                return res;
+            }
+        }
+        return 0;
+    };
+    while (start + 1 < end) {
+        int64_t mid = start + (end - start) / 2;
+        if (compare(target, mid) == 0) {
+            start = mid;
+        } else {
+            end = mid;
+        }
+    }
+    if (compare(target, end - 1) == 0) {
+        return end;
+    }
+    return end - 1;
+}
+
 void Analytor::_find_candidate_partition_ends() {
     if (!_partition_statistics.is_high_cardinality()) {
         return;
@@ -794,7 +826,8 @@ void Analytor::_find_candidate_peer_group_ends() {
 
 AnalytorPtr AnalytorFactory::create(int i) {
     if (!_analytors[i]) {
-        _analytors[i] = std::make_shared<Analytor>(_tnode, _child_row_desc, _result_tuple_desc);
+        _analytors[i] =
+                std::make_shared<Analytor>(_tnode, _child_row_desc, _result_tuple_desc, _use_hash_based_partition);
     }
     return _analytors[i];
 }

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -543,7 +543,7 @@ void Analytor::find_partition_end() {
         SCOPED_TIMER(_partition_search_timer);
         if (_use_hash_based_partition) {
             _found_partition_end.second =
-                    _find_first_not_equal_for_hash_baed_partition(_partition_end, start, _found_partition_end.second);
+                    _find_first_not_equal_for_hash_based_partition(_partition_end, start, _found_partition_end.second);
         } else {
             for (auto& column : _partition_columns) {
                 _found_partition_end.second =
@@ -766,7 +766,9 @@ int64_t Analytor::_find_first_not_equal(Column* column, int64_t target, int64_t 
     return end - 1;
 }
 
-int64_t Analytor::_find_first_not_equal_for_hash_baed_partition(int64_t target, int64_t start, int64_t end) {
+int64_t Analytor::_find_first_not_equal_for_hash_based_partition(int64_t target, int64_t start, int64_t end) {
+    // In this case, we cannot compare each column one by one like Analytor::_find_first_not_equal does,
+    // and we must compare all the partition columns for one comparation
     auto compare = [this](size_t left, size_t right) {
         for (auto& column : _partition_columns) {
             auto res = column->compare_at(left, right, *column, 1);

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -87,7 +87,8 @@ public:
             close(_state);
         }
     }
-    Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc, const TupleDescriptor* result_tuple_desc);
+    Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc, const TupleDescriptor* result_tuple_desc,
+             bool use_hash_based_partition);
 
     Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile);
     Status open(RuntimeState* state);
@@ -179,6 +180,8 @@ private:
     const TPlanNode& _tnode;
     const RowDescriptor& _child_row_desc;
     const TupleDescriptor* _result_tuple_desc;
+    const bool _use_hash_based_partition;
+
     ObjectPool* _pool;
     std::unique_ptr<MemPool> _mem_pool;
     // The open phase still relies on the TFunction object for some initialization operations
@@ -286,6 +289,7 @@ private:
                                        int64_t frame_end);
 
     int64_t _find_first_not_equal(Column* column, int64_t target, int64_t start, int64_t end);
+    int64_t _find_first_not_equal_for_hash_baed_partition(int64_t target, int64_t start, int64_t end);
     void _find_candidate_partition_ends();
     void _find_candidate_peer_group_ends();
 };
@@ -320,8 +324,12 @@ using AnalytorFactoryPtr = std::shared_ptr<AnalytorFactory>;
 class AnalytorFactory {
 public:
     AnalytorFactory(size_t dop, const TPlanNode& tnode, const RowDescriptor& child_row_desc,
-                    const TupleDescriptor* result_tuple_desc)
-            : _analytors(dop), _tnode(tnode), _child_row_desc(child_row_desc), _result_tuple_desc(result_tuple_desc) {}
+                    const TupleDescriptor* result_tuple_desc, const bool use_hash_based_partition)
+            : _analytors(dop),
+              _tnode(tnode),
+              _child_row_desc(child_row_desc),
+              _result_tuple_desc(result_tuple_desc),
+              _use_hash_based_partition(use_hash_based_partition) {}
     AnalytorPtr create(int i);
 
 private:
@@ -329,5 +337,6 @@ private:
     const TPlanNode& _tnode;
     const RowDescriptor& _child_row_desc;
     const TupleDescriptor* _result_tuple_desc;
+    const bool _use_hash_based_partition;
 };
 } // namespace starrocks

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -289,7 +289,7 @@ private:
                                        int64_t frame_end);
 
     int64_t _find_first_not_equal(Column* column, int64_t target, int64_t start, int64_t end);
-    int64_t _find_first_not_equal_for_hash_baed_partition(int64_t target, int64_t start, int64_t end);
+    int64_t _find_first_not_equal_for_hash_based_partition(int64_t target, int64_t start, int64_t end);
     void _find_candidate_partition_ends();
     void _find_candidate_peer_group_ends();
 };

--- a/be/src/exec/pipeline/hash_partition_context.h
+++ b/be/src/exec/pipeline/hash_partition_context.h
@@ -46,6 +46,8 @@ public:
     // Return true if sink completed and all the data in the chunks_sorters has been pulled out
     bool is_finished();
 
+    int32_t num_partitions() const { return _chunks_partitioner->num_partitions(); }
+
 private:
     const std::vector<TExpr>& _t_partition_exprs;
     std::vector<ExprContext*> _partition_exprs;

--- a/be/src/exec/pipeline/hash_partition_sink_operator.cpp
+++ b/be/src/exec/pipeline/hash_partition_sink_operator.cpp
@@ -18,6 +18,7 @@ namespace starrocks::pipeline {
 
 Status HashPartitionSinkOperator::prepare(RuntimeState* state) {
     Operator::prepare(state);
+    _partition_num = ADD_COUNTER(_unique_metrics, "PartitionNumber", TUnit::UNIT);
     return _hash_partition_ctx->prepare(state);
 }
 
@@ -31,6 +32,7 @@ Status HashPartitionSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr
 
 Status HashPartitionSinkOperator::set_finishing(RuntimeState* state) {
     _hash_partition_ctx->sink_complete();
+    COUNTER_UPDATE(_partition_num, _hash_partition_ctx->num_partitions());
     _is_finished = true;
     return Status::OK();
 }

--- a/be/src/exec/pipeline/hash_partition_sink_operator.h
+++ b/be/src/exec/pipeline/hash_partition_sink_operator.h
@@ -65,6 +65,8 @@ public:
 private:
     bool _is_finished = false;
     HashPartitionContext* _hash_partition_ctx;
+
+    RuntimeProfile::Counter* _partition_num;
 };
 
 class HashPartitionSinkOperatorFactory final : public OperatorFactory {

--- a/be/test/exec/analytor_test.cpp
+++ b/be/test/exec/analytor_test.cpp
@@ -28,7 +28,7 @@ public:
 TEST_F(AnalytorTest, find_peer_group_end) {
     TPlanNode plan_node;
     RowDescriptor row_desc;
-    Analytor analytor(plan_node, row_desc, nullptr);
+    Analytor analytor(plan_node, row_desc, nullptr, false);
 
     int32_t v;
     auto c1 = Int32Column::create();
@@ -49,7 +49,7 @@ TEST_F(AnalytorTest, find_peer_group_end) {
 TEST_F(AnalytorTest, reset_state_for_cur_partition) {
     TPlanNode plan_node;
     RowDescriptor row_desc;
-    Analytor analytor(plan_node, row_desc, nullptr);
+    Analytor analytor(plan_node, row_desc, nullptr, false);
 
     analytor._partition_start = 3;
     analytor._partition_end = 10;
@@ -64,7 +64,7 @@ TEST_F(AnalytorTest, reset_state_for_cur_partition) {
 TEST_F(AnalytorTest, reset_state_for_next_partition) {
     TPlanNode plan_node;
     RowDescriptor row_desc;
-    Analytor analytor(plan_node, row_desc, nullptr);
+    Analytor analytor(plan_node, row_desc, nullptr, false);
 
     analytor._partition_start = 10;
     analytor._partition_end = 10;
@@ -79,7 +79,7 @@ TEST_F(AnalytorTest, reset_state_for_next_partition) {
 TEST_F(AnalytorTest, find_partition_end) {
     TPlanNode plan_node;
     RowDescriptor row_desc;
-    Analytor analytor1(plan_node, row_desc, nullptr);
+    Analytor analytor1(plan_node, row_desc, nullptr, false);
 
     int32_t v;
     auto c1 = Int32Column::create();
@@ -118,7 +118,7 @@ TEST_F(AnalytorTest, find_partition_end) {
     ASSERT_EQ(analytor1.found_partition_end().second, 20);
 
     // partition columns is empty
-    Analytor analytor2(plan_node, row_desc, nullptr);
+    Analytor analytor2(plan_node, row_desc, nullptr, false);
     analytor2.update_input_rows(20);
 
     analytor2._current_row_position = analytor2.found_partition_end().second;
@@ -127,7 +127,7 @@ TEST_F(AnalytorTest, find_partition_end) {
     ASSERT_EQ(analytor2.found_partition_end().second, 20);
 
     // input rows = 0
-    Analytor analytor3(plan_node, row_desc, nullptr);
+    Analytor analytor3(plan_node, row_desc, nullptr, false);
     analytor3.update_input_rows(0);
 
     analytor2._current_row_position = analytor2.found_partition_end().second;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#1979](https://github.com/StarRocks/StarRocksTest/issues/1979)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For sorted based partition, we can use binary-search column by column.

For hash-based partition, we can also use binary-search, but every time we need to compare all partition columns.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
