### PR TITLE
[Enhancement] Optimize the performance of bitmap_contains on cross join for non-pipeline engine (#20653)

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -98,7 +98,7 @@ void ArrayColumn::append_selective(const Column& src, const uint32_t* indexes, u
     }
 }
 
-void ArrayColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void ArrayColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     for (uint32_t i = 0; i < size; i++) {
         append(src, index, 1);
     }

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -66,7 +66,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -73,7 +73,7 @@ void BinaryColumn::append_selective(const Column& src, const uint32_t* indexes, 
     _slices_cache = false;
 }
 
-void BinaryColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void BinaryColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     auto& src_column = down_cast<const BinaryColumn&>(src);
     auto& src_offsets = src_column.get_offset();
     auto& src_bytes = src_column.get_bytes();

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -140,7 +140,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override { return false; }
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -151,7 +151,8 @@ public:
     }
 
     // This function will get row through 'from' index from src, and copy size elements to this column.
-    virtual void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) = 0;
+    // Currently only `ObjectColumn<BitmapValue>` support shallow copy
+    virtual void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) = 0;
 
     // Append multiple `null` values into this column.
     // Return false if this is a non-nullable column, i.e, if `is_nullable` return false.

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -30,7 +30,7 @@ void ConstColumn::append_selective(const Column& src, const uint32_t* indexes, u
     append(src, indexes[from], size);
 }
 
-void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     append(src, index, size);
 }
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -43,8 +43,6 @@ public:
 
     bool is_constant() const override { return true; }
 
-    bool low_cardinality() const override { return false; }
-
     const uint8_t* raw_data() const override { return _data->raw_data(); }
 
     uint8_t* mutable_raw_data() override { return reinterpret_cast<uint8_t*>(_data->mutable_raw_data()); }
@@ -87,7 +85,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override {
         if (_data->is_nullable()) {

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -32,7 +32,8 @@ void FixedLengthColumnBase<T>::append_selective(const Column& src, const uint32_
 }
 
 template <typename T>
-void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size,
+                                                           bool deep_copy) {
     const T* src_data = reinterpret_cast<const T*>(src.raw_data());
     size_t orig_size = _data.size();
     _data.resize(orig_size + size);

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -92,7 +92,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count __attribute__((unused))) override { return false; }
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -88,7 +88,7 @@ void NullableColumn::append_selective(const Column& src, const uint32_t* indexes
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
 
-void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
+void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     uint32_t orig_size = _null_column->size();
 
@@ -97,12 +97,12 @@ void NullableColumn::append_value_multiple_times(const Column& src, uint32_t ind
 
         DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());
 
-        _null_column->append_value_multiple_times(*src_column._null_column, index, size);
-        _data_column->append_value_multiple_times(*src_column._data_column, index, size);
+        _null_column->append_value_multiple_times(*src_column._null_column, index, size, deep_copy);
+        _data_column->append_value_multiple_times(*src_column._data_column, index, size, deep_copy);
         _has_null = _has_null || SIMD::count_nonzero(&_null_column->get_data()[orig_size], size);
     } else {
         _null_column->resize(orig_size + size);
-        _data_column->append_value_multiple_times(src, index, size);
+        _data_column->append_value_multiple_times(src, index, size, deep_copy);
     }
 
     DCHECK_EQ(_null_column->size(), _data_column->size());

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -64,8 +64,6 @@ public:
         return _has_null && immutable_null_column_data()[index];
     }
 
-    bool low_cardinality() const override { return false; }
-
     const uint8_t* raw_data() const override { return _data_column->raw_data(); }
 
     uint8_t* mutable_raw_data() override { return reinterpret_cast<uint8_t*>(_data_column->mutable_raw_data()); }
@@ -119,7 +117,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -80,16 +80,22 @@ void ObjectColumn<T>::append_selective(const starrocks::vectorized::Column& src,
     for (uint32_t j = 0; j < size; ++j) {
         append(obj_col.get_object(indexes[from + j]));
     }
-};
+}
 
 template <typename T>
-void ObjectColumn<T>::append_value_multiple_times(const starrocks::vectorized::Column& src, uint32_t index,
-                                                  uint32_t size) {
+void ObjectColumn<T>::append_value_multiple_times(const vectorized::Column& src, uint32_t index, uint32_t size,
+                                                  bool deep_copy) {
     const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
-    for (uint32_t j = 0; j < size; ++j) {
-        append(obj_col.get_object(index));
+    if constexpr (std::is_same_v<T, BitmapValue>) {
+        for (uint32_t i = 0; i < size; i++) {
+            append({*obj_col.get_object(index), deep_copy});
+        }
+    } else {
+        for (uint32_t i = 0; i < size; i++) {
+            append(obj_col.get_object(index));
+        }
     }
-};
+}
 
 template <typename T>
 bool ObjectColumn<T>::append_strings(const Buffer<starrocks::Slice>& strs) {

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -86,7 +86,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override { return false; }
 

--- a/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
+++ b/be/src/exec/pipeline/crossjoin/cross_join_left_operator.cpp
@@ -75,7 +75,7 @@ void CrossJoinLeftOperator::_copy_probe_rows_with_index_base_probe(vectorized::C
             dest_col->append_nulls(copy_number);
         } else {
             // repeat the value from probe table for copy_number times
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number, false);
         }
     } else {
         if (src_col->is_constant()) {
@@ -86,7 +86,7 @@ void CrossJoinLeftOperator::_copy_probe_rows_with_index_base_probe(vectorized::C
             dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, copy_number);
         } else {
             // repeat the value from probe table for copy_number times
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number, false);
         }
     }
 }
@@ -150,14 +150,14 @@ void CrossJoinLeftOperator::_copy_build_rows_with_index_base_build(vectorized::C
             _buf_selective.assign(row_count, 0);
             dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, row_count);
         } else {
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count, false);
         }
     } else {
         if (src_col->is_constant()) {
             // current can't reach here
             dest_col->append_nulls(row_count);
         } else {
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count, false);
         }
     }
 }

--- a/be/src/exec/vectorized/cross_join_node.cpp
+++ b/be/src/exec/vectorized/cross_join_node.cpp
@@ -165,7 +165,7 @@ void CrossJoinNode::_copy_probe_rows_with_index_base_probe(ColumnPtr& dest_col, 
             dest_col->append_nulls(copy_number);
         } else {
             // repeat the value from probe table for copy_number times
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number, false);
         }
     } else {
         if (src_col->is_constant()) {
@@ -176,7 +176,7 @@ void CrossJoinNode::_copy_probe_rows_with_index_base_probe(ColumnPtr& dest_col, 
             dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, copy_number);
         } else {
             // repeat the value from probe table for copy_number times
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number, false);
         }
     }
 }
@@ -237,14 +237,14 @@ void CrossJoinNode::_copy_build_rows_with_index_base_build(ColumnPtr& dest_col, 
             _buf_selective.assign(row_count, 0);
             dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, row_count);
         } else {
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count, false);
         }
     } else {
         if (src_col->is_constant()) {
             // current can't reach here
             dest_col->append_nulls(row_count);
         } else {
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count, false);
         }
     }
 }


### PR DESCRIPTION
For large bitmap, if we deep make many copies (chunk size), it will consume much memory.

Currently, in the executor and the expr framework, the elements in the Column will not be modified in place, so it is safe to do so. Currently only ObjectColumn real supports shallow copy.

Later, Column::append and Column::append_selective also need to be supported, which can be extended to more scenarios

select t1.c1, bitmap_count(t1.c2) from l2, t1 where bitmap_contains(c2, lo_orderkey);

Before Optimization: peak memory (3.36G), consume time(7s)
After Optimization: peak memory (3M), consume time (0.01s)
