### PR TITLE
[Enhancement] support to set io tasks on connector scan node

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -755,6 +755,7 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
 CONF_Int32(io_tasks_per_scan_operator, "4");
+CONF_Int32(io_tasks_connector_max_ratio, "4");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -755,7 +755,7 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
 CONF_Int32(io_tasks_per_scan_operator, "4");
-CONF_Int32(io_tasks_connector_max_ratio, "4");
+CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -122,7 +122,17 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ScanNode::init(tnode, state));
     RETURN_IF_ERROR(_data_source_provider->init(_pool, state));
     _estimate_scan_row_bytes();
+    _adjust_io_tasks_per_scan_operator(state);
     return Status::OK();
+}
+
+void ConnectorScanNode::_adjust_io_tasks_per_scan_operator(RuntimeState* state) {
+    const TQueryOptions& options = state->query_options();
+    int32_t ratio = config::io_tasks_connector_max_ratio;
+    if (options.__isset.io_tasks_connector_max_ratio) {
+        ratio = options.io_tasks_connector_max_ratio;
+    }
+    _io_tasks_per_scan_operator *= ratio;
 }
 
 void ConnectorScanNode::_estimate_scan_row_bytes() {

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -128,11 +128,10 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
 void ConnectorScanNode::_adjust_io_tasks_per_scan_operator(RuntimeState* state) {
     const TQueryOptions& options = state->query_options();
-    int32_t ratio = config::io_tasks_connector_max_ratio;
-    if (options.__isset.io_tasks_connector_max_ratio) {
-        ratio = options.io_tasks_connector_max_ratio;
+    _io_tasks_per_scan_operator = config::connector_io_tasks_per_scan_operator;
+    if (options.__isset.connector_io_tasks_per_scan_operator) {
+        _io_tasks_per_scan_operator = options.connector_io_tasks_per_scan_operator;
     }
-    _io_tasks_per_scan_operator *= ratio;
 }
 
 void ConnectorScanNode::_estimate_scan_row_bytes() {

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -67,6 +67,7 @@ private:
     void _close_pending_scanners();
     void _push_pending_scanner(ConnectorScanner* scanner);
     ConnectorScanner* _pop_pending_scanner();
+    void _adjust_io_tasks_per_scan_operator(RuntimeState* state);
 
     // non-pipeline fields.
     std::vector<TScanRangeParams> _scan_ranges;

--- a/be/test/formats/parquet/parquet_footer_test.cpp
+++ b/be/test/formats/parquet/parquet_footer_test.cpp
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "formats/parquet/file_reader.h"
-
-#include "exec/hdfs_scanner.h"
-#include "common/statusor.h"
 #include <gtest/gtest.h>
+
 #include <filesystem>
+
+#include "common/statusor.h"
+#include "exec/hdfs_scanner.h"
+#include "formats/parquet/file_reader.h"
 
 namespace starrocks::parquet {
 
 class ParquetFooterTest : public testing::Test {
 public:
-    ParquetFooterTest() {
-        ctx.stats = &stats;
-    }
+    ParquetFooterTest() { ctx.stats = &stats; }
+
 protected:
     std::unique_ptr<RandomAccessFile> open_file(const std::string& file_path) {
         return *FileSystem::Default()->new_random_access_file(file_path);
@@ -38,8 +38,8 @@ protected:
 TEST_F(ParquetFooterTest, TestEmptyParquetFile) {
     const std::string file_path = "./be/test/formats/parquet/test_data/empty.parquet";
     auto file = open_file(file_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(file_path));
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path));
     Status status = file_reader->init(&ctx);
     EXPECT_TRUE(status.is_corruption());
 }
@@ -47,10 +47,10 @@ TEST_F(ParquetFooterTest, TestEmptyParquetFile) {
 TEST_F(ParquetFooterTest, TestEncryptedParquetFile) {
     const std::string file_path = "./be/test/formats/parquet/test_data/encrypt_columns_and_footer.parquet.encrypted";
     auto file = open_file(file_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(file_path));
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path));
     Status status = file_reader->init(&ctx);
     EXPECT_TRUE(status.is_not_supported());
 }
 
-}
+} // namespace starrocks::parquet

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1018,6 +1018,7 @@ public class CoordinatorPreprocessor {
         queryOptions.setEnable_populate_block_cache(sv.getEnablePopulateBlockCache());
         queryOptions.setHudi_mor_force_jni_reader(sv.getHudiMORForceJNIReader());
         queryOptions.setIo_tasks_per_scan_operator(sv.getIoTasksPerScanOperator());
+        queryOptions.setIo_tasks_connector_max_ratio(sv.getIoTasksConnectorMaxRatio());
 
         // set scan ranges/locations for scan nodes
         for (ScanNode scanNode : scanNodes) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1018,7 +1018,7 @@ public class CoordinatorPreprocessor {
         queryOptions.setEnable_populate_block_cache(sv.getEnablePopulateBlockCache());
         queryOptions.setHudi_mor_force_jni_reader(sv.getHudiMORForceJNIReader());
         queryOptions.setIo_tasks_per_scan_operator(sv.getIoTasksPerScanOperator());
-        queryOptions.setIo_tasks_connector_max_ratio(sv.getIoTasksConnectorMaxRatio());
+        queryOptions.setConnector_io_tasks_per_scan_operator(sv.getConnectorIoTasksPerScanOperator());
 
         // set scan ranges/locations for scan nodes
         for (ScanNode scanNode : scanNodes) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -322,6 +322,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
     public static final String HUDI_MOR_FORCE_JNI_READER = "hudi_mor_force_jni_reader";
     public static final String IO_TASKS_PER_SCAN_OPERATOR = "io_tasks_per_scan_operator";
+    public static final String IO_TASKS_CONNECTOR_MAX_RATIO = "io_tasks_connector_max_ratio";
 
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
@@ -883,6 +884,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = IO_TASKS_PER_SCAN_OPERATOR)
     private int ioTasksPerScanOperator = 4;
 
+    @VariableMgr.VarAttr(name = IO_TASKS_CONNECTOR_MAX_RATIO)
+    private int ioTasksConnectorMaxRatio = 4;
+
     @VariableMgr.VarAttr(name = ENABLE_POPULATE_BLOCK_CACHE)
     private boolean enablePopulateBlockCache = true;
 
@@ -895,6 +899,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getIoTasksPerScanOperator() {
         return ioTasksPerScanOperator;
+    }
+
+    public int getIoTasksConnectorMaxRatio() {
+        return ioTasksConnectorMaxRatio;
     }
 
     @VarAttr(name = ENABLE_QUERY_CACHE)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -322,7 +322,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
     public static final String HUDI_MOR_FORCE_JNI_READER = "hudi_mor_force_jni_reader";
     public static final String IO_TASKS_PER_SCAN_OPERATOR = "io_tasks_per_scan_operator";
-    public static final String IO_TASKS_CONNECTOR_MAX_RATIO = "io_tasks_connector_max_ratio";
+    public static final String CONNECTOR_IO_TASKS_PER_SCAN_OPERATOR = "connector_io_tasks_per_scan_operator";
 
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
@@ -884,8 +884,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = IO_TASKS_PER_SCAN_OPERATOR)
     private int ioTasksPerScanOperator = 4;
 
-    @VariableMgr.VarAttr(name = IO_TASKS_CONNECTOR_MAX_RATIO)
-    private int ioTasksConnectorMaxRatio = 4;
+    @VariableMgr.VarAttr(name = CONNECTOR_IO_TASKS_PER_SCAN_OPERATOR)
+    private int connectorIoTasksPerScanOperator = 16;
 
     @VariableMgr.VarAttr(name = ENABLE_POPULATE_BLOCK_CACHE)
     private boolean enablePopulateBlockCache = true;
@@ -901,8 +901,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return ioTasksPerScanOperator;
     }
 
-    public int getIoTasksConnectorMaxRatio() {
-        return ioTasksConnectorMaxRatio;
+    public int getConnectorIoTasksPerScanOperator() {
+        return connectorIoTasksPerScanOperator;
     }
 
     @VarAttr(name = ENABLE_QUERY_CACHE)

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -182,6 +182,7 @@ struct TQueryOptions {
   76: optional TSpillMode spill_mode;
   77: optional i64 rpc_http_min_size;
   78: optional i32 io_tasks_per_scan_operator = 4;
+  79: optional i32 io_tasks_connector_max_ratio = 4;
 }
 
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -182,7 +182,7 @@ struct TQueryOptions {
   76: optional TSpillMode spill_mode;
   77: optional i64 rpc_http_min_size;
   78: optional i32 io_tasks_per_scan_operator = 4;
-  79: optional i32 io_tasks_connector_max_ratio = 4;
+  79: optional i32 connector_io_tasks_per_scan_operator = 16;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR can be perceived as fix of this https://github.com/StarRocks/starrocks/pull/20289

In that pr, I move `io_tasks_per_scan_operator` to sv, but delete `connector_io_tasks_per_scan_operator`(16). 

So fix that pr, I add another sv `io_tasks_connector_max_ratio`(default value = 4). which means by default, the connector io tasks per operator is still 16.

But this PR is more than a just fix. With this PR, we can only adjust io tasks for connector scan node. And in future, I'll add a mechanism based on this PR to adjust io tasks dynamically to control memory usage.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
