### PR TITLE
[BugFix] BE stream load rollback failure

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -281,6 +281,7 @@ Status StreamLoadExecutor::rollback_txn(StreamLoadContext* ctx) {
     TLoadTxnRollbackRequest request;
     set_request_auth(&request, ctx->auth);
     request.db = ctx->db;
+    request.tbl = ctx->table;
     request.txnId = ctx->txn_id;
     request.failInfos = std::move(ctx->fail_infos);
     request.__set_reason(ctx->status.get_error_msg());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/21129

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the BE stream load executor initiates a txn rollback, the BE doesn't include table info. The FE checks the authorization with user table info and database info. When the user's LOAD grant is granted with the specific table, the authorization check will fail, and `Access denied; you need (at least one of) the LOAD privilege(s) for this operation` would be returned.
![image](https://user-images.githubusercontent.com/16649269/230534018-8df0b19c-7969-4e3a-a86c-8cf20e7fcbcb.png)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
