### PR TITLE
[BugFix] Fix null partition value missed bug after mv union rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -28,12 +28,9 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
-import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
-import com.starrocks.sql.optimizer.operator.Operator;
-import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
@@ -41,8 +38,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
@@ -270,24 +265,11 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
     @Override
     protected OptExpression queryBasedRewrite(RewriteContext rewriteContext, ScalarOperator compensationPredicates,
                                               OptExpression queryExpression) {
-        // query predicate and (not viewToQueryCompensationPredicate) is the final query compensation predicate
-        ScalarOperator queryCompensationPredicate = MvUtils.canonizePredicate(
-                Utils.compoundAnd(
-                        rewriteContext.getQueryPredicateSplit().toScalarOperator(),
-                        CompoundPredicateOperator.not(compensationPredicates)));
-        // add filter above input and put filter under aggExpr
-        OptExpression input = queryExpression.inputAt(0);
-        if (!ConstantOperator.TRUE.equals(queryCompensationPredicate)) {
-            // add filter
-            Operator.Builder builder = OperatorBuilderFactory.build(input.getOp());
-            builder.withOperator(input.getOp());
-            builder.setPredicate(queryCompensationPredicate);
-            Operator newInputOp = builder.build();
-            OptExpression newInputExpr = OptExpression.create(newInputOp, input.getInputs());
-            // create new OptExpression to strip GroupExpression
-            return OptExpression.create(queryExpression.getOp(), newInputExpr);
+        OptExpression child = super.queryBasedRewrite(rewriteContext, compensationPredicates, queryExpression.inputAt(0));
+        if (child == null) {
+            return null;
         }
-        return null;
+        return OptExpression.create(queryExpression.getOp(), child);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -181,7 +181,8 @@ public class MaterializedViewRewriter {
 
         ScalarOperator mvPredicate = MvUtils.rewriteOptExprCompoundPredicate(mvExpression, mvColumnRefRewriter);
 
-        if (materializationContext.getMvPartialPartitionPredicate() != null) {
+        if (materializationContext.getMvPartialPartitionPredicate() != null
+                && !(mvPredicate instanceof IsNullPredicateOperator)) {
             // add latest partition predicate to mv predicate
             ScalarOperator rewritten =
                     mvColumnRefRewriter.rewrite(materializationContext.getMvPartialPartitionPredicate());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -181,12 +181,16 @@ public class MaterializedViewRewriter {
 
         ScalarOperator mvPredicate = MvUtils.rewriteOptExprCompoundPredicate(mvExpression, mvColumnRefRewriter);
 
-        if (materializationContext.getMvPartialPartitionPredicate() != null
-                && !(mvPredicate instanceof IsNullPredicateOperator)) {
-            // add latest partition predicate to mv predicate
-            ScalarOperator rewritten =
-                    mvColumnRefRewriter.rewrite(materializationContext.getMvPartialPartitionPredicate());
-            mvPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(mvPredicate, rewritten));
+        if (materializationContext.getMvPartialPartitionPredicate() != null) {
+            List<ScalarOperator> partitionPredicates =
+                    getPartitionRelatedPredicates(mvPredicate, mvRewriteContext.getMaterializationContext().getMv());
+            if (partitionPredicates.stream().noneMatch(p -> p instanceof IsNullPredicateOperator)) {
+                // there is no partition column is null predicate
+                // add latest partition predicate to mv predicate
+                ScalarOperator rewritten =
+                        mvColumnRefRewriter.rewrite(materializationContext.getMvPartialPartitionPredicate());
+                mvPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(mvPredicate, rewritten));
+            }
         }
         final PredicateSplit mvPredicateSplit = PredicateSplit.splitPredicate(mvPredicate);
 
@@ -927,55 +931,11 @@ public class MaterializedViewRewriter {
                         new ReplaceColumnRefRewriter(queryExpression.getOp().getProjection().getColumnRefMap());
                 queryCompensationPredicate = rewriter.rewrite(queryCompensationPredicate);
             }
-            MaterializedView mv = mvRewriteContext.getMaterializationContext().getMv();
-            PartitionInfo partitionInfo = mv.getPartitionInfo();
-            if (partitionInfo instanceof ExpressionRangePartitionInfo) {
-                ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
-                List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns();
-                Preconditions.checkState(partitionColumns.size() == 1);
-                ScalarOperator queryPredicate = rewriteContext.getQueryPredicateSplit().toScalarOperator();
-                List<ScalarOperator> queryPredicates = Utils.extractConjuncts(queryPredicate);
-                List<ScalarOperator> queryPartitionRelatedScalars = queryPredicates.stream()
-                        .filter(predicate -> isRelatedPredicate(predicate, partitionColumns.get(0).getName()))
-                        .collect(Collectors.toList());
-
-                ScalarOperator mvPredicate = rewriteContext.getMvPredicateSplit().toScalarOperator();
-                List<ScalarOperator> mvPredicates = Utils.extractConjuncts(mvPredicate);
-                List<ScalarOperator> mvPartitionRelatedScalars = mvPredicates.stream()
-                        .filter(predicate -> isRelatedPredicate(predicate, partitionColumns.get(0).getName()))
-                        .collect(Collectors.toList());
-                // when query has no partition related predicates and mv has,
-                // we should consider to add null value predicate into compensation predicates
-                ColumnRefOperator partitionColumnRef =
-                        getRelatedPredicate(mvPredicate, partitionColumns.get(0).getName());
-                if (queryPartitionRelatedScalars.isEmpty()
-                        && !mvPartitionRelatedScalars.isEmpty() && partitionColumnRef.isNullable()) {
-                    ColumnRewriter columnRewriter = new ColumnRewriter(rewriteContext);
-                    partitionColumnRef = columnRewriter.rewriteViewToQuery(partitionColumnRef).cast();
-                    IsNullPredicateOperator isNullPredicateOperator = new IsNullPredicateOperator(partitionColumnRef);
-                    IsNullPredicateOperator isNotNullPredicateOperator = new IsNullPredicateOperator(true, partitionColumnRef);
-                    List<ScalarOperator> predicates = Utils.extractConjuncts(queryCompensationPredicate);
-                    List<ScalarOperator> partitionRelatedPredicates = predicates.stream()
-                            .filter(predicate -> isRelatedPredicate(predicate, partitionColumns.get(0).getName()))
-                            .collect(Collectors.toList());
-                    predicates.removeAll(partitionRelatedPredicates);
-                    if (partitionRelatedPredicates.contains(isNullPredicateOperator)
-                            || partitionRelatedPredicates.contains(isNotNullPredicateOperator)) {
-                        if (partitionRelatedPredicates.size() != 1) {
-                            // has other partition predicates except partition column is null
-                            // do not support now
-                            // can it happend?
-                            return null;
-                        }
-                        predicates.addAll(partitionRelatedPredicates);
-                    } else {
-                        ScalarOperator partitionPredicate =
-                                Utils.compoundOr(Utils.compoundAnd(partitionRelatedPredicates), isNullPredicateOperator);
-                        predicates.add(partitionPredicate);
-                    }
-                    queryCompensationPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(predicates));
-                }
+            queryCompensationPredicate = processNullPartition(rewriteContext, queryCompensationPredicate);
+            if (queryCompensationPredicate == null) {
+                return null;
             }
+
             // add filter to op
             Operator.Builder builder = OperatorBuilderFactory.build(queryExpression.getOp());
             builder.withOperator(queryExpression.getOp());
@@ -988,7 +948,78 @@ public class MaterializedViewRewriter {
         return null;
     }
 
-    boolean isRelatedPredicate(ScalarOperator scalarOperator, String name) {
+    private List<ScalarOperator> getPartitionRelatedPredicates(ScalarOperator predicate, MaterializedView mv) {
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        if (!(partitionInfo instanceof ExpressionRangePartitionInfo)) {
+            return Lists.newArrayList();
+        }
+        ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
+        List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns();
+        Preconditions.checkState(partitionColumns.size() == 1);
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        List<ScalarOperator> partitionRelatedPredicates = conjuncts.stream()
+                .filter(p -> isRelatedPredicate(p, partitionColumns.get(0).getName()))
+                .collect(Collectors.toList());
+        return partitionRelatedPredicates;
+    }
+
+    // process null value partition
+    // when query select all data from base tables,
+    // should add partition column is null predicate into queryCompensationPredicate to get null partition value related data
+    private ScalarOperator processNullPartition(RewriteContext rewriteContext, ScalarOperator queryCompensationPredicate) {
+        MaterializedView mv = mvRewriteContext.getMaterializationContext().getMv();
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        if (!(partitionInfo instanceof ExpressionRangePartitionInfo)) {
+            return queryCompensationPredicate;
+        }
+        ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
+        List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns();
+        Preconditions.checkState(partitionColumns.size() == 1);
+        ScalarOperator queryPredicate = rewriteContext.getQueryPredicateSplit().toScalarOperator();
+        List<ScalarOperator> queryPartitionRelatedScalars = getPartitionRelatedPredicates(queryPredicate, mv);
+
+        ScalarOperator mvPredicate = rewriteContext.getMvPredicateSplit().toScalarOperator();
+        List<ScalarOperator> mvPartitionRelatedScalars = getPartitionRelatedPredicates(mvPredicate, mv);
+        if (queryPartitionRelatedScalars.isEmpty() && !mvPartitionRelatedScalars.isEmpty()) {
+            // when query has no partition related predicates and mv has,
+            // we should consider to add null value predicate into compensation predicates
+            ColumnRefOperator partitionColumnRef =
+                    getColumnRefFromPredicate(mvPredicate, partitionColumns.get(0).getName());
+            Preconditions.checkState(partitionColumnRef != null);
+            if (!partitionColumnRef.isNullable()) {
+                // only add null value into compensation predicate when partition column is nullable
+                return queryCompensationPredicate;
+            }
+            ColumnRewriter columnRewriter = new ColumnRewriter(rewriteContext);
+            partitionColumnRef = columnRewriter.rewriteViewToQuery(partitionColumnRef).cast();
+            IsNullPredicateOperator isNullPredicateOperator = new IsNullPredicateOperator(partitionColumnRef);
+            IsNullPredicateOperator isNotNullPredicateOperator = new IsNullPredicateOperator(true, partitionColumnRef);
+            List<ScalarOperator> predicates = Utils.extractConjuncts(queryCompensationPredicate);
+            List<ScalarOperator> partitionRelatedPredicates = predicates.stream()
+                    .filter(predicate -> isRelatedPredicate(predicate, partitionColumns.get(0).getName()))
+                    .collect(Collectors.toList());
+            predicates.removeAll(partitionRelatedPredicates);
+            if (partitionRelatedPredicates.contains(isNullPredicateOperator)
+                    || partitionRelatedPredicates.contains(isNotNullPredicateOperator)) {
+                if (partitionRelatedPredicates.size() != 1) {
+                    // has other partition predicates except partition column is null
+                    // do not support now
+                    // can it happend?
+                    return null;
+                }
+                predicates.addAll(partitionRelatedPredicates);
+            } else {
+                // add partition column is null into compensation predicates
+                ScalarOperator partitionPredicate =
+                        Utils.compoundOr(Utils.compoundAnd(partitionRelatedPredicates), isNullPredicateOperator);
+                predicates.add(partitionPredicate);
+            }
+            queryCompensationPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(predicates));
+        }
+        return queryCompensationPredicate;
+    }
+
+    private boolean isRelatedPredicate(ScalarOperator scalarOperator, String name) {
         ScalarOperatorVisitor<Boolean, Void> visitor = new ScalarOperatorVisitor<Boolean, Void>() {
             @Override
             public Boolean visit(ScalarOperator scalarOperator, Void context) {
@@ -1009,7 +1040,7 @@ public class MaterializedViewRewriter {
         return scalarOperator.accept(visitor, null);
     }
 
-    ColumnRefOperator getRelatedPredicate(ScalarOperator predicate, String name) {
+    private ColumnRefOperator getColumnRefFromPredicate(ScalarOperator predicate, String name) {
         ScalarOperatorVisitor<ColumnRefOperator, Void> visitor = new ScalarOperatorVisitor<ColumnRefOperator, Void>() {
             @Override
             public ColumnRefOperator visit(ScalarOperator scalarOperator, Void context) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.planner;
 
+import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -542,9 +543,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                     "GROUP BY `test_base_part`.`c3`, `test_base_part`.`c1`;");
 
             String query = "select c1, c3, sum(c4) from test_base_part group by c1, c3;";
-            testRewriteOK(query)
-                    .contains("partial_mv_9")
-                    .contains("PREDICATES: (10: c3 >= 1000) OR (10: c3 IS NULL)");
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "partial_mv_9", "PREDICATES: (10: c3 >= 1000) OR (10: c3 IS NULL)");
             starRocksAssert.dropMaterializedView("partial_mv_9");
         }
 
@@ -564,11 +564,9 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                     "GROUP BY `test_base_part`.`c3`, `test_base_part`.`c1`;");
 
             String query = "select c1, c3, sum(c4) from test_base_part where c3 < 2000 group by c1, c3;";
-            testRewriteOK(query)
-                    .contains("partial_mv_11")
-                    .contains("PREDICATES: 10: c3 > 999")
-                    .contains("partitions=2/5")
-                    .notContains("10: c3 IS NULL");
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "partial_mv_11", "PREDICATES: 10: c3 > 999", "partitions=2/5");
+            PlanTestBase.assertNotContains(plan, "10: c3 IS NULL");
             starRocksAssert.dropMaterializedView("partial_mv_11");
         }
 
@@ -598,9 +596,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                     "GROUP BY `c3`, `c1`;");
 
             String query = "select c1, c3, sum(c4) from test_base_part_not_null group by c1, c3;";
-            testRewriteOK(query)
-                    .contains("partial_mv_10")
-                    .contains("partitions=2/5");
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "partial_mv_10", "partitions=2/5");
             starRocksAssert.dropMaterializedView("partial_mv_10");
         }
 
@@ -620,9 +617,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                     "GROUP BY `test_base_part`.`c3`, `test_base_part`.`c1`;");
 
             String query = "select c1, c3, sum(c4) from test_base_part group by c1, c3;";
-            testRewriteOK(query)
-                    .contains("partial_mv_12")
-                    .contains("PREDICATES: 10: c3 IS NOT NULL");
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "partial_mv_12", "PREDICATES: 10: c3 IS NOT NULL");
             starRocksAssert.dropMaterializedView("partial_mv_12");
         }
 
@@ -642,9 +638,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                     "GROUP BY `test_base_part`.`c3`, `test_base_part`.`c1`;");
 
             String query = "select c1, c3, sum(c4) from test_base_part group by c1, c3;";
-            testRewriteOK(query)
-                    .contains("partial_mv_13")
-                    .contains("PREDICATES: 10: c3 IS NULL");
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "partial_mv_13", "PREDICATES: 10: c3 IS NULL");
             starRocksAssert.dropMaterializedView("partial_mv_13");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -1751,7 +1751,8 @@ public class MvRewriteOptimizationTest {
         String plan10 = getFragmentPlan(query10);
         PlanTestBase.assertContains(plan10, "partial_mv_6", "UNION", "TABLE: test_base_part\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     partitions=2/6\n" +
+                "     PREDICATES: (10: c3 >= 2000) OR (10: c3 IS NULL)\n" +
+                "     partitions=3/6\n" +
                 "     rollup: test_base_part");
 
         String query12 = "select c1, c3, c2 from test_base_part where c3 < 2000";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -2361,4 +2361,35 @@ public class MvRewriteOptimizationTest {
                 "     PREAGGREGATION: ON");
         dropMv("test", "forbid_mv_1");
     }
+
+    @Test
+    public void testNullPartitionRewriteWithLoad() throws Exception {
+        {
+            cluster.runSql("test", "insert into test_base_part values(1, 1, 2, 3)");
+            cluster.runSql("test", "insert into test_base_part values(100, 1, 2, 3)");
+            cluster.runSql("test", "insert into test_base_part values(200, 1, 2, 3)");
+            cluster.runSql("test", "insert into test_base_part values(1000, 1, 2, 3)");
+            cluster.runSql("test", "insert into test_base_part values(2000, 1, 2, 3)");
+            cluster.runSql("test", "insert into test_base_part values(2500, 1, 2, 3)");
+
+            createAndRefreshMv("test", "partial_mv_12", "CREATE MATERIALIZED VIEW `partial_mv_12`\n" +
+                    "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                    "PARTITION BY (`c3`)\n" +
+                    "DISTRIBUTED BY HASH(`c1`) BUCKETS 6\n" +
+                    "REFRESH MANUAL\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"storage_medium\" = \"HDD\"\n" +
+                    ")\n" +
+                    "AS SELECT `c1`, `c3`, sum(`c4`) AS `total`\n" +
+                    "FROM `test_base_part`\n" +
+                    "WHERE `c3` is null\n" +
+                    "GROUP BY `c3`, `c1`;");
+
+            String query = "select c1, c3, sum(c4) from test_base_part group by c1, c3;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "partial_mv_12", "PREDICATES: 10: c3 IS NOT NULL");
+            starRocksAssert.dropMaterializedView("partial_mv_12");
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21321 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix null partition value missed bug after mv union rewrite. Fix it by compensating partition_column is null into predicate.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
