### PR TITLE
[BugFix] consider null values when remove scan predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -364,18 +364,16 @@ public class OptOlapPartitionPruner {
             newPredicate = newPredicate.accept(shuttle, null);
 
             ScalarOperator value = scalarRewriter.rewrite(newPredicate, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
-            if (value.isConstantRef() && ((ConstantOperator) value).isNull()) {
-                newPredicateFilterNulls = true;
-            } else if (value.equals(ConstantOperator.createBoolean(false))) {
+            if ((value.isConstantRef() && ((ConstantOperator) value).isNull()) ||
+                    value.equals(ConstantOperator.createBoolean(false))) {
                 newPredicateFilterNulls = true;
             }
         }
 
         predicate = predicate.accept(shuttle, null);
         ScalarOperator value = scalarRewriter.rewrite(predicate, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
-        if (value.isConstantRef() && ((ConstantOperator) value).isNull()) {
-            predicateFilterNulls = true;
-        } else if (value.equals(ConstantOperator.createBoolean(false))) {
+        if ((value.isConstantRef() && ((ConstantOperator) value).isNull())
+                || value.equals(ConstantOperator.createBoolean(false))) {
             predicateFilterNulls = true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.transformation.ListPartitionPruner;
 import org.apache.logging.log4j.LogManager;
@@ -182,6 +183,12 @@ public class OptOlapPartitionPruner {
         }
 
         scanPredicates.removeAll(prunedPartitionPredicates);
+
+        if (column.isAllowNull() && containsNullValue(column, minRange)
+                && !checkFilterNullValue(scanPredicates, logicalOlapScanOperator.getPredicate().clone())) {
+            return null;
+        }
+
         return Pair.create(Utils.compoundAnd(scanPredicates), prunedPartitionPredicates);
     }
 
@@ -329,5 +336,50 @@ public class OptOlapPartitionPruner {
         return probeResult;
     }
 
+    private static boolean containsNullValue(Column column, PartitionKey minRange) {
+        PartitionKey nullValue = new PartitionKey();
+        try {
+            nullValue.pushColumn(LiteralExpr.createInfinity(column.getType(), false), column.getPrimitiveType());
+            return minRange.compareTo(nullValue) <= 0;
+        } catch (AnalysisException e) {
+            return false;
+        }
+    }
+
+
+    private static boolean checkFilterNullValue(List<ScalarOperator> scanPredicates, ScalarOperator predicate) {
+        ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
+        ScalarOperator newPredicate = Utils.compoundAnd(scanPredicates);
+        boolean newPredicateFilterNulls = false;
+        boolean predicateFilterNulls = false;
+
+        BaseScalarOperatorShuttle shuttle = new BaseScalarOperatorShuttle() {
+            @Override
+            public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
+                return ConstantOperator.createNull(variable.getType());
+            }
+        };
+
+        if (newPredicate != null) {
+            newPredicate = newPredicate.accept(shuttle, null);
+
+            ScalarOperator value = scalarRewriter.rewrite(newPredicate, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+            if (value.isConstantRef() && ((ConstantOperator) value).isNull()) {
+                newPredicateFilterNulls = true;
+            } else if (value.equals(ConstantOperator.createBoolean(false))) {
+                newPredicateFilterNulls = true;
+            }
+        }
+
+        predicate = predicate.accept(shuttle, null);
+        ScalarOperator value = scalarRewriter.rewrite(predicate, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+        if (value.isConstantRef() && ((ConstantOperator) value).isNull()) {
+            predicateFilterNulls = true;
+        } else if (value.equals(ConstantOperator.createBoolean(false))) {
+            predicateFilterNulls = true;
+        }
+
+        return newPredicateFilterNulls == predicateFilterNulls;
+    }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -90,9 +90,10 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     tabletRatio=8/8")
                 .contains("TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     partitions=1/5\n" +
+                        "     PREDICATES: 10: c3 > 1999\n" +
+                        "     partitions=2/5\n" +
                         "     rollup: test_base_part\n" +
-                        "     tabletRatio=2/2");
+                        "     tabletRatio=4/4");
 
         // test query delta
         testRewriteOK("select c1, c3, c2 from test_base_part where c3 < 1000")
@@ -278,11 +279,14 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 3000")
                 .contains("TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 3: c3 < 3000\n" +
                         "     partitions=5/5\n" +
                         "     rollup: test_base_part\n" +
                         "     tabletRatio=10/10")
-                .contains("TABLE: test_base_part2\n" +
+                .contains("OlapScanNode\n" +
+                        "     TABLE: test_base_part2\n" +
                         "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 7: c3 < 3000\n" +
                         "     partitions=5/5\n" +
                         "     rollup: test_base_part2\n" +
                         "     tabletRatio=10/10");
@@ -375,11 +379,13 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         " where t1.c3 < 3000")
                 .contains("TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 3: c3 < 3000\n" +
                         "     partitions=5/5\n" +
                         "     rollup: test_base_part\n" +
                         "     tabletRatio=10/10")
                 .contains("TABLE: test_base_part2\n" +
                         "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 7: c3 < 3000\n" +
                         "     partitions=5/5\n" +
                         "     rollup: test_base_part2\n" +
                         "     tabletRatio=10/10");
@@ -445,6 +451,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
         testRewriteOK("select c1, c3, c2 from test_base_part where c3 < 1000")
                 .contains("TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 3: c3 < 1000\n" +
                         "     partitions=3/5\n" +
                         "     rollup: test_base_part\n" +
                         "     tabletRatio=6/6");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21130

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the minimum partition range contains the minimum value of a data type, the partition implicitly includes null values. Therefore, when determining if the partition range matches the predicate range, it is necessary to consider whether the predicate filters null values.

About the changes in test `testPartitionPrune_SingleTable1`:
Table `test_base_part` with partation [-∞, 100), [100, 200), [200, 1000), [1000, 2000), [2000, 3000),
MV `partial_mv_6` with query `select c1, c3, c2 from test_base_part where c3 < 2000`
For sql `select c1, c3, c2 from test_base_part where c3 < 3000`, the plan rewrited by mv is 
```
select * from test_base_part where c3 > 1999
union
select * from partial_mv_6
```
For sql `select c1, c3, c2 from test_base_part`, the plan rewrited by mv is 
```
select * from test_base_part where c3 >= 2000
union
select * from partial_mv_6
```
Actually data with `c3 > 1999` can only in the last range, but the compare resutlt between `1999` and  range[1000, 2000) cannot notice it, it select range[1000, 2000) and range [2000, 3000). 



## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
