### PR TITLE
[Enhancement] support auto spill mode in aggregate blocking operator

### DIFF
--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -180,16 +180,7 @@ pipeline::OpFactories AggregateBlockingNode::_decompose_to_pipeline(pipeline::Op
     auto spill_channel_factory =
             std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism, std::move(executor));
     if (std::is_same_v<SinkFactory, SpillableAggregateBlockingSinkOperatorFactory>) {
-        OpFactories spill_process_operators;
-
-        auto spill_process_factory = std::make_shared<SpillProcessOperatorFactory>(
-                context->next_operator_id(), "spill-process", id(), spill_channel_factory);
-        spill_process_factory->set_degree_of_parallelism(degree_of_parallelism);
-        spill_process_operators.emplace_back(std::move(spill_process_factory));
-
-        auto noop_sink_factory = std::make_shared<NoopSinkOperatorFactory>(context->next_operator_id(), id());
-        spill_process_operators.emplace_back(std::move(noop_sink_factory));
-        context->add_pipeline(std::move(spill_process_operators));
+        context->interpolate_spill_process(spill_channel_factory, degree_of_parallelism);
     }
 
     // create aggregator factory

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -1228,7 +1228,7 @@ void Aggregator::build_hash_map_with_selection_and_allocation(size_t chunk_size,
     });
 }
 
-Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk) {
+Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk, bool* use_intermediate_as_output) {
     SCOPED_TIMER(_agg_stat->get_results_timer);
 
     RETURN_IF_ERROR(_hash_map_variant.visit([&](auto& variant_value) {
@@ -1240,7 +1240,8 @@ Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk
 
         const auto hash_map_size = _hash_map_variant.size();
         auto num_rows = std::min<size_t>(hash_map_size - _num_rows_processed, chunk_size);
-        auto use_intermediate = _use_intermediate_as_output();
+        auto use_intermediate =
+                use_intermediate_as_output != nullptr ? *use_intermediate_as_output : _use_intermediate_as_output();
         Columns group_by_columns = _create_group_by_columns(num_rows);
         Columns agg_result_columns = _create_agg_result_columns(num_rows, use_intermediate);
 

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -475,7 +475,7 @@ public:
     void build_hash_map(size_t chunk_size, bool agg_group_by_with_limit = false);
     void build_hash_map_with_selection(size_t chunk_size);
     void build_hash_map_with_selection_and_allocation(size_t chunk_size, bool agg_group_by_with_limit = false);
-    Status convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk);
+    Status convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk, bool* use_intermediate_as_output = nullptr);
 
     void build_hash_set(size_t chunk_size);
     void build_hash_set_with_selection(size_t chunk_size);
@@ -599,6 +599,9 @@ public:
     void set_aggr_mode(AggrMode aggr_mode) { _aggr_mode = aggr_mode; }
 
     const AggregatorParamsPtr& aggregator_param() { return _aggregator_param; }
+
+    const TPlanNode& t_node() { return _tnode; }
+    const AggrMode aggr_mode() { return _aggr_mode; }
 
 private:
     const TPlanNode& _tnode;

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -44,13 +44,15 @@ public:
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
-private:
+protected:
     // It is used to perform aggregation algorithms shared by
     // AggregateBlockingSourceOperator. It is
     // - prepared at SinkOperator::prepare(),
     // - reffed at constructor() of both sink and source operator,
     // - unreffed at close() of both sink and source operator.
     AggregatorPtr _aggregator = nullptr;
+
+private:
     // Whether prev operator has no output
     bool _is_finished = false;
     // whether enable aggregate group by limit optimize

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_source_operator.h
@@ -40,7 +40,7 @@ public:
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
-private:
+protected:
     // It is used to perform aggregation algorithms shared by
     // AggregateBlockingSinkOperator. It is
     // - prepared at SinkOperator::prepare(),

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -28,7 +28,7 @@
 
 namespace starrocks::pipeline {
 bool SpillableAggregateBlockingSinkOperator::need_input() const {
-    return !is_finished() && !_aggregator->is_full();
+    return !is_finished() && !_aggregator->is_full() && !_aggregator->spill_channel()->has_task();
 }
 
 bool SpillableAggregateBlockingSinkOperator::is_finished() const {
@@ -37,12 +37,13 @@ bool SpillableAggregateBlockingSinkOperator::is_finished() const {
 
 Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {
     RETURN_IF_ERROR(AggregateBlockingSinkOperator::set_finishing(state));
-
     // ugly code
     // TODO: fixme
     auto io_executor = _aggregator->spill_channel()->io_executor();
-    RETURN_IF_ERROR(_aggregator->spiller()->flush(state, *io_executor, spill::MemTrackerGuard(tls_mem_tracker)));
 
+    auto flush_function = [this](RuntimeState* state, auto io_executor) {
+        return _aggregator->spiller()->flush(state, *io_executor, spill::MemTrackerGuard(tls_mem_tracker));
+    };
     auto set_call_back_function = [this](RuntimeState* state, auto io_executor) {
         _aggregator->spill_channel()->set_finishing();
         return _aggregator->spiller()->set_flush_all_call_back(
@@ -52,7 +53,23 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
                 },
                 state, *io_executor, spill::MemTrackerGuard(tls_mem_tracker));
     };
-    RETURN_IF_ERROR(set_call_back_function(state, io_executor));
+
+    if (_aggregator->spill_channel()->is_working()) {
+        DCHECK(_spill_strategy == spill::SpillStrategy::SPILL_ALL);
+        std::function<StatusOr<ChunkPtr>()> task = [state, io_executor, flush_function,
+                                                    set_call_back_function]() -> StatusOr<ChunkPtr> {
+            RETURN_IF_ERROR(flush_function(state, io_executor));
+            RETURN_IF_ERROR(set_call_back_function(state, io_executor));
+            return Status::EndOfFile("eos");
+        };
+        _aggregator->spill_channel()->add_spill_task({task});
+    } else {
+        if (_spill_strategy == spill::SpillStrategy::SPILL_ALL) {
+            // if spilling happens, should flush data
+            RETURN_IF_ERROR(flush_function(state, io_executor));
+        }
+        RETURN_IF_ERROR(set_call_back_function(state, io_executor));
+    }
 
     return Status::OK();
 }
@@ -77,26 +94,60 @@ Status SpillableAggregateBlockingSinkOperator::push_chunk(RuntimeState* state, c
     if (chunk == nullptr || chunk->is_empty()) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
-    if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
-        return AggregateBlockingSinkOperator::push_chunk(state, chunk);
-    } else if (_spill_strategy == spill::SpillStrategy::SPILL_ALL) {
+    RETURN_IF_ERROR(AggregateBlockingSinkOperator::push_chunk(state, chunk));
+    set_revocable_mem_bytes(_aggregator->hash_map_memory_usage());
+    if (_spill_strategy == spill::SpillStrategy::SPILL_ALL) {
         return _spill_all_inputs(state, chunk);
-    } else {
-        return Status::OK();
     }
+    return Status::OK();
 }
 
 Status SpillableAggregateBlockingSinkOperator::_spill_all_inputs(RuntimeState* state, const ChunkPtr& chunk) {
     // spill all data
-    auto spillable = std::make_shared<Chunk>();
-    RETURN_IF_ERROR(_aggregator->convert_to_spill_format(chunk.get(), &spillable));
+    DCHECK(!_aggregator->is_none_group_by_exprs());
+    _aggregator->hash_map_variant().visit(
+            [&](auto& hash_map_with_key) { _aggregator->it_hash() = _aggregator->_state_allocator.begin(); });
+    CHECK(!_aggregator->spill_channel()->has_task());
+    RETURN_IF_ERROR(_spill_aggregated_data(state));
+    return Status::OK();
+}
 
-    auto executor = _aggregator->spill_channel()->io_executor();
-    RETURN_IF_ERROR(
-            _aggregator->spiller()->spill(state, spillable, *executor, spill::MemTrackerGuard(tls_mem_tracker)));
+Status SpillableAggregateBlockingSinkOperator::_spill_aggregated_data(RuntimeState* state) {
+    auto io_executor = _aggregator->spill_channel()->io_executor();
+    auto spiller = _aggregator->spiller();
+    auto spill_channel = _aggregator->spill_channel();
+    auto process_task = _generate_spill_task(state);
+    while (!_aggregator->spiller()->is_full()) {
+        auto chunk_st = process_task();
+        if (chunk_st.ok()) {
+            RETURN_IF_ERROR(
+                    spiller->spill(state, chunk_st.value(), *io_executor, spill::MemTrackerGuard(tls_mem_tracker)));
+        } else if (chunk_st.status().is_end_of_file()) {
+            // no more data in aggregator, reset state
+            RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
+            return Status::OK();
+        } else {
+            return chunk_st.status();
+        }
+    }
+    spill_channel->add_spill_task(std::move(process_task));
 
     return Status::OK();
+}
+
+std::function<StatusOr<ChunkPtr>()> SpillableAggregateBlockingSinkOperator::_generate_spill_task(RuntimeState* state) {
+    return [this, state]() -> StatusOr<ChunkPtr> {
+        bool use_intermediate_as_output = true;
+        if (!_aggregator->is_ht_eos()) {
+            auto chunk = std::make_shared<Chunk>();
+            RETURN_IF_ERROR(
+                    _aggregator->convert_hash_map_to_chunk(state->chunk_size(), &chunk, &use_intermediate_as_output));
+            chunk->check_or_die();
+            return chunk;
+        }
+        RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
+        return Status::EndOfFile("no more data in current aggregator");
+    };
 }
 
 Status SpillableAggregateBlockingSinkOperatorFactory::prepare(RuntimeState* state) {
@@ -126,6 +177,7 @@ Status SpillableAggregateBlockingSinkOperatorFactory::prepare(RuntimeState* stat
 OperatorPtr SpillableAggregateBlockingSinkOperatorFactory::create(int32_t degree_of_parallelism,
                                                                   int32_t driver_sequence) {
     auto aggregator = _aggregator_factory->get_or_create(driver_sequence);
+
     auto op = std::make_shared<SpillableAggregateBlockingSinkOperator>(aggregator, this, _id, _plan_node_id,
                                                                        driver_sequence);
     // create spiller

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -153,7 +153,6 @@ std::function<StatusOr<ChunkPtr>()> SpillableAggregateBlockingSinkOperator::_gen
             auto chunk = std::make_shared<Chunk>();
             RETURN_IF_ERROR(
                     _aggregator->convert_hash_map_to_chunk(state->chunk_size(), &chunk, &use_intermediate_as_output));
-            chunk->check_or_die();
             return chunk;
         }
         RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -62,13 +62,14 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
 
     if (_aggregator->spill_channel()->is_working()) {
         DCHECK(_spill_strategy == spill::SpillStrategy::SPILL_ALL);
-        std::function<StatusOr<ChunkPtr>()> flush_task = [this, state, io_executor, flush_function]() ->StatusOr<ChunkPtr> {
+        std::function<StatusOr<ChunkPtr>()> flush_task = [this, state, io_executor,
+                                                          flush_function]() -> StatusOr<ChunkPtr> {
             RETURN_IF_ERROR(flush_function(state, io_executor));
             return Status::EndOfFile("eos");
         };
         _aggregator->spill_channel()->add_spill_task({flush_task});
-        std::function<StatusOr<ChunkPtr>()> task = [state, io_executor,
-                                                    set_call_back_function, this]() -> StatusOr<ChunkPtr> {
+        std::function<StatusOr<ChunkPtr>()> task = [state, io_executor, set_call_back_function,
+                                                    this]() -> StatusOr<ChunkPtr> {
             RETURN_IF_ERROR(set_call_back_function(state, io_executor));
             return Status::EndOfFile("eos");
         };

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
@@ -25,10 +25,9 @@ namespace starrocks::pipeline {
 class SpillableAggregateBlockingSinkOperator : public AggregateBlockingSinkOperator {
 public:
     template <class... Args>
-    SpillableAggregateBlockingSinkOperator(SortedStreamingAggregatorPtr aggregator, Args&&... args)
+    SpillableAggregateBlockingSinkOperator(AggregatorPtr aggregator, Args&&... args)
             : AggregateBlockingSinkOperator(aggregator, std::forward<Args>(args)...,
-                                            "spillable_aggregate_block_sink_operator"),
-              _aggregator(aggregator) {}
+                                            "spillable_aggregate_block_sink_operator") {}
 
     ~SpillableAggregateBlockingSinkOperator() override = default;
 
@@ -42,10 +41,18 @@ public:
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
     bool pending_finish() const override { return _aggregator->has_pending_data(); }
 
+    void mark_need_spill() override {
+        Operator::mark_need_spill();
+        _spill_strategy = spill::SpillStrategy::SPILL_ALL;
+        TRACE_SPILL_LOG << "AggregateBlockingSink, mark spill " << (void*)this;
+    }
+
 private:
     Status _spill_all_inputs(RuntimeState* state, const ChunkPtr& chunk);
+    Status _spill_aggregated_data(RuntimeState* state);
 
-    SortedStreamingAggregatorPtr _aggregator;
+    std::function<StatusOr<ChunkPtr>()> _generate_spill_task(RuntimeState* state);
+
     spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
 
     bool _is_finished = false;
@@ -54,7 +61,7 @@ private:
 class SpillableAggregateBlockingSinkOperatorFactory : public OperatorFactory {
 public:
     SpillableAggregateBlockingSinkOperatorFactory(int32_t id, int32_t plan_node_id,
-                                                  StreamingAggregatorFactoryPtr aggregator_factory,
+                                                  AggregatorFactoryPtr aggregator_factory,
                                                   SpillProcessChannelFactoryPtr spill_channel_factory)
             : OperatorFactory(id, "spillable_aggregate_blocking_sink", plan_node_id),
               _aggregator_factory(std::move(aggregator_factory)),
@@ -73,7 +80,7 @@ private:
 
     std::shared_ptr<spill::SpilledOptions> _spill_options;
     std::shared_ptr<spill::SpillerFactory> _spill_factory = std::make_shared<spill::SpillerFactory>();
-    StreamingAggregatorFactoryPtr _aggregator_factory;
+    AggregatorFactoryPtr _aggregator_factory;
     SpillProcessChannelFactoryPtr _spill_channel_factory;
 };
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -50,7 +50,7 @@ bool SpillableAggregateBlockingSourceOperator::is_finished() const {
     if (!_aggregator->spiller()->spilled()) {
         return AggregateBlockingSourceOperator::is_finished();
     }
-    return AggregateBlockingSourceOperator::is_finished() && _aggregator->is_spilled_eos() && !_has_last_chunk;
+    return _aggregator->is_spilled_eos() && !_has_last_chunk;
 }
 
 Status SpillableAggregateBlockingSourceOperator::set_finished(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -69,8 +69,8 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::pull_chunk(RuntimeS
 
     if (res != nullptr) {
         const int64_t old_size = res->num_rows();
-        RETURN_IF_ERROR(eval_conjuncts_and_in_filters(_aggregator->conjunct_ctxs(), res.get()));
-        _aggregator->update_num_rows_returned(-(old_size - static_cast<int64_t>(res->num_rows())));
+        RETURN_IF_ERROR(eval_conjuncts_and_in_filters(_stream_aggregator->conjunct_ctxs(), res.get()));
+        _stream_aggregator->update_num_rows_returned(-(old_size - static_cast<int64_t>(res->num_rows())));
     }
 
     return res;
@@ -78,7 +78,16 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::pull_chunk(RuntimeS
 
 StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk(RuntimeState* state) {
     DCHECK(_accumulator.need_input());
+
+    // first time, lazy init
+    if (!_stream_aggregator_inited) {
+        RETURN_IF_ERROR(_stream_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get()));
+        RETURN_IF_ERROR(_stream_aggregator->open(state));
+        _stream_aggregator_inited = true;
+    }
+
     ChunkPtr res;
+
     if (!_aggregator->is_spilled_eos()) {
         auto executor = _aggregator->spill_channel()->io_executor();
         ASSIGN_OR_RETURN(auto chunk,
@@ -87,15 +96,14 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
         if (chunk->is_empty()) {
             return chunk;
         }
-
-        RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
-        RETURN_IF_ERROR(_aggregator->evaluate_agg_fn_exprs(chunk.get(), true));
-        ASSIGN_OR_RETURN(res, _aggregator->streaming_compute_agg_state(chunk->num_rows(), false));
+        RETURN_IF_ERROR(_stream_aggregator->evaluate_groupby_exprs(chunk.get()));
+        RETURN_IF_ERROR(_stream_aggregator->evaluate_agg_fn_exprs(chunk.get(), true));
+        ASSIGN_OR_RETURN(res, _stream_aggregator->streaming_compute_agg_state(chunk->num_rows(), false));
         _accumulator.push(std::move(res));
 
     } else {
         _has_last_chunk = false;
-        ASSIGN_OR_RETURN(res, _aggregator->pull_eos_chunk());
+        ASSIGN_OR_RETURN(res, _stream_aggregator->pull_eos_chunk());
         if (res != nullptr && !res->is_empty()) {
             _accumulator.push(std::move(res));
         }
@@ -110,4 +118,16 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
     return nullptr;
 }
 
+Status SpillableAggregateBlockingSourceOperatorFactory::prepare(RuntimeState* state) {
+    _stream_aggregator_factory = std::make_shared<StreamingAggregatorFactory>(_hash_aggregator_factory->t_node());
+    _stream_aggregator_factory->set_aggr_mode(_hash_aggregator_factory->aggr_mode());
+    return Status::OK();
+}
+
+OperatorPtr SpillableAggregateBlockingSourceOperatorFactory::create(int32_t degree_of_parallelism,
+                                                                    int32_t driver_sequence) {
+    return std::make_shared<SpillableAggregateBlockingSourceOperator>(
+            _hash_aggregator_factory->get_or_create(driver_sequence),
+            _stream_aggregator_factory->get_or_create(driver_sequence), this, _id, _plan_node_id, driver_sequence);
+}
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
For #17541

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

support auto spilling mode in aggregate blocking operator.

here is the basic idea:

at the beginning, we use hash-based aggregation in sink side, just like it in the AggregateBlockingSinkOperator.
if the conditions to trigger spilling are not met, we still use hash-based aggregation in source side, 
otherwise we will spill the aggregated data to disk in sink side , and use sorted-based aggregation in source side.



## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
