### PR TITLE
[BugFix] fix query stuck issue due to prepare failure when enable_profile=true

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1030,6 +1030,7 @@ public class Coordinator {
                             LOG.warn("exec plan fragment failed, errmsg={}, code: {}, fragmentId={}, backend={}:{}",
                                     errMsg, code, pair.first.fragmentId,
                                     pair.first.address.hostname, pair.first.address.port);
+                            profileDoneSignal.markedCountDown(pair.first.fragmentInstanceId(), -1L);
                             if (errorBackendExecState == null) {
                                 errorBackendExecState = pair.first;
                                 errorCode = code;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20963

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

when enable_profile is true, FE should wait until all fragment instances finish or profile_timeout exceeds.

![image](https://user-images.githubusercontent.com/3675229/229738453-39711cd8-ab41-4f40-8eb0-442da259d858.png)

profileDoneSignal will only count down when  the reportExecStatus request of related fragment instance is received.

in BE side, if a failure occurs during prepare phase, it has no chance to send reportExecStatus request, so profileDoneSignal will never count down and endProfile method will wait until profile_timeout exceeds.

in fact, we can count down immediately when we receive an error from RPC, so the above problem can be solved.  



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
