### PR TITLE
[BugFix] Fix bug of Replay recover table throws NPE 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -539,6 +539,7 @@ public class CatalogRecycleBin extends LeaderDaemon implements Writable {
             db.createTable(table);
             LOG.info("recover db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
             iterator.remove();
+            nameToTableInfo.remove(dbId, table.getName());
             removeRecycleMarkers(table.getId());
             tableNames.remove(table.getName());
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21047
Recovering database only removes the idToTableInfo from RecycleBin. If drop table with force options from the db which is recovered from RecycleBin, that table can still be recovered, because the nameToTableInfo remains the table's info. But when replaying the recover table log, we use idToTableInfo to find the tableInfo, this will cause NPE, because the tableInfo is cleared from idToTableInfo after the db is recovered.
To fix this bug: remove the related table from nameToTableInfo when recovering database;

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
