### PR TITLE
[BugFix][Cherry-pick-2.3] Fix wrong state of 'isExecuteInOneTablet' when it comes to agg or analytic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -42,8 +42,10 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Internal representation of table-related metadata. A table contains several partitions.
@@ -305,6 +307,10 @@ public class Table extends MetaObject implements Writable {
 
     public Partition getPartition(String partitionName) {
         return null;
+    }
+
+    public Set<String> getDistributionColumnNames() {
+        return Collections.emptySet();
     }
 
     public String getEngine() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
@@ -100,8 +100,8 @@ public class ExpressionContext {
         return childrenProperty.get(index).getLeftMostScanTabletsNum();
     }
 
-    public boolean isExecuteInOneTablet(int index) {
-        return childrenProperty.get(index).isExecuteInOneTablet();
+    public LogicalProperty.OneTabletProperty oneTabletProperty(int index) {
+        return childrenProperty.get(index).oneTabletProperty();
     }
 
     public Operator getChildOperator(int index) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefSet.java
@@ -33,6 +33,12 @@ public class ColumnRefSet implements Cloneable {
         }
     }
 
+    public static ColumnRefSet createByIds(Collection<Integer> colIds) {
+        ColumnRefSet columnRefSet = new ColumnRefSet();
+        colIds.stream().forEach(columnRefSet::union);
+        return columnRefSet;
+    }
+
     public int[] getColumnIds() {
         return bitSet.toArray();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/LogicalProperty.java
@@ -3,10 +3,12 @@
 package com.starrocks.sql.optimizer.base;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Column;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalExceptOperator;
@@ -20,7 +22,17 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.logical.MockOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import jersey.repackaged.com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class LogicalProperty implements Property {
     // Operator's output columns
@@ -28,7 +40,7 @@ public class LogicalProperty implements Property {
     // The tablets num of left most scan node
     private int leftMostScanTabletsNum;
     // The flag for execute upon less than or equal one tablet
-    private boolean isExecuteInOneTablet;
+    private OneTabletProperty oneTabletProperty;
 
     public ColumnRefSet getOutputColumns() {
         return outputColumns;
@@ -42,8 +54,8 @@ public class LogicalProperty implements Property {
         return leftMostScanTabletsNum;
     }
 
-    public boolean isExecuteInOneTablet() {
-        return isExecuteInOneTablet;
+    public OneTabletProperty oneTabletProperty() {
+        return oneTabletProperty;
     }
 
     public void setLeftMostScanTabletsNum(int leftMostScanTabletsNum) {
@@ -61,14 +73,14 @@ public class LogicalProperty implements Property {
     public LogicalProperty(LogicalProperty other) {
         outputColumns = other.outputColumns.clone();
         leftMostScanTabletsNum = other.leftMostScanTabletsNum;
-        isExecuteInOneTablet = other.isExecuteInOneTablet;
+        oneTabletProperty = other.oneTabletProperty;
     }
 
     public void derive(ExpressionContext expressionContext) {
         LogicalOperator op = (LogicalOperator) expressionContext.getOp();
         outputColumns = op.getOutputColumns(expressionContext);
         leftMostScanTabletsNum = op.accept(new LeftMostScanTabletsNumVisitor(), expressionContext);
-        isExecuteInOneTablet = op.accept(new OneTabletExecutorVisitor(), expressionContext);
+        oneTabletProperty = op.accept(new OneTabletExecutorVisitor(), expressionContext);
     }
 
     static class LeftMostScanTabletsNumVisitor extends OperatorVisitor<Integer, ExpressionContext> {
@@ -118,66 +130,133 @@ public class LogicalProperty implements Property {
         }
     }
 
-    static class OneTabletExecutorVisitor extends OperatorVisitor<Boolean, ExpressionContext> {
+    public static final class OneTabletProperty {
+        public final boolean supportOneTabletOpt;
+        public final boolean distributionIntact;
+        public final ColumnRefSet bucketColumns;
+
+        private OneTabletProperty(boolean supportOneTabletOpt, boolean distributionIntact,
+                                  ColumnRefSet bucketColumns) {
+            this.supportOneTabletOpt = supportOneTabletOpt;
+            this.distributionIntact = distributionIntact;
+            this.bucketColumns = bucketColumns;
+        }
+
+        private static OneTabletProperty supportButChangeDistribution(ColumnRefSet bucketColumns) {
+            return new OneTabletProperty(true, false, bucketColumns);
+        }
+
+        private static OneTabletProperty supportWithoutChangeDistribution(ColumnRefSet bucketColumns) {
+            return new OneTabletProperty(true, true, bucketColumns);
+        }
+
+        private static OneTabletProperty notSupport() {
+            return new OneTabletProperty(false, false, null);
+        }
+    }
+
+    static class OneTabletExecutorVisitor extends OperatorVisitor<OneTabletProperty, ExpressionContext> {
         @Override
-        public Boolean visitOperator(Operator node, ExpressionContext context) {
+        public OneTabletProperty visitOperator(Operator node, ExpressionContext context) {
             Preconditions.checkState(context.arity() != 0);
-            return context.isExecuteInOneTablet(0);
+            return context.oneTabletProperty(0);
         }
 
         @Override
-        public Boolean visitMockOperator(MockOperator node, ExpressionContext context) {
-            return true;
+        public OneTabletProperty visitMockOperator(MockOperator node, ExpressionContext context) {
+            return OneTabletProperty.supportWithoutChangeDistribution(new ColumnRefSet());
         }
 
         @Override
-        public Boolean visitLogicalTableScan(LogicalScanOperator node, ExpressionContext context) {
+        public OneTabletProperty visitLogicalTableScan(LogicalScanOperator node, ExpressionContext context) {
             if (node instanceof LogicalOlapScanOperator) {
-                return ((LogicalOlapScanOperator) node).getSelectedTabletId().size() <= 1;
-            } else {
-                return node instanceof LogicalMysqlScanOperator || node instanceof LogicalJDBCScanOperator;
+                if (((LogicalOlapScanOperator) node).getSelectedTabletId().size() <= 1) {
+                    Set<String> distributionColumnNames = node.getTable().getDistributionColumnNames();
+                    List<ColumnRefOperator> bucketColumns = Lists.newArrayList();
+                    for (Map.Entry<ColumnRefOperator, Column> entry : node.getColRefToColumnMetaMap().entrySet()) {
+                        if (distributionColumnNames.contains(entry.getValue().getName())) {
+                            bucketColumns.add(entry.getKey());
+                        }
+                    }
+                    return OneTabletProperty.supportWithoutChangeDistribution(new ColumnRefSet(bucketColumns));
+                }
+                return OneTabletProperty.notSupport();
+            } else if (node instanceof LogicalMysqlScanOperator || node instanceof LogicalJDBCScanOperator) {
+                return OneTabletProperty.supportWithoutChangeDistribution(new ColumnRefSet());
             }
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalValues(LogicalValuesOperator node, ExpressionContext context) {
-            return true;
+        public OneTabletProperty visitLogicalValues(LogicalValuesOperator node, ExpressionContext context) {
+            return OneTabletProperty.supportWithoutChangeDistribution(new ColumnRefSet());
         }
 
         @Override
-        public Boolean visitLogicalJoin(LogicalJoinOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalAnalytic(LogicalWindowOperator node, ExpressionContext context) {
+            OneTabletProperty isExecuteInOneTablet = context.oneTabletProperty(0);
+            if (isExecuteInOneTablet.distributionIntact) {
+                List<Integer> partitionColumnRefSet = new ArrayList<>();
+                node.getPartitionExpressions().forEach(e -> partitionColumnRefSet
+                        .addAll(Arrays.stream(e.getUsedColumns().getColumnIds()).boxed().collect(Collectors.toList())));
+                ColumnRefSet partitionColumns = ColumnRefSet.createByIds(partitionColumnRefSet);
+                if (partitionColumns.isSame(isExecuteInOneTablet.bucketColumns)) {
+                    return isExecuteInOneTablet;
+                }
+                return OneTabletProperty.supportButChangeDistribution(isExecuteInOneTablet.bucketColumns);
+            }
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalUnion(LogicalUnionOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalAggregation(LogicalAggregationOperator node,
+                                                         ExpressionContext context) {
+            OneTabletProperty isExecuteInOneTablet = context.oneTabletProperty(0);
+            if (isExecuteInOneTablet.distributionIntact) {
+                ColumnRefSet groupByColumns = new ColumnRefSet(node.getGroupingKeys());
+                if (groupByColumns.isSame(isExecuteInOneTablet.bucketColumns)) {
+                    return isExecuteInOneTablet;
+                }
+                return OneTabletProperty.supportButChangeDistribution(isExecuteInOneTablet.bucketColumns);
+            }
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalExcept(LogicalExceptOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalJoin(LogicalJoinOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalIntersect(LogicalIntersectOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalUnion(LogicalUnionOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalTableFunction(LogicalTableFunctionOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalExcept(LogicalExceptOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
         }
 
         @Override
-        public Boolean visitLogicalCTEAnchor(LogicalCTEAnchorOperator node, ExpressionContext context) {
+        public OneTabletProperty visitLogicalIntersect(LogicalIntersectOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
+        }
+
+        @Override
+        public OneTabletProperty visitLogicalTableFunction(LogicalTableFunctionOperator node,
+                                                           ExpressionContext context) {
+            return OneTabletProperty.notSupport();
+        }
+
+        @Override
+        public OneTabletProperty visitLogicalCTEAnchor(LogicalCTEAnchorOperator node, ExpressionContext context) {
             Preconditions.checkState(context.arity() == 2);
-            return context.isExecuteInOneTablet(1);
+            return context.oneTabletProperty(1);
         }
 
         @Override
-        public Boolean visitLogicalCTEConsume(LogicalCTEConsumeOperator node, ExpressionContext context) {
-            return false;
+        public OneTabletProperty visitLogicalCTEConsume(LogicalCTEConsumeOperator node, ExpressionContext context) {
+            return OneTabletProperty.notSupport();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -115,7 +115,7 @@ public class SplitAggregateRule extends TransformationRule {
             return false;
         }
         // 4. If scan tablet sum leas than 1, do one phase aggregate is enough
-        if (aggStage == 0 && input.getLogicalProperty().isExecuteInOneTablet()) {
+        if (aggStage == 0 && input.getLogicalProperty().oneTabletProperty().supportOneTabletOpt) {
             return false;
         }
         // Default, we could generate two stage aggregate

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
@@ -2,6 +2,7 @@
 
 package com.starrocks.sql.optimizer.rule;
 
+import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.Memo;
@@ -20,9 +21,13 @@ public class BinderTest {
 
     @Test
     public void testBinder() {
+        OlapTable table1 = new OlapTable();
+        table1.setDefaultDistributionInfo(new HashDistributionInfo());
+        OlapTable table2 = new OlapTable();
+        table2.setDefaultDistributionInfo(new HashDistributionInfo());
         OptExpression expr = OptExpression.create(new LogicalJoinOperator(),
-                new OptExpression(new LogicalOlapScanOperator(new OlapTable())),
-                new OptExpression(new LogicalOlapScanOperator(new OlapTable())));
+                new OptExpression(new LogicalOlapScanOperator(table1)),
+                new OptExpression(new LogicalOlapScanOperator(table2)));
 
         Pattern pattern = Pattern.create(OperatorType.LOGICAL_JOIN)
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF))

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -593,7 +593,7 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select SUM(v2) from (select v2, sum(v1) as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
@@ -601,7 +601,7 @@ public class AggregateTest extends PlanTestBase {
                 "  |  group by: 2: v2\n");
         sql = "select SUM(v2) from (select v2, sum(distinct v2) as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
@@ -636,7 +636,7 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select SUM(x1) from (select v2 as x1 from t0 group by v2) as q";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "  2:AGGREGATE (update serialize)\n" +
                 "  |  output: sum(2: v2)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
@@ -270,13 +270,13 @@ public class GroupingSetTest extends PlanTestBase {
                 "    ) tev,unnest(x2) \n" +
                 ") tev group by GROUPING SETS((u2, r1)) ";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "6:Project\n" +
+        assertContains(plan, "8:Project\n" +
                 "  |  <slot 10> : 10: unnest\n" +
                 "  |  <slot 11> : datediff(CAST(split(9: array_join, ',')[2] AS DATETIME), CAST(10: unnest AS DATETIME))\n" +
                 "  |  \n" +
-                "  5:TableValueFunction\n" +
+                "  7:TableValueFunction\n" +
                 "  |  \n" +
-                "  4:Project\n" +
+                "  6:Project\n" +
                 "  |  <slot 6> : 6: array_agg\n" +
                 "  |  <slot 9> : array_join(7: array_agg, ',')");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -134,21 +134,23 @@ public class WindowTest extends PlanTestBase {
     public void testWindowPartitionAndSortSameColumn() throws Exception {
         String sql = "SELECT k3, avg(k3) OVER (partition by k3 order by k3) AS sum FROM baseall;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  3:ANALYTIC\n" +
+        assertContains(plan, "  2:ANALYTIC\n" +
                 "  |  functions: [, avg(3: k3), ]\n" +
                 "  |  partition by: 3: k3\n" +
-                "  |  order by: 3: k3 ASC");
-        assertContains(plan, "  2:SORT\n" +
-                "  |  order by: <slot 3> 3: k3 ASC");
+                "  |  order by: 3: k3 ASC\n" +
+                "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: <slot 3> 3: k3 ASC\n" +
+                "  |  offset: 0");
     }
 
     @Test
     public void testWindowDuplicatePartition() throws Exception {
         String sql = "select max(v3) over (partition by v2,v2,v2 order by v2,v2) from t0;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:SORT\n"
-                + "  |  order by: <slot 2> 2: v2 ASC\n"
-                + "  |  offset: 0");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: <slot 2> 2: v2 ASC\n" +
+                "  |  offset: 0");
 
     }
 
@@ -216,16 +218,11 @@ public class WindowTest extends PlanTestBase {
         // Normal case.
         sql = "select v1, v2, NTILE(2) over (partition by v1 order by v2) as j1 from t0";
         String plan = getFragmentPlan(sql);
-        assertContains(plan,
-                "  3:ANALYTIC\n" +
-                        "  |  functions: [, ntile(2), ]\n" +
-                        "  |  partition by: 1: v1\n" +
-                        "  |  order by: 2: v2 ASC\n" +
-                        "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
-                        "  |  \n" +
-                        "  2:SORT\n" +
-                        "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC\n" +
-                        "  |  offset: 0");
+        assertContains(plan, "  2:ANALYTIC\n" +
+                "  |  functions: [, ntile(2), ]\n" +
+                "  |  partition by: 1: v1\n" +
+                "  |  order by: 2: v2 ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT RO");
     }
 
     @Test
@@ -391,7 +388,7 @@ public class WindowTest extends PlanTestBase {
                 "(select v1 from t0 where v1 = 1) b " +
                 "where a.v1 = b.v1";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  2:SORT\n" +
+        assertContains(plan, "  1:SORT\n" +
                 "  |  order by: [1, BIGINT, true] ASC, [2, BIGINT, true] DESC\n" +
                 "  |  offset: 0\n" +
                 "  |  cardinality: 1\n" +
@@ -407,13 +404,67 @@ public class WindowTest extends PlanTestBase {
                 "where a.v1 = b.v1";
 
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "3:ANALYTIC\n" +
-                "  |  functions: [, sum[([2: v2, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true; result nullable: true], ]\n" +
+        assertContains(plan, "  2:ANALYTIC\n" +
+                "  |  functions: [, sum[([2: v2, BIGINT, true]); args: BIGINT; " +
+                "result: BIGINT; args nullable: true; result nullable: true], ]\n" +
                 "  |  partition by: [3: v3, BIGINT, true]\n" +
                 "  |  order by: [2: v2, BIGINT, true] DESC\n" +
                 "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                 "  |  cardinality: 1\n" +
                 "  |  probe runtime filters:\n" +
                 "  |  - filter_id = 0, probe_expr = (1: v1)");
+    }
+
+    @Test
+    public void testOneTablet() throws Exception {
+        {
+            String sql = "select v1 from (" +
+                    "select v1, dense_rank() over (partition by v1 order by v3) rk from t0" +
+                    ") temp " +
+                    "where rk = 1 " +
+                    "group by v1";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, dense_rank(), ]\n" +
+                    "  |  partition by: 1: v1\n" +
+                    "  |  order by: 3: v3 ASC\n" +
+                    "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  1:SORT\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
+            assertContains(plan, "  5:AGGREGATE (update finalize)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  4:Project\n" +
+                    "  |  <slot 1> : 1: v1");
+        }
+        {
+            String sql = "select v1 from (" +
+                    "select v1, dense_rank() over (partition by v1, v2 order by v3) rk from t0" +
+                    ") temp " +
+                    "where rk = 1 " +
+                    "group by v1";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, dense_rank(), ]\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  order by: 3: v3 ASC\n" +
+                    "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  1:SORT\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  offset: 0\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0");
+            assertContains(plan, "  7:AGGREGATE (merge finalize)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  6:EXCHANGE");
+        }
     }
 }


### PR DESCRIPTION


## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
