### PR TITLE
[BugFix] LoadingTask mem_limit = 0 will limit chunk buffer capacity

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -169,13 +169,17 @@ int64_t FileDataSource::cpu_time_spent() const {
 void FileDataSource::_init_counter() {
     // Profile
     _scanner_total_timer = ADD_TIMER(_runtime_profile, "ScannerTotalTime");
-    RuntimeProfile* p = _runtime_profile->create_child("FileScanner", true, true);
-    _scanner_fill_timer = ADD_TIMER(p, "FillTime");
-    _scanner_read_timer = ADD_TIMER(p, "ReadTime");
-    _scanner_cast_chunk_timer = ADD_TIMER(p, "CastChunkTime");
-    _scanner_materialize_timer = ADD_TIMER(p, "MaterializeTime");
-    _scanner_init_chunk_timer = ADD_TIMER(p, "CreateChunkTime");
-    _scanner_file_reader_timer = ADD_TIMER(p->create_child("FilePRead", true, true), "FileReadTime");
+    {
+        static const char* prefix = "FileScanner";
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
+        RuntimeProfile* p = _runtime_profile;
+        _scanner_fill_timer = ADD_CHILD_TIMER(p, "FillTime", prefix);
+        _scanner_read_timer = ADD_CHILD_TIMER(p, "ReadTime", prefix);
+        _scanner_cast_chunk_timer = ADD_CHILD_TIMER(p, "CastChunkTime", prefix);
+        _scanner_materialize_timer = ADD_CHILD_TIMER(p, "MaterializeTime", prefix);
+        _scanner_init_chunk_timer = ADD_CHILD_TIMER(p, "CreateChunkTime", prefix);
+        _scanner_file_reader_timer = ADD_CHILD_TIMER(p, "FileReadTime", prefix);
+    }
 }
 
 void FileDataSource::_update_counter() {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/StarRocks/StarRocksBenchmark/issues/372

The root cause is  we don't specify mem_limit(and by default is 0). And if we set 0 explicitly, backend will use mem_limit = 0, which will make chunk buffer capacity extremely small(1)

After this PR:

```
             - ChunkBufferCapacity: 1.664K (1664)
             - DefaultChunkBufferCapacity: 1.049K (1049)
```

----


This PR also fixes following warning. I don't know what's the root cause, but another writing will fix the problem.

![img_v2_a0dd041e-1b5a-4a17-97ed-d31df81e5e3g](https://user-images.githubusercontent.com/1081215/230919609-b300fd24-8eaf-43c9-a1be-24ead2fb190b.jpg)


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
