### PR TITLE
[Enhancement] Optimize hint message in parallel stream load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -222,7 +222,7 @@ public class TransactionLoadAction extends RestBaseAction {
             int channelId = Integer.parseInt(channelIdStr);
             TransactionResult resp = new TransactionResult();
             TNetworkAddress redirectAddr = GlobalStateMgr.getCurrentState().getStreamLoadManager().executeLoadTask(
-                    label, channelId, request.getRequest().headers(), resp);
+                    label, channelId, request.getRequest().headers(), resp, dbName, tableName);
             if (!resp.stateOK() || resp.containMsg()) {
                 sendResult(request, response, resp);
                 return;

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadManager.java
@@ -141,6 +141,10 @@ public class StreamLoadManager {
 
     public void unprotectedCheckMeta(Database db, String tblName)
             throws UserException {
+        if (tblName == null) {
+            throw new AnalysisException("Table name must be specified when calling /begin/transaction/ first time");
+        }
+
         Table table = db.getTable(tblName);
         if (table == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tblName);
@@ -193,7 +197,8 @@ public class StreamLoadManager {
         GlobalStateMgr.getCurrentGlobalTransactionMgr().getCallbackFactory().addCallback(task);
     }
 
-    public TNetworkAddress executeLoadTask(String label, int channelId, HttpHeaders headers, TransactionResult resp)
+    public TNetworkAddress executeLoadTask(String label, int channelId, HttpHeaders headers,
+                                           TransactionResult resp, String dbName, String tableName)
             throws UserException {
         boolean needUnLock = true;
         readLock();
@@ -202,6 +207,18 @@ public class StreamLoadManager {
                 throw new UserException("stream load task " + label + " does not exist");
             }
             StreamLoadTask task = idToStreamLoadTask.get(label);
+
+            // check whether the database and table are consistent with the transaction,
+            // for single database and single table are supported so far
+            if (!task.getDBName().equals(dbName)) {
+                throw new UserException(
+                        String.format("Request table %s not equal transaction table %s", dbName, task.getDBName()));
+            }
+            if (!task.getTableName().equals(tableName)) {
+                throw new UserException(
+                        String.format("Request table %s not equal transaction table %s", tableName, task.getTableName()));
+            }
+
             readUnlock();
             needUnLock = false;
             TNetworkAddress redirectAddress = task.tryLoad(channelId, resp);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

- Optimize the hint message when catch a exception

If the tablename is not specified when calling /begin/transaction for the first time, a null pointer exception will be reported

![image](https://user-images.githubusercontent.com/13373748/230584887-1a2bb75f-911a-43b2-832f-4aa2dcc3dc14.png)

- Check whether the db and table name are consistent with those specified in the transaction in FE when calling /transaction/load, instead of directly forwarding to BE
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
