### PR TITLE
[BugFix][branch-2.3] Incorrect query during compaction with delete predicates (backport #20362)

### DIFF
--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -222,6 +222,8 @@ public:
 
     bool contains_version(Version version) const { return rowset_meta()->version().contains(version); }
 
+    DeletePredicatePB* mutable_delete_predicate() { return _rowset_meta->mutable_delete_predicate(); }
+
     static bool comparator(const RowsetSharedPtr& left, const RowsetSharedPtr& right) {
         return left->end_version() < right->end_version();
     }

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1546,6 +1546,11 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
             break;
         }
         LOG(INFO) << "new rowset has " << (*new_rowset)->num_segments() << " segments";
+        if (sc_params.rowsets_to_change[i]->rowset_meta()->has_delete_predicate()) {
+            (*new_rowset)
+                    ->mutable_delete_predicate()
+                    ->CopyFrom(sc_params.rowsets_to_change[i]->rowset_meta()->delete_predicate());
+        }
         status = sc_params.new_tablet->add_rowset(*new_rowset, false);
         if (status.is_already_exist()) {
             LOG(WARNING) << "version already exist, version revert occurred. "

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -302,10 +302,15 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
     PredicateParser pred_parser(_tablet->tablet_schema());
 
     std::shared_lock header_lock(_tablet->get_header_lock());
-    for (const DeletePredicatePB& pred_pb : _tablet->delete_predicates()) {
-        if (pred_pb.version() > _delete_predicates_version.second) {
+    // here we can not use DeletePredicatePB from  _tablet->delete_predicates() because
+    // _rowsets maybe stale rowset, and stale rowset's delete predicates may be removed
+    // from _tablet->delete_predicates() after compation
+    for (const RowsetSharedPtr& rowset : _rowsets) {
+        const RowsetMetaSharedPtr& rowset_meta = rowset->rowset_meta();
+        if (!rowset_meta->has_delete_predicate()) {
             continue;
         }
+        const DeletePredicatePB& pred_pb = rowset_meta->delete_predicate();
 
         ConjunctivePredicates conjunctions;
         for (int i = 0; i != pred_pb.sub_predicates_size(); ++i) {


### PR DESCRIPTION
For duplicate tablet with delete predicate rowset, compaction will merge serveral rowsets(with delete predicate rowset) into 1 large rowset(without delete predicate). After compaction, stale rowsets' delete predications will be removed in tablet_meta(TabletMeta::modify_rs_metas function).

There exists an contention case if a query during compaction with delete predicates.

For example, if table's rowset is [0-2],[3-3], rowset [3,3] is delete rowset And query and compaction happen in the following order: (1) a query come before the compaction, and its version is [0,3], then TabletReader will select rowset [0,2] and [3,3] in prepare(). (2) Compaction happens, rowset [0,2] and [3,3] are merged into rowset [0,3], rowset [0-3] doesn't contain delete predicate. After that, delete predicates for [3,3] is removed in _del_pred_array of tablet_meta. (3) TabletReader executes TabletReader::open and _init_delete_predicates, because delete predicates for [3,3] has been removed in tablet_meta, then _init_delete_predicates will return 0 delete predicates, and the query will ignore the delete predicate of [3,3], this will result in incorrect query result.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20084

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
