### PR TITLE
[UT] Fix the problem of routine load test case (#20691)

### DIFF
--- a/be/test/runtime/routine_load_task_executor_test.cpp
+++ b/be/test/runtime/routine_load_task_executor_test.cpp
@@ -57,6 +57,7 @@ public:
 
         config::routine_load_thread_pool_size = 5;
         config::max_consumer_num_per_group = 3;
+        config::routine_load_kafka_timeout_second = 3;
     }
 
     void TearDown() override {


### PR DESCRIPTION
If not init, the config::routine_load_kafka_timeout_second default is zero, the KafkaDataConsumer::group_consume  will be infinite loop.
