### PR TITLE
[BugFix] Missing last empty EOS chunk caused query cache hangs (backport #20699)

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -461,7 +461,9 @@ void PipelineDriver::_update_overhead_timer() {
 
 std::string PipelineDriver::to_readable_string() const {
     std::stringstream ss;
-    ss << "driver=" << this << ", status=" << ds_to_string(this->driver_state()) << ", operator-chain: [";
+    ss << "query_id=" << print_id(this->query_ctx()->query_id())
+       << " fragment_id=" << print_id(this->fragment_ctx()->fragment_instance_id()) << " driver=" << this
+       << ", status=" << ds_to_string(this->driver_state()) << ", operator-chain: [";
     for (size_t i = 0; i < _operators.size(); ++i) {
         if (i == 0) {
             ss << _operators[i]->get_name();


### PR DESCRIPTION
cherry-pick #20722 

Daily cases as follows hangs utill query evaluation reach timeout.
- test_query_cache_invalidated_by_delete_operation
- test_query_cache_invalidated_by_delete_operation_and_repopulate
- test_query_cache_invalidated_by_new_ingestion
- test_query_cache_invalidated_by_new_ingestion_and_repopulate
- test_query_cache_probe_predicates_is_subset

The root cause is that when appending a empty chunk into PerLaneBuffer of CacheOperator, if the PerLaneBuffer is not empty, the empty EOS chunk is neglected.  the Operator following the CacheOperator would consume all the chunks in he PerLaneBuffer before the CacheOperator invokes popolate_cache, this facts leads to the Lane is not released. For an examples. scan_operator->project->per_tablet_agg->cache_operator->inter_tablet_agg 
- t0: scan_operator reads out chunks 1[num_rows=10, EOS=false, tablet_id=100]; 
- t1: scan_operator reads out chunks 2[num_rows=2, EOS=false, tablet_id=100]; 
- t2: cache_operator consumes chunks1 and chunks2
- t3: inter_tablet_agg consumes chunks1 and chunks2
- t4: scan_operator emit EOS chunk 3[num_rows=0, EOS=true, tablet_id=100]; 
- t5: cache_operator neglects empty EOS chunk 3, then populate_cache. 
- t6: cache_operator invokes has_output which invokes PerLaneBuffer.has_chunks return false, so pull_chunk has no chance to invoke LaneArbiter::release_lane to make the Lane available again for re-use.

Last empty EOS chunk some like a barrier interpolated between popolate_cache and release_lane, so we must guarantee invariants as follows: append EOS chunk[PLBS_TOTAL] -> propulate_cache[PLBS_POPULATE] -> pull last EOS chunk -> release_lane 

-----
Signed-off-by: satanson <ranpanf@gmail.com>
(cherry picked from commit 6d90b219158457a1d2b0a09bee1f4d33b2c52f62)

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
