### PR TITLE
[Enhancement] revert delete the predicate_slots to maintain compatibility

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -195,6 +195,19 @@ void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
     param->output_tuple_column_timer = _output_tuple_column_timer;
     param->output_slots = _output_slots;
 
+    std::set<SlotId> predicate_slots;
+    for (ExprContext* expr_context : _conjunct_ctxs) {
+        std::vector<SlotId> expr_slots;
+        expr_context->root()->get_slot_ids(&expr_slots);
+        predicate_slots.insert(expr_slots.begin(), expr_slots.end());
+    }
+    for (ExprContext* expr_context : _other_join_conjunct_ctxs) {
+        std::vector<SlotId> expr_slots;
+        expr_context->root()->get_slot_ids(&expr_slots);
+        predicate_slots.insert(expr_slots.begin(), expr_slots.end());
+    }
+    param->predicate_slots = predicate_slots;
+
     for (auto i = 0; i < _build_expr_ctxs.size(); i++) {
         Expr* expr = _build_expr_ctxs[i]->root();
         if (expr->is_slotref()) {

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -206,7 +206,7 @@ void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
         expr_context->root()->get_slot_ids(&expr_slots);
         predicate_slots.insert(expr_slots.begin(), expr_slots.end());
     }
-    param->predicate_slots = predicate_slots;
+    param->predicate_slots = std::move(predicate_slots);
 
     for (auto i = 0; i < _build_expr_ctxs.size(); i++) {
         Expr* expr = _build_expr_ctxs[i]->root();

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -150,7 +150,7 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
         expr_context->root()->get_slot_ids(&expr_slots);
         predicate_slots.insert(expr_slots.begin(), expr_slots.end());
     }
-    param->predicate_slots = predicate_slots;
+    param->predicate_slots = std::move(predicate_slots);
 
     for (auto i = 0; i < _build_expr_ctxs.size(); i++) {
         Expr* expr = _build_expr_ctxs[i]->root();

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -139,6 +139,18 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->output_probe_column_timer = probe_metrics().output_probe_column_timer;
     param->output_tuple_column_timer = probe_metrics().output_tuple_column_timer;
     param->output_slots = _output_slots;
+    std::set<SlotId> predicate_slots;
+    for (ExprContext* expr_context : _conjunct_ctxs) {
+        std::vector<SlotId> expr_slots;
+        expr_context->root()->get_slot_ids(&expr_slots);
+        predicate_slots.insert(expr_slots.begin(), expr_slots.end());
+    }
+    for (ExprContext* expr_context : _other_join_conjunct_ctxs) {
+        std::vector<SlotId> expr_slots;
+        expr_context->root()->get_slot_ids(&expr_slots);
+        predicate_slots.insert(expr_slots.begin(), expr_slots.end());
+    }
+    param->predicate_slots = predicate_slots;
 
     for (auto i = 0; i < _build_expr_ctxs.size(); i++) {
         Expr* expr = _build_expr_ctxs[i]->root();

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -290,8 +290,11 @@ void JoinHashTable::create(const HashTableParam& param) {
         for (const auto& slot : tuple_desc->slots()) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
-            if (param.output_slots.empty() || std::find(param.output_slots.begin(), param.output_slots.end(),
-                                                        slot->id()) != param.output_slots.end()) {
+            if (param.output_slots.empty() ||
+                std::find(param.output_slots.begin(), param.output_slots.end(), slot->id()) !=
+                        param.output_slots.end() ||
+                std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                        param.predicate_slots.end()) {
                 hash_table_slot.need_output = true;
             } else {
                 hash_table_slot.need_output = false;
@@ -310,8 +313,11 @@ void JoinHashTable::create(const HashTableParam& param) {
         for (const auto& slot : tuple_desc->slots()) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
-            if (param.output_slots.empty() || std::find(param.output_slots.begin(), param.output_slots.end(),
-                                                        slot->id()) != param.output_slots.end()) {
+            if (param.output_slots.empty() ||
+                std::find(param.output_slots.begin(), param.output_slots.end(), slot->id()) !=
+                        param.output_slots.end() ||
+                std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                        param.predicate_slots.end()) {
                 hash_table_slot.need_output = true;
             } else {
                 hash_table_slot.need_output = false;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In this #20564 , we generate output cols of join contains both cols referenced by select list  and other predicates and remove this step in BE. This may have some problem when upgrade BE firstly then upgrade FE. To maintain compatibility, we should put this step back in BE. 


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
