### PR TITLE
[Enhancement] add compaction to script engine

### DIFF
--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -110,23 +110,13 @@ Status get_params(HttpRequest* req, uint64_t* tablet_id) {
     return Status::OK();
 }
 
-Status CompactionAction::_handle_compaction(HttpRequest* req, std::string* json_result) {
-    bool expected = false;
-    if (!_running.compare_exchange_strong(expected, true)) {
-        return Status::TooManyTasks("Manual compaction task is running");
-    }
-    DeferOp defer([&]() { _running = false; });
-    auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_compaction"));
-
-    uint64_t tablet_id;
-    RETURN_IF_ERROR(get_params(req, &tablet_id));
-
+Status CompactionAction::do_compaction(uint64_t tablet_id, const string& compaction_type,
+                                       const string& rowset_ids_string) {
     TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     RETURN_IF(tablet == nullptr, Status::InvalidArgument(fmt::format("Not Found tablet:{}", tablet_id)));
 
     auto* mem_tracker = ExecEnv::GetInstance()->compaction_mem_tracker();
     if (tablet->updates() != nullptr) {
-        string rowset_ids_string = req->param("rowset_ids");
         if (rowset_ids_string.empty()) {
             RETURN_IF_ERROR(tablet->updates()->compaction(mem_tracker));
         } else {
@@ -150,11 +140,9 @@ Status CompactionAction::_handle_compaction(HttpRequest* req, std::string* json_
             }
             RETURN_IF_ERROR(tablet->updates()->compaction(mem_tracker, rowset_ids));
         }
-        *json_result = R"({"status": "Success", "msg": "compaction task executed successful"})";
         return Status::OK();
     }
 
-    std::string compaction_type = req->param(PARAM_COMPACTION_TYPE);
     if (compaction_type != to_string(CompactionType::BASE_COMPACTION) &&
         compaction_type != to_string(CompactionType::CUMULATIVE_COMPACTION)) {
         return Status::NotSupported(fmt::format("unsupport compaction type:{}", compaction_type));
@@ -230,6 +218,22 @@ Status CompactionAction::_handle_compaction(HttpRequest* req, std::string* json_
     } else {
         __builtin_unreachable();
     }
+    return Status::OK();
+}
+
+Status CompactionAction::_handle_compaction(HttpRequest* req, std::string* json_result) {
+    bool expected = false;
+    if (!_running.compare_exchange_strong(expected, true)) {
+        return Status::TooManyTasks("Manual compaction task is running");
+    }
+    DeferOp defer([&]() { _running = false; });
+    auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_compaction"));
+
+    uint64_t tablet_id;
+    RETURN_IF_ERROR(get_params(req, &tablet_id));
+    std::string compaction_type = req->param(PARAM_COMPACTION_TYPE);
+    string rowset_ids_string = req->param("rowset_ids");
+    RETURN_IF_ERROR(do_compaction(tablet_id, compaction_type, rowset_ids_string));
     *json_result = R"({"status": "Success", "msg": "compaction task executed successful"})";
     return Status::OK();
 }

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -53,6 +53,9 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    static Status do_compaction(uint64_t tablet_id, const std::string& compaction_type,
+                                const std::string& rowset_ids_string);
+
 private:
     Status _handle_show_compaction(HttpRequest* req, std::string* json_result);
     Status _handle_compaction(HttpRequest* req, std::string* json_result);

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -21,6 +21,7 @@
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "gutil/strings/substitute.h"
+#include "http/action/compaction_action.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
 #include "storage/storage_engine.h"
@@ -181,6 +182,15 @@ public:
 
     static std::vector<DataDir*> get_data_dirs() { return StorageEngine::instance()->get_stores(); }
 
+    /**
+     * @param tablet_id
+     * @param type base|cumulative|update
+     * @return
+     */
+    static Status do_compaction(int64_t tablet_id, const string& type) {
+        return CompactionAction::do_compaction(tablet_id, type, "");
+    }
+
     static void bind(ForeignModule& m) {
         {
             auto& cls = m.klass<TabletBasicInfo>("TabletBasicInfo");
@@ -294,7 +304,6 @@ public:
             REG_METHOD(TabletUpdates, version_history_count);
             REG_METHOD(TabletUpdates, get_average_row_size);
             REG_METHOD(TabletUpdates, debug_string);
-            REG_METHOD(TabletUpdates, get_compaction_score);
             REG_METHOD(TabletUpdates, get_version_list);
             REG_METHOD(TabletUpdates, get_edit_version);
             REG_METHOD(TabletUpdates, get_rowset_map);
@@ -324,6 +333,7 @@ public:
             REG_STATIC_METHOD(StorageEngineRef, get_tablet);
             REG_STATIC_METHOD(StorageEngineRef, drop_tablet);
             REG_STATIC_METHOD(StorageEngineRef, get_data_dirs);
+            REG_STATIC_METHOD(StorageEngineRef, do_compaction);
         }
     }
 };


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds the ability to invoke compaction for arbitrary tablets through SQL

```
mysql> admin execute on 10004 '
    '> System.print(StorageEngine.get_tablet(12007).updates().get_compaction_score())
    '> ';
Query OK, 0 rows affected (0.01 sec)
167772160

mysql> admin execute on 10004 '
System.print(StorageEngine.do_compaction(12007, "").toString())
';
Query OK, 0 rows affected (0.01 sec)
OK

mysql> select log from information_schema.be_logs where log rlike 'compaction.*12007' limit 6;
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| log                                                                                                                                                                                                                                              |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| I0406 20:33:29.044531 289809 tablet_updates.cpp:1958] update compaction start tablet:12007 version:18 score:167772160 pick:6/valid:6/all:6 14,15,16,17,18,19 #rows:0->0 bytes:0->0(estimate)                                                     |
| I0406 20:33:29.044611 289809 rowset_merger.cpp:252] compaction merge finished. tablet=12007 #key=1 algorithm=HORIZONTAL_COMPACTION column_group_size=0 input(entry=6 rows=0 del=0 actual=0 bytes=0) output(rows=0 chunk=0 bytes=0) duration: 0ms |
| I0406 20:33:29.048313 289809 tablet_updates.cpp:1463] commit compaction tablet:12007 version:18.1 rowset:20 #seg:0 #row:0 size:0 #pending:0 state_memory:0                                                                                       |
| I0406 20:33:29.048430 290135 tablet_updates.cpp:1492] apply_compaction_commit start tablet:12007 version:18.1 rowset:20                                                                                                                          |
| I0406 20:33:29.051198 290135 tablet_updates.cpp:1668] apply_compaction_commit finish tablet:12007 version:18.1 total del/row:0/0 0% rowset:20 #row:0 #del:0 #delvec:0 duration:2ms(0/0/2)                                                        |
| I0406 20:33:35.007369 289207 schema_be_logs_scanner.cpp:68] grep_log pattern:compaction.*12007 level: start_ts:0 end_ts:0 limit:4 #result:4 duration:3ms                                                                                         |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
6 rows in set (0.01 sec)


```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
