### PR TITLE
[BugFix] Missing last empty EOS chunk caused query cache hangs

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -494,7 +494,9 @@ void PipelineDriver::_update_overhead_timer() {
 
 std::string PipelineDriver::to_readable_string() const {
     std::stringstream ss;
-    ss << "driver=" << this << ", status=" << ds_to_string(this->driver_state()) << ", operator-chain: [";
+    ss << "query_id=" << print_id(this->query_ctx()->query_id())
+       << " fragment_id=" << print_id(this->fragment_ctx()->fragment_instance_id()) << " driver=" << this
+       << ", status=" << ds_to_string(this->driver_state()) << ", operator-chain: [";
     for (size_t i = 0; i < _operators.size(); ++i) {
         if (i == 0) {
             ss << _operators[i]->get_name();

--- a/be/src/exec/query_cache/cache_operator.cpp
+++ b/be/src/exec/query_cache/cache_operator.cpp
@@ -81,15 +81,15 @@ struct PerLaneBuffer {
         }
         // CRITICAL!!!: we should append last empty chunk to the empty buffer to guarantee that pull_chunk method
         // would fetch a chunk and reset_lane.
-        if (!chunk->is_empty() || (chunks.empty() && chunk->owner_info().is_last_chunk())) {
+        // We must guarantee happen-before invariant as follows:
+        // append EOS chunk[PLBS_TOTAL] -> propulate_cache[PLBS_POPULATE] -> pull last EOS chunk -> release_lane
+        if (!chunk->is_empty() || chunk->owner_info().is_last_chunk()) {
             chunks.push_back(chunk);
             num_rows += chunk->num_rows();
             num_bytes += chunk->bytes_usage();
         }
 
-        if (chunk->owner_info().is_last_chunk()) {
-            state = chunk->owner_info().is_last_chunk() ? PLBS_TOTAL : PLBS_PARTIAL;
-        }
+        state = chunk->owner_info().is_last_chunk() ? PLBS_TOTAL : PLBS_PARTIAL;
     }
 
     bool has_chunks() const { return next_chunk_idx < chunks.size(); }
@@ -100,7 +100,7 @@ struct PerLaneBuffer {
         }
     }
 
-    bool can_release() {
+    bool can_release() const {
         return (state == PLBS_POPULATE || state == PLBS_PASSTHROUGH || state == PLBS_HIT_TOTAL) && !has_chunks();
     }
 
@@ -466,7 +466,7 @@ bool CacheOperator::is_finished() const {
 bool CacheOperator::has_output() const {
     for (const auto& [_, lane_id] : _owner_to_lanes) {
         auto& buffer = _per_lane_buffers[lane_id];
-        if (buffer->has_chunks()) {
+        if (buffer->has_chunks() || buffer->can_release()) {
             return true;
         }
     }
@@ -556,10 +556,13 @@ Status CacheOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
 }
 
 ChunkPtr CacheOperator::_pull_chunk_from_per_lane_buffer(PerLaneBufferPtr& buffer) {
-    if (buffer->has_chunks()) {
+    if (buffer->can_release()) {
+        _lane_arbiter->release_lane(buffer->lane_owner);
+        buffer->reset();
+    } else if (buffer->has_chunks()) {
         auto chunk = buffer->get_next_chunk();
         if (buffer->can_release()) {
-            _lane_arbiter->release_lane(chunk->owner_info().owner_id());
+            _lane_arbiter->release_lane(buffer->lane_owner);
             buffer->reset();
         }
         return chunk;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Daily cases as follows hangs utill query evaluation reach timeout.
- test_query_cache_invalidated_by_delete_operation
- test_query_cache_invalidated_by_delete_operation_and_repopulate
- test_query_cache_invalidated_by_new_ingestion
- test_query_cache_invalidated_by_new_ingestion_and_repopulate
- test_query_cache_probe_predicates_is_subset

The root cause is that when appending a empty chunk into PerLaneBuffer of CacheOperator, if the PerLaneBuffer is not empty, the empty EOS chunk is neglected.  the Operator following the CacheOperator would consume all the chunks in he PerLaneBuffer before the CacheOperator invokes popolate_cache, this facts leads to the Lane is not released. For an examples.
scan_operator->project->per_tablet_agg->cache_operator->inter_tablet_agg
t0: scan_operator reads out chunks 1[num_rows=10, EOS=false, tablet_id=100];
t1: scan_operator reads out chunks 2[num_rows=2, EOS=false, tablet_id=100];
t2: cache_operator consumes chunks1 and chunks2
t3: inter_tablet_agg consumes chunks1 and chunks2
t4: scan_operator emit EOS chunk 3[num_rows=0, EOS=true, tablet_id=100];
t5: cache_operator neglects empty EOS chunk 3, then populate_cache.
t6: cache_operator invokes has_output which invokes PerLaneBuffer.has_chunks return false, so pull_chunk has no chance to invoke LaneArbiter::release_lane to make the Lane available again for re-use. 

Last empty EOS chunk some like a barrier interpolated between popolate_cache and release_lane, so we must guarantee invariants as follows:
append EOS chunk[PLBS_TOTAL] -> propulate_cache[PLBS_POPULATE] -> pull last EOS chunk -> release_lane

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
