### PR TITLE
[BugFix] Remove `--use-staros` parameter in artifacts build cmd

### DIFF
--- a/docker/dockerfiles/artifacts/artifact.Dockerfile
+++ b/docker/dockerfiles/artifacts/artifact.Dockerfile
@@ -36,7 +36,7 @@ ARG MAVEN_OPTS
 ARG BUILD_TYPE=Release
 COPY . /build/starrocks
 WORKDIR /build/starrocks
-RUN --mount=type=cache,target=/root/.m2/ STARROCKS_VERSION=${RELEASE_VERSION} BUILD_TYPE=${BUILD_TYPE} MAVEN_OPTS=${MAVEN_OPTS} ./build.sh --be --use-staros --clean -j `nproc`
+RUN --mount=type=cache,target=/root/.m2/ STARROCKS_VERSION=${RELEASE_VERSION} BUILD_TYPE=${BUILD_TYPE} MAVEN_OPTS=${MAVEN_OPTS} ./build.sh --be --clean -j `nproc`
 
 
 FROM busybox:latest


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [X] 2.5
  - [ ] 2.4
  - [ ] 2.3
