### PR TITLE
[Refactor] rename HiveMetastoreThriftClient to HiveMetastoreClient

### DIFF
--- a/fe/checkstyle.xml
+++ b/fe/checkstyle.xml
@@ -48,7 +48,7 @@ https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_c
     <module name="SuppressWarningsFilter"/>
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern"
-                  value="(.*[\\/]starrocks[\\/](analysis)|(planner)[\\/].*$)|Log4jConfig.java|FunctionSet.java|HiveMetaStoreThriftClient.java|Platform.java|.*[\\/]udf-extensions[\\/].*"/>
+                  value="(.*[\\/]starrocks[\\/](analysis)|(planner)[\\/].*$)|Log4jConfig.java|FunctionSet.java|HiveMetaStoreClient.java|Platform.java|.*[\\/]udf-extensions[\\/].*"/>
     </module>
 
     <module name="FileTabCharacter">

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -23,6 +23,7 @@ import com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient;
 import com.starrocks.sql.PlannerProfile;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -91,7 +92,7 @@ public class HiveMetaClient {
                         AWSCatalogMetastoreClient.class.getName());
             } else {
                 hiveClient = RetryingMetaStoreClient.getProxy(conf, DUMMY_HOOK_LOADER,
-                        HiveMetaStoreThriftClient.class.getName());
+                        HiveMetaStoreClient.class.getName());
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/HiveClientPool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/HiveClientPool.java
@@ -16,10 +16,10 @@
 package com.starrocks.connector.iceberg.hive;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.starrocks.connector.hive.HiveMetaStoreThriftClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -49,7 +49,7 @@ public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException>
         try {
             try {
                 return GET_CLIENT.invoke(hiveConf, (HiveMetaHookLoader) tbl -> null,
-                        HiveMetaStoreThriftClient.class.getName());
+                        HiveMetaStoreClient.class.getName());
             } catch (RuntimeException e) {
                 // any MetaException would be wrapped into RuntimeException during reflection, so let's double-check type here
                 if (e.getCause() instanceof MetaException) {

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -32,16 +32,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package com.starrocks.connector.hive;
+package org.apache.hadoop.hive.metastore;
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
-import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
-import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.PartitionDropOptions;
-import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.AggrStats;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Catalog;
@@ -188,8 +184,8 @@ import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCa
  * ,getTableColumnStatistics, getPartitionColumnStatistics.
  * Newly added method should cover hive0/1/2/3 metastore server.
  */
-public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseable {
-    private static final Logger LOG = LogManager.getLogger(HiveMetaStoreThriftClient.class);
+public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
+    private static final Logger LOG = LogManager.getLogger(HiveMetaStoreClient.class);
 
     ThriftHiveMetastore.Iface client = null;
     private TTransport transport = null;
@@ -224,15 +220,15 @@ public class HiveMetaStoreThriftClient implements IMetaStoreClient, AutoCloseabl
 
     private final ClientCapabilities version;
 
-    public HiveMetaStoreThriftClient(Configuration conf) throws MetaException {
+    public HiveMetaStoreClient(Configuration conf) throws MetaException {
         this(conf, null, true);
     }
 
-    public HiveMetaStoreThriftClient(Configuration conf, HiveMetaHookLoader hookLoader) throws MetaException {
+    public HiveMetaStoreClient(Configuration conf, HiveMetaHookLoader hookLoader) throws MetaException {
         this(conf, hookLoader, true);
     }
 
-    public HiveMetaStoreThriftClient(Configuration conf, HiveMetaHookLoader hookLoader, Boolean allowEmbedded)
+    public HiveMetaStoreClient(Configuration conf, HiveMetaHookLoader hookLoader, Boolean allowEmbedded)
             throws MetaException {
 
         if (conf == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -22,6 +22,7 @@ import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -41,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 public class HiveMetaClientTest {
     @Test
-    public void testClientPool(@Mocked HiveMetaStoreThriftClient metaStoreClient) throws Exception {
+    public void testClientPool(@Mocked HiveMetaStoreClient metaStoreClient) throws Exception {
         new Expectations() {
             {
                 metaStoreClient.getTable(anyString, anyString);
@@ -104,7 +105,7 @@ public class HiveMetaClientTest {
     }
 
     @Test
-    public void testRecyclableClient(@Mocked HiveMetaStoreThriftClient metaStoreClient) throws TException {
+    public void testRecyclableClient(@Mocked HiveMetaStoreClient metaStoreClient) throws TException {
         new Expectations() {
             {
                 metaStoreClient.getTable(anyString, anyString);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/hive/HiveClientPoolTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/hive/HiveClientPoolTest.java
@@ -15,14 +15,13 @@
 
 package com.starrocks.connector.iceberg.hive;
 
-import com.starrocks.connector.hive.HiveMetaStoreThriftClient;
-import com.starrocks.connector.iceberg.hive.HiveClientPool;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -102,7 +101,7 @@ public class HiveClientPoolTest {
     }
 
     @Test
-    public void testGetTablesFailsForNonReconnectableException(@Mocked HiveMetaStoreThriftClient hmsClient)
+    public void testGetTablesFailsForNonReconnectableException(@Mocked HiveMetaStoreClient hmsClient)
             throws Exception {
         new MockUp<HiveClientPool>() {
             @Mock
@@ -124,8 +123,8 @@ public class HiveClientPoolTest {
 
     @Test
     public void testConnectionFailureRestoreForMetaException(
-            @Mocked HiveMetaStoreThriftClient hmsClient,
-            @Mocked HiveMetaStoreThriftClient newClient) throws Exception {
+            @Mocked HiveMetaStoreClient hmsClient,
+            @Mocked HiveMetaStoreClient newClient) throws Exception {
         new MockUp<HiveClientPool>() {
             @Mock
             protected IMetaStoreClient newClient() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -18,12 +18,12 @@ package com.starrocks.server;
 import com.google.common.collect.Lists;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.connector.hive.HiveMetaStoreThriftClient;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
@@ -50,7 +50,7 @@ public class MetadataMgrTest {
     }
 
     @Test
-    public void testListDbNames(@Mocked HiveMetaStoreThriftClient metaStoreThriftClient) throws TException, DdlException {
+    public void testListDbNames(@Mocked HiveMetaStoreClient metaStoreThriftClient) throws TException, DdlException {
         new Expectations() {
             {
                 metaStoreThriftClient.getAllDatabases();
@@ -68,7 +68,7 @@ public class MetadataMgrTest {
     }
 
     @Test
-    public void testListTblNames(@Mocked HiveMetaStoreThriftClient metaStoreThriftClient) throws TException, DdlException {
+    public void testListTblNames(@Mocked HiveMetaStoreClient metaStoreThriftClient) throws TException, DdlException {
         new Expectations() {
             {
                 metaStoreThriftClient.getAllTables("db2");
@@ -95,7 +95,7 @@ public class MetadataMgrTest {
     }
 
     @Test
-    public void testGetDb(@Mocked HiveMetaStoreThriftClient metaStoreThriftClient) throws TException {
+    public void testGetDb(@Mocked HiveMetaStoreClient metaStoreThriftClient) throws TException {
         new Expectations() {
             {
                 metaStoreThriftClient.getDatabase("db2");
@@ -122,7 +122,7 @@ public class MetadataMgrTest {
     }
 
     @Test
-    public void testGetTable(@Mocked HiveMetaStoreThriftClient metaStoreThriftClient) throws TException {
+    public void testGetTable(@Mocked HiveMetaStoreClient metaStoreThriftClient) throws TException {
         List<FieldSchema> partKeys = Lists.newArrayList(new FieldSchema("col1", "BIGINT", ""));
         List<FieldSchema> unPartKeys = Lists.newArrayList(new FieldSchema("col2", "INT", ""));
         String hdfsPath = "hdfs://127.0.0.1:10000/hive";


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
After port the HiveMetastoreClient class. we could
1. Remove iceberg's excessive wrapper classes
2. If you want to use yourself hive metastore jars, you can adapt it without changing the code.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
