### PR TITLE
[Enhancement] check os config first before be startup

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -52,6 +52,32 @@ export_env_from_conf() {
     done < $1
 }
 
+check_os_conf() {
+  if [ -f /proc/sys/vm/overcommit_memory ]; then
+    overcommit_memory=$(cat /proc/sys/vm/overcommit_memory)
+    if [ "$overcommit_memory" != "1" ]; then
+      echo "[WARNING] It is recommended to set /proc/sys/vm/overcommit_memory to 1, " \
+           "otherwise OOM will occur in some scenarios"
+    fi
+  fi
+
+  if [ -f /proc/sys/vm/swappiness ]; then
+    swappiness=$(cat /proc/sys/vm/swappiness)
+    if [ "$swappiness" != "0" ]; then
+      echo "[WARNING] It is recommended to close swap, otherwise turning on swap will cause some performance " \
+        "jitter problems and in extreme cases it will cause StarRocks to be unstable"
+    fi
+  fi
+
+  if [ -f /proc/sys/vm/max_map_count ]; then
+    max_map_count=$(cat /proc/sys/vm/max_map_count)
+    if [ "$max_map_count" -lt 200000 ]; then
+      echo "[WARNING] It is recommended to set vm.max_map_count larger then 200000, " \
+           "otherwise in a high-concurrency scenario, mmap exceeding the limit will cause a memory allocation error"
+    fi
+  fi
+}
+
 # Read the config [mem_limit] from configuration file of BE and set the upper limit of TCMalloc memory allocation
 # if mem_limit is not set, use 90% of machine memory
 export_mem_limit_from_conf() {

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -56,6 +56,8 @@ done
 export STARROCKS_HOME=`cd "$curdir/.."; pwd`
 source $STARROCKS_HOME/bin/common.sh
 
+check_os_conf
+
 export_shared_envvars
 if [ ${RUN_BE} -eq 1 ] ; then
     export_env_from_conf $STARROCKS_HOME/conf/be.conf
@@ -133,7 +135,6 @@ export CLASSPATH=$STARROCKS_HOME/conf:$STARROCKS_HOME/lib/jni-packages/*:$HADOOP
 # ================= native section =====================
 export LD_LIBRARY_PATH=$STARROCKS_HOME/lib/hadoop/native:$LD_LIBRARY_PATH
 export_cachelib_lib_path
-
 
 # ================== kill/start =======================
 if [ ! -d $LOG_DIR ]; then


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If the operating system configuration is unreasonable, it will cause some stability problems, so these configurations will be verified before starting BE, and if unreasonable, the warning log will be printed.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
