### PR TITLE
[Enhancement] Get stacktrace by function name

### DIFF
--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -27,6 +27,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_manager.h"
+#include "storage/tablet_meta_manager.h"
 #include "storage/tablet_updates.h"
 #include "util/stack_util.h"
 #include "wrenbind17/wrenbind17.hpp"
@@ -125,6 +126,7 @@ void bind_exec_env(ForeignModule& m) {
         cls.funcStaticExt<&get_stack_trace_for_thread>("get_stack_trace_for_thread");
         cls.funcStaticExt<&get_stack_trace_for_threads>("get_stack_trace_for_threads");
         cls.funcStaticExt<&get_stack_trace_for_all_threads>("get_stack_trace_for_all_threads");
+        cls.funcStaticExt<&get_stack_trace_for_function>("get_stack_trace_for_function");
         cls.funcStaticExt<&grep_log_as_string>("grep_log_as_string");
         REG_METHOD(ExecEnv, process_mem_tracker);
         REG_METHOD(ExecEnv, query_pool_mem_tracker);
@@ -191,6 +193,20 @@ public:
         return CompactionAction::do_compaction(tablet_id, type, "");
     }
 
+    static std::string get_tablet_meta_json(int64_t tablet_id) {
+        auto tablet = get_tablet(tablet_id);
+        if (!tablet) {
+            return "tablet not found";
+        }
+        std::string ret;
+        auto st = TabletMetaManager::get_json_meta(tablet->data_dir(), tablet->tablet_id(), &ret);
+        if (!st.ok()) {
+            return st.to_string();
+        } else {
+            return ret;
+        }
+    }
+
     static void bind(ForeignModule& m) {
         {
             auto& cls = m.klass<TabletBasicInfo>("TabletBasicInfo");
@@ -234,6 +250,7 @@ public:
             REG_METHOD(Tablet, debug_string);
             REG_METHOD(Tablet, support_binlog);
             REG_METHOD(Tablet, updates);
+            REG_METHOD(Tablet, save_meta);
         }
         {
             auto& cls = m.klass<EditVersionPB>("EditVersionPB");
@@ -330,6 +347,7 @@ public:
             auto& cls = m.klass<StorageEngineRef>("StorageEngine");
             REG_STATIC_METHOD(StorageEngineRef, get_tablet_info);
             REG_STATIC_METHOD(StorageEngineRef, get_tablet_infos);
+            REG_STATIC_METHOD(StorageEngineRef, get_tablet_meta_json);
             REG_STATIC_METHOD(StorageEngineRef, get_tablet);
             REG_STATIC_METHOD(StorageEngineRef, drop_tablet);
             REG_STATIC_METHOD(StorageEngineRef, get_data_dirs);

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -33,6 +33,8 @@ bool install_stack_trace_sighandler();
 std::string get_stack_trace_for_thread(int tid, int timeout_ms);
 std::string get_stack_trace_for_threads(const std::vector<int>& tids, int timeout_ms);
 std::string get_stack_trace_for_all_threads();
+// get all thread stack trace, and filter by function pattern
+std::string get_stack_trace_for_function(const std::string& function_pattern);
 
 // wrap libc's _cxa_throw to print stack trace of exceptions
 extern "C" {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds the ability to filter stacktraces by function name, the reason is: there are too many threads(~1000 depending on num of cores) in BE currently, it's hard to only get the stacktrace you want.
It also add bind for save tablet meta and get tablet meta json.
```
mysql> admin execute on 11001 '
System.print(ExecEnv.get_stack_trace_for_function("ProcessRpcRequest"))
';
Query OK, 0 rows affected (0.45 sec)
tid: 550881
    0x7ff67236b76d  syscall
         0x5b10e71  starrocks::get_stack_trace_for_threads_with_pattern()
         0x5b11e66  starrocks::get_stack_trace_for_function()
         0x5b9402a  wrenbind17::detail::ForeignFunctionCaller<>::call<>()
         0x5bef56c  runInterpreter
         0x5b8bcf4  starrocks::execute_script()
         0x59e69b9  starrocks::execute_command()
         0x5a07d1d  starrocks::PInternalServiceImplBase<>::execute_command()
         0x6c8ddd7  brpc::policy::ProcessRpcRequest()
         0x6c7e4fb  brpc::ProcessInputMessage()
         0x6c7f450  brpc::InputMessenger::OnNewMessages()
         0x6d43f52  brpc::Socket::ProcessEvent()
         0x6bbefd6  bthread::TaskGroup::task_runner()
         0x6ba5f81  bthread_make_fcontext

total 932 threads, 55 identical groups
```
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
