### PR TITLE
[BugFix][Cherry-Pick][Branch-2.5] Avoid BE crash when CSV reader try to read complex types

### DIFF
--- a/be/src/formats/csv/converter.cpp
+++ b/be/src/formats/csv/converter.cpp
@@ -44,8 +44,14 @@ static std::unique_ptr<Converter> get_converter(const TypeDescriptor& t) {
         return std::make_unique<DateConverter>();
     case TYPE_DATETIME:
         return std::make_unique<DatetimeConverter>();
-    case TYPE_ARRAY:
-        return std::make_unique<ArrayConverter>(get_converter(t.children[0], true));
+    case TYPE_ARRAY {
+        auto c = get_converter(t.children[0], true);
+        if (c == nullptr) {
+            return nullptr;
+        } else {
+            return std::make_unique<ArrayConverter>(c);
+        }
+    }
     case TYPE_DECIMAL32:
         return std::make_unique<DecimalV3Converter<int32_t>>(t.precision, t.scale);
     case TYPE_DECIMAL64:

--- a/be/src/formats/csv/converter.cpp
+++ b/be/src/formats/csv/converter.cpp
@@ -45,14 +45,12 @@ static std::unique_ptr<Converter> get_converter(const TypeDescriptor& t) {
     case TYPE_DATETIME:
         return std::make_unique<DatetimeConverter>();
     case TYPE_ARRAY {
-        auto c = get_converter(t.children[0], true);
-        if (c == nullptr) {
+        auto c = get_converter(t.children[0], true); if (c == nullptr) {
             return nullptr;
         } else {
             return std::make_unique<ArrayConverter>(c);
         }
-    }
-    case TYPE_DECIMAL32:
+    } case TYPE_DECIMAL32:
         return std::make_unique<DecimalV3Converter<int32_t>>(t.precision, t.scale);
     case TYPE_DECIMAL64:
         return std::make_unique<DecimalV3Converter<int64_t>>(t.precision, t.scale);

--- a/be/src/formats/csv/converter.cpp
+++ b/be/src/formats/csv/converter.cpp
@@ -44,13 +44,15 @@ static std::unique_ptr<Converter> get_converter(const TypeDescriptor& t) {
         return std::make_unique<DateConverter>();
     case TYPE_DATETIME:
         return std::make_unique<DatetimeConverter>();
-    case TYPE_ARRAY {
-        auto c = get_converter(t.children[0], true); if (c == nullptr) {
+    case TYPE_ARRAY: {
+        auto c = get_converter(t.children[0], true);
+        if (c == nullptr) {
             return nullptr;
         } else {
             return std::make_unique<ArrayConverter>(c);
         }
-    } case TYPE_DECIMAL32:
+    }
+    case TYPE_DECIMAL32:
         return std::make_unique<DecimalV3Converter<int32_t>>(t.precision, t.scale);
     case TYPE_DECIMAL64:
         return std::make_unique<DecimalV3Converter<int64_t>>(t.precision, t.scale);

--- a/be/src/formats/csv/converter.cpp
+++ b/be/src/formats/csv/converter.cpp
@@ -49,7 +49,7 @@ static std::unique_ptr<Converter> get_converter(const TypeDescriptor& t) {
         if (c == nullptr) {
             return nullptr;
         } else {
-            return std::make_unique<ArrayConverter>(c);
+            return std::make_unique<ArrayConverter>(std::move(c));
         }
     }
     case TYPE_DECIMAL32:


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Only cherry-pick a few code from https://github.com/StarRocks/starrocks/pull/20233, avoid BE crashed when read array contains struct or map in csv.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
