### PR TITLE
[Refactor] change tablet_meta_mem_tracker to metadata_mem_tracker (#10466)

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -181,10 +181,10 @@ void calculate_metrics(void* arg_this) {
 
         LOG(INFO) << fmt::format(
                 "Current memory statistics: process({}), query_pool({}), load({}), "
-                "tablet_meta({}), compaction({}), schema_change({}), column_pool({}), "
+                "metadata({}), compaction({}), schema_change({}), column_pool({}), "
                 "page_cache({}), update({}), chunk_allocator({}), clone({}), consistency({})",
                 mem_metrics->process_mem_bytes.value(), mem_metrics->query_mem_bytes.value(),
-                mem_metrics->load_mem_bytes.value(), mem_metrics->tablet_meta_mem_bytes.value(),
+                mem_metrics->load_mem_bytes.value(), mem_metrics->metadata_mem_bytes.value(),
                 mem_metrics->compaction_mem_bytes.value(), mem_metrics->schema_change_mem_bytes.value(),
                 mem_metrics->column_pool_mem_bytes.value(), mem_metrics->storage_page_cache_mem_bytes.value(),
                 mem_metrics->update_mem_bytes.value(), mem_metrics->chunk_allocator_mem_bytes.value(),

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -59,7 +59,7 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id << " schema hash:" << schema_hash;
         return Status::InternalError("no tablet exist");
     }
-    auto tablet_meta = TabletMeta::create(StorageEngine::instance()->tablet_meta_mem_tracker());
+    auto tablet_meta = TabletMeta::create(StorageEngine::instance()->metadata_mem_tracker());
     tablet->generate_tablet_meta_copy(tablet_meta);
     json2pb::Pb2JsonOptions json_options;
     json_options.pretty_json = true;

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -116,7 +116,7 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
             start_mem_tracker = ExecEnv::GetInstance()->load_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "tablet_meta") {
-            start_mem_tracker = ExecEnv::GetInstance()->tablet_meta_mem_tracker();
+            start_mem_tracker = ExecEnv::GetInstance()->metadata_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "query_pool") {
             start_mem_tracker = ExecEnv::GetInstance()->query_pool_mem_tracker();
@@ -155,7 +155,7 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
 
     // Metadata memory statistics use the old memory framework,
     // not in RootMemTrackerTree, so it needs to be added here
-    MemTracker* meta_mem_tracker = ExecEnv::GetInstance()->tablet_meta_mem_tracker();
+    MemTracker* meta_mem_tracker = ExecEnv::GetInstance()->metadata_mem_tracker();
     MemTracker::SimpleItem meta_item{"tablet_meta",
                                      "process",
                                      2,

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -276,7 +276,7 @@ Status ExecEnv::init_mem_tracker() {
     int64_t load_mem_limit = calc_max_load_memory(_mem_tracker->limit());
     _load_mem_tracker = new MemTracker(MemTracker::LOAD, load_mem_limit, "load", _mem_tracker);
     // Metadata statistics memory statistics do not use new mem statistics framework with hook
-    _tablet_meta_mem_tracker = new MemTracker(-1, "tablet_meta", nullptr);
+    _metadata_mem_tracker = new MemTracker(-1, "tablet_meta", nullptr);
 
     int64_t compaction_mem_limit = calc_max_compaction_memory(_mem_tracker->limit());
     _compaction_mem_tracker = new MemTracker(compaction_mem_limit, "compaction", _mem_tracker);
@@ -292,7 +292,7 @@ Status ExecEnv::init_mem_tracker() {
 
     ChunkAllocator::init_instance(_chunk_allocator_mem_tracker, config::chunk_reserved_bytes_limit);
 
-    GlobalTabletSchemaMap::Instance()->set_mem_tracker(_tablet_meta_mem_tracker);
+    GlobalTabletSchemaMap::Instance()->set_mem_tracker(_metadata_mem_tracker);
     SetMemTrackerForColumnPool op(_column_pool_mem_tracker);
     vectorized::ForEach<vectorized::ColumnPoolList>(op);
     starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
@@ -442,9 +442,10 @@ void ExecEnv::_destroy() {
         delete _compaction_mem_tracker;
         _compaction_mem_tracker = nullptr;
     }
-    if (_tablet_meta_mem_tracker) {
-        delete _tablet_meta_mem_tracker;
-        _tablet_meta_mem_tracker = nullptr;
+
+    if (_metadata_mem_tracker) {
+        delete _metadata_mem_tracker;
+        _metadata_mem_tracker = nullptr;
     }
     if (_load_mem_tracker) {
         delete _load_mem_tracker;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -115,7 +115,7 @@ public:
     MemTracker* process_mem_tracker() { return _mem_tracker; }
     MemTracker* query_pool_mem_tracker() { return _query_pool_mem_tracker; }
     MemTracker* load_mem_tracker() { return _load_mem_tracker; }
-    MemTracker* tablet_meta_mem_tracker() { return _tablet_meta_mem_tracker; }
+    MemTracker* metadata_mem_tracker() { return _metadata_mem_tracker; }
     MemTracker* compaction_mem_tracker() { return _compaction_mem_tracker; }
     MemTracker* schema_change_mem_tracker() { return _schema_change_mem_tracker; }
     MemTracker* column_pool_mem_tracker() { return _column_pool_mem_tracker; }
@@ -191,7 +191,7 @@ private:
     MemTracker* _load_mem_tracker = nullptr;
 
     // The memory for tablet meta
-    MemTracker* _tablet_meta_mem_tracker = nullptr;
+    MemTracker* _metadata_mem_tracker = nullptr;
 
     // The memory used for compaction
     MemTracker* _compaction_mem_tracker = nullptr;

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char** argv) {
     starrocks::EngineOptions options;
     options.store_paths = paths;
     options.backend_uid = starrocks::UniqueId::gen_uid();
-    options.tablet_meta_mem_tracker = exec_env->tablet_meta_mem_tracker();
+    options.metadata_mem_tracker = exec_env->metadata_mem_tracker();
     options.schema_change_mem_tracker = exec_env->schema_change_mem_tracker();
     options.compaction_mem_tracker = exec_env->compaction_mem_tracker();
     options.update_mem_tracker = exec_env->update_mem_tracker();

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -33,8 +33,8 @@ namespace starrocks {
 class MemTracker;
 
 struct StorePath {
-    StorePath() {}
-    StorePath(std::string path_) : path(std::move(path_)), storage_medium(TStorageMedium::HDD) {}
+    StorePath() = default;
+    explicit StorePath(std::string path_) : path(std::move(path_)), storage_medium(TStorageMedium::HDD) {}
     std::string path;
     TStorageMedium::type storage_medium{TStorageMedium::HDD};
 };
@@ -49,7 +49,7 @@ struct EngineOptions {
     std::vector<StorePath> store_paths;
     // BE's UUID. It will be reset every time BE restarts.
     UniqueId backend_uid{0, 0};
-    MemTracker* tablet_meta_mem_tracker = nullptr;
+    MemTracker* metadata_mem_tracker = nullptr;
     MemTracker* compaction_mem_tracker = nullptr;
     MemTracker* schema_change_mem_tracker = nullptr;
     MemTracker* update_mem_tracker = nullptr;

--- a/be/src/storage/rowset/beta_rowset.cpp
+++ b/be/src/storage/rowset/beta_rowset.cpp
@@ -77,8 +77,8 @@ Status BetaRowset::do_load() {
     size_t footer_size_hint = 16 * 1024;
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
-        auto res = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), block_mgr, seg_path, seg_id,
-                                 _schema, &footer_size_hint, rowset_meta()->partial_rowset_footer(seg_id));
+        auto res = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), block_mgr, seg_path, seg_id, _schema,
+                                 &footer_size_hint, rowset_meta()->partial_rowset_footer(seg_id));
         if (!res.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
             _segments.clear();
@@ -359,8 +359,8 @@ Status BetaRowset::reload() {
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
         block_mgr->erase_block_cache(seg_path);
-        auto res = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), block_mgr, seg_path, seg_id,
-                                 _schema, &footer_size_hint);
+        auto res = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), block_mgr, seg_path, seg_id, _schema,
+                                 &footer_size_hint);
         if (!res.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
             _segments.clear();

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -464,9 +464,8 @@ Status HorizontalBetaRowsetWriter::_final_merge() {
         std::string tmp_segment_file =
                 BetaRowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
 
-        auto segment_ptr =
-                Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), fs::fs_util::block_manager(),
-                              tmp_segment_file, seg_id, _context.tablet_schema);
+        auto segment_ptr = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs::fs_util::block_manager(),
+                                         tmp_segment_file, seg_id, _context.tablet_schema);
         if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
             return segment_ptr.status();

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -28,15 +28,13 @@
 #include "storage/rowset/beta_rowset_writer.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/vectorized/rowset_writer_adapter.h"
-#include "storage/vectorized/type_utils.h"
 
 namespace starrocks {
 
 Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::string& rowset_path,
                                     const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {
     if (rowset_meta->rowset_type() == BETA_ROWSET) {
-        *rowset =
-                BetaRowset::create(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), schema, rowset_path, rowset_meta);
+        *rowset = BetaRowset::create(ExecEnv::GetInstance()->metadata_mem_tracker(), schema, rowset_path, rowset_meta);
         RETURN_IF_ERROR((*rowset)->init());
         return Status::OK();
     }

--- a/be/src/storage/rowset/vectorized/segment_iterator.cpp
+++ b/be/src/storage/rowset/vectorized/segment_iterator.cpp
@@ -438,7 +438,7 @@ Status SegmentIterator::_get_row_ranges_by_keys() {
         return Status::OK();
     }
     DCHECK_EQ(0, _scan_range.span_size());
-    RETURN_IF_ERROR(_segment->_load_index(StorageEngine::instance()->tablet_meta_mem_tracker()));
+    RETURN_IF_ERROR(_segment->_load_index(StorageEngine::instance()->metadata_mem_tracker()));
     for (const SeekRange& range : _opts.ranges) {
         rowid_t lower_rowid = 0;
         rowid_t upper_rowid = num_rows();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -92,9 +92,8 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _available_storage_medium_type_count(0),
           _effective_cluster_id(-1),
           _is_all_cluster_id_exist(true),
-
           _file_cache(nullptr),
-          _tablet_manager(new TabletManager(options.tablet_meta_mem_tracker, config::tablet_map_shard_size)),
+          _tablet_manager(new TabletManager(options.metadata_mem_tracker, config::tablet_map_shard_size)),
           _txn_manager(new TxnManager(config::txn_map_shard_size, config::txn_shard_size, options.store_paths.size())),
           _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
           _memtable_flush_executor(nullptr),

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -181,7 +181,7 @@ public:
 
     bool bg_worker_stopped() { return _bg_worker_stopped.load(std::memory_order_consume); }
 
-    MemTracker* tablet_meta_mem_tracker() { return _options.tablet_meta_mem_tracker; }
+    MemTracker* metadata_mem_tracker() { return _options.metadata_mem_tracker; }
 
     void do_manual_compact(bool force_compact);
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -147,8 +147,7 @@ public:
     Status delete_shutdown_tablet(int64_t tablet_id);
 
     Status delete_shutdown_tablet_before_clone(int64_t tablet_id);
-
-    MemTracker* tablet_meta_mem_tracker() { return _mem_tracker; }
+    MemTracker* metadata_mem_tracker() { return _mem_tracker; }
 
 private:
     using TabletMap = std::unordered_map<int64_t, TabletSharedPtr>;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2611,7 +2611,7 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
         }
         std::string seg_path =
                 BetaRowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), rssid - iter->first);
-        auto segment = Segment::open(ExecEnv::GetInstance()->tablet_meta_mem_tracker(), fs::fs_util::block_manager(),
+        auto segment = Segment::open(ExecEnv::GetInstance()->metadata_mem_tracker(), fs::fs_util::block_manager(),
                                      seg_path, rssid - iter->first, &rowset->schema());
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -626,7 +626,7 @@ Status EngineCloneTask::_clone_incremental_data(Tablet* tablet, const TabletMeta
     }
 
     // clone_data to tablet
-    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->tablet_meta_mem_tracker(),
+    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->metadata_mem_tracker(),
                                            rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to incremental clone. [tablet=" << tablet->full_name() << " status=" << st << "]";
     return st;
@@ -707,7 +707,7 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
     // 2. local tablet has error in push
     // 3. local tablet cloned rowset from other nodes
     // 4. if cleared alter task info, then push will not write to new tablet, the report info is error
-    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->tablet_meta_mem_tracker(),
+    Status st = tablet->revise_tablet_meta(ExecEnv::GetInstance()->storage_engine()->metadata_mem_tracker(),
                                            rowsets_to_clone, versions_to_delete);
     LOG(INFO) << "finish to full clone. tablet=" << tablet->full_name() << ", res=" << st;
     // in previous step, copy all files from CLONE_DIR to tablet dir

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -203,7 +203,7 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("process_mem_bytes", &_memory_metrics->process_mem_bytes);
     registry->register_metric("query_mem_bytes", &_memory_metrics->query_mem_bytes);
     registry->register_metric("load_mem_bytes", &_memory_metrics->load_mem_bytes);
-    registry->register_metric("tablet_meta_mem_bytes", &_memory_metrics->tablet_meta_mem_bytes);
+    registry->register_metric("tablet_meta_mem_bytes", &_memory_metrics->metadata_mem_bytes);
     registry->register_metric("compaction_mem_bytes", &_memory_metrics->compaction_mem_bytes);
     registry->register_metric("schema_change_mem_bytes", &_memory_metrics->schema_change_mem_bytes);
     registry->register_metric("column_pool_mem_bytes", &_memory_metrics->column_pool_mem_bytes);
@@ -266,9 +266,8 @@ void SystemMetrics::_update_memory_metrics() {
     if (ExecEnv::GetInstance()->load_mem_tracker() != nullptr) {
         _memory_metrics->load_mem_bytes.set_value(ExecEnv::GetInstance()->load_mem_tracker()->consumption());
     }
-    if (ExecEnv::GetInstance()->tablet_meta_mem_tracker() != nullptr) {
-        _memory_metrics->tablet_meta_mem_bytes.set_value(
-                ExecEnv::GetInstance()->tablet_meta_mem_tracker()->consumption());
+    if (ExecEnv::GetInstance()->metadata_mem_tracker() != nullptr) {
+        _memory_metrics->metadata_mem_bytes.set_value(ExecEnv::GetInstance()->metadata_mem_tracker()->consumption());
     }
     if (ExecEnv::GetInstance()->compaction_mem_tracker() != nullptr) {
         _memory_metrics->compaction_mem_bytes.set_value(

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -52,7 +52,7 @@ public:
     // Load memory usage
     METRIC_DEFINE_INT_GAUGE(load_mem_bytes, MetricUnit::BYTES);
     // Tablet meta memory usage
-    METRIC_DEFINE_INT_GAUGE(tablet_meta_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(metadata_mem_bytes, MetricUnit::BYTES);
     // Compaction memory usage
     METRIC_DEFINE_INT_GAUGE(compaction_mem_bytes, MetricUnit::BYTES);
     // SchemaChange memory usage

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -42,7 +42,7 @@ using google::protobuf::RepeatedPtrField;
 namespace starrocks {
 
 static StorageEngine* k_engine = nullptr;
-static MemTracker* k_tablet_meta_mem_tracker = nullptr;
+static MemTracker* k_metadata_mem_tracker = nullptr;
 static MemTracker* k_schema_change_mem_tracker = nullptr;
 
 void set_up() {
@@ -59,11 +59,11 @@ void set_up() {
     config::txn_shard_size = 1;
     config::storage_format_version = 2;
 
-    k_tablet_meta_mem_tracker = new MemTracker();
+    k_metadata_mem_tracker = new MemTracker();
     k_schema_change_mem_tracker = new MemTracker();
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.tablet_meta_mem_tracker = k_tablet_meta_mem_tracker;
+    options.metadata_mem_tracker = k_metadata_mem_tracker;
     options.schema_change_mem_tracker = k_schema_change_mem_tracker;
     Status s = starrocks::StorageEngine::open(options, &k_engine);
     ASSERT_TRUE(s.ok()) << s.to_string();
@@ -73,9 +73,9 @@ void tear_down() {
     config::storage_root_path = std::filesystem::current_path().string() + "/data_test";
     FileUtils::remove_all(config::storage_root_path);
     FileUtils::remove_all(string(getenv("STARROCKS_HOME")) + UNUSED_PREFIX);
-    k_tablet_meta_mem_tracker->release(k_tablet_meta_mem_tracker->consumption());
+    k_metadata_mem_tracker->release(k_metadata_mem_tracker->consumption());
     k_schema_change_mem_tracker->release(k_schema_change_mem_tracker->consumption());
-    delete k_tablet_meta_mem_tracker;
+    delete k_metadata_mem_tracker;
     delete k_schema_change_mem_tracker;
 }
 

--- a/be/test/storage/rowset/beta_rowset_test.cpp
+++ b/be/test/storage/rowset/beta_rowset_test.cpp
@@ -78,7 +78,7 @@ protected:
 
         starrocks::EngineOptions options;
         options.store_paths = paths;
-        options.tablet_meta_mem_tracker = _metadata_mem_tracker.get();
+        options.metadata_mem_tracker = _metadata_mem_tracker.get();
         options.schema_change_mem_tracker = _schema_change_mem_tracker.get();
         Status s = starrocks::StorageEngine::open(options, &k_engine);
         ASSERT_TRUE(s.ok()) << s.to_string();

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -64,7 +64,7 @@ public:
     ~ColumnReaderWriterTest() override = default;
 
 protected:
-    void SetUp() override { _tablet_meta_mem_tracker = std::make_unique<MemTracker>(); }
+    void SetUp() override { _metadata_mem_tracker = std::make_unique<MemTracker>(); }
 
     void TearDown() override {}
 
@@ -103,7 +103,7 @@ protected:
         std::vector<int32_t> column_indexes;
         std::shared_ptr<TabletSchema> tablet_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
 
-        MemTracker* mem_tracker = _tablet_meta_mem_tracker.get();
+        MemTracker* mem_tracker = _metadata_mem_tracker.get();
         return std::shared_ptr<Segment>(
                 new Segment(Segment::private_type(0), block_mgr.get(), fname, 1, tablet_schema.get(), mem_tracker),
                 DeleterWithMemTracker<Segment>(mem_tracker));
@@ -588,7 +588,7 @@ protected:
     }
 
     MemPool _pool;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
 };
 
 // NOLINTNEXTLINE

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -31,7 +31,7 @@ public:
         _block_mgr = new fs::FileBlockManager(_env, fs::BlockManagerOptions());
         ASSERT_TRUE(_env->create_dir(kSegmentDir).ok());
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -45,7 +45,7 @@ public:
     EnvMemory* _env = nullptr;
     fs::FileBlockManager* _block_mgr = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
 };
 
 // NOLINTNEXTLINE
@@ -61,7 +61,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
 
     std::vector<Slice> data_strs;
     for (const auto& data : values) {
-        data_strs.push_back(data);
+        data_strs.emplace_back(data);
     }
 
     ColumnPB c1 = create_int_key_pb(1);
@@ -125,7 +125,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     }
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -256,7 +256,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     }
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -43,7 +43,7 @@ protected:
         ASSERT_TRUE(_env->create_dir(kSegmentDir).ok());
 
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -57,7 +57,7 @@ protected:
     Env* _env = nullptr;
     fs::BlockManager* _block_mgr = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
 };
 
 TEST_F(SegmentRewriterTest, rewrite_test) {
@@ -104,7 +104,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     partial_rowset_footer.set_size(file_size - footer_position);
 
     auto partial_segment =
-            *Segment::open(_tablet_meta_mem_tracker.get(), _block_mgr, file_name, 0, partial_tablet_schema.get());
+            *Segment::open(_metadata_mem_tracker.get(), _block_mgr, file_name, 0, partial_tablet_schema.get());
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
     std::unique_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
@@ -127,7 +127,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, *tablet_schema, read_column_ids, write_columns,
                                        partial_segment->id(), partial_rowset_footer));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _block_mgr, dst_file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _block_mgr, dst_file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -68,7 +68,7 @@ protected:
         _block_mgr = new fs::FileBlockManager(_env, fs::BlockManagerOptions());
         ASSERT_TRUE(_env->create_dir(kSegmentDir).ok());
         _page_cache_mem_tracker = std::make_unique<MemTracker>();
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
         StoragePageCache::create_global_cache(_page_cache_mem_tracker.get(), 1000000000);
     }
 
@@ -104,7 +104,7 @@ protected:
         uint64_t file_size, index_size, footer_position;
         ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-        *res = *Segment::open(_tablet_meta_mem_tracker.get(), _block_mgr, filename, 0, &query_schema);
+        *res = *Segment::open(_metadata_mem_tracker.get(), _block_mgr, filename, 0, &query_schema);
         ASSERT_EQ(nrows, (*res)->num_rows());
     }
 
@@ -113,7 +113,7 @@ protected:
     EnvMemory* _env = nullptr;
     fs::FileBlockManager* _block_mgr = nullptr;
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker = nullptr;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker = nullptr;
 };
 
 TEST_F(SegmentReaderWriterTest, estimate_segment_size) {
@@ -222,7 +222,7 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
     uint64_t footer_position;
     ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -335,7 +335,7 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
 
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;
@@ -442,7 +442,7 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
     }
 
     ASSERT_OK(writer.finalize_footer(&file_size));
-    auto segment = *Segment::open(_tablet_meta_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
+    auto segment = *Segment::open(_metadata_mem_tracker.get(), _block_mgr, file_name, 0, tablet_schema.get());
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     vectorized::SegmentReadOptions seg_options;

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <iostream>
+#include <memory>
 
 #include "column/datum_tuple.h"
 #include "env/env_memory.h"
@@ -37,8 +38,8 @@ namespace starrocks {
 class RowsetUpdateStateTest : public ::testing::Test {
 public:
     void SetUp() override {
-        _compaction_mem_tracker.reset(new MemTracker(-1));
-        _tablet_meta_mem_tracker = std::make_unique<MemTracker>();
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+        _metadata_mem_tracker = std::make_unique<MemTracker>();
     }
 
     void TearDown() override {
@@ -155,7 +156,7 @@ public:
 protected:
     TabletSharedPtr _tablet;
     std::unique_ptr<MemTracker> _compaction_mem_tracker;
-    std::unique_ptr<MemTracker> _tablet_meta_mem_tracker;
+    std::unique_ptr<MemTracker> _metadata_mem_tracker;
 };
 
 static vectorized::ChunkIteratorPtr create_tablet_iterator(vectorized::TabletReader& reader,

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -347,14 +347,14 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
-    std::unique_ptr<starrocks::MemTracker> table_meta_mem_tracker = std::make_unique<starrocks::MemTracker>();
+    std::unique_ptr<starrocks::MemTracker> metadata_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> schema_change_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> compaction_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> update_mem_tracker = std::make_unique<starrocks::MemTracker>();
     starrocks::StorageEngine* engine = nullptr;
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.tablet_meta_mem_tracker = table_meta_mem_tracker.get();
+    options.metadata_mem_tracker = metadata_mem_tracker.get();
     options.schema_change_mem_tracker = schema_change_mem_tracker.get();
     options.compaction_mem_tracker = compaction_mem_tracker.get();
     options.update_mem_tracker = update_mem_tracker.get();

--- a/be/test/storage/vectorized/cumulative_compaction_test.cpp
+++ b/be/test/storage/vectorized/cumulative_compaction_test.cpp
@@ -181,7 +181,7 @@ public:
 
         starrocks::EngineOptions options;
         options.store_paths = paths;
-        options.tablet_meta_mem_tracker = _tablet_meta_mem_tracker.get();
+        options.metadata_mem_tracker = _tablet_meta_mem_tracker.get();
         options.compaction_mem_tracker = _compaction_mem_tracker.get();
         if (k_engine == nullptr) {
             Status s = starrocks::StorageEngine::open(options, &k_engine);

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -49,14 +49,14 @@ int main(int argc, char** argv) {
     std::vector<starrocks::StorePath> paths;
     paths.emplace_back(starrocks::config::storage_root_path);
 
-    std::unique_ptr<starrocks::MemTracker> table_meta_mem_tracker = std::make_unique<starrocks::MemTracker>();
+    std::unique_ptr<starrocks::MemTracker> metadata_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> schema_change_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> compaction_mem_tracker = std::make_unique<starrocks::MemTracker>();
     std::unique_ptr<starrocks::MemTracker> update_mem_tracker = std::make_unique<starrocks::MemTracker>();
     starrocks::StorageEngine* engine = nullptr;
     starrocks::EngineOptions options;
     options.store_paths = paths;
-    options.tablet_meta_mem_tracker = table_meta_mem_tracker.get();
+    options.metadata_mem_tracker = metadata_mem_tracker.get();
     options.schema_change_mem_tracker = schema_change_mem_tracker.get();
     options.compaction_mem_tracker = compaction_mem_tracker.get();
     options.update_mem_tracker = update_mem_tracker.get();


### PR DESCRIPTION
In some user clusters, the metadata memory usage is too high, but our current metadata memory statistics are not detailed enough, which makes it difficult to troubleshoot the problem.

Therefore, more fine-grained statistical metadata memory is required. such as detail mem statistics for tablet(tablet_meta, tablet_schema, tablet_struct)/rowset(rowset_meta, rowset_struct)/segment/column/index

But tablet_meta_mem_bytes is ambiguous, so it is changed to metadata_mem_bytes. Currently, StarRocksManager has not collected these metrics, so there will be no compatibility issues. The pr is the first step, change tablet_meta_mem_tracker to metadata_mem_tracker
