### PR TITLE
[BugFix][Cherry-pick][Branch-2.5]  Fix disk space occupation problems of multiple replicas

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -579,7 +579,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                         // Mark schema changed tablet not to move to trash.
                         long baseTabletId = partitionIndexTabletMap.get(
                                                     partitionId, shadowIdxId).get(shadowTablet.getId());
-                        GlobalStateMgr.getCurrentInvertedIndex().markTabletForceDelete(baseTabletId);
+                        GlobalStateMgr.getCurrentInvertedIndex().
+                                    markTabletForceDelete(baseTabletId, shadowTablet.getBackendIds());
                         List<Replica> replicas = ((LocalTablet) shadowTablet).getImmutableReplicas();
                         int healthyReplicaNum = 0;
                         for (Replica replica : replicas) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -77,7 +77,8 @@ public class TabletInvertedIndex {
     // replica id -> tablet id
     private Map<Long, Long> replicaToTabletMap = Maps.newHashMap();
 
-    private Set<Long> forceDeleteTablets = Sets.newHashSet();
+    // tablet id -> backend set
+    private Map<Long, Set<Long>> forceDeleteTablets = Maps.newHashMap();
 
     // tablet id -> (backend id -> replica)
     private Table<Long, Long, Replica> replicaMetaTable = HashBasedTable.create();
@@ -414,20 +415,60 @@ public class TabletInvertedIndex {
     }
 
     @VisibleForTesting
-    public Set<Long> getForceDeleteTablets() {
-        return forceDeleteTablets;
+    public Map<Long, Set<Long>> getForceDeleteTablets() {
+        readLock();
+        try {
+            return forceDeleteTablets;
+        } finally {
+            readUnlock();
+        }
     }
 
-    public boolean tabletForceDelete(long tabletId) {
-        return forceDeleteTablets.contains(tabletId);
+    public boolean tabletForceDelete(long tabletId, long backendId) {
+        readLock();
+        try {
+            if (forceDeleteTablets.containsKey(tabletId)) {
+                return forceDeleteTablets.get(tabletId).contains(backendId);
+            }
+            return false;
+        } finally {
+            readUnlock();
+        }
     }
 
-    public void markTabletForceDelete(long tabletId) {
-        forceDeleteTablets.add(tabletId);
+    public void markTabletForceDelete(long tabletId, long backendId) {
+        writeLock();
+        try {
+            if (forceDeleteTablets.containsKey(tabletId)) {
+                forceDeleteTablets.get(tabletId).add(tabletId);
+            } else {
+                Set<Long> backendIds = Sets.newHashSet();
+                backendIds.add(tabletId);
+                forceDeleteTablets.put(tabletId, backendIds);
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void markTabletForceDelete(long tabletId, Set<Long> backendIds) {
+        writeLock();
+        forceDeleteTablets.put(tabletId, backendIds);
+        writeUnlock();
     }
     
-    public void eraseTabletForceDelete(long tabletId) {
-        forceDeleteTablets.remove(tabletId);
+    public void eraseTabletForceDelete(long tabletId, long backendId) {
+        writeLock();
+        try {
+            if (forceDeleteTablets.containsKey(tabletId)) {
+                forceDeleteTablets.get(tabletId).remove(backendId);
+                if (forceDeleteTablets.get(tabletId).size() == 0) {
+                    forceDeleteTablets.remove(tabletId);
+                }
+            }
+        } finally {
+            writeUnlock();
+        }
     }
 
     public void deleteTablet(long tabletId) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1172,8 +1172,7 @@ public class TabletScheduler extends LeaderDaemon {
             // process.
             sendDeleteReplicaTask(replica.getBackendId(), tabletCtx.getTabletId(), tabletCtx.getSchemaHash());
         }
-
-        invertedIndex.markTabletForceDelete(tabletCtx.getTabletId());
+        invertedIndex.markTabletForceDelete(tabletCtx.getTabletId(), replica.getBackendId());
 
         // write edit log
         ReplicaPersistInfo info = ReplicaPersistInfo.createForDelete(tabletCtx.getDbId(),

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -863,9 +863,9 @@ public class ReportHandler extends Daemon {
                 // continue to report them to FE forever and add some processing overhead(the tablet report
                 // process is protected with DB S lock).
                 addDropReplicaTask(batchTask, backendId, tabletId,
-                        -1 /* Unknown schema hash */, "not found in meta", invertedIndex.tabletForceDelete(tabletId));
+                        -1 /* Unknown schema hash */, "not found in meta", invertedIndex.tabletForceDelete(tabletId, backendId));
                 if (!FeConstants.runningUnitTest) {
-                    invertedIndex.eraseTabletForceDelete(tabletId);
+                    invertedIndex.eraseTabletForceDelete(tabletId, backendId);
                 }
                 ++deleteFromBackendCounter;
                 --maxTaskSendPerBe;

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -4,6 +4,7 @@ package com.starrocks.load;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -27,6 +28,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.load.InsertOverwriteJobState.OVERWRITE_FAILED;
@@ -230,7 +233,7 @@ public class InsertOverwriteJobRunner {
             }
             Preconditions.checkState(table instanceof OlapTable);
             OlapTable targetTable = (OlapTable) table;
-            List<Long> sourceTabletIds = Lists.newArrayList();
+            Map<Long, Set<Long>> sourceTabletIds = Maps.newHashMap();
             if (job.getTmpPartitionIds() != null) {
                 for (long pid : job.getTmpPartitionIds()) {
                     LOG.info("drop temp partition:{}", pid);
@@ -239,7 +242,9 @@ public class InsertOverwriteJobRunner {
                     if (partition != null) {
                         for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                             for (Tablet tablet : index.getTablets()) {
-                                sourceTabletIds.add(tablet.getId());
+                                if (!sourceTabletIds.containsKey(tablet.getId())) {
+                                    sourceTabletIds.put(tablet.getId(), tablet.getBackendIds());
+                                }
                             }
                         }
                         targetTable.dropTempPartition(partition.getName(), true);
@@ -252,8 +257,8 @@ public class InsertOverwriteJobRunner {
                 // mark all source tablet ids force delete to drop it directly on BE,
                 // not to move it to trash
                 TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
-                for (long tabletId : sourceTabletIds) {
-                    invertedIndex.markTabletForceDelete(tabletId);
+                for (long tabletId : sourceTabletIds.keySet()) {
+                    invertedIndex.markTabletForceDelete(tabletId, sourceTabletIds.get(tabletId));
                 }
 
                 InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
@@ -277,12 +282,14 @@ public class InsertOverwriteJobRunner {
             List<String> tmpPartitionNames = job.getTmpPartitionIds().stream()
                     .map(partitionId -> targetTable.getPartition(partitionId).getName())
                     .collect(Collectors.toList());
-            List<Long> sourceTabletIds = Lists.newArrayList();
+            Map<Long, Set<Long>> sourceTabletIds = Maps.newHashMap();
             sourcePartitionNames.forEach(name -> {
                 Partition partition = targetTable.getPartition(name);
                 for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                     for (Tablet tablet : index.getTablets()) {
-                        sourceTabletIds.add(tablet.getId());
+                        if (!sourceTabletIds.containsKey(tablet.getId())) {
+                            sourceTabletIds.put(tablet.getId(), tablet.getBackendIds());
+                        }
                     }
                 }
             });
@@ -296,8 +303,8 @@ public class InsertOverwriteJobRunner {
                 // mark all source tablet ids force delete to drop it directly on BE,
                 // not to move it to trash
                 TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
-                for (long tabletId : sourceTabletIds) {
-                    invertedIndex.markTabletForceDelete(tabletId);
+                for (long tabletId : sourceTabletIds.keySet()) {
+                    invertedIndex.markTabletForceDelete(tabletId, sourceTabletIds.get(tabletId));
                 }
 
                 InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4593,8 +4593,8 @@ public class LocalMetastore implements ConnectorMetadata {
 
         // if it is lake table, need to delete shard and drop tablet
         if (olapTable.isLakeTable() && !isReplay) {
-            stateMgr.getShardManager().getShardDeleter().addUnusedShardId(oldTabletIds);
-            editLog.logAddUnusedShard(oldTabletIds);
+            stateMgr.getShardManager().getShardDeleter().addUnusedShardId(oldTabletIds.keySet());
+            editLog.logAddUnusedShard(oldTabletIds.keySet());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4561,14 +4561,16 @@ public class LocalMetastore implements ConnectorMetadata {
     private void truncateTableInternal(OlapTable olapTable, List<Partition> newPartitions,
                                        boolean isEntireTable, boolean isReplay) {
         // use new partitions to replace the old ones.
-        Set<Long> oldTabletIds = Sets.newHashSet();
+        Map<Long, Set<Long>> oldTabletIds = Maps.newHashMap();
         for (Partition newPartition : newPartitions) {
             Partition oldPartition = olapTable.replacePartition(newPartition);
             // save old tablets to be removed
             for (MaterializedIndex index : oldPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-                index.getTablets().stream().forEach(t -> {
-                    oldTabletIds.add(t.getId());
-                });
+                for (Tablet tablet : index.getTablets()) {
+                    if (!oldTabletIds.containsKey(tablet.getId())) {
+                        oldTabletIds.put(tablet.getId(), tablet.getBackendIds());
+                    }
+                }
             }
         }
 
@@ -4578,14 +4580,14 @@ public class LocalMetastore implements ConnectorMetadata {
         }
 
         // remove the tablets in old partitions
-        for (Long tabletId : oldTabletIds) {
+        for (Long tabletId : oldTabletIds.keySet()) {
             GlobalStateMgr.getCurrentInvertedIndex().deleteTablet(tabletId);
             // Ensure that only the leader records truncate information.
             // TODO(yangzaorang): the information will be lost when failover occurs. The probability of this case
             // happening is small, and the trash data will be deleted by BE anyway, but we need to find a better
             // solution.
             if (!isReplay) {
-                GlobalStateMgr.getCurrentInvertedIndex().markTabletForceDelete(tabletId);
+                GlobalStateMgr.getCurrentInvertedIndex().markTabletForceDelete(tabletId, oldTabletIds.get(tabletId));
             }
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
#14726 fixed the disk occupation problem with schema change, but #14726 does not take into account multiple replicas, which results in only one tablet on BE not moving into the trash directory. This PR fixes the problem.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
