### PR TITLE
[Enhancement][Cherry-Pick][Branch-2.5] Report error state tablet to FE and show error state tablet in statistic (#19517)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2130,6 +2130,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     info->__set_version_count(rowsets.size());
     info->__set_row_count(total_row);
     info->__set_data_size(total_size);
+    info->__set_is_error_state(_error);
 }
 
 int64_t TabletUpdates::get_average_row_size() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -158,6 +158,18 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         addReplica(replica, true);
     }
 
+    public int getErrorStateReplicaNum() {
+        int num = 0;
+        Iterator<Replica> iterator = replicas.iterator();
+        while (iterator.hasNext()) {
+            Replica replica = iterator.next();
+            if (replica.isErrorState()) {
+                num++;
+            }
+        }
+        return num;
+    }
+
     /**
      * @return Immutable list of replicas
      * notice: the list is immutable, not replica

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -163,6 +163,8 @@ public class Replica implements Writable {
     // if lastWriteFail is true, we can not use it as replicated storage primary replica
     private volatile boolean lastWriteFail = false;
 
+    private boolean isErrorState = false;
+
     public Replica() {
     }
 
@@ -298,6 +300,18 @@ public class Replica implements Writable {
 
     public boolean isSetBadForce() {
         return this.setBadForce;
+    }
+
+    public boolean isErrorState() {
+        return this.isErrorState;
+    }
+
+    public boolean setIsErrorState(boolean state) {
+        if (this.isErrorState == state) {
+            return false;
+        }
+        this.isErrorState = state;
+        return true;
     }
 
     public boolean needFurtherRepair() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -151,6 +151,9 @@ public class TabletInvertedIndex {
                         TTablet backendTablet = backendTablets.get(tabletId);
                         Replica replica = entry.getValue();
                         for (TTabletInfo backendTabletInfo : backendTablet.getTablet_infos()) {
+                            if (backendTabletInfo.isSetIs_error_state()) {
+                                replica.setIsErrorState(backendTabletInfo.is_error_state);
+                            }
                             if (tabletMeta.containsSchemaHash(backendTabletInfo.getSchema_hash())) {
                                 foundTabletsWithValidSchema.add(tabletId);
                                 // 1. (intersection)

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IncompleteTabletsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IncompleteTabletsProcNode.java
@@ -29,19 +29,23 @@ import java.util.List;
 public class IncompleteTabletsProcNode implements ProcNodeInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("UnhealthyTablets").add("InconsistentTablets").add("CloningTablets")
+            .add("ErrorStateTablets")
             .build();
     private static final Joiner JOINER = Joiner.on(",");
 
     Collection<Long> unhealthyTabletIds;
     Collection<Long> inconsistentTabletIds;
     Collection<Long> cloningTabletIds;
+    Collection<Long> errorStateTabletIds;
 
     public IncompleteTabletsProcNode(Collection<Long> unhealthyTabletIds,
                                      Collection<Long> inconsistentTabletIds,
-                                     Collection<Long> cloningTabletIds) {
+                                     Collection<Long> cloningTabletIds,
+                                     Collection<Long> errorStateTabletIds) {
         this.unhealthyTabletIds = unhealthyTabletIds;
         this.inconsistentTabletIds = inconsistentTabletIds;
         this.cloningTabletIds = cloningTabletIds;
+        this.errorStateTabletIds = errorStateTabletIds;
     }
 
     @Override
@@ -55,9 +59,11 @@ public class IncompleteTabletsProcNode implements ProcNodeInterface {
         String incompleteTablets = JOINER.join(Arrays.asList(unhealthyTabletIds));
         String inconsistentTablets = JOINER.join(Arrays.asList(inconsistentTabletIds));
         String cloningTablets = JOINER.join(Arrays.asList(cloningTabletIds));
+        String errorStateTablets = JOINER.join(Arrays.asList(errorStateTabletIds));
         row.add(incompleteTablets);
         row.add(inconsistentTablets);
         row.add(cloningTablets);
+        row.add(errorStateTablets);
 
         result.addRow(row);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ReplicasProcNode.java
@@ -42,7 +42,7 @@ public class ReplicasProcNode implements ProcNodeInterface {
             .add("LstFailedVersion").add("LstFailedVersionHash")
             .add("LstFailedTime").add("SchemaHash").add("DataSize").add("RowCount").add("State")
             .add("IsBad").add("IsSetBadForce").add("VersionCount").add("PathHash").add("MetaUrl")
-            .add("CompactionStatus")
+            .add("CompactionStatus").add("IsErrorState")
             .build();
 
     private long tabletId;
@@ -97,7 +97,8 @@ public class ReplicasProcNode implements ProcNodeInterface {
                     String.valueOf(replica.getVersionCount()),
                     String.valueOf(replica.getPathHash()),
                     metaUrl,
-                    compactionUrl));
+                    compactionUrl,
+                    String.valueOf(replica.isErrorState())));
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/StatisticProcDir.java
@@ -53,7 +53,7 @@ public class StatisticProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("DbId").add("DbName").add("TableNum").add("PartitionNum")
             .add("IndexNum").add("TabletNum").add("ReplicaNum").add("UnhealthyTabletNum")
-            .add("InconsistentTabletNum").add("CloningTabletNum")
+            .add("InconsistentTabletNum").add("CloningTabletNum").add("ErrorStateTabletNum")
             .build();
     private static final Logger LOG = LogManager.getLogger(StatisticProcDir.class);
 
@@ -65,12 +65,15 @@ public class StatisticProcDir implements ProcDirInterface {
     Multimap<Long, Long> inconsistentTabletIds;
     // db id -> set(tablet id)
     Multimap<Long, Long> cloningTabletIds;
+    // db id -> set(tablet id)
+    Multimap<Long, Long> errorStateTabletIds;
 
     public StatisticProcDir(GlobalStateMgr globalStateMgr) {
         this.globalStateMgr = globalStateMgr;
         unhealthyTabletIds = HashMultimap.create();
         inconsistentTabletIds = HashMultimap.create();
         cloningTabletIds = HashMultimap.create();
+        errorStateTabletIds = HashMultimap.create();
     }
 
     @Override
@@ -97,6 +100,7 @@ public class StatisticProcDir implements ProcDirInterface {
 
         unhealthyTabletIds.clear();
         inconsistentTabletIds.clear();
+        errorStateTabletIds.clear();
         cloningTabletIds = AgentTaskQueue.getTabletIdsByType(TTaskType.CLONE);
         List<List<Comparable>> lines = new ArrayList<List<Comparable>>();
         for (Long dbId : dbIds) {
@@ -142,6 +146,9 @@ public class StatisticProcDir implements ProcDirInterface {
 
                                 LocalTablet localTablet = (LocalTablet) tablet;
                                 dbReplicaNum += localTablet.getImmutableReplicas().size();
+                                if (localTablet.getErrorStateReplicaNum() > 0) {
+                                    errorStateTabletIds.put(dbId, tablet.getId());
+                                }
 
                                 Pair<TabletStatus, Priority> res = localTablet.getHealthStatusWithPriority(
                                         infoService, partition.getVisibleVersion(),
@@ -173,6 +180,7 @@ public class StatisticProcDir implements ProcDirInterface {
                 oneLine.add(unhealthyTabletIds.get(dbId).size());
                 oneLine.add(inconsistentTabletIds.get(dbId).size());
                 oneLine.add(cloningTabletIds.get(dbId).size());
+                oneLine.add(errorStateTabletIds.get(dbId).size());
 
                 lines.add(oneLine);
 
@@ -202,6 +210,7 @@ public class StatisticProcDir implements ProcDirInterface {
         finalLine.add(unhealthyTabletIds.size());
         finalLine.add(inconsistentTabletIds.size());
         finalLine.add(cloningTabletIds.size());
+        finalLine.add(errorStateTabletIds.size());
         lines.add(finalLine);
 
         // add result
@@ -236,6 +245,7 @@ public class StatisticProcDir implements ProcDirInterface {
 
         return new IncompleteTabletsProcNode(unhealthyTabletIds.get(dbId),
                 inconsistentTabletIds.get(dbId),
-                cloningTabletIds.get(dbId));
+                cloningTabletIds.get(dbId),
+                errorStateTabletIds.get(dbId));
     }
 }

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -46,6 +46,10 @@ struct TTabletInfo {
     14: optional bool is_in_memory
     15: optional bool enable_persistent_index
     16: optional Types.TVersion min_readable_version
+
+    // skip num 17 because num 17 is used in later version, so we skip it in 
+    // order to support degrade
+    18: optional bool is_error_state
 }
 
 struct TTabletVersionPair {


### PR DESCRIPTION
To avoid some serious bugs, we add many check for primary key tablet and if check failed, primary key tablet state will be set error which will refuse all operation. However, the error state is not easily observable and this pr report the error state tablet to FE and we can use show proc '/statistic/; to check if there are some tablet in error state.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
