### PR TITLE
[BugFix] `tablet_writer_add_chunk` timeout leads data lost

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -177,13 +177,14 @@ Status NodeChannel::open_wait() {
 
     // add batch closure
     _add_batch_closure = ReusableClosure<PTabletWriterAddBatchResult>::create();
-    _add_batch_closure->addFailedHandler([this](const std::string &err_msg) {
+    _add_batch_closure->addFailedHandler([this](const std::string& err_msg) {
         _cancelled = true;
         _err_st = _add_batch_closure->result.status();
         if (_err_st.ok()) {
             _err_st = Status::Cancelled(err_msg);
         }
-        LOG(WARNING) << "tablet_writer_add_chunk failed, load_info: " << this->print_load_info() << " ,error: " << err_msg;
+        LOG(WARNING) << "tablet_writer_add_chunk failed, load_info: " << this->print_load_info()
+                     << " ,error: " << err_msg;
     });
 
     _add_batch_closure->addSuccessHandler([this](const PTabletWriterAddBatchResult& result, bool is_last_rpc) {

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -177,9 +177,13 @@ Status NodeChannel::open_wait() {
 
     // add batch closure
     _add_batch_closure = ReusableClosure<PTabletWriterAddBatchResult>::create();
-    _add_batch_closure->addFailedHandler([this]() {
+    _add_batch_closure->addFailedHandler([this](const std::string &err_msg) {
         _cancelled = true;
         _err_st = _add_batch_closure->result.status();
+        if (_err_st.ok()) {
+            _err_st = Status::Cancelled(err_msg);
+        }
+        LOG(WARNING) << "tablet_writer_add_chunk failed, load_info: " << this->print_load_info() << " ,error: " << err_msg;
     });
 
     _add_batch_closure->addSuccessHandler([this](const PTabletWriterAddBatchResult& result, bool is_last_rpc) {

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -90,7 +90,7 @@ public:
 
     static ReusableClosure<T>* create() { return new ReusableClosure<T>(); }
 
-    void addFailedHandler(std::function<void()> fn) { failed_handler = std::move(fn); }
+    void addFailedHandler(std::function<void(const std::string& err_msg)> fn) { failed_handler = std::move(fn); }
     void addSuccessHandler(std::function<void(const T&, bool)> fn) { success_handler = fn; }
 
     void join() {
@@ -124,7 +124,7 @@ public:
         if (cntl.Failed()) {
             LOG(WARNING) << "failed to send brpc batch, error=" << berror(cntl.ErrorCode())
                          << ", error_text=" << cntl.ErrorText();
-            failed_handler();
+            failed_handler(cntl.ErrorText());
         } else {
             success_handler(result, _is_last_rpc);
         }
@@ -138,7 +138,7 @@ private:
     brpc::CallId cid;
     std::atomic<bool> _packet_in_flight{false};
     std::atomic<bool> _is_last_rpc{false};
-    std::function<void()> failed_handler;
+    std::function<void(const std::string& err_msg)> failed_handler;
     std::function<void(const T&, bool)> success_handler;
 };
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
https://github.com/StarRocks/starrocks/blob/5c80457dbe3b5153859fc5a5c07ad46a902efb14/gensrc/proto/internal_service.proto#L185-L190
When the RPC `tablet_writer_add_chunk` is timeout, the write thread would exit and return the request status. 
But `status` in `PTabletWriterAddBatchResult` is unset, so a `Status::OK()` is returned. The corresponding transaction would commit successfully.
The routine load would update the consuming progress according to the status of the transaction.
For those transactions with timeout `tablet_writer_add_chunk` requests, the consuming progress would be updated wrongly and Kafka messages are probably lost.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
  - [x] 2.2
