### PR TITLE
[Feature] Support log rejected record through stream load / routine load / broker load with csv/json format

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -397,6 +397,18 @@ std::string Chunk::debug_row(size_t index) const {
     return os.str();
 }
 
+std::string Chunk::rebuild_csv_row(size_t index, const std::string& delimiter) const {
+    std::stringstream os;
+    for (size_t col = 0; col < _columns.size() - 1; ++col) {
+        os << _columns[col]->debug_item(index);
+        os << delimiter;
+    }
+    if (_columns.size() > 0) {
+        os << _columns[_columns.size() - 1]->debug_item(index);
+    }
+    return os.str();
+}
+
 std::string Chunk::debug_columns() const {
     std::stringstream os;
     os << "nullable[";

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -155,6 +155,10 @@ public:
 
     void set_columns(const Columns& columns) { _columns = columns; }
 
+    void set_source_filename(const std::string& source_filename) { _source_filename = source_filename; }
+
+    const std::string& source_filename() const { return _source_filename; }
+
     // Create an empty chunk with the same meta and reserve it of size chunk _num_rows
     // not clone tuple column
     ChunkUniquePtr clone_empty() const;
@@ -278,6 +282,8 @@ public:
 
     std::string debug_columns() const;
 
+    std::string rebuild_csv_row(size_t index, const std::string& delimiter) const;
+
     bool capacity_limit_reached(std::string* msg = nullptr) const {
         for (const auto& column : _columns) {
             if (column->capacity_limit_reached(msg)) {
@@ -304,6 +310,7 @@ private:
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
     query_cache::owner_info _owner_info;
     ChunkExtraDataPtr _extra_data;
+    std::string _source_filename;
 };
 
 inline const ColumnPtr& Chunk::get_column_by_name(const std::string& column_name) const {

--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -72,6 +72,11 @@ Status FileDataSource::_create_scanner() {
     if (_scan_range.ranges.empty()) {
         return Status::EndOfFile("scan range is empty");
     }
+    if (_runtime_state->enable_log_rejected_record() &&
+        _scan_range.ranges[0].format_type != TFileFormatType::FORMAT_CSV_PLAIN &&
+        _scan_range.ranges[0].format_type != TFileFormatType::FORMAT_JSON) {
+        return Status::InternalError("only support csv/json format to log rejected record");
+    }
     // create scanner object and open
     if (_scan_range.ranges[0].format_type == TFileFormatType::FORMAT_ORC) {
         _scanner = std::make_unique<ORCScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);

--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -25,6 +25,10 @@
 
 namespace starrocks {
 
+const std::string& CSVScanner::ScannerCSVReader::filename() {
+    return _file->filename();
+}
+
 Status CSVScanner::ScannerCSVReader::_fill_buffer() {
     SCOPED_RAW_TIMER(&_counter->file_read_ns);
 
@@ -294,11 +298,21 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
 
                 _report_error(record.to_string(), error_msg.str());
             }
+            if (_state->enable_log_rejected_record()) {
+                std::stringstream error_msg;
+                error_msg << "Value count does not match column count. "
+                          << "Expect " << _num_fields_in_csv << ", but got " << row.columns.size();
+                _state->append_rejected_record_to_file(record.to_string(), error_msg.str(), _curr_reader->filename());
+            }
             continue;
         }
         if (!validate_utf8(record.data, record.size)) {
             if (_counter->num_rows_filtered++ < 50) {
                 _report_error(record.to_string(), "Invalid UTF-8 row");
+            }
+            if (_state->enable_log_rejected_record()) {
+                _state->append_rejected_record_to_file(record.to_string(), "Invalid UTF-8 row",
+                                                       _curr_reader->filename());
             }
             continue;
         }
@@ -327,6 +341,13 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
                     error_msg << "Value '" << data.to_string() << "' is out of range. "
                               << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
                     _report_error(record.to_string(), error_msg.str());
+                }
+                if (_state->enable_log_rejected_record()) {
+                    std::stringstream error_msg;
+                    error_msg << "Value '" << data.to_string() << "' is out of range. "
+                              << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
+                    _state->append_rejected_record_to_file(record.to_string(), error_msg.str(),
+                                                           _curr_reader->filename());
                 }
                 has_error = true;
                 break;
@@ -377,11 +398,21 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
                           << "Expect " << _num_fields_in_csv << ", but got " << fields.size();
                 _report_error(record.to_string(), error_msg.str());
             }
+            if (_state->enable_log_rejected_record()) {
+                std::stringstream error_msg;
+                error_msg << "Value count does not match column count. "
+                          << "Expect " << _num_fields_in_csv << ", but got " << fields.size();
+                _state->append_rejected_record_to_file(record.to_string(), error_msg.str(), _curr_reader->filename());
+            }
             continue;
         }
         if (!validate_utf8(record.data, record.size)) {
             if (_counter->num_rows_filtered++ < 50) {
                 _report_error(record.to_string(), "Invalid UTF-8 row");
+            }
+            if (_state->enable_log_rejected_record()) {
+                _state->append_rejected_record_to_file(record.to_string(), "Invalid UTF-8 row",
+                                                       _curr_reader->filename());
             }
             continue;
         }
@@ -402,6 +433,13 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
                     error_msg << "Value '" << field.to_string() << "' is out of range. "
                               << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
                     _report_error(record.to_string(), error_msg.str());
+                }
+                if (_state->enable_log_rejected_record()) {
+                    std::stringstream error_msg;
+                    error_msg << "Value '" << field.to_string() << "' is out of range. "
+                              << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
+                    _state->append_rejected_record_to_file(record.to_string(), error_msg.str(),
+                                                           _curr_reader->filename());
                 }
                 has_error = true;
                 break;

--- a/be/src/exec/csv_scanner.h
+++ b/be/src/exec/csv_scanner.h
@@ -56,6 +56,8 @@ private:
 
         Status _fill_buffer() override;
 
+        const std::string& filename();
+
     private:
         std::shared_ptr<SequentialFile> _file;
         ScannerCounter* _counter = nullptr;

--- a/be/src/exec/file_scan_node.cpp
+++ b/be/src/exec/file_scan_node.cpp
@@ -221,6 +221,11 @@ Status FileScanNode::_scanner_scan(const TBrokerScanRange& scan_range, const std
     if (scan_range.ranges.empty()) {
         return Status::EndOfFile("scan range is empty");
     }
+    if (runtime_state()->enable_log_rejected_record() &&
+        scan_range.ranges[0].format_type != TFileFormatType::FORMAT_CSV_PLAIN &&
+        scan_range.ranges[0].format_type != TFileFormatType::FORMAT_JSON) {
+        return Status::InternalError("only support csv/json format to log rejected record");
+    }
     //create scanner object and open
     std::unique_ptr<FileScanner> scanner = _create_scanner(scan_range, counter);
     if (scanner == nullptr) {

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -491,6 +491,12 @@ Status JsonReader::_read_rows(Chunk* chunk, int32_t rows_to_read, int32_t* rows_
                 _state->append_error_msg_to_file(std::string(sv.data(), sv.size()), st.to_string());
                 LOG(WARNING) << "failed to construct row: " << st;
             }
+            if (_state->enable_log_rejected_record()) {
+                std::string_view sv;
+                (void)!row.raw_json().get(sv);
+                _state->append_rejected_record_to_file(std::string(sv.data(), sv.size()), st.to_string(),
+                                                       _file->filename());
+            }
             // Before continuing to process other rows, we need to first clean the fail parsed row.
             chunk->set_num_rows(chunk_row_num);
         }

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -93,6 +93,9 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Quer
         if (!runtime_state->get_error_log_file_path().empty()) {
             params.__set_tracking_url(to_load_error_http_path(runtime_state->get_error_log_file_path()));
         }
+        if (!runtime_state->get_rejected_record_file_path().empty()) {
+            params.__set_rejected_record_path(runtime_state->get_rejected_record_file_path());
+        }
         if (!runtime_state->export_output_files().empty()) {
             params.__isset.export_files = true;
             params.export_files = runtime_state->export_output_files();

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -397,7 +397,7 @@ Status OlapTablePartitionParam::add_partitions(const std::vector<TOlapTableParti
 
 Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTablePartition*>* partitions,
                                              std::vector<uint32_t>* indexes, std::vector<uint8_t>* selection,
-                                             int* invalid_row_index, int64_t txn_id,
+                                             std::vector<int>* invalid_row_indexs, int64_t txn_id,
                                              std::vector<std::vector<std::string>>* partition_not_exist_row_values) {
     size_t num_rows = chunk->num_rows();
     partitions->resize(num_rows);
@@ -441,8 +441,8 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
                                 << row.debug_string();
                         (*partitions)[i] = nullptr;
                         (*selection)[i] = 0;
-                        if (invalid_row_index != nullptr) {
-                            *invalid_row_index = i;
+                        if (invalid_row_indexs != nullptr) {
+                            invalid_row_indexs->emplace_back(i);
                         }
                     }
                 } else if (LIKELY(is_list_partition || _part_contains(it->second, &row))) {
@@ -464,8 +464,8 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
                                 << " end " << it->second->end_key.debug_string();
                         (*partitions)[i] = nullptr;
                         (*selection)[i] = 0;
-                        if (invalid_row_index != nullptr) {
-                            *invalid_row_index = i;
+                        if (invalid_row_indexs != nullptr) {
+                            invalid_row_indexs->emplace_back(i);
                         }
                     }
                 }

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -212,7 +212,7 @@ public:
     // has been filtered out for not being able to find tablet.
     // it could be any row, becauset it's just for outputing error message for user to diagnose.
     Status find_tablets(Chunk* chunk, std::vector<OlapTablePartition*>* partitions, std::vector<uint32_t>* indexes,
-                        std::vector<uint8_t>* selection, int* invalid_row_index, int64_t txn_id,
+                        std::vector<uint8_t>* selection, std::vector<int>* invalid_row_indexs, int64_t txn_id,
                         std::vector<std::vector<std::string>>* partition_not_exist_row_values);
 
     const std::map<int64_t, OlapTablePartition*>& get_partitions() const { return _partitions; }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -928,6 +928,13 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     if (table_sink.__isset.enable_replicated_storage) {
         _enable_replicated_storage = table_sink.enable_replicated_storage;
     }
+    if (table_sink.__isset.db_name) {
+        state->set_db(table_sink.db_name);
+    }
+    state->set_txn_id(table_sink.txn_id);
+    if (table_sink.__isset.label) {
+        state->set_load_label(table_sink.label);
+    }
 
     // profile must add to state's object pool
     _profile = state->obj_pool()->add(new RuntimeProfile("OlapTableSink"));
@@ -1344,7 +1351,7 @@ Status OlapTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
         }
         {
             uint32_t num_rows_after_validate = SIMD::count_nonzero(_validate_selection);
-            int invalid_row_index = 0;
+            std::vector<int> invalid_row_indexs;
 
             // _enable_automatic_partition is true means destination table using automatic partition
             // _has_automatic_partition is true means last send_chunk already create partition in nonblocking mode
@@ -1355,7 +1362,7 @@ Status OlapTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
                 _partition_not_exist_row_values.resize(1);
 
                 RETURN_IF_ERROR(_vectorized_partition->find_tablets(chunk, &_partitions, &_tablet_indexes,
-                                                                    &_validate_selection, &invalid_row_index, _txn_id,
+                                                                    &_validate_selection, &invalid_row_indexs, _txn_id,
                                                                     &_partition_not_exist_row_values));
 
                 if (!_partition_not_exist_row_values[0].empty()) {
@@ -1376,13 +1383,13 @@ Status OlapTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
                         _automatic_partition_token->wait();
                         // after the partition is created, go through the data again
                         RETURN_IF_ERROR(_vectorized_partition->find_tablets(chunk, &_partitions, &_tablet_indexes,
-                                                                            &_validate_selection, &invalid_row_index,
+                                                                            &_validate_selection, &invalid_row_indexs,
                                                                             _txn_id, nullptr));
                     }
                 }
             } else {
                 RETURN_IF_ERROR(_vectorized_partition->find_tablets(chunk, &_partitions, &_tablet_indexes,
-                                                                    &_validate_selection, &invalid_row_index, _txn_id,
+                                                                    &_validate_selection, &invalid_row_indexs, _txn_id,
                                                                     nullptr));
                 _has_automatic_partition = false;
             }
@@ -1402,15 +1409,22 @@ Status OlapTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
             _validate_select_idx.resize(selected_size);
 
             if (num_rows_after_validate - _validate_select_idx.size() > 0) {
-                if (!state->has_reached_max_error_msg_num()) {
-                    std::string debug_row = chunk->debug_row(invalid_row_index);
-                    if (_enable_automatic_partition) {
-                        state->append_error_msg_to_file(debug_row,
-                                                        fmt::format("The row create partition failed since {}.",
-                                                                    _automatic_partition_status.to_string()));
+                std::stringstream ss;
+                if (_enable_automatic_partition) {
+                    ss << "The row create partition failed since " << _automatic_partition_status.to_string();
+                } else {
+                    ss << "The row is out of partition ranges. Please add a new partition.";
+                }
+                if (!state->has_reached_max_error_msg_num() && invalid_row_indexs.size() > 0) {
+                    std::string debug_row = chunk->debug_row(invalid_row_indexs.back());
+                    state->append_error_msg_to_file(debug_row, ss.str());
+                }
+                for (auto i : invalid_row_indexs) {
+                    if (state->enable_log_rejected_record()) {
+                        state->append_rejected_record_to_file(chunk->rebuild_csv_row(i, ","), ss.str(),
+                                                              chunk->source_filename());
                     } else {
-                        state->append_error_msg_to_file(
-                                debug_row, "The row is out of partition ranges. Please add a new partition.");
+                        break;
                     }
                 }
             }
@@ -1897,7 +1911,7 @@ void _print_decimalv3_error_msg(RuntimeState* state, const CppType& decimal, con
 }
 
 template <LogicalType LT>
-void OlapTableSink::_validate_decimal(RuntimeState* state, Column* column, const SlotDescriptor* desc,
+void OlapTableSink::_validate_decimal(RuntimeState* state, Chunk* chunk, Column* column, const SlotDescriptor* desc,
                                       std::vector<uint8_t>* validate_selection) {
     using CppType = RunTimeCppType<LT>;
     using ColumnType = RunTimeColumnType<LT>;
@@ -1915,6 +1929,15 @@ void OlapTableSink::_validate_decimal(RuntimeState* state, Column* column, const
             if (datum > max_decimal || datum < min_decimal) {
                 (*validate_selection)[i] = VALID_SEL_FAILED;
                 _print_decimalv3_error_msg<LT>(state, datum, desc);
+                if (state->enable_log_rejected_record()) {
+                    auto decimal_str =
+                            DecimalV3Cast::to_string<CppType>(datum, desc->type().precision, desc->type().scale);
+                    std::string error_msg =
+                            strings::Substitute("Decimal '$0' is out of range. The type of '$1' is $2'", decimal_str,
+                                                desc->col_name(), desc->type().debug_string());
+                    state->append_rejected_record_to_file(chunk->rebuild_csv_row(i, ","), error_msg,
+                                                          chunk->source_filename());
+                }
             }
         }
     }
@@ -1941,11 +1964,17 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
             // increment column, we abort the entire chunk and append a single error msg. Because be know
             // nothing about whether this row is specified by the user as null or setted during planning.
             if (nullable->has_null() && _null_expr_in_auto_increment) {
-                for (size_t j = 0; j < num_rows; ++j) {
-                    _validate_selection[j] = VALID_SEL_FAILED;
-                }
                 std::stringstream ss;
                 ss << "NULL value in auto increment column '" << desc->col_name() << "'";
+
+                for (size_t j = 0; j < num_rows; ++j) {
+                    _validate_selection[j] = VALID_SEL_FAILED;
+                    // If enable_log_rejected_record is true, we need to log the rejected record.
+                    if (nullable->is_null(j) && state->enable_log_rejected_record()) {
+                        state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), ss.str(),
+                                                              chunk->source_filename());
+                    }
+                }
 #if BE_TEST
                 LOG(INFO) << ss.str();
 #else
@@ -1982,6 +2011,10 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                             state->append_error_msg_to_file(chunk->debug_row(j), ss.str());
                         }
 #endif
+                        if (state->enable_log_rejected_record()) {
+                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(i, ","), ss.str(),
+                                                                  chunk->source_filename());
+                        }
                     }
                 }
             }
@@ -2012,6 +2045,13 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                     if (offset[j + 1] - offset[j] > len) {
                         _validate_selection[j] = VALID_SEL_FAILED;
                         _print_varchar_error_msg(state, binary->get_slice(j), desc);
+                        if (state->enable_log_rejected_record()) {
+                            std::string error_msg =
+                                    strings::Substitute("String (length=$0) is too long. The max length of '$1' is $2",
+                                                        binary->get_slice(j).size, desc->col_name(), desc->type().len);
+                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), error_msg,
+                                                                  chunk->source_filename());
+                        }
                     }
                 }
             }
@@ -2031,19 +2071,26 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                     if (datas[j] > _max_decimalv2_val[i] || datas[j] < _min_decimalv2_val[i]) {
                         _validate_selection[j] = VALID_SEL_FAILED;
                         _print_decimal_error_msg(state, datas[j], desc);
+                        if (state->enable_log_rejected_record()) {
+                            std::string error_msg = strings::Substitute(
+                                    "Decimal '$0' is out of range. The type of '$1' is $2'", datas[j].to_string(),
+                                    desc->col_name(), desc->type().debug_string());
+                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), error_msg,
+                                                                  chunk->source_filename());
+                        }
                     }
                 }
             }
             break;
         }
         case TYPE_DECIMAL32:
-            _validate_decimal<TYPE_DECIMAL32>(state, column, desc, &_validate_selection);
+            _validate_decimal<TYPE_DECIMAL32>(state, chunk, column, desc, &_validate_selection);
             break;
         case TYPE_DECIMAL64:
-            _validate_decimal<TYPE_DECIMAL64>(state, column, desc, &_validate_selection);
+            _validate_decimal<TYPE_DECIMAL64>(state, chunk, column, desc, &_validate_selection);
             break;
         case TYPE_DECIMAL128:
-            _validate_decimal<TYPE_DECIMAL128>(state, column, desc, &_validate_selection);
+            _validate_decimal<TYPE_DECIMAL128>(state, chunk, column, desc, &_validate_selection);
             break;
         default:
             break;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -336,7 +336,7 @@ public:
 
 private:
     template <LogicalType LT>
-    void _validate_decimal(RuntimeState* state, Column* column, const SlotDescriptor* desc,
+    void _validate_decimal(RuntimeState* state, Chunk* chunk, Column* column, const SlotDescriptor* desc,
                            std::vector<uint8_t>* validate_selection);
     // This method will change _validate_selection
     void _validate_data(RuntimeState* state, Chunk* chunk);

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -531,6 +531,17 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
             return Status::InvalidArgument("Invalid load_dop format");
         }
     }
+    if (!http_req->header(HTTP_LOG_REJECTED_RECORD_NUM).empty()) {
+        try {
+            auto log_rejected_record_num = std::stoll(http_req->header(HTTP_LOG_REJECTED_RECORD_NUM));
+            if (log_rejected_record_num < -1) {
+                return Status::InvalidArgument("log_rejected_record_num must be equal or greater than -1");
+            }
+            request.__set_log_rejected_record_num(log_rejected_record_num);
+        } catch (const std::invalid_argument& e) {
+            return Status::InvalidArgument("Invalid log_rejected_record_num format");
+        }
+    }
     int32_t rpc_timeout_ms = config::txn_commit_rpc_timeout_ms;
     if (ctx->timeout_second != -1) {
         request.__set_timeout(ctx->timeout_second);

--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -70,6 +70,7 @@ static const std::string HTTP_TRANSMISSION_COMPRESSION_TYPE = "transmission_comp
 static const std::string HTTP_LOAD_DOP = "load_dop";
 static const std::string HTTP_ENABLE_REPLICATED_STORAGE = "enable_replicated_storage";
 static const std::string HTTP_MERGE_CONDITION = "merge_condition";
+static const std::string HTTP_LOG_REJECTED_RECORD_NUM = "log_rejected_record_num";
 
 static const std::string HTTP_100_CONTINUE = "100-continue";
 static const std::string HTTP_CHANNEL_ID = "channel_id";

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -286,6 +286,9 @@ void FragmentExecState::coordinator_callback(const Status& status, RuntimeProfil
         if (!runtime_state->get_error_log_file_path().empty()) {
             params.__set_tracking_url(to_load_error_http_path(runtime_state->get_error_log_file_path()));
         }
+        if (!runtime_state->get_rejected_record_file_path().empty()) {
+            params.__set_rejected_record_path(runtime_state->get_rejected_record_file_path());
+        }
         if (!runtime_state->export_output_files().empty()) {
             params.__isset.export_files = true;
             params.export_files = runtime_state->export_output_files();

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -144,6 +144,7 @@ void LoadPathMgr::get_load_data_path(std::vector<std::string>* data_paths) {
 }
 
 const std::string ERROR_FILE_NAME = "error_log";
+const std::string REJECTED_RECORD_FILE_NAME = "rejected_record";
 
 Status LoadPathMgr::get_load_error_file_name(const TUniqueId& fragment_instance_id, std::string* error_path) {
     std::stringstream ss;
@@ -159,6 +160,23 @@ std::string LoadPathMgr::get_load_error_absolute_path(const std::string& file_pa
     path.append("/");
     path.append(file_path);
     return path;
+}
+
+std::string LoadPathMgr::get_load_rejected_record_absolute_path(const std::string& rejected_record_dir,
+                                                                const std::string& db, const std::string& label,
+                                                                const int64_t id,
+                                                                const TUniqueId& fragment_instance_id) {
+    std::string path;
+    if (rejected_record_dir.empty()) {
+        path = _exec_env->store_paths()[0].path + REJECTED_RECORD_PREFIX;
+    } else {
+        path = rejected_record_dir;
+    }
+
+    std::stringstream ss;
+    ss << path << "/" << db << "/" << label << "/" << id << "/" << std::hex << fragment_instance_id.hi << "_"
+       << fragment_instance_id.lo;
+    return ss.str();
 }
 
 void LoadPathMgr::process_path(time_t now, const std::string& path, int64_t reserve_hours) {

--- a/be/src/runtime/load_path_mgr.h
+++ b/be/src/runtime/load_path_mgr.h
@@ -66,6 +66,10 @@ public:
     std::string get_load_error_absolute_path(const std::string& file_path);
     const std::string& get_load_error_file_dir() const { return _error_log_dir; }
 
+    std::string get_load_rejected_record_absolute_path(const std::string& rejected_record_dir, const std::string& db,
+                                                       const std::string& label, const int64_t id,
+                                                       const TUniqueId& fragment_instance_id);
+
 private:
     bool is_too_old(time_t cur_time, const std::string& label_dir, int64_t reserve_hours);
     void clean_one_path(const std::string& path);

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -87,10 +87,6 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
     DCHECK(_runtime_state->chunk_size() > 0);
 
     _runtime_state->set_be_number(request.backend_num);
-    if (request.__isset.load_job_id) {
-        _runtime_state->set_load_job_id(request.load_job_id);
-    }
-
     if (request.query_options.__isset.enable_profile) {
         enable_profile = request.query_options.enable_profile;
     }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -46,6 +46,7 @@
 #include "common/status.h"
 #include "exec/exec_node.h"
 #include "exec/pipeline/query_context.h"
+#include "fs/fs_util.h"
 #include "runtime/datetime_value.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
@@ -122,6 +123,10 @@ RuntimeState::~RuntimeState() {
         _error_log_file->close();
         delete _error_log_file;
         _error_log_file = nullptr;
+    }
+    // close rejected record file
+    if (_rejected_record_file != nullptr && _rejected_record_file->is_open()) {
+        _rejected_record_file->close();
     }
 }
 
@@ -307,6 +312,22 @@ Status RuntimeState::create_error_log_file() {
     return Status::OK();
 }
 
+Status RuntimeState::create_rejected_record_file() {
+    auto rejected_record_absolute_path = _exec_env->load_path_mgr()->get_load_rejected_record_absolute_path(
+            "", _db, _load_label, _txn_id, _fragment_instance_id);
+    RETURN_IF_ERROR(fs::create_directories(std::filesystem::path(rejected_record_absolute_path).parent_path()));
+
+    _rejected_record_file = std::make_unique<std::ofstream>(rejected_record_absolute_path, std::ifstream::out);
+    if (!_rejected_record_file->is_open()) {
+        std::stringstream error_msg;
+        error_msg << "Fail to open rejected record file: [" << rejected_record_absolute_path << "].";
+        LOG(WARNING) << error_msg.str();
+        return Status::InternalError(error_msg.str());
+    }
+    _rejected_record_file_path = rejected_record_absolute_path;
+    return Status::OK();
+}
+
 bool RuntimeState::has_reached_max_error_msg_num(bool is_summary) {
     if (_num_print_error_rows.load(std::memory_order_relaxed) > MAX_ERROR_NUM && !is_summary) {
         return true;
@@ -352,6 +373,32 @@ void RuntimeState::append_error_msg_to_file(const std::string& line, const std::
     if (!out.str().empty()) {
         (*_error_log_file) << out.str() << std::endl;
     }
+}
+
+void RuntimeState::append_rejected_record_to_file(const std::string& record, const std::string& error_msg,
+                                                  const std::string& source) {
+    std::lock_guard<std::mutex> l(_rejected_record_lock);
+    // Only load job need to write rejected record
+    if (_query_options.query_type != TQueryType::LOAD) {
+        return;
+    }
+
+    // If file havn't been opened, open it here
+    if (_rejected_record_file == nullptr) {
+        Status status = create_rejected_record_file();
+        if (!status.ok()) {
+            LOG(WARNING) << "Create rejected record file failed. because: " << status.get_error_msg();
+            if (_rejected_record_file != nullptr) {
+                _rejected_record_file->close();
+                _rejected_record_file.reset();
+            }
+            return;
+        }
+    }
+    _num_log_rejected_rows.fetch_add(1, std::memory_order_relaxed);
+
+    // TODO(meegoo): custom delimiter
+    (*_rejected_record_file) << record << "\t" << error_msg << "\t" << source << std::endl;
 }
 
 int64_t RuntimeState::get_load_mem_limit() const {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -223,16 +223,36 @@ public:
 
     void add_export_output_file(const std::string& file) { _export_output_files.push_back(file); }
 
-    void set_load_job_id(int64_t job_id) { _load_job_id = job_id; }
+    void set_txn_id(int64_t txn_id) { _txn_id = txn_id; }
 
-    int64_t load_job_id() const { return _load_job_id; }
+    int64_t load_job_id() const { return _txn_id; }
+
+    void set_db(const std::string& db) { _db = db; }
+
+    const std::string& db() const { return _db; }
+
+    void set_load_label(const std::string& label) { _load_label = label; }
+
+    const std::string& load_label() const { return _load_label; }
 
     const std::string& get_error_log_file_path() const { return _error_log_file_path; }
+
+    const std::string& get_rejected_record_file_path() const { return _rejected_record_file_path; }
 
     // is_summary is true, means we are going to write the summary line
     void append_error_msg_to_file(const std::string& line, const std::string& error_msg, bool is_summary = false);
 
     bool has_reached_max_error_msg_num(bool is_summary = false);
+
+    Status create_rejected_record_file();
+
+    bool enable_log_rejected_record() {
+        return _query_options.log_rejected_record_num == -1 ||
+               _query_options.log_rejected_record_num > _num_log_rejected_rows;
+    }
+
+    void append_rejected_record_to_file(const std::string& record, const std::string& error_msg,
+                                        const std::string& source);
 
     int64_t num_bytes_load_from_source() const noexcept { return _num_bytes_load_from_source.load(); }
 
@@ -375,6 +395,10 @@ private:
     // Logs error messages.
     std::vector<std::string> _error_log;
 
+    std::mutex _rejected_record_lock;
+    std::string _rejected_record_file_path;
+    std::unique_ptr<std::ofstream> _rejected_record_file;
+
     // _error_log[_unreported_error_idx+] has been not reported to the coordinator.
     int _unreported_error_idx;
 
@@ -445,10 +469,13 @@ private:
     std::atomic<int64_t> _num_rows_load_unselected{0}; // rows filtered by predicates
 
     std::atomic<int64_t> _num_print_error_rows{0};
+    std::atomic<int64_t> _num_log_rejected_rows{0}; // rejected rows
 
     std::vector<std::string> _export_output_files;
 
-    int64_t _load_job_id = 0;
+    int64_t _txn_id = 0;
+    std::string _load_label;
+    std::string _db;
 
     std::string _error_log_file_path;
     std::ofstream* _error_log_file = nullptr; // error file path, absolute path

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -34,6 +34,8 @@
 
 #include "runtime/stream_load/stream_load_context.h"
 
+#include <fmt/format.h>
+
 namespace starrocks {
 
 std::string StreamLoadContext::to_resp_json(const std::string& txn_op, const Status& st) const {
@@ -114,6 +116,10 @@ std::string StreamLoadContext::to_resp_json(const std::string& txn_op, const Sta
         writer.Key("ErrorURL");
         writer.String(error_url.c_str());
     }
+    if (!rejected_record_path.empty()) {
+        writer.Key("RejectedRecordPath");
+        writer.String(rejected_record_path.c_str());
+    }
     writer.EndObject();
     return s.GetString();
 }
@@ -183,6 +189,10 @@ std::string StreamLoadContext::to_json() const {
     if (!error_url.empty()) {
         writer.Key("ErrorURL");
         writer.String(error_url.c_str());
+    }
+    if (!rejected_record_path.empty()) {
+        writer.Key("RejectedRecordPath");
+        writer.String(rejected_record_path.c_str());
     }
     writer.EndObject();
     return s.GetString();

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -199,6 +199,8 @@ public:
     int32_t timeout_second = -1;
     AuthInfo auth;
 
+    int64_t log_rejected_record_num = 0;
+
     // the following members control the max progress of a consuming
     // process. if any of them reach, the consuming will finish.
     int64_t max_interval_s = 5;
@@ -235,6 +237,7 @@ public:
     int64_t last_active_ts = 0;
 
     std::string error_url;
+    std::string rejected_record_path;
     // if label already be used, set existing job's status here
     // should be RUNNING or FINISHED
     std::string existing_job_status;

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -126,6 +126,11 @@ Status StreamLoadExecutor::execute_plan_fragment(StreamLoadContext* ctx) {
                     ctx->error_url = to_load_error_http_path(executor->runtime_state()->get_error_log_file_path());
                 }
 
+                if (!executor->runtime_state()->get_rejected_record_file_path().empty()) {
+                    ctx->rejected_record_path = fmt::format("{}:{}", BackendOptions::get_localBackend().host,
+                                                            executor->runtime_state()->get_rejected_record_file_path());
+                }
+
                 if (ctx->unref()) {
                     delete ctx;
                 }

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -61,17 +61,18 @@ enum OLAPDataVersion {
 };
 
 // storage_root_path file path
-static const std::string ALIGN_TAG_PREFIX = "/align_tag";   // NOLINT
-static const std::string MINI_PREFIX = "/mini_download";    // NOLINT
-static const std::string CLUSTER_ID_PREFIX = "/cluster_id"; // NOLINT
-static const std::string DATA_PREFIX = "/data";             // NOLINT
-static const std::string DPP_PREFIX = "/dpp_download";      // NOLINT
-static const std::string SNAPSHOT_PREFIX = "/snapshot";     // NOLINT
-static const std::string TRASH_PREFIX = "/trash";           // NOLINT
-static const std::string UNUSED_PREFIX = "/unused";         // NOLINT
-static const std::string ERROR_LOG_PREFIX = "/error_log";   // NOLINT
-static const std::string CLONE_PREFIX = "/clone";           // NOLINT
-static const std::string TMP_PREFIX = "/tmp";               // NOLINT
+static const std::string ALIGN_TAG_PREFIX = "/align_tag";             // NOLINT
+static const std::string MINI_PREFIX = "/mini_download";              // NOLINT
+static const std::string CLUSTER_ID_PREFIX = "/cluster_id";           // NOLINT
+static const std::string DATA_PREFIX = "/data";                       // NOLINT
+static const std::string DPP_PREFIX = "/dpp_download";                // NOLINT
+static const std::string SNAPSHOT_PREFIX = "/snapshot";               // NOLINT
+static const std::string TRASH_PREFIX = "/trash";                     // NOLINT
+static const std::string UNUSED_PREFIX = "/unused";                   // NOLINT
+static const std::string ERROR_LOG_PREFIX = "/error_log";             // NOLINT
+static const std::string REJECTED_RECORD_PREFIX = "/rejected_record"; // NOLINT
+static const std::string CLONE_PREFIX = "/clone";                     // NOLINT
+static const std::string TMP_PREFIX = "/tmp";                         // NOLINT
 
 static const int32_t OLAP_DATA_VERSION_APPLIED = STARROCKS_V1;
 

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -111,9 +111,8 @@ Status TableReader::multi_get(Chunk& keys, const std::vector<std::string>& value
     std::vector<uint8_t> validate_selection;
     std::vector<uint32_t> validate_select_idx;
     validate_selection.assign(num_rows, 1);
-    int invalid_row_index = 0;
-    RETURN_IF_ERROR(_partition_param->find_tablets(&keys, &partitions, &tablet_indexes, &validate_selection,
-                                                   &invalid_row_index, 0, nullptr));
+    RETURN_IF_ERROR(_partition_param->find_tablets(&keys, &partitions, &tablet_indexes, &validate_selection, nullptr, 0,
+                                                   nullptr));
     // Arrange selection_idx by merging _validate_selection
     // If chunk num_rows is 6
     // _validate_selection is [1, 0, 0, 0, 1, 1]

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -590,6 +590,7 @@ public class SchemaTable extends Table {
                                     .column("ERROR_MSG", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .column("TRACKING_URL", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .column("TRACKING_SQL", ScalarType.createVarchar(NAME_CHAR_LEN))
+                                    .column("REJECTED_RECORD_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
                                     .build()))
                     .put("load_tracking_logs", new SchemaTable(
                             SystemId.LOAD_TRACKING_LOGS_ID,

--- a/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
@@ -67,6 +67,7 @@ public class EtlStatus implements Writable {
 
     private TEtlState state;
     private String trackingUrl;
+    private List<String> rejectedRecordPaths = Lists.newArrayList();
 
     /**
      * This field is useless in RUNTIME
@@ -123,6 +124,14 @@ public class EtlStatus implements Writable {
 
     public void setTrackingUrl(String trackingUrl) {
         this.trackingUrl = Strings.nullToEmpty(trackingUrl);
+    }
+
+    public List<String> getRejectedRecordPaths() {
+        return rejectedRecordPaths;
+    }
+
+    public void setRejectedRecordPaths(List<String> rejectedRecordPaths) {
+        this.rejectedRecordPaths = rejectedRecordPaths;
     }
 
     public Map<String, String> getCounters() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -380,6 +380,9 @@ public class BrokerLoadJob extends BulkLoadJob {
         if (attachment.getTrackingUrl() != null) {
             loadingStatus.setTrackingUrl(attachment.getTrackingUrl());
         }
+        if (!attachment.getRejectedRecordPaths().isEmpty()) {
+            loadingStatus.setRejectedRecordPaths(attachment.getRejectedRecordPaths());
+        }
         commitInfos.addAll(attachment.getCommitInfoList());
         failInfos.addAll(attachment.getFailInfoList());
         progress = (int) ((double) finishedTaskIds.size() / idToTasks.size() * 100);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
@@ -46,14 +46,17 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
     private String trackingUrl;
     private List<TabletCommitInfo> commitInfoList;
     private List<TabletFailInfo> failInfoList;
+    private List<String> rejectedRecordPaths;
 
     public BrokerLoadingTaskAttachment(long taskId, Map<String, String> counters, String trackingUrl,
-                                       List<TabletCommitInfo> commitInfoList, List<TabletFailInfo> failInfoList) {
+                                       List<TabletCommitInfo> commitInfoList, List<TabletFailInfo> failInfoList,
+                                       List<String> rejectedRecordPaths) {
         super(taskId);
         this.trackingUrl = trackingUrl;
         this.counters = counters;
         this.commitInfoList = commitInfoList;
         this.failInfoList = failInfoList;
+        this.rejectedRecordPaths = rejectedRecordPaths;
     }
 
     public String getCounter(String key) {
@@ -74,5 +77,9 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
 
     public List<TabletFailInfo> getFailInfoList() {
         return failInfoList;
+    }
+
+    public List<String> getRejectedRecordPaths() {
+        return rejectedRecordPaths;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -96,6 +96,7 @@ public abstract class BulkLoadJob extends LoadJob {
     protected Map<String, String> sessionVariables = Maps.newHashMap();
 
     protected static final String PRIORITY_SESSION_VARIABLE_KEY = "priority.session.variable.key";
+    public static final String LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY = "log.rejected.record.num.session.variable.key";
 
     // only for log replay
     public BulkLoadJob() {
@@ -148,6 +149,10 @@ public abstract class BulkLoadJob extends LoadJob {
             if (bulkLoadJob.priority != 0) {
                 bulkLoadJob.sessionVariables.put(BulkLoadJob.PRIORITY_SESSION_VARIABLE_KEY,
                         Integer.toString(bulkLoadJob.priority));
+            }
+            if (bulkLoadJob.logRejectedRecordNum != 0) {
+                bulkLoadJob.sessionVariables.put(BulkLoadJob.LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY,
+                        Long.toString(bulkLoadJob.logRejectedRecordNum));
             }
             bulkLoadJob.checkAndSetDataSourceInfo(db, stmt.getDataDescriptions());
             return bulkLoadJob;
@@ -354,6 +359,9 @@ public abstract class BulkLoadJob extends LoadJob {
             }
             if (sessionVariables.containsKey(PRIORITY_SESSION_VARIABLE_KEY)) {
                 priority = Integer.parseInt(sessionVariables.get(PRIORITY_SESSION_VARIABLE_KEY));
+            }
+            if (sessionVariables.containsKey(LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY)) {
+                logRejectedRecordNum = Long.parseLong(sessionVariables.get(LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY));
             }
         } else {
             // old version of load does not have sqlmode, set it to default

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -126,6 +126,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     protected boolean partialUpdate = false;
     protected int priority = LoadPriority.NORMAL_VALUE;
+    protected long logRejectedRecordNum = 0;
     // reuse deleteFlag as partialUpdate
     // @Deprecated
     // protected boolean deleteFlag = false;
@@ -339,6 +340,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
             if (properties.containsKey(LoadStmt.PRIORITY)) {
                 priority = LoadPriority.priorityByName(properties.get(LoadStmt.PRIORITY));
+            }
+
+            if (properties.containsKey(LoadStmt.LOG_REJECTED_RECORD_NUM)) {
+                logRejectedRecordNum = Long.parseLong(properties.get(LoadStmt.LOG_REJECTED_RECORD_NUM));
             }
         }
     }
@@ -877,6 +882,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             if (!loadingStatus.getTrackingUrl().equals(EtlStatus.DEFAULT_TRACKING_URL)) {
                 info.setUrl(loadingStatus.getTrackingUrl());
                 info.setTracking_sql("select tracking_log from information_schema.load_tracking_logs where job_id=" + id);
+            }
+            if (!loadingStatus.getRejectedRecordPaths().isEmpty()) {
+                info.setRejected_record_path(Joiner.on(", ").join(loadingStatus.getRejectedRecordPaths()));
             }
             info.setJob_details(loadingStatus.getLoadStatistic().toShowInfoStr());
             info.setNum_filtered_rows(loadingStatus.getLoadStatistic().totalFilteredRows());

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -269,7 +269,8 @@ public class LoadLoadingTask extends LoadTask {
                         curCoordinator.getLoadCounters(),
                         curCoordinator.getTrackingUrl(),
                         TabletCommitInfo.fromThrift(curCoordinator.getCommitInfos()),
-                        TabletFailInfo.fromThrift(curCoordinator.getFailInfos()));
+                        TabletFailInfo.fromThrift(curCoordinator.getFailInfos()),
+                        curCoordinator.getRejectedRecordPaths());
             } else {
                 throw new LoadException(status.getErrorMsg());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -156,9 +156,9 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
             throw new MetaNotFoundException("table " + routineLoadJob.getTableId() + " does not exist");
         }
         tRoutineLoadTask.setTbl(tbl.getName());
-        // label = job_name+job_id+task_id+txn_id
+        // label = job_name+job_id+task_id
         String label =
-                Joiner.on("-").join(routineLoadJob.getName(), routineLoadJob.getId(), DebugUtil.printId(id), txnId);
+                Joiner.on("-").join(routineLoadJob.getName(), routineLoadJob.getId(), DebugUtil.printId(id));
         tRoutineLoadTask.setLabel(label);
         tRoutineLoadTask.setAuth_code(routineLoadJob.getAuthCode());
         TKafkaLoadInfo tKafkaLoadInfo = new TKafkaLoadInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.load.routineload;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
@@ -203,8 +204,10 @@ public abstract class RoutineLoadTaskInfo {
         // begin a txn for task
         RoutineLoadJob routineLoadJob = routineLoadManager.getJob(jobId);
         MetricRepo.COUNTER_LOAD_ADD.increase(1L);
+        String label =
+                Joiner.on("-").join(routineLoadJob.getName(), routineLoadJob.getId(), DebugUtil.printId(id));
         txnId = GlobalStateMgr.getCurrentGlobalTransactionMgr().beginTransaction(
-                routineLoadJob.getDbId(), Lists.newArrayList(routineLoadJob.getTableId()), DebugUtil.printId(id), null,
+                routineLoadJob.getDbId(), Lists.newArrayList(routineLoadJob.getTableId()), label, null,
                 new TxnCoordinator(TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
                 TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK, routineLoadJob.getId(),
                 timeoutMs / 1000);

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -78,6 +78,7 @@ public class StreamLoadInfo {
     private int loadParallelRequestNum = 0;
     private boolean enableReplicatedStorage = false;
     private String confluentSchemaRegistryUrl;
+    private long logRejectedRecordNum = 0;
 
     public StreamLoadInfo(TUniqueId id, long txnId, TFileType fileType, TFileFormatType formatType) {
         this.id = id;
@@ -112,6 +113,10 @@ public class StreamLoadInfo {
 
     public long getTxnId() {
         return txnId;
+    }
+
+    public void setTxnId(long txnId) {
+        this.txnId = txnId;
     }
 
     public TFileType getFileType() {
@@ -224,6 +229,14 @@ public class StreamLoadInfo {
 
     public int getLoadParallelRequestNum() {
         return loadParallelRequestNum;
+    }
+
+    public long getLogRejectedRecordNum() {
+        return logRejectedRecordNum;
+    }
+
+    public void setLogRejectedRecordNum(long logRejectedRecordNum) {
+        this.logRejectedRecordNum = logRejectedRecordNum;
     }
 
     public static StreamLoadInfo fromStreamLoadContext(TUniqueId id, long txnId, int timeout, StreamLoadParam context)
@@ -388,6 +401,10 @@ public class StreamLoadInfo {
         if (request.isSetMerge_condition()) {
             mergeConditionStr = request.getMerge_condition();
         }
+
+        if (request.isSetLog_rejected_record_num()) {
+            logRejectedRecordNum = request.getLog_rejected_record_num();
+        }
     }
 
     public static StreamLoadInfo fromRoutineLoadJob(RoutineLoadJob routineLoadJob) throws UserException {
@@ -402,6 +419,7 @@ public class StreamLoadInfo {
         StreamLoadInfo streamLoadInfo = new StreamLoadInfo(dummyId, -1L /* dummy txn id */,
                 TFileType.FILE_STREAM, fileFormatType);
         streamLoadInfo.setOptionalFromRoutineLoadJob(routineLoadJob);
+        streamLoadInfo.setLogRejectedRecordNum(routineLoadJob.getLogRejectedRecordNum());
         return streamLoadInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -45,6 +45,7 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
@@ -165,6 +166,7 @@ public class OlapTableSink extends DataSink {
                         .getTransactionState(dbId, txnId);
         if (txnState != null) {
             tSink.setTxn_trace_parent(txnState.getTraceParent());
+            tSink.setLabel(txnState.getLabel());
         }
         tSink.setDb_id(dbId);
         tSink.setLoad_channel_timeout_s(loadChannelTimeoutS);
@@ -172,6 +174,10 @@ public class OlapTableSink extends DataSink {
         tSink.setKeys_type(dstTable.getKeysType().toThrift());
         tSink.setWrite_quorum_type(writeQuorum);
         tSink.setEnable_replicated_storage(enableReplicatedStorage);
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db != null) {
+            tSink.setDb_name(db.getFullName());
+        }
         tDataSink = new TDataSink(TDataSinkType.DATA_SPLIT_SINK);
         tDataSink.setType(TDataSinkType.OLAP_TABLE_SINK);
         tDataSink.setOlap_table_sink(tSink);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -225,6 +225,7 @@ public class StreamLoadPlanner {
         queryOptions.setQuery_type(TQueryType.LOAD);
         queryOptions.setQuery_timeout(streamLoadInfo.getTimeout());
         queryOptions.setLoad_transmission_compression_type(streamLoadInfo.getTransmisionCompressionType());
+        queryOptions.setLog_rejected_record_num(streamLoadInfo.getLogRejectedRecordNum());
 
         // Disable load_dop for LakeTable temporary, because BE's `LakeTabletsChannel` does not support
         // parallel send from a single sender.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -174,6 +174,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MV_PLANNER = "enable_mv_planner";
     public static final String ENABLE_INCREMENTAL_REFRESH_MV = "enable_incremental_mv";
 
+    public static final String LOG_REJECTED_RECORD_NUM = "log_rejected_record_num";
+
     /**
      * Whether to allow the generation of one-phase local aggregation with the local shuffle operator
      * (ScanNode->LocalShuffleNode->OnePhaseAggNode) regardless of the differences between grouping keys
@@ -454,6 +456,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PREFER_COMPUTE_NODE)
     private boolean preferComputeNode = false;
+
+    @VariableMgr.VarAttr(name = LOG_REJECTED_RECORD_NUM)
+    private long logRejectedRecordNum = 0;
 
     /**
      * If enable this variable (only take effect for pipeline), it will deliver fragment instances
@@ -1499,6 +1504,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableIncrementalRefreshMv(boolean enable) {
         this.enableIncrementalRefreshMV = enable;
+    }
+
+    public long getLogRejectedRecordNum() {
+        return logRejectedRecordNum;
+    }
+
+    public void setLogRejectedRecordNum(long logRejectedRecordNum) {
+        this.logRejectedRecordNum = logRejectedRecordNum;
     }
 
     public boolean isEnablePipelineEngine() {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1432,6 +1432,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 throw new UserException("txn does not exist: " + request.getTxnId());
             }
             txnState.addTableIndexes((OlapTable) table);
+            plan.setImport_label(txnState.getLabel());
+            plan.setDb_name(dbName);
+            plan.setLoad_job_id(request.getTxnId());
 
             return plan;
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -98,6 +98,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String MAX_BATCH_ROWS_PROPERTY = "max_batch_rows";
     public static final String MAX_BATCH_SIZE_PROPERTY = "max_batch_size";  // deprecated
 
+    public static final String LOG_REJECTED_RECORD_NUM_PROPERTY = "log_rejected_record_num";
+
     // the value is csv or json, default is csv
     public static final String FORMAT = "format";
     public static final String STRIP_OUTER_ARRAY = "strip_outer_array";
@@ -148,6 +150,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(TRIMSPACE)
             .add(ENCLOSE)
             .add(ESCAPE)
+            .add(LOG_REJECTED_RECORD_NUM_PROPERTY)
             .build();
 
     private static final ImmutableSet<String> KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -183,6 +186,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     private long maxErrorNum = -1;
     private long maxBatchIntervalS = -1;
     private long maxBatchRows = -1;
+    private long logRejectedRecordNum = 0;
     private boolean strictMode = true;
     private String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     private boolean partialUpdate = false;
@@ -227,6 +231,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final Predicate<Long> MAX_ERROR_NUMBER_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> MAX_BATCH_INTERVAL_PRED = (v) -> v >= 5;
     public static final Predicate<Long> MAX_BATCH_ROWS_PRED = (v) -> v >= 200000;
+    public static final Predicate<Long> LOG_REJECTED_RECORD_NUM_PRED = (v) -> v >= -1L;
 
     public CreateRoutineLoadStmt(LabelName labelName, String tableName, List<ParseNode> loadPropertyList,
                                  Map<String, String> jobProperties,
@@ -322,6 +327,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     public long getMaxBatchRows() {
         return maxBatchRows;
+    }
+
+    public long getLogRejectedRecordNum() {
+        return logRejectedRecordNum;
     }
 
     public boolean isStrictMode() {
@@ -501,6 +510,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         maxBatchRows = Util.getLongPropertyOrDefault(jobProperties.get(MAX_BATCH_ROWS_PROPERTY),
                 RoutineLoadJob.DEFAULT_MAX_BATCH_ROWS, MAX_BATCH_ROWS_PRED,
                 MAX_BATCH_ROWS_PROPERTY + " should >= 200000");
+
+        logRejectedRecordNum = Util.getLongPropertyOrDefault(jobProperties.get(LOG_REJECTED_RECORD_NUM_PROPERTY),
+                0, LOG_REJECTED_RECORD_NUM_PRED,
+                LOG_REJECTED_RECORD_NUM_PROPERTY + " should >= -1");
 
         strictMode = Util.getBooleanPropertyOrDefault(jobProperties.get(LoadStmt.STRICT_MODE),
                 RoutineLoadJob.DEFAULT_STRICT_MODE,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LoadStmt.java
@@ -99,6 +99,7 @@ public class LoadStmt extends DdlStmt {
     public static final String PRIORITY = "priority";
     public static final String MERGE_CONDITION = "merge_condition";
     public static final String CASE_SENSITIVE = "case_sensitive";
+    public static final String LOG_REJECTED_RECORD_NUM = "log_rejected_record_num";
 
 
     // for load data from Baidu Object Store(BOS)
@@ -138,6 +139,7 @@ public class LoadStmt extends DdlStmt {
             .add(PARTIAL_UPDATE)
             .add(PRIORITY)
             .add(CASE_SENSITIVE)
+            .add(LOG_REJECTED_RECORD_NUM)
             .build();
 
     public LoadStmt(LabelName label, List<DataDescription> dataDescriptions, BrokerDesc brokerDesc,
@@ -292,6 +294,19 @@ public class LoadStmt extends DdlStmt {
         if (priorityProperty != null) {
             if (LoadPriority.priorityByName(priorityProperty) == null) {
                 throw new DdlException(PRIORITY + " should in HIGHEST/HIGH/NORMAL/LOW/LOWEST");
+            }
+        }
+
+        // log rejected record num
+        final String logRejectedRecordNumProperty = properties.get(LOG_REJECTED_RECORD_NUM);
+        if (logRejectedRecordNumProperty != null) {
+            try {
+                final long logRejectedRecordNum = Long.parseLong(logRejectedRecordNumProperty);
+                if (logRejectedRecordNum < -1) {
+                    throw new DdlException(LOG_REJECTED_RECORD_NUM + " must be equal or greater than -1");
+                }
+            } catch (NumberFormatException e) {
+                throw new DdlException(LOG_REJECTED_RECORD_NUM + " is not a number.");
             }
         }
     }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -197,6 +197,7 @@ struct TOlapTableSink {
     23: optional bool abort_delete // Deprecated
     24: optional i32 auto_increment_slot_id
     25: optional Types.TPartialUpdateMode partial_update_mode
+    26: optional string label
 }
 
 struct TSchemaTableSink {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -464,6 +464,7 @@ struct TLoadInfo {
     21: optional i64 num_filtered_rows
     22: optional i64 num_unselected_rows
     23: optional i64 num_sink_rows
+    24: optional string rejected_record_path
 }
 
 // getTableNames returns a list of unqualified table names
@@ -549,6 +550,8 @@ struct TReportExecStatusParams {
   22: optional i64 filtered_rows
 
   23: optional i64 unselected_rows
+
+  24: optional string rejected_record_path
 }
 
 struct TFeResult {
@@ -696,6 +699,7 @@ struct TStreamLoadPutRequest {
     29: optional i32 load_dop
     30: optional bool enable_replicated_storage
     31: optional string merge_condition
+    32: optional i64 log_rejected_record_num
     // only valid when file type is CSV
     50: optional string rowDelimiter
     // only valid when file type is CSV

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -188,6 +188,8 @@ struct TQueryOptions {
   86: optional i32 io_tasks_per_scan_operator = 4;
   87: optional i32 connector_io_tasks_per_scan_operator = 16;
   88: optional double runtime_filter_early_return_selectivity = 0.05;
+
+  90: optional i64 log_rejected_record_num = 0;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Users can determine whether to record data rows that fail to write during the loading process by specifying the `log_rejected_record_num`
`0` means no records are logged, which is the default value.
`-1` means logging all rejected records.
`>0` means logging up to the specified number of rejected records on each BE node.

### stream load
```
curl --location-trusted -u root: -T a -X PUT -H log_rejected_record_num:1 http://172.26.34.214:8040/api/t/tt/_stream_load
{
    "TxnId": 28029,
    "Label": "74469448-9990-40ad-991d-1eb8f80f1e9d",
    "Status": "Fail",
    "Message": "too many filtered rows",
    "NumberTotalRows": 2,
    "NumberLoadedRows": 2,
    "NumberFilteredRows": 1,
    "NumberUnselectedRows": 0,
    "LoadBytes": 8,
    "LoadTimeMs": 254,
    "BeginTxnTimeMs": 95,
    "StreamLoadPlanTimeMs": 140,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 19,
    "CommitAndPublishTimeMs": 0,
    "ErrorURL": "http://172.26.34.214:8040/api/_load_error_log?file=error_log_8d47259b59066ce5_25a86eb4561a3690",
    "RejectedRecordPath": "172.26.34.214:/disk1/hujie/storage/rejected_record/t/74469448-9990-40ad-991d-1eb8f80f1e9d/28029/8d47259b59066ce5_25a86eb4561a3690"
}
```

### broker load
```
mysql> LOAD LABEL rj2 (DATA INFILE("hdfs://172.26.194.238:9000/starrocks_test_data/benchmark_data/load_benchmark/clickbench/csv/hits.tsv") INTO TABLE
    -> clickbench) WITH BROKER ("username"="","password"="") PROPERTIES("log_rejected_record_num"="1000");

Query OK, 0 rows affected (0.11 sec)

mysql> select * from information_schema.loads where database_name='t' order by create_time desc limit 1;
+--------+-------+---------------+-----------+-------------------+--------+----------+-----------+---------------+-----------------+-----------+----------+------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| JOB_ID | LABEL | DATABASE_NAME | STATE     | PROGRESS          | TYPE   | PRIORITY | SCAN_ROWS | FILTERED_ROWS | UNSELECTED_ROWS | SINK_ROWS | ETL_INFO | TASK_INFO                                            | CREATE_TIME         | ETL_START_TIME      | ETL_FINISH_TIME     | LOAD_START_TIME     | LOAD_FINISH_TIME    | JOB_DETAILS                                                                                                                                                                                                                                                                                                            | ERROR_MSG                                                | TRACKING_URL                                                                                   | TRACKING_SQL                                                                      | REJECTED_RECORD_PATH                                                                                                                                                                                                                                                                                 |
+--------+-------+---------------+-----------+-------------------+--------+----------+-----------+---------------+-----------------+-----------+----------+------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|  75028 | rj2   | t             | CANCELLED | ETL:N/A; LOAD:N/A | BROKER | NORMAL   |  99997497 |      99997497 |               0 |  99997497 |          | resource:N/A; timeout(s):77377; max_filter_ratio:0.5 | 2023-04-12 20:02:44 | 2023-04-12 20:02:47 | 2023-04-12 20:02:47 | 2023-04-12 20:02:47 | 2023-04-12 20:07:35 | {"All backends":{"1cc2492c-b6fb-4114-bee4-948fb8d2ebe3":[10006,10005,10004]},"FileNumber":1,"FileSize":74807831229,"InternalTableLoadBytes":71823324097,"InternalTableLoadRows":99997497,"ScanBytes":74807831229,"ScanRows":99997497,"TaskNumber":1,"Unfinished backends":{"1cc2492c-b6fb-4114-bee4-948fb8d2ebe3":[]}} | type:LOAD_RUN_FAIL; msg:all partitions have no load data | http://172.26.34.213:8040/api/_load_error_log?file=error_log_1cc2492cb6fb4114_bee4948fb8d2ebe4 | select tracking_log from information_schema.load_tracking_logs where job_id=75028 | 172.26.34.213:/disk1/hujie/storage/rejected_record/t/rj2/30031/1cc2492cb6fb4114_bee4948fb8d2ebe4, 172.26.34.214:/disk1/hujie/storage/rejected_record/t/rj2/30031/1cc2492cb6fb4114_bee4948fb8d2ebe5, 172.26.34.215:/disk1/hujie/storage/rejected_record/t/rj2/30031/1cc2492cb6fb4114_bee4948fb8d2ebe6 |
+--------+-------+---------------+-----------+-------------------+--------+----------+-----------+---------------+-----------------+-----------+----------+------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.04 sec)

```

### routine load
```
mysql> CREATE ROUTINE LOAD rtl on rt_load_test COLUMNS (col1,col2,col3),COLUMNS TERMINATED BY ',' PROPERTIES ("desired_concurrent_number"="1","max_error_number"="100000","max_batch_interval"="5","log_rejected_record_num"="-1") FROM KAFKA ("kafka_broker_list"="172.26.92.141:9092","kafka_topic"="rt_alter_test","kafka_partitions"="0,1,2,3,4","kafka_offsets"="OFFSET_BEGINNING,OFFSET_BEGINNING,OFFSET_BEGINNING,OFFSET_BEGINNING,OFFSET_BEGINNING");
Query OK, 0 rows affected (0.08 sec)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
