### PR TITLE
[Enhancement] Add query execution statistics to QueryDetail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -260,6 +260,16 @@ public class ConnectProcessor {
         queryDetail.setEndTime(endTime);
         queryDetail.setLatency(elapseMs);
         queryDetail.setResourceGroupName(ctx.getResourceGroup() != null ? ctx.getResourceGroup().getName() : "");
+        // add execution statistics into queryDetail
+        queryDetail.setReturnRows(ctx.getReturnRows());
+        PQueryStatistics statistics = executor.getQueryStatisticsForAuditLog();
+        if (statistics != null) {
+            queryDetail.setScanBytes(statistics.scanBytes);
+            queryDetail.setScanRows(statistics.scanRows);
+            queryDetail.setCpuCostNs(statistics.cpuCostNs == null ? -1 : statistics.cpuCostNs);
+            queryDetail.setMemCostBytes(statistics.memCostBytes == null ? -1 : statistics.memCostBytes);
+        }
+
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -34,7 +34,6 @@
 
 package com.starrocks.qe;
 
-
 import java.io.Serializable;
 
 public class QueryDetail implements Serializable {
@@ -72,6 +71,11 @@ public class QueryDetail implements Serializable {
     private String explain;
     private String profile;
     private String resourceGroupName;
+    private long scanRows = -1;
+    private long scanBytes = -1;
+    private long returnRows = -1;
+    private long cpuCostNs = -1;
+    private long memCostBytes = -1;
 
     public QueryDetail() {
     }
@@ -118,6 +122,11 @@ public class QueryDetail implements Serializable {
         queryDetail.errorMessage = this.errorMessage;
         queryDetail.explain = this.explain;
         queryDetail.profile = this.profile;
+        queryDetail.scanRows = this.scanRows;
+        queryDetail.scanBytes = this.scanBytes;
+        queryDetail.returnRows = this.returnRows;
+        queryDetail.cpuCostNs = this.cpuCostNs;
+        queryDetail.memCostBytes = this.memCostBytes;
         return queryDetail;
     }
 
@@ -239,5 +248,45 @@ public class QueryDetail implements Serializable {
 
     public void setResourceGroupName(String workGroupName) {
         this.resourceGroupName = workGroupName;
+    }
+
+    public long getScanRows() {
+        return scanRows;
+    }
+
+    public void setScanRows(long scanRows) {
+        this.scanRows = scanRows;
+    }
+
+    public long getScanBytes() {
+        return scanBytes;
+    }
+
+    public void setScanBytes(long scanBytes) {
+        this.scanBytes = scanBytes;
+    }
+
+    public long getReturnRows() {
+        return returnRows;
+    }
+
+    public void setReturnRows(long returnRows) {
+        this.returnRows = returnRows;
+    }
+
+    public long getCpuCostNs() {
+        return cpuCostNs;
+    }
+
+    public void setCpuCostNs(long cpuCostNs) {
+        this.cpuCostNs = cpuCostNs;
+    }
+
+    public long getMemCostBytes() {
+        return memCostBytes;
+    }
+
+    public void setMemCostBytes(long memCostBytes) {
+        this.memCostBytes = memCostBytes;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -47,6 +47,11 @@ public class QueryDetailQueueTest {
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                 "testDb", "select * from table1 limit 1",
                 "root", "");
+        startQueryDetail.setScanRows(100);
+        startQueryDetail.setScanBytes(10001);
+        startQueryDetail.setReturnRows(1);
+        startQueryDetail.setCpuCostNs(1002);
+        startQueryDetail.setMemCostBytes(100003);
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(startQueryDetail);
 
         List<QueryDetail> queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startQueryDetail.getEventTime() - 1);
@@ -62,7 +67,12 @@ public class QueryDetailQueueTest {
                 + "\"startTime\":" + startQueryDetail.getStartTime() + ",\"endTime\":-1,\"latency\":-1,"
                 + "\"state\":\"RUNNING\",\"database\":\"testDb\","
                 + "\"sql\":\"select * from table1 limit 1\","
-                + "\"user\":\"root\"}]";
+                + "\"user\":\"root\","
+                + "\"scanRows\":100,"
+                + "\"scanBytes\":10001,"
+                + "\"returnRows\":1,"
+                + "\"cpuCostNs\":1002,"
+                + "\"memCostBytes\":100003}]";
         Assert.assertEquals(jsonString, queryDetailString);
 
         queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startQueryDetail.getEventTime());


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #

## Problem Summary(Required) ：

For Aliyun EMR Serverless StarRocks, we use /api/query_detail api to collect user's query logs and store the logs in user's StarRocks query log table. Our user can use that table to audit their query histories, which acts like the role of audit.log.

However, the real audit.log contains some query execution statistics, such as returnRows, scanBytes, scanRows, cpuCostNs, memCostBytes, all of these are not a part of query_detail.

So in this PR, we want to add those query execution statistics to QueryDetail, so we can collect and store them in our user's query log table.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
