### PR TITLE
[Enhancement] Support for alternation of confluent schema registry addr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/RoutineLoadDataSourceProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/RoutineLoadDataSourceProperties.java
@@ -56,6 +56,7 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
     private static final ImmutableSet<String> CONFIGURABLE_KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
             .add(CreateRoutineLoadStmt.KAFKA_PARTITIONS_PROPERTY)
             .add(CreateRoutineLoadStmt.KAFKA_OFFSETS_PROPERTY)
+            .add(CreateRoutineLoadStmt.CONFLUENT_SCHEMA_REGISTRY_URL)
             .build();
 
     private static final ImmutableSet<String> CONFIGURABLE_PULSAR_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -77,6 +78,8 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
     private List<Pair<String, Long>> pulsarPartitionInitialPositions = Lists.newArrayList();
     @SerializedName(value = "customPulsarProperties")
     private Map<String, String> customPulsarProperties = Maps.newHashMap();
+    @SerializedName(value = "confluentSchemaRegistryUrl")
+    private String confluentSchemaRegistryUrl;
 
     private final NodePosition pos;
 
@@ -111,6 +114,10 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
 
     public String getType() {
         return type;
+    }
+
+    public String getConfluentSchemaRegistryUrl() {
+        return confluentSchemaRegistryUrl;
     }
 
     public List<Pair<Integer, Long>> getKafkaPartitionOffsets() {
@@ -151,7 +158,7 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
     private void checkKafkaProperties() throws AnalysisException {
         Optional<String> optional = properties.keySet().stream().filter(
                 entity -> !CONFIGURABLE_KAFKA_PROPERTIES_SET.contains(entity)).filter(
-                entity -> !entity.startsWith("property.")).findFirst();
+                entity -> !entity.startsWith("property.") && !entity.startsWith("confluent.")).findFirst();
         if (optional.isPresent()) {
             throw new AnalysisException(optional.get() + " is invalid kafka custom property");
         }
@@ -179,6 +186,8 @@ public class RoutineLoadDataSourceProperties implements ParseNode {
 
         // check custom properties
         CreateRoutineLoadStmt.analyzeKafkaCustomProperties(properties, customKafkaProperties);
+
+        confluentSchemaRegistryUrl = properties.get(CreateRoutineLoadStmt.CONFLUENT_SCHEMA_REGISTRY_URL);
     }
 
     private void checkPulsarProperties() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -616,6 +616,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
             convertCustomProperties(true);
         }
 
+        confluentSchemaRegistryUrl = dataSourceProperties.getConfluentSchemaRegistryUrl();
+
         LOG.info("modify the data source properties of kafka routine load job: {}, datasource properties: {}",
                 this.id, dataSourceProperties);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
@@ -107,7 +107,8 @@ public class AlterRoutineLoadStmtTest {
                 + "(\n"
                 + "\"kafka_partitions\" = \"0, 1, 2\",\n"
                 + "\"kafka_offsets\" = \"100, 200, 100\",\n"
-                + "\"property.group.id\" = \"group1\"\n"
+                + "\"property.group.id\" = \"group1\",\n"
+                + "\"confluent.schema.registry.url\" = \"https://key:passwrod@addr\"\n"
                 + ");";
         List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, 32);
         AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt)stmts.get(0);
@@ -122,6 +123,7 @@ public class AlterRoutineLoadStmtTest {
         Assert.assertEquals(1, stmt.getDataSourceProperties().getCustomKafkaProperties().size());
         Assert.assertTrue(stmt.getDataSourceProperties().getCustomKafkaProperties().containsKey("group.id"));
         Assert.assertEquals(3, stmt.getDataSourceProperties().getKafkaPartitionOffsets().size());
+        Assert.assertEquals("https://key:passwrod@addr", stmt.getDataSourceProperties().getConfluentSchemaRegistryUrl());
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR allows you to change the confluent schema registry address for a routine load. If you want to change this property, you can use this SQL:
```
ALTER ROUTINE LOAD FOR db1.label1
FROM Kafka
(
   "confluent.schema.registry.url"="https:key:password@registryserverAddr"
);
```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
