### PR TITLE
[Enhancement] mv add partition in batch

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -71,10 +71,12 @@ import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRelation;
@@ -481,12 +483,13 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         Map<String, String> partitionProperties = getPartitionProperties(materializedView);
         DistributionDesc distributionDesc = getDistributionDesc(materializedView);
         Map<String, Range<PartitionKey>> adds = partitionDiff.getAdds();
+
+        addPartitions(database, materializedView, adds, partitionProperties, distributionDesc);
         for (Map.Entry<String, Range<PartitionKey>> addEntry : adds.entrySet()) {
             String mvPartitionName = addEntry.getKey();
-            addPartition(database, materializedView, mvPartitionName,
-                    addEntry.getValue(), partitionProperties, distributionDesc);
             mvPartitionMap.put(mvPartitionName, addEntry.getValue());
         }
+
         LOG.info("The process of synchronizing materialized view [{}] add partitions range [{}]",
                 materializedView.getName(), adds);
 
@@ -982,27 +985,41 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         return new HashDistributionDesc(hashDistributionInfo.getBucketNum(), distColumnNames);
     }
 
-    private void addPartition(Database database, MaterializedView materializedView, String partitionName,
-                              Range<PartitionKey> partitionKeyRange, Map<String, String> partitionProperties,
-                              DistributionDesc distributionDesc) {
-        String lowerBound = partitionKeyRange.lowerEndpoint().getKeys().get(0).getStringValue();
-        String upperBound = partitionKeyRange.upperEndpoint().getKeys().get(0).getStringValue();
-        boolean isMaxValue = partitionKeyRange.upperEndpoint().isMaxValue();
-        PartitionValue upperPartitionValue;
-        if (isMaxValue) {
-            upperPartitionValue = PartitionValue.MAX_VALUE;
-        } else {
-            upperPartitionValue = new PartitionValue(upperBound);
+    private void addPartitions(Database database, MaterializedView materializedView,
+                               Map<String, Range<PartitionKey>> adds, Map<String, String> partitionProperties,
+                               DistributionDesc distributionDesc) {
+        if (adds.isEmpty()) {
+            return;
         }
-        PartitionKeyDesc partitionKeyDesc = new PartitionKeyDesc(
-                Collections.singletonList(new PartitionValue(lowerBound)),
-                Collections.singletonList(upperPartitionValue));
-        SingleRangePartitionDesc singleRangePartitionDesc =
-                new SingleRangePartitionDesc(false, partitionName, partitionKeyDesc, partitionProperties);
+        List<PartitionDesc> partitionDescs = Lists.newArrayList();
+
+        for (Map.Entry<String, Range<PartitionKey>> addEntry : adds.entrySet()) {
+            String mvPartitionName = addEntry.getKey();
+            Range<PartitionKey> partitionKeyRange = addEntry.getValue();
+
+            String lowerBound = partitionKeyRange.lowerEndpoint().getKeys().get(0).getStringValue();
+            String upperBound = partitionKeyRange.upperEndpoint().getKeys().get(0).getStringValue();
+            boolean isMaxValue = partitionKeyRange.upperEndpoint().isMaxValue();
+            PartitionValue upperPartitionValue;
+            if (isMaxValue) {
+                upperPartitionValue = PartitionValue.MAX_VALUE;
+            } else {
+                upperPartitionValue = new PartitionValue(upperBound);
+            }
+            PartitionKeyDesc partitionKeyDesc = new PartitionKeyDesc(
+                    Collections.singletonList(new PartitionValue(lowerBound)),
+                    Collections.singletonList(upperPartitionValue));
+            SingleRangePartitionDesc singleRangePartitionDesc =
+                    new SingleRangePartitionDesc(false, mvPartitionName, partitionKeyDesc, partitionProperties);
+            partitionDescs.add(singleRangePartitionDesc);
+        }
+        RangePartitionDesc rangePartitionDesc =
+                new RangePartitionDesc(materializedView.getPartitionColumnNames(), partitionDescs);
+
         try {
             GlobalStateMgr.getCurrentState().addPartitions(
                     database, materializedView.getName(),
-                    new AddPartitionClause(singleRangePartitionDesc, distributionDesc,
+                    new AddPartitionClause(rangePartitionDesc, distributionDesc,
                             partitionProperties, false));
         } catch (Exception e) {
             throw new DmlException("Expression add partition failed: %s, db: %s, table: %s", e, e.getMessage(),

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -822,12 +822,10 @@ public class LocalMetastore implements ConnectorMetadata {
         if (partitionDesc instanceof SingleItemListPartitionDesc
                 || partitionDesc instanceof MultiItemListPartitionDesc
                 || partitionDesc instanceof SingleRangePartitionDesc) {
-            if (partitionInfo.getType() == PartitionType.EXPR_RANGE && !partitionDesc.isSystem()) {
-                throw new DdlException("Automatically partitioned tables only support the syntax " +
-                        "for adding partitions in batches.");
-            }
+            checkNotSystemTableForAutoPartition(partitionInfo, partitionDesc);
             addPartitions(db, tableName, ImmutableList.of(partitionDesc), addPartitionClause);
         } else if (partitionDesc instanceof RangePartitionDesc) {
+            checkNotSystemTableForAutoPartition(partitionInfo, partitionDesc);
             addPartitions(db, tableName,
                     Lists.newArrayList(((RangePartitionDesc) partitionDesc).getSingleRangePartitionDescs()),
                     addPartitionClause);
@@ -874,6 +872,14 @@ public class LocalMetastore implements ConnectorMetadata {
             List<PartitionDesc> partitionDescs = singleRangePartitionDescs.stream()
                     .map(item -> (PartitionDesc) item).collect(Collectors.toList());
             addPartitions(db, tableName, partitionDescs, addPartitionClause);
+        }
+    }
+
+    private void checkNotSystemTableForAutoPartition(PartitionInfo partitionInfo, PartitionDesc partitionDesc)
+            throws DdlException {
+        if (partitionInfo.getType() == PartitionType.EXPR_RANGE && !partitionDesc.isSystem()) {
+            throw new DdlException("Automatically partitioned tables only support the syntax " +
+                    "for adding partitions in batches.");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -181,6 +181,7 @@ import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PartitionRangeDesc;
 import com.starrocks.sql.ast.PartitionRenameClause;
 import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.RecoverDbStmt;
 import com.starrocks.sql.ast.RecoverPartitionStmt;
 import com.starrocks.sql.ast.RecoverTableStmt;
@@ -826,6 +827,10 @@ public class LocalMetastore implements ConnectorMetadata {
                         "for adding partitions in batches.");
             }
             addPartitions(db, tableName, ImmutableList.of(partitionDesc), addPartitionClause);
+        } else if (partitionDesc instanceof RangePartitionDesc) {
+            addPartitions(db, tableName,
+                    Lists.newArrayList(((RangePartitionDesc) partitionDesc).getSingleRangePartitionDescs()),
+                    addPartitionClause);
         } else if (partitionDesc instanceof MultiRangePartitionDesc) {
             RangePartitionInfo rangePartitionInfo;
             rangePartitionInfo = (RangePartitionInfo) partitionInfo;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Moving synchronized partitions with the base table can take a long time (8-20 minutes for 2000 partitions) if too many partitions need to be added. To address this issue, I propose changing the process to add partitions in batches. However, due to the lack of support for deleting multiple partitions in the current SQL syntax, this issue cannot be handled at this time.
https://hsn4s18zbn.feishu.cn/docx/NGYWdw5VNop6F1xzJ9wcygfnnve
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
