### PR TITLE
[BugFix] Fix unstable TabletBinlogTest#test_generate_binlog

### DIFF
--- a/be/test/storage/tablet_binlog_test.cpp
+++ b/be/test/storage/tablet_binlog_test.cpp
@@ -121,9 +121,8 @@ TEST_F(TabletBinlogTest, test_generate_binlog) {
         }
         RowsetSharedPtr rowset;
         create_rowset(_tablet, segment_rows, &rowset);
-        int64_t timestamp = rowset->creation_time() * 1000000;
         ASSERT_OK(_tablet->add_inc_rowset(rowset, version));
-
+        int64_t timestamp = rowset->creation_time() * 1000000;
         version_infos.push_back(DupKeyVersionInfo(version, num_segments, num_rows_per_segment, timestamp));
     }
 
@@ -149,9 +148,8 @@ TEST_F(TabletBinlogTest, test_publish_out_of_order) {
             }
             RowsetSharedPtr rowset;
             create_rowset(_tablet, segment_rows, &rowset);
-            int64_t timestamp = rowset->creation_time() * 1000000;
             ASSERT_OK(_tablet->add_inc_rowset(rowset, sub_version));
-
+            int64_t timestamp = rowset->creation_time() * 1000000;
             if (k == 1) {
                 version_infos.push_back(DupKeyVersionInfo(sub_version, num_segments, num_rows_per_segment, timestamp));
             }


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`TabletBinlogTest#test_generate_binlog` is unstable, and will fail because of the following exception. It's the problem of the test, not the problem of binlog logic code.

```
[ RUN      ] TabletBinlogTest.test_generate_binlog
/root/starrocks/be/test/storage/binlog_test_base.cpp:139: Failure
Expected equality of these values:
  expect->timestamp
    Which is: 1680230581000000
  actual->timestamp_in_us
    Which is: 1680230582000000
/root/starrocks/be/test/storage/binlog_test_base.cpp:139: Failure
Expected equality of these values:
  expect->timestamp
    Which is: 1680230581000000
  actual->timestamp_in_us
    Which is: 1680230582000000
/root/starrocks/be/test/storage/binlog_test_base.cpp:139: Failure
Expected equality of these values:
  expect->timestamp
    Which is: 1680230581000000
  actual->timestamp_in_us
    Which is: 1680230582000000
```

The exception happens when verifying the timestamp of binlog is as expected. We get the timestamp of binlog from `Rowset#creation_time()`. The return values could be different before and after making rowset visible in  `Tablet#add_inc_rowset`, and we actually need the one after it's visible. But the test calls `Rowset#creation_time()` before the rowset is visible, and think it's the expected timestamp which leads to the test failure. 
 Because the time unit of `Rowset#creation_time()`  is second, so it's possible that the timestamps could be same before and after the rowset is visible if `add_inc_rowset` executes fast. And this is why the test is unstable.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
