### PR TITLE
[BugFix] Fix PlainPasswordAuthenticationProvider miss plain password check result bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/PlainPasswordAuthenticationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/PlainPasswordAuthenticationProvider.java
@@ -95,7 +95,9 @@ public class PlainPasswordAuthenticationProvider implements AuthenticationProvid
             // Plain remote password, scramble it first.
             byte[] scrambledRemotePass =
                     MysqlPassword.makeScrambledPassword(new String(remotePassword, StandardCharsets.UTF_8));
-            MysqlPassword.checkScrambledPlainPass(authenticationInfo.getPassword(), scrambledRemotePass);
+            if (!MysqlPassword.checkScrambledPlainPass(authenticationInfo.getPassword(), scrambledRemotePass)) {
+                throw new AuthenticationException("password mismatch!");
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/PlainPasswordAuthenticationProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/PlainPasswordAuthenticationProviderTest.java
@@ -58,7 +58,7 @@ public class PlainPasswordAuthenticationProviderTest {
     }
 
     @Test
-    public void testAuthentica() throws Exception {
+    public void testAuthentication() throws Exception {
         UserIdentity testUser = UserIdentity.createAnalyzedUserIdentWithIp("test", "%");
         String[] passwords = {"asdf123", "starrocks", "testtest"};
         byte[] seed = "petals on a wet black bough".getBytes(StandardCharsets.UTF_8);
@@ -99,5 +99,29 @@ public class PlainPasswordAuthenticationProviderTest {
             Assert.assertTrue(e.getMessage().contains("password mismatch!"));
         }
 
+        try {
+            provider.authenticate(
+                    testUser.getQualifiedUser(),
+                    "10.1.1.1",
+                    MysqlPassword.scramble(seed, "bb"),
+                    seed,
+                    info);
+
+        } catch (AuthenticationException e) {
+            Assert.fail();
+        }
+
+        try {
+            byte[] remotePassword = "bb".getBytes(StandardCharsets.UTF_8);
+            provider.authenticate(
+                    testUser.getQualifiedUser(),
+                    "10.1.1.1",
+                    remotePassword,
+                    null,
+                    info);
+
+        } catch (AuthenticationException e) {
+            Assert.fail();
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
