### PR TITLE
[Enhancement] Optimize the performance of bitmap_contains on cross join for non-pipeline engine (#20653)

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -102,9 +102,10 @@ void AdaptiveNullableColumn::append_selective(const Column& src, const uint32_t*
     NullableColumn::append_selective(src, indexes, from, size);
 }
 
-void AdaptiveNullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void AdaptiveNullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size,
+                                                         bool deep_copy) {
     materialized_nullable();
-    NullableColumn::append_value_multiple_times(src, index, size);
+    NullableColumn::append_value_multiple_times(src, index, size, deep_copy);
 }
 
 bool AdaptiveNullableColumn::append_nulls(size_t count) {

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -270,7 +270,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -111,7 +111,7 @@ void ArrayColumn::append_selective(const Column& src, const uint32_t* indexes, u
 }
 
 // TODO(fzh): directly copy elements for un-nested arrays
-void ArrayColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void ArrayColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     for (uint32_t i = 0; i < size; i++) {
         append(src, index, 1);
     }

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -70,7 +70,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -77,7 +77,8 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
 }
 
 template <typename T>
-void BinaryColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void BinaryColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size,
+                                                      bool deep_copy) {
     auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
     auto& src_offsets = src_column.get_offset();
     auto& src_bytes = src_column.get_bytes();

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -79,7 +79,6 @@ public:
         }
     }
 
-    bool low_cardinality() const override { return false; }
     bool is_binary() const override { return std::is_same_v<T, uint32_t> != 0; }
     bool is_large_binary() const override { return std::is_same_v<T, uint64_t> != 0; }
 
@@ -167,7 +166,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override { return false; }
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -84,8 +84,6 @@ public:
 
     virtual bool is_struct() const { return false; }
 
-    virtual bool low_cardinality() const { return false; }
-
     virtual const uint8_t* raw_data() const = 0;
 
     virtual uint8_t* mutable_raw_data() = 0;
@@ -164,7 +162,7 @@ public:
         DCHECK(this->size() >= dest_size) << "The size of the source column is less when duplicating it.";
         dest->reserve(offsets.back());
         for (int i = 0; i < dest_size; ++i) {
-            dest->append_value_multiple_times(*this, i, offsets[i + 1] - offsets[i]);
+            dest->append_value_multiple_times(*this, i, offsets[i + 1] - offsets[i], true);
         }
         return dest;
     }
@@ -197,7 +195,8 @@ public:
     }
 
     // This function will get row through 'from' index from src, and copy size elements to this column.
-    virtual void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) = 0;
+    // Currently only `ObjectColumn<BitmapValue>` support shallow copy
+    virtual void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) = 0;
 
     // Append multiple `null` values into this column.
     // Return false if this is a non-nullable column, i.e, if `is_nullable` return false.

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -31,7 +31,7 @@ void ConstColumn::append_selective(const Column& src, const uint32_t* indexes, u
     append(src, indexes[from], size);
 }
 
-void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     append(src, index, size);
 }
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -43,8 +43,6 @@ public:
 
     bool is_constant() const override { return true; }
 
-    bool low_cardinality() const override { return false; }
-
     const uint8_t* raw_data() const override { return _data->raw_data(); }
 
     uint8_t* mutable_raw_data() override { return reinterpret_cast<uint8_t*>(_data->mutable_raw_data()); }
@@ -87,7 +85,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     virtual ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
 

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -41,7 +41,8 @@ void FixedLengthColumnBase<T>::append_selective(const Column& src, const uint32_
 }
 
 template <typename T>
-void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size,
+                                                           bool deep_copy) {
     const T* src_data = reinterpret_cast<const T*>(src.raw_data());
     size_t orig_size = _data.size();
     _data.resize(orig_size + size);

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -102,7 +102,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count __attribute__((unused))) override { return false; }
 

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -116,7 +116,7 @@ void MapColumn::append_selective(const Column& src, const uint32_t* indexes, uin
     }
 }
 
-void MapColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void MapColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     for (uint32_t i = 0; i < size; i++) {
         append(src, index, 1);
     }

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -68,7 +68,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -94,7 +94,7 @@ void NullableColumn::append_selective(const Column& src, const uint32_t* indexes
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
 
-void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     uint32_t orig_size = _null_column->size();
 
@@ -103,12 +103,12 @@ void NullableColumn::append_value_multiple_times(const Column& src, uint32_t ind
 
         DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());
 
-        _null_column->append_value_multiple_times(*src_column._null_column, index, size);
-        _data_column->append_value_multiple_times(*src_column._data_column, index, size);
+        _null_column->append_value_multiple_times(*src_column._null_column, index, size, deep_copy);
+        _data_column->append_value_multiple_times(*src_column._data_column, index, size, deep_copy);
         _has_null = _has_null || SIMD::contain_nonzero(_null_column->get_data(), orig_size, size);
     } else {
         _null_column->resize(orig_size + size);
-        _data_column->append_value_multiple_times(src, index, size);
+        _data_column->append_value_multiple_times(src, index, size, deep_copy);
     }
 
     DCHECK_EQ(_null_column->size(), _data_column->size());

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -67,8 +67,6 @@ public:
         return _has_null && immutable_null_column_data()[index];
     }
 
-    bool low_cardinality() const override { return false; }
-
     const uint8_t* raw_data() const override { return _data_column->raw_data(); }
 
     uint8_t* mutable_raw_data() override { return reinterpret_cast<uint8_t*>(_data_column->mutable_raw_data()); }
@@ -122,7 +120,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -81,16 +81,22 @@ void ObjectColumn<T>::append_selective(const starrocks::vectorized::Column& src,
     for (uint32_t j = 0; j < size; ++j) {
         append(obj_col.get_object(indexes[from + j]));
     }
-};
+}
 
 template <typename T>
 void ObjectColumn<T>::append_value_multiple_times(const starrocks::vectorized::Column& src, uint32_t index,
-                                                  uint32_t size) {
+                                                  uint32_t size, bool deep_copy) {
     const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
-    for (uint32_t j = 0; j < size; ++j) {
-        append(obj_col.get_object(index));
+    if constexpr (std::is_same_v<T, BitmapValue>) {
+        for (uint32_t i = 0; i < size; i++) {
+            append({*obj_col.get_object(index), deep_copy});
+        }
+    } else {
+        for (uint32_t i = 0; i < size; i++) {
+            append(obj_col.get_object(index));
+        }
     }
-};
+}
 
 template <typename T>
 bool ObjectColumn<T>::append_strings(const Buffer<starrocks::Slice>& strs) {

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -89,7 +89,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override { return false; }
 

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -149,12 +149,12 @@ void StructColumn::append_selective(const Column& src, const uint32_t* indexes, 
     }
 }
 
-void StructColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void StructColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     DCHECK(src.is_struct());
     const auto& src_column = down_cast<const StructColumn&>(src);
     DCHECK_EQ(_fields.size(), src_column._fields.size());
     for (size_t i = 0; i < _fields.size(); i++) {
-        _fields[i]->append_value_multiple_times(*src_column._fields[i], index, size);
+        _fields[i]->append_value_multiple_times(*src_column._fields[i], index, size, deep_copy);
     }
 }
 

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -79,7 +79,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     [[nodiscard]] bool append_nulls(size_t count) override;
 

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -387,7 +387,7 @@ void NLJoinProbeOperator::_permute_probe_row(RuntimeState* state, const ChunkPtr
         ColumnPtr& dst_col = chunk->get_column_by_slot_id(slot->id());
         if (is_probe) {
             ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot->id());
-            dst_col->append_value_multiple_times(*src_col, _probe_row_current, cur_build_chunk_rows);
+            dst_col->append_value_multiple_times(*src_col, _probe_row_current, cur_build_chunk_rows, true);
         } else {
             ColumnPtr& src_col = _curr_build_chunk->get_column_by_slot_id(slot->id());
             dst_col->append(*src_col);

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -226,7 +226,7 @@ void CrossJoinNode::_copy_probe_rows_with_index_base_probe(ColumnPtr& dest_col, 
             dest_col->append_nulls(copy_number);
         } else {
             // repeat the value from probe table for copy_number times
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number, false);
         }
     } else {
         if (src_col->is_constant()) {
@@ -237,7 +237,7 @@ void CrossJoinNode::_copy_probe_rows_with_index_base_probe(ColumnPtr& dest_col, 
             dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, copy_number);
         } else {
             // repeat the value from probe table for copy_number times
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number, false);
         }
     }
 }
@@ -298,14 +298,14 @@ void CrossJoinNode::_copy_build_rows_with_index_base_build(ColumnPtr& dest_col, 
             _buf_selective.assign(row_count, 0);
             dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, row_count);
         } else {
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count, false);
         }
     } else {
         if (src_col->is_constant()) {
             // current can't reach here
             dest_col->append_nulls(row_count);
         } else {
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count, false);
         }
     }
 }

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -140,6 +140,28 @@ TEST(ObjectColumnTest, test_object_column_upgrade_if_overflow) {
 }
 
 // NOLINTNEXTLINE
+TEST(ObjectColumnTest, test_append_value_multiple_times) {
+    auto src_col = BitmapColumn::create();
+    auto deep_copy_col = BitmapColumn::create();
+    auto shallow_copy_col = BitmapColumn::create();
+
+    BitmapValue bitmap;
+    for (size_t i = 0; i < 64; i++) {
+        bitmap.add(i);
+    }
+    src_col->append(&bitmap);
+
+    deep_copy_col->append_value_multiple_times(*src_col, 0, 4, true);
+    shallow_copy_col->append_value_multiple_times(*src_col, 0, 4, false);
+    src_col->get_object(0)->add(64);
+
+    for (size_t i = 0; i < 4; i++) {
+        ASSERT_EQ(deep_copy_col->get_object(0)->cardinality(), 64);
+        ASSERT_EQ(shallow_copy_col->get_object(0)->cardinality(), 65);
+    }
+}
+
+// NOLINTNEXTLINE
 TEST(ObjectColumnTest, test_object_column_downgrade) {
     auto c = HyperLogLogColumn::create();
     c->append(HyperLogLog());


### PR DESCRIPTION
For large bitmap, if we deep make many copies (chunk size), it will consume much memory.

Currently, in the executor and the expr framework, the elements in the Column will not be modified in place, so it is safe to do so. Currently only ObjectColumn real supports shallow copy.

Later, Column::append and Column::append_selective also need to be supported, which can be extended to more scenarios

select t1.c1, bitmap_count(t1.c2) from l2, t1 where bitmap_contains(c2, lo_orderkey);

Before Optimization: peak memory (3.36G), consume time(7s)
After Optimization: peak memory (3M), consume time (0.01s)

