### PR TITLE
[BugFix][Cherry-pick] Fix the failure to refresh when joining the internal and external tables of the materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -97,7 +97,7 @@ public class BaseTableInfo {
     }
 
     public String getTableIdentifier() {
-        return this.tableIdentifier;
+        return this.tableIdentifier == null ? String.valueOf(tableId) : this.tableIdentifier;
     }
 
     public long getDbId() {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
@@ -859,7 +859,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 "CREATE MATERIALIZED VIEW `hive_join_internal_mv`\n" +
                 "COMMENT \"MATERIALIZED_VIEW\"\n" +
                 "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
-                "REFRESH DEFERRED MANUAL\n" +
+                "REFRESH MANUAL\n" +
                 "PROPERTIES (\n" +
                 "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
@@ -551,6 +551,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         testAutoPartitionRefreshWithUnPartitionedHiveTable();
         testAutoPartitionRefreshWithPartitionedHiveTable1();
         testAutoPartitionRefreshWithPartitionedHiveTable2();
+        testAutoPartitionRefreshWithPartitionedHiveTableJoinInternalTable();
         testAutoPartitionRefreshWithHiveTableJoin1();
         testAutoPartitionRefreshWithHiveTableJoin2();
 
@@ -850,6 +851,51 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         Assert.assertEquals(3, materializedView.getPartition("hive_tbl_mv2").getVisibleVersion());
 
         starRocksAssert.useDatabase("test").dropMaterializedView("hive_tbl_mv2");
+    }
+
+
+    public void testAutoPartitionRefreshWithPartitionedHiveTableJoinInternalTable() throws Exception {
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "CREATE MATERIALIZED VIEW `hive_join_internal_mv`\n" +
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"storage_medium\" = \"HDD\"\n" +
+                ")\n" +
+                "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a" +
+                        " join test.tbl1 b on a.l_suppkey=b.k2;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_join_internal_mv"));
+
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+                taskRun.getProcessor();
+
+        MvTaskRunContext mvContext = processor.getMvContext();
+        ExecPlan execPlan = mvContext.getExecPlan();
+        assertPlanContains(execPlan, "partitions=6/6");
+
+        MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
+        mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
+                ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
+
+        taskRun.executeTaskRun();
+        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        mvContext = processor.getMvContext();
+        execPlan = mvContext.getExecPlan();
+        assertPlanContains(execPlan, "partitions=6/6");
+
+        Collection<Partition> partitions = materializedView.getPartitions();
+        Assert.assertEquals(1, partitions.size());
+        Assert.assertEquals(3, materializedView.getPartition("hive_join_internal_mv").getVisibleVersion());
+
+        starRocksAssert.useDatabase("test").dropMaterializedView("hive_join_internal_mv");
     }
 
     public void testPartitionRefreshWithUpperCaseTable() throws Exception {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20926

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
