### PR TITLE
[Feature] dict query function

### DIFF
--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -97,6 +97,7 @@ set(EXPR_FILES
   map_apply_expr.cpp
   map_expr.cpp
   substring_index.cpp
+  dict_query_expr.cpp
 )
 
 add_library(Exprs ${EXPR_FILES})

--- a/be/src/exprs/dict_query_expr.cpp
+++ b/be/src/exprs/dict_query_expr.cpp
@@ -112,7 +112,7 @@ Status DictQueryExpr::open(RuntimeState* state, ExprContext* context, FunctionCo
     params.timeout_ms = 30000;
 
     _table_reader = std::make_shared<TableReader>();
-    _table_reader->init(params);
+    RETURN_IF_ERROR(_table_reader->init(params));
 
     _key_slots.resize(_dict_query_expr.key_fields.size());
     for (int i = 0; i < _dict_query_expr.key_fields.size(); ++i) {

--- a/be/src/exprs/dict_query_expr.cpp
+++ b/be/src/exprs/dict_query_expr.cpp
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/dict_query_expr.h"
+
+#include "agent/master_info.h"
+#include "column/chunk.h"
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "column/column_viewer.h"
+#include "gutil/casts.h"
+#include "runtime/client_cache.h"
+#include "storage/chunk_helper.h"
+#include "storage/table_reader.h"
+#include "util/thrift_rpc_helper.h"
+
+namespace starrocks {
+
+DictQueryExpr::DictQueryExpr(const TExprNode& node) : Expr(node), _dict_query_expr(node.dict_query_expr) {}
+
+StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
+    Columns columns(children().size());
+    size_t size = ptr != nullptr ? ptr->num_rows() : 1;
+    for (int i = 0; i < _children.size(); ++i) {
+        columns[i] = _children[i]->evaluate(context, ptr);
+    }
+
+    ColumnPtr res;
+    for (auto& column : columns) {
+        if (column->is_constant()) {
+            column = ColumnHelper::unpack_and_duplicate_const_column(size, column);
+        }
+    }
+    ChunkPtr key_chunk = ChunkHelper::new_chunk(_key_slots, size);
+    key_chunk->reset();
+    for (int i = 0; i < _dict_query_expr.key_fields.size(); ++i) {
+        ColumnPtr key_column = columns[1 + i];
+        key_chunk->update_column_by_index(key_column, i);
+    }
+
+    for (auto& column : key_chunk->columns()) {
+        if (column->is_nullable()) {
+            column = ColumnHelper::update_column_nullable(false, column, column->size());
+        }
+    }
+
+    std::vector<bool> found;
+    ChunkPtr value_chunk = ChunkHelper::new_chunk(_value_slot, key_chunk->num_rows());
+
+    Status status = _table_reader->multi_get(*key_chunk, {_dict_query_expr.value_field}, found, *value_chunk);
+    if (!status.ok()) {
+        // todo retry
+        LOG(WARNING) << "fail to execute multi get: " << status.detailed_message();
+        return status;
+    }
+    res = ColumnHelper::create_column(_value_slot[0]->type(), true);
+
+    int res_idx = 0;
+    for (int idx = 0; idx < size; ++idx) {
+        if (found[idx]) {
+            res->append_datum(value_chunk->get_column_by_index(0)->get(res_idx));
+            res_idx++;
+        } else {
+            if (_dict_query_expr.strict_mode) {
+                return Status::NotFound("In strict mode, query failed if record not exist in dict table.");
+            }
+            res->append_nulls(1);
+        }
+    }
+
+    return res;
+}
+
+Status DictQueryExpr::prepare(RuntimeState* state, ExprContext* context) {
+    RETURN_IF_ERROR(Expr::prepare(state, context));
+    _runtime_state = state;
+    return Status::OK();
+}
+
+Status DictQueryExpr::open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
+    // init parent open
+    RETURN_IF_ERROR(Expr::open(state, context, scope));
+
+    TGetDictQueryParamRequest request;
+    request.__set_db_name(_dict_query_expr.db_name);
+    request.__set_table_name(_dict_query_expr.tbl_name);
+    TGetDictQueryParamResponse response;
+
+    TNetworkAddress master_addr = get_master_address();
+    RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
+            master_addr.hostname, master_addr.port,
+            [&request, &response](FrontendServiceConnection& client) { client->getDictQueryParam(response, request); },
+            30000));
+
+    TableReaderParams params;
+    params.schema = response.schema;
+    params.partition_param = response.partition;
+    params.location_param = response.location;
+    params.nodes_info = response.nodes_info;
+    params.partition_versions = _dict_query_expr.partition_version;
+    params.timeout_ms = 30000;
+
+    _table_reader = std::make_shared<TableReader>();
+    _table_reader->init(params);
+
+    _key_slots.resize(_dict_query_expr.key_fields.size());
+    for (int i = 0; i < _dict_query_expr.key_fields.size(); ++i) {
+        vector<TSlotDescriptor>& slot_descs = response.schema.slot_descs;
+        for (auto& slot : slot_descs) {
+            if (slot.colName == _dict_query_expr.key_fields[i]) {
+                _key_slots[i] = state->obj_pool()->add(new SlotDescriptor(slot));
+            }
+        }
+    }
+    _value_slot.resize(1);
+    for (auto& slot : response.schema.slot_descs) {
+        if (slot.colName == _dict_query_expr.value_field) {
+            _value_slot[0] = state->obj_pool()->add(new SlotDescriptor(slot));
+        }
+    }
+
+    return Status::OK();
+}
+
+void DictQueryExpr::close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
+    Expr::close(state, context, scope);
+}
+
+} // namespace starrocks

--- a/be/src/exprs/dict_query_expr.h
+++ b/be/src/exprs/dict_query_expr.h
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <memory>
+
+#include "common/object_pool.h"
+#include "exprs/expr.h"
+#include "runtime/runtime_state.h"
+#include "storage/table_reader.h"
+
+namespace starrocks {
+
+class DictQueryExpr final : public Expr {
+public:
+    DictQueryExpr(const TExprNode& node);
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new DictQueryExpr(*this)); }
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
+    Status prepare(RuntimeState* state, ExprContext* context) override;
+    Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
+    void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
+
+private:
+    RuntimeState* _runtime_state;
+    TDictQueryExpr _dict_query_expr;
+
+    Schema _key_schema;
+    std::vector<SlotDescriptor*> _key_slots;
+    std::vector<SlotDescriptor*> _value_slot;
+    std::shared_ptr<TableReader> _table_reader;
+};
+} // namespace starrocks

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -54,6 +54,7 @@
 #include "exprs/column_ref.h"
 #include "exprs/compound_predicate.h"
 #include "exprs/condition_expr.h"
+#include "exprs/dict_query_expr.h"
 #include "exprs/dictmapping_expr.h"
 #include "exprs/function_call_expr.h"
 #include "exprs/in_predicate.h"
@@ -386,6 +387,9 @@ Status Expr::create_vectorized_expr(starrocks::ObjectPool* pool, const starrocks
         break;
     case TExprNodeType::CLONE_EXPR:
         *expr = pool->add(new CloneExpr(texpr_node));
+        break;
+    case TExprNodeType::DICT_QUERY_EXPR:
+        *expr = pool->add(new DictQueryExpr(texpr_node));
         break;
     case TExprNodeType::ARRAY_SLICE_EXPR:
     case TExprNodeType::AGG_EXPR:

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -109,6 +109,8 @@ public:
 
     int32_t col_unique_id() const { return _col_unique_id; }
 
+    SlotDescriptor(const TSlotDescriptor& tdesc);
+
 private:
     friend class DescriptorTbl;
     friend class TupleDescriptor;
@@ -136,7 +138,6 @@ private:
     // @todo: replace _null_indicator_offset when remove _null_indicator_offset
     const bool _is_nullable;
 
-    SlotDescriptor(const TSlotDescriptor& tdesc);
     SlotDescriptor(const PSlotDescriptor& pdesc);
 };
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DictQueryExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DictQueryExpr.java
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.analysis;
+
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.thrift.TDictQueryExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+
+import java.util.List;
+
+// dict_mapping(STRING dict_table_name, ANY... keys [, STRING value_column_name])
+public class DictQueryExpr extends FunctionCallExpr {
+
+    private TDictQueryExpr dictQueryExpr;
+
+    public DictQueryExpr(List<Expr> params) throws SemanticException {
+        super(FunctionSet.DICT_MAPPING, params);
+    }
+
+    public DictQueryExpr(List<Expr> params, TDictQueryExpr dictQueryExpr, Function fn) {
+        super(FunctionSet.DICT_MAPPING, params);
+        this.dictQueryExpr = dictQueryExpr;
+        this.fn = fn;
+        setType(fn.getReturnType());
+    }
+
+    protected DictQueryExpr(DictQueryExpr other) {
+        super(other);
+        this.dictQueryExpr = other.getDictQueryExpr();
+    }
+
+
+    @Override
+    protected void toThrift(TExprNode msg) {
+        msg.setNode_type(TExprNodeType.DICT_QUERY_EXPR);
+        msg.setDict_query_expr(dictQueryExpr);
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitDictQueryExpr(this, context);
+    }
+
+    @Override
+    public boolean isAggregateFunction() {
+        return false;
+    }
+
+    @Override
+    public Expr clone() {
+        return new DictQueryExpr(this);
+    }
+
+    public TDictQueryExpr getDictQueryExpr() {
+        return dictQueryExpr;
+    }
+
+    public void setDictQueryExpr(TDictQueryExpr dictQueryExpr) {
+        this.dictQueryExpr = dictQueryExpr;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -449,6 +449,9 @@ public class FunctionSet {
     public static final Function JSON_QUERY_FUNC = new Function(
             new FunctionName(JSON_QUERY), new Type[] {Type.JSON, Type.VARCHAR}, Type.JSON, false);
 
+    // dict query function
+    public static final String DICT_MAPPING = "dict_mapping";
+
     private static final Logger LOGGER = LogManager.getLogger(FunctionSet.class);
 
     private static final Set<Type> STDDEV_ARG_TYPE =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -26,6 +26,7 @@ import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.CloneExpr;
 import com.starrocks.analysis.CollectionElementExpr;
 import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.DictQueryExpr;
 import com.starrocks.analysis.ExistsPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -334,6 +335,11 @@ public class AggregationAnalyzer {
         @Override
         public Boolean visitCloneExpr(CloneExpr node, Void context) {
             return visit(node.getChild(0));
+        }
+
+        @Override
+        public Boolean visitDictQueryExpr(DictQueryExpr node, Void context) {
+            return node.getChildren().stream().allMatch(this::visit);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -27,6 +27,7 @@ import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.CollectionElementExpr;
 import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.DecimalLiteral;
+import com.starrocks.analysis.DictQueryExpr;
 import com.starrocks.analysis.ExistsPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -1175,6 +1176,11 @@ public class AstToStringBuilder {
                     break;
             }
             return strBuilder.toString();
+        }
+
+        @Override
+        public String visitDictQueryExpr(DictQueryExpr node, Void context) {
+            return visitFunctionCall(node, context);
         }
 
         private String visitAstList(List<? extends ParseNode> contexts) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -25,6 +25,7 @@ import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.CloneExpr;
 import com.starrocks.analysis.CollectionElementExpr;
 import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.DictQueryExpr;
 import com.starrocks.analysis.ExistsPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -1194,5 +1195,9 @@ public abstract class AstVisitor<R, C> {
 
     public R visitGroupByClause(GroupByClause node, C context) {
         return null;
+    }
+
+    public R visitDictQueryExpr(DictQueryExpr node, C context) {
+        return visitExpression(node, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictQueryOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictQueryOperator.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.optimizer.operator.scalar;
+
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+import com.starrocks.thrift.TDictQueryExpr;
+
+import java.util.List;
+
+public class DictQueryOperator extends CallOperator {
+
+    private final TDictQueryExpr dictQueryExpr;
+    private final Function fn;
+
+    public DictQueryOperator(List<ScalarOperator> arguments, TDictQueryExpr dictQueryExpr, Function fn) {
+        super(FunctionSet.DICT_MAPPING, Type.BIGINT, arguments);
+        this.dictQueryExpr = dictQueryExpr;
+        this.fn = fn;
+    }
+
+    @Override
+    public <R, C> R accept(ScalarOperatorVisitor<R, C> visitor, C context) {
+        return visitor.visitDictQueryOperator(this, context);
+    }
+
+    public TDictQueryExpr getDictQueryExpr() {
+        return dictQueryExpr;
+    }
+
+    public Function getFn() {
+        return fn;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorVisitor.java
@@ -114,4 +114,8 @@ public abstract class ScalarOperatorVisitor<R, C> {
     public R visitSubqueryOperator(SubqueryOperator operator, C context) {
         return visit(operator, context);
     }
+
+    public R visitDictQueryOperator(DictQueryOperator operator, C context) {
+        return visit(operator, context);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -27,6 +27,7 @@ import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.CloneExpr;
 import com.starrocks.analysis.CollectionElementExpr;
 import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.DictQueryExpr;
 import com.starrocks.analysis.ExistsPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -82,6 +83,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictQueryOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -820,6 +822,15 @@ public final class SqlToScalarOperatorTranslator {
         @Override
         public ScalarOperator visitCloneExpr(CloneExpr node, Context context) {
             return new CloneOperator(visit(node.getChild(0), context.clone(node)));
+        }
+
+        @Override
+        public ScalarOperator visitDictQueryExpr(DictQueryExpr node, Context context) {
+            List<ScalarOperator> arguments = node.getChildren()
+                    .stream()
+                    .map(child -> visit(child, context.clone(node)))
+                    .collect(Collectors.toList());
+            return new DictQueryOperator(arguments, node.getDictQueryExpr(), node.getFn());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -36,6 +36,7 @@ import com.starrocks.analysis.ColumnPosition;
 import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.DecimalLiteral;
+import com.starrocks.analysis.DictQueryExpr;
 import com.starrocks.analysis.ExistsPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FloatLiteral;
@@ -5669,6 +5670,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                         fnName, Lists.newArrayList(e1, e2, new StringLiteral(" ")), pos);
                 return functionCallExpr;
             }
+        }
+
+        if (functionName.equals(FunctionSet.DICT_MAPPING)) {
+            List<Expr> params = visit(context.expression(), Expr.class);
+            return new DictQueryExpr(params);
         }
 
         FunctionCallExpr functionCallExpr = new FunctionCallExpr(fnName,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -31,6 +31,7 @@ import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.DecimalLiteral;
 import com.starrocks.analysis.DictMappingExpr;
+import com.starrocks.analysis.DictQueryExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FloatLiteral;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -70,6 +71,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictQueryOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -596,6 +598,14 @@ public class ScalarOperatorToExpr {
             Subquery subquery = new Subquery(operator.getQueryStatement());
             subquery.setUseSemiAnti(operator.getApplyOperator().isUseSemiAnti());
             return subquery;
+        }
+
+        @Override
+        public Expr visitDictQueryOperator(DictQueryOperator operator, FormatterContext context) {
+            List<Expr> arg = operator.getChildren().stream()
+                    .map(expr -> buildExpr.build(expr, context))
+                    .collect(Collectors.toList());
+            return new DictQueryExpr(arg, operator.getDictQueryExpr(), operator.getFn());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -199,7 +199,7 @@ public class OlapTableSinkTest {
 
     @Test
     public void testCreateLocationWithLocalTablet(@Mocked GlobalStateMgr globalStateMgr,
-                                                  @Mocked SystemInfoService systemInfoService) {
+                                                  @Mocked SystemInfoService systemInfoService) throws Exception {
         long dbId = 1L;
         long tableId = 2L;
         long partitionId = 3L;
@@ -263,9 +263,8 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId),
-                TWriteQuorumType.MAJORITY, false, false, false);
-        TOlapTableLocationParam param = (TOlapTableLocationParam) Deencapsulation.invoke(sink, "createLocation", table);
+        TOlapTableLocationParam param = OlapTableSink.createLocation(
+                table, table.getClusterId(), Lists.newArrayList(partitionId), false);
         System.out.println(param);
 
         // Check
@@ -280,7 +279,7 @@ public class OlapTableSinkTest {
 
     @Test
     public void testReplicatedStorageWithLocalTablet(@Mocked GlobalStateMgr globalStateMgr,
-            @Mocked SystemInfoService systemInfoService) {
+            @Mocked SystemInfoService systemInfoService) throws Exception {
         long dbId = 1L;
         long tableId = 2L;
         long partitionId = 3L;
@@ -347,9 +346,8 @@ public class OlapTableSinkTest {
             }
         };
 
-        OlapTableSink sink = new OlapTableSink(table, null, Lists.newArrayList(partitionId),
-                TWriteQuorumType.MAJORITY, true, false, false);
-        TOlapTableLocationParam param = (TOlapTableLocationParam) Deencapsulation.invoke(sink, "createLocation", table);
+        TOlapTableLocationParam param = OlapTableSink.createLocation(
+                table, table.getClusterId(), Lists.newArrayList(partitionId), true);
         System.out.println(param);
 
         // Check

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
@@ -1,0 +1,210 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DictQueryFunctionTest {
+
+    private static final String TEST_DICT_DATABASE = "dict";
+
+    public static ConnectContext connectContext;
+    public static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+
+        starRocksAssert.withDatabase(TEST_DICT_DATABASE);
+        starRocksAssert.useDatabase(TEST_DICT_DATABASE);
+
+
+        String dictTable = "" +
+                "CREATE TABLE dict_table(    \n" +
+                "   key_varchar VARCHAR NOT NULL,\n" +
+                "   key_dt DATETIME NOT NULL,\n" +
+                "   value BIGINT(20) NOT NULL AUTO_INCREMENT    \n" +
+                ") ENGINE=OLAP \n" +
+                "PRIMARY KEY(`key_varchar`, `key_dt`)\n" +
+                "PARTITION BY RANGE(`key_dt`)\n" +
+                "(PARTITION p20230506 VALUES [(\"2023-05-06 00:00:00\"), (\"2023-05-07 00:00:00\")))\n" +
+                "DISTRIBUTED BY HASH(`key_varchar`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"enable_persistent_index\" = \"false\",\n" +
+                "    \"replicated_storage\" = \"true\"\n" +
+                ");";
+
+        String dictTableDup = "" +
+                "CREATE TABLE dict_table_dup(    \n" +
+                "   key_varchar VARCHAR NOT NULL,\n" +
+                "   key_dt DATETIME NOT NULL,\n" +
+                "   value BIGINT(20) NOT NULL     \n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`key_varchar`, `key_dt`)\n" +
+                "PARTITION BY RANGE(`key_dt`)\n" +
+                "(PARTITION p20230506 VALUES [(\"2023-05-06 00:00:00\"), (\"2023-05-07 00:00:00\")))\n" +
+                "DISTRIBUTED BY HASH(`key_varchar`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"enable_persistent_index\" = \"false\",\n" +
+                "    \"replicated_storage\" = \"true\"\n" +
+                ");";
+
+        String dictTableNoAutoInc = "" +
+                "CREATE TABLE dict_table_without_inc(    \n" +
+                "   key_varchar VARCHAR NOT NULL,\n" +
+                "   key_dt DATETIME NOT NULL,\n" +
+                "   value STRING NOT NULL    \n" +
+                ") ENGINE=OLAP \n" +
+                "PRIMARY KEY(`key_varchar`, `key_dt`)\n" +
+                "PARTITION BY RANGE(`key_dt`)\n" +
+                "(PARTITION p20230506 VALUES [(\"2023-05-06 00:00:00\"), (\"2023-05-07 00:00:00\")))\n" +
+                "DISTRIBUTED BY HASH(`key_varchar`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"enable_persistent_index\" = \"false\",\n" +
+                "    \"replicated_storage\" = \"true\"\n" +
+                ");";
+        starRocksAssert.withTable(dictTable);
+        starRocksAssert.withTable(dictTableDup);
+        starRocksAssert.withTable(dictTableNoAutoInc);
+    }
+
+    @Test
+    public void testFunction() throws Exception {
+        new ExceptionChecker("SELECT dict_mapping('dict.dict_table', 'key', CAST('2023-05-06' AS DATETIME))")
+                .ok();
+
+        new ExceptionChecker("SELECT dict_mapping('dict_table', 'key', CAST('2023-05-06' AS DATETIME))")
+                .ok();
+
+        new ExceptionChecker("SELECT dict_mapping('dict.dict_table', 'key', CAST('2023-05-06' AS DATETIME), 'value')")
+                .ok();
+
+        new ExceptionChecker("SELECT dict_mapping('dict.dict_table', 'key', CAST('2023-05-06' AS DATETIME), 'value', true)")
+                .ok();
+
+    }
+
+    @Test
+    public void testFunctionWithException() throws Exception {
+        testDictMappingFunction(
+                "SELECT dict_mapping('catalog.db.tbl', 'k');",
+                "dict_mapping function first param table_name should be 'db.tbl' or 'tbl' format.");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('not_exist.dict_table', 'key', '2023-05-06');",
+                "Database not_exist is not found.");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table_not_exist', 'key', '2023-05-06');",
+                "dict table dict_table_not_exist is not found.");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table_dup', 'key', '2023-05-06', 'value');",
+                "dict table dict.dict_table_dup should be primary key table.");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table', 'key', '2023-05-06', 'value', 'extra');",
+                "dict_mapping function strict_mode param should be bool constant.");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table', 'key', CAST('2023-05-06' AS datetime), 'v');",
+                "dict_mapping function can't find value column v in dict table.");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table_without_inc', 'key', CAST('2023-05-06' AS datetime));",
+                "dict_mapping function can't find auto increment column in dict table.");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table', 'key', '2023-05-06');",
+                "dict_mapping function params not match expected");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table', 'key', '2023-05-06', 'value', 'extra', true);",
+                "dict_mapping function param size should be 3 - 5.");
+
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table', 'key', null, 'value', true);",
+                "dict_mapping function params not match expected");
+    }
+
+    private void testDictMappingFunction(String sql, String expectException) {
+        new ExceptionChecker(sql)
+                .withException(SemanticException.class)
+                .containMessage(expectException)
+                .ok();
+    }
+
+    static class ExceptionChecker {
+        private final String stmt;
+        private Class<? extends Exception> expectException = null;
+        private String expectMsg = null;
+
+
+        ExceptionChecker(String stmt) {
+            this.stmt = stmt;
+        }
+
+        public ExceptionChecker withException(Class<? extends Exception> expectException) {
+            this.expectException = expectException;
+            return this;
+        }
+
+        public ExceptionChecker containMessage(String expectMsg) {
+            this.expectMsg = expectMsg;
+            return this;
+        }
+
+        public void ok() {
+            try {
+                starRocksAssert.query(stmt).explainQuery();
+            } catch (Exception e) {
+                if (expectException != null) {
+                    if (!e.getClass().isAssignableFrom(expectException)) {
+                        throw new RuntimeException(
+                            String.format("expect exception: %s, actual: %s", expectException.getName(), e.getClass().getName()),
+                            e);
+                    }
+                    if (expectMsg != null) {
+                        if (!e.getMessage().contains(expectMsg)) {
+                            throw new RuntimeException(
+                                String.format("expect exception message: %s, actual: %s", expectMsg, e.getMessage()),
+                                e);
+                        } else {
+                            return;
+                        }
+                    }
+                }
+                throw new RuntimeException("expect no exception, actual: " + e.getMessage(), e);
+            }
+            if (expectException != null) {
+                throw new RuntimeException(String.format("expect exception: %s, actual no exception", expectException.getName()));
+            }
+        }
+
+    }
+
+
+}

--- a/gensrc/thrift/Exprs.thrift
+++ b/gensrc/thrift/Exprs.thrift
@@ -82,6 +82,7 @@ enum TExprNodeType {
   MAP_ELEMENT_EXPR,
   BINARY_LITERAL,
   MAP_EXPR,
+  DICT_QUERY_EXPR,
 }
 
 struct TAggregateExpr {
@@ -171,6 +172,15 @@ struct TFunctionCallExpr {
   2: optional i32 vararg_start_idx
 }
 
+struct TDictQueryExpr {
+  1: required string db_name
+  2: required string tbl_name
+  3: required map<i64, i64> partition_version
+  4: required list<string> key_fields
+  5: required string value_field
+  6: required bool strict_mode
+}
+
 // This is essentially a union over the subclasses of Expr.
 struct TExprNode {
   1: required TExprNodeType node_type
@@ -219,6 +229,8 @@ struct TExprNode {
   52: optional bool is_nullable
   53: optional Types.TTypeDesc child_type_desc
   54: optional bool is_monotonic
+
+  55: optional TDictQueryExpr dict_query_expr
 }
 
 struct TPartitionLiteral {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -99,7 +99,7 @@ struct TDescribeTableParams {
   6: optional i64 limit
 
   // If not set, match default_catalog
-  7: optional string catalog_name 
+  7: optional string catalog_name
 }
 
 // Results of a call to describeTable()
@@ -371,8 +371,8 @@ struct TMaterializedViewStatus {
     1: optional string id
     2: optional string database_name
     3: optional string name
-    4: optional string refresh_type 
-    5: optional string is_active 
+    4: optional string refresh_type
+    5: optional string is_active
     6: optional string last_refresh_start_time
     7: optional string last_refresh_finished_time
     8: optional string last_refresh_duration
@@ -382,7 +382,7 @@ struct TMaterializedViewStatus {
     12: optional string text
     13: optional string rows
 
-    14: optional string partition_type 
+    14: optional string partition_type
     15: optional string last_refresh_force_refresh
     16: optional string last_refresh_start_partition
     17: optional string last_refresh_end_partition
@@ -406,7 +406,7 @@ struct TListPipesInfo {
     // pipe entity
     1: optional i64 pipe_id
     2: optional string pipe_name
-    
+
     // schema info
     10: optional string database_name
 
@@ -431,8 +431,8 @@ struct TListPipeFilesInfo {
     // pipe entity
     1: optional i64 pipe_id
     2: optional string pipe_name
-    3: optional string database_name    
-    
+    3: optional string database_name
+
 
     // file entity
     10: optional string file_name
@@ -441,12 +441,12 @@ struct TListPipeFilesInfo {
     13: optional i64 file_size
     14: optional i64 file_rows
     15: optional string last_modified
-    
+
     // load status
     20: optional string staged_time
     21: optional string start_load
     22: optional string finish_load
-    
+
     // error information
     30: optional string first_error_msg
     31: optional i64 error_count
@@ -1314,7 +1314,7 @@ struct TAuthInfo {
     2: optional string user   // deprecated
     3: optional string user_ip    // deprecated
     4: optional Types.TUserIdentity current_user_ident // to replace the user and user ip
-    
+
     // If not set, match default_catalog
     5: optional string catalog_name
 }
@@ -1405,7 +1405,7 @@ struct TRequireSlotRequest {
 }
 
 struct TRequireSlotResponse {
-    
+
 }
 
 struct TFinishSlotRequirementRequest {
@@ -1523,6 +1523,18 @@ struct TGetProfileResponse {
     2: optional list<string> query_result
 }
 
+struct TGetDictQueryParamRequest {
+    1: optional string db_name
+    2: optional string table_name
+}
+
+struct TGetDictQueryParamResponse {
+  1: required Descriptors.TOlapTableSchemaParam schema
+  2: required Descriptors.TOlapTablePartitionParam partition
+  3: required Descriptors.TOlapTableLocationParam location
+  4: required Descriptors.TNodesInfo nodes_info
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -1593,7 +1605,7 @@ service FrontendService {
     TUpdateResourceUsageResponse updateResourceUsage(1: TUpdateResourceUsageRequest request)
 
     TGetWarehousesResponse getWarehouses(1: TGetWarehousesRequest request)
-    
+
     // For Materialized View
     MVMaintenance.TMVReportEpochResponse mvReport(1: MVMaintenance.TMVMaintenanceTasks request)
 
@@ -1607,7 +1619,9 @@ service FrontendService {
     TRequireSlotResponse requireSlotAsync(1: TRequireSlotRequest request)
     TFinishSlotRequirementResponse finishSlotRequirement(1: TFinishSlotRequirementRequest request)
     TReleaseSlotResponse releaseSlot(1: TReleaseSlotRequest request)
-    
+
     TGetLoadTxnStatusResult getLoadTxnStatus(1: TGetLoadTxnStatusRequest request)
+
+    TGetDictQueryParamResponse getDictQueryParam(1: TGetDictQueryParamRequest request)
 }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：

implement function 'dict_mapping' support query a primary key table, and return a numeric value column.

dict_mapping(dict_table, keys... [, value_column])

argument:
dict_table: STRING, with 'db.table' or 'table' format, needs a table to exist and is the primary key model.
keys: same as dict_table pk length, order, and type, not support implicit type cast.
value_column: STRING optional, if don't specific value column, find first AUTO_INCREMENT column as value column, value column must be BIGINT type.
strict_mode: BOOLEAN optional, default is false, in strict mode, the query will be failed if dict record does not exist.

return:
BIGINT, the actual value of value column.
<img width="669" alt="image" src="https://github.com/StarRocks/starrocks/assets/51392299/3a008146-3143-4bb8-b4d2-cf85079d48c0">


Use case:
Create a primary key table with auto-increment column as the global dictionary.
use 'dict_mapping' function when loading data to the base table, mapping the string type key to ordered number, then use BITMAP type to create rollup mv speed up count distinct query.

Detail:
Intercept 'dict_mapping' function in SQL planner, and transfer dict table metadata in TExprNode to BE. DictQueryExpr does real work using TableReader multi_get API query records from dict table and return id.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
