### PR TITLE
[Enhancement] make spill_local_storage_dir not dependent on storage_root_path

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -843,7 +843,7 @@ CONF_Int16(jdbc_minimum_idle_connections, "1");
 CONF_Int32(jdbc_connection_idle_timeout_ms, "600000");
 
 // spill dirs
-CONF_String(spill_local_storage_dir, "spill");
+CONF_String(spill_local_storage_dir, "${STARROCKS_HOME}/spill");
 // when spill occurs, whether enable skip synchronous flush
 CONF_mBool(experimental_spill_skip_sync, "true");
 // spill Initial number of partitions

--- a/be/src/exec/spill/dir_manager.cpp
+++ b/be/src/exec/spill/dir_manager.cpp
@@ -21,13 +21,13 @@ namespace starrocks::spill {
 
 Status DirManager::init() {
     std::vector<starrocks::StorePath> storage_paths;
-    RETURN_IF_ERROR(parse_conf_store_paths(config::storage_root_path, &storage_paths));
+    RETURN_IF_ERROR(parse_conf_store_paths(config::spill_local_storage_dir, &storage_paths));
     if (storage_paths.empty()) {
-        return Status::InvalidArgument("cannot find storage_root_path");
+        return Status::InvalidArgument("cannot find spill_local_storage_dir");
     }
 
     for (const auto& path : storage_paths) {
-        std::string spill_dir_path = path.path + "/" + config::spill_local_storage_dir;
+        std::string spill_dir_path = path.path;
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(spill_dir_path));
         RETURN_IF_ERROR(fs->create_dir_if_missing(spill_dir_path));
         RETURN_IF_ERROR(fs->iterate_dir(spill_dir_path, [fs, &spill_dir_path](std::string_view sub_dir) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
