### PR TITLE
[Enhancement] add batch insert statistics on fe

### DIFF
--- a/be/src/exprs/hyperloglog_functions.cpp
+++ b/be/src/exprs/hyperloglog_functions.cpp
@@ -85,8 +85,7 @@ DEFINE_UNARY_FN_WITH_IMPL(HllSerializeImpl, hll) {
     return std::string(data, size);
 }
 
-
-StatusOr<ColumnPtr> HyperloglogFunctions::hll_serialize(FunctionContext* context, const Columns& columns) {    
+StatusOr<ColumnPtr> HyperloglogFunctions::hll_serialize(FunctionContext* context, const Columns& columns) {
     return VectorizedStringStrictUnaryFunction<HllSerializeImpl>::evaluate<TYPE_HLL, TYPE_VARCHAR>(columns[0]);
 }
 
@@ -111,6 +110,5 @@ StatusOr<ColumnPtr> HyperloglogFunctions::hll_deserialize(FunctionContext* conte
         return hll_column;
     }
 }
-
 
 } // namespace starrocks

--- a/be/src/exprs/hyperloglog_functions.cpp
+++ b/be/src/exprs/hyperloglog_functions.cpp
@@ -77,4 +77,40 @@ StatusOr<ColumnPtr> HyperloglogFunctions::hll_empty(FunctionContext* context, co
     return ConstColumn::create(p, 1);
 }
 
+// hll_serialize
+DEFINE_UNARY_FN_WITH_IMPL(HllSerializeImpl, hll) {
+    size_t size = hll->serialize_size();
+    char data[size];
+    size = hll->serialize((uint8_t*)data);
+    return std::string(data, size);
+}
+
+
+StatusOr<ColumnPtr> HyperloglogFunctions::hll_serialize(FunctionContext* context, const Columns& columns) {    
+    return VectorizedStringStrictUnaryFunction<HllSerializeImpl>::evaluate<TYPE_HLL, TYPE_VARCHAR>(columns[0]);
+}
+
+// hll_deserialize
+StatusOr<ColumnPtr> HyperloglogFunctions::hll_deserialize(FunctionContext* context, const Columns& columns) {
+    ColumnViewer<TYPE_VARCHAR> str_viewer(columns[0]);
+    auto hll_column = HyperLogLogColumn::create();
+    size_t size = columns[0]->size();
+    for (int row = 0; row < size; ++row) {
+        HyperLogLog hll;
+        if (!str_viewer.is_null(row)) {
+            Slice s = str_viewer.value(row);
+            hll.deserialize(s);
+        }
+
+        hll_column->append(&hll);
+    }
+
+    if (ColumnHelper::is_all_const(columns)) {
+        return ConstColumn::create(hll_column, columns[0]->size());
+    } else {
+        return hll_column;
+    }
+}
+
+
 } // namespace starrocks

--- a/be/src/exprs/hyperloglog_functions.h
+++ b/be/src/exprs/hyperloglog_functions.h
@@ -49,7 +49,7 @@ public:
     DEFINE_VECTORIZED_FN(hll_empty);
 
     DEFINE_VECTORIZED_FN(hll_serialize);
-    
+
     DEFINE_VECTORIZED_FN(hll_deserialize);
 };
 

--- a/be/src/exprs/hyperloglog_functions.h
+++ b/be/src/exprs/hyperloglog_functions.h
@@ -47,6 +47,10 @@ public:
      * @return: HllColumn
      */
     DEFINE_VECTORIZED_FN(hll_empty);
+
+    DEFINE_VECTORIZED_FN(hll_serialize);
+    
+    DEFINE_VECTORIZED_FN(hll_deserialize);
 };
 
 } // namespace starrocks

--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -28,6 +28,7 @@ const int STATISTIC_DATA_VERSION1 = 1;
 const int STATISTIC_HISTOGRAM_VERSION = 2;
 const int DICT_STATISTIC_DATA_VERSION = 101;
 const int STATISTIC_TABLE_VERSION = 3;
+const int STATISTIC_BATCH_VERSION = 4;
 
 StatisticResultWriter::StatisticResultWriter(BufferControlBlock* sinker,
                                              const std::vector<ExprContext*>& output_expr_ctxs,
@@ -143,6 +144,9 @@ StatusOr<TFetchDataResultPtr> StatisticResultWriter::_process_chunk(Chunk* chunk
                                   "Fill histogram statistic data failed");
     } else if (version == STATISTIC_TABLE_VERSION) {
         RETURN_IF_ERROR_WITH_WARN(_fill_table_statistic_data(version, result_columns, chunk, result.get()),
+                                  "Fill table statistic data failed");
+    } else if (version == STATISTIC_BATCH_VERSION) {
+        RETURN_IF_ERROR_WITH_WARN(_fill_full_statistic_data_v4(version, result_columns, chunk, result.get()),
                                   "Fill table statistic data failed");
     }
     return result;
@@ -269,6 +273,61 @@ Status StatisticResultWriter::_fill_table_statistic_data(int version, const Colu
     for (int i = 0; i < num_rows; ++i) {
         data_list[i].__set_partitionId(partitionId->get(i).get_int64());
         data_list[i].__set_rowCount(rowCounts->get(i).get_int64());
+    }
+
+    result->result_batch.rows.resize(num_rows);
+    result->result_batch.__set_statistic_version(version);
+
+    ThriftSerializer serializer(true, chunk->memory_usage());
+    for (int i = 0; i < num_rows; ++i) {
+        RETURN_IF_ERROR(serializer.serialize(&data_list[i], &result->result_batch.rows[i]));
+    }
+    return Status::OK();
+}
+
+/*
+FE SQL:    
+    SELECT cast(4 as INT), 
+         cast(7164015 as BIGINT), 
+         'k1', 
+         cast(COUNT(1) as BIGINT), 
+         cast(COUNT(1) * 4 as BIGINT), 
+         hll_serialize(IFNULL(hll_raw(`k1`), hll_empty())), 
+         cast(COUNT(1) - COUNT(`k1`) as BIGINT), 
+         IFNULL(MAX(`k1`), ''), 
+         IFNULL(MIN(`k1`), '')
+    FROM xx
+*/
+Status StatisticResultWriter::_fill_full_statistic_data_v4(int version, const Columns& columns, const Chunk* chunk,
+                                                           TFetchDataResult* result) {
+    SCOPED_TIMER(_serialize_timer);
+
+    // mapping with Data.thrift.TStatisticData
+    DCHECK(columns.size() == 9);
+
+    // skip read version
+    auto pid = ColumnViewer<TYPE_BIGINT>(columns[1]);
+    auto name = ColumnViewer<TYPE_VARCHAR>(columns[2]);
+    auto rowCounts = ColumnViewer<TYPE_BIGINT>(columns[3]);
+    auto dataSizes = ColumnViewer<TYPE_BIGINT>(columns[4]);
+    auto hll = ColumnViewer<TYPE_VARCHAR>(columns[5]);
+    auto nullCounts = ColumnViewer<TYPE_BIGINT>(columns[6]);
+    auto max = ColumnViewer<TYPE_VARCHAR>(columns[7]);
+    auto min = ColumnViewer<TYPE_VARCHAR>(columns[8]);
+
+    std::vector<TStatisticData> data_list;
+    int num_rows = chunk->num_rows();
+
+    data_list.resize(num_rows);
+    for (int i = 0; i < num_rows; ++i) {
+        data_list[i].__set_partitionId(pid.value(i));
+        data_list[i].__set_columnName(name.value(i).to_string());
+        data_list[i].__set_rowCount(rowCounts.value(i));
+        data_list[i].__set_dataSize(dataSizes.value(i));
+        data_list[i].__set_hll(hll.value(i).to_string());
+        data_list[i].__set_nullCount(nullCounts.value(i));
+        data_list[i].__set_max(max.value(i).to_string());
+        data_list[i].__set_min(min.value(i).to_string());
     }
 
     result->result_batch.rows.resize(num_rows);

--- a/be/src/runtime/statistic_result_writer.h
+++ b/be/src/runtime/statistic_result_writer.h
@@ -54,6 +54,8 @@ private:
     Status _fill_table_statistic_data(int version, const Columns& columns, const Chunk* chunk,
                                       TFetchDataResult* result);
 
+    Status _fill_full_statistic_data_v4(int version, const Columns& columns, const Chunk* chunk, TFetchDataResult* result);
+
 private:
     BufferControlBlock* _sinker;
     const std::vector<ExprContext*>& _output_expr_ctxs;

--- a/be/src/runtime/statistic_result_writer.h
+++ b/be/src/runtime/statistic_result_writer.h
@@ -54,7 +54,8 @@ private:
     Status _fill_table_statistic_data(int version, const Columns& columns, const Chunk* chunk,
                                       TFetchDataResult* result);
 
-    Status _fill_full_statistic_data_v4(int version, const Columns& columns, const Chunk* chunk, TFetchDataResult* result);
+    Status _fill_full_statistic_data_v4(int version, const Columns& columns, const Chunk* chunk,
+                                        TFetchDataResult* result);
 
 private:
     BufferControlBlock* _sinker;

--- a/be/test/exprs/hyperloglog_functions_test.cpp
+++ b/be/test/exprs/hyperloglog_functions_test.cpp
@@ -170,4 +170,63 @@ TEST_F(HyperLogLogFunctionsTest, hllCardinalityFromStringTest) {
     }
 }
 
+TEST_F(HyperLogLogFunctionsTest, hllSerializeTest) {
+    {
+        auto col1 = HyperLogLogColumn::create();
+
+        HyperLogLog h1;
+        h1.update(1);
+        HyperLogLog h2;
+        h2.update(1);
+        h2.update(2);
+        h2.update(1);
+
+        HyperLogLog h3;
+        h3.update(2);
+        h3.update(2);
+        h3.update(2);
+
+        HyperLogLog h4;
+        h4.update(3);
+        h4.update(2);
+        h4.update(5);
+
+        HyperLogLog h5;
+        for (int i = 0; i < 10000; i++) {
+            h5.update(i);
+        }
+
+        HyperLogLog h6;
+        for (int i = 0; i < 100000; i++) {
+            h6.update(i);
+        }
+
+        col1->append(std::move(h1));
+        col1->append(std::move(h2));
+        col1->append(std::move(h3));
+        col1->append(std::move(h4));
+        col1->append(std::move(h5));
+        col1->append(std::move(h6));
+
+        ColumnPtr v = nullptr;
+        v = HyperloglogFunctions::hll_cardinality(ctx, {col1}).value();
+        ASSERT_TRUE(v->is_numeric());
+        auto expect = ColumnHelper::cast_to<TYPE_BIGINT>(v);
+
+
+        v = HyperloglogFunctions::hll_serialize(ctx, {col1}).value();
+        ASSERT_TRUE(v->is_binary());
+        v = HyperloglogFunctions::hll_deserialize(ctx, {v}).value();
+        ASSERT_TRUE(v->is_object());
+        v = HyperloglogFunctions::hll_cardinality(ctx, {v}).value();
+        ASSERT_TRUE(v->is_numeric());
+
+        auto autcal = ColumnHelper::cast_to<TYPE_BIGINT>(v);
+
+        ASSERT_EQ(expect->size(), autcal->size());
+        for (size_t i = 0; i < expect->size(); i++) {
+            ASSERT_EQ(expect->get_data()[i], autcal->get_data()[i]);
+        }
+    }
+}
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -74,7 +74,7 @@ public class TabletStatMgr extends LeaderDaemon {
     // for lake table
     private final Map<Long, Long> partitionToUpdatedVersion;
 
-    private LocalDateTime lastWorkTimestamp;
+    private LocalDateTime lastWorkTimestamp = LocalDateTime.MIN;
 
     public TabletStatMgr() {
         super("tablet stat mgr", Config.tablet_stat_update_interval_second * 1000L);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1518,6 +1518,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static double statistic_auto_collect_ratio = 0.8;
 
+    @ConfField(mutable = true)
+    public static double statistics_full_collect_buffer = 1024 * 1024 * 20; // 20MB
+
     // If the health in statistic_full_collect_interval is lower than this value,
     // choose collect sample statistics first
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1527,10 +1527,13 @@ public class Config extends ConfigBase {
     public static double statistic_auto_collect_sample_threshold = 0.3;
 
     @ConfField(mutable = true)
-    public static long statistic_auto_collect_table_interval_size = 5L * 1024 * 1024 * 1024; // 5G
+    public static long statistic_auto_collect_small_table_size = 5L * 1024 * 1024 * 1024; // 5G
 
     @ConfField(mutable = true)
-    public static long statistic_auto_collect_table_interval = 3600L * 12; // unit: second, default 12h
+    public static long statistic_auto_collect_small_table_interval = 0; // unit: second, default 0
+
+    @ConfField(mutable = true)
+    public static long statistic_auto_collect_large_table_interval = 3600L * 12; // unit: second, default 12h
 
     /**
      * Full statistics collection max data size

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1519,7 +1519,7 @@ public class Config extends ConfigBase {
     public static double statistic_auto_collect_ratio = 0.8;
 
     @ConfField(mutable = true)
-    public static double statistics_full_collect_buffer = 1024 * 1024 * 20; // 20MB
+    public static long statistics_full_collect_buffer = 1024L * 1024 * 20; // 20MB
 
     // If the health in statistic_full_collect_interval is lower than this value,
     // choose collect sample statistics first

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1656,6 +1656,8 @@ public class StmtExecutor {
     public Pair<List<TResultBatch>, Status> executeStmtWithExecPlan(ConnectContext context, ExecPlan plan) {
         List<TResultBatch> sqlResult = Lists.newArrayList();
         try {
+            UUID uuid = context.getQueryId();
+            context.setExecutionId(UUIDUtil.toTUniqueId(uuid));
             coord = new Coordinator(context, plan.getFragments(), plan.getScanNodes(), plan.getDescTbl().toThrift());
             QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(), coord);
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -189,13 +189,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         int maxRetryTimes = 5;
         StatementBase insertStmt = createInsertStmt();
         do {
-            // don't work if not leader, because origin statement is a mock SQL and can't forward to leader
-            if (!(GlobalStateMgr.getCurrentState().isLeader())) {
-                LOG.info("Statistics collect fail because this isn't leader");
-                return;
-            }
-
-            LOG.debug("statistics insert sql : " + insertStmt.getOrigStmt().originStmt);
+            LOG.debug("statistics insert sql size:" + rowsBuffer.size());
             StmtExecutor executor = new StmtExecutor(context, insertStmt);
             context.setExecutor(executor);
             context.setQueryId(UUIDUtil.genUUID());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -15,15 +15,34 @@
 package com.starrocks.statistic;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.OriginStatement;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.thrift.TStatisticData;
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.VelocityContext;
@@ -52,14 +71,10 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             ", $minFunction " + // VARCHAR
             " FROM `$dbName`.`$tableName` partition `$partitionName`";
 
-    private static final String BATCH_INSERT_INTO_STATISTICS_TEMPLATE = "INSERT INTO column_statistics values " +
-            "($tableId, $partitionId, '$columnName', $dbId, '$dbName.$tableName', '$partitionName'," +
-            " $count, $dataSize, hll_deserialize('$hll'), $countNull," +
-            " $maxFunction, $minFunction, NOW())";
-
     private final List<Long> partitionIdList;
 
-    private final StringBuilder buffer = new StringBuilder();
+    private final StringBuilder sqlBuffer = new StringBuilder();
+    private final List<List<Expr>> rowsBuffer = Lists.newArrayList();
 
     public FullStatisticsCollectJob(Database db, Table table, List<Long> partitionIdList, List<String> columns,
                                     StatsConstants.AnalyzeType type, StatsConstants.ScheduleType scheduleType,
@@ -91,53 +106,132 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
 
             String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
 
-            collectStatisticsData(sql, context);
+            collectStatisticSync(sql, context);
             finishedSQLNum++;
             analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
             GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
         }
 
-        syncInsertStatisticsData(context, true);
+        flushInsertStatisticsData(context, true);
+    }
+
+    private Expr hllDeserialize(String hll) {
+        Function fn = Expr.getBuiltinFunction("hll_deserialize", new Type[] {Type.VARCHAR},
+                Function.CompareMode.IS_IDENTICAL);
+        FunctionCallExpr fe = new FunctionCallExpr("hll_deserialize", Lists.newArrayList(new StringLiteral(hll)));
+        fe.setFn(fn);
+        fe.setType(fn.getReturnType());
+        return fe;
+    }
+
+    private Expr nowFn() {
+        Function fn = Expr.getBuiltinFunction(FunctionSet.NOW, new Type[] {}, Function.CompareMode.IS_IDENTICAL);
+        FunctionCallExpr fe = new FunctionCallExpr("now", Lists.newArrayList());
+        fe.setType(fn.getReturnType());
+        return fe;
     }
 
     // INSERT INTO column_statistics values
     // ($tableId, $partitionId, '$columnName', $dbId, '$dbName.$tableName', '$partitionName',
     //  $count, $dataSize, hll_deserialize('$hll'), $countNull, $maxFunction, $minFunction, NOW());
-    private void collectStatisticsData(String sql, ConnectContext context) throws Exception {
+    @Override
+    public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
         LOG.debug("statistics collect sql : " + sql);
         StatisticExecutor executor = new StatisticExecutor();
         List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
 
         List<String> params = Lists.newArrayList();
+        List<Expr> row = Lists.newArrayList();
         for (TStatisticData data : dataList) {
             params.add(String.valueOf(table.getId()));
             params.add(String.valueOf(data.getPartitionId()));
             params.add("'" + data.getColumnName() + "'");
             params.add(String.valueOf(db.getId()));
             params.add("'" + db.getOriginName() + "." + table.getName() + "'");
+            params.add("'" + table.getPartition(data.getPartitionId()).getName() + "'");
             params.add(String.valueOf(data.getRowCount()));
             params.add(String.valueOf(data.getDataSize()));
-            params.add("hll_deserialize('" + data.getHll() + "'");
+            params.add("hll_deserialize('mockData')");
             params.add(String.valueOf(data.getNullCount()));
-            params.add(data.getMax());
-            params.add(data.getMin());
+            params.add("'" + data.getMax() + "'");
+            params.add("'" + data.getMin() + "'");
             params.add("now()");
-        }
-        if (buffer.length() > 1) {
-            buffer.append(", ");
-        }
-        buffer.append("(").append(String.join(", ", params)).append(")");
+            // int
+            row.add(new IntLiteral(table.getId(), Type.BIGINT)); // table id, 8 byte
+            row.add(new IntLiteral(data.getPartitionId(), Type.BIGINT)); // partition id, 8 byte
+            row.add(new StringLiteral(data.getColumnName())); // column name, 20 byte
+            row.add(new IntLiteral(db.getId(), Type.BIGINT)); // db id, 8 byte
+            row.add(new StringLiteral(db.getOriginName() + "." + table.getName())); // table name, 50 byte
+            row.add(new StringLiteral(table.getPartition(data.getPartitionId()).getName())); // partition name, 10 byte
+            row.add(new IntLiteral(data.getRowCount(), Type.BIGINT)); // row count, 8 byte
+            row.add(new IntLiteral((long) data.getDataSize(), Type.BIGINT)); // data size, 8 byte
+            row.add(hllDeserialize(data.getHll())); // hll, 16 kB
+            row.add(new IntLiteral(data.getNullCount(), Type.BIGINT)); // null count, 8 byte
+            row.add(new StringLiteral(data.getMax())); // max, 200 byte
+            row.add(new StringLiteral(data.getMin())); // min, 200 byte
+            row.add(nowFn()); // update time, 8 byte
 
-        syncInsertStatisticsData(context, false);
+            Preconditions.checkState(params.size() == row.size());
+            rowsBuffer.add(row);
+        }
+        if (sqlBuffer.length() > 1) {
+            sqlBuffer.append(", ");
+        }
+        sqlBuffer.append("(").append(String.join(", ", params)).append(")");
+
+        flushInsertStatisticsData(context, false);
     }
 
-    private void syncInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
-        if (buffer.length() < Config.statistics_full_collect_buffer && !force) {
+    private void flushInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
+        // about 17kb
+        long bufferSize = 17L * 1024 * rowsBuffer.size();
+        if (bufferSize < Config.statistics_full_collect_buffer && !force) {
             return;
         }
 
-        String sql = "INSERT INTO column_statistics values " + buffer;
-        collectStatisticSync(sql, context);
+        int count = 0;
+        int maxRetryTimes = 5;
+        StatementBase insertStmt = createInsertStmt();
+        do {
+            // don't work if not leader, because origin statement is a mock SQL and can't forward to leader
+            if (!(GlobalStateMgr.getCurrentState().isLeader())) {
+                LOG.info("Statistics collect fail because this isn't leader");
+                return;
+            }
+
+            StmtExecutor executor = new StmtExecutor(context, insertStmt);
+            context.setExecutor(executor);
+            context.setQueryId(UUIDUtil.genUUID());
+            context.setStartTime();
+            executor.execute();
+
+            if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+                LOG.warn("Statistics collect fail | Error Message [{}]", context.getState().getErrorMessage());
+                if (StringUtils.contains(context.getState().getErrorMessage(), "Too many versions")) {
+                    Thread.sleep(Config.statistic_collect_too_many_version_sleep);
+                    count++;
+                } else {
+                    throw new DdlException(context.getState().getErrorMessage());
+                }
+            } else {
+                sqlBuffer.delete(0, sqlBuffer.length());
+                rowsBuffer.clear();
+                return;
+            }
+        } while (count < maxRetryTimes);
+
+        throw new DdlException(context.getState().getErrorMessage());
+    }
+
+    private StatementBase createInsertStmt() {
+        String sql = "INSERT INTO column_statistics values " + sqlBuffer;
+        List<String> names = Lists.newArrayList("column_0", "column_1", "column_2", "column_3",
+                "column_4", "column_5", "column_6", "column_7", "column_8", "column_9",
+                "column_10", "column_11", "column_12");
+        QueryStatement qs = new QueryStatement(new ValuesRelation(rowsBuffer, names));
+        InsertStmt insert = new InsertStmt(new TableName("_statistics_", "column_statistics"), qs);
+        insert.setOrigStmt(new OriginStatement(sql, 0));
+        return insert;
     }
 
     /*
@@ -176,6 +270,9 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         context.put("partitionId", partition.getId());
         context.put("columnName", columnName);
         context.put("dataSize", getDataSize(column));
+        context.put("partitionName", partition.getName());
+        context.put("dbName", db.getOriginName());
+        context.put("tableName", table.getName());
 
         if (!column.getType().canStatistic()) {
             context.put("hllFunction", "hll_serialize(hll_empty())");

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -31,6 +31,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
@@ -197,7 +198,8 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             executor.execute();
 
             if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
-                LOG.warn("Statistics collect fail | Error Message [{}]", context.getState().getErrorMessage());
+                LOG.warn("Statistics collect fail | {} | Error Message [{}]", DebugUtil.printId(context.getQueryId()),
+                        context.getState().getErrorMessage());
                 if (StringUtils.contains(context.getState().getErrorMessage(), "Too many versions")) {
                     Thread.sleep(Config.statistic_collect_too_many_version_sleep);
                     count++;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -20,8 +20,12 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TStatisticData;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.velocity.VelocityContext;
 
 import java.util.ArrayList;
@@ -29,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 public class FullStatisticsCollectJob extends StatisticsCollectJob {
+    private static final Logger LOG = LogManager.getLogger(FullStatisticsCollectJob.class);
 
     private static final String COLLECT_FULL_STATISTIC_TEMPLATE =
             "SELECT $tableId, $partitionId, '$columnName', $dbId," +
@@ -36,7 +41,25 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
                     " COUNT(1), $dataSize, $countDistinctFunction, $countNullFunction, $maxFunction, $minFunction, NOW() "
                     + "FROM `$dbName`.`$tableName` partition `$partitionName`";
 
+    private static final String BATCH_FULL_STATISTIC_TEMPLATE = "SELECT cast($version as INT)" +
+            ", cast($partitionId as BIGINT)" + // BIGINT
+            ", '$columnName'" + // VARCHAR
+            ", cast(COUNT(1) as BIGINT)" + // BIGINT
+            ", cast($dataSize as BIGINT)" + // BIGINT
+            ", $hllFunction" + // VARCHAR
+            ", cast($countNullFunction as BIGINT)" + // BIGINT
+            ", $maxFunction" + // VARCHAR
+            ", $minFunction " + // VARCHAR
+            " FROM `$dbName`.`$tableName` partition `$partitionName`";
+
+    private static final String BATCH_INSERT_INTO_STATISTICS_TEMPLATE = "INSERT INTO column_statistics values " +
+            "($tableId, $partitionId, '$columnName', $dbId, '$dbName.$tableName', '$partitionName'," +
+            " $count, $dataSize, hll_deserialize('$hll'), $countNull," +
+            " $maxFunction, $minFunction, NOW())";
+
     private final List<Long> partitionIdList;
+
+    private final StringBuilder buffer = new StringBuilder();
 
     public FullStatisticsCollectJob(Database db, Table table, List<Long> partitionIdList, List<String> columns,
                                     StatsConstants.AnalyzeType type, StatsConstants.ScheduleType scheduleType,
@@ -66,12 +89,55 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
                 context.getSessionVariable().setPipelineDop(1);
             }
 
-            String sql = "INSERT INTO column_statistics " + Joiner.on(" UNION ALL ").join(sqlUnion);
-            collectStatisticSync(sql, context);
+            String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
+
+            collectStatisticsData(sql, context);
             finishedSQLNum++;
             analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
             GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
         }
+
+        syncInsertStatisticsData(context, true);
+    }
+
+    // INSERT INTO column_statistics values
+    // ($tableId, $partitionId, '$columnName', $dbId, '$dbName.$tableName', '$partitionName',
+    //  $count, $dataSize, hll_deserialize('$hll'), $countNull, $maxFunction, $minFunction, NOW());
+    private void collectStatisticsData(String sql, ConnectContext context) throws Exception {
+        LOG.debug("statistics collect sql : " + sql);
+        StatisticExecutor executor = new StatisticExecutor();
+        List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
+
+        List<String> params = Lists.newArrayList();
+        for (TStatisticData data : dataList) {
+            params.add(String.valueOf(table.getId()));
+            params.add(String.valueOf(data.getPartitionId()));
+            params.add("'" + data.getColumnName() + "'");
+            params.add(String.valueOf(db.getId()));
+            params.add("'" + db.getOriginName() + "." + table.getName() + "'");
+            params.add(String.valueOf(data.getRowCount()));
+            params.add(String.valueOf(data.getDataSize()));
+            params.add("hll_deserialize('" + data.getHll() + "'");
+            params.add(String.valueOf(data.getNullCount()));
+            params.add(data.getMax());
+            params.add(data.getMin());
+            params.add("now()");
+        }
+        if (buffer.length() > 1) {
+            buffer.append(", ");
+        }
+        buffer.append("(").append(String.join(", ", params)).append(")");
+
+        syncInsertStatisticsData(context, false);
+    }
+
+    private void syncInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
+        if (buffer.length() < Config.statistics_full_collect_buffer && !force) {
+            return;
+        }
+
+        String sql = "INSERT INTO column_statistics values " + buffer;
+        collectStatisticSync(sql, context);
     }
 
     /*
@@ -86,7 +152,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         for (Long partitionId : partitionIdList) {
             Partition partition = table.getPartition(partitionId);
             for (String columnName : columns) {
-                totalQuerySQL.add(buildCollectFullStatisticSQL(db, table, partition, columnName));
+                totalQuerySQL.add(buildBatchCollectFullStatisticSQL(table, partition, columnName));
             }
         }
 
@@ -101,34 +167,60 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         return "COUNT(1) * " + typeSize;
     }
 
-    private String buildCollectFullStatisticSQL(Database database, Table table, Partition partition,
-                                                String columnName) {
+    private String buildBatchCollectFullStatisticSQL(Table table, Partition partition, String columnName) {
         StringBuilder builder = new StringBuilder();
         VelocityContext context = new VelocityContext();
         Column column = table.getColumn(columnName);
 
-        context.put("dbId", database.getId());
-        context.put("tableId", table.getId());
+        context.put("version", StatsConstants.STATISTIC_BATCH_VERSION);
         context.put("partitionId", partition.getId());
         context.put("columnName", columnName);
-        context.put("dbName", database.getOriginName());
-        context.put("tableName", table.getName());
-        context.put("partitionName", partition.getName());
         context.put("dataSize", getDataSize(column));
 
         if (!column.getType().canStatistic()) {
-            context.put("countDistinctFunction", "hll_empty()");
+            context.put("hllFunction", "hll_serialize(hll_empty())");
             context.put("countNullFunction", "0");
             context.put("maxFunction", "''");
             context.put("minFunction", "''");
         } else {
-            context.put("countDistinctFunction", "IFNULL(hll_raw(`" + columnName + "`), hll_empty())");
+            context.put("hllFunction", "hll_serialize(IFNULL(hll_raw(`" + columnName + "`), hll_empty()))");
             context.put("countNullFunction", "COUNT(1) - COUNT(`" + columnName + "`)");
             context.put("maxFunction", getMinMaxFunction(column, StatisticUtils.quoting(columnName), true));
             context.put("minFunction", getMinMaxFunction(column, StatisticUtils.quoting(columnName), false));
         }
 
-        builder.append(build(context, COLLECT_FULL_STATISTIC_TEMPLATE));
+        builder.append(build(context, BATCH_FULL_STATISTIC_TEMPLATE));
         return builder.toString();
     }
+
+    // private String buildCollectFullStatisticSQL(Database database, Table table, Partition partition,
+    //                                             String columnName) {
+    //     StringBuilder builder = new StringBuilder();
+    //     VelocityContext context = new VelocityContext();
+    //     Column column = table.getColumn(columnName);
+    //
+    //     context.put("dbId", database.getId());
+    //     context.put("tableId", table.getId());
+    //     context.put("partitionId", partition.getId());
+    //     context.put("columnName", columnName);
+    //     context.put("dbName", database.getOriginName());
+    //     context.put("tableName", table.getName());
+    //     context.put("partitionName", partition.getName());
+    //     context.put("dataSize", getDataSize(column));
+    //
+    //     if (!column.getType().canStatistic()) {
+    //         context.put("countDistinctFunction", "hll_empty()");
+    //         context.put("countNullFunction", "0");
+    //         context.put("maxFunction", "''");
+    //         context.put("minFunction", "''");
+    //     } else {
+    //         context.put("countDistinctFunction", "IFNULL(hll_raw(`" + columnName + "`), hll_empty())");
+    //         context.put("countNullFunction", "COUNT(1) - COUNT(`" + columnName + "`)");
+    //         context.put("maxFunction", getMinMaxFunction(column, StatisticUtils.quoting(columnName), true));
+    //         context.put("minFunction", getMinMaxFunction(column, StatisticUtils.quoting(columnName), false));
+    //     }
+    //
+    //     builder.append(build(context, COLLECT_FULL_STATISTIC_TEMPLATE));
+    //     return builder.toString();
+    // }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -274,6 +275,8 @@ public class StatisticExecutor {
         StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
         ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
         StmtExecutor executor = new StmtExecutor(context, parsedStmt);
+        context.setExecutor(executor);
+        context.setQueryId(UUIDUtil.genUUID());
         Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(context, execPlan);
         if (!sqlResult.second.ok()) {
             throw new SemanticException(sqlResult.second.getErrorMsg());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
@@ -279,7 +280,8 @@ public class StatisticExecutor {
         context.setQueryId(UUIDUtil.genUUID());
         Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(context, execPlan);
         if (!sqlResult.second.ok()) {
-            throw new SemanticException(sqlResult.second.getErrorMsg());
+            throw new SemanticException("Statistics query fail | Error Message [{}] | {} | SQL [{}]",
+                    context.getState().getErrorMessage(), DebugUtil.printId(context.getQueryId()), sql);
         } else {
             return sqlResult.first;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -95,7 +95,7 @@ public abstract class StatisticsCollectJob {
         return properties;
     }
 
-    public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
+    protected void collectStatisticSync(String sql, ConnectContext context) throws Exception {
         int count = 0;
         int maxRetryTimes = 5;
         do {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -99,7 +99,7 @@ public abstract class StatisticsCollectJob {
         int count = 0;
         int maxRetryTimes = 5;
         do {
-            LOG.debug("statistics collect sql : " + sql);
+            LOG.debug("statistics collect sql : {}", sql);
             StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
             context.setExecutor(executor);
@@ -108,8 +108,8 @@ public abstract class StatisticsCollectJob {
             executor.execute();
 
             if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
-                LOG.warn("Statistics collect fail | Error Message [" + context.getState().getErrorMessage() + "] | " +
-                        "SQL [" + sql + "]");
+                LOG.warn("Statistics collect fail | Error Message [{}] | SQL [{}]",
+                        context.getState().getErrorMessage(), sql);
                 if (StringUtils.contains(context.getState().getErrorMessage(), "Too many versions")) {
                     Thread.sleep(Config.statistic_collect_too_many_version_sleep);
                     count++;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
@@ -108,8 +109,8 @@ public abstract class StatisticsCollectJob {
             executor.execute();
 
             if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
-                LOG.warn("Statistics collect fail | Error Message [{}] | SQL [{}]",
-                        context.getState().getErrorMessage(), sql);
+                LOG.warn("Statistics collect fail | Error Message [{}] | {} | SQL [{}]",
+                        context.getState().getErrorMessage(), DebugUtil.printId(context.getQueryId()), sql);
                 if (StringUtils.contains(context.getState().getErrorMessage(), "Too many versions")) {
                     Thread.sleep(Config.statistic_collect_too_many_version_sleep);
                     count++;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -138,10 +138,6 @@ public class StatisticsCollectJobFactory {
                 return;
             }
 
-            long timeInterval = job.getProperties().get(StatsConstants.STATISTIC_AUTO_COLLECT_INTERVAL) != null ?
-                    Long.parseLong(job.getProperties().get(StatsConstants.STATISTIC_AUTO_COLLECT_INTERVAL)) :
-                    Config.statistic_auto_collect_table_interval;
-
             long sumDataSize = 0;
             for (Partition partition : table.getPartitions()) {
                 LocalDateTime partitionUpdateTime = StatisticUtils.getPartitionLastUpdateTime(partition);
@@ -150,8 +146,16 @@ public class StatisticsCollectJobFactory {
                 }
             }
 
+            long defaultInterval = sumDataSize > Config.statistic_auto_collect_small_table_size ?
+                    Config.statistic_auto_collect_large_table_interval :
+                    Config.statistic_auto_collect_small_table_interval;
+
+            long timeInterval = job.getProperties().get(StatsConstants.STATISTIC_AUTO_COLLECT_INTERVAL) != null ?
+                    Long.parseLong(job.getProperties().get(StatsConstants.STATISTIC_AUTO_COLLECT_INTERVAL)) :
+                    defaultInterval;
+
             if (statisticsUpdateTime.plusSeconds(timeInterval).isAfter(LocalDateTime.now()) &&
-                    sumDataSize > Config.statistic_auto_collect_table_interval_size) {
+                    sumDataSize > Config.statistic_auto_collect_small_table_size) {
                 LOG.debug("statistics job doesn't work on the interval table: {}, " +
                                 "last collect time: {}, interval: {}, table size: {}MB",
                         table.getName(), tableUpdateTime, timeInterval, ByteSizeUnit.BYTES.toMB(sumDataSize));
@@ -169,13 +173,13 @@ public class StatisticsCollectJobFactory {
                         table.getName(), healthy, statisticAutoCollectRatio);
                 return;
             } else if (healthy < Config.statistic_auto_collect_sample_threshold) {
-                if (sumDataSize > Config.statistic_auto_collect_table_interval_size) {
+                if (sumDataSize > Config.statistic_auto_collect_small_table_size) {
                     LOG.debug("statistics job choose sample on real-time update table: {}" +
                                     ", last collect time: {}, current healthy: {}, full collect healthy limit: {}<, " +
                                     ", update data size: {}MB, full collect healthy data size limit: <{}MB",
                             table.getName(), statisticsUpdateTime, healthy,
                             Config.statistic_auto_collect_sample_threshold, ByteSizeUnit.BYTES.toMB(sumDataSize),
-                            ByteSizeUnit.BYTES.toMB(Config.statistic_auto_collect_table_interval_size));
+                            ByteSizeUnit.BYTES.toMB(Config.statistic_auto_collect_small_table_size));
                     createSampleStatsJob(allTableJobMap, job, db, table, columns);
                     return;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -22,6 +22,8 @@ public class StatsConstants {
     public static final int STATISTIC_DICT_VERSION = 101;
     public static final int STATISTIC_HISTOGRAM_VERSION = 2;
     public static final int STATISTIC_TABLE_VERSION = 3;
+    public static final int STATISTIC_BATCH_VERSION = 4;
+
 
     public static final int STATISTICS_PARTITION_UPDATED_THRESHOLD = 10;
     public static final String STATISTICS_DB_NAME = "_statistics_";

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -549,9 +549,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 StatsConstants.AnalyzeType.FULL,
                 StatsConstants.ScheduleType.ONCE,
                 Maps.newHashMap());
-        sql = Deencapsulation.invoke(fullStatisticsCollectJob, "buildCollectFullStatisticSQL",
-                db, olapTable, olapTable.getPartition("tcount"),
-                "count");
+        sql = Deencapsulation.invoke(fullStatisticsCollectJob, "buildBatchCollectFullStatisticSQL",
+                olapTable, olapTable.getPartition("tcount"), "count");
         assertContains(sql, "`stats`.`tcount` partition `tcount`");
         UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -604,14 +604,14 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         new MockUp<Partition>() {
             @Mock
             public long getDataSize() {
-                return Config.statistic_auto_collect_table_interval_size + 10;
+                return Config.statistic_auto_collect_small_table_size + 10;
             }
         };
 
         Database db = GlobalStateMgr.getCurrentState().getDb("test");
         BasicStatsMeta execMeta1 = new BasicStatsMeta(db.getId(), t0StatsTableId, null,
                 StatsConstants.AnalyzeType.FULL,
-                now.minusSeconds(Config.statistic_auto_collect_table_interval).minusHours(1),
+                now.minusSeconds(Config.statistic_auto_collect_large_table_interval).minusHours(1),
                 Maps.newHashMap());
         GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(execMeta1);
 
@@ -668,14 +668,14 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         new MockUp<Partition>() {
             @Mock
             public long getDataSize() {
-                return Config.statistic_auto_collect_table_interval_size + 10;
+                return Config.statistic_auto_collect_small_table_size + 10;
             }
         };
 
         Database db = GlobalStateMgr.getCurrentState().getDb("test");
         BasicStatsMeta execMeta = new BasicStatsMeta(db.getId(), t0StatsTableId, null,
                 StatsConstants.AnalyzeType.FULL,
-                now.minusSeconds(Config.statistic_auto_collect_table_interval).minusHours(1),
+                now.minusSeconds(Config.statistic_auto_collect_large_table_interval).minusHours(1),
                 Maps.newHashMap());
         GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(execMeta);
 
@@ -737,7 +737,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             new MockUp<Partition>() {
                 @Mock
                 public long getDataSize() {
-                    return Config.statistic_auto_collect_table_interval_size - 10;
+                    return Config.statistic_auto_collect_small_table_size - 10;
                 }
             };
             // healthy = 0.1 && small table

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -80,9 +80,9 @@ public class StatisticsExecutorTest extends PlanTestBase {
         OlapTable table = (OlapTable) database.getTable("t0_stats");
         List<Long> partitionIdList = table.getAllPartitions().stream().map(Partition::getId).collect(Collectors.toList());
 
-        FullStatisticsCollectJob collectJob = new FullStatisticsCollectJob(database, table, partitionIdList,
+        SampleStatisticsCollectJob collectJob = new SampleStatisticsCollectJob(database, table,
                 Lists.newArrayList("v1", "v2", "v3", "v4", "v5"),
-                StatsConstants.AnalyzeType.FULL,
+                StatsConstants.AnalyzeType.SAMPLE,
                 StatsConstants.ScheduleType.SCHEDULE,
                 Maps.newHashMap());
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -101,5 +101,6 @@ public class StatisticsSQLTest extends PlanTestBase {
         plan = getFragmentPlan(sqls.get(1).get(0));
         assertCContains(plan, "left(");
         assertCContains(plan, "char_length(");
+        assertCContains(plan, "hll_serialize(");
     }
 }

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -526,8 +526,8 @@ vectorized_functions = [
     [80020, 'hll_hash', 'HLL', ['VARCHAR'], 'HyperloglogFunctions::hll_hash'],
     [80030, 'hll_empty', 'HLL', [], 'HyperloglogFunctions::hll_empty'],
 
-    [80040, 'hll_serialize', 'VARCHAR', ['HLL'], 'HyperloglogFunctions::hll_serialize'],
-    [80041, 'hll_deserialize', 'HLL', ['VARCHAR'], 'HyperloglogFunctions::hll_deserialize'],
+    [80040, 'hll_serialize', 'VARBINARY', ['HLL'], 'HyperloglogFunctions::hll_serialize'],
+    [80041, 'hll_deserialize', 'HLL', ['VARBINARY'], 'HyperloglogFunctions::hll_deserialize'],
 
     # bitmap function
     [90010, 'to_bitmap', 'BITMAP', ['VARCHAR'], 'BitmapFunctions::to_bitmap', False],

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -526,6 +526,9 @@ vectorized_functions = [
     [80020, 'hll_hash', 'HLL', ['VARCHAR'], 'HyperloglogFunctions::hll_hash'],
     [80030, 'hll_empty', 'HLL', [], 'HyperloglogFunctions::hll_empty'],
 
+    [80040, 'hll_serialize', 'VARCHAR', ['HLL'], 'HyperloglogFunctions::hll_serialize'],
+    [80041, 'hll_deserialize', 'HLL', ['VARCHAR'], 'HyperloglogFunctions::hll_deserialize'],
+
     # bitmap function
     [90010, 'to_bitmap', 'BITMAP', ['VARCHAR'], 'BitmapFunctions::to_bitmap', False],
     [90020, 'bitmap_hash', 'BITMAP', ['VARCHAR'], 'BitmapFunctions::bitmap_hash', False],

--- a/gensrc/thrift/Data.thrift
+++ b/gensrc/thrift/Data.thrift
@@ -117,7 +117,7 @@ struct TStatisticData {
     13: optional i64 meta_version
     14: optional i64 partitionId
     // the batch load version
-    15: optional string hll
+    15: optional binary hll
 }
 
 // Result data for user variable

--- a/gensrc/thrift/Data.thrift
+++ b/gensrc/thrift/Data.thrift
@@ -116,6 +116,8 @@ struct TStatisticData {
     // the latest partition version for this table
     13: optional i64 meta_version
     14: optional i64 partitionId
+    // the batch load version
+    15: optional string hll
 }
 
 // Result data for user variable


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
1. full statistics collect will save statistics data in fe’s buffer
2. fe will generate `insert` sql written the data to BE when the buffer is full

* add hll serialized/deserialized function
* update full statistics collect logical
* update statistics config name



## Test case:
1. I create 20s table on flat ssb table with large partition by month, like that:
```
CREATE TABLE `lineorder_flat_x1` (
  `lo_orderdate` date NOT NULL COMMENT "",
  `lo_orderkey` int(11) NOT NULL COMMENT "",
  `lo_linenumber` tinyint(4) NOT NULL COMMENT "",
  `lo_custkey` int(11) NOT NULL COMMENT "",
  `lo_partkey` int(11) NOT NULL COMMENT "",
  `lo_suppkey` int(11) NOT NULL COMMENT "",
  `lo_orderpriority` varchar(100) NOT NULL COMMENT "",
  `lo_shippriority` tinyint(4) NOT NULL COMMENT "",
  `lo_quantity` tinyint(4) NOT NULL COMMENT "",
  `lo_extendedprice` int(11) NOT NULL COMMENT "",
  `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
  `lo_discount` tinyint(4) NOT NULL COMMENT "",
  `lo_revenue` int(11) NOT NULL COMMENT "",
  `lo_supplycost` int(11) NOT NULL COMMENT "",
  `lo_tax` tinyint(4) NOT NULL COMMENT "",
  `lo_commitdate` date NOT NULL COMMENT "",
  `lo_shipmode` varchar(100) NOT NULL COMMENT "",
  `c_name` varchar(100) NOT NULL COMMENT "",
  `c_address` varchar(100) NOT NULL COMMENT "",
  `c_city` varchar(100) NOT NULL COMMENT "",
  `c_nation` varchar(100) NOT NULL COMMENT "",
  `c_region` varchar(100) NOT NULL COMMENT "",
  `c_phone` varchar(100) NOT NULL COMMENT "",
  `c_mktsegment` varchar(100) NOT NULL COMMENT "",
  `s_name` varchar(100) NOT NULL COMMENT "",
  `s_address` varchar(100) NOT NULL COMMENT "",
  `s_city` varchar(100) NOT NULL COMMENT "",
  `s_nation` varchar(100) NOT NULL COMMENT "",
  `s_region` varchar(100) NOT NULL COMMENT "",
  `s_phone` varchar(100) NOT NULL COMMENT "",
  `p_name` varchar(100) NOT NULL COMMENT "",
  `p_mfgr` varchar(100) NOT NULL COMMENT "",
  `p_category` varchar(100) NOT NULL COMMENT "",
  `p_brand` varchar(100) NOT NULL COMMENT "",
  `p_color` varchar(100) NOT NULL COMMENT "",
  `p_type` varchar(100) NOT NULL COMMENT "",
  `p_size` tinyint(4) NOT NULL COMMENT "",
  `p_container` varchar(100) NOT NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`lo_orderdate`, `lo_orderkey`)
COMMENT "olap"
PARTITION BY RANGE(`lo_orderdate`)
(
PARTITION p0 VALUES [("0000-01-01"), ("1993-01-01")),
PARTITION p1 VALUES [("1993-01-01"), ("1993-02-01")),
PARTITION p2 VALUES [("1993-02-01"), ("1993-03-01")),
PARTITION p3 VALUES [("1993-03-01"), ("1993-04-01")),
..........
PARTITION p82 VALUES [("1999-10-01"), ("1999-11-01")),
PARTITION p83 VALUES [("1999-11-01"), ("1999-12-01"))
)
DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
PROPERTIES (
"replication_num" = "1",
"colocate_with" = "groupxx1",
"in_memory" = "false",
"storage_format" = "DEFAULT",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"compression" = "LZ4"
);
```

2. load 10 rows data on every partitions, the statistics table should be 69 partition * 38 columns * 20 tables = 52440 rows least 
3. execute `anlyze full table` on all tables.

before this PR: version (1 -> 524265), row(54264)
```
MySQL hk_test> show tablet from _statistics_.column_statistics;
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
| TabletId | ReplicaId | BackendId | SchemaHash | Version | VersionHash | LstSuccessVersion | LstSuccessVersionHash | LstFailedVersion | LstFailedVersionHash | LstFailedTime | DataSize | RowCount | State  | LstConsistencyCheckTime | CheckVersion | CheckVersionHash | VersionCount | PathHash | MetaUrl                                           | CompactionStatus                                                |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
| 191154   | 191155    | 10075     | 0          | 1       | 0           | 1                 | 0                     | -1               | 0                    | <null>        | 0B       | 0        | NORMAL | <null>                  | -1           | 0                | 0            | 0        | http://172.26.197.102:8040/api/meta/header/191154 | http://172.26.197.102:8040/api/compaction/show?tablet_id=191154 |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
MySQL hk_test> show tablet from _statistics_.column_statistics;
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
| TabletId | ReplicaId | BackendId | SchemaHash | Version | VersionHash | LstSuccessVersion | LstSuccessVersionHash | LstFailedVersion | LstFailedVersionHash | LstFailedTime | DataSize | RowCount | State  | LstConsistencyCheckTime | CheckVersion | CheckVersionHash | VersionCount | PathHash | MetaUrl                                           | CompactionStatus                                                |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
| 191154   | 191155    | 10075     | 0          | 54265   | 0           | 54265             | 0                     | -1               | 0                    | <null>        | 2.5MB    | 54264    | NORMAL | <null>                  | -1           | 0                | 1            | 0        | http://172.26.197.102:8040/api/meta/header/191154 | http://172.26.197.102:8040/api/compaction/show?tablet_id=191154 |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
```


after this PR: version (1 -> 70), row(54264)
```
MySQL hk_test> show tablet from _statistics_.column_statistics;
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
| TabletId | ReplicaId | BackendId | SchemaHash | Version | VersionHash | LstSuccessVersion | LstSuccessVersionHash | LstFailedVersion | LstFailedVersionHash | LstFailedTime | DataSize | RowCount | State  | LstConsistencyCheckTime | CheckVersion | CheckVersionHash | VersionCount | PathHash | MetaUrl                                           | CompactionStatus                                                |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
| 245484   | 245485    | 10076     | 0          | 1       | 0           | 1                 | 0                     | -1               | 0                    | <null>        | 0B       | 0        | NORMAL | <null>                  | -1           | 0                | 0            | 0        | http://172.26.197.103:8040/api/meta/header/245484 | http://172.26.197.103:8040/api/compaction/show?tablet_id=245484 |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
MySQL hk_test> show tablet from _statistics_.column_statistics;
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
| TabletId | ReplicaId | BackendId | SchemaHash | Version | VersionHash | LstSuccessVersion | LstSuccessVersionHash | LstFailedVersion | LstFailedVersionHash | LstFailedTime | DataSize | RowCount | State  | LstConsistencyCheckTime | CheckVersion | CheckVersionHash | VersionCount | PathHash | MetaUrl                                           | CompactionStatus                                                |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
| 245484   | 245485    | 10076     | 0          | 70      | 0           | 70                | 0                     | -1               | 0                    | <null>        | 2.5MB    | 54264    | NORMAL | <null>                  | -1           | 0                | 6            | 0        | http://172.26.197.103:8040/api/meta/header/245484 | http://172.26.197.103:8040/api/compaction/show?tablet_id=245484 |
+----------+-----------+-----------+------------+---------+-------------+-------------------+-----------------------+------------------+----------------------+---------------+----------+----------+--------+-------------------------+--------------+------------------+--------------+----------+---------------------------------------------------+-----------------------------------------------------------------+
```

Considering the actual number of tablets is 10,  after this PR, the version should be reduced from 5000 to 70

cost time:
before this PR: (17:09:26 ~ 18:05:05)，55min
after this PR: (19:05:05 ~ 19:12:53)，7min
```
MySQL (none)> show analyze status;
+--------+----------+----------------+---------+------+----------+---------+---------------------+---------------------+------------+------------------------------------------------------------------+
| Id     | Database | Table          | Columns | Type | Schedule | Status  | StartTime           | EndTime             | Properties | Reason                                                           |
+--------+----------+----------------+---------+------+----------+---------+---------------------+---------------------+------------+------------------------------------------------------------------+
| 191198 | hk_test  | test_0         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:09:26 | 2023-04-11 17:12:05 | {}         |                                                                  |
| 193783 | hk_test  | test_1         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:12:06 | 2023-04-11 17:14:45 | {}         |                                                                  |
| 196368 | hk_test  | test_2         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:14:45 | 2023-04-11 17:17:24 | {}         |                                                                  |
| 198953 | hk_test  | test_3         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:17:24 | 2023-04-11 17:20:02 | {}         |                                                                  |
| 201538 | hk_test  | test_4         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:20:03 | 2023-04-11 17:22:42 | {}         |                                                                  |
| 204123 | hk_test  | test_5         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:22:42 | 2023-04-11 17:25:20 | {}         |                                                                  |
| 206708 | hk_test  | test_6         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:25:20 | 2023-04-11 17:27:59 | {}         |                                                                  |
| 209293 | hk_test  | test_7         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:27:59 | 2023-04-11 17:30:38 | {}         |                                                                  |
| 211878 | hk_test  | test_8         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:30:38 | 2023-04-11 17:33:17 | {}         |                                                                  |
| 214463 | hk_test  | test_9         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:33:17 | 2023-04-11 17:35:56 | {}         |                                                                  |
| 217048 | hk_test  | test_10        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:35:56 | 2023-04-11 17:38:34 | {}         |                                                                  |
| 219633 | hk_test  | test_11        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:38:35 | 2023-04-11 17:41:13 | {}         |                                                                  |
| 222218 | hk_test  | test_12        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:41:14 | 2023-04-11 17:43:52 | {}         |                                                                  |
| 224803 | hk_test  | test_13        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:43:52 | 2023-04-11 17:46:31 | {}         |                                                                  |
| 227388 | hk_test  | test_14        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:46:31 | 2023-04-11 17:49:09 | {}         |                                                                  |
| 229973 | hk_test  | test_15        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:49:09 | 2023-04-11 17:51:50 | {}         |                                                                  |
| 232558 | hk_test  | test_16        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:51:51 | 2023-04-11 17:54:29 | {}         |                                                                  |
| 235143 | hk_test  | test_17        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:54:30 | 2023-04-11 17:57:08 | {}         |                                                                  |
| 237728 | hk_test  | test_18        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:57:09 | 2023-04-11 17:59:47 | {}         |                                                                  |
| 240313 | hk_test  | test_19        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 17:59:47 | 2023-04-11 18:02:26 | {}         |                                                                  |
| 242898 | hk_test  | test_20        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 18:02:27 | 2023-04-11 18:05:05 | {}         |                                                                  |
| 246002 | hk_test  | test_0         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:05:05 | 2023-04-11 19:05:31 | {}         |                                                                  |
| 246006 | hk_test  | test_1         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:05:31 | 2023-04-11 19:05:54 | {}         |                                                                  |
| 246010 | hk_test  | test_2         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:05:54 | 2023-04-11 19:06:16 | {}         |                                                                  |
| 246014 | hk_test  | test_3         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:06:16 | 2023-04-11 19:06:38 | {}         |                                                                  |
| 246018 | hk_test  | test_4         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:06:38 | 2023-04-11 19:07:00 | {}         |                                                                  |
| 246022 | hk_test  | test_5         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:07:00 | 2023-04-11 19:07:22 | {}         |                                                                  |
| 246026 | hk_test  | test_6         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:07:22 | 2023-04-11 19:07:44 | {}         |                                                                  |
| 246030 | hk_test  | test_7         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:07:44 | 2023-04-11 19:08:06 | {}         |                                                                  |
| 246034 | hk_test  | test_8         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:08:06 | 2023-04-11 19:08:28 | {}         |                                                                  |
| 246038 | hk_test  | test_9         | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:08:28 | 2023-04-11 19:08:50 | {}         |                                                                  |
| 246042 | hk_test  | test_10        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:08:50 | 2023-04-11 19:09:12 | {}         |                                                                  |
| 246046 | hk_test  | test_11        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:09:12 | 2023-04-11 19:09:34 | {}         |                                                                  |
| 246050 | hk_test  | test_12        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:09:34 | 2023-04-11 19:09:56 | {}         |                                                                  |
| 246054 | hk_test  | test_13        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:09:56 | 2023-04-11 19:10:18 | {}         |                                                                  |
| 246058 | hk_test  | test_14        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:10:18 | 2023-04-11 19:10:40 | {}         |                                                                  |
| 246062 | hk_test  | test_15        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:10:40 | 2023-04-11 19:11:02 | {}         |                                                                  |
| 246066 | hk_test  | test_16        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:11:03 | 2023-04-11 19:11:24 | {}         |                                                                  |
| 246070 | hk_test  | test_17        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:11:25 | 2023-04-11 19:11:47 | {}         |                                                                  |
| 246074 | hk_test  | test_18        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:11:47 | 2023-04-11 19:12:09 | {}         |                                                                  |
| 246078 | hk_test  | test_19        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:12:09 | 2023-04-11 19:12:31 | {}         |                                                                  |
| 246082 | hk_test  | test_20        | ALL     | FULL | ONCE     | SUCCESS | 2023-04-11 19:12:31 | 2023-04-11 19:12:53 | {}         |                                                                  |
+--------+----------+----------------+---------+------+----------+---------+---------------------+---------------------+------------+------------------------------------------------------------------+
55 rows in set
Time: 0.033s
````


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
