### PR TITLE
[BugFix] fix librdkafka undefined symbol rd_kafka_sasl_scram*

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -126,7 +126,7 @@ BUILD_DIR=starrocks_build
 MACHINE_TYPE=$(uname -m)
 
 # handle mac m1 platform, change arm64 to aarch64
-if [[ "${MACHINE_TYPE}" == "arm64" ]]; then 
+if [[ "${MACHINE_TYPE}" == "arm64" ]]; then
     MACHINE_TYPE="aarch64"
 fi
 
@@ -257,9 +257,9 @@ build_protobuf() {
     check_if_source_exist $PROTOBUF_SOURCE
     cd $TP_SOURCE_DIR/$PROTOBUF_SOURCE
     rm -fr gmock
-    mkdir gmock 
-    cd gmock 
-    tar xf ${TP_SOURCE_DIR}/$GTEST_NAME 
+    mkdir gmock
+    cd gmock
+    tar xf ${TP_SOURCE_DIR}/$GTEST_NAME
     mv $GTEST_SOURCE gtest
     cd $TP_SOURCE_DIR/$PROTOBUF_SOURCE
     ./autogen.sh
@@ -295,7 +295,7 @@ build_glog() {
     LDFLAGS="-L${TP_LIB_DIR}" \
     CPPFLAGS="-I${TP_INCLUDE_DIR}" \
     ./configure --prefix=$TP_INSTALL_DIR --enable-frame-pointers --disable-shared --enable-static
-    make -j$PARALLEL 
+    make -j$PARALLEL
     make install
 }
 
@@ -309,7 +309,7 @@ build_gtest() {
     rm -rf CMakeCache.txt CMakeFiles/
     $CMAKE_CMD -G "${CMAKE_GENERATOR}" -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_POSITION_INDEPENDENT_CODE=On ../
-    ${BUILD_SYSTEM} -j$PARALLEL 
+    ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
 }
 
@@ -351,7 +351,7 @@ build_snappy() {
     -DCMAKE_POSITION_INDEPENDENT_CODE=On \
     -DCMAKE_INSTALL_INCLUDEDIR=$TP_INCLUDE_DIR/snappy \
     -DSNAPPY_BUILD_TESTS=0 ../
-    ${BUILD_SYSTEM} -j$PARALLEL 
+    ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
     if [ -f $TP_INSTALL_DIR/lib64/libsnappy.a ]; then
         mkdir -p $TP_INSTALL_DIR/lib
@@ -370,7 +370,7 @@ build_snappy() {
 build_gperftools() {
     check_if_source_exist $GPERFTOOLS_SOURCE
     cd $TP_SOURCE_DIR/$GPERFTOOLS_SOURCE
-    
+
     OLD_FLAGS=$CFLAGS
     CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g"
 
@@ -382,7 +382,7 @@ build_gperftools() {
     ./configure --prefix=$TP_INSTALL_DIR/gperftools --disable-shared --enable-static --disable-libunwind --with-pic --enable-frame-pointers
     make -j$PARALLEL
     make install
-    
+
     CFLAGS=$OLD_FLAGS
 }
 
@@ -488,7 +488,7 @@ build_brpc() {
     make -j$PARALLEL
     cp -rf output/* ${TP_INSTALL_DIR}/
     if [ -f $TP_INSTALL_DIR/lib/libbrpc.a ]; then
-        mkdir -p $TP_INSTALL_DIR/lib64 
+        mkdir -p $TP_INSTALL_DIR/lib64
         cp $TP_SOURCE_DIR/$BRPC_SOURCE/output/lib/libbrpc.a $TP_INSTALL_DIR/lib64/
     fi
 }
@@ -521,7 +521,7 @@ build_librdkafka() {
     cd $TP_SOURCE_DIR/$LIBRDKAFKA_SOURCE
 
     $CMAKE_CMD -DCMAKE_LIBRARY_PATH=$TP_INSTALL_DIR/lib -DCMAKE_INCLUDE_PATH=$TP_INSTALL_DIR/include \
-        -DBUILD_SHARED_LIBS=0 -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR -DRDKAFKA_BUILD_STATIC=ON -DWITH_SASL=OFF \
+        -DBUILD_SHARED_LIBS=0 -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR -DRDKAFKA_BUILD_STATIC=ON -DWITH_SASL=OFF -DWITH_SASL_SCRAM=ON \
         -DRDKAFKA_BUILD_EXAMPLES=OFF -DRDKAFKA_BUILD_TESTS=OFF -DWITH_SASL_OAUTHBEARER=ON -DCMAKE_INSTALL_LIBDIR=lib
 
     ${BUILD_SYSTEM} -j$PARALLEL
@@ -606,7 +606,7 @@ build_arrow() {
         cp -rf ./zstd_ep-install/lib/libzstd.a $TP_INSTALL_DIR/lib64/libzstd.a
     fi
     # copy zstd headers
-    mkdir -p ${TP_INSTALL_DIR}/include/zstd 
+    mkdir -p ${TP_INSTALL_DIR}/include/zstd
     cp ./zstd_ep-install/include/* ${TP_INSTALL_DIR}/include/zstd
 
     export CXXFLAGS=$OLD_FLAGS
@@ -618,7 +618,7 @@ build_arrow() {
 build_s2() {
     check_if_source_exist $S2_SOURCE
     cd $TP_SOURCE_DIR/$S2_SOURCE
-    mkdir -p $BUILD_DIR 
+    mkdir -p $BUILD_DIR
     cd $BUILD_DIR
     rm -rf CMakeCache.txt CMakeFiles/
     LDFLAGS="-L${TP_LIB_DIR} -static-libstdc++ -static-libgcc" \
@@ -630,7 +630,7 @@ build_s2() {
     -DGLOG_ROOT_DIR="$TP_INSTALL_DIR/include" \
     -DWITH_GLOG=ON \
     -DCMAKE_LIBRARY_PATH="$TP_INSTALL_DIR/lib;$TP_INSTALL_DIR/lib64" ..
-    ${BUILD_SYSTEM} -j$PARALLEL 
+    ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
 }
 
@@ -714,7 +714,7 @@ build_croaringbitmap() {
     -DROARING_DISABLE_NATIVE=ON \
     -DFORCE_AVX=$FORCE_AVX \
     -DCMAKE_LIBRARY_PATH="$TP_INSTALL_DIR/lib;$TP_INSTALL_DIR/lib64" ..
-    ${BUILD_SYSTEM} -j$PARALLEL 
+    ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
 }
 #orc
@@ -745,7 +745,7 @@ build_cctz() {
     check_if_source_exist $CCTZ_SOURCE
     cd $TP_SOURCE_DIR/$CCTZ_SOURCE
 
-    make -j$PARALLEL 
+    make -j$PARALLEL
     PREFIX=${TP_INSTALL_DIR} make install
 }
 
@@ -1026,7 +1026,7 @@ build_avro_c() {
     mkdir -p build
     cd build
     $CMAKE_CMD .. -DCMAKE_INSTALL_PREFIX=${TP_INSTALL_DIR} -DCMAKE_INSTALL_LIBDIR=lib64 -DCMAKE_BUILD_TYPE=Release
-    ${BUILD_SYSTEM} -j$PARALLEL    
+    ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
     rm ${TP_INSTALL_DIR}/lib64/libavro.so*
 }
@@ -1038,7 +1038,7 @@ build_serdes() {
     export CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g"
     check_if_source_exist $SERDES_SOURCE
     cd $TP_SOURCE_DIR/$SERDES_SOURCE
-    export LIBS="-lrt -lpthread -lcurl -ljansson -lrdkafka -lrdkafka++ -lavro -lssl -lcrypto -ldl" 
+    export LIBS="-lrt -lpthread -lcurl -ljansson -lrdkafka -lrdkafka++ -lavro -lssl -lcrypto -ldl"
     ./configure --prefix=${TP_INSTALL_DIR} \
                 --libdir=${TP_INSTALL_DIR}/lib \
                 --CFLAGS="-I ${TP_INSTALL_DIR}/include"  \


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In StarRocks 2.2, the symbol rd_kafka_sasl_scram_provider was correctly defined in librdkafka.a.
However, after updating to version 2.5, we found that BE reported an error: 'No provider for SASL mechanism SCRAM-SHA-512' due to undefined symbol rd_kafka_sasl_scram_provider.

This PR adds relevant option.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
