### PR TITLE
[Enhancement] CrossJoinNode try catch chunk memory alloc (#20706)

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -248,6 +248,7 @@ Status ExecNode::get_next_big_chunk(RuntimeState* state, ChunkPtr* chunk, bool* 
         ChunkPtr cur_chunk = nullptr;
 
         RETURN_IF_ERROR(specific_get_next(state, &cur_chunk, &cur_eos));
+        TRY_CATCH_ALLOC_SCOPE_START()
         if (cur_eos) {
             if (pre_output_chunk != nullptr) {
                 *eos = false;
@@ -291,6 +292,7 @@ Status ExecNode::get_next_big_chunk(RuntimeState* state, ChunkPtr* chunk, bool* 
                 }
             }
         }
+        TRY_CATCH_ALLOC_SCOPE_END()
     }
 }
 

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -303,6 +303,7 @@ Status CrossJoinNode::get_next_internal(RuntimeState* state, ChunkPtr* chunk, bo
             continue;
         }
 
+        TRY_CATCH_ALLOC_SCOPE_START()
         if ((*chunk) == nullptr) {
             // we need a valid probe chunk to initialize the new chunk.
             _init_chunk(chunk);
@@ -396,6 +397,8 @@ Status CrossJoinNode::get_next_internal(RuntimeState* state, ChunkPtr* chunk, bo
         if ((*chunk)->num_rows() < runtime_state()->chunk_size()) {
             continue;
         }
+
+        TRY_CATCH_ALLOC_SCOPE_END()
 
         ExecNode::eval_conjuncts(_conjunct_ctxs, (*chunk).get());
 


### PR DESCRIPTION
Currently, the CrossJoinNode does not support memory checking before applying. When the Chunk is relatively large (large Bitmap column), there will be a problem of excessive memory usage. So add TryCatchBadAlloc here to check the actual memory before allocating
