### PR TITLE
[BugFix][branch-2.4] Incorrect query during compaction with delete predicates (backport #20362) 

### DIFF
--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -252,6 +252,8 @@ public:
 
     bool contains_version(Version version) const { return rowset_meta()->version().contains(version); }
 
+    DeletePredicatePB* mutable_delete_predicate() { return _rowset_meta->mutable_delete_predicate(); }
+
     static bool comparator(const RowsetSharedPtr& left, const RowsetSharedPtr& right) {
         return left->end_version() < right->end_version();
     }

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1547,6 +1547,11 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
             break;
         }
         LOG(INFO) << "new rowset has " << (*new_rowset)->num_segments() << " segments";
+        if (sc_params.rowsets_to_change[i]->rowset_meta()->has_delete_predicate()) {
+            (*new_rowset)
+                    ->mutable_delete_predicate()
+                    ->CopyFrom(sc_params.rowsets_to_change[i]->rowset_meta()->delete_predicate());
+        }
         status = sc_params.new_tablet->add_rowset(*new_rowset, false);
         if (status.is_already_exist()) {
             LOG(WARNING) << "version already exist, version revert occurred. "

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -303,10 +303,15 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
     PredicateParser pred_parser(_tablet->tablet_schema());
 
     std::shared_lock header_lock(_tablet->get_header_lock());
-    for (const DeletePredicatePB& pred_pb : _tablet->delete_predicates()) {
-        if (pred_pb.version() > _delete_predicates_version.second) {
+    // here we can not use DeletePredicatePB from  _tablet->delete_predicates() because
+    // _rowsets maybe stale rowset, and stale rowset's delete predicates may be removed
+    // from _tablet->delete_predicates() after compation
+    for (const RowsetSharedPtr& rowset : _rowsets) {
+        const RowsetMetaSharedPtr& rowset_meta = rowset->rowset_meta();
+        if (!rowset_meta->has_delete_predicate()) {
             continue;
         }
+        const DeletePredicatePB& pred_pb = rowset_meta->delete_predicate();
 
         ConjunctivePredicates conjunctions;
         for (int i = 0; i != pred_pb.sub_predicates_size(); ++i) {

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -11,6 +11,7 @@
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
+#include "storage/base_compaction.h"
 #include "storage/chunk_helper.h"
 #include "storage/compaction.h"
 #include "storage/compaction_utils.h"
@@ -19,6 +20,8 @@
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_meta.h"
+#include "storage/tablet_reader.h"
+#include "storage/tablet_reader_params.h"
 #include "testutil/assert.h"
 
 namespace starrocks::vectorized {
@@ -78,6 +81,24 @@ public:
         in_pred->set_is_not_in(false);
         in_pred->add_values("0");
 
+        tablet_meta->add_rs_meta(src_rowset->rowset_meta());
+    }
+
+    void write_delete_version2(const TabletMetaSharedPtr& tablet_meta, int64_t version) {
+        RowsetWriterContext rowset_writer_context(kDataFormatV2, config::storage_format_version);
+        create_rowset_writer_context(&rowset_writer_context, version);
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(rowset_writer_context, &rowset_writer).ok());
+
+        rowset_writer->flush();
+        RowsetSharedPtr src_rowset = *rowset_writer->build();
+        ASSERT_TRUE(src_rowset != nullptr);
+        ASSERT_EQ(0, src_rowset->num_rows());
+
+        auto* delete_predicate = src_rowset->rowset_meta()->mutable_delete_predicate();
+        delete_predicate->set_version(version);
+        string condition_str = "k1<=100000";
+        delete_predicate->add_sub_predicates(condition_str);
         tablet_meta->add_rs_meta(src_rowset->rowset_meta());
     }
 
@@ -852,6 +873,110 @@ TEST_F(CumulativeCompactionTest, test_read_chunk_size) {
     mem_limit = 0;
     ASSERT_EQ(config_chunk_size, CompactionUtils::get_read_chunk_size(mem_limit, config_chunk_size, total_num_rows,
                                                                       total_mem_footprint, source_num));
+}
+
+TEST_F(CumulativeCompactionTest, test_issue_20084) {
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta);
+    write_new_version(tablet_meta);
+    write_new_version(tablet_meta);
+    write_delete_version2(tablet_meta, _version);
+    _version++;
+    write_new_version(tablet_meta);
+    write_new_version(tablet_meta);
+
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(
+            tablet_meta, starrocks::ExecEnv::GetInstance()->storage_engine()->get_stores()[0]);
+    tablet->init();
+
+    std::shared_ptr<Schema> schema = std::make_shared<Schema>(ChunkHelper::convert_schema(*_tablet_schema));
+    // test reader
+    auto reader = std::make_shared<TabletReader>(tablet, Version(0, _version - 1), *schema);
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*schema, 1024);
+    int count_rows = 0;
+    while (true) {
+        read_chunk_ptr->reset();
+        auto res = reader->get_next(read_chunk_ptr.get());
+        if (res.is_end_of_file()) {
+            break;
+        }
+        count_rows += read_chunk_ptr->num_rows();
+    }
+    ASSERT_EQ(count_rows, 2048);
+    reader->close();
+
+    reader = std::make_shared<TabletReader>(tablet, Version(0, _version - 1), *schema);
+    ASSERT_OK(reader->prepare());
+
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+        ASSERT_EQ(4, tablet->version_count());
+        ASSERT_EQ(3, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(4, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(2, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(4, versions[2].second);
+        ASSERT_EQ(5, versions[3].first);
+        ASSERT_EQ(5, versions[3].second);
+    }
+
+    {
+        CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = cumulative_compaction.compact();
+        ASSERT_TRUE(res.ok());
+        ASSERT_EQ(3, tablet->version_count());
+        ASSERT_EQ(6, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(3, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(2, versions[0].second);
+        ASSERT_EQ(3, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+        ASSERT_EQ(4, versions[2].first);
+        ASSERT_EQ(5, versions[2].second);
+    }
+
+    {
+        BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
+        auto res = base_compaction.compact();
+        ASSERT_TRUE(res.ok());
+        ASSERT_EQ(1, tablet->version_count());
+        ASSERT_EQ(6, tablet->cumulative_layer_point());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(1, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(5, versions[0].second);
+    }
+
+    ASSERT_OK(reader->open(params));
+    count_rows = 0;
+    while (true) {
+        read_chunk_ptr->reset();
+        auto res = reader->get_next(read_chunk_ptr.get());
+        if (res.is_end_of_file()) {
+            break;
+        }
+        count_rows += read_chunk_ptr->num_rows();
+    }
+    ASSERT_EQ(count_rows, 2048);
+    reader->close();
 }
 
 } // namespace starrocks::vectorized


### PR DESCRIPTION
For duplicate tablet with delete predicate rowset, compaction will merge serveral rowsets(with delete predicate rowset) into 1 large rowset(without delete predicate). After compaction, stale rowsets' delete predications will be removed in tablet_meta(TabletMeta::modify_rs_metas function).

There exists an contention case if a query during compaction with delete predicates.

For example, if table's rowset is [0-2],[3-3], rowset [3,3] is delete rowset And query and compaction happen in the following order: (1) a query come before the compaction, and its version is [0,3], then TabletReader will select rowset [0,2] and [3,3] in prepare(). (2) Compaction happens, rowset [0,2] and [3,3] are merged into rowset [0,3], rowset [0-3] doesn't contain delete predicate. After that, delete predicates for [3,3] is removed in _del_pred_array of tablet_meta. (3) TabletReader executes TabletReader::open and _init_delete_predicates, because delete predicates for [3,3] has been removed in tablet_meta, then _init_delete_predicates will return 0 delete predicates, and the query will ignore the delete predicate of [3,3], this will result in incorrect query result.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20084

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
