### PR TITLE
[Feature] Support get ip by host for stream load in some enviroment like k8s

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -765,6 +765,12 @@ public class Config extends ConfigBase {
     public static int insert_load_default_timeout_second = 3600; // 1 hour
 
     /**
+     * stream load force using ip for be or not
+     */
+    @ConfField(mutable = true)
+    public static boolean stream_load_force_use_ip = false;
+
+    /**
      * Default stream load and streaming mini load timeout
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -35,6 +35,7 @@
 package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -49,9 +50,12 @@ import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 
 public class LoadAction extends RestBaseAction {
@@ -105,7 +109,20 @@ public class LoadAction extends RestBaseAction {
             throw new DdlException("No backend alive.");
         }
 
-        TNetworkAddress redirectAddr = new TNetworkAddress(backend.getHost(), backend.getHttpPort());
+        String redirectHost = backend.getHost();
+        if (Config.stream_load_force_use_ip) {
+            InetAddressValidator validator = InetAddressValidator.getInstance();
+            if (!validator.isValidInet4Address(redirectHost) && !validator.isValidInet6Address(redirectHost)) {
+                try {
+                    InetAddress host = InetAddress.getByName(redirectHost);
+                    redirectHost = host.getHostAddress();
+                } catch (UnknownHostException ex) {
+                    LOG.warn("get redirect host for be {} failed!", redirectHost);
+                }
+            }
+        }
+
+        TNetworkAddress redirectAddr = new TNetworkAddress(redirectHost, backend.getHttpPort());
 
         LOG.info("redirect load action to destination={}, db: {}, tbl: {}, label: {}",
                 redirectAddr.toString(), dbName, tableName, label);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In order to adapt to the k8s environment, our BE registration logic currently uses hostname directly. However, this hostname cannot be recognized in the external environment, so an unknownhost exception like 'java.net.UnknownHostException: backend-1' will be thrown when importing data using stream load. This pr supports obtaining ip according to hostname and returning it to the client.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
