### PR TITLE
[BugFix] Ensure persisting tablet meta after schemachange

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2476,7 +2476,9 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version) {
         LOG(WARNING) << "link_from skipped: max_version:" << this->max_version()
                      << " >= alter_version:" << request_version << " tablet:" << _tablet.tablet_id()
                      << " base_tablet:" << base_tablet->tablet_id();
+        std::unique_lock wrlock(_tablet.get_header_lock());
         _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
+        _tablet.save_meta();
         return Status::OK();
     }
     vector<RowsetSharedPtr> rowsets;
@@ -2578,6 +2580,7 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version) {
                      << " >= alter_version:" << request_version << " tablet:" << _tablet.tablet_id()
                      << " base_tablet:" << base_tablet->tablet_id();
         _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
+        _tablet.save_meta();
         return Status::OK();
     }
     st = kv_store->write_batch(&wb);
@@ -2625,7 +2628,9 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
         LOG(WARNING) << "convert_from skipped: max_version:" << this->max_version()
                      << " >= alter_version:" << request_version << " tablet:" << _tablet.tablet_id()
                      << " base_tablet:" << base_tablet->tablet_id();
+        std::unique_lock wrlock(_tablet.get_header_lock());
         _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
+        _tablet.save_meta();
         return Status::OK();
     }
     std::vector<RowsetSharedPtr> src_rowsets;
@@ -2754,6 +2759,7 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
                      << " >= alter_version:" << request_version << " tablet:" << _tablet.tablet_id()
                      << " base_tablet:" << base_tablet->tablet_id();
         _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
+        _tablet.save_meta();
         return Status::OK();
     }
     status = kv_store->write_batch(&wb);
@@ -2847,7 +2853,9 @@ Status TabletUpdates::reorder_from(const std::shared_ptr<Tablet>& base_tablet, i
         LOG(WARNING) << "reorder_from skipped: max_version:" << this->max_version()
                      << " >= alter_version:" << request_version << " tablet:" << _tablet.tablet_id()
                      << " base_tablet:" << base_tablet->tablet_id();
+        std::unique_lock wrlock(_tablet.get_header_lock());
         _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
+        _tablet.save_meta();
         return Status::OK();
     }
     std::vector<RowsetSharedPtr> src_rowsets;
@@ -3032,6 +3040,7 @@ Status TabletUpdates::reorder_from(const std::shared_ptr<Tablet>& base_tablet, i
                      << " >= alter_version:" << request_version << " tablet:" << _tablet.tablet_id()
                      << " base_tablet:" << base_tablet->tablet_id();
         _tablet.set_tablet_state(TabletState::TABLET_RUNNING);
+        _tablet.save_meta();
         return Status::OK();
     }
     status = kv_store->write_batch(&wb);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21223

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR fixes the bug when compaction is skipped tablet state is changed from not_ready to running, but only in memory, not persisted to disk, if BE shutdown before another process like GC persisted the meta, the tablet's state will always be `not_ready`

```
be.INFO.log.20230404-150119:I0404 18:08:25.002785 19610 agent_server.cpp:367] Submit task success. type=CREATE, signature=2695437
be.INFO.log.20230404-150119:I0404 18:08:29.227303 24744 tablet_manager.cpp:140] Creating tablet 2695437
be.INFO.log.20230404-150119:I0404 18:08:29.259428 24744 tablet_manager.cpp:209] Created tablet 2695437
be.INFO.log.20230404-150119:I0404 18:08:39.870968 19610 agent_server.cpp:424] Submit task success. type=ALTER, signature=2695437
be.INFO.log.20230404-150119:I0404 18:09:24.286820 24748 agent_task.cpp:217] get alter table task, signature: 2695437
be.INFO.log.20230404-150119:I0404 18:09:24.286826 24748 schema_change.cpp:675] begin to do request alter tablet: base_tablet_id=2691804, base_schema_hash=1196453435, new_tablet_id=2695437, new_schema_hash=2023052784, alter_version=1
be.INFO.log.20230404-150119:I0404 18:09:24.286832 24748 schema_change.cpp:725] finish to validate alter tablet request. begin to convert data from base tablet to new tablet base_tablet=2691804.1196453435.1641c5f5135261b4-29f68f9ffa2a4fb9 new_tablet=2695437.2023052784.6a46707a81dd673b-4fab47284343e3a2
be.INFO.log.20230404-150119:I0404 18:09:24.286844 24748 tablet_updates.cpp:2499] convert_from start tablet:2695437 #pending:0 base_tablet:2691804 request_version:1
be.INFO.log.20230404-150119:W0404 18:09:24.286849 24748 tablet_updates.cpp:2509] convert_from skipped: max_version:1 >= alter_version:1 tablet:2695437 base_tablet:2691804
be.INFO.log.20230404-150119:I0404 18:09:24.286866 24748 agent_task.cpp:80] alter finished. signature: 2695437
be.INFO.log.20230404-150119:I0404 18:09:24.286870 24748 tablet_manager.cpp:780] Reporting tablet info. tablet_id=2695437
be.INFO.log.20230404-150119:I0404 18:09:24.286873 24748 agent_task.cpp:113] alter success. signature: 2695437


tablet meta:
"tablet_meta": {
    "table_id": 17600,
    "partition_id": 2665303,
    "tablet_id": 2695429,
    "schema_hash": 2023052784,
    "shard_id": 985,
    "creation_time": 1680602909,
    "cumulative_layer_point": -1,
    "tablet_state": "PB_NOTREADY",
...

```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
