### PR TITLE
[Refactor] refactor the index page reader for easy mem statistics (#10778)

### DIFF
--- a/be/src/storage/rowset/index_page.h
+++ b/be/src/storage/rowset/index_page.h
@@ -50,6 +50,8 @@ class IndexPageBuilder {
 public:
     explicit IndexPageBuilder(size_t index_page_size, bool is_leaf)
             : _index_page_size(index_page_size), _is_leaf(is_leaf) {}
+    IndexPageBuilder(const IndexPageBuilder&) = delete;
+    const IndexPageBuilder& operator=(const IndexPageBuilder&) = delete;
 
     void add(const Slice& key, const PagePointer& ptr);
 
@@ -61,10 +63,6 @@ public:
 
     uint64_t size() { return _buffer.size(); }
 
-    // Return the key of the first entry in this index block.
-    // The pointed-to data is only valid until the next call to this builder.
-    Status get_first_key(Slice* key) const;
-
     void reset() {
         _finished = false;
         _buffer.clear();
@@ -72,8 +70,6 @@ public:
     }
 
 private:
-    IndexPageBuilder(const IndexPageBuilder&) = delete;
-    const IndexPageBuilder& operator=(const IndexPageBuilder&) = delete;
     const size_t _index_page_size;
     const bool _is_leaf;
     bool _finished = false;
@@ -84,36 +80,29 @@ private:
 class IndexPageIterator;
 class IndexPageReader {
 public:
-    IndexPageReader() {}
+    IndexPageReader() = default;
 
     Status parse(const Slice& body, const IndexPageFooterPB& footer);
 
     inline size_t count() const {
         DCHECK(_parsed);
-        return _footer.num_entries();
-    }
-
-    inline bool is_leaf() const {
-        DCHECK(_parsed);
-        return _footer.type() == IndexPageFooterPB::LEAF;
+        return _num_entries;
     }
 
     inline const Slice& get_key(int idx) const {
         DCHECK(_parsed);
-        DCHECK(idx >= 0 && idx < _footer.num_entries());
+        DCHECK(idx >= 0 && idx < _num_entries);
         return _keys[idx];
     }
 
     inline const PagePointer& get_value(int idx) const {
         DCHECK(_parsed);
-        DCHECK(idx >= 0 && idx < _footer.num_entries());
+        DCHECK(idx >= 0 && idx < _num_entries);
         return _values[idx];
     }
 
     size_t mem_usage() const {
-        // _footer.SpaceUsedLong() conatain the memory of sizeof(IndexPageFooterPB),
-        // so substract the sizeof(IndexPageFooterPB) from size
-        size_t size = sizeof(IndexPageReader) + _footer.SpaceUsedLong() - sizeof(IndexPageFooterPB);
+        size_t size = sizeof(IndexPageReader);
         size += _keys.size() * sizeof(Slice) + _values.size() * sizeof(PagePointer);
         return size;
     }
@@ -121,9 +110,13 @@ public:
     const std::vector<Slice>& get_keys() const { return _keys; }
 
 private:
+    void _reset();
+    Status _parse(const Slice& body, const IndexPageFooterPB& footer);
+
     bool _parsed{false};
 
-    IndexPageFooterPB _footer;
+    uint32_t _num_entries = 0;
+
     std::vector<Slice> _keys;
     std::vector<PagePointer> _values;
 };
@@ -153,8 +146,6 @@ public:
         }
         return true;
     }
-
-    const Slice& current_key() const { return _reader->get_key(_pos); }
 
     const PagePointer& current_page_pointer() const { return _reader->get_value(_pos); }
 

--- a/be/test/storage/rowset/index_page_test.cpp
+++ b/be/test/storage/rowset/index_page_test.cpp
@@ -13,7 +13,7 @@ TEST_F(IndexPageTest, test_seek_at_or_before) {
     IndexPageReader reader1;
     reader1._parsed = true;
     reader1._keys = {"111"};
-    reader1._footer.set_num_entries(1);
+    reader1._num_entries = 1;
     std::vector<Slice> keys1 = {"000", "111", "222"};
     std::vector<int> pos1 = {-1, 0, 0};
     IndexPageIterator iter1(&reader1);
@@ -31,7 +31,7 @@ TEST_F(IndexPageTest, test_seek_at_or_before) {
     IndexPageReader reader2;
     reader2._parsed = true;
     reader2._keys = {"111", "333"};
-    reader2._footer.set_num_entries(2);
+    reader2._num_entries = 2;
     std::vector<Slice> keys2 = {"000", "111", "222", "333", "444"};
     std::vector<int> pos2 = {-1, 0, 0, 1, 1};
     IndexPageIterator iter2(&reader2);
@@ -49,7 +49,7 @@ TEST_F(IndexPageTest, test_seek_at_or_before) {
     IndexPageReader reader3;
     reader3._parsed = true;
     reader3._keys = {"111", "333", "555"};
-    reader3._footer.set_num_entries(3);
+    reader3._num_entries = 3;
     std::vector<Slice> keys3 = {"000", "111", "222", "333", "444", "555", "666"};
     std::vector<int> pos3 = {-1, 0, 0, 1, 1, 2, 2};
     IndexPageIterator iter3(&reader3);
@@ -69,7 +69,7 @@ TEST_F(IndexPageTest, test_seek_at_or_after) {
     IndexPageReader reader1;
     reader1._parsed = true;
     reader1._keys = {"111"};
-    reader1._footer.set_num_entries(1);
+    reader1._num_entries = 1;
     std::vector<Slice> keys1 = {"000", "111", "222"};
     std::vector<int> pos1 = {0, 0, 0};
     IndexPageIterator iter1(&reader1);
@@ -83,7 +83,7 @@ TEST_F(IndexPageTest, test_seek_at_or_after) {
     IndexPageReader reader2;
     reader2._parsed = true;
     reader2._keys = {"111", "333"};
-    reader2._footer.set_num_entries(2);
+    reader2._num_entries = 2;
     std::vector<Slice> keys2 = {"000", "111", "222", "333", "444"};
     std::vector<int> pos2 = {0, 0, 0, 1, 1};
     IndexPageIterator iter2(&reader2);
@@ -97,7 +97,7 @@ TEST_F(IndexPageTest, test_seek_at_or_after) {
     IndexPageReader reader3;
     reader3._parsed = true;
     reader3._keys = {"111", "333", "555"};
-    reader3._footer.set_num_entries(3);
+    reader3._num_entries = 3;
     std::vector<Slice> keys3 = {"000", "111", "222", "333", "444", "555", "666"};
     std::vector<int> pos3 = {0, 0, 0, 1, 1, 2, 2};
     IndexPageIterator iter3(&reader3);


### PR DESCRIPTION
* Remove IndexPageFooterPB from IndexPageReader to reduce the mem usage and easy mem statistics
* Reset all the items of IndexPageReader if load failed, otherwise the mem usage statistics is invalid
* Remove unused code
