### PR TITLE
[BugFix] Distinguish join's on-predicates and where-predicates for non inner/cross join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
@@ -16,8 +16,10 @@
 package com.starrocks.sql.optimizer;
 
 import com.starrocks.catalog.Table;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 
 import java.util.List;
@@ -32,6 +34,10 @@ public class MvRewriteContext {
     private final OptExpression queryExpression;
     private final ReplaceColumnRefRewriter queryColumnRefRewriter;
     private final PredicateSplit queryPredicateSplit;
+
+    private ColumnRefSet queryJoinOnPredicateColumnRefSet;
+
+    private ColumnRefSet mvJoinOnPredicateColumnRefSet;
 
     // mv's partition and distribution related conjunct predicate,
     // used to prune partitions and buckets of scan mv operator after rewrite
@@ -72,6 +78,22 @@ public class MvRewriteContext {
 
     public ScalarOperator getMvPruneConjunct() {
         return mvPruneConjunct;
+    }
+
+    public ColumnRefSet getQueryExtraJoinOnPredicateColumnRefSet() {
+        if (queryJoinOnPredicateColumnRefSet == null) {
+            queryJoinOnPredicateColumnRefSet =
+                    MvUtils.getExtraJoinOnPredicateColumnRefSet(queryExpression);
+        }
+        return queryJoinOnPredicateColumnRefSet;
+    }
+
+    public ColumnRefSet getMVExtraJoinOnPredicateColumnRefSet() {
+        if (mvJoinOnPredicateColumnRefSet == null) {
+            mvJoinOnPredicateColumnRefSet =
+                    MvUtils.getExtraJoinOnPredicateColumnRefSet(materializationContext.getMvExpression());
+        }
+        return mvJoinOnPredicateColumnRefSet;
     }
 
     public void setMvPruneConjunct(ScalarOperator mvPruneConjunct) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
@@ -16,7 +16,6 @@
 package com.starrocks.sql.optimizer;
 
 import com.starrocks.catalog.Table;
-import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -35,9 +34,9 @@ public class MvRewriteContext {
     private final ReplaceColumnRefRewriter queryColumnRefRewriter;
     private final PredicateSplit queryPredicateSplit;
 
-    private ColumnRefSet queryJoinOnPredicateColumnRefSet;
+    private List<ScalarOperator> queryJoinOnPredicates;
 
-    private ColumnRefSet mvJoinOnPredicateColumnRefSet;
+    private List<ScalarOperator> mvJoinOnPredicates;
 
     // mv's partition and distribution related conjunct predicate,
     // used to prune partitions and buckets of scan mv operator after rewrite
@@ -80,20 +79,19 @@ public class MvRewriteContext {
         return mvPruneConjunct;
     }
 
-    public ColumnRefSet getQueryExtraJoinOnPredicateColumnRefSet() {
-        if (queryJoinOnPredicateColumnRefSet == null) {
-            queryJoinOnPredicateColumnRefSet =
-                    MvUtils.getExtraJoinOnPredicateColumnRefSet(queryExpression);
+    public List<ScalarOperator> getQueryJoinOnPredicates() {
+        if (queryJoinOnPredicates == null) {
+            queryJoinOnPredicates = MvUtils.getJoinOnPredicates(queryExpression);
         }
-        return queryJoinOnPredicateColumnRefSet;
+        return queryJoinOnPredicates;
     }
 
-    public ColumnRefSet getMVExtraJoinOnPredicateColumnRefSet() {
-        if (mvJoinOnPredicateColumnRefSet == null) {
-            mvJoinOnPredicateColumnRefSet =
-                    MvUtils.getExtraJoinOnPredicateColumnRefSet(materializationContext.getMvExpression());
+    public List<ScalarOperator> getMvJoinOnPredicates() {
+        if (mvJoinOnPredicates == null) {
+            mvJoinOnPredicates = MvUtils.getJoinOnPredicates(materializationContext.getMvExpression());
+
         }
-        return mvJoinOnPredicateColumnRefSet;
+        return mvJoinOnPredicates;
     }
 
     public void setMvPruneConjunct(ScalarOperator mvPruneConjunct) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -21,7 +21,6 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 
 import java.util.Collections;
 import java.util.List;
-
 import javax.annotation.Nullable;
 
 import static java.util.Objects.requireNonNull;
@@ -61,6 +60,13 @@ public abstract class ScalarOperator implements Cloneable {
             return false;
         }
         return op.isTrue();
+    }
+
+    public static boolean isFalse(@Nullable ScalarOperator op) {
+        if (op == null) {
+            return false;
+        }
+        return op.isFalse();
     }
 
     public boolean isTrue() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -22,6 +22,8 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import static java.util.Objects.requireNonNull;
 
 public abstract class ScalarOperator implements Cloneable {
@@ -52,6 +54,21 @@ public abstract class ScalarOperator implements Cloneable {
         }
 
         return true;
+    }
+
+    public static boolean isTrue(@Nullable ScalarOperator op) {
+        if (op == null) {
+            return false;
+        }
+        return op.isTrue();
+    }
+
+    public boolean isTrue() {
+        return this.equals(ConstantOperator.TRUE);
+    }
+
+    public boolean isFalse() {
+        return this.equals(ConstantOperator.FALSE);
     }
 
     public abstract boolean isNullable();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
@@ -133,6 +133,7 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
         LogicalJoinOperator newJoinOperator = new LogicalJoinOperator.Builder().withOperator(join)
                 .setJoinType(newJoinType)
                 .setOnPredicate(newJoinOnPredicate)
+                .setOriginalOnPredicate(join.getOnPredicate())
                 .build();
         root = OptExpression.create(newJoinOperator, input.getInputs());
         if (!join.hasDeriveIsNotNullPredicate()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -708,6 +708,7 @@ public class MaterializedViewRewriter {
         }
     }
 
+    // Rewrite non-inner/cross join's on-predicates, all on-predicates should not compensated.
     private ScalarOperator rewriteJoinOnPredicates(ColumnRewriter columnRewriter,
                                                    Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns,
                                                    List<ScalarOperator> srcJoinOnPredicates,
@@ -717,13 +718,15 @@ public class MaterializedViewRewriter {
             return ConstantOperator.TRUE;
         }
         if (srcJoinOnPredicates.isEmpty() && !targetJoinOnPredicates.isEmpty()) {
-            return null;
+            return ConstantOperator.TRUE;
         }
         if (!srcJoinOnPredicates.isEmpty() && targetJoinOnPredicates.isEmpty()) {
             return null;
         }
-        final PredicateSplit srcJoinOnPredicateSplit = PredicateSplit.splitPredicate(Utils.compoundAnd(srcJoinOnPredicates));
-        final PredicateSplit targetJoinOnPredicateSplit = PredicateSplit.splitPredicate(Utils.compoundAnd(targetJoinOnPredicates));
+        final PredicateSplit srcJoinOnPredicateSplit =
+                PredicateSplit.splitPredicate(Utils.compoundAnd(srcJoinOnPredicates));
+        final PredicateSplit targetJoinOnPredicateSplit =
+                PredicateSplit.splitPredicate(Utils.compoundAnd(targetJoinOnPredicates));
 
         final EquivalenceClasses sourceEquivalenceClasses =
                 createEquivalenceClasses(srcJoinOnPredicateSplit.getEqualPredicates());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1362,9 +1362,10 @@ public class MaterializedViewRewriter {
         return result;
     }
 
-    private PredicateSplit getCompensationPredicatesQueryToView(ColumnRewriter columnRewriter,
-                                                                RewriteContext rewriteContext,
-                                                                Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns) {
+    private PredicateSplit getCompensationPredicatesQueryToView(
+            ColumnRewriter columnRewriter,
+            RewriteContext rewriteContext,
+            Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns) {
         final List<ScalarOperator> queryJoinOnPredicates = mvRewriteContext.getQueryJoinOnPredicates();
         final List<ScalarOperator> mvJoinOnPredicates = mvRewriteContext.getMvJoinOnPredicates();
         final ScalarOperator queryJoinOnPredicateCompensations =
@@ -1382,9 +1383,10 @@ public class MaterializedViewRewriter {
                 true);
     }
 
-    private PredicateSplit getCompensationPredicatesViewToQuery(ColumnRewriter columnRewriter,
-                                                                RewriteContext rewriteContext,
-                                                                Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns) {
+    private PredicateSplit getCompensationPredicatesViewToQuery(
+            ColumnRewriter columnRewriter,
+            RewriteContext rewriteContext,
+            Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns) {
         final List<ScalarOperator> queryJoinOnPredicates = mvRewriteContext.getQueryJoinOnPredicates();
         final List<ScalarOperator> mvJoinOnPredicates = mvRewriteContext.getMvJoinOnPredicates();
         final ScalarOperator queryJoinOnPredicateCompensations =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -420,14 +420,6 @@ public class MvUtils {
         }
     }
 
-    public static ColumnRefSet getPredicateColumnRefSet(List<ScalarOperator> predicates) {
-        final ColumnRefSet predicateColumnRefSet = new ColumnRefSet();
-        for (ScalarOperator pred: predicates) {
-            predicateColumnRefSet.union(pred.getUsedColumns());
-        }
-        return predicateColumnRefSet;
-    }
-
     public static ScalarOperator rewriteOptExprCompoundPredicate(OptExpression root,
                                                                  ReplaceColumnRefRewriter columnRefRewriter) {
         List<ScalarOperator> conjuncts = MvUtils.getAllPredicates(root);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -83,7 +83,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
-import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
@@ -456,7 +455,7 @@ public class MvUtils {
             JoinOperator joinOperatorType = joinOperator.getJoinType();
             // Collect all join on predicates which join type are not inner/cross join.
             if ((joinOperatorType != JoinOperator.INNER_JOIN
-                    && joinOperatorType != JoinOperator.CROSS_JOIN) &&joinOperator.getOnPredicate() != null) {
+                    && joinOperatorType != JoinOperator.CROSS_JOIN) && joinOperator.getOnPredicate() != null) {
                 // Now join's on-predicates may be pushed down below join, so use original on-predicates
                 // instead of new on-predicates.
                 List<ScalarOperator> conjuncts = Utils.extractConjuncts(joinOperator.getOriginalOnPredicate());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RangeSimplifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RangeSimplifier.java
@@ -43,7 +43,13 @@ public class RangeSimplifier {
     public ScalarOperator simplify(List<ScalarOperator> targets) {
         try {
             Map<Integer, Range<ConstantOperator>> srcColumnIdToRange = extractColumnIdRangeMapping(srcPredicates);
+            if (srcColumnIdToRange == null) {
+                return null;
+            }
             Map<Integer, Range<ConstantOperator>> targetColumnIdToRange = extractColumnIdRangeMapping(targets);
+            if (targetColumnIdToRange == null) {
+                return null;
+            }
 
             List<Integer> resultColumnIds = Lists.newArrayList();
             for (Map.Entry<Integer, Range<ConstantOperator>> targetEntry : targetColumnIdToRange.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RangeSimplifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RangeSimplifier.java
@@ -28,7 +28,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 public class RangeSimplifier {
@@ -43,50 +42,12 @@ public class RangeSimplifier {
     // left is ColumnRefOperator and right is ConstantOperator
     public ScalarOperator simplify(List<ScalarOperator> targets) {
         try {
-            Map<Integer, Range<ConstantOperator>> srcColumnIdToRange = Maps.newHashMap();
-            for (ScalarOperator rangePredicate : srcPredicates) {
-                Preconditions.checkState(rangePredicate instanceof BinaryPredicateOperator);
-                Preconditions.checkState(rangePredicate.getChild(0) instanceof ColumnRefOperator);
-                Preconditions.checkState(rangePredicate.getChild(1) instanceof ConstantOperator);
-                BinaryPredicateOperator srcBinary = (BinaryPredicateOperator) rangePredicate;
-                Preconditions.checkState(srcBinary.getBinaryType().isRange() || srcBinary.getBinaryType().isEqual());
-                ColumnRefOperator srcColumn = (ColumnRefOperator) srcBinary.getChild(0);
-                ConstantOperator srcConstant = (ConstantOperator) srcBinary.getChild(1);
-                if (!srcColumnIdToRange.containsKey(srcColumn.getId())) {
-                    srcColumnIdToRange.put(srcColumn.getId(), Range.all());
-                }
-                Range<ConstantOperator> columnRange = srcColumnIdToRange.get(srcColumn.getId());
-                Range<ConstantOperator> range = range(srcBinary.getBinaryType(), srcConstant);
-                columnRange = columnRange.intersection(range);
-                if (columnRange.isEmpty()) {
-                    return null;
-                }
-                srcColumnIdToRange.put(srcColumn.getId(), columnRange);
-            }
-            Map<Integer, Range<ConstantOperator>> targetColumnIdToRange = Maps.newHashMap();
-            for (ScalarOperator rangePredicate : targets) {
-                Preconditions.checkState(rangePredicate instanceof BinaryPredicateOperator);
-                Preconditions.checkState(rangePredicate.getChild(0) instanceof ColumnRefOperator);
-                Preconditions.checkState(rangePredicate.getChild(1) instanceof ConstantOperator);
-                BinaryPredicateOperator srcBinary = (BinaryPredicateOperator) rangePredicate;
-                Preconditions.checkState(srcBinary.getBinaryType().isRange() || srcBinary.getBinaryType().isEqual());
-                ColumnRefOperator targetColumn = (ColumnRefOperator) srcBinary.getChild(0);
-                ConstantOperator targetConstant = (ConstantOperator) srcBinary.getChild(1);
-                if (!targetColumnIdToRange.containsKey(targetColumn.getId())) {
-                    targetColumnIdToRange.put(targetColumn.getId(), Range.all());
-                }
-                Range<ConstantOperator> columnRange = targetColumnIdToRange.get(targetColumn.getId());
-                Range<ConstantOperator> range = range(srcBinary.getBinaryType(), targetConstant);
-                columnRange = columnRange.intersection(range);
-                if (columnRange.isEmpty()) {
-                    return null;
-                }
-                targetColumnIdToRange.put(targetColumn.getId(), columnRange);
-            }
+            Map<Integer, Range<ConstantOperator>> srcColumnIdToRange = extractColumnIdRangeMapping(srcPredicates);
+            Map<Integer, Range<ConstantOperator>> targetColumnIdToRange = extractColumnIdRangeMapping(targets);
 
             List<Integer> resultColumnIds = Lists.newArrayList();
-
             for (Map.Entry<Integer, Range<ConstantOperator>> targetEntry : targetColumnIdToRange.entrySet()) {
+                // Source columnId range must contain any target columnId.
                 if (!srcColumnIdToRange.containsKey(targetEntry.getKey())
                         && !targetEntry.getValue().hasUpperBound()
                         && !targetEntry.getValue().hasLowerBound()) {
@@ -112,7 +73,7 @@ public class RangeSimplifier {
             if (resultColumnIds.isEmpty()) {
                 return ConstantOperator.createBoolean(true);
             } else {
-                AtomicReference<ScalarOperator> result = new AtomicReference<>();
+                List<ScalarOperator> rewrittenRangePredicates = Lists.newArrayList();
                 for (int columnId : resultColumnIds) {
                     Range<ConstantOperator> columnRange = srcColumnIdToRange.get(columnId);
                     if (isSingleValueRange(columnRange)) {
@@ -124,22 +85,44 @@ public class RangeSimplifier {
                         BinaryPredicateOperator eqBinary = new BinaryPredicateOperator(
                                 BinaryPredicateOperator.BinaryType.EQ,
                                 binary.getChild(0), columnRange.lowerEndpoint());
-                        result.set(Utils.compoundAnd(result.get(), eqBinary));
+                        rewrittenRangePredicates.add(eqBinary);
                     } else {
                         List<ScalarOperator> columnScalars = srcPredicates.stream().filter(
                                 predicate -> isScalarForColumns(predicate, columnId)
                         ).collect(Collectors.toList());
                         columnScalars = filterScalarOperators(columnScalars, columnRange);
-                        columnScalars.forEach(
-                                predicate -> result.set(Utils.compoundAnd(result.get(), predicate))
-                        );
+                        rewrittenRangePredicates.addAll(columnScalars);
                     }
                 }
-                return result.get();
+                return Utils.compoundAnd(rewrittenRangePredicates);
             }
         } catch (Exception e) {
             return null;
         }
+    }
+
+    private Map<Integer, Range<ConstantOperator>> extractColumnIdRangeMapping(List<ScalarOperator> predicates) {
+        Map<Integer, Range<ConstantOperator>> columnIdToRange = Maps.newHashMap();
+        for (ScalarOperator rangePredicate : predicates) {
+            Preconditions.checkState(rangePredicate instanceof BinaryPredicateOperator);
+            Preconditions.checkState(rangePredicate.getChild(0) instanceof ColumnRefOperator);
+            Preconditions.checkState(rangePredicate.getChild(1) instanceof ConstantOperator);
+            BinaryPredicateOperator srcBinary = (BinaryPredicateOperator) rangePredicate;
+            Preconditions.checkState(srcBinary.getBinaryType().isRange() || srcBinary.getBinaryType().isEqual());
+            ColumnRefOperator srcColumn = (ColumnRefOperator) srcBinary.getChild(0);
+            ConstantOperator srcConstant = (ConstantOperator) srcBinary.getChild(1);
+            if (!columnIdToRange.containsKey(srcColumn.getId())) {
+                columnIdToRange.put(srcColumn.getId(), Range.all());
+            }
+            Range<ConstantOperator> columnRange = columnIdToRange.get(srcColumn.getId());
+            Range<ConstantOperator> range = range(srcBinary.getBinaryType(), srcConstant);
+            columnRange = columnRange.intersection(range);
+            if (columnRange.isEmpty()) {
+                return null;
+            }
+            columnIdToRange.put(srcColumn.getId(), columnRange);
+        }
+        return columnIdToRange;
     }
 
     private List<ScalarOperator> filterScalarOperators(

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -417,25 +417,46 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     }
 
     @Test
-    public void testMultiOuterJoinQueryComplete() {
-        for (String joinType : outerJoinTypes) {
-            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
-                    "" + joinType + " join locations on emps.locationid = locations.locationid";
-            testRewriteOK(mv, "select count(*) from " +
-                    "emps " + joinType + " join locations on emps.locationid = locations.locationid");
-            testRewriteOK(mv, "select empid as col2, emps.locationid from " +
-                    "emps " + joinType + " join locations on emps.locationid = locations.locationid " +
-                    "and emps.locationid > 10");
-            testRewriteOK(mv, "select count(*) from " +
-                    "emps " + joinType + " join locations on emps.locationid = locations.locationid " +
-                    "and emps.locationid > 10");
-            testRewriteOK(mv, "select empid as col2, locations.locationid from " +
-                    "emps " + joinType + " join locations on emps.locationid = locations.locationid " +
-                    "and locations.locationid > 10");
-            testRewriteFail(mv, "select empid as col2, locations.locationid from " +
-                    "emps inner join locations on emps.locationid = locations.locationid " +
-                    "and locations.locationid > 10");
-        }
+    public void testLeftOuterJoinQueryComplete() {
+        String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                " left join locations on emps.locationid = locations.locationid";
+        testRewriteOK(mv, "select count(*) from " +
+                "emps  left join locations on emps.locationid = locations.locationid");
+        testRewriteOK(mv, "select empid as col2, emps.locationid from " +
+                "emps  left join locations on emps.locationid = locations.locationid " +
+                "where emps.deptno > 10");
+        testRewriteOK(mv, "select count(*) from " +
+                "emps  left join locations on emps.locationid = locations.locationid " +
+                "where emps.deptno > 10");
+        // TODO: `locations.locationid ` will be pushed into `emps.locationid`.
+        testRewriteFail(mv, "select empid as col2, locations.locationid from " +
+                "emps  left join locations on emps.locationid = locations.locationid " +
+                "where locations.locationid > 10");
+        testRewriteFail(mv, "select empid as col2, locations.locationid from " +
+                "emps inner join locations on emps.locationid = locations.locationid " +
+                "and locations.locationid > 10");
+    }
+
+    @Test
+    public void testRightOuterJoinQueryComplete() {
+        String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                " right join locations on emps.locationid = locations.locationid";
+        testRewriteOK(mv, "select count(*) from " +
+                "emps  right join locations on emps.locationid = locations.locationid");
+        // TODO: Query's right outer join will be converted to Inner Join.
+        testRewriteFail(mv, "select empid as col2, emps.locationid from " +
+                "emps  right join locations on emps.locationid = locations.locationid " +
+                "where emps.deptno > 10");
+        // TODO: Query's right outer join will be converted to Inner Join.
+        testRewriteFail(mv, "select count(*) from " +
+                "emps  right join locations on emps.locationid = locations.locationid " +
+                "where emps.deptno > 10");
+        testRewriteFail(mv, "select empid as col2, locations.locationid from " +
+                "emps  right join locations on emps.locationid = locations.locationid " +
+                "where locations.locationid > 10");
+        testRewriteFail(mv, "select empid as col2, locations.locationid from " +
+                "emps inner join locations on emps.locationid = locations.locationid " +
+                "and locations.locationid > 10");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -428,13 +428,19 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv, "select count(*) from " +
                 "emps  left join locations on emps.locationid = locations.locationid " +
                 "where emps.deptno > 10");
-        // TODO: `locations.locationid ` will be pushed into `emps.locationid`.
+        testRewriteOK(mv, "select empid as col2, locations.locationid from " +
+                "emps left join locations on emps.locationid = locations.locationid " +
+                "where emps.locationid > 10");
+        // TODO: Query's left outer join will be converted to Inner Join.
         testRewriteFail(mv, "select empid as col2, locations.locationid from " +
-                "emps  left join locations on emps.locationid = locations.locationid " +
+                "emps left join locations on emps.locationid = locations.locationid " +
                 "where locations.locationid > 10");
         testRewriteFail(mv, "select empid as col2, locations.locationid from " +
                 "emps inner join locations on emps.locationid = locations.locationid " +
                 "and locations.locationid > 10");
+        testRewriteFail(mv, "select empid as col2, locations.locationid from " +
+                "emps inner join locations on emps.locationid = locations.locationid " +
+                "and emps.locationid > 10");
     }
 
     @Test
@@ -451,12 +457,15 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteFail(mv, "select count(*) from " +
                 "emps  right join locations on emps.locationid = locations.locationid " +
                 "where emps.deptno > 10");
-        testRewriteFail(mv, "select empid as col2, locations.locationid from " +
+        testRewriteOK(mv, "select empid as col2, locations.locationid from " +
                 "emps  right join locations on emps.locationid = locations.locationid " +
                 "where locations.locationid > 10");
         testRewriteFail(mv, "select empid as col2, locations.locationid from " +
                 "emps inner join locations on emps.locationid = locations.locationid " +
                 "and locations.locationid > 10");
+        testRewriteFail(mv, "select empid as col2, locations.locationid from " +
+                "emps inner join locations on emps.locationid = locations.locationid " +
+                "and emps.locationid > 10");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.planner;
 
 import com.google.common.collect.ImmutableList;
-import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
@@ -95,29 +95,3 @@ as select
    from
               customer
    group by c_custkey, c_phone, c_acctbal, substring(c_phone, 1  ,2);
-
--- query13
-create materialized view customer_order_mv_agg_mv1
-distributed by hash( c_custkey,
-       o_comment) buckets 24
-refresh deferred manual
-properties (
-    "replication_num" = "1"
-)
-as select
-              c_custkey,
-              o_comment,
-              count(o_orderkey) as c_count,
-              count(1) as c_count_star
-   from
-              (select
-                   c_custkey,o_comment,o_orderkey
-               from
-                   customer
-                       left outer join
-                   orders
-                   on orders.o_custkey=customer.c_custkey) a
-   group by
-       c_custkey,
-       o_comment
-;

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q13.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q13.sql
@@ -20,14 +20,16 @@ order by
     custdist desc,
     c_count desc ;
 [result]
-TOP-N (order by [[19: count DESC NULLS LAST, 18: count DESC NULLS LAST]])
-    TOP-N (order by [[19: count DESC NULLS LAST, 18: count DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{19: count=count(19: count)}] group by [[18: count]] having [null]
-            EXCHANGE SHUFFLE[18]
-                AGGREGATE ([LOCAL] aggregate [{19: count=count()}] group by [[18: count]] having [null]
-                    AGGREGATE ([GLOBAL] aggregate [{89: count=sum(89: count)}] group by [[81: c_custkey]] having [null]
-                        EXCHANGE SHUFFLE[81]
-                            AGGREGATE ([LOCAL] aggregate [{89: count=sum(83: c_count)}] group by [[81: c_custkey]] having [null]
-                                SCAN (mv[customer_order_mv_agg_mv1] columns[81: c_custkey, 82: o_comment, 83: c_count] predicate[NOT 82: o_comment LIKE %unusual%deposits%])
+TOP-N (order by [[: count DESC NULLS LAST, : count DESC NULLS LAST]])
+    TOP-N (order by [[: count DESC NULLS LAST, : count DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{: count=count(: count)}] group by [[: count]] having [null]
+            EXCHANGE SHUFFLE[]
+                AGGREGATE ([LOCAL] aggregate [{: count=count()}] group by [[: count]] having [null]
+                    AGGREGATE ([GLOBAL] aggregate [{: count=count(: o_orderkey)}] group by [[: c_custkey]] having [null]
+                        RIGHT OUTER JOIN (join-predicate [: o_custkey = : c_custkey] post-join-predicate [null])
+                            EXCHANGE SHUFFLE[]
+                                SCAN (table[orders] columns[: o_comment, : o_orderkey, : o_custkey] predicate[NOT : o_comment LIKE %unusual%deposits%])
+                            EXCHANGE SHUFFLE[]
+                                SCAN (table[customer] columns[: c_custkey] predicate[null])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
@@ -32,11 +32,11 @@ order by
     nation,
     o_year desc ;
 [result]
-TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
-    TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{53: sum=sum(53: sum)}] group by [[48: n_name, 51: year]] having [null]
-            EXCHANGE SHUFFLE[48, 51]
-                AGGREGATE ([LOCAL] aggregate [{53: sum=sum(52: expr)}] group by [[48: n_name, 51: year]] having [null]
-                    SCAN (mv[lineitem_mv] columns[101: c_nationkey, 123: p_name, 127: s_nationkey, 130: l_amount, 132: o_orderyear, 135: n_name2] predicate[127: s_nationkey = 101: c_nationkey AND 123: p_name LIKE %peru%])
+TOP-N (order by [[: n_name ASC NULLS FIRST, : year DESC NULLS LAST]])
+    TOP-N (order by [[: n_name ASC NULLS FIRST, : year DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{: sum=sum(: sum)}] group by [[: n_name, : year]] having [null]
+            EXCHANGE SHUFFLE[, ]
+                AGGREGATE ([LOCAL] aggregate [{: sum=sum(: expr)}] group by [[: n_name, : year]] having [null]
+                    SCAN (mv[lineitem_mv] columns[: c_nationkey, : p_name, : s_nationkey, : l_amount, : o_orderyear, : n_name] predicate[: c_nationkey = : s_nationkey AND : p_name LIKE %peru%])
 [end]
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
- Distinguish join's on-predicates and where-predicates for non inner/cross join;
- For non-inner/cross join, all on-predicates must be rewritten, otherwise may cause correct bugs.


```
  // If join is not cross/inner join, MV Rewrite must rewrite, otherwise may cause bad results.
    // eg.
    // mv: select * from customer left outer join orders on c_custkey = o_custkey;
    //
    //query（cannot rewrite）:
    //select count(1) from customer left outer join orders
    //  on c_custkey = o_custkey and o_comment not like '%special%requests%';
    //
    //query（can rewrite）:
    //select count(1)
    //          from customer left outer join orders on c_custkey = o_custkey
    //          where o_comment not like '%special%requests%';
```


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
