### PR TITLE
[Enhancement] Add BE strack trace util to script

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -31,6 +31,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "util/logging.h"
+#include "util/stack_util.h"
 
 namespace starrocks {
 

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -18,12 +18,16 @@
 #include "util/stack_util.h"
 
 #include <cxxabi.h>
+#include <dirent.h>
 #include <fmt/format.h>
+#include <sys/syscall.h>
 
 #include <exception>
 
 #include "common/config.h"
+#include "gutil/strings/join.h"
 #include "gutil/strings/split.h"
+#include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
 #include "util/time.h"
 
@@ -31,12 +35,217 @@ namespace google::glog_internal_namespace_ {
 void DumpStackTraceToString(std::string* stacktrace);
 } // namespace google::glog_internal_namespace_
 
+// import hidden stack trace functions from glog
+namespace google {
+int GetStackTrace(void** result, int max_depth, int skip_count);
+bool Symbolize(void* pc, char* out, int out_size);
+} // namespace google
+
 namespace starrocks {
 
 std::string get_stack_trace() {
     std::string s;
     google::glog_internal_namespace_::DumpStackTraceToString(&s);
     return s;
+}
+
+struct StackTraceTask {
+    static constexpr int kMaxStackDepth = 64;
+    void* addrs[kMaxStackDepth];
+    int depth{0};
+    bool done = false;
+    string to_string() const {
+        string ret;
+        for (int i = 0; i < depth; ++i) {
+            char line[2048];
+            char buf[1024];
+            if (google::Symbolize(addrs[i], buf, sizeof(buf))) {
+                snprintf(line, 2048, "  %16p  %s\n", addrs[i], buf);
+            } else {
+                snprintf(line, 2048, "  %16p  (unknown)\n", addrs[i]);
+            }
+            ret += line;
+        }
+        return ret;
+    }
+    bool operator==(const StackTraceTask& other) const {
+        if (depth != other.depth) {
+            return false;
+        }
+        for (int i = 0; i < depth; ++i) {
+            if (addrs[i] != other.addrs[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+struct StackTraceTaskHash {
+    size_t operator()(const StackTraceTask& task) const {
+        size_t hash = 0;
+        for (int i = 0; i < task.depth; ++i) {
+            hash = hash * 31 + reinterpret_cast<size_t>(task.addrs[i]);
+        }
+        return hash;
+    }
+};
+
+void get_stack_trace_sighandler(int signum, siginfo_t* siginfo, void* ucontext) {
+    auto task = reinterpret_cast<StackTraceTask*>(siginfo->si_value.sival_ptr);
+    task->depth = google::GetStackTrace(task->addrs, StackTraceTask::kMaxStackDepth, 2);
+    task->done = true;
+}
+
+bool install_stack_trace_sighandler() {
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_sigaction = get_stack_trace_sighandler;
+    action.sa_flags = SA_RESTART | SA_SIGINFO;
+    return 0 == sigaction(SIGRTMIN, &action, nullptr);
+}
+
+int signal_thread(pid_t pid, pid_t tid, uid_t uid, int signum, sigval payload) {
+    siginfo_t info;
+    memset(&info, '\0', sizeof(info));
+    info.si_signo = signum;
+    info.si_code = SI_QUEUE;
+    info.si_pid = pid;
+    info.si_uid = uid;
+    info.si_value = payload;
+    return syscall(SYS_rt_tgsigqueueinfo, pid, tid, signum, &info);
+}
+
+std::string get_stack_trace_for_thread(int tid, int timeout_ms) {
+    static bool sighandler_installed = false;
+    if (!sighandler_installed) {
+        if (!install_stack_trace_sighandler()) {
+            auto msg = strings::Substitute("install stack trace signal handler failed, error: $0 tid: $1",
+                                           strerror(errno), tid);
+            LOG(WARNING) << msg;
+            return msg;
+        }
+        sighandler_installed = true;
+    }
+    StackTraceTask task;
+    const auto pid = getpid();
+    const auto uid = getuid();
+    union sigval payload;
+    payload.sival_ptr = &task;
+    auto err = signal_thread(pid, tid, uid, SIGRTMIN, payload);
+    if (0 != err) {
+        auto msg = strings::Substitute("collect stack trace failed, signal thread error: $0 tid: $1", strerror(errno),
+                                       tid);
+        LOG(WARNING) << msg;
+        return msg;
+    }
+    int timeout_us = timeout_ms * 1000;
+    while (!task.done) {
+        usleep(1000);
+        timeout_us -= 1000;
+        if (timeout_us <= 0) {
+            auto msg = strings::Substitute("collect stack trace timeout tid: $0", tid);
+            LOG(WARNING) << msg;
+            return msg;
+        }
+    }
+    std::string ret = "Stack trace tid: " + std::to_string(tid) + "\n" + task.to_string();
+    LOG(INFO) << ret;
+    return ret;
+}
+
+std::string get_stack_trace_for_threads(const std::vector<int>& tids, int timeout_ms) {
+    static bool sighandler_installed = false;
+    if (!sighandler_installed) {
+        if (!install_stack_trace_sighandler()) {
+            auto msg = strings::Substitute("install stack trace signal handler failed, error: $0", strerror(errno));
+            LOG(WARNING) << msg;
+            return msg;
+        }
+        sighandler_installed = true;
+    }
+    vector<StackTraceTask> tasks(tids.size());
+    const auto pid = getpid();
+    const auto uid = getuid();
+    for (int i = 0; i < tids.size(); ++i) {
+        union sigval payload;
+        payload.sival_ptr = &tasks[i];
+        auto err = signal_thread(pid, tids[i], uid, SIGRTMIN, payload);
+        if (0 != err) {
+            auto msg = strings::Substitute("collect stack trace failed, signal thread error: $0 tid: $1",
+                                           strerror(errno), tids[i]);
+            LOG(WARNING) << msg;
+        }
+    }
+    int timeout_us = timeout_ms * 1000;
+    while (true) {
+        usleep(1000);
+        int done = 0;
+        for (int i = 0; i < tids.size(); ++i) {
+            if (tasks[i].done) {
+                ++done;
+            }
+        }
+        // ignore jemalloc_bg_thd thread, it cannot be signal/sampled
+        if (done >= tids.size() - 1) {
+            break;
+        }
+        timeout_us -= 1000;
+        if (timeout_us <= 0) {
+            auto msg = strings::Substitute("collect stack trace timeout $0/$1 done", done, tids.size());
+            LOG(WARNING) << msg;
+            break;
+        }
+    }
+    // group threads with same stack trace together
+    std::unordered_map<StackTraceTask, std::vector<int>, StackTraceTaskHash> task_map;
+    for (int i = 0; i < tids.size(); ++i) {
+        if (tasks[i].done) {
+            task_map[tasks[i]].push_back(tids[i]);
+        }
+    }
+    string ret;
+    for (auto& e : task_map) {
+        if (e.second.size() == 1) {
+            ret += strings::Substitute("tid: $0\n", e.second[0]);
+        } else {
+            ret += strings::Substitute("$0 tids: ", e.second.size());
+            for (size_t i = 0; i < e.second.size(); i++) {
+                if (i > 0) {
+                    ret += ",";
+                }
+                ret += std::to_string(e.second[i]);
+            }
+            ret += "\n";
+        }
+        ret += e.first.to_string();
+        ret += "\n";
+    }
+    ret += strings::Substitute("total $0 threads, $1 identical groups", tids.size(), task_map.size());
+    return ret;
+}
+
+std::string get_stack_trace_for_all_threads() {
+    return get_stack_trace_for_threads(get_thread_id_list(), 3000);
+}
+
+std::vector<int> get_thread_id_list() {
+    std::vector<int> thread_id_list;
+    auto dir = opendir("/proc/self/task");
+    if (dir == nullptr) {
+        return thread_id_list;
+    }
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        if (entry->d_type == DT_DIR) {
+            int tid = atoi(entry->d_name);
+            if (tid != 0) {
+                thread_id_list.push_back(tid);
+            }
+        }
+    }
+    closedir(dir);
+    return thread_id_list;
 }
 
 class ExceptionStackContext {

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <typeinfo>
+#include <vector>
 
 namespace starrocks {
 
@@ -26,6 +27,12 @@ namespace starrocks {
 // Note: there is a libc bug that causes this not to work on 64 bit machines
 // for recursive calls.
 std::string get_stack_trace();
+
+std::vector<int> get_thread_id_list();
+bool install_stack_trace_sighandler();
+std::string get_stack_trace_for_thread(int tid, int timeout_ms);
+std::string get_stack_trace_for_threads(const std::vector<int>& tids, int timeout_ms);
+std::string get_stack_trace_for_all_threads();
 
 // wrap libc's _cxa_throw to print stack trace of exceptions
 extern "C" {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20506

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
After pr #20473 adding thread information to information_schema table, an admin can get the thread status running on each BE, the next step is to inspect those threads,  e.g. get a stack trace of the suspected thread. 
Currently, to get stacktrace, an admin needs to login in to BE machine, using gdb or pstack, this process may not always be feasible.  This feature allows an admin to get stackstrace using a SQL command through MySQL connection directly:

```
mysql> select * from be_threads where idle=false;
+-------+-------------+-----------------+-----------------+--------+------+----------------+
| BE_ID | GROUP       | NAME            | PTHREAD_ID      | TID    | IDLE | FINISHED_TASKS |
+-------+-------------+-----------------+-----------------+--------+------+----------------+
| 10004 | thread pool | pip_wg_executor | 140035889227520 | 363319 |    0 |              1 |
+-------+-------------+-----------------+-----------------+--------+------+----------------+
1 row in set (0.03 sec)

mysql> admin execute on 10004 '
    '> System.print(ExecEnv.get_stack_trace_for_thread(363319,1000))
    '> ';
Query OK, 0 rows affected (0.04 sec)
Stack trace tid: 363319:
    0x7f5d2f4e93c0  (unknown)
    0x7f5d2f4e4374  __pthread_cond_wait
         0x87fc1e0  std::condition_variable::wait()
         0x389b714  starrocks::pipeline::WorkGroupDriverQueue::take()
         0x3895955  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
         0x599a7bb  starrocks::ThreadPool::dispatch_thread()
         0x59944cb  starrocks::Thread::supervise_thread()
    0x7f5d2f4dd609  start_thread
    0x7f5d2f166163  clone
             (nil)  (unknown)


mysql> admin execute on 10004 '
System.print(ExecEnv.get_stack_trace_for_all_threads())
';
Query OK, 0 rows affected (0.44 sec)
tid: 451069
    0x7f1ebd9b09cf  __poll
         0x684cef6  apache::thrift::transport::TSocket::read()
         0x6855631  apache::thrift::transport::TBufferedTransport::readSlow()
         0x59429e8  apache::thrift::transport::readAll<>()
         0x30501e6  apache::thrift::protocol::TVirtualProtocol<>::readMessageBegin_virt()
         0x5aa9960  apache::thrift::TDispatchProcessor::process()
         0x68575c6  apache::thrift::server::TConnectedClient::run()
         0x685c618  apache::thrift::server::TThreadedServer::TConnectedClientRunner::run()
         0x685f161  apache::thrift::concurrency::Thread::threadMain()
         0x6838909  std::thread::_State_impl<>::_M_run()
         0x88747a4  execute_native_thread_routine
    0x7f1ebdd34609  start_thread
    0x7f1ebd9bd163  clone
             (nil)  (unknown)
...
23 tids: 450805,450806,450807,450808,450809,450810,450812,450813,450858,450859,450860,450861,450862,450863,450864,450865,450866,450867,450868,450869,450870,450871,450872
    0x7f1ebd9b676b  syscall
         0x69f9ada  bthread::TaskGroup::wait_task()
         0x69fcc6b  bthread::TaskGroup::run_main_task()
         0x69f669d  bthread::TaskControl::worker_thread()
    0x7f1ebdd34609  start_thread
    0x7f1ebd9bd163  clone
             (nil)  (unknown)

total 932 threads, 55 identical groups


``` 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
