### PR TITLE
[Enhancement] Constructor of BitmapValue support shallow copy (#20617)

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -939,11 +939,14 @@ public:
     // Construct an empty bitmap.
     BitmapValue() {}
 
-    BitmapValue(const BitmapValue& other)
-            : _bitmap(other._bitmap == nullptr ? nullptr : std::make_shared<detail::Roaring64Map>(*other._bitmap)),
-              _set(other._set),
-              _sv(other._sv),
-              _type(other._type) {}
+    BitmapValue(const BitmapValue& other, bool deep_copy = true)
+            : _set(other._set), _sv(other._sv), _type(other._type) {
+        if (deep_copy) {
+            _bitmap = (other._bitmap == nullptr) ? nullptr : std::make_shared<detail::Roaring64Map>(*other._bitmap);
+        } else {
+            _bitmap = (other._bitmap == nullptr) ? nullptr : other._bitmap;
+        }
+    }
 
     BitmapValue& operator=(const BitmapValue& other) {
         if (this != &other) {

--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -30,6 +30,17 @@
 
 namespace starrocks {
 
+TEST(BitmapValueTest, Constructor) {
+    BitmapValue bitmap;
+    for (size_t i = 0; i < 64; i++) {
+        bitmap.add(i);
+    }
+
+    BitmapValue shallow_bitmap(bitmap, false);
+    shallow_bitmap.add(64);
+    ASSERT_EQ(bitmap.cardinality(), 65);
+}
+
 TEST(BitmapValueTest, bitmap_union) {
     BitmapValue empty;
     BitmapValue single(1024);


### PR DESCRIPTION
Constructor of BitmapValue support shallow copy.

For large bitmap, if we deep copy many copies (chunk size), it will consume large memory usage, on some scene, it's no need to deep copy, so i add one param to control whether to perform deep copy.

Signed-off-by: trueeyu <lxhhust350@qq.com>
(cherry picked from commit 410ff357cb8072fc80878c3c5082e01e047e05de)

