### PR TITLE
[Enhancement] Support grep log in web API, script and information_schema.be_logs

### DIFF
--- a/be/src/common/CMakeLists.txt
+++ b/be/src/common/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/common")
 
 add_library(Common STATIC
   daemon.cpp
+  greplog.cpp
   status.cpp
   statusor.cpp
   logconfig.cpp

--- a/be/src/common/greplog.cpp
+++ b/be/src/common/greplog.cpp
@@ -1,0 +1,272 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "common/greplog.h"
+
+#include <deque>
+#include <filesystem>
+
+#include "common/config.h"
+#include "gutil/strings/substitute.h"
+#include "hs/hs_compile.h"
+#include "hs/hs_runtime.h"
+#include "util/defer_op.h"
+
+using namespace std;
+
+namespace starrocks {
+
+static std::vector<string> list_log_files_in_dir(const string& log_dir, char level) {
+    std::vector<string> files;
+    // if level in WARNING, ERROR, FATAL, use logging logs, else use info logs
+    const std::string pattern = string("WEF").find(level) == string::npos ? "be.INFO.log." : "be.WARNING.log.";
+    for (const auto& entry : filesystem::directory_iterator(log_dir)) {
+        if (entry.is_regular_file()) {
+            auto name = entry.path().filename().string();
+            if (name.length() > pattern.length() && name.substr(0, pattern.length()) == pattern) {
+                files.push_back(entry.path().string());
+            }
+        }
+    }
+    std::sort(files.begin(), files.end(), std::greater<string>());
+    return files;
+}
+
+std::vector<string> list_log_files(char level) {
+    return list_log_files_in_dir(config::sys_log_dir, level);
+}
+
+struct GrepLogContext {
+    int64_t start_ts{0};
+    int64_t end_ts{0};
+    char level{'I'};
+    int64_t limit{0};
+    int64_t cur_ts{0};
+    int32_t cur_year{0};
+    char* line_start{nullptr};
+    size_t line_len{0};
+    bool stop_scan{false};
+    std::deque<GrepLogEntry>* entries;
+};
+
+inline bool is_log_prefix(const string& log) {
+    if (log.length() < 30) {
+        return false;
+    }
+    if (log[5] == ' ') {
+        if (log[0] == 'I' || log[0] == 'W' || log[0] == 'E' || log[0] == 'F') {
+            if (std::isdigit(log[1]) && std::isdigit(log[2]) && std::isdigit(log[3]) && std::isdigit(log[4])) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static void parse_log(GrepLogEntry& entry, GrepLogContext* context) {
+    if (!is_log_prefix(entry.log)) {
+        return;
+    }
+    entry.level = entry.log[0];
+    // convert time string to timestamp
+    tm local_tm;
+    memset(&local_tm, 0, sizeof(tm));
+    if (strptime(entry.log.c_str() + 1, "%m%d %H:%M:%S", &local_tm) != nullptr) {
+        // handle the case log file was created on 2020-12-31 23:59:59, but the log was written on 2021-01-01 00:00:03
+        local_tm.tm_year = context->cur_year - 1900;
+        int64_t candi1 = mktime(&local_tm);
+        local_tm.tm_year++;
+        int64_t candi2 = mktime(&local_tm);
+        if (std::abs(candi1 - context->cur_ts) < std::abs(candi2 - context->cur_ts)) {
+            entry.timestamp = candi1;
+        } else {
+            entry.timestamp = candi2;
+        }
+    }
+    auto tid_start = entry.log.find(' ', 6);
+    if (tid_start != string::npos) {
+        entry.thread_id = ::strtoll(entry.log.c_str() + tid_start + 1, nullptr, 10);
+    }
+}
+
+static int scan_by_line_handler(unsigned int id, unsigned long long from, unsigned long long to, unsigned int flags,
+                                void* ctx) {
+    GrepLogContext* context = (GrepLogContext*)ctx;
+    auto& new_log = context->entries->emplace_back();
+    new_log.log.assign(context->line_start, context->line_len);
+    parse_log(new_log, context);
+    if (context->start_ts > 0 && new_log.timestamp < context->start_ts) {
+        context->entries->pop_back();
+    }
+    if (context->end_ts > 0 && new_log.timestamp >= context->end_ts) {
+        context->entries->pop_back();
+        context->stop_scan = true;
+    }
+    if (context->limit > 0) {
+        while (context->entries->size() > context->limit) {
+            context->entries->pop_front();
+        }
+    }
+    return 0;
+}
+
+static void parse_ts_from_filename(const string& path, int64_t& ts, int32_t& year) {
+    auto default_time = [&ts, &year]() {
+        time_t rawtime;
+        struct tm timeinfo;
+        time(&rawtime);
+        localtime_r(&rawtime, &timeinfo);
+        ts = (int64_t)rawtime;
+        year = timeinfo.tm_year + 1900;
+    };
+    auto pos = path.find_last_of('.');
+    if (pos == string::npos) {
+        default_time();
+        return;
+    }
+    tm local_tm_create;
+    memset(&local_tm_create, 0, sizeof(tm));
+    if (strptime(path.c_str() + pos + 1, "%Y%m%d-%H%M%S", &local_tm_create) == nullptr) {
+        default_time();
+        return;
+    }
+    ts = mktime(&local_tm_create);
+    year = local_tm_create.tm_year + 1900;
+}
+
+Status grep_log_single_file(const string& path, int64_t start_ts, int64_t end_ts, char level, hs_database_t* database,
+                            hs_scratch_t* scratch, size_t limit, std::deque<GrepLogEntry>& entries) {
+    FILE* fp = fopen(path.c_str(), "r");
+    if (fp == nullptr) {
+        return Status::InternalError(strings::Substitute("grep log failed open $0 failed", path));
+    }
+    DeferOp fclose_defer([&fp]() { fclose(fp); });
+    char* line = (char*)malloc(1024 * 10);
+    DeferOp free_line_defer([&line]() { free(line); });
+    size_t line_len = 1024 * 10;
+    GrepLogContext ctx;
+    ctx.start_ts = start_ts;
+    ctx.end_ts = end_ts;
+    parse_ts_from_filename(path, ctx.cur_ts, ctx.cur_year);
+    ctx.level = level;
+    ctx.limit = limit;
+    ctx.entries = &entries;
+    while (true) {
+        ssize_t read = getline(&line, &line_len, fp);
+        if (read == -1) {
+            break;
+        }
+        ctx.line_start = line;
+        if (read > 0 && line[read - 1] == '\n') {
+            read--;
+        }
+        if (read > 0 && line[read - 1] == '\r') {
+            read--;
+        }
+        ctx.line_len = read;
+        if (database == nullptr) {
+            // no pattern, add all lines
+            scan_by_line_handler(0, 0, 0, 0, &ctx);
+        } else {
+            if (hs_scan(database, line, read, 0, scratch, scan_by_line_handler, &ctx) != HS_SUCCESS) {
+                break;
+            }
+        }
+        if (ctx.stop_scan) {
+            break;
+        }
+    }
+    return Status::OK();
+}
+
+Status grep_log(int64_t start_ts, int64_t end_ts, char level, const std::string& pattern, size_t limit,
+                std::deque<GrepLogEntry>& entries) {
+    const string log_dir = config::sys_log_dir;
+    if (log_dir.empty()) {
+        return Status::InternalError(strings::Substitute("grep log failed $0 is empty", log_dir));
+    }
+    // check log_dir is directory
+    if (!filesystem::is_directory(log_dir)) {
+        return Status::InternalError(strings::Substitute("grep log failed $0 is not dir", log_dir));
+    }
+    hs_database_t* database = nullptr;
+    if (!pattern.empty()) {
+        hs_compile_error_t* compile_err;
+        if (hs_compile(pattern.c_str(), 0, HS_MODE_BLOCK, NULL, &database, &compile_err) != HS_SUCCESS) {
+            hs_free_compile_error(compile_err);
+            return Status::InternalError(
+                    strings::Substitute("grep log failed compile pattern $0 failed $1", pattern, compile_err->message));
+        }
+    }
+    DeferOp free_database_defer([&database]() {
+        if (database != nullptr) hs_free_database(database);
+    });
+
+    hs_scratch_t* scratch = nullptr;
+    if (database != nullptr) {
+        if (hs_alloc_scratch(database, &scratch) != HS_SUCCESS) {
+            hs_free_database(database);
+            return Status::InternalError(
+                    strings::Substitute("grep log failed alloc scratch failed pattern:$0", pattern));
+        }
+    }
+    DeferOp free_scratch_defer([&scratch]() {
+        if (scratch != nullptr) hs_free_scratch(scratch);
+    });
+
+    for (const auto& path : list_log_files_in_dir(log_dir, level)) {
+        if (limit > 0 && entries.size() >= limit) {
+            break;
+        }
+        size_t cur_limit = 0;
+        if (limit > 0) {
+            cur_limit = limit - entries.size();
+        }
+        std::deque<GrepLogEntry> tmp_entries;
+        auto st = grep_log_single_file(path, start_ts, end_ts, level, database, scratch, cur_limit, tmp_entries);
+        if (!st.ok()) {
+            LOG(WARNING) << "grep_log_single_file failed: " << st.to_string() << " file:" << path;
+            continue;
+        }
+        for (auto itr = tmp_entries.rbegin(); itr != tmp_entries.rend(); ++itr) {
+            auto& added = entries.emplace_front();
+            added.log.swap(itr->log);
+            added.level = itr->level;
+            added.timestamp = itr->timestamp;
+            added.thread_id = itr->thread_id;
+        }
+    }
+    return Status::OK();
+}
+
+std::string grep_log_as_string(int64_t start_ts, int64_t end_ts, char level, const std::string& pattern, size_t limit) {
+    std::ostringstream ss;
+    std::deque<GrepLogEntry> entries;
+    auto st = grep_log(start_ts, end_ts, level, pattern, limit, entries);
+    if (!st.ok()) {
+        ss << strings::Substitute("grep log failed $0 start_ts:$1 end_ts:$2 level:$3 pattern:$4 limit:$5\n",
+                                  st.to_string(), start_ts, end_ts, level, pattern, limit);
+        return ss.str();
+    }
+    for (auto& entry : entries) {
+        ss << entry.log << "\n";
+    }
+    ss << "Lines: " << entries.size() << "\n";
+    return ss.str();
+}
+
+} // namespace starrocks

--- a/be/src/common/greplog.h
+++ b/be/src/common/greplog.h
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+
+#include "common/status.h"
+
+namespace starrocks {
+
+struct GrepLogEntry {
+    int64_t timestamp{0};
+    char level{'I'}; // I, W, E, F
+    uint64_t thread_id{0};
+    std::string log;
+};
+
+std::vector<std::string> list_log_files(char level);
+
+/**
+ * Grep log file.
+ * @param start_ts start timestamp, seconds since epoch
+ * @param end_ts end timestamp, seconds since epoch
+ * @param level log level, 'I', 'W', 'E', 'F'
+ * @param pattern grep pattern, can be empty(means match all)
+ * @param limit max number of entries
+ * @param entries output entries
+ * @return Status
+ */
+Status grep_log(int64_t start_ts, int64_t end_ts, char level, const std::string& pattern, size_t limit,
+                std::deque<GrepLogEntry>& entries);
+
+/**
+ * Grep log file and return all line as whole string, parameters are same as grep_log
+ * @return log string
+ */
+std::string grep_log_as_string(int64_t start_ts, int64_t end_ts, char level, const std::string& pattern, size_t limit);
+
+} // namespace starrocks

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -125,6 +125,7 @@ set(EXEC_FILES
     schema_scanner/schema_be_txns_scanner.cpp
     schema_scanner/schema_be_configs_scanner.cpp
     schema_scanner/schema_be_threads_scanner.cpp
+    schema_scanner/schema_be_logs_scanner.cpp
     schema_scanner/schema_fe_tablet_schedules_scanner.cpp
     schema_scanner/schema_be_compactions_scanner.cpp
     schema_scanner/schema_helper.cpp

--- a/be/src/exec/pipeline/scan/olap_schema_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_schema_scan_context.cpp
@@ -96,6 +96,21 @@ Status OlapSchemaScanContext::_prepare_params(RuntimeState* state) {
     if (_tnode.schema_scan_node.__isset.state) {
         _param->state = _obj_pool.add(new std::string(_tnode.schema_scan_node.state));
     }
+    if (_tnode.schema_scan_node.__isset.log_start_ts) {
+        _param->log_start_ts = _tnode.schema_scan_node.log_start_ts;
+    }
+    if (_tnode.schema_scan_node.__isset.log_end_ts) {
+        _param->log_end_ts = _tnode.schema_scan_node.log_end_ts;
+    }
+    if (_tnode.schema_scan_node.__isset.log_level) {
+        _param->log_level = _obj_pool.add(new std::string(_tnode.schema_scan_node.log_level));
+    }
+    if (_tnode.schema_scan_node.__isset.log_pattern) {
+        _param->log_pattern = _obj_pool.add(new std::string(_tnode.schema_scan_node.log_pattern));
+    }
+    if (_tnode.schema_scan_node.__isset.log_limit) {
+        _param->log_limit = _tnode.schema_scan_node.log_limit;
+    }
 
     return Status::OK();
 }

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -17,6 +17,7 @@
 #include "column/type_traits.h"
 #include "exec/schema_scanner/schema_be_compactions_scanner.h"
 #include "exec/schema_scanner/schema_be_configs_scanner.h"
+#include "exec/schema_scanner/schema_be_logs_scanner.h"
 #include "exec/schema_scanner/schema_be_metrics_scanner.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "exec/schema_scanner/schema_be_threads_scanner.h"
@@ -137,6 +138,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaBeConfigsScanner>();
     case TSchemaTableType::SCH_BE_THREADS:
         return std::make_unique<SchemaBeThreadsScanner>();
+    case TSchemaTableType::SCH_BE_LOGS:
+        return std::make_unique<SchemaBeLogsScanner>();
     case TSchemaTableType::SCH_FE_TABLET_SCHEDULES:
         return std::make_unique<SchemaFeTabletSchedulesScanner>();
     case TSchemaTableType::SCH_BE_COMPACTIONS:

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -59,6 +59,11 @@ struct SchemaScannerParam {
     int64_t txn_id{-1};
     const std::string* type{nullptr};
     const std::string* state{nullptr};
+    int64_t log_start_ts{-1};
+    int64_t log_end_ts{-1};
+    const std::string* log_level{nullptr};
+    const std::string* log_pattern{nullptr};
+    int64_t log_limit{-1};
 
     RuntimeProfile::Counter* _rpc_timer = nullptr;
     RuntimeProfile::Counter* _fill_chunk_timer = nullptr;

--- a/be/src/exec/schema_scanner/schema_be_logs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_logs_scanner.cpp
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_be_logs_scanner.h"
+
+#include "agent/master_info.h"
+#include "exec/schema_scanner/schema_helper.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/string_value.h"
+#include "types/logical_type.h"
+#include "util/thread.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaBeLogsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},     {"LEVEL", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"TIMESTAMP", TYPE_BIGINT, sizeof(int64_t), false}, {"TID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"LOG", TYPE_VARCHAR, sizeof(StringValue), false},
+};
+
+SchemaBeLogsScanner::SchemaBeLogsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeLogsScanner::~SchemaBeLogsScanner() = default;
+
+Status SchemaBeLogsScanner::start(RuntimeState* state) {
+    auto o_id = get_backend_id();
+    _be_id = o_id.has_value() ? o_id.value() : -1;
+    _infos.clear();
+    int64_t start_ts = 0;
+    if (_param->log_start_ts > 0) {
+        start_ts = _param->log_start_ts;
+    }
+    int64_t end_ts = 0;
+    if (_param->log_end_ts > 0) {
+        end_ts = _param->log_end_ts;
+    }
+    string level;
+    string pattern;
+    if (_param->log_level != nullptr) {
+        level = *_param->log_level;
+    }
+    if (_param->log_pattern != nullptr) {
+        pattern = *_param->log_pattern;
+    }
+    size_t limit = 0;
+    if (_param->log_limit > 0) {
+        limit = _param->log_limit;
+    }
+    int64_t ts0 = MonotonicMillis();
+    Status st = grep_log(start_ts, end_ts, level[0], pattern, limit, _infos);
+    int64_t ts1 = MonotonicMillis();
+    string msg =
+            strings::Substitute("grep_log pattern:$0 level:$1 start_ts:$2 end_ts:$3 limit:$4 #result:$5 duration:$6ms",
+                                pattern, level, start_ts, end_ts, limit, _infos.size(), (ts1 - ts0));
+    if (st.ok()) {
+        LOG(INFO) << msg;
+    } else {
+        LOG(WARNING) << msg << " error:" << st.get_error_msg();
+        // send err info to client as log
+        auto& err_log = _infos.emplace_back();
+        err_log.log = strings::Substitute("grep_log failed pattern:$0 level:$1 limit:$2 error:$3", pattern, level,
+                                          _param->limit, st.get_error_msg());
+    }
+    _cur_idx = 0;
+    return Status::OK();
+}
+
+Status SchemaBeLogsScanner::fill_chunk(ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    for (; _cur_idx < _infos.size(); _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 5) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                // level
+                Slice v(&info.level, 1);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 3: {
+                // timestamp
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.timestamp);
+                break;
+            }
+            case 4: {
+                // tid
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.thread_id);
+                break;
+            }
+            case 5: {
+                // log
+                Slice v(info.log);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeLogsScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_be_logs_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_logs_scanner.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "common/greplog.h"
+#include "exec/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+class SchemaBeLogsScanner : public SchemaScanner {
+public:
+    SchemaBeLogsScanner();
+    ~SchemaBeLogsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status fill_chunk(ChunkPtr* chunk);
+    int64_t _be_id{0};
+    std::deque<GrepLogEntry> _infos;
+    size_t _cur_idx{0};
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(Webserver STATIC
   http_client.cpp
   action/health_action.cpp
   action/checksum_action.cpp
+  action/greplog_action.cpp
   action/snapshot_action.cpp
   action/reload_tablet_action.cpp
   action/restore_tablet_action.cpp

--- a/be/src/http/action/greplog_action.cpp
+++ b/be/src/http/action/greplog_action.cpp
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/greplog_action.h"
+
+#include "common/greplog.h"
+#include "http/http_channel.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+const int64_t GREP_LOG_LIMIT = 1000000;
+
+Status get_int64_param(HttpRequest* req, const std::string& name, int64_t* value) {
+    std::string str_value = req->param(name);
+    if (!str_value.empty()) {
+        try {
+            *value = std::stoll(str_value);
+        } catch (const std::exception& e) {
+            return Status::InternalError("Invalid param " + name + ": " + str_value);
+        }
+    }
+    return Status::OK();
+}
+
+void GrepLogAction::handle(HttpRequest* req) {
+    if (req->method() != HttpMethod::GET) {
+        HttpChannel::send_reply(req, HttpStatus::METHOD_NOT_ALLOWED, "Method Not Allowed");
+        return;
+    }
+    int64_t start_ts = 0;
+    int64_t end_ts = 0;
+    if (!get_int64_param(req, "start_ts", &start_ts).ok()) {
+        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, "Invalid param start_ts");
+        return;
+    }
+    if (!get_int64_param(req, "end_ts", &end_ts).ok()) {
+        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, "Invalid param end_ts");
+        return;
+    }
+    std::string pattern = req->param("pattern");
+    std::string level = req->param("level");
+    if (level.empty()) {
+        level = "I";
+    }
+    int64_t limit = GREP_LOG_LIMIT;
+    if (!get_int64_param(req, "limit", &limit).ok()) {
+        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, "Invalid param limit");
+        return;
+    }
+    if (limit <= 0 || limit > GREP_LOG_LIMIT) {
+        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, "Invalid param limit");
+        return;
+    }
+
+    auto ret = grep_log_as_string(start_ts, end_ts, std::toupper(level[0]), pattern, limit);
+
+    HttpChannel::send_reply(req, HttpStatus::OK, ret);
+}
+
+} // namespace starrocks

--- a/be/src/http/action/greplog_action.h
+++ b/be/src/http/action/greplog_action.h
@@ -1,0 +1,33 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+
+#include "common/status.h"
+#include "http/http_handler.h"
+
+namespace starrocks {
+
+class GrepLogAction : public HttpHandler {
+public:
+    explicit GrepLogAction() = default;
+
+    ~GrepLogAction() override = default;
+
+    void handle(HttpRequest* req) override;
+};
+
+} // namespace starrocks

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -16,6 +16,7 @@
 
 #include <google/protobuf/util/json_util.h>
 
+#include "common/greplog.h"
 #include "common/logging.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "gen_cpp/olap_file.pb.h"
@@ -123,6 +124,7 @@ void bind_exec_env(ForeignModule& m) {
         cls.funcStaticExt<&get_stack_trace_for_thread>("get_stack_trace_for_thread");
         cls.funcStaticExt<&get_stack_trace_for_threads>("get_stack_trace_for_threads");
         cls.funcStaticExt<&get_stack_trace_for_all_threads>("get_stack_trace_for_all_threads");
+        cls.funcStaticExt<&grep_log_as_string>("grep_log_as_string");
         REG_METHOD(ExecEnv, process_mem_tracker);
         REG_METHOD(ExecEnv, query_pool_mem_tracker);
         REG_METHOD(ExecEnv, load_mem_tracker);

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -39,6 +39,7 @@
 #include "http/action/checksum_action.h"
 #include "http/action/compact_rocksdb_meta_action.h"
 #include "http/action/compaction_action.h"
+#include "http/action/greplog_action.h"
 #include "http/action/health_action.h"
 #include "http/action/meta_action.h"
 #include "http/action/metrics_action.h"
@@ -236,6 +237,10 @@ Status HttpServiceBE::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/pipeline_blocking_drivers/{action}",
                                       pipeline_driver_poller_action);
     _http_handlers.emplace_back(pipeline_driver_poller_action);
+
+    auto* greplog_action = new GrepLogAction();
+    _ev_http_server->register_handler(HttpMethod::GET, "/greplog", greplog_action);
+    _http_handlers.emplace_back(greplog_action);
 
     RETURN_IF_ERROR(_ev_http_server->start());
     return Status::OK();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -725,6 +725,17 @@ public class SchemaTable extends Table {
                                     .column("IDLE", ScalarType.createType(PrimitiveType.BOOLEAN))
                                     .column("FINISHED_TASKS", ScalarType.createType(PrimitiveType.BIGINT))
                                     .build()))
+                    .put("be_logs", new SchemaTable(
+                            SystemId.BE_THREADS_ID,
+                            "be_logs",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("LEVEL", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("TIMESTAMP", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("LOG", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .build()))
                     .build();
 
     public static class Builder {
@@ -826,7 +837,8 @@ public class SchemaTable extends Table {
         SCH_BE_CONFIGS("BE_CONFIGS", "BE_CONFIGS", TSchemaTableType.SCH_BE_CONFIGS),
         SCH_FE_TABLET_SCHEDULES("FE_TABLET_SCHEDULES", "FE_TABLET_SCHEDULES", TSchemaTableType.SCH_FE_TABLET_SCHEDULES),
         SCH_BE_COMPACTIONS("BE_COMPACTIONS", "BE_COMPACTIONS", TSchemaTableType.SCH_BE_COMPACTIONS),
-        SCH_BE_THREADS("BE_THREADS", "BE_THREADS", TSchemaTableType.SCH_BE_THREADS);
+        SCH_BE_THREADS("BE_THREADS", "BE_THREADS", TSchemaTableType.SCH_BE_THREADS),
+        SCH_BE_LOGS("BE_LOGS", "BE_LOGS", TSchemaTableType.SCH_BE_LOGS);
 
         private final String description;
         private final String tableName;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -222,7 +222,8 @@ public class Config extends ConfigBase {
      * Used to limit the maximum number of partitions that can be created when creating a dynamic partition table,
      * to avoid creating too many partitions at one time.
      */
-    @ConfField(mutable = true) public static int max_dynamic_partition_num = 500;
+    @ConfField(mutable = true)
+    public static int max_dynamic_partition_num = 500;
 
     /**
      * plugin_dir:
@@ -1937,7 +1938,7 @@ public class Config extends ConfigBase {
     // Enables or disables SSL connections to AWS services. Not support for now
     // @ConfField
     // public static String aws_s3_enable_ssl = "true";
-    
+
     // ***********************************************************
     // * END: of Cloud native meta server related configurations
     // ***********************************************************
@@ -2151,4 +2152,8 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean enable_experimental_temporary_table = false;
+
+    @ConfField(mutable = true)
+    public static long max_per_node_grep_log_limit = 500000;
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
@@ -89,4 +89,5 @@ public class SystemId {
     public static final long BE_COMPACTIONS_ID = 35L;
 
     public static final long BE_THREADS_ID = 36L;
+    public static final long BE_LOGS_ID = 37L;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -75,6 +75,12 @@ public class SchemaScanNode extends ScanNode {
     private Long txnId = null;
     private String type = null;
     private String state = null;
+    private Long logStartTs = null;
+    private Long logEndTs = null;
+    private String logLevel = null;
+    private String logPattern = null;
+    private Long logLimit = null;
+
     private List<TScanRangeLocations> beScanRanges = null;
 
     public void setSchemaDb(String schemaDb) {
@@ -192,6 +198,21 @@ public class SchemaScanNode extends ScanNode {
         if (state != null) {
             msg.schema_scan_node.setState(state);
         }
+        if (logStartTs != null) {
+            msg.schema_scan_node.setLog_start_ts(logStartTs);
+        }
+        if (logEndTs != null) {
+            msg.schema_scan_node.setLog_end_ts(logEndTs);
+        }
+        if (logLevel != null) {
+            msg.schema_scan_node.setLog_level(logLevel);
+        }
+        if (logPattern != null) {
+            msg.schema_scan_node.setLog_pattern(logPattern);
+        }
+        if (logLimit != null) {
+            msg.schema_scan_node.setLog_limit(logLimit);
+        }
         // setting limit for the scanner may cause query to return less rows than expected
         // but this is for the purpose of protect FE resource usage, so it's acceptable
         if (getLimit() > 0) {
@@ -225,6 +246,26 @@ public class SchemaScanNode extends ScanNode {
 
     public void setState(String state) {
         this.state = state;
+    }
+
+    public void setLogStartTs(long logStartTs) {
+        this.logStartTs = logStartTs;
+    }
+
+    public void setLogEndTs(long logEndTs) {
+        this.logEndTs = logEndTs;
+    }
+
+    public void setLogLevel(String logLevel) {
+        this.logLevel = logLevel;
+    }
+
+    public void setLogPattern(String logPattern) {
+        this.logPattern = logPattern;
+    }
+
+    public void setLogLimit(long logLimit) {
+        this.logLimit = logLimit;
     }
 
     public boolean isBeSchemaTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -106,6 +106,7 @@ import com.starrocks.sql.ast.AssertNumRowsElement;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -156,6 +157,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamAggOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamJoinOperator;
@@ -1102,51 +1104,86 @@ public class PlanFragmentBuilder {
                 // if user set table_schema or table_name in where condition and is
                 // binary predicate operator, we can set table_schema and table_name
                 // into scan-node, which can reduce time from be to fe
+                if (!(predicate.getChildren().size() == 2 && predicate.getChildren().get(0) instanceof ColumnRefOperator &&
+                        predicate.getChildren().get(1) instanceof ConstantOperator)) {
+                    continue;
+                }
+                ColumnRefOperator columnRefOperator = (ColumnRefOperator) predicate.getChildren().get(0);
+                ConstantOperator constantOperator = (ConstantOperator) predicate.getChildren().get(1);
                 if (predicate instanceof BinaryPredicateOperator) {
-                    if (((BinaryPredicateOperator) predicate).getBinaryType() ==
-                            BinaryPredicateOperator.BinaryType.EQ) {
-                        if (predicate.getChildren().get(0) instanceof ColumnRefOperator &&
-                                predicate.getChildren().get(1) instanceof ConstantOperator) {
-                            ColumnRefOperator columnRefOperator = (ColumnRefOperator) predicate.getChildren().get(0);
-                            ConstantOperator constantOperator = (ConstantOperator) predicate.getChildren().get(1);
-                            switch (columnRefOperator.getName()) {
-                                case "TABLE_SCHEMA":
-                                case "DATABASE_NAME":
-                                    scanNode.setSchemaDb(constantOperator.getVarchar());
-                                    break;
-                                case "TABLE_NAME":
-                                    scanNode.setSchemaTable(constantOperator.getVarchar());
-                                    break;
-                                case "BE_ID":
-                                    scanNode.setBeId(constantOperator.getBigint());
-                                    break;
-                                case "TABLE_ID":
-                                    scanNode.setTableId(constantOperator.getBigint());
-                                    break;
-                                case "PARTITION_ID":
-                                    scanNode.setPartitionId(constantOperator.getBigint());
-                                    break;
-                                case "TABLET_ID":
-                                    scanNode.setTabletId(constantOperator.getBigint());
-                                    break;
-                                case "TXN_ID":
-                                    scanNode.setTxnId(constantOperator.getBigint());
-                                    break;
-                                case "LABEL":
-                                    scanNode.setLabel(constantOperator.getVarchar());
-                                    break;
-                                case "JOB_ID":
-                                    scanNode.setJobId(constantOperator.getBigint());
-                                    break;
-                                case "TYPE":
-                                    scanNode.setType(constantOperator.getVarchar());
-                                    break;
-                                case "STATE":
-                                    scanNode.setState(constantOperator.getVarchar());
-                                    break;
-                                default:
-                                    break;
-                            }
+                    BinaryPredicateOperator binaryPredicateOperator = (BinaryPredicateOperator) predicate;
+                    if (binaryPredicateOperator.getBinaryType() == BinaryPredicateOperator.BinaryType.EQ) {
+                        switch (columnRefOperator.getName()) {
+                            case "TABLE_SCHEMA":
+                            case "DATABASE_NAME":
+                                scanNode.setSchemaDb(constantOperator.getVarchar());
+                                break;
+                            case "TABLE_NAME":
+                                scanNode.setSchemaTable(constantOperator.getVarchar());
+                                break;
+                            case "BE_ID":
+                                scanNode.setBeId(constantOperator.getBigint());
+                                break;
+                            case "TABLE_ID":
+                                scanNode.setTableId(constantOperator.getBigint());
+                                break;
+                            case "PARTITION_ID":
+                                scanNode.setPartitionId(constantOperator.getBigint());
+                                break;
+                            case "TABLET_ID":
+                                scanNode.setTabletId(constantOperator.getBigint());
+                                break;
+                            case "TXN_ID":
+                                scanNode.setTxnId(constantOperator.getBigint());
+                                break;
+                            case "LABEL":
+                                scanNode.setLabel(constantOperator.getVarchar());
+                                break;
+                            case "JOB_ID":
+                                scanNode.setJobId(constantOperator.getBigint());
+                                break;
+                            case "TYPE":
+                                scanNode.setType(constantOperator.getVarchar());
+                                break;
+                            case "STATE":
+                                scanNode.setState(constantOperator.getVarchar());
+                                break;
+                            case "LOG":
+                                // support full match, `log = 'xxxx'`
+                                // TODO: to be fully accurate, need to escape parameter
+                                scanNode.setLogPattern("^" + constantOperator.getVarchar() + "$");
+                                break;
+                            case "LEVEL":
+                                scanNode.setLogLevel(constantOperator.getVarchar());
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    // support be_logs.timestamp filter
+                    if (columnRefOperator.getName().equals("TIMESTAMP")) {
+                        BinaryPredicateOperator.BinaryType opType = binaryPredicateOperator.getBinaryType();
+                        if (opType == BinaryPredicateOperator.BinaryType.EQ) {
+                            scanNode.setLogStartTs(constantOperator.getBigint());
+                            scanNode.setLogEndTs(constantOperator.getBigint() + 1);
+                        } else if (opType == BinaryPredicateOperator.BinaryType.GT) {
+                            scanNode.setLogStartTs(constantOperator.getBigint() + 1);
+                        } else if (opType == BinaryPredicateOperator.BinaryType.GE) {
+                            scanNode.setLogStartTs(constantOperator.getBigint());
+                        } else if (opType == BinaryPredicateOperator.BinaryType.LT) {
+                            scanNode.setLogEndTs(constantOperator.getBigint());
+                        } else if (opType == BinaryPredicateOperator.BinaryType.LE) {
+                            scanNode.setLogEndTs(constantOperator.getBigint() + 1);
+                        }
+                    }
+                } else if (predicate instanceof LikePredicateOperator) {
+                    LikePredicateOperator like = (LikePredicateOperator) predicate;
+                    // currently, we only optimize `log rlike xxx` or `log regexp xxx`, raise an error if using `like`
+                    if (columnRefOperator.getName().equals("LOG")) {
+                        if (like.getLikeType() == LikePredicateOperator.LikeType.REGEXP) {
+                            scanNode.setLogPattern(((ConstantOperator) like.getChildren().get(1)).getVarchar());
+                        } else {
+                            throw UnsupportedException.unsupportedException("only support `regexp` or `rlike` for log grep");
                         }
                     }
                 }
@@ -1154,6 +1191,13 @@ public class PlanFragmentBuilder {
 
             if (scanNode.isBeSchemaTable()) {
                 scanNode.computeBeScanRanges();
+            }
+
+            // set a per node log scan limit to prevent BE/CN OOM
+            if (scanNode.getLimit() > 0) {
+                scanNode.setLogLimit(Math.min(scanNode.getLimit(), Config.max_per_node_grep_log_limit));
+            } else {
+                scanNode.setLogLimit(Config.max_per_node_grep_log_limit);
             }
 
             context.getScanNodes().add(scanNode);

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -145,7 +145,8 @@ enum TSchemaTableType {
     SCH_LOAD_TRACKING_LOGS,
     SCH_FE_TABLET_SCHEDULES,
     SCH_BE_COMPACTIONS,
-    SCH_BE_THREADS
+    SCH_BE_THREADS,
+    SCH_BE_LOGS,
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -428,6 +428,11 @@ struct TSchemaScanNode {
   18: optional string type
   19: optional string state
   20: optional i64 limit
+  21: optional i64 log_start_ts;
+  22: optional i64 log_end_ts;
+  23: optional string log_level;
+  24: optional string log_pattern;
+  25: optional i64 log_limit;
 }
 
 // If you find yourself changing this struct, see also TLakeScanNode


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds the ability to grep BE log and add access points like information_schema.be_logs, web API, and scripting engine. The function will scan all glog files in the sys_log_dir directory and grep the lines that match the given regexp specified by the where condition in the query. 
Only `log regexp`, `log rlike`, `level = 'x'` `timestamp <cmp> <ts>`  predicates are supported/optimized, meaning only these predicates will be pushed down to the scanner and can reduce the log scanned.
Other predicates will be performed on the execution engine layer, meaning all logs may need to be scanned and returned by greplog_scanner, causing suboptimal performance or even OOM.
So it is always recommended to add some predicates like timestamp range or log pattern.  
To prevent a full log scan, there is a FE config `max_per_node_grep_log_limit` to limit the per BE max log scan lines limit, if for a scanner this limit is reached, only the latest logs will be returned.

```
-- list tablet 12009's rowset commit log
mysql> select log from be_logs where log regexp 'commit rowset.*12009';
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| log                                                                                                                                                                                                                |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| I0403 17:21:54.643549 111843 tablet_updates.cpp:529] commit rowset tablet:12009 version:2 txn_id: 1002 02000000000000038c4ecc8ae869a6e97e84c796c7f8ca9e rowset:0 #seg:1 #delfile:0 #row:1 size:466.00 B #pending:0 |
| I0403 17:21:55.584167 111846 tablet_updates.cpp:529] commit rowset tablet:12009 version:3 txn_id: 1003 02000000000000078c4ecc8ae869a6e97e84c796c7f8ca9e rowset:1 #seg:1 #delfile:0 #row:1 size:466.00 B #pending:0 |
| I0403 17:21:56.629778 111843 tablet_updates.cpp:529] commit rowset tablet:12009 version:4 txn_id: 1004 020000000000000b8c4ecc8ae869a6e97e84c796c7f8ca9e rowset:2 #seg:1 #delfile:0 #row:1 size:466.00 B #pending:0 |
| I0403 17:21:57.400697 111845 tablet_updates.cpp:529] commit rowset tablet:12009 version:5 txn_id: 1005 020000000000000f8c4ecc8ae869a6e97e84c796c7f8ca9e rowset:3 #seg:1 #delfile:0 #row:1 size:466.00 B #pending:0 |
| I0403 17:21:58.151300 111844 tablet_updates.cpp:529] commit rowset tablet:12009 version:6 txn_id: 1006 02000000000000138c4ecc8ae869a6e97e84c796c7f8ca9e rowset:4 #seg:1 #delfile:0 #row:1 size:466.00 B #pending:0 |
| I0403 17:21:58.791062 111843 tablet_updates.cpp:529] commit rowset tablet:12009 version:7 txn_id: 1007 02000000000000178c4ecc8ae869a6e97e84c796c7f8ca9e rowset:5 #seg:1 #delfile:0 #row:1 size:466.00 B #pending:0 |
| I0403 17:21:59.407322 111846 tablet_updates.cpp:529] commit rowset tablet:12009 version:8 txn_id: 1008 020000000000001b8c4ecc8ae869a6e97e84c796c7f8ca9e rowset:6 #seg:1 #delfile:0 #row:1 size:466.00 B #pending:0 |
| I0403 20:06:05.950912 134090 schema_be_logs_scanner.cpp:65] grep_log pattern:commit rowset.*12009 level: limit:0 result size:7 duration:1ms                                                                        |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
8 rows in set (0.02 sec)


-- List logs within the last 20s
mysql> select timestamp, log from be_logs where timestamp > unix_timestamp(now()-20);
+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| timestamp  | log                                                                                                                                                                                                                                                        |
+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 1680521077 | I0403 19:24:37.723484 124985 daemon.cpp:201] Current memory statistics: process(7402024), query_pool(0), load(0), metadata(74973), compaction(0), schema_change(0), column_pool(0), page_cache(0), update(0), chunk_allocator(0), clone(0), consistency(0) |
| 1680521083 | I0403 19:24:43.371744 125191 fragment_executor.cpp:165] Prepare(): query_id=219d61ec-d212-11ed-87fd-0242200cdddf fragment_instance_id=219d61ec-d212-11ed-87fd-0242200cdde1 is_stream_pipeline=0 backend_num=0                                              |
| 1680521083 | I0403 19:24:43.373117 125192 fragment_executor.cpp:165] Prepare(): query_id=219d61ec-d212-11ed-87fd-0242200cdddf fragment_instance_id=219d61ec-d212-11ed-87fd-0242200cdde0 is_stream_pipeline=0 backend_num=1                                              |
| 1680521083 | I0403 19:24:43.383152 125304 schema_be_logs_scanner.cpp:65] grep_log pattern: level: limit:0 result size:3563 duration:9ms                                                                                                                                 |
| 1680521083 | W0403 19:24:43.385182 125257 exec_state_reporter.cpp:142] Retrying ReportExecStatus: No more data to read.                                                                                                                                                 |
| 1680521083 | W0403 19:24:43.385214 126138 exec_state_reporter.cpp:142] Retrying ReportExecStatus: No more data to read.                                                                                                                                                 |
| 1680521083 | I0403 19:24:43.386631 125257 pipeline_driver_executor.cpp:268] [Driver] Succeed to report exec state: fragment_instance_id=219d61ec-d212-11ed-87fd-0242200cdde1                                                                                            |
| 1680521083 | I0403 19:24:43.386966 126138 pipeline_driver_executor.cpp:261] [Driver] Fail to report exec state due to query not found: fragment_instance_id=219d61ec-d212-11ed-87fd-0242200cdde0                                                                        |
| 1680521092 | I0403 19:24:52.725091 124985 daemon.cpp:201] Current memory statistics: process(8843504), query_pool(0), load(0), metadata(74973), compaction(0), schema_change(0), column_pool(0), page_cache(0), update(0), chunk_allocator(0), clone(0), consistency(0) |
| 1680521093 | I0403 19:24:53.822162 125193 fragment_executor.cpp:165] Prepare(): query_id=27d8fe7d-d212-11ed-87fd-0242200cdddf fragment_instance_id=27d8fe7d-d212-11ed-87fd-0242200cdde1 is_stream_pipeline=0 backend_num=0                                              |
| 1680521093 | I0403 19:24:53.823721 125194 fragment_executor.cpp:165] Prepare(): query_id=27d8fe7d-d212-11ed-87fd-0242200cdddf fragment_instance_id=27d8fe7d-d212-11ed-87fd-0242200cdde0 is_stream_pipeline=0 backend_num=1                                              |
+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
11 rows in set (0.02 sec)

```
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
