### PR TITLE
[Enhancement] Enhance FE/BE to output logs to console directly (#20967)

### DIFF
--- a/docker/dockerfiles/be/be_entrypoint.sh
+++ b/docker/dockerfiles/be/be_entrypoint.sh
@@ -108,4 +108,10 @@ update_conf_from_configmap
 collect_env_info
 add_self $svc_name || exit $?
 log_stderr "run start_be.sh"
-$STARROCKS_HOME/bin/start_be.sh
+
+addition_args=
+if [[ "x$LOG_CONSOLE" == "x1" ]] ; then
+    # env var `LOG_CONSOLE=1` can be added to enable logging to console
+    addition_args="--logconsole"
+fi
+$STARROCKS_HOME/bin/start_be.sh $addition_args

--- a/docker/dockerfiles/be/cn_entrypoint.sh
+++ b/docker/dockerfiles/be/cn_entrypoint.sh
@@ -166,4 +166,10 @@ trap exit_clean SIGTERM
 
 update_conf_from_configmap
 log_stderr "run start_cn.sh"
-$STARROCKS_HOME/bin/start_cn.sh
+
+addition_args=
+if [[ "x$LOG_CONSOLE" == "x1" ]] ; then
+    # env var `LOG_CONSOLE=1` can be added to enable logging to console
+    addition_args="--logconsole"
+fi
+$STARROCKS_HOME/bin/start_cn.sh $addition_args

--- a/docker/dockerfiles/fe/fe_entrypoint.sh
+++ b/docker/dockerfiles/fe/fe_entrypoint.sh
@@ -223,6 +223,9 @@ start_fe_no_meta()
         done
     fi
 
+    if [[ "x$LOG_CONSOLE" == "x1" ]] ; then
+        opts+=" --logconsole"
+    fi
     log_stderr "first start with no meta run start_fe.sh with additional options: '$opts'"
     $STARROCKS_HOME/bin/start_fe.sh $opts
 }
@@ -234,6 +237,9 @@ start_fe_with_meta()
         opts+=" --host_type $HOST_TYPE"
     fi
 
+    if [[ "x$LOG_CONSOLE" == "x1" ]] ; then
+        opts+=" --logconsole"
+    fi
     log_stderr "start with meta run start_fe.sh with additional options: '$opts'"
     $STARROCKS_HOME/bin/start_fe.sh $opts
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -90,6 +90,11 @@ public class Config extends ConfigBase {
     @Deprecated
     @ConfField
     public static String sys_log_roll_mode = "SIZE-MB-1024";
+    /**
+     * Log to file by default. set to `true` if want to log to console
+     */
+    @ConfField
+    public static boolean sys_log_to_console = false;
 
     /**
      * audit_log_dir:

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -52,10 +52,13 @@ import java.util.Map;
 public class Log4jConfig extends XmlConfiguration {
     private static final long serialVersionUID = 1L;
 
-    private static String xmlConfTemplate = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+    private static String xmlConfTemplateAppenders = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
             "\n" +
             "<Configuration status=\"info\" packages=\"com.starrocks.common\">\n" +
             "  <Appenders>\n" +
+            "    <Console name=\"ConsoleErr\" target=\"SYSTEM_ERR\" follow=\"true\">\n" +
+            "      <PatternLayout pattern=\"%d{yyyy-MM-dd HH:mm:ss,SSS} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>\n" +
+            "    </Console>\n" +
             "    <RollingFile name=\"Sys\" fileName=\"${sys_log_dir}/fe.log\" filePattern=\"${sys_log_dir}/fe.log.${sys_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
             "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
@@ -131,7 +134,10 @@ public class Log4jConfig extends XmlConfiguration {
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
-            "  </Appenders>\n" +
+            "  </Appenders>\n";
+
+    // Predefined loggers to write log to file
+    private static String xmlConfTemplateFileLoggers =
             "  <Loggers>\n" +
             "    <Root level=\"${sys_log_level}\">\n" +
             "      <AppenderRef ref=\"Sys\"/>\n" +
@@ -162,6 +168,15 @@ public class Log4jConfig extends XmlConfiguration {
             "  </Loggers>\n" +
             "</Configuration>";
 
+    // Predefined console logger, all logs will be written to console
+    private static String xmlConfTemplateConsoleLoggers =
+            "  <Loggers>\n" +
+            "    <Root level=\"${sys_log_level}\">\n" +
+            "      <AppenderRef ref=\"ConsoleErr\"/>\n" +
+            "    </Root>\n" +
+            "    <!--REPLACED BY AUDIT AND VERBOSE MODULE NAMES-->\n" +
+            "  </Loggers>\n" +
+            "</Configuration>";
     private static StrSubstitutor strSub;
     private static String sysLogLevel;
     private static String[] verboseModules;
@@ -170,7 +185,8 @@ public class Log4jConfig extends XmlConfiguration {
     private static String[] bigQueryModules;
 
     private static void reconfig() throws IOException {
-        String newXmlConfTemplate = xmlConfTemplate;
+        String newXmlConfTemplate = xmlConfTemplateAppenders;
+        newXmlConfTemplate += Config.sys_log_to_console ? xmlConfTemplateConsoleLoggers : xmlConfTemplateFileLoggers;
 
         // sys log config
         String sysLogDir = Config.sys_log_dir;


### PR DESCRIPTION
1. LOG_CONSOLE env var is checked in fe/be/cn entrypoint script and pass `--logconsole` parameter to start_<fe|be|cn>.sh
2. start_fe.sh force set `syslog_to_console = true` in fe.conf so all logs are written to console stderr
3. start_be.sh/start_cn.sh force set `GLOG_logtostderr=1` env var to redirect glog output to console stderr
4. remove writing to pidfile, FE/BE application code will take care it.

Signed-off-by: Kevin Xiaohua Cai <caixiaohua@starrocks.com>
(cherry picked from commit 35044f9eb7aec4596dacf4f0862eccb5b26ab0ec)

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [X] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
