### PR TITLE
[Enhancement] Support parallel merge (2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ StarRocksLex.tokens
 .project
 .settings/
 .idea/
+.gradle/
 /Default/
 be/cmake-build*
 be/.vscode

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
@@ -59,7 +59,6 @@ Status ExchangeParallelMergeSourceOperator::set_finishing(RuntimeState* state) {
 }
 
 StatusOr<ChunkPtr> ExchangeParallelMergeSourceOperator::pull_chunk(RuntimeState* state) {
-    // TODO process limit
     auto chunk = _merger->try_get_next(_driver_sequence);
 
     if (_merger->is_finished()) {
@@ -107,8 +106,8 @@ merge_path::MergePathCascadeMerger* ExchangeParallelMergeSourceOperatorFactory::
         auto chunk_providers = _stream_recvr->create_merge_path_chunk_providers();
         SortDescs sort_descs(_is_asc_order, _nulls_first);
         _merger = std::make_unique<merge_path::MergePathCascadeMerger>(
-                degree_of_parallelism(), _sort_exec_exprs->lhs_ordering_expr_ctxs(), sort_descs, chunk_providers,
-                state->chunk_size());
+                state->chunk_size(), degree_of_parallelism(), _sort_exec_exprs->lhs_ordering_expr_ctxs(), sort_descs,
+                _row_desc.tuple_descriptors()[0], _offset, _limit, chunk_providers);
     }
     return _merger.get();
 }

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
@@ -93,8 +93,8 @@ OperatorPtr LocalParallelMergeSortSourceOperatorFactory::create(int32_t degree_o
             });
         }
         _merger = std::make_unique<merge_path::MergePathCascadeMerger>(
-                degree_of_parallelism, sort_context->sort_exprs(), sort_context->sort_descs(), chunk_providers,
-                _state->chunk_size());
+                _state->chunk_size(), degree_of_parallelism, sort_context->sort_exprs(), sort_context->sort_descs(),
+                _tuple_desc, sort_context->offset(), sort_context->limit(), chunk_providers);
     }
 
     return std::make_shared<LocalParallelMergeSortSourceOperator>(this, _id, _plan_node_id, driver_sequence,

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.h
@@ -87,7 +87,10 @@ public:
     Status prepare(RuntimeState* state) override;
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
+    void set_tuple_desc(const TupleDescriptor* tuple_desc) { _tuple_desc = tuple_desc; }
+
 private:
+    const TupleDescriptor* _tuple_desc;
     RuntimeState* _state;
 
     // share data with multiple partition sort sink opeartor through _sort_context.

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -57,6 +57,8 @@ public:
         DCHECK_LT(driver_sequence, _chunks_sorter_partitions.size());
         return _chunks_sorter_partitions[driver_sequence].get();
     }
+    int64_t offset() const { return _offset; }
+    int64_t limit() const { return _limit; }
     const std::vector<ExprContext*>& sort_exprs() const { return _sort_exprs; }
     const SortDescs& sort_descs() const { return _sort_desc; }
 

--- a/be/src/exec/sorting/merge_path.cpp
+++ b/be/src/exec/sorting/merge_path.cpp
@@ -555,6 +555,8 @@ ChunkPtr detail::LeafNode::_generate_ordinal(size_t chunk_id, size_t num_rows) {
     auto* raw_array = down_cast<Int64Column*>(ordinal_column.get())->get_data().data();
 
     for (size_t row = 0; row < num_rows; row++) {
+        // The first (64 - OFFSET_BITS) bits are used for chunk_id
+        // The last OFFSET_BITS bits are used for offset in chunk
         raw_array[row] =
                 (static_cast<int64_t>(chunk_id) << MergePathCascadeMerger::OFFSET_BITS) | static_cast<int64_t>(row);
     }
@@ -1131,6 +1133,8 @@ ChunkPtr MergePathCascadeMerger::_restore_according_to_ordinal(int32_t parallel_
     };
 
     for (int64_t ordinal : ordinals) {
+        // The first (64 - OFFSET_BITS) bits are used for chunk_id
+        // The last OFFSET_BITS bits are used for offset in chunk
         const auto chunk_id = static_cast<size_t>(ordinal) >> OFFSET_BITS;
         const auto row = static_cast<size_t>(ordinal) & MAX_CHUNK_SIZE;
         if (prev_chunk_id == -1) {

--- a/be/src/exec/sorting/merge_path.h
+++ b/be/src/exec/sorting/merge_path.h
@@ -411,6 +411,11 @@ private:
     void _reset_output();
 
 public:
+    // The ordinal value is comprising the following two parts
+    // 1. chunk_id, which is assigned by `add_original_chunk
+    // 2. offset in chunk
+    // And for sake of performance, we use 64-bit to store these two parts, chunk_id takes first 44-bits
+    // and offset takes 20-bits.
     constexpr static size_t MAX_CHUNK_SIZE = 0xfffff;
     constexpr static size_t OFFSET_BITS = 20;
 

--- a/be/src/exec/sorting/merge_path.h
+++ b/be/src/exec/sorting/merge_path.h
@@ -14,12 +14,15 @@
 
 #pragma once
 
+#include <mutex>
+#include <unordered_map>
 #include <utility>
 
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "exec/sorting/merge.h"
 #include "exec/sorting/sorting.h"
+#include "runtime/descriptors.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks::merge_path {
@@ -149,6 +152,8 @@ using MergePathChunkProvider = std::function<bool(bool only_check_if_has_data, C
 
 namespace detail {
 
+class MergeNode;
+
 // A merge tree is composed by a group of node, node can be either LeafNode or MergeNode
 // LeafNode gets data from the specific providers, and has no child
 // MergeNode has two children, and combine two streams of data into one.
@@ -159,23 +164,29 @@ public:
     virtual void process_input(int32_t parallel_idx) = 0;
     virtual void process_input_done(){};
     virtual bool is_leaf() { return false; }
-    // Means the previous node reaches eos, no more data will flow to current node,
-    // but there still may be some data in the input buffer to be consumed.
-    virtual bool dependency_finished() = 0;
-    // Means based on dependency_finished state, all the data in the input buffer has been consumed.
-    virtual bool input_finished() = 0;
-    // Return true if current node is active but cannot provide more data at this moment.
-    virtual bool is_pending() { return false; }
+
+    // Current node can produce more output if one of the following conditions are met.
+    // 1. It's dependency is not reaching eos. For LeafNode, dependency can be MergePathChunkProvider;
+    // For MergeNode, dependencies can be its left and right children.
+    // 2. Input buffer has not exhausted yet.
+    virtual bool has_more_output() = 0;
+
+    // Return true if current node cannot produce any more data, and the output segments of the latest
+    // processing has been fetched.
+    bool eos() { return !has_more_output() && _output_segments.empty(); }
+    std::vector<OutputSegmentPtr>& output_segments() { return _output_segments; }
+
+    void bind_parent(MergeNode* parent) { _parent = parent; }
+    bool parent_input_full();
+
     size_t degree_of_parallelism() { return _global_2_local_parallel_idx.size(); }
     void bind_parallel_idxs(std::unordered_map<int32_t, int32_t>&& global_2_local_parallel_idx) {
         _global_2_local_parallel_idx = std::move(global_2_local_parallel_idx);
     }
-    bool output_empty() { return _output_segments.empty(); }
-    bool eos() { return dependency_finished() && input_finished() && output_empty(); }
-    std::vector<OutputSegmentPtr>&& output_segments() { return std::move(_output_segments); }
 
 protected:
     MergePathCascadeMerger* _merger;
+    MergeNode* _parent = nullptr;
 
     // There may be multiply workers work on the same Node. So wee need to know
     // the local parallel_idx which the global parallel_idx corresponds to.
@@ -187,7 +198,7 @@ protected:
     // pair.first store global parallel_idx, pair.second store local parallel_idx
     std::unordered_map<int32_t, int32_t> _global_2_local_parallel_idx;
 
-    // Every time traversing, current node must all the output of its children
+    // Output segments of current processing, it will be all fetched by its parent
     std::vector<OutputSegmentPtr> _output_segments;
 
     std::mutex _m;
@@ -196,15 +207,13 @@ using NodePtr = std::unique_ptr<Node>;
 
 class MergeNode final : public Node {
 public:
-    MergeNode(MergePathCascadeMerger* merger, Node* left, Node* right) : Node(merger), _left(left), _right(right) {}
+    MergeNode(MergePathCascadeMerger* merger, Node* left, Node* right)
+            : Node(merger), _left(left), _right(right), _left_buffer({}, 0, 0), _right_buffer({}, 0, 0) {}
 
     void process_input(int32_t parallel_idx) override;
     void process_input_done() override;
-    bool dependency_finished() override { return _left->eos() && _right->eos(); }
-    bool input_finished() override {
-        return dependency_finished() && _left_input != nullptr && _left_input->len == 0 && _right_input != nullptr &&
-               _right_input->len == 0;
-    }
+    bool has_more_output() override;
+    bool input_full(Node* child);
 
 private:
     void _setup_input();
@@ -212,28 +221,31 @@ private:
     Node* _left;
     Node* _right;
 
-    InputSegmentPtr _left_input;
-    InputSegmentPtr _right_input;
+    InputSegment _left_buffer;
+    InputSegment _right_buffer;
     bool _input_ready = false;
 
-    size_t _merge_length;
+    size_t _merge_length = 0;
 };
 
 class LeafNode final : public Node {
 public:
-    LeafNode(MergePathCascadeMerger* merger) : Node(merger) {}
+    LeafNode(MergePathCascadeMerger* merger, bool late_materialization)
+            : Node(merger), _late_materialization(late_materialization) {}
 
     void process_input(int32_t parallel_idx) override;
-    bool dependency_finished() override { return _provider_eos; }
     bool is_leaf() override { return true; }
-    bool input_finished() override { return dependency_finished(); }
-    bool is_pending() override { return !_provider_eos && !_provider(true, nullptr, nullptr); }
+    bool has_more_output() override { return !_provider_eos; }
+    bool provider_pending() { return has_more_output() && !_provider(true, nullptr, nullptr); }
 
-    void set_provider(MergePathChunkProvider&& provider) { _provider = std::move(provider); }
+    void set_provider(MergePathChunkProvider provider) { _provider = std::move(provider); }
 
 private:
-    bool _provider_eos = false;
+    ChunkPtr _generate_ordinal(size_t chunk_id, size_t num_rows);
+
+    const bool _late_materialization;
     MergePathChunkProvider _provider;
+    bool _provider_eos = false;
 };
 
 // Transition graph is as follows:
@@ -335,14 +347,20 @@ struct Metrics {
     // 6 -> Stage::FINISHED
     std::vector<RuntimeProfile::Counter*> stage_timers;
     std::vector<RuntimeProfile::Counter*> stage_counters;
+
+    RuntimeProfile::Counter* _provider_timer;
+    RuntimeProfile::Counter* _late_materialization_generate_ordinal_timer;
+    RuntimeProfile::Counter* _late_materialization_restore_from_ordinal_timer;
+    RuntimeProfile::Counter* _late_materialization_max_buffer_chunk_num;
 };
 } // namespace detail
 
 class MergePathCascadeMerger {
 public:
-    MergePathCascadeMerger(const int32_t degree_of_parallelism, std::vector<ExprContext*> sort_exprs,
-                           const SortDescs& sort_descs, std::vector<MergePathChunkProvider> chunk_providers,
-                           const size_t chunk_size);
+    MergePathCascadeMerger(const size_t chunk_size, const int32_t degree_of_parallelism,
+                           std::vector<ExprContext*> sort_exprs, const SortDescs& sort_descs,
+                           const TupleDescriptor* tuple_desc, const int64_t offset, const int64_t limit,
+                           std::vector<MergePathChunkProvider> chunk_providers);
     const std::vector<ExprContext*>& sort_exprs() const { return _sort_exprs; }
     const SortDescs& sort_descs() const { return _sort_descs; }
 
@@ -365,6 +383,9 @@ public:
 
     void bind_profile(int32_t parallel_idx, RuntimeProfile* profile);
 
+    size_t add_original_chunk(ChunkPtr&& chunk);
+    detail::Metrics& get_metrics(int32_t parallel_idx) { return _metrics[parallel_idx]; }
+
 private:
     bool _is_current_stage_done();
     void _forward_stage(const detail::Stage& stage, int32_t worker_num, std::vector<size_t>* process_cnts = nullptr);
@@ -374,6 +395,12 @@ private:
     void _process(int32_t parallel_idx);
     void _split_chunk(int32_t parallel_idx);
     void _fetch_chunk(int32_t parallel_idx, ChunkPtr& chunk);
+    void _finishing();
+
+    void _init_late_materialization();
+    ChunkPtr _restore_from_ordinal(int32_t parallel_idx, const ChunkPtr& chunk);
+
+    void _process_limit(ChunkPtr& chunk);
 
     void _find_unfinished_level();
     using Action = std::function<void()>;
@@ -383,30 +410,40 @@ private:
 
     void _reset_output();
 
+public:
+    constexpr static size_t MAX_CHUNK_SIZE = 0xfffff;
+    constexpr static size_t OFFSET_BITS = 20;
+
 private:
     // For each MergeNode, there may be multiply threads working on the same merge processing.
     // And here we need to guarantee that each parallelism can process a certain amount of data. Assuming it
     // equals to chunk_size right now (can be later optimized), so the total size of the merge should be
     // chunk_size * degree_of_parallelism, which is called _streaming_batch_size here.
+    // And each MergeNode can hold left/right buffer of size within 2 * _streaming_batch_size.
+    // So the total amount size the whole merge tree will hold is around _degree_of_parallelism * 2 * _streaming_batch_size
+    // (The number of MergeNode approximately equals to _degree_of_parallelism)
     const size_t _chunk_size;
     const size_t _streaming_batch_size;
 
     const int32_t _degree_of_parallelism;
     const std::vector<ExprContext*> _sort_exprs;
     const SortDescs _sort_descs;
-    std::vector<MergePathChunkProvider> _chunk_providers;
+    const TupleDescriptor* _tuple_desc;
+    const int64_t _offset;
+    const int64_t _limit;
+    const std::vector<MergePathChunkProvider> _chunk_providers;
     Action _finish_merge_action;
 
-    // In order to get high performance, all the condition methods like `is_current_stage_finished/is_finished/is_pending`
-    // don't use global mutex. But here is one critical section of forwarding stage, during which we need to mute all these
-    // methods to avoid undefined concurrent behaviors.
+    // The atomicity is provided by the following three atomic fields. The write-read order of these atomic fields must be
+    // the same among all threads, so the `std::memory_order_seq_cst` is requied when manipulating them.
+    // 1. _is_forwarding_stage is used for creating a critical section because all the condition methods, like
+    // `is_current_stage_finished/is_finished/is_pending`, are not protected by global mutex.
+    // 2. _process_cnts[i] represents how many times for parallel_idx=<i> that method `try_get_next` can be executed. Besides,
+    // it provides the final consistency of all the following non-atomic fields through
+    //      1. Read _process_cnts at the begining of try_get_next
+    //      2. Write _process_cnts at the end of try_get_next
     std::atomic<bool> _is_forwarding_stage = false;
     std::atomic<detail::Stage> _stage;
-    // _process_cnts[i] represents how many times for parallel_idx=<i> that method `try_get_next` can be executed
-    // The final consistency of all the following non-atomic fields are protected by _process_cnts
-    // Through
-    //      1. Read _process_cnts at the begining of try_get_next
-    //      2. Write _process_cnts at tne end of try_get_next
     std::vector<std::atomic<size_t>> _process_cnts;
 
     // Merge nodes
@@ -423,10 +460,19 @@ private:
     // _working_nodes[i] represents the node list for parallel_idx=<i>
     std::vector<std::vector<detail::Node*>> _working_nodes;
 
+    // Fields used for late materialization
+    bool _late_materialization = false;
+    size_t _chunk_id_generator = 0;
+    size_t _dequeued_chunk_num = 0;
+    size_t _max_buffer_chunk_num = 0;
+    std::deque<std::pair<ChunkPtr, size_t>> _original_chunk_buffer;
+
     // Output chunks for each parallelism
     std::vector<std::vector<ChunkPtr>> _output_chunks;
     std::vector<ChunkPtr> _flat_output_chunks;
     size_t _output_idx = 0;
+    size_t _output_row_num = 0;
+    bool _short_circuit = false;
 
     std::vector<detail::Metrics> _metrics;
     std::chrono::steady_clock::time_point _pending_start;

--- a/be/src/exec/sorting/merge_path.h
+++ b/be/src/exec/sorting/merge_path.h
@@ -348,9 +348,9 @@ struct Metrics {
     std::vector<RuntimeProfile::Counter*> stage_timers;
     std::vector<RuntimeProfile::Counter*> stage_counters;
 
-    RuntimeProfile::Counter* _provider_timer;
+    RuntimeProfile::Counter* _sorted_run_provider_timer;
     RuntimeProfile::Counter* _late_materialization_generate_ordinal_timer;
-    RuntimeProfile::Counter* _late_materialization_restore_from_ordinal_timer;
+    RuntimeProfile::Counter* _late_materialization_restore_according_to_ordinal_timer;
     RuntimeProfile::Counter* _late_materialization_max_buffer_chunk_num;
 };
 } // namespace detail
@@ -398,7 +398,7 @@ private:
     void _finishing();
 
     void _init_late_materialization();
-    ChunkPtr _restore_from_ordinal(int32_t parallel_idx, const ChunkPtr& chunk);
+    ChunkPtr _restore_according_to_ordinal(int32_t parallel_idx, const ChunkPtr& chunk);
 
     void _process_limit(ChunkPtr& chunk);
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Background

Please refer to #20534 for details.

This is a continuation work of #18525 

## Enhancement

1. Enlightend by [[Enhancement] Full sort late materialization](https://github.com/StarRocks/starrocks/pull/17814), this pr provide a similar late materialization if there are too many non-ordering related columns or the merge tree is too deep.
2. Provide limit processing.

## Next pr

1. An overall performance test, and do the optimizations that found in test.
2. Delete the session variable `enable_parallel_merge` and old logic if this process outperforms in all scenerios.
3. Performance tunning, like `stream_batch_size`

## Test

Experiment should cover many dimensions, include:

1. The number order by columns
5. The type of order by columns
6. The cardinality of order by columns
7. Order by columns is skewed or not
8. The number of output columns(non-order by columns)

But here we only test part of this, and I'll do the final overall experiment in the final pr.

* 3be/1fe, 16c/64g
* ssb_100g

```sql
-- Q1
select sum(wv) from (
    select *,
    rank() over(order by lo_suppkey) as wv
    from lineorder
) a;

-- Q2
select sum(lo_orderkey), sum(wv) from (
    select *,
    rank() over(order by lo_suppkey) as wv
    from lineorder
) a;

-- Q3
select sum(lo_orderkey), sum(lo_linenumber), sum(wv) from (
    select *,
    rank() over(order by lo_suppkey) as wv
    from lineorder
) a;

-- Q4
select sum(lo_orderkey), sum(lo_linenumber), sum(lo_custkey), sum(wv) from (
    select *,
    rank() over(order by lo_suppkey) as wv
    from lineorder
) a;

-- Q5
select sum(lo_orderkey), sum(lo_linenumber), sum(lo_custkey), sum(lo_partkey), sum(wv) from (
    select *,
    rank() over(order by lo_suppkey) as wv
    from lineorder
) a;

-- Q6
select sum(lo_orderkey), sum(lo_linenumber), sum(lo_custkey), sum(lo_partkey), sum(lo_suppkey), sum(wv) from (
    select *,
    rank() over(order by lo_suppkey) as wv
    from lineorder
) a;

-- Q7
select sum(lo_orderkey), sum(lo_linenumber), sum(lo_custkey), sum(lo_partkey), sum(lo_suppkey), sum(lo_orderdate), sum(wv) from (
     select *,
     rank() over(order by lo_suppkey) as wv
     from lineorder
) a;
```

**!!!NOTICE, the execution time of each operator can be overlaped, so the `local merge time` + `global merge time` may greater than the total execution time!!!**


### Minimum parallelism(dop=1)

<table>
  <tr>
    <th rowspan="2" width="80px">Query</th>
    <th colspan="2" width="240px">Time(enable_parallel_merge=false)</th>
    <th colspan="2" width="240px">Time(enable_parallel_merge=true)</th>
    <th colspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th width="80px">Overall</th>
    <th width="160px">Merge</th>
    <th width="80px">Overall</th>
    <th width="160px">Merge</th>
    <th width="80px">Overall</th>
    <th width="80px">Merge</th>
  </tr>
  <tr>
    <td>Q1</td>
    <td>39.632s</td>
    <td>0.4+7.15=7.55s</td>
    <td>39.511s</td>
    <td>0.25+3.76=4.01s</td>
    <td>1.00</td>
    <td>1.88</td>
  </tr>
  <tr>
    <td>Q2</td>
    <td>50.066s</td>
    <td>0.72+11.06=11.78s</td>
    <td>48.937s</td>
    <td>0.39+5.28=5.67s</td>
    <td>1.02</td>
    <td>2.07</td>
  </tr>
  <tr>
    <td>Q3</td>
    <td>62.489s</td>
    <td>0.97+13.03=14s</td>
    <td>56.578s</td>
    <td>0.54+6.24=6.78s</td>
    <td>1.10</td>
    <td>2.06</td>
  </tr>
  <tr>
    <td>Q4</td>
    <td>73.959s</td>
    <td>1.38+17.29=18.67s</td>
    <td>66.714s</td>
    <td>0.64+7.87=8.51s</td>
    <td>1.11</td>
    <td>2.19</td>
  </tr>
  <tr>
    <td>Q5</td>
    <td>80.926s</td>
    <td>1.65+20.6=22.25s</td>
    <td>75.592s</td>
    <td>0.78+10.69=11.47s</td>
    <td>1.07</td>
    <td>1.93</td>
  </tr>
  <tr>
    <td>Q6</td>
    <td>82.808s</td>
    <td>1.57+18.6=20.17s</td>
    <td>70.578s</td>
    <td>0.77+11.19=11.96s</td>
    <td>1.17</td>
    <td>1.68</td>
  </tr>
  <tr>
    <td>Q7</td>
    <td>89.972s</td>
    <td>2.06+24.1=26.16s</td>
    <td>78.183s</td>
    <td>0.91+11.68=12.59s</td>
    <td>1.15</td>
    <td>2.07</td>
  </tr>
</table>


### Default parallelism(dop=0)

<table>
  <tr>
    <th rowspan="2" width="80px">Query</th>
    <th colspan="2" width="240px">Time(enable_parallel_merge=false)</th>
    <th colspan="2" width="240px">Time(enable_parallel_merge=true)</th>
    <th colspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th width="80px">Overall</th>
    <th width="160px">Merge</th>
    <th width="80px">Overall</th>
    <th width="160px">Merge</th>
    <th width="80px">Overall</th>
    <th width="80px">Merge</th>
  </tr>
  <tr>
    <td>Q1</td>
    <td>14.698s</td>
    <td>4.48+6.9=11.38s</td>
    <td>12.915s</td>
    <td>0.99+2.17=3.16s</td>
    <td>1.14</td>
    <td>3.6</td>
  </tr>
  <tr>
    <td>Q2</td>
    <td>18.327s</td>
    <td>6.54+9.72=16.26s</td>
    <td>14.507s</td>
    <td>1.41+3.05=4.46s</td>
    <td>1.26</td>
    <td>3.60</td>
  </tr>
  <tr>
    <td>Q3</td>
    <td>24.174s</td>
    <td>8.5+14.44=22.94s</td>
    <td>15.528s</td>
    <td>1.89+3.82=5.71s</td>
    <td>1.55</td>
    <td>4.0</td>
  </tr>
  <tr>
    <td>Q4</td>
    <td>26.825s</td>
    <td>10.48+16.73=27.21s</td>
    <td>17.962s</td>
    <td>2.92+4.65=7.57s</td>
    <td>1.49</td>
    <td>3.59</td>
  </tr>
  <tr>
    <td>Q5</td>
    <td>29.480s</td>
    <td>11.82+19.01=30.83s</td>
    <td>20.136s</td>
    <td>3.37+6.02=9.39s</td>
    <td>1.46</td>
    <td>3.28</td>
  </tr>
  <tr>
    <td>Q6</td>
    <td>31.341s</td>
    <td>12.98+20.69=33.67s</td>
    <td>19.484s</td>
    <td>3.33+5.78=9.11s</td>
    <td>1.6</td>
    <td>3.69</td>
  </tr>
  <tr>
    <td>Q7</td>
    <td>35.793s</td>
    <td>14.79+23.93=38.72s</td>
    <td>22.965s</td>
    <td>3.76+6.95=10.71s</td>
    <td>1.56</td>
    <td>3.61</td>
  </tr>
</table>

### Maximum parallelism(dop=16)

<table>
  <tr>
    <th rowspan="2" width="80px">Query</th>
    <th colspan="2" width="240px">Time(enable_parallel_merge=false)</th>
    <th colspan="2" width="240px">Time(enable_parallel_merge=true)</th>
    <th colspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th width="80px">Overall</th>
    <th width="160px">Merge</th>
    <th width="80px">Overall</th>
    <th width="160px">Merge</th>
    <th width="80px">Overall</th>
    <th width="80px">Merge</th>
  </tr>
  <tr>
    <td>Q1</td>
    <td>13.240s</td>
    <td>5.45+6.72=12.17s</td>
    <td>10.539s</td>
    <td>0.9+1.61=2.51s</td>
    <td>1.25</td>
    <td>4.84</td>
  </tr>
  <tr>
    <td>Q2</td>
    <td>18.338s</td>
    <td>8.75+11.11=19.86s</td>
    <td>11.721s</td>
    <td>1.37+2.59=3.96s</td>
    <td>1.56</td>
    <td>5.00</td>
  </tr>
  <tr>
    <td>Q3</td>
    <td>22.391s</td>
    <td>11.31+15.06=26.37s</td>
    <td>13.177s</td>
    <td>1.78+2.98=4.76s</td>
    <td>1.69</td>
    <td>5.50</td>
  </tr>
  <tr>
    <td>Q4</td>
    <td>23.771s</td>
    <td>15.19+16.44=31.63s</td>
    <td>14.947s</td>
    <td>3.4+3.8=7.2s</td>
    <td>1.59</td>
    <td>4.39</td>
  </tr>
  <tr>
    <td>Q5</td>
    <td>29.195s</td>
    <td>17.73+20.6=38.33s</td>
    <td>17.538s</td>
    <td>3.8+5.3=9.1s</td>
    <td>1.66</td>
    <td>4.2</td>
  </tr>
  <tr>
    <td>Q6</td>
    <td>28.658s</td>
    <td>17.98+20.39=38.37s</td>
    <td>17.262s</td>
    <td>3.88+5.12=9s</td>
    <td>1.66</td>
    <td>4.26</td>
  </tr>
  <tr>
    <td>Q7</td>
    <td>31.417s</td>
    <td>20.69+22.68=43.37s</td>
    <td>19.210s</td>
    <td>4.2+6.2=10.4s</td>
    <td>1.63</td>
    <td>4.17</td>
  </tr>
</table>

### Conclusion

The above results shows that the parallel algorithm & process outperforms the current implementation in all the above  scenerios.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
