### PR TITLE
[BugFix] Fix not support GCS authentication in broker load and custom core-site.xml in GCS and Azure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -100,7 +100,7 @@ public class FileTable extends Table {
     }
 
     public List<RemoteFileDesc> getFileDescs() throws DdlException {
-        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(fileProperties, null);
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(fileProperties);
         Configuration configuration = hdfsEnvironment.getConfiguration();
         HiveRemoteFileIO remoteFileIO = new HiveRemoteFileIO(configuration);
         boolean recursive = Boolean.parseBoolean(fileProperties.getOrDefault(JSON_RECURSIVE_DIRECTORIES, "false"));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/HdfsEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/HdfsEnvironment.java
@@ -30,17 +30,19 @@ public class HdfsEnvironment {
         this.hdfsConfiguration = new HdfsConfiguration();
     }
 
-    public HdfsEnvironment(Map<String, String> properties, CloudConfiguration cloudConfiguration) {
-        this.hdfsConfiguration = new HdfsConfiguration();
+    public HdfsEnvironment(Map<String, String> properties) {
+        this();
+        if (properties != null) {
+            this.hdfsConfiguration.applyToCloudConfiguration(
+                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties));
+        }
+    }
+
+    public HdfsEnvironment(CloudConfiguration cloudConfiguration) {
+        this();
         if (cloudConfiguration != null) {
             this.hdfsConfiguration.applyToCloudConfiguration(cloudConfiguration);
-        } else if (properties != null) {
-            CloudConfiguration tmp = CloudConfigurationFactory.tryBuildForStorage(properties);
-            if (tmp != null) {
-                this.hdfsConfiguration.applyToCloudConfiguration(tmp);
-            }
         }
-        // If both is null, we just create a default HdfsEnvironment
     }
 
     public Configuration getConfiguration() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeConnector.java
@@ -42,8 +42,8 @@ public class DeltaLakeConnector implements Connector {
     public DeltaLakeConnector(ConnectorContext context) {
         this.catalogName = context.getCatalogName();
         this.properties = context.getProperties();
-        this.cloudConfiguration = CloudConfigurationFactory.tryBuildForStorage(properties);
-        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(null, cloudConfiguration);
+        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.internalMgr = new DeltaLakeInternalMgr(catalogName, properties, hdfsEnvironment);
         this.metadataFactory = createMetadataFactory();
         validate();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -46,8 +46,8 @@ public class HiveConnector implements Connector {
     public HiveConnector(ConnectorContext context) {
         this.properties = context.getProperties();
         this.catalogName = context.getCatalogName();
-        this.cloudConfiguration = CloudConfigurationFactory.tryBuildForStorage(properties);
-        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(null, cloudConfiguration);
+        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.internalMgr = new HiveConnectorInternalMgr(catalogName, properties, hdfsEnvironment);
         this.metadataFactory = createMetadataFactory();
         validate();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -127,7 +127,7 @@ public class HiveMetastoreApiConverter {
             HudiConnector connector = (HudiConnector) GlobalStateMgr.getCurrentState().getConnectorMgr().
                     getConnector(catalogName);
             CloudConfiguration cloudConfiguration = connector.getCloudConfiguration();
-            HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(null, cloudConfiguration);
+            HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
             configuration = hdfsEnvironment.getConfiguration();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
@@ -42,8 +42,8 @@ public class HudiConnector implements Connector {
 
     public HudiConnector(ConnectorContext context) {
         this.properties = context.getProperties();
-        this.cloudConfiguration = CloudConfigurationFactory.tryBuildForStorage(properties);
-        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(null, cloudConfiguration);
+        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.catalogName = context.getCatalogName();
         this.internalMgr = new HudiConnectorInternalMgr(catalogName, properties, hdfsEnvironment);
         this.metadataFactory = createMetadataFactory();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -53,8 +53,8 @@ public class IcebergConnector implements Connector {
     public IcebergConnector(ConnectorContext context) {
         this.catalogName = context.getCatalogName();
         this.properties = context.getProperties();
-        this.cloudConfiguration = CloudConfigurationFactory.tryBuildForStorage(properties);
-        this.hdfsEnvironment = new HdfsEnvironment(null, cloudConfiguration);
+        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        this.hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
     }
 
     private IcebergCatalog buildIcebergNativeCatalog() {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
@@ -18,11 +18,13 @@ import com.starrocks.credential.aliyun.AliyunCloudConfigurationFactory;
 import com.starrocks.credential.aws.AWSCloudConfigurationFactory;
 import com.starrocks.credential.azure.AzureCloudConfigurationFactory;
 import com.starrocks.credential.gcp.GCPCloudConfigurationFactory;
+import com.starrocks.thrift.TCloudConfiguration;
+import org.apache.hadoop.conf.Configuration;
 
 import java.util.Map;
 
 public abstract class CloudConfigurationFactory {
-    public static CloudConfiguration tryBuildForStorage(Map<String, String> properties) {
+    public static CloudConfiguration buildCloudConfigurationForStorage(Map<String, String> properties) {
         CloudConfigurationFactory factory = new AWSCloudConfigurationFactory(properties);
         CloudConfiguration cloudConfiguration = factory.buildForStorage();
         if (cloudConfiguration != null) {
@@ -46,7 +48,34 @@ public abstract class CloudConfigurationFactory {
         if (cloudConfiguration != null) {
             return cloudConfiguration;
         }
-        return cloudConfiguration;
+        return buildDefaultCloudConfiguration();
+    }
+
+    // If user didn't specific any credential, we create DefaultCloudConfiguration instead.
+    // It will use Hadoop default constructor instead, user can put core-site.xml into java CLASSPATH to control
+    // authentication manually
+    public static CloudConfiguration buildDefaultCloudConfiguration() {
+        return new CloudConfiguration() {
+            @Override
+            public void toThrift(TCloudConfiguration tCloudConfiguration) {
+
+            }
+
+            @Override
+            public void applyToConfiguration(Configuration configuration) {
+
+            }
+
+            @Override
+            public CloudType getCloudType() {
+                return CloudType.DEFAULT;
+            }
+
+            @Override
+            public String getCredentialString() {
+                return "default";
+            }
+        };
     }
 
     protected abstract CloudConfiguration buildForStorage();

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudType.java
@@ -14,20 +14,10 @@
 
 package com.starrocks.credential;
 
-import com.starrocks.thrift.TCloudConfiguration;
-import org.apache.hadoop.conf.Configuration;
-
-public interface CloudConfiguration {
-
-    void toThrift(TCloudConfiguration tCloudConfiguration);
-
-    void applyToConfiguration(Configuration configuration);
-
-    // Hadoop FileSystem has a cache itself, it used request uri as a cache key by default,
-    // so it cannot sense the CloudCredential changed.
-    // So we need to generate an identifier for different CloudCredential, and used it as cache key.
-    // getCredentialString() Method just like toString()
-    String getCredentialString();
-
-    CloudType getCloudType();
+public enum CloudType {
+    // Means nothing, don't do anything
+    DEFAULT,
+    AWS,
+    AZURE,
+    GCP
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
@@ -16,6 +16,7 @@ package com.starrocks.credential.aws;
 
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationConstants;
+import com.starrocks.credential.CloudType;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudProperty;
 import com.starrocks.thrift.TCloudType;
@@ -64,6 +65,11 @@ public class AWSCloudConfiguration implements CloudConfiguration {
         properties.add(new TCloudProperty(CloudConfigurationConstants.AWS_S3_ENABLE_SSL, String.valueOf(enableSSL)));
         awsCloudCredential.toThrift(properties);
         tCloudConfiguration.setCloud_properties(properties);
+    }
+
+    @Override
+    public CloudType getCloudType() {
+        return CloudType.AWS;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
@@ -15,6 +15,7 @@
 package com.starrocks.credential.azure;
 
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudType;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudProperty;
 import com.starrocks.thrift.TCloudType;
@@ -43,6 +44,11 @@ public class AzureCloudConfiguration implements CloudConfiguration {
     @Override
     public void applyToConfiguration(Configuration configuration) {
         azureStorageCloudCredential.applyToConfiguration(configuration);
+    }
+
+    @Override
+    public CloudType getCloudType() {
+        return CloudType.AZURE;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -37,7 +37,6 @@ abstract class AzureStorageCloudCredential implements CloudCredential {
 
     protected Map<String, String> generatedConfigurationMap = new HashMap<>();
 
-
     @Override
     public void applyToConfiguration(Configuration configuration) {
         for (Map.Entry<String, String> entry : generatedConfigurationMap.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
@@ -16,6 +16,7 @@ package com.starrocks.credential.gcp;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudType;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudProperty;
 import com.starrocks.thrift.TCloudType;
@@ -45,6 +46,11 @@ public class GCPCloudConfiguration implements CloudConfiguration {
     @Override
     public void applyToConfiguration(Configuration configuration) {
         gcpCloudCredential.applyToConfiguration(configuration);
+    }
+
+    @Override
+    public CloudType getCloudType() {
+        return CloudType.GCP;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.RemoteFileBlockDesc;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.credential.CloudType;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
@@ -43,9 +44,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class FileTableScanNode extends ScanNode {
-    private List<TScanRangeLocations> scanRangeLocationsList = new ArrayList<>();
-    private FileTable fileTable;
-    private HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
+    private final List<TScanRangeLocations> scanRangeLocationsList = new ArrayList<>();
+    private final FileTable fileTable;
+    private final HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
     private CloudConfiguration cloudConfiguration = null;
 
     public FileTableScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
@@ -63,7 +64,7 @@ public class FileTableScanNode extends ScanNode {
     }
 
     private void setupCredential() {
-        cloudConfiguration = CloudConfigurationFactory.tryBuildForStorage(fileTable.getFileProperties());
+        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(fileTable.getFileProperties());
     }
 
     @Override
@@ -194,8 +195,11 @@ public class FileTableScanNode extends ScanNode {
             msg.hdfs_scan_node.setTable_name(fileTable.getName());
         }
 
-        if (cloudConfiguration != null) {
-            TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
+        // TODO(SmithCruise)
+        // We only set cloudConfiguration when CloudType is non-default.
+        // Because BE didn't handle CloudType.DEFAULT situation now
+        if (cloudConfiguration != null && cloudConfiguration.getCloudType() != CloudType.DEFAULT) {
+           TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
             cloudConfiguration.toThrift(tCloudConfiguration);
             msg.hdfs_scan_node.setCloud_configuration(tCloudConfiguration);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -26,6 +26,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.connector.RemoteScanRangeLocations;
 import com.starrocks.connector.hive.HiveConnector;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudType;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.thrift.TCloudConfiguration;
@@ -53,11 +54,11 @@ import static com.starrocks.thrift.TExplainLevel.VERBOSE;
  * TODO: Dictionary pruning
  */
 public class HdfsScanNode extends ScanNode {
-    private RemoteScanRangeLocations scanRangeLocations = new RemoteScanRangeLocations();
+    private final RemoteScanRangeLocations scanRangeLocations = new RemoteScanRangeLocations();
 
     private HiveTable hiveTable = null;
     private CloudConfiguration cloudConfiguration = null;
-    private HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
+    private final HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
 
     public HdfsScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
         super(id, desc, planNodeName);
@@ -203,7 +204,10 @@ public class HdfsScanNode extends ScanNode {
             msg.hdfs_scan_node.setTable_name(hiveTable.getName());
         }
 
-        if (cloudConfiguration != null) {
+        // TODO(SmithCruise)
+        // We only set cloudConfiguration when CloudType is non-default.
+        // Because BE didn't handle CloudType.DEFAULT situation now
+        if (cloudConfiguration != null && cloudConfiguration.getCloudType() != CloudType.DEFAULT) {
             TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
             cloudConfiguration.toThrift(tCloudConfiguration);
             msg.hdfs_scan_node.setCloud_configuration(tCloudConfiguration);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

In this pr, we do the following things:
1. Fix not supporting GCS authentication in broker load.
2. If the user does not specify credential information in SQL's properties, we will not throw error msgs anymore, use `EmptyCloudConfiguration` instead, so that people can use `core-site.xml` for further configuration. (Only changed for Azure and GCS, AWS is supported already)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
