### PR TITLE
[Enhancement] remove delete restriction on the auto-increment table(#20702)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -206,7 +206,6 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
     request.set_node_id(_node_id);
     request.set_write_quorum(_write_quorum_type);
     request.set_miss_auto_increment_column(_parent->_miss_auto_increment_column);
-    request.set_abort_delete(_parent->_abort_delete);
     request.set_is_incremental(incremental_open);
     request.set_sender_id(_parent->_sender_id);
     for (auto& tablet : tablets) {
@@ -921,7 +920,6 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     if (table_sink.__isset.null_expr_in_auto_increment) {
         _null_expr_in_auto_increment = table_sink.null_expr_in_auto_increment;
         _miss_auto_increment_column = table_sink.miss_auto_increment_column;
-        _abort_delete = table_sink.abort_delete;
         _auto_increment_slot_id = table_sink.auto_increment_slot_id;
     }
     if (table_sink.__isset.write_quorum_type) {

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -502,8 +502,6 @@ private:
 
     bool _miss_auto_increment_column = false;
 
-    bool _abort_delete = false;
-
     std::unique_ptr<ThreadPoolToken> _automatic_partition_token;
 
     std::vector<std::vector<std::string>> _partition_not_exist_row_values;

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -482,7 +482,6 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         options.timeout_ms = params.timeout_ms();
         options.write_quorum = params.write_quorum();
         options.miss_auto_increment_column = params.miss_auto_increment_column();
-        options.abort_delete = params.abort_delete();
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);
@@ -662,7 +661,6 @@ Status LocalTabletsChannel::incremental_open(const PTabletWriterOpenRequest& par
         options.timeout_ms = params.timeout_ms();
         options.write_quorum = params.write_quorum();
         options.miss_auto_increment_column = params.miss_auto_increment_column();
-        options.abort_delete = params.abort_delete();
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -254,7 +254,6 @@ Status DeltaWriter::_init() {
     writer_context.segments_overlap = OVERLAPPING;
     writer_context.global_dicts = _opt.global_dicts;
     writer_context.miss_auto_increment_column = _opt.miss_auto_increment_column;
-    writer_context.abort_delete = _opt.abort_delete;
     Status st = RowsetFactory::create_rowset_writer(writer_context, &_rowset_writer);
     if (!st.ok()) {
         auto msg = strings::Substitute("Fail to create rowset writer. tablet_id: $0, error: $1", _opt.tablet_id,
@@ -438,7 +437,6 @@ void DeltaWriter::_reset_mem_table() {
                                                 _mem_table_sink.get(), "", _mem_tracker);
     }
     _mem_table->set_write_buffer_row(_memtable_buffer_row);
-    _mem_table->set_abort_delete(_opt.abort_delete);
 }
 
 Status DeltaWriter::commit() {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -63,7 +63,6 @@ struct DeltaWriterOptions {
     std::string merge_condition;
     ReplicaState replica_state;
     bool miss_auto_increment_column = false;
-    bool abort_delete = false;
 };
 
 enum State {

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -378,11 +378,6 @@ Status MemTable::_split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, std::u
         *upserts = src;
         return Status::OK();
     }
-    if (_abort_delete) {
-        return Status::InternalError(fmt::format(
-                "delete is forbidden when auto increment column is not the Key for Primary Key table. tablet_id: {}",
-                _tablet_id));
-    }
     if (!_merge_condition.empty()) {
         // Do not support delete with condition now
         return Status::InternalError(

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -66,8 +66,6 @@ public:
 
     static Schema convert_schema(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>* slot_descs);
 
-    void set_abort_delete(bool abort) { _abort_delete = abort; }
-
     ChunkPtr get_result_chunk() { return _result_chunk; }
 
 private:
@@ -122,8 +120,6 @@ private:
     size_t _chunk_bytes_usage = 0;
     size_t _aggregator_memory_usage = 0;
     size_t _aggregator_bytes_usage = 0;
-
-    bool _abort_delete = false;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const MemTable& table) {

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -86,8 +86,6 @@ public:
     std::string merge_condition;
 
     bool miss_auto_increment_column = false;
-
-    bool abort_delete = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -51,6 +51,7 @@ struct AutoIncrementPartialUpdateState {
     uint32_t id;
     uint32_t segment_id;
     std::vector<uint32_t> rowids;
+    std::unique_ptr<Column> delete_pks;
     bool skip_rewrite;
     AutoIncrementPartialUpdateState() : rowset(nullptr), schema(nullptr), id(0), segment_id(0), skip_rewrite(false) {}
 
@@ -65,6 +66,7 @@ struct AutoIncrementPartialUpdateState {
         src_rss_rowids.clear();
         rowids.clear();
         write_column.reset();
+        delete_pks.reset();
 
         rowset = nullptr;
         schema = nullptr;
@@ -84,7 +86,7 @@ public:
     Status load(Tablet* tablet, Rowset* rowset);
 
     Status apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, uint32_t segment_id,
-                 EditVersion latest_applied_version, const PrimaryIndex& index);
+                 EditVersion latest_applied_version, const PrimaryIndex& index, std::unique_ptr<Column>& delete_pks);
 
     const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
     const std::vector<ColumnUniquePtr>& deletes() const { return _deletes; }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -577,20 +577,6 @@ public class OlapTable extends Table {
         }
     }
 
-    public boolean isAbortDelete() {
-        boolean abortDelete = false;
-        if (keysType == keysType.PRIMARY_KEYS) {
-            for (Column col : getBaseSchema()) {
-                if (col.isAutoIncrement() && !col.isKey()) {
-                    abortDelete = true;
-                    break;
-                }
-            }
-        }
-
-        return abortDelete;
-    }
-
     public Status resetIdsForRestore(GlobalStateMgr globalStateMgr, Database db, int restoreReplicationNum) {
         // table id
         id = globalStateMgr.getNextId();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -119,7 +119,6 @@ public class OlapTableSink extends DataSink {
 
     private boolean nullExprInAutoIncrement;
     private boolean missAutoIncrementColumn;
-    private boolean abortDelete;
     private int autoIncrementSlotId;
 
     public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
@@ -140,7 +139,6 @@ public class OlapTableSink extends DataSink {
         this.enableReplicatedStorage = enableReplicatedStorage;
         this.nullExprInAutoIncrement = nullExprInAutoIncrement;
         this.missAutoIncrementColumn = false;
-        this.abortDelete = dstTable.isAbortDelete();
 
         this.autoIncrementSlotId = -1;
         if (tupleDescriptor != null) {
@@ -161,7 +159,6 @@ public class OlapTableSink extends DataSink {
         tSink.setTxn_id(txnId);
         tSink.setNull_expr_in_auto_increment(nullExprInAutoIncrement);
         tSink.setMiss_auto_increment_column(missAutoIncrementColumn);
-        tSink.setAbort_delete(abortDelete);
         tSink.setAuto_increment_slot_id(autoIncrementSlotId);
         TransactionState txnState =
                 GlobalStateMgr.getCurrentGlobalTransactionMgr()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -27,7 +27,6 @@ import com.starrocks.planner.DataSink;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -81,10 +80,6 @@ public class DeletePlanner {
             TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
 
             OlapTable table = (OlapTable) deleteStatement.getTable();
-            if (table.isAbortDelete()) {
-                throw new SemanticException(
-                    "Delete statement is forbidden when auto increment column is not the Key for Primary Key table.");
-            }
             for (Column column : table.getBaseSchema()) {
                 if (column.isKey()) {
                     SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -168,7 +168,7 @@ message PTabletWriterOpenRequest {
     optional WriteQuorumTypePB write_quorum = 25;
     optional string merge_condition = 26;
     optional bool miss_auto_increment_column = 27;
-    optional bool abort_delete = 28;
+    optional bool abort_delete = 28; // Deprecated
     // before data load, the all current partitions will be opened
     // When the data load in progress, the partition created by automatic partition needs incremental open
     optional bool is_incremental = 29 [default = false];

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -194,8 +194,8 @@ struct TOlapTableSink {
     20: optional string merge_condition
     21: optional bool null_expr_in_auto_increment
     22: optional bool miss_auto_increment_column
-    23: optional bool abort_delete
-    24: optional i32 auto_increment_slot_id;
+    23: optional bool abort_delete // Deprecated
+    24: optional i32 auto_increment_slot_id
 }
 
 struct TSchemaTableSink {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20702

## Problem Summary(Required) ：
In current implementation, when the auto increment column is value column but not the key column,
this kind of table can not support delete. The pr will remove restriction, but has some side affect as following:

1. If the delete-partial update conflict happen, partial update operation maybe lost.
2. If it is the streamload combine with the delete and partial update ops and manipulate on a row which has existed
    in the previous version, all the partial update ops after delete ops maybe lost for this row if they contained in
    different segment file.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
