### PR TITLE
[Enhancement] Constructor of BitmapValue support shallow copy (#20617)

### DIFF
--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -50,9 +50,9 @@ class Roaring64Map;
 class BitmapValue {
 public:
     // Construct an empty bitmap.
-    BitmapValue(){};
+    BitmapValue() = default;
 
-    BitmapValue(const BitmapValue& other);
+    BitmapValue(const BitmapValue& other, bool deep_copy = true);
     BitmapValue& operator=(const BitmapValue& other);
 
     BitmapValue(BitmapValue&& other) noexcept

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -237,6 +237,7 @@ set(EXEC_FILES
         ./runtime/memory_scratch_sink_test.cpp
         ./serde/column_array_serde_test.cpp
         ./serde/protobuf_serde_test.cpp
+        ./types/bitmap_value_test.cpp
         ./simd/simd_test.cpp
         ./simd/simd_selector_test.cpp
         ./simd/simd_mulselector_test.cpp

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/bitmap_value.h"
+#include "util/phmap/phmap.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+class BitmapTest : public testing::Test {};
+
+TEST_F(BitmapTest, Constructor) {
+    BitmapValue bitmap;
+    for (size_t i = 0; i < 64; i++) {
+        bitmap.add(i);
+    }
+
+    BitmapValue shallow_bitmap(bitmap, false);
+    shallow_bitmap.add(64);
+    ASSERT_EQ(bitmap.cardinality(), 65);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
Constructor of BitmapValue support shallow copy.

For large bitmap, if we deep copy many copies (chunk size), it will consume large memory usage, on some scene, it's no need to deep copy, so i add one param to control whether to perform deep copy.

Signed-off-by: trueeyu <lxhhust350@qq.com>
(cherry picked from commit 410ff357cb8072fc80878c3c5082e01e047e05de)
