### PR TITLE
[BugFix] Fix compareTo NPE when system privilegeCollection merge

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeCollection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeCollection.java
@@ -20,6 +20,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -71,7 +72,15 @@ public class PrivilegeCollection {
         }
 
         @Override
-        public int compareTo(PrivilegeEntry o) {
+        public int compareTo(@NotNull PrivilegeEntry o) {
+            //object is null when objectType is SYSTEM
+            if (this.object == null && o.object == null) {
+                return 0;
+            } else if (this.object == null) {
+                return -1;
+            } else if (o.object == null) {
+                return 1;
+            }
             return this.object.compareTo(o.object);
         }
     }
@@ -96,9 +105,7 @@ public class PrivilegeCollection {
             }
         } else {
             for (PrivilegeEntry privilegeEntry : privilegeEntryList) {
-                if (privilegeEntry.object != null
-                        && object.equals(privilegeEntry.object)
-                        && withGrantOption == privilegeEntry.withGrantOption) {
+                if (object.equals(privilegeEntry.object) && withGrantOption == privilegeEntry.withGrantOption) {
                     return privilegeEntry;
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 public class PrivilegeCollectionTest {
 
@@ -238,6 +239,15 @@ public class PrivilegeCollectionTest {
         collection.merge(createTable);
         Assert.assertTrue(collection.allowGrant(db, Arrays.asList(drop), Arrays.asList(db1)));
         Assert.assertTrue(collection.check(db, drop, db1));
+
+        PrivilegeCollection systemCollection1 = new PrivilegeCollection();
+        systemCollection1.grant(ObjectType.SYSTEM, Arrays.asList(PrivilegeType.NODE),
+                Collections.singletonList(null), true);
+
+        PrivilegeCollection systemCollection2 = new PrivilegeCollection();
+        systemCollection2.grant(ObjectType.SYSTEM, Arrays.asList(PrivilegeType.OPERATE),
+                Collections.singletonList(null), false);
+        systemCollection1.merge(systemCollection2);
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes (https://github.com/StarRocks/StarRocksTest/issues/2126)

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When two PrivilegeCollections of type System are merged, the sorting logic is invoked, and the Object of System is NULL
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
