### PR TITLE
[BugFix] Broadcast prober always different from builder

### DIFF
--- a/be/src/exec/pipeline/hashjoin/hash_joiner_factory.h
+++ b/be/src/exec/pipeline/hashjoin/hash_joiner_factory.h
@@ -18,50 +18,61 @@ using HashJoinerFactoryPtr = std::shared_ptr<HashJoinerFactory>;
 
 class HashJoinerFactory {
 public:
-    HashJoinerFactory(starrocks::vectorized::HashJoinerParam& param, int dop) : _param(param), _hash_joiners(dop) {}
+    HashJoinerFactory(starrocks::vectorized::HashJoinerParam& param, int dop)
+            : _param(param), _builder_map(dop), _read_only_prober_map(dop) {}
 
     Status prepare(RuntimeState* state);
     void close(RuntimeState* state);
 
     HashJoinerPtr create_prober(int driver_sequence) {
-        if (!_hash_joiners[driver_sequence]) {
-            _param._is_buildable = is_buildable(driver_sequence);
-            _hash_joiners[driver_sequence] = std::make_shared<HashJoiner>(_param, _read_only_probers);
+        if (!_need_read_only_prober()) {
+            return create_builder(driver_sequence);
         }
 
-        if (!_hash_joiners[driver_sequence]->is_buildable()) {
-            _read_only_probers.emplace_back(_hash_joiners[driver_sequence]);
+        if (!_read_only_prober_map[driver_sequence]) {
+            _read_only_prober_map[driver_sequence] = std::make_shared<HashJoiner>(_param, _read_only_probers);
+            _read_only_probers.emplace_back(_read_only_prober_map[driver_sequence]);
         }
-
-        return _hash_joiners[driver_sequence];
+        return _read_only_prober_map[driver_sequence];
     }
 
     HashJoinerPtr create_builder(int driver_sequence) {
-        if (_param._distribution_mode == TJoinDistributionMode::BROADCAST) {
+        if (_is_broadcast()) {
             driver_sequence = BROADCAST_BUILD_DRIVER_SEQUENCE;
         }
-        if (!_hash_joiners[driver_sequence]) {
-            _param._is_buildable = true;
-            _hash_joiners[driver_sequence] = std::make_shared<HashJoiner>(_param, _read_only_probers);
+
+        if (!_builder_map[driver_sequence]) {
+            _builder_map[driver_sequence] = std::make_shared<HashJoiner>(_param, _read_only_probers);
         }
-
-        return _hash_joiners[driver_sequence];
-    }
-
-    bool is_buildable(int driver_sequence) const {
-        return _param._distribution_mode != TJoinDistributionMode::BROADCAST ||
-               driver_sequence == BROADCAST_BUILD_DRIVER_SEQUENCE;
+        return _builder_map[driver_sequence];
     }
 
     const HashJoiners& get_read_only_probers() const { return _read_only_probers; }
 
 private:
+    bool _is_broadcast() const { return _param._distribution_mode == TJoinDistributionMode::BROADCAST; }
+
+    bool _need_read_only_prober() const {
+        const size_t prober_dop = _read_only_prober_map.size();
+        return _is_broadcast() && prober_dop > 1;
+    }
+
     // Broadcast join need only create one hash table, because all the HashJoinProbeOperators
     // use the same hash table with their own different probe states.
     static constexpr int BROADCAST_BUILD_DRIVER_SEQUENCE = 0;
 
     starrocks::vectorized::HashJoinerParam _param;
-    HashJoiners _hash_joiners;
+    // For broadcast join:
+    // - There are one builder and `DOP` probers.
+    // - Each prober references the same hash table from the builder and has its own probe state.
+    //   - When DOP > 1, the prober and builder are different.
+    //   - When DOP = 1, the prober and builder share the same joiner.
+    //
+    // For none-broadcast join:
+    // - There are `DOP` joiners.
+    // - The builder and joiner with the same driver sequence share the same joiner.
+    HashJoiners _builder_map;
+    HashJoiners _read_only_prober_map;
     HashJoiners _read_only_probers;
 };
 

--- a/be/src/exec/vectorized/hash_joiner.cpp
+++ b/be/src/exec/vectorized/hash_joiner.cpp
@@ -39,7 +39,6 @@ HashJoiner::HashJoiner(const HashJoinerParam& param, const std::vector<HashJoine
           _build_conjunct_ctxs_is_empty(param._build_conjunct_ctxs_is_empty),
           _output_slots(param._output_slots),
           _build_runtime_filters(param._build_runtime_filters.begin(), param._build_runtime_filters.end()),
-          _is_buildable(param._is_buildable),
           _read_only_join_probers(read_only_join_probers) {
     _is_push_down = param._hash_join_node.is_push_down;
     if (_join_type == TJoinOp::LEFT_ANTI_JOIN && param._hash_join_node.is_rewritten_from_not_in) {
@@ -53,8 +52,6 @@ HashJoiner::HashJoiner(const HashJoinerParam& param, const std::vector<HashJoine
 }
 
 Status HashJoiner::prepare_builder(RuntimeState* state, RuntimeProfile* runtime_profile) {
-    DCHECK(_is_buildable);
-
     if (_runtime_state == nullptr) {
         _runtime_state = state;
     }

--- a/be/src/exec/vectorized/hash_joiner.h
+++ b/be/src/exec/vectorized/hash_joiner.h
@@ -96,7 +96,6 @@ struct HashJoinerParam {
     std::set<SlotId> _output_slots;
 
     const TJoinDistributionMode::type _distribution_mode;
-    bool _is_buildable = false;
 };
 
 class HashJoiner final : public pipeline::ContextWithDependency {
@@ -150,8 +149,6 @@ public:
     Status create_runtime_filters(RuntimeState* state);
 
     void reference_hash_table(HashJoiner* src_join_builder);
-
-    bool is_buildable() const { return _is_buildable; }
 
     // These two methods are used only by the hash join builder.
     void set_builder_finished();
@@ -375,8 +372,6 @@ private:
     // hash table doesn't have reserved data
     bool _ht_has_remain = false;
     // right table have not output data for right outer join/right semi join/right anti join/full outer join
-
-    const bool _is_buildable;
 
     // These two fields are used only by the hash join builder.
     const std::vector<HashJoinerPtr>& _read_only_join_probers;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20952.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For broadcast join:
- There are one builder and `DOP` probers.
- Each prober references the same hash table from the builder and has its own probe state.
- The prober whose driver sequence is 0 share **the same joiner** as the builder.

If the `HashJoinProbeOperator` short-circuits, whose driver sequence is 0, it will make the builder enters `EOS` stage directly, which leads to the other `HashJoinProbeOperator`s also see the builder is at the `EOS` stage and cannot probe the hash table anymore.

```C++
Status HashJoinProbeOperator::set_finished(RuntimeState* state) {
    _join_prober->enter_eos_phase();
    _join_builder->set_prober_finished();
    return Status::OK();
}
```

## Solutions
Disallow the probers share the same joiner as the builder. That is, each prober use different joiner from the builder.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
