### PR TITLE
[BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (backport #19690)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
@@ -96,12 +96,17 @@ public class ExpressionContext {
         return childrenProperty.get(index).getOutputColumns();
     }
 
+<<<<<<< HEAD
     public int getChildLeftMostScanTabletsNum(int index) {
         return childrenProperty.get(index).getLeftMostScanTabletsNum();
     }
 
     public boolean isExecuteInOneTablet(int index) {
         return childrenProperty.get(index).isExecuteInOneTablet();
+=======
+    public LogicalProperty.OneTabletProperty oneTabletProperty(int index) {
+        return childrenProperty.get(index).oneTabletProperty();
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
     }
 
     public Operator getChildOperator(int index) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -1,4 +1,20 @@
+<<<<<<< HEAD
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+=======
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
 
 package com.starrocks.sql.optimizer;
 
@@ -134,10 +150,30 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
     }
 
     @Override
+<<<<<<< HEAD
+=======
+    public Void visitPhysicalNestLoopJoin(PhysicalNestLoopJoinOperator node, ExpressionContext context) {
+        if (node.getJoinType().isRightJoin() || node.getJoinType().isFullOuterJoin()) {
+            // Right join needs to maintain build_match_flag for right table, which could not be maintained on multiple nodes,
+            // instead it should be gathered to one node
+            PhysicalPropertySet gather =
+                    new PhysicalPropertySet(new DistributionProperty(DistributionSpec.createGatherDistributionSpec()));
+            requiredProperties.add(Lists.newArrayList(gather, gather));
+        } else {
+            PhysicalPropertySet rightBroadcastProperty =
+                    new PhysicalPropertySet(
+                            new DistributionProperty(DistributionSpec.createReplicatedDistributionSpec()));
+            requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY, rightBroadcastProperty));
+        }
+        return null;
+    }
+
+    @Override
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
     public Void visitPhysicalHashAggregate(PhysicalHashAggregateOperator node, ExpressionContext context) {
-        // If scan tablet sum leas than 1, do one phase local aggregate is enough
+        // If scan tablet sum less than 1, do one phase local aggregate is enough
         if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == 0
-                && context.getRootProperty().isExecuteInOneTablet()
+                && context.getRootProperty().oneTabletProperty().supportOneTabletOpt
                 && node.isOnePhaseAgg()) {
             requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY));
             return null;
@@ -188,7 +224,12 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
         if (partitionColumnRefSet.isEmpty()) {
             distributionProperty = new DistributionProperty(DistributionSpec.createGatherDistributionSpec());
         } else {
-            distributionProperty = createShuffleAggProperty(partitionColumnRefSet);
+            // If scan tablet sum less than 1, no distribution property is required
+            if (context.getRootProperty().oneTabletProperty().supportOneTabletOpt) {
+                distributionProperty = DistributionProperty.EMPTY;
+            } else {
+                distributionProperty = createShuffleAggProperty(partitionColumnRefSet);
+            }
         }
         requiredProperties.add(Lists.newArrayList(new PhysicalPropertySet(distributionProperty, sortProperty)));
 
@@ -227,7 +268,7 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
     public Void visitPhysicalLimit(PhysicalLimitOperator node, ExpressionContext context) {
         // @todo: check the condition is right?
         //
-        // If scan tablet sum leas than 1, don't need required gather, because work machine always less than 1?
+        // If scan tablet sum less than 1, don't need required gather, because work machine always less than 1?
         // if (context.getRootProperty().isExecuteInOneTablet()) {
         //     requiredProperties.add(Lists.newArrayList(PhysicalPropertySet.EMPTY));
         //     return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
@@ -1,12 +1,33 @@
+<<<<<<< HEAD
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+=======
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
 
 package com.starrocks.sql.optimizer.base;
 
 import com.google.common.base.Preconditions;
+<<<<<<< HEAD
 import com.starrocks.common.FeConstants;
+=======
+import com.starrocks.catalog.Column;
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalExceptOperator;
@@ -20,7 +41,17 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.logical.MockOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import jersey.repackaged.com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class LogicalProperty implements Property {
     // Operator's output columns
@@ -28,7 +59,7 @@ public class LogicalProperty implements Property {
     // The tablets num of left most scan node
     private int leftMostScanTabletsNum;
     // The flag for execute upon less than or equal one tablet
-    private boolean isExecuteInOneTablet;
+    private OneTabletProperty oneTabletProperty;
 
     public ColumnRefSet getOutputColumns() {
         return outputColumns;
@@ -38,12 +69,17 @@ public class LogicalProperty implements Property {
         this.outputColumns = outputColumns;
     }
 
+<<<<<<< HEAD
     public int getLeftMostScanTabletsNum() {
         return leftMostScanTabletsNum;
     }
 
     public boolean isExecuteInOneTablet() {
         return isExecuteInOneTablet;
+=======
+    public OneTabletProperty oneTabletProperty() {
+        return oneTabletProperty;
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
     }
 
     public void setLeftMostScanTabletsNum(int leftMostScanTabletsNum) {
@@ -60,13 +96,18 @@ public class LogicalProperty implements Property {
 
     public LogicalProperty(LogicalProperty other) {
         outputColumns = other.outputColumns.clone();
+<<<<<<< HEAD
         leftMostScanTabletsNum = other.leftMostScanTabletsNum;
         isExecuteInOneTablet = other.isExecuteInOneTablet;
+=======
+        oneTabletProperty = other.oneTabletProperty;
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
     }
 
     public void derive(ExpressionContext expressionContext) {
         LogicalOperator op = (LogicalOperator) expressionContext.getOp();
         outputColumns = op.getOutputColumns(expressionContext);
+<<<<<<< HEAD
         leftMostScanTabletsNum = op.accept(new LeftMostScanTabletsNumVisitor(), expressionContext);
         isExecuteInOneTablet = op.accept(new OneTabletExecutorVisitor(), expressionContext);
     }
@@ -119,65 +160,138 @@ public class LogicalProperty implements Property {
     }
 
     static class OneTabletExecutorVisitor extends OperatorVisitor<Boolean, ExpressionContext> {
+=======
+        oneTabletProperty = op.accept(new OneTabletExecutorVisitor(), expressionContext);
+    }
+
+    public static final class OneTabletProperty {
+        public final boolean supportOneTabletOpt;
+        public final boolean distributionIntact;
+        public final ColumnRefSet bucketColumns;
+
+        private OneTabletProperty(boolean supportOneTabletOpt, boolean distributionIntact,
+                                  ColumnRefSet bucketColumns) {
+            this.supportOneTabletOpt = supportOneTabletOpt;
+            this.distributionIntact = distributionIntact;
+            this.bucketColumns = bucketColumns;
+        }
+
+        private static OneTabletProperty supportButChangeDistribution(ColumnRefSet bucketColumns) {
+            return new OneTabletProperty(true, false, bucketColumns);
+        }
+
+        private static OneTabletProperty supportWithoutChangeDistribution(ColumnRefSet bucketColumns) {
+            return new OneTabletProperty(true, true, bucketColumns);
+        }
+
+        private static OneTabletProperty notSupport() {
+            return new OneTabletProperty(false, false, null);
+        }
+    }
+
+    static class OneTabletExecutorVisitor extends OperatorVisitor<OneTabletProperty, ExpressionContext> {
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
         @Override
-        public Boolean visitOperator(Operator node, ExpressionContext context) {
+        public OneTabletProperty visitOperator(Operator node, ExpressionContext context) {
             Preconditions.checkState(context.arity() != 0);
-            return context.isExecuteInOneTablet(0);
+            return context.oneTabletProperty(0);
         }
 
         @Override
-        public Boolean visitMockOperator(MockOperator node, ExpressionContext context) {
-            return true;
+        public OneTabletProperty visitMockOperator(MockOperator node, ExpressionContext context) {
+            return OneTabletProperty.supportWithoutChangeDistribution(new ColumnRefSet());
         }
 
         @Override
-        public Boolean visitLogicalTableScan(LogicalScanOperator node, ExpressionContext context) {
+        public OneTabletProperty visitLogicalTableScan(LogicalScanOperator node, ExpressionContext context) {
             if (node instanceof LogicalOlapScanOperator) {
-                return ((LogicalOlapScanOperator) node).getSelectedTabletId().size() <= 1;
-            } else {
-                return node instanceof LogicalMysqlScanOperator || node instanceof LogicalJDBCScanOperator;
+                if (((LogicalOlapScanOperator) node).getSelectedTabletId().size() <= 1) {
+                    Set<String> distributionColumnNames = node.getTable().getDistributionColumnNames();
+                    List<ColumnRefOperator> bucketColumns = Lists.newArrayList();
+                    for (Map.Entry<ColumnRefOperator, Column> entry : node.getColRefToColumnMetaMap().entrySet()) {
+                        if (distributionColumnNames.contains(entry.getValue().getName())) {
+                            bucketColumns.add(entry.getKey());
+                        }
+                    }
+                    return OneTabletProperty.supportWithoutChangeDistribution(new ColumnRefSet(bucketColumns));
+                }
+                return OneTabletProperty.notSupport();
+            } else if (node instanceof LogicalMysqlScanOperator || node instanceof LogicalJDBCScanOperator) {
+                return OneTabletProperty.supportWithoutChangeDistribution(new ColumnRefSet());
             }
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalValues(LogicalValuesOperator node, ExpressionContext context) {
-            return true;
+        public OneTabletProperty visitLogicalValues(LogicalValuesOperator node, ExpressionContext context) {
+            return OneTabletProperty.supportWithoutChangeDistribution(new ColumnRefSet());
         }
 
         @Override
-        public Boolean visitLogicalJoin(LogicalJoinOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalAnalytic(LogicalWindowOperator node, ExpressionContext context) {
+            OneTabletProperty isExecuteInOneTablet = context.oneTabletProperty(0);
+            if (isExecuteInOneTablet.distributionIntact) {
+                List<Integer> partitionColumnRefSet = new ArrayList<>();
+                node.getPartitionExpressions().forEach(e -> partitionColumnRefSet
+                        .addAll(Arrays.stream(e.getUsedColumns().getColumnIds()).boxed().collect(Collectors.toList())));
+                ColumnRefSet partitionColumns = ColumnRefSet.createByIds(partitionColumnRefSet);
+                if (partitionColumns.isSame(isExecuteInOneTablet.bucketColumns)) {
+                    return isExecuteInOneTablet;
+                }
+                return OneTabletProperty.supportButChangeDistribution(isExecuteInOneTablet.bucketColumns);
+            }
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalUnion(LogicalUnionOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalAggregation(LogicalAggregationOperator node,
+                                                         ExpressionContext context) {
+            OneTabletProperty isExecuteInOneTablet = context.oneTabletProperty(0);
+            if (isExecuteInOneTablet.distributionIntact) {
+                ColumnRefSet groupByColumns = new ColumnRefSet(node.getGroupingKeys());
+                if (groupByColumns.isSame(isExecuteInOneTablet.bucketColumns)) {
+                    return isExecuteInOneTablet;
+                }
+                return OneTabletProperty.supportButChangeDistribution(isExecuteInOneTablet.bucketColumns);
+            }
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalExcept(LogicalExceptOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalJoin(LogicalJoinOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalIntersect(LogicalIntersectOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalUnion(LogicalUnionOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalTableFunction(LogicalTableFunctionOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalExcept(LogicalExceptOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalCTEAnchor(LogicalCTEAnchorOperator node, ExpressionContext context) {
+        public OneTabletProperty visitLogicalIntersect(LogicalIntersectOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
+        }
+
+        @Override
+        public OneTabletProperty visitLogicalTableFunction(LogicalTableFunctionOperator node,
+                                                           ExpressionContext context) {
+            return OneTabletProperty.notSupport();
+        }
+
+        @Override
+        public OneTabletProperty visitLogicalCTEAnchor(LogicalCTEAnchorOperator node, ExpressionContext context) {
             Preconditions.checkState(context.arity() == 2);
-            return context.isExecuteInOneTablet(1);
+            return context.oneTabletProperty(1);
         }
 
         @Override
-        public Boolean visitLogicalCTEConsume(LogicalCTEConsumeOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalCTEConsume(LogicalCTEConsumeOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -1,4 +1,20 @@
+<<<<<<< HEAD
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Limited.
+=======
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
@@ -51,7 +67,17 @@ public class SplitAggregateRule extends TransformationRule {
         super(RuleType.TF_SPLIT_AGGREGATE, Pattern.create(OperatorType.LOGICAL_AGGR, OperatorType.PATTERN_LEAF));
     }
 
+<<<<<<< HEAD
     private static final SplitAggregateRule instance = new SplitAggregateRule();
+=======
+    private static final SplitAggregateRule INSTANCE = new SplitAggregateRule();
+
+    private static final int AUTO_MODE = 0;
+
+    private static final int ONE_STAGE = 1;
+
+    private static final int TWO_STAGE = 2;
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
 
     public static SplitAggregateRule getInstance() {
         return instance;
@@ -115,7 +141,11 @@ public class SplitAggregateRule extends TransformationRule {
             return false;
         }
         // 4. If scan tablet sum leas than 1, do one phase aggregate is enough
+<<<<<<< HEAD
         if (aggStage == 0 && input.getLogicalProperty().isExecuteInOneTablet()) {
+=======
+        if (aggStage == AUTO_MODE && input.getLogicalProperty().oneTabletProperty().supportOneTabletOpt) {
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
             return false;
         }
         // Default, we could generate two stage aggregate
@@ -635,6 +665,15 @@ public class SplitAggregateRule extends TransformationRule {
             Type intermediateType = getIntermediateType(aggregation);
             CallOperator callOperator;
             if (!type.isLocal()) {
+<<<<<<< HEAD
+=======
+                List<ScalarOperator> arguments =
+                        Lists.newArrayList(
+                                new ColumnRefOperator(column.getId(), aggregation.getType(), column.getName(),
+                                        aggregation.isNullable()));
+                appendConstantColumns(arguments, aggregation);
+
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
                 callOperator = new CallOperator(
                         aggregation.getFnName(),
                         aggregation.getType(),

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1,0 +1,731 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.parser.trino;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TrinoQueryTest extends TrinoTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TrinoTestBase.beforeClass();
+    }
+
+    @Test
+    public void testSelectStarClause() throws Exception {
+        String sql = "select * from t0;";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3");
+
+        sql = "select t0.* from t0";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3");
+
+        sql = "select test.t0.* from test.t0";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3");
+
+        sql = "select test.t0.* from default_catalog.test.t0";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3");
+
+        sql = "select default_catalog.test.t0.* from default_catalog.test.t0";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3");
+    }
+
+    @Test
+    public void testSelectPrefixExpression() throws Exception {
+        String sql = "select v1 from t0";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1");
+
+        sql = "select t0.v1 from t0";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1");
+
+        sql = "select test.t0.v1 from test.t0";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1");
+
+        sql = "select default_catalog.test.t0.v1 from test.t0";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1");
+    }
+
+    @Test
+    public void testSelectArithmeticExpression() throws Exception {
+        String sql = "select v1 + 1 from t0";
+        assertPlanContains(sql, "<slot 4> : 1: v1 + 1");
+
+        sql = "select v1 + 's' from t0";
+        assertPlanContains(sql, "<slot 4> : CAST(1: v1 AS DOUBLE) + CAST('s' AS DOUBLE)");
+
+        sql = "select v1 + 1.234e5 from t0";
+        assertPlanContains(sql, " <slot 4> : CAST(1: v1 AS DECIMAL128(20,0)) + 123400.0");
+
+        sql = "select v1 + 1.234 from t0";
+        assertPlanContains(sql, "<slot 4> : CAST(1: v1 AS DECIMAL128(22,0)) + 1.234");
+
+        sql = "select v1 - v2 * 10 / 5 from t0";
+        assertPlanContains(sql, "<slot 4> : CAST(1: v1 AS DOUBLE) - CAST(2: v2 * 10 AS DOUBLE) / 5.0");
+    }
+
+    @Test
+    public void testCastExpression() throws Exception {
+        String sql = "select cast(tb as varchar(10)) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(2: tb AS VARCHAR(10))");
+
+        sql = "select cast(tb as char(10)) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(2: tb AS CHAR(10))");
+
+        sql = "select cast(tb as int) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(2: tb AS INT)");
+
+        sql = "select cast(ti as datetime) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(9: ti AS DATETIME)");
+
+        sql = "select cast(th as date) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(8: th AS DATE)");
+
+        sql = "select cast(th as time) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(8: th AS TIME)");
+
+        sql = "select cast(ti as timestamp) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(9: ti AS DATETIME)");
+    }
+
+    @Test
+    public void testSelectLiteral() throws Exception {
+        String sql = "select date '1998-12-01'";
+        assertPlanContains(sql, "<slot 2> : '1998-12-01'");
+        System.out.println(getFragmentPlan(sql));
+    }
+
+    @Test
+    public void testSelectAnalytic() throws Exception {
+        String sql = "select sum(v1) over(partition by v2) from t0";
+        assertPlanContains(sql, "2:ANALYTIC\n" +
+                "  |  functions: [, sum(1: v1), ]\n" +
+                "  |  partition by: 2: v2");
+
+        sql = "select sum(v1) over(partition by v2 order by v3) from t0";
+        assertPlanContains(sql, "2:ANALYTIC\n" +
+                "  |  functions: [, sum(1: v1), ]\n" +
+                "  |  partition by: 2: v2\n" +
+                "  |  order by: 3: v3 ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql = "select lead(v1,1,0) over(partition by v2 order by v3) from t0";
+        assertPlanContains(sql, "2:ANALYTIC\n" +
+                "  |  functions: [, lead(1: v1, 1, 0), ]\n" +
+                "  |  partition by: 2: v2\n" +
+                "  |  order by: 3: v3 ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING");
+
+        sql = "select lag(v1) over(partition by v2 order by v3) from t0";
+        assertPlanContains(sql, "2:ANALYTIC\n" +
+                "  |  functions: [, lag(1: v1, 1, NULL), ]\n" +
+                "  |  partition by: 2: v2\n" +
+                "  |  order by: 3: v3 ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING");
+
+        sql =
+                "select first_value(v1) over(partition by v2 order by v3 range between unbounded preceding and unbounded " +
+                        "following) from t0";
+        assertPlanContains(sql, "2:ANALYTIC\n" +
+                "  |  functions: [, first_value(1: v1), ]\n" +
+                "  |  partition by: 2: v2\n" +
+                "  |  order by: 3: v3 ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql = "select last_value(v1) over(partition by v2 order by v3 rows 6 preceding) from t0";
+        assertPlanContains(sql, "2:ANALYTIC\n" +
+                "  |  functions: [, last_value(1: v1), ]\n" +
+                "  |  partition by: 2: v2\n" +
+                "  |  order by: 3: v3 ASC\n" +
+                "  |  window: ROWS BETWEEN 6 PRECEDING AND CURRENT ROW");
+
+        sql = "select row_number() over(partition by v2 order by v3) from t0";
+        assertPlanContains(sql, "2:ANALYTIC\n" +
+                "  |  functions: [, row_number(), ]\n" +
+                "  |  partition by: 2: v2\n" +
+                "  |  order by: 3: v3 ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql = "select rank() over(partition by v2 order by v3) from t0";
+        assertPlanContains(sql, "2:ANALYTIC\n" +
+                "  |  functions: [, rank(), ]\n" +
+                "  |  partition by: 2: v2\n" +
+                "  |  order by: 3: v3 ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql = "select dense_rank() over(partition by v2 order by v3) from t0";
+        assertPlanContains(sql, " 2:ANALYTIC\n" +
+                "  |  functions: [, dense_rank(), ]\n" +
+                "  |  partition by: 2: v2\n" +
+                "  |  order by: 3: v3 ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql =
+                "select sum(v1) over(partition by v2 order by v3 range between unbounded preceding and unbounded following) " +
+                        "from t0";
+        assertPlanContains(sql, "window: RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING");
+
+        sql = "select count(v1) over(partition by v2 order by v3 rows between unbounded preceding and unbounded following) " +
+                        "from t0";
+        assertPlanContains(sql, "window: ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING");
+
+        sql = "select min(v1) over(partition by v2 order by v3 rows current row) from t0";
+        assertPlanContains(sql, "window: ROWS BETWEEN CURRENT ROW AND CURRENT ROW");
+
+        sql = "select min(v1) over(partition by v2 order by v3 range UNBOUNDED PRECEDING) from t0";
+        assertPlanContains(sql, "window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql = "select min(v1) over(partition by v2 order by v3 rows 10 PRECEDING) from t0";
+        assertPlanContains(sql, "window: ROWS BETWEEN 10 PRECEDING AND CURRENT ROW");
+    }
+
+    @Test
+    public void testSelectArray() throws Exception {
+        String sql = "select c1[1] from test_array";
+        assertPlanContains(sql, "<slot 4> : 2: c1[1]");
+
+        sql = "select c0, sum(c2[1]) from test_array group by c0";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 1> : 1: c0\n" +
+                "  |  <slot 4> : 3: c2[1]");
+
+        sql = "select distinct c2 from test_array order by c2[1];";
+        assertPlanContains(sql, "2:Project\n" +
+                "  |  <slot 3> : 3: c2\n" +
+                "  |  <slot 4> : 3: c2[1]");
+        sql = "select array[array[1,2],array[3,4]][1][2]";
+        assertPlanContains(sql, "ARRAY<ARRAY<tinyint(4)>>[[1,2],[3,4]][1][2]");
+
+        sql = "select array[][1]";
+        assertPlanContains(sql, "ARRAY<boolean>[][1]");
+
+        sql = "select array[v1 = 1, v2 = 2, true] from t0";
+        assertPlanContains(sql, "<slot 4> : ARRAY<boolean>[1: v1 = 1,2: v2 = 2,TRUE]");
+
+        sql = "select array[v1,v2] from t0";
+        assertPlanContains(sql, "ARRAY<bigint(20)>[1: v1,2: v2]");
+
+
+        sql = "select array[NULL][1] + 1, array[1,2,3][1] + array[array[1,2,3],array[1,1,1]][2][2];";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 2> : NULL\n" +
+                "  |  <slot 3> : CAST(ARRAY<tinyint(4)>[1,2,3][1] AS SMALLINT) + CAST(ARRAY<ARRAY<tinyint(4)>>" +
+                "[[1,2,3],[1,1,1]][2][2] AS SMALLINT)");
+
+        sql = "select c0, c2[1] + array[1,2,3][1] as v, sum(c2[1]) from test_array group by c0, v order by v";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 1> : 1: c0\n" +
+                "  |  <slot 4> : CAST(7: expr AS BIGINT) + CAST(ARRAY<tinyint(4)>[1,2,3][1] AS BIGINT)\n" +
+                "  |  <slot 5> : 7: expr\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 7> : 3: c2[1]");
+    }
+
+    @Test
+    public void testSelectArrayFunction() throws Exception {
+        String sql =  "select array_distinct(c1) from test_array";
+        assertPlanContains(sql, "array_distinct(2: c1)");
+
+        sql =  "select array_intersect(c1, array['star','rocks']) from test_array";
+        assertPlanContains(sql, "array_intersect(2: c1, ARRAY<varchar>['star','rocks'])");
+
+        sql = "select array_join(c1, '_') from test_array";
+        assertPlanContains(sql, "array_join(2: c1, '_')");
+
+        sql = "select array_max(c1) from test_array";
+        assertPlanContains(sql, "array_max(2: c1)");
+
+        sql = "select array_min(c1) from test_array";
+        assertPlanContains(sql, "array_min(2: c1)");
+
+        sql = "select array_position(array[1,2,3], 2) from test_array";
+        assertPlanContains(sql, "array_position(ARRAY<tinyint(4)>[1,2,3], 2)");
+
+        sql = "select array_remove(array[1,2,3], 2) from test_array";
+        assertPlanContains(sql, "array_remove(ARRAY<tinyint(4)>[1,2,3], 2)");
+
+        sql = "select array_sort(c1) from test_array";
+        assertPlanContains(sql, "array_sort(2: c1)");
+
+        sql =  "select arrays_overlap(c1, array['star','rocks']) from test_array";
+        assertPlanContains(sql, "arrays_overlap(2: c1, ARRAY<varchar>['star','rocks'])");
+    }
+
+    @Test
+    public void testSelectStruct() throws Exception {
+        String sql = "select c0, c1.a from test_struct";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 1> : 1: c0\n" +
+                "  |  <slot 4> : 2: c1.a");
+
+        sql = "select c0, test_struct.c1.a from test_struct";
+        assertPlanContains(sql, "<slot 4> : 2: c1.a");
+
+        sql = "select c0, test.test_struct.c1.a from test_struct";
+        assertPlanContains(sql, "<slot 4> : 2: c1.a");
+
+        sql = "select c0, default_catalog.test.test_struct.c1.a from test_struct";
+        assertPlanContains(sql, "<slot 4> : 2: c1.a");
+
+        sql = "select c1.a[10].b from test_struct";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 4> : 2: c1.a[10].b");
+
+        sql = "select c2.a, c2.b from test_struct";
+        assertPlanContains(sql, "  1:Project\n" +
+                "  |  <slot 4> : 3: c2.a\n" +
+                "  |  <slot 5> : 3: c2.b");
+
+        sql = "select c2.a + c2.b from test_struct";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 4> : CAST(3: c2.a AS DOUBLE) + 3: c2.b");
+
+        sql = "select sum(c2.b) from test_struct group by c2.a";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 4> : 3: c2.a\n" +
+                "  |  <slot 5> : 3: c2.b");
+    }
+
+    @Test
+    public void testSelectRow() throws Exception {
+        String sql = "select row(1,2)";
+        assertPlanContains(sql, " <slot 2> : row(1, 2)");
+
+        sql = "select row(1.1, 2.2, 3.3)";
+        assertPlanContains(sql, "<slot 2> : row(1.1, 2.2, 3.3)");
+
+        sql = "select row(1, 'xxx', 1.23)";
+        assertPlanContains(sql, "<slot 2> : row(1, 'xxx', 1.23)");
+    }
+
+    @Test
+    public void testSelectMap() throws Exception {
+        String sql = "select c0, c1[1] from test_map";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 1> : 1: c0\n" +
+                "  |  <slot 4> : 2: c1[1]");
+
+        sql = "select c0 from test_map where c1[1] > 10";
+        assertPlanContains(sql, "PREDICATES: 2: c1[1] > 10");
+
+        sql = "select avg(c1[1]) from test_map where c1[1] is not null";
+        assertPlanContains(sql, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: avg(2: c1[1])");
+
+        sql = "select c2[2][1] from test_map";
+        assertPlanContains(sql, "<slot 4> : 3: c2[2][1]");
+    }
+
+    @Test
+    public void testSelectMapFunction() throws Exception {
+        String sql = "select map_keys(c1) from test_map";
+        assertPlanContains(sql, "<slot 4> : map_keys(2: c1)");
+
+        sql = "select map_values(c1) from test_map";
+        assertPlanContains(sql, "<slot 4> : map_values(2: c1)");
+    }
+
+    @Test
+    public void testAliasRelation() throws Exception {
+        String sql = "select * from (select 1,2,3)";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 2> : 1\n" +
+                "  |  <slot 3> : 2\n" +
+                "  |  <slot 4> : 3");
+
+        sql = "select 1 from (select 1,2)";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 4> : 1");
+
+        sql = "select v1+1 from (select v1,v2 from t0)";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 4> : 1: v1 + 1");
+
+        sql = "select a.v1+1 from (select v1, v2 from t0) a";
+        assertPlanContains(sql, "<slot 4> : 1: v1 + 1");
+
+        sql = "select v1 from (select v1 ,v4 from t0 join t1 on v2 = v5)";
+        assertPlanContains(sql, " 5:Project\n" +
+                "  |  <slot 1> : 1: v1");
+
+        sql = "select v1 from (select v1 from t0 cross join t1)";
+        assertPlanContains(sql, "5:Project\n" +
+                "  |  <slot 1> : 1: v1");
+
+        sql = "select\n" +
+                "    o_year,\n" +
+                "    sum(case\n" +
+                "            when nation = 'IRAN' then volume\n" +
+                "            else 0\n" +
+                "        end) / sum(volume) as mkt_share\n" +
+                "from\n" +
+                "    (\n" +
+                "        select\n" +
+                "            extract(year from o_orderdate) as o_year,\n" +
+                "            l_extendedprice * (1 - l_discount) as volume,\n" +
+                "            n2.n_name as nation\n" +
+                "        from\n" +
+                "            part,\n" +
+                "            supplier,\n" +
+                "            lineitem,\n" +
+                "            orders,\n" +
+                "            customer,\n" +
+                "            nation n1,\n" +
+                "            nation n2,\n" +
+                "            region\n" +
+                "        where\n" +
+                "                p_partkey = l_partkey\n" +
+                "          and s_suppkey = l_suppkey\n" +
+                "          and l_orderkey = o_orderkey\n" +
+                "          and o_custkey = c_custkey\n" +
+                "          and c_nationkey = n1.n_nationkey\n" +
+                "          and n1.n_regionkey = r_regionkey\n" +
+                "          and r_name = 'MIDDLE EAST'\n" +
+                "          and s_nationkey = n2.n_nationkey\n" +
+                "          and o_orderdate between date '1995-01-01' and date '1996-12-31'\n" +
+                "          and p_type = 'ECONOMY ANODIZED STEEL'\n" +
+                "    ) \n" +
+                "group by\n" +
+                "    o_year\n" +
+                "order by\n" +
+                "    o_year ";
+        assertPlanContains(sql, "  41:Project\n" +
+                "  |  <slot 69> : 69: year\n" +
+                "  |  <slot 74> : 72: sum / 73: sum");
+    }
+
+    @Test
+    public void testSelectSetOperation() throws Exception {
+        String sql = "select * from t0 union select * from t1 union select * from t0";
+        assertPlanContains(sql, "7:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: 10: v1, 11: v2, 12: v3\n" +
+                "  |  \n" +
+                "  0:UNION");
+
+        sql = "select * from t0 intersect select * from t1 intersect select * from t0";
+        assertPlanContains(sql, "0:INTERSECT");
+
+        sql = "select v1 from t0 except select v4 from t1 except select v2 from t0";
+        assertPlanContains(sql, "0:EXCEPT");
+
+        sql = "select v1 from t0 union all select v4 from t1 union select v2 from t0 limit 10";
+        assertPlanContains(sql, "0:UNION", "11:AGGREGATE (merge finalize)\n" +
+                "  |  group by: 11: v1\n" +
+                "  |  limit: 10");
+
+        sql = "select * from (select * from t0 union all select * from t1 union all select * from t0) tt;";
+        assertPlanContains(sql, "0:UNION");
+
+        sql = "select * from (select v1 from t0 union all select v4 from t1 union all select v3 from t0) tt order by v1 " +
+                "limit 2;";
+        assertPlanContains(sql, "0:UNION", "7:TOP-N\n" +
+                "  |  order by: <slot 10> 10: v1 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  limit: 2");
+
+        sql = "select * from (select v1 from t0 intersect select v4 from t1 intersect select v3 from t0 limit 10) tt " +
+                "order by v1 limit 2;";
+        assertPlanContains(sql, "0:INTERSECT\n" +
+                "  |  limit: 10",
+                "8:TOP-N\n" +
+                        "  |  order by: <slot 10> 10: v1 ASC\n" +
+                        "  |  offset: 0\n" +
+                        "  |  limit: 2");
+    }
+
+    @Test
+    public void testSelectGroupBy() throws Exception {
+        String sql = "select v1, count(v2) from t0 group by v1";
+        assertPlanContains(sql, "output: count(2: v2)\n" +
+                "  |  group by: 1: v1");
+
+        sql = "select v1 % 5 as k1, count(v2) from t0 group by k1";
+        assertPlanContains(sql, " 2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(2: v2)\n" +
+                "  |  group by: 4: expr\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 4> : 1: v1 % 5");
+
+        sql = "select v1, v2, sum(v3) from t0 group by v1,v2";
+        assertPlanContains(sql, "output: sum(3: v3)\n" +
+                "  |  group by: 1: v1, 2: v2");
+
+        sql = "select v1+1, sum(v2) from t0 group by v1+1";
+        assertPlanContains(sql, "group by: 4: expr");
+
+        sql = "select v1+1, sum(v2) from t0 group by v1";
+        assertPlanContains(sql, "group by: 1: v1");
+
+        sql = "select v1+1, v1, sum(v2) from t0 group by v1";
+        assertPlanContains(sql, "2:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 4> : 4: sum\n" +
+                "  |  <slot 5> : 1: v1 + 1");
+
+        sql = "select v1, v2, sum(v3) from t0 group by rollup(v1,v2)";
+        assertPlanContains(sql, "group by: 1: v1, 2: v2, 5: GROUPING_ID");
+
+        sql = "select v1, v2, sum(v3) from t0 group by CUBE(v1,v2)";
+        assertPlanContains(sql, "group by: 1: v1, 2: v2, 5: GROUPING_ID");
+
+        sql = "select v1, v2, sum(v3) from t0 group by GROUPING SETS ((v1, v2),(v1),(v2),())";
+        assertPlanContains(sql, "group by: 1: v1, 2: v2, 5: GROUPING_ID");
+    }
+
+    @Test
+    public void testSelectCTE() throws Exception {
+        String sql = "with c1(a,b,c) as (select * from t0) select c1.* from c1";
+        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
+
+        sql = "with c1(a,b,c) as (select * from t0) select t.* from c1 t";
+        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
+
+        sql = "with c1 as (select * from t0) select c1.* from c1";
+        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
+
+        sql = "with c1 as (select * from t0) select a.* from c1 a";
+        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
+
+        sql = "with c1(a,b,c) as (select * from t0), c2 as (select * from t1) select c2.*,t.* from c1 t,c2";
+        assertPlanContains(sql, "3:NESTLOOP JOIN");
+
+        sql = "with tbl1 as (select v1, v2 from t0), tbl2 as (select v4, v5 from t1) select tbl1.*, tbl2.* from " +
+                "tbl1 join tbl2 on tbl1.v1 = tbl2.v4";
+        assertPlanContains(sql, "4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 7: v1 = 10: v4");
+
+        sql = "with cte1 as ( with cte1 as (select * from t0) select * from cte1) select * from cte1";
+        assertPlanContains(sql, "10: v1 | 11: v2 | 12: v3");
+
+        sql = "with cte1 as (select * from test.t0), cte2 as (select * from cte1) select * from cte1";
+        assertPlanContains(sql, "7: v1 | 8: v2 | 9: v3");
+
+        sql = "with cte1(c1,c2) as (select v1,v2 from test.t0) select c1,c2 from cte1";
+        assertPlanContains(sql, "4: v1 | 5: v2");
+
+        sql = "with x0 as (select * from t0), x1 as (select * from t1) " +
+                "select * from (select * from x0 union all select * from x1 union all select * from x0) tt;";
+        assertPlanContains(sql, "0:UNION");
+
+        sql = "with x0 as (select * from t0), x1 as (select * from x0) " +
+                "select * from (select * from x0 union all select * from x1 union all select * from x0) tt;";
+        assertPlanContains(sql, "0:UNION");
+
+        sql = "with x0 as (select * from t0) " +
+                "select * from (with x1 as (select * from t1) select * from x1 join x0 on x1.v4 = x0.v1) tt";
+        assertPlanContains(sql, "4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 7: v4 = 10: v1");
+
+        sql = "with x0 as (select * from t0) " +
+                "select * from x0 x,t1 y where v1 in (select v2 from x0 z where z.v1 = x.v1)";
+        assertPlanContains(sql, "8:NESTLOOP JOIN", "LEFT SEMI JOIN (PARTITIONED)");
+    }
+
+    @Test
+    public void testBinaryPredicate() throws Exception {
+        String sql = "select v1 from t0 where v2 = 1";
+        assertPlanContains(sql, "2: v2 = 1");
+
+        sql = "select v1 from t0 where v2 = v1";
+        assertPlanContains(sql, "2: v2 = 1: v1");
+
+        sql = "select v1 from t0 where v1 = 2 and v2 =1";
+        assertPlanContains(sql, "1: v1 = 2, 2: v2 = 1");
+    }
+
+    @Test
+    public void testLikePredicate() throws Exception {
+        String sql = "select * from part where  p_type like \'%COPPER\'";
+        assertPlanContains(sql, "P_TYPE LIKE '%COPPER'");
+
+        sql = "select * from part where  p_type not like \'%COPPER\'";
+        assertPlanContains(sql, "NOT (5: P_TYPE LIKE '%COPPER')");
+    }
+
+    @Test
+    public void testBetweenPredicate() throws Exception {
+        String sql = "select l_extendedprice*l_discount as revenue from lineitem where l_discount between 0.02 and 0.04";
+        assertPlanContains(sql, "7: L_DISCOUNT >= 0.02, 7: L_DISCOUNT <= 0.04");
+
+        sql = "select l_extendedprice*l_discount as revenue from lineitem where l_discount not between 0.02 and 0.04";
+        assertPlanContains(sql, "(7: L_DISCOUNT < 0.02) OR (7: L_DISCOUNT > 0.04)");
+    }
+
+    @Test
+    public void testAggFunction() throws Exception {
+        String sql = "select count(v1) from t0";
+        assertPlanContains(sql, "output: count(1: v1)");
+
+        sql = "select count(*) from t0";
+        assertPlanContains(sql, "output: count(*)");
+
+        sql = "select count(1) from t0";
+        assertPlanContains(sql, "output: count(1)");
+
+        sql = "select count(distinct v1) from t0";
+        assertPlanContains(sql, "output: multi_distinct_count(1: v1)");
+    }
+
+    @Test
+    public void testCaseWhen() throws Exception {
+        String sql = "select v1, sum(case when v2 =1 then 1 else 0 end) from t0 group by v1";
+        assertPlanContains(sql, "<slot 4> : if(2: v2 = 1, 1, 0)");
+
+        sql = "select v1, sum(case v2 when 1 then 1 else 0 end) from t0 group by v1";
+        assertPlanContains(sql, "<slot 4> : if(2: v2 = 1, 1, 0)");
+
+        sql = "select sum(case when 1=1 then v2 else NULL end) from t0";
+        assertPlanContains(sql, "output: sum(2: v2)");
+
+        sql = "select sum(case v1 when false then v2 when v2 then 1 else NULL end) from t0";
+        assertPlanContains(sql, "output: sum(CASE 1: v1 WHEN 0 THEN 2: v2 WHEN 2: v2 THEN 1 ELSE NULL END)");
+
+        sql = "select count(case when v1 then 1 end) from t0";
+        assertPlanContains(sql, "<slot 1> : 1: v1", "output: count(if(CAST(1: v1 AS BOOLEAN), 1, NULL))");
+    }
+
+
+    @Test
+    public void testLimit() throws Exception {
+        String sql = "select * from t0 limit 10";
+        assertPlanContains(sql, "limit: 10");
+
+        sql = "select v1 from t0 order by v1 limit 20";
+        assertPlanContains(sql, "limit: 20");
+    }
+
+    @Test
+    public void testHaving() throws Exception {
+        String sql = "select sum(v1) from t0 having sum(v1) > 0";
+        assertPlanContains(sql, "having: 4: sum > 0");
+
+        sql = "select v2,sum(v1) from t0 group by v2 having v2 > 0";
+        assertPlanContains(sql, "PREDICATES: 2: v2 > 0");
+
+        sql = "select sum(v1) from t0 having avg(v1) - avg(v2) > 10";
+        assertPlanContains(sql, "5: avg - 6: avg > 10.0");
+    }
+
+    @Test
+    public void testSort() throws Exception {
+        String sql = "select v1 from t0 order by v1";
+        assertPlanContains(sql, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select v1 from t0 order by v1 asc ,v2 desc";
+        assertPlanContains(sql, "order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 DESC");
+
+        sql = "select v1 as v from t0 order by v+1";
+        assertPlanContains(sql, "order by: <slot 4> 4: expr ASC");
+
+        sql = "select v1+1 as v from t0 order by v";
+        assertPlanContains(sql, "order by: <slot 4> 4: expr ASC");
+
+        sql = "select v1, sum(v2) as v from t0 group by v1 order by sum(v2)";
+        assertPlanContains(sql, "order by: <slot 4> 4: sum ASC");
+
+        sql = "select v1+1 as v from t0 group by v1+1 order by v";
+        assertPlanContains(sql, "order by: <slot 4> 4: expr ASC");
+    }
+
+    @Test
+    public void testJoin() throws Exception {
+        String sql = "select v1, v2 from t0,t1";
+        assertPlanContains(sql, "join op: CROSS JOIN");
+
+        sql = "select v1, v2 from t0 inner join t1 on t0.v1 = t1.v4";
+        assertPlanContains(sql, "equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select a.v1 from (select v1, v2, v5, v4 from t0 inner join t1 on t0.v1 = t1.v4) a";
+        assertPlanContains(sql, "equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select * from t0 a join t1 b on a.v1=b.v4";
+        assertPlanContains(sql, "equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select * from t0 a join (select * from t1) b on a.v1=b.v4";
+        assertPlanContains(sql, "equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select v1 from t0 left join t1 on v1 = v4";
+        assertPlanContains(sql, "equal join conjunct: 1: v1 = 4: v4", "join op: LEFT OUTER JOIN (PARTITIONED)");
+
+        sql = "select v1 from t0 right join t1 on v1 = v4";
+        assertPlanContains(sql, "join op: RIGHT OUTER JOIN (PARTITIONED)", "equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select v1 from t0 full join t1 on v1 = v4";
+        assertPlanContains(sql, "join op: FULL OUTER JOIN (PARTITIONED)", "equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "SELECT * FROM t0,t1 INNER JOIN t2 on t1.v4 = t2.v7";
+        assertPlanContains(sql, " join op: INNER JOIN (PARTITIONED)", "join op: CROSS JOIN");
+
+        sql = "select * from t0 inner join t1 on t0.v1 = t1.v4 inner join t2 on t0.v2 = t2.v7";
+        assertPlanContains(sql, "equal join conjunct: 2: v2 = 7: v7", "equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select * from t0 a join t0 b using(v1)";
+        assertPlanContains(sql, "equal join conjunct: 1: v1 = 4: v1");
+
+        sql = "select * from t0 x,t0 y inner join t0 z using(v1)";
+        assertPlanContains(sql, "join op: CROSS JOIN", "equal join conjunct: 4: v1 = 7: v1");
+
+        sql = "select * from (t0 a join t0 b using(v1)) , t1";
+        assertPlanContains(sql, "equal join conjunct: 1: v1 = 4: v1");
+    }
+
+    @Test
+    public void testExplain() throws Exception {
+        String sql = "explain (TYPE logical) select v1, v2 from t0,t1";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(getExplain(sql),
+                "SCAN [t1] => [8:auto_fill_col]\n" +
+                "                    Estimates: {row: 1, cpu: 2.00, memory: 0.00, network: 0.00, cost: 1.00}\n" +
+                "                    partitionRatio: 0/1, tabletRatio: 0/0\n" +
+                "                    8:auto_fill_col := 1"));
+
+        sql = "explain select v1, v2 from t0,t1";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(getExplain(sql),
+                "2:Project\n" +
+                        "  |  <slot 8> : 1\n" +
+                        "  |  \n" +
+                        "  1:OlapScanNode\n" +
+                        "     TABLE: t1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=0/1"));
+
+        sql = "explain (Type DISTRIBUTED)select v1, v2 from t0,t1";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(getExplain(sql),
+                "5:Project\n" +
+                        "  |  output columns:\n" +
+                        "  |  1 <-> [1: v1, BIGINT, true]\n" +
+                        "  |  2 <-> [2: v2, BIGINT, true]\n" +
+                        "  |  cardinality: 1\n" +
+                        "  |  \n" +
+                        "  4:NESTLOOP JOIN"));
+
+        sql = "explain (Type io)select v1, v2 from t0,t1";
+        Assert.assertTrue(StringUtils.containsIgnoreCase(getExplain(sql),
+                "5:Project\n" +
+                        "  |  output columns:\n" +
+                        "  |  1 <-> [1: v1, BIGINT, true]\n" +
+                        "  |  2 <-> [2: v2, BIGINT, true]\n" +
+                        "  |  cardinality: 1\n" +
+                        "  |  column statistics: \n" +
+                        "  |  * v1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                        "  |  * v2-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.sql.optimizer.rule;
 
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.Memo;
@@ -20,9 +21,13 @@ public class BinderTest {
 
     @Test
     public void testBinder() {
+        OlapTable table1 = new OlapTable();
+        table1.setDefaultDistributionInfo(new HashDistributionInfo());
+        OlapTable table2 = new OlapTable();
+        table2.setDefaultDistributionInfo(new HashDistributionInfo());
         OptExpression expr = OptExpression.create(new LogicalJoinOperator(),
-                new OptExpression(new LogicalOlapScanOperator(new OlapTable())),
-                new OptExpression(new LogicalOlapScanOperator(new OlapTable())));
+                new OptExpression(new LogicalOlapScanOperator(table1)),
+                new OptExpression(new LogicalOlapScanOperator(table2)));
 
         Pattern pattern = Pattern.create(OperatorType.LOGICAL_JOIN)
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF))

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -593,7 +593,7 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select SUM(v2) from (select v2, sum(v1) as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
@@ -601,7 +601,7 @@ public class AggregateTest extends PlanTestBase {
                 "  |  group by: 2: v2\n");
         sql = "select SUM(v2) from (select v2, sum(distinct v2) as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
@@ -636,7 +636,7 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select SUM(x1) from (select v2 as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
@@ -1625,7 +1625,471 @@ public class AggregateTest extends PlanTestBase {
             public int getAvgNumOfHardwareCoresOfBe() {
                 return numCores;
             }
+<<<<<<< HEAD
         };
+=======
+        }
+        connectContext.getSessionVariable().setEnableSortAggregate(false);
+    }
+
+    @Test
+    public void testMergeAggPruneColumnPruneWindow() throws Exception {
+        String sql = "select v2 " +
+                "from ( " +
+                "   select v2, x3 " +
+                "   from (select v2, sum(v1) over (partition by v3) as x3 from t0) as tt0 " +
+                "   group by v2, x3 " +
+                ") ttt0 " +
+                "group by v2";
+        String plan = getFragmentPlan(sql);
+        Assert.assertFalse(plan.contains("ANALYTIC"));
+        Assert.assertEquals(1, StringUtils.countMatches(plan, ":AGGREGATE"));
+    }
+
+    @Test
+    public void testExtractProject() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSumByAssociativeRule(false);
+        String sql;
+        String plan;
+
+        sql = "select sum(t1c + 1) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(CAST(3: t1c AS BIGINT) + 1)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : 3: t1c\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+
+        sql = "select sum(t1c), sum(t1c + 1) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(3: t1c), sum(CAST(3: t1c AS BIGINT) + 1)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : 3: t1c");
+
+        sql = "select sum(t1c + 1), sum(t1c + 2) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(15: cast + 1), sum(15: cast + 2)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 15> : 15: cast\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 15> : CAST(3: t1c AS BIGINT)");
+
+        sql = "select sum(t1c), sum(t1c + 1), sum(t1c + 2) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(3: t1c), sum(16: cast + 1), sum(16: cast + 2)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : 3: t1c\n" +
+                "  |  <slot 16> : 16: cast\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 16> : CAST(3: t1c AS BIGINT)");
+
+        sql = "select sum(t1c + 1), sum(t1c + 1 + 2), sum(t1d + 1 + 3) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(11: expr), sum(18: add + 2), sum(4: t1d + 1 + 3)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 4> : 4: t1d\n" +
+                "  |  <slot 11> : 18: add\n" +
+                "  |  <slot 18> : 18: add\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 17> : CAST(3: t1c AS BIGINT)\n" +
+                "  |  <slot 18> : 17: cast + 1");
+        connectContext.getSessionVariable().setEnableRewriteSumByAssociativeRule(true);
+
+        connectContext.getSessionVariable().setNewPlanerAggStage(3);
+        sql = "select count(distinct t1c, upper(id_datetime)) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  5:AGGREGATE (update serialize)\n" +
+                "  |  output: count(if(3: t1c IS NULL, NULL, 11: upper))\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  4:AGGREGATE (merge serialize)\n" +
+                "  |  group by: 3: t1c, 11: upper");
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+
+    }
+
+    @Test
+    public void testSimpleMinMaxAggRewrite() throws Exception {
+        // normal case
+        String sql = "select min(t1b),max(t1b),min(id_datetime) from test_all_type_not_null";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                "  |  output: min(min_t1b), max(max_t1b), min(min_id_datetime)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  0:MetaScan\n" +
+                "     Table: test_all_type_not_null\n" +
+                "     <id 16> : min_id_datetime\n" +
+                "     <id 14> : min_t1b\n" +
+                "     <id 15> : max_t1b");
+
+        // The following cases will not use MetaScan because some conditions are not met
+        // with group by key
+        sql = "select t1b,max(id_datetime) from test_all_type_not_null group by t1b";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: max(8: id_datetime)\n" +
+                "  |  group by: 2: t1b\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: test_all_type_not_null");
+        // with expr in agg function
+        sql = "select min(t1b+1),max(t1b) from test_all_type_not_null";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: min(CAST(2: t1b AS INT) + 1), max(2: t1b)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+        // with unsupported type in agg function
+        sql = "select min(t1b),max(t1a) from test_all_type_not_null";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: min(2: t1b), max(1: t1a)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+        // with filter
+        sql = "select min(t1b) from test_all_type_not_null where t1c > 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: min(2: t1b)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+
+        sql = "select min(t1b) from test_all_type_not_null having abs(1) = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: min(2: t1b)\n" +
+                "  |  group by: \n" +
+                "  |  having: abs(1) = 2\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+        // with nullable column
+        sql = "select min(t1b) from test_all_type";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: min(2: t1b)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+    }
+
+    @Test
+    public void testGroupByLiteral() throws Exception {
+        String sql = "select -9223372036854775808 group by TRUE;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 3> : -9223372036854775808");
+    }
+
+    @Test
+    public void testRewriteSumByAssociativeRule() throws Exception {
+        // 1. different types
+        // 1.1 nullable
+        String sql = "select sum(t1b+1),sum(t1c+1),sum(t1d+1),sum(t1e+1),sum(t1f+1),sum(t1g+1),sum(id_decimal+1)" +
+                " from test_all_type";
+        String plan = getVerboseExplain(sql);
+        // for each sum(col + 1), should rewrite to sum(col) + count(col) * 1
+        assertContains(plan, "  3:Project\n" +
+                "  |  output columns:\n" +
+                "  |  18 <-> [26: sum, BIGINT, true] + [27: count, BIGINT, true] * 1\n" +
+                "  |  19 <-> [29: sum, BIGINT, true] + [30: count, BIGINT, true] * 1\n" +
+                "  |  20 <-> [32: sum, BIGINT, true] + [33: count, BIGINT, true] * 1\n" +
+                "  |  21 <-> [35: sum, DOUBLE, true] + cast([36: count, BIGINT, true] as DOUBLE) * 1.0\n" +
+                "  |  22 <-> [38: sum, DOUBLE, true] + cast([39: count, BIGINT, true] as DOUBLE) * 1.0\n" +
+                "  |  23 <-> [41: sum, BIGINT, true] + [42: count, BIGINT, true] * 1\n" +
+                "  |  24 <-> [44: sum, DECIMAL128(38,2), true] + cast([45: count, BIGINT, true] as DECIMAL128(18,0)) * 1");
+        // 1.2 not null
+        sql = "select sum(t1b+1),sum(t1c+1),sum(t1d+1),sum(t1e+1),sum(t1f+1),sum(t1g+1),sum(id_decimal+1)" +
+                " from test_all_type_not_null";
+        plan = getVerboseExplain(sql);
+        // for each sum(col + 1), should rewrite to sum(col) + count() * 1,
+        // so count() will be a common expression
+        assertContains(plan, "  3:Project\n" +
+                "  |  output columns:\n" +
+                "  |  18 <-> [26: sum, BIGINT, true] + [46: multiply, BIGINT, true]\n" +
+                "  |  19 <-> [29: sum, BIGINT, true] + [46: multiply, BIGINT, true]\n" +
+                "  |  20 <-> [32: sum, BIGINT, true] + [46: multiply, BIGINT, true]\n" +
+                "  |  21 <-> [35: sum, DOUBLE, true] + cast([36: count, BIGINT, true] as DOUBLE) * 1.0\n" +
+                "  |  22 <-> [38: sum, DOUBLE, true] + cast([33: count, BIGINT, true] as DOUBLE) * 1.0\n" +
+                "  |  23 <-> [41: sum, BIGINT, true] + [46: multiply, BIGINT, true]\n" +
+                "  |  24 <-> [44: sum, DECIMAL128(38,2), true] + cast([33: count, BIGINT, true] as DECIMAL128(18,0)) * 1\n" +
+                "  |  common expressions:\n" +
+                "  |  46 <-> [33: count, BIGINT, true] * 1");
+
+        // 2. aggregate result reuse
+        sql = "select sum(t1b), sum(t1b+1), sum(t1b+2) from test_all_type";
+        // if a column appears multiple times in different sum functions,
+        // we can reuse the results of sum and count
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  output columns:\n" +
+                "  |  13 <-> [18: sum, BIGINT, true]\n" +
+                "  |  14 <-> [18: sum, BIGINT, true] + [17: count, BIGINT, true] * 1\n" +
+                "  |  15 <-> [18: sum, BIGINT, true] + [17: count, BIGINT, true] * 2");
+
+        sql = "select sum(id_decimal), sum(id_decimal+1.0), sum(id_decimal+1.00), sum(id_decimal+1.000), " +
+                "sum(id_decimal+1.000000000000000000) from test_all_type";
+        plan = getVerboseExplain(sql);
+        // for decimal sum with different scales,
+        // the original ADD operator need to cast id_decimal to decimal128 with different scales,
+        // e.g.
+        // sum(id_decimal+1.0) -> sum(add(cast(cast(id_decimal as decimal128(28,9) as decimal128(37,9)))), 1.0)
+        // sum(id_decimal+1.00) -> sum(add(cast(cast(id_decimal as decimal128(28,9) as decimal128(36,9)))), 1.00)
+        // after applying RewriteSumByAssociativeRule, we can remove all unnecessary cast
+        // and reuse the result of sum(id_decimal) and count() multiple times.
+        assertContains(plan, "  2:Project\n" +
+                "  |  output columns:\n" +
+                "  |  15 <-> [20: sum, DECIMAL128(38,2), true]\n" +
+                "  |  16 <-> [20: sum, DECIMAL128(38,2), true] + [28: cast, DECIMAL128(18,0), true] * 1.0\n" +
+                "  |  17 <-> [20: sum, DECIMAL128(38,2), true] + [28: cast, DECIMAL128(18,0), true] * 1.00\n" +
+                "  |  18 <-> [20: sum, DECIMAL128(38,2), true] + [28: cast, DECIMAL128(18,0), true] * 1.000\n" +
+                "  |  19 <-> [20: sum, DECIMAL128(38,2), true] + [28: cast, DECIMAL128(18,0), true] * 1.000000000000000000\n" +
+                "  |  common expressions:\n" +
+                "  |  28 <-> cast([21: count, BIGINT, true] as DECIMAL128(18,0))");
+
+        // 3. mix sum and other agg functions
+        sql = "select avg(t1b), max(t1b), sum(t1b), sum(t1b+1) from test_all_type";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  output columns:\n" +
+                "  |  12 <-> [12: avg, DOUBLE, true]\n" +
+                "  |  13 <-> [13: max, SMALLINT, true]\n" +
+                "  |  14 <-> [14: sum, BIGINT, true]\n" +
+                "  |  15 <-> [14: sum, BIGINT, true] + [17: count, BIGINT, true] * 1");
+
+        // 4. with group by key
+        // if the number of agg function can be reduced after applying this rule, do it
+        sql = "select t1c, sum(t1b),sum(t1b+1),sum(t1b+2) from test_all_type group by t1c";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  output columns:\n" +
+                "  |  3 <-> [3: t1c, INT, true]\n" +
+                "  |  13 <-> [18: sum, BIGINT, true]\n" +
+                "  |  14 <-> [18: sum, BIGINT, true] + [17: count, BIGINT, true] * 1\n" +
+                "  |  15 <-> [18: sum, BIGINT, true] + [17: count, BIGINT, true] * 2");
+        assertContains(plan, "  |  group by: [3: t1c, INT, true]");
+        // if the number of agg function cannot be reduced after applying this rule, skip it
+        sql = "select t1c, sum(t1b+1),avg(t1b) from test_all_type group by t1c";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  2 <-> [2: t1b, SMALLINT, true]\n" +
+                "  |  3 <-> [3: t1c, INT, true]\n" +
+                "  |  11 <-> cast([2: t1b, SMALLINT, true] as INT) + 1");
+
+        // 4.2 with group by key and having
+        sql = "select t1c, sum(t1b)+2,sum(t1b+1),sum(t1b+2)+1 from test_all_type group by t1c having sum(t1b+1) > 10";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  output columns:\n" +
+                "  |  3 <-> [3: t1c, INT, true]\n" +
+                "  |  14 <-> [18: sum, BIGINT, true] + [19: count, BIGINT, true] * 1\n" +
+                "  |  16 <-> [18: sum, BIGINT, true] + 2\n" +
+                "  |  17 <-> [18: sum, BIGINT, true] + [19: count, BIGINT, true] * 2 + 1");
+        assertContains(plan, "  |  group by: [3: t1c, INT, true]\n" +
+                "  |  having: [18: sum, BIGINT, true] + [19: count, BIGINT, true] * 1 > 10");
+    }
+
+    @Test
+    public void testPruneGroupByKeysRule() throws Exception {
+        String sql = "select t1b,t1b+1,count(*) from test_all_type group by 1,2";
+        String plan = getFragmentPlan(sql);
+        // t1b+1 will be pruned
+        assertContains(plan, "  2:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  <slot 11> : CAST(2: t1b AS INT) + 1\n" +
+                "  |  <slot 12> : 12: count\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(*)\n" +
+                "  |  group by: 2: t1b");
+
+        sql = "select t1b,t1b+1,count(*) from test_all_type group by 2,1";
+        plan = getFragmentPlan(sql);
+        // both keys will be reserved because expr occurs in the first place
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(*)\n" +
+                "  |  group by: 11: expr, 2: t1b\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  <slot 11> : CAST(2: t1b AS INT) + 1");
+
+        // only the keys after original column will be pruned
+        sql = "select t1b+1,t1b,t1b+2,count(*) from test_all_type group by 1,2,3";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  <slot 11> : 11: expr\n" +
+                "  |  <slot 12> : CAST(2: t1b AS INT) + 2\n" +
+                "  |  <slot 13> : 13: count\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(*)\n" +
+                "  |  group by: 11: expr, 2: t1b\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  <slot 11> : CAST(2: t1b AS INT) + 1");
+
+        sql = "select t1b,t1c,t1b+1,t1c+1,count(*) from test_all_type group by 1,2,3,4";
+        plan = getFragmentPlan(sql);
+        // t1b+1, t1c+1 will be pruned
+        assertContains(plan, "  2:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  <slot 3> : 3: t1c\n" +
+                "  |  <slot 11> : CAST(2: t1b AS INT) + 1\n" +
+                "  |  <slot 12> : CAST(3: t1c AS BIGINT) + 1\n" +
+                "  |  <slot 13> : 13: count\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(*)\n" +
+                "  |  group by: 2: t1b, 3: t1c");
+        // the first group by key is not simple column ref, can't be pruned
+        sql = "select 1 from test_all_type group by t1b+rand(), t1b+rand()+1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:Project\n" +
+                "  |  <slot 13> : 1\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  group by: 11: expr, 12: expr\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 11> : 14: cast + rand()\n" +
+                "  |  <slot 12> : 14: cast + rand() + 1.0\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 14> : CAST(2: t1b AS DOUBLE)");
+        sql =
+                "select cast(id_decimal as decimal(38,2)),cast(id_decimal as decimal(37,2)) from test_all_type group by 1, 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  group by: 11: cast, 12: cast\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 11> : CAST(10: id_decimal AS DECIMAL128(38,2))\n" +
+                "  |  <slot 12> : CAST(10: id_decimal AS DECIMAL128(37,2))");
+        // complex projections, aggregations and group by keys
+        sql = "select v4,abs(v4),cast(v5 as largeint),max(v4+v5+v6) from t1 group by v4,abs(v4),cast(v5 as largeint);";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:Project\n" +
+                "  |  <slot 1> : 1: v4\n" +
+                "  |  <slot 4> : abs(1: v4)\n" +
+                "  |  <slot 5> : 5: cast\n" +
+                "  |  <slot 7> : 7: max\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: max(6: expr)\n" +
+                "  |  group by: 1: v4, 5: cast\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 1> : 1: v4\n" +
+                "  |  <slot 5> : CAST(2: v5 AS LARGEINT)\n" +
+                "  |  <slot 6> : 1: v4 + 2: v5 + 3: v6");
+        // if all group by keys are constant and the query has aggregations
+        // we should reserve one key to ensure the correct result
+        sql = "select 'a',count(t1b) from test_all_type where t1c>10 group by 'c'";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(2: t1b)\n" +
+                "  |  group by: 11: expr\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  <slot 11> : 'c'");
+        sql = "select 'a','b',count(t1b) from test_all_type where t1c>10 group by 'c','d'";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(2: t1b)\n" +
+                "  |  group by: 11: expr\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: t1b\n" +
+                "  |  <slot 11> : 'c'");
+        // if all group by keys and projections are constant, we can remove the agg node and add a limit operator.
+        sql = "select 'a','b' from test_all_type group by 'c','d'";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 13> : 'a'\n" +
+                "  |  <slot 14> : 'b'");
+        assertContains(plan, "  2:EXCHANGE\n" +
+                "     limit: 1");
+    }
+
+    @Test
+    public void testPruneGroupByKeysRule2() throws Exception {
+        String sql = "select 1 from test_all_type group by NULL " +
+                "having (NOT (((DROUND(0.09733420538671422) ) IS NOT NULL)))";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "3:Project\n" +
+                "  |  <slot 12> : 1\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  group by: 11: expr\n" +
+                "  |  having: dround(0.09733420538671422) IS NULL\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 11> : NULL");
+    }
+
+    @Test
+    public void testPruneGroupByKeysRule3() throws Exception {
+        String sql = "select count(*), sum(t1b) from test_all_type group by NULL " +
+                "having (NOT (((DROUND(0.09733420538671422) ) IS NOT NULL)))";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "3:Project\n" +
+                "  |  <slot 12> : 12: count\n" +
+                "  |  <slot 13> : 13: sum\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(*), sum(2: t1b)\n" +
+                "  |  group by: 11: expr\n" +
+                "  |  having: dround(0.09733420538671422) IS NULL");
+    }
+
+    @Test
+    public void testDistinctRewrite() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "select count(distinct t1a), sum(t1c) from test_all_type group by t1b";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "sum[([13: sum, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true;");
+
+        sql = "select multi_distinct_count(t1a), max(t1c) from test_all_type group by t1b, t1c";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "max[([13: max, INT, true]); args: INT;");
+
+        sql = "select sum(distinct v1), hll_union(hll_hash(v3)) from test_object group by v2";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "hll_union[([16: hll_union, HLL, true]); args: HLL; result: HLL; args nullable: true;");
+
+        sql = "select count(distinct v1), BITMAP_UNION(b1) from test_object group by v2, v3";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "bitmap_union[([15: bitmap_union, BITMAP, true]); args: BITMAP; result: BITMAP; " +
+                "args nullable: true;");
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
 
         new MockUp<DistributionSpec.PropertyInfo>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
@@ -270,13 +270,20 @@ public class GroupingSetTest extends PlanTestBase {
                 "    ) tev,unnest(x2) \n" +
                 ") tev group by GROUPING SETS((u2, r1)) ";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "6:Project\n" +
+        assertContains(plan, "8:Project\n" +
                 "  |  <slot 10> : 10: unnest\n" +
                 "  |  <slot 11> : datediff(CAST(split(9: array_join, ',')[2] AS DATETIME), CAST(10: unnest AS DATETIME))\n" +
                 "  |  \n" +
+<<<<<<< HEAD
                 "  5:TableValueFunction\n" +
+=======
+                "  7:TableValueFunction\n" +
+                "  |  tableFunctionName: unnest\n" +
+                "  |  columns: [unnest]\n" +
+                "  |  returnTypes: [BIGINT]\n" +
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
                 "  |  \n" +
-                "  4:Project\n" +
+                "  6:Project\n" +
                 "  |  <slot 6> : 6: array_agg\n" +
                 "  |  <slot 9> : array_join(7: array_agg, ',')");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -100,4 +100,416 @@ public class OrderByTest extends PlanTestBase {
         connectContext.getSessionVariable().setSqlSelectLimit(SessionVariable.DEFAULT_SELECT_LIMIT);
     }
 
+<<<<<<< HEAD
 }
+=======
+    @Test
+    public void testOrderByWithSubquery() throws Exception {
+        String sql = "select t0.*, " +
+                "(select sum(v5) from t1) as x1, " +
+                "(select sum(v7) from t2) as x2 from t0 order by t0.v3";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  15:SORT\n" +
+                "  |  order by: <slot 3> 3: v3 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  14:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 8> : 8: sum\n" +
+                "  |  <slot 13> : 12: sum\n" +
+                "  |  \n" +
+                "  13:NESTLOOP JOIN");
+    }
+
+    @Test
+    public void tstOrderByNullLiteral() throws Exception {
+        String sql;
+        String plan;
+
+        sql = "select * from t0 order by null limit 10;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  0:OlapScanNode\n" +
+                "     TABLE: t0\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=0/1\n" +
+                "     rollup: t0\n" +
+                "     tabletRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     cardinality=1\n" +
+                "     avgRowSize=3.0\n" +
+                "     numNodes=0\n" +
+                "     limit: 10");
+
+        sql = "select * from (select max(v5) from t1) tmp order by null limit 10;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: max(2: v5)\n" +
+                "  |  group by: \n" +
+                "  |  limit: 10");
+
+        // TODO opt this case
+        sql = "select * from (select max(v5) from t1) tmp order by \"\" > null limit 10;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:TOP-N\n" +
+                "  |  order by: <slot 5> 5: expr ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  limit: 10\n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  <slot 4> : 4: max\n" +
+                "  |  <slot 5> : NULL");
+    }
+
+    @Test
+    public void testOrderByGroupByWithSubquery() throws Exception {
+        String sql = "select t0.v2, sum(v3) as x3, " +
+                "(select sum(v5) from t1) as x1, " +
+                "(select sum(v7) from t2) as x2 from t0 group by v2 order by x3";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  16:SORT\n" +
+                "  |  order by: <slot 4> 4: sum ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  15:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 4> : 4: sum\n" +
+                "  |  <slot 9> : 9: sum\n" +
+                "  |  <slot 14> : 13: sum\n" +
+                "  |  \n" +
+                "  14:NESTLOOP JOIN\n");
+    }
+
+    @Test
+    public void testOrderByTransform() throws Exception {
+        String sql = "select v1, * from test.t0 order by v2";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 2> 2: v2 ASC");
+
+        sql = "select v1+1 as v from t0 group by v1+1 order by v";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 4> 4: expr ASC");
+        assertContains(plan, "<slot 4> : 1: v1 + 1");
+
+        sql = "select distinct v1, v2 from t0 order by v2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:SORT\n" +
+                "  |  order by: <slot 2> 2: v2 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  group by: 1: v1, 2: v2");
+
+        sql = "select distinct v1, v2 from t0 order by v1 + 1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "3:SORT\n" +
+                "  |  order by: <slot 4> 4: expr ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 4> : 1: v1 + 1");
+
+        sql = "select * from t0 a join t0 b where a.v1 = b.v1 order by a.v2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 2> 2: v2 ASC");
+
+        sql = "select v1 v from t0 order by v";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select v1 v from t0 order by v1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select sum(v1) as v, v2, v3 from t0 group by v2, v3 order by v";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "2:SORT\n" +
+                "  |  order by: <slot 4> 4: sum ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(1: v1)\n" +
+                "  |  group by: 2: v2, 3: v3");
+
+        sql = "select sum(v1) as v, v2 from t0 group by v2, v3 order by v";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  3:SORT\n" +
+                "  |  order by: <slot 4> 4: sum ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 4> : 4: sum\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(1: v1)\n" +
+                "  |  group by: 2: v2, 3: v3");
+
+
+        sql = "select abs(t0.v1), abs(t1.v1) from t0, t0_not_null t1 order by t1.v2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "5:SORT\n" +
+                "  |  order by: <slot 5> 5: v2 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  4:Project\n" +
+                "  |  <slot 5> : 5: v2\n" +
+                "  |  <slot 7> : abs(1: v1)\n" +
+                "  |  <slot 8> : abs(4: v1)");
+
+        sql = "select abs(t0.v1), abs(t1.v1) from t0, t0_not_null t1 order by t1.v1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, " 5:SORT\n" +
+                "  |  order by: <slot 4> 4: v1 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  4:Project\n" +
+                "  |  <slot 4> : 4: v1\n" +
+                "  |  <slot 7> : abs(1: v1)\n" +
+                "  |  <slot 8> : abs(4: v1)");
+    }
+
+    @Test
+    public void testUDTFWithOrderBy() throws Exception {
+        String sql = "select t.* from t0, unnest([1,2,3]) as t order by `unnest`";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 4> 4: unnest ASC");
+    }
+
+    @Test
+    public void testOrderByWithSameColumnName() throws Exception {
+        String sql = "select t0_not_null.*, t0.* from t0, t0_not_null order by t0_not_null.v1";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 4> 4: v1 ASC");
+
+        sql = "select t0_not_null.*, t0.* from t0, t0_not_null order by t0.v1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select t0.*, t0_not_null.* from t0, t0_not_null order by t0.v1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select t0.*, t0_not_null.* from t0, t0_not_null order by t0_not_null.v1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 4> 4: v1 ASC");
+
+        sql = "select t0.v1, t0_not_null.v1 from t0, t0_not_null order by t0_not_null.v1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 4> 4: v1 ASC");
+    }
+
+    @Test
+    public void testOrderByWithFieldReference() throws Exception {
+        String sql = "select * from t0 order by 1";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select * from t0 order by 3";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 3> 3: v3 ASC");
+
+        sql = "select *, v1 from t0 order by 3";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 3> 3: v3 ASC");
+
+        sql = "select *, v1 from t0 order by 4";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select v1, v1 from t0 order by 1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select v1, v1 from t0 order by 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select v1 as v, v1 as v from t0 order by 1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select v1 as v, v1 as v from t0 order by 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 1> 1: v1 ASC");
+
+        sql = "select v1 as v, *, v2 + 1 as vv from t0 order by 5";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "2:SORT\n" +
+                "  |  order by: <slot 4> 4: expr ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 4> : 2: v2 + 1");
+    }
+
+    @Test
+    public void testOrderByWithWindow() throws Exception {
+        String sql = "select sum(v1) over(partition by v1 + 1) from t0 order by v1";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 4> 4: v1 ASC");
+
+        sql = "select sum(v1) over(partition by v1 + 1) from t0 order by v2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 5> 5: v2 ASC");
+
+        sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by v2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 5> 5: v2 ASC");
+
+        sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by v";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "5:SORT\n" +
+                "  |  order by: <slot 8> 8: sum(4: v1) ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  4:Project\n" +
+                "  |  <slot 4> : 4: v1\n" +
+                "  |  <slot 5> : 5: v2\n" +
+                "  |  <slot 8> : 8: sum(4: v1)\n" +
+                "  |  \n" +
+                "  3:ANALYTIC\n" +
+                "  |  functions: [, sum(4: v1), ]\n" +
+                "  |  partition by: 7: expr");
+
+        sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by avg(v1) over(partition by v1 + 1)";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "5:SORT\n" +
+                "  |  order by: <slot 9> 9: avg(4: v1) ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  4:Project\n" +
+                "  |  <slot 4> : 4: v1\n" +
+                "  |  <slot 5> : 5: v2\n" +
+                "  |  <slot 8> : 8: sum(4: v1)\n" +
+                "  |  <slot 9> : 9: avg(4: v1)\n" +
+                "  |  \n" +
+                "  3:ANALYTIC\n" +
+                "  |  functions: [, sum(4: v1), ], [, avg(4: v1), ]");
+
+        sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "order by: <slot 5> 5: v2 ASC");
+
+        sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by 3";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "5:SORT\n" +
+                "  |  order by: <slot 8> 8: sum(4: v1) ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  4:Project\n" +
+                "  |  <slot 4> : 4: v1\n" +
+                "  |  <slot 5> : 5: v2\n" +
+                "  |  <slot 8> : 8: sum(4: v1)\n" +
+                "  |  \n" +
+                "  3:ANALYTIC\n" +
+                "  |  functions: [, sum(4: v1), ]\n" +
+                "  |  partition by: 7: expr");
+
+        sql = "select avg(v1) over(partition by sum(v2) + 1) as v from t0 group by v1 order by v";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, " 6:SORT\n" +
+                "  |  order by: <slot 9> 9: avg(1: v1) ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  5:Project\n" +
+                "  |  <slot 9> : 9: avg(1: v1)\n" +
+                "  |  \n" +
+                "  4:ANALYTIC\n" +
+                "  |  functions: [, avg(1: v1), ]\n" +
+                "  |  partition by: 8: expr\n" +
+                "  |  \n" +
+                "  3:SORT\n" +
+                "  |  order by: <slot 8> 8: expr ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 8> : 4: sum + 1\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(2: v2)\n" +
+                "  |  group by: 1: v1");
+
+        sql = "select v1, avg(v1) over(partition by sum(v2) + 1) as v from t0 group by v1 order by 2,1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "6:SORT\n" +
+                "  |  order by: <slot 9> 9: avg(1: v1) ASC, <slot 1> 1: v1 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  5:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 9> : 9: avg(1: v1)\n" +
+                "  |  \n" +
+                "  4:ANALYTIC\n" +
+                "  |  functions: [, avg(1: v1), ]\n" +
+                "  |  partition by: 8: expr\n" +
+                "  |  \n" +
+                "  3:SORT\n" +
+                "  |  order by: <slot 8> 8: expr ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 8> : 4: sum + 1");
+
+        sql = "select avg(v1) over(partition by sum(v2) + 1) as v from t0 group by v1 order by v1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, " 6:SORT\n" +
+                "  |  order by: <slot 1> 1: v1 ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  5:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 9> : 9: avg(1: v1)\n" +
+                "  |  \n" +
+                "  4:ANALYTIC\n" +
+                "  |  functions: [, avg(1: v1), ]\n" +
+                "  |  partition by: 8: expr\n" +
+                "  |  \n" +
+                "  3:SORT\n" +
+                "  |  order by: <slot 8> 8: expr ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 8> : 4: sum + 1\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(2: v2)\n" +
+                "  |  group by: 1: v1");
+    }
+
+    @Test
+    public void testTopNFilter() throws Exception {
+        String sql = "select * from test_all_type_not_null order by t1a limit 10";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  1:TOP-N\n" +
+                "  |  order by: [1, VARCHAR, false] ASC\n" +
+                "  |  build runtime filters:\n" +
+                "  |  - filter_id = 0, build_expr = (<slot 1> 1: t1a), remote = false");
+
+        assertContains(plan, "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (<slot 1> 1: t1a)");
+
+        // TopN filter only works in no-nullable column
+        sql = "select * from test_all_type order by t1a limit 10";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "runtime filters");
+
+        // only first order by column can use top n filter
+        sql = "select * from test_all_type_not_null order by t1a, t1b limit 10";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  1:TOP-N\n" +
+                "  |  order by: [1, VARCHAR, false] ASC, [2, SMALLINT, false] ASC\n" +
+                "  |  build runtime filters:\n" +
+                "  |  - filter_id = 0, build_expr = (<slot 1> 1: t1a), remote = false");
+    }
+}
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StructTypePlanTest extends PlanTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        FeConstants.runningUnitTest = true;
+        starRocksAssert.withTable("create table test(c0 INT, " +
+                "c1 struct<a int, b array<struct<a int, b int>>>," +
+                "c2 struct<a int, b int>," +
+                "c3 struct<a int, b int, c struct<a int, b int>, d array<int>>) " +
+                "duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Before
+    public void setup() throws Exception {
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+    }
+
+    @Test
+    public void testSubfield() throws Exception {
+        String sql = "select c1.a from test";
+        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [STRUCT<a int(11)>]");
+
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
+        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [STRUCT<a int(11), b ARRAY<STRUCT<a int(11), b int(11)>>>]");
+    }
+
+    @Test
+    public void testStructMultiSelect() throws Exception {
+        String sql = "select c2.a, c2.b from test";
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11), b int(11)>]");
+    }
+
+    @Test
+    public void testSubfieldWindow() throws Exception {
+        String sql = "select c3.a, row_number() over (partition by c0 order by c2.a) from test";
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11)>]");
+        assertVerbosePlanContains(sql, "Pruned type: 4 <-> [STRUCT<a int(11)>]");
+    }
+
+    @Test
+    public void testSelectArrayStruct() throws Exception {
+        String sql = "select c1.b[10].a from test";
+        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [STRUCT<b ARRAY<STRUCT<a int(11)>>>]");
+    }
+
+    @Test
+    public void testJoinOn() throws Exception {
+        String sql = "select t1.c0 from test as t1 join test as t2 on t1.c2.a=t2.c2.a";
+        assertVerbosePlanContains(sql, "Pruned type: 7 <-> [STRUCT<a int(11)>]");
+    }
+
+    @Test
+    public void testAggregate() throws Exception {
+        String sql = "select sum(c2.a) as t from test";
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11)>]");
+
+        sql = "select sum(c2.b) as t from test group by c2.a";
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11), b int(11)>]");
+
+        sql = "select count(c1.b[10].a) from test";
+        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [STRUCT<b ARRAY<STRUCT<a int(11)>>>]");
+
+        sql = "select count(c3.c.b) from test group by c1.a, c2.b";
+        assertVerbosePlanContains(sql, " Pruned type: 2 <-> [STRUCT<a int(11)>]\n" +
+                "     Pruned type: 3 <-> [STRUCT<b int(11)>]\n" +
+                "     Pruned type: 4 <-> [STRUCT<c STRUCT<b int(11)>>]");
+
+        sql = "select sum(c3.c.b + c2.a) as t from test group by c1.a, c2.b";
+        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [STRUCT<a int(11)>]\n" +
+                "     Pruned type: 3 <-> [STRUCT<a int(11), b int(11)>]\n" +
+                "     Pruned type: 4 <-> [STRUCT<c STRUCT<b int(11)>>]");
+    }
+
+    @Test
+    public void testSelectPredicate() throws Exception {
+        String sql = "select c0 from test where (c0+c2.a)>5";
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11)>]");
+    }
+
+    @Test
+    public void testSelectStar() throws Exception {
+        String sql = "select *, c1.b[10].a from test";
+        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [STRUCT<a int(11), b ARRAY<STRUCT<a int(11), b int(11)>>>]");
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11), b int(11)>]");
+        assertVerbosePlanContains(sql,
+                "Pruned type: 4 <-> [STRUCT<a int(11), b int(11), c STRUCT<a int(11), b int(11)>, d ARRAY<int(11)>>]");
+    }
+
+    @Test
+    public void testSubQuery() throws Exception {
+        String sql = "select c2.a from (select c1, c2 from test) t";
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11)>]");
+        sql = "select t1.a, rn from (select c3.c as t1, row_number() over (partition by c0 order by c2.a) as rn from test) as t";
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11)>]\n" +
+                "     Pruned type: 4 <-> [STRUCT<c STRUCT<a int(11)>>]");
+    }
+
+    @Test
+    public void testStructWithWindow() throws Exception {
+        String sql = "select sum(c2.b) over(partition by c2.a order by c0) from test";
+        assertPlanContains(sql, " 3:ANALYTIC\n" +
+                "  |  functions: [, sum(7: c2.b), ]\n" +
+                "  |  partition by: 9: c2.a\n" +
+                "  |  order by: 1: c0 ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql = "select sum(c0) over(partition by c2.a order by c2.b) from test";
+        assertPlanContains(sql, " 3:ANALYTIC\n" +
+                "  |  functions: [, sum(5: c0), ]\n" +
+                "  |  partition by: 9: c2.a\n" +
+                "  |  order by: 10: c2.b ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql = "select sum(c1.b[10].b) over(partition by c2.a order by c2.b) from test";
+        assertPlanContains(sql, "3:ANALYTIC\n" +
+                "  |  functions: [, sum(6: c1.b[10].b), ]\n" +
+                "  |  partition by: 9: c2.a\n" +
+                "  |  order by: 10: c2.b ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+    }
+
+    @Test
+    public void testExcept() throws Exception {
+        String sql = "select c2.a + 1 from test except select c3.a from test";
+        assertVerbosePlanContains(sql, "Pruned type: 9 <-> [STRUCT<a int(11)>]");
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11)>]");
+    }
+
+    @Test
+    public void testIntersect() throws Exception {
+        String sql = "select c2.a + 1 from test intersect select c3.a from test";
+        assertVerbosePlanContains(sql, "Pruned type: 9 <-> [STRUCT<a int(11)>]");
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11)>]");
+    }
+
+    @Test
+    public void testLambda() throws Exception {
+        String sql = "select array_map(x->x, [])";
+        assertVerbosePlanContains(sql, "ARRAY<boolean>[]");
+        sql = "select array_map(x->x+1, c3.d) from test";
+        assertVerbosePlanContains(sql, "[STRUCT<d ARRAY<int(11)>>]");
+        sql = "select array_sortby(x->x+1, c3.d) from test";
+        assertVerbosePlanContains(sql, "[STRUCT<d ARRAY<int(11)>>]");
+        sql = "select array_filter((x,y) -> x<y, c3.d, c3.d) from test";
+        assertVerbosePlanContains(sql, "[STRUCT<d ARRAY<int(11)>>]");
+        sql = "select map_values(col_map), map_keys(col_map) from (select map_from_arrays([],[]) as col_map)A";
+        assertPlanContains(sql, "ARRAY<boolean>[], ARRAY<boolean>[]");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -134,21 +134,23 @@ public class WindowTest extends PlanTestBase {
     public void testWindowPartitionAndSortSameColumn() throws Exception {
         String sql = "SELECT k3, avg(k3) OVER (partition by k3 order by k3) AS sum FROM baseall;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  3:ANALYTIC\n" +
+        assertContains(plan, "  2:ANALYTIC\n" +
                 "  |  functions: [, avg(3: k3), ]\n" +
                 "  |  partition by: 3: k3\n" +
-                "  |  order by: 3: k3 ASC");
-        assertContains(plan, "  2:SORT\n" +
-                "  |  order by: <slot 3> 3: k3 ASC");
+                "  |  order by: 3: k3 ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: <slot 3> 3: k3 ASC\n" +
+                "  |  offset: 0");
     }
 
     @Test
     public void testWindowDuplicatePartition() throws Exception {
         String sql = "select max(v3) over (partition by v2,v2,v2 order by v2,v2) from t0;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:SORT\n"
-                + "  |  order by: <slot 2> 2: v2 ASC\n"
-                + "  |  offset: 0");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: <slot 2> 2: v2 ASC\n" +
+                "  |  offset: 0");
 
     }
 
@@ -216,16 +218,11 @@ public class WindowTest extends PlanTestBase {
         // Normal case.
         sql = "select v1, v2, NTILE(2) over (partition by v1 order by v2) as j1 from t0";
         String plan = getFragmentPlan(sql);
-        assertContains(plan,
-                "  3:ANALYTIC\n" +
-                        "  |  functions: [, ntile(2), ]\n" +
-                        "  |  partition by: 1: v1\n" +
-                        "  |  order by: 2: v2 ASC\n" +
-                        "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
-                        "  |  \n" +
-                        "  2:SORT\n" +
-                        "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC\n" +
-                        "  |  offset: 0");
+        assertContains(plan, "  2:ANALYTIC\n" +
+                "  |  functions: [, ntile(2), ]\n" +
+                "  |  partition by: 1: v1\n" +
+                "  |  order by: 2: v2 ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT RO");
     }
 
     @Test
@@ -391,7 +388,7 @@ public class WindowTest extends PlanTestBase {
                 "(select v1 from t0 where v1 = 1) b " +
                 "where a.v1 = b.v1";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  2:SORT\n" +
+        assertContains(plan, "  1:SORT\n" +
                 "  |  order by: [1, BIGINT, true] ASC, [2, BIGINT, true] DESC\n" +
                 "  |  offset: 0\n" +
                 "  |  cardinality: 1\n" +
@@ -407,8 +404,14 @@ public class WindowTest extends PlanTestBase {
                 "where a.v1 = b.v1";
 
         String plan = getVerboseExplain(sql);
+<<<<<<< HEAD
         assertContains(plan, "3:ANALYTIC\n" +
                 "  |  functions: [, sum[([2: v2, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true; result nullable: true], ]\n" +
+=======
+        assertContains(plan, "  2:ANALYTIC\n" +
+                "  |  functions: [, sum[([2: v2, BIGINT, true]); args: BIGINT; " +
+                "result: BIGINT; args nullable: true; result nullable: true], ]\n" +
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
                 "  |  partition by: [3: v3, BIGINT, true]\n" +
                 "  |  order by: [2: v2, BIGINT, true] DESC\n" +
                 "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
@@ -416,4 +419,101 @@ public class WindowTest extends PlanTestBase {
                 "  |  probe runtime filters:\n" +
                 "  |  - filter_id = 0, probe_expr = (1: v1)");
     }
+<<<<<<< HEAD
+=======
+
+    @Test
+    public void testHashBasedWindowTest() throws Exception {
+        {
+            String sql = "select sum(v1) over ([hash] partition by v1,v2 )," +
+                    "sum(v1/v3) over ([hash] partition by v1,v2 ) " +
+                    "from t0";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  1:ANALYTIC\n" +
+                    "  |  functions: [, sum(1: v1), ], [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  useHashBasedPartition");
+        }
+        {
+            String sql = "select sum(v1) over ( partition by v1,v2 )," +
+                    "sum(v1/v3) over ([hash] partition by v1,v2 ) " +
+                    "from t0";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  4:ANALYTIC\n" +
+                    "  |  functions: [, sum(1: v1), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2");
+            assertContains(plan, "  1:ANALYTIC\n" +
+                    "  |  functions: [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  useHashBasedPartition");
+        }
+        {
+            String sql = "select sum(v1) over ([hash] partition by v1 )," +
+                    "sum(v1/v3) over ([hash] partition by v1,v2 ) " +
+                    "from t0";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  3:ANALYTIC\n" +
+                    "  |  functions: [, sum(1: v1), ]\n" +
+                    "  |  partition by: 1: v1\n" +
+                    "  |  useHashBasedPartition");
+            assertContains(plan, "  1:ANALYTIC\n" +
+                    "  |  functions: [, sum(CAST(1: v1 AS DOUBLE) / CAST(3: v3 AS DOUBLE)), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  useHashBasedPartition");
+        }
+    }
+
+    @Test
+    public void testOneTablet() throws Exception {
+        {
+            String sql = "select v1 from (" +
+                    "select v1, dense_rank() over (partition by v1 order by v3) rk from t0" +
+                    ") temp " +
+                    "where rk = 1 " +
+                    "group by v1";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, dense_rank(), ]\n" +
+                    "  |  partition by: 1: v1\n" +
+                    "  |  order by: 3: v3 ASC\n" +
+                    "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  1:SORT\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
+            assertContains(plan, "  5:AGGREGATE (update finalize)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  4:Project\n" +
+                    "  |  <slot 1> : 1: v1");
+        }
+        {
+            String sql = "select v1 from (" +
+                    "select v1, dense_rank() over (partition by v1, v2 order by v3) rk from t0" +
+                    ") temp " +
+                    "where rk = 1 " +
+                    "group by v1";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, dense_rank(), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  order by: 3: v3 ASC\n" +
+                    "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  1:SORT\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
+            assertContains(plan, "  7:AGGREGATE (merge finalize)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  6:EXCHANGE");
+        }
+    }
+>>>>>>> 45f45d98e1 ([BugFix] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic (#19690))
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15-1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15-1.sql
@@ -1,0 +1,22 @@
+[sql]
+select
+    max(total_revenue)
+from
+    (	select
+             l_suppkey as supplier_no,
+             sum(l_extendedprice * (1 - l_discount)) as total_revenue
+         from
+             lineitem
+         where
+                 l_shipdate >= date '1995-07-01'
+           and l_shipdate < date '1995-10-01'
+         group by
+             l_suppkey) b;
+[result]
+AGGREGATE ([GLOBAL] aggregate [{19: max=max(19: max)}] group by [[]] having [null]
+    EXCHANGE GATHER
+        AGGREGATE ([LOCAL] aggregate [{19: max=max(18: sum)}] group by [[]] having [null]
+            AGGREGATE ([GLOBAL] aggregate [{110: sum=sum(33: sum_disc_price)}] group by [[24: l_suppkey]] having [null]
+                SCAN (mv[lineitem_agg_mv2] columns[24: l_suppkey, 25: l_shipdate, 33: sum_disc_price] predicate[25: l_shipdate >= 1995-07-01 AND 25: l_shipdate < 1995-10-01 AND 25: l_shipdate >= 1995-01-01 AND 25: l_shipdate < 1996-01-01])
+[end]
+


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
