### PR TITLE
[BugFix] Fix compaction scheduler hang when tablet has many segments and disk io full

### DIFF
--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -70,34 +70,36 @@ void CompactionManager::_schedule() {
     while (!_stop.load(std::memory_order_consume)) {
         ++_round;
         _wait_to_run();
-        std::shared_ptr<CompactionTask> compaction_task = _try_get_next_compaction_task();
-        if (!compaction_task) {
+        CompactionCandidate compaction_candidate;
+
+        if (!pick_candidate(&compaction_candidate)) {
             std::unique_lock<std::mutex> lk(_mutex);
             _cv.wait_for(lk, 1000ms);
         } else {
-            if (compaction_task->compaction_type() == CompactionType::BASE_COMPACTION) {
-                StarRocksMetrics::instance()->tablet_base_max_compaction_score.set_value(
-                        compaction_task->compaction_score());
+            if (compaction_candidate.type == CompactionType::BASE_COMPACTION) {
+                StarRocksMetrics::instance()->tablet_base_max_compaction_score.set_value(compaction_candidate.score);
             } else {
                 StarRocksMetrics::instance()->tablet_cumulative_max_compaction_score.set_value(
-                        compaction_task->compaction_score());
+                        compaction_candidate.score);
             }
 
-            compaction_task->set_task_id(next_compaction_task_id());
+            auto task_id = next_compaction_task_id();
             LOG(INFO) << "submit task to compaction pool"
-                      << ", task_id:" << compaction_task->task_id()
-                      << ", tablet_id:" << compaction_task->tablet()->tablet_id()
-                      << ", compaction_type:" << starrocks::to_string(compaction_task->compaction_type())
-                      << ", compaction_score:" << compaction_task->compaction_score() << " for round:" << _round
+                      << ", task_id:" << task_id << ", tablet_id:" << compaction_candidate.tablet->tablet_id()
+                      << ", compaction_type:" << starrocks::to_string(compaction_candidate.type)
+                      << ", compaction_score:" << compaction_candidate.score << " for round:" << _round
                       << ", task_queue_size:" << candidates_size();
-            auto st = _compaction_pool->submit_func([compaction_task] { compaction_task->start(); });
+            auto st = _compaction_pool->submit_func([compaction_candidate, task_id] {
+                auto compaction_task = compaction_candidate.tablet->create_compaction_task();
+                if (compaction_task != nullptr) {
+                    compaction_task->set_task_id(task_id);
+                    compaction_task->start();
+                }
+            });
             if (!st.ok()) {
-                LOG(WARNING) << "submit compaction task " << compaction_task->task_id()
+                LOG(WARNING) << "submit compaction task " << task_id
                              << " to compaction pool failed. status:" << st.to_string();
-                compaction_task->tablet()->reset_compaction();
-                CompactionCandidate candidate;
-                candidate.tablet = compaction_task->tablet();
-                update_candidates({candidate});
+                update_tablet_async(compaction_candidate.tablet);
             }
         }
     }
@@ -315,6 +317,9 @@ void CompactionManager::update_tablet_async(TabletSharedPtr tablet) {
 }
 
 void CompactionManager::update_tablet(TabletSharedPtr tablet) {
+    if (tablet == nullptr) {
+        return;
+    }
     if (_disable_update_tablet) {
         return;
     }

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1313,8 +1313,6 @@ std::shared_ptr<CompactionTask> Tablet::create_compaction_task() {
             _compaction_task = _compaction_context->policy->create_compaction(
                     std::static_pointer_cast<Tablet>(shared_from_this()));
         }
-    }
-    if (_compaction_task && _compaction_task.use_count() == 1) {
         return _compaction_task;
     } else {
         return nullptr;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21104

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
https://github.com/StarRocks/starrocks/pull/7225 acquire segment `num_rows` to skip empty segment, it may be hang when disk io full, so that we move create_compaction_task to thread_pool.
```
Thread 217 (Thread 0x7f13dc772700 (LWP 24347)):
#0  0x00007f175c448fc3 in pread64 () from /lib64/libpthread.so.0
#1  0x0000000003e9b8b3 in starrocks::io::FdInputStream::read(void*, long) ()
#2  0x0000000003e9c4b0 in starrocks::io::Readable::read_fully(void*, long) ()
#3  0x0000000003e9c00d in starrocks::io::SeekableInputStream::read_at_fully(long, void*, long) ()
#4  0x0000000003fe3c6c in starrocks::Segment::parse_segment_footer(starrocks::RandomAccessFile*, starrocks::SegmentFooterPB*, unsigned long*, starrocks::FooterPointerPB const*) ()
#5  0x0000000003fe6723 in starrocks::Segment::_open(unsigned long*, starrocks::FooterPointerPB const*) ()
#6  0x0000000003fe6b20 in starrocks::Segment::open(std::shared_ptr<starrocks::FileSystem>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int, starrocks::TabletSchema const*, unsigned long*, starrocks::FooterPointerPB const*) ()
#7  0x000000000461a53a in starrocks::Rowset::do_load() ()
#8  0x000000000461ab4f in starrocks::Rowset::load() ()
#9  0x000000000461ad55 in starrocks::Rowset::estimate_compaction_segment_iterator_num() ()
#10 0x00000000045d0e87 in starrocks::CompactionTaskFactory::create_compaction_task() ()
#11 0x00000000040f9dff in starrocks::vectorized::SizeTieredCompactionPolicy::create_compaction(std::shared_ptr<starrocks::Tablet>) ()
#12 0x0000000003f1d402 in starrocks::Tablet::create_compaction_task() ()
#13 0x00000000040f3b8d in starrocks::CompactionManager::_try_get_next_compaction_task() ()
#14 0x00000000040f3e2e in starrocks::CompactionManager::_schedule() ()
#15 0x0000000007cabb80 in execute_native_thread_routine ()
#16 0x00007f175c441ea5 in start_thread () from /lib64/libpthread.so.0
#17 0x00007f175ba5cb0d in clone () from /lib64/libc.so.6
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
