### PR TITLE
[BugFix] Fix thread running out for avro import

### DIFF
--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -248,6 +248,7 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
                         if (err) {
                             auto err_msg = strings::Substitute("serdes deserialize avro failed: $0", errstr);
                             LOG(ERROR) << err_msg;
+                            delete msg;
                             return Status::InternalError(err_msg);
                         }
                         DeferOp op([&] { avro_value_decref(&avro); });
@@ -255,6 +256,7 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
                         if (avro_value_to_json(&avro, 1, &as_json)) {
                             auto err_msg = strings::Substitute("avro to json failed: $0", avro_strerror());
                             LOG(ERROR) << err_msg;
+                            delete msg;
                             return Status::InternalError(err_msg);
                         }
                         st = (kafka_pipe.get()->*append_data)(as_json, strlen(as_json), row_delimiter);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21152

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the confluent schema registry server is not started, the consuming thread returns an error, but then the consuming thread blocks on the destructor of rdkafka consumer, see https://github.com/confluentinc/librdkafka/issues/3143. This PR fixes the problem.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
