### PR TITLE
[Enhancement] Improve accuracy of broker load progress

### DIFF
--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -64,6 +64,8 @@ Status CSVScanner::ScannerCSVReader::_fill_buffer() {
             // Has reached the end of file and the buffer is empty.
             return Status::EndOfFile(_file->filename());
         }
+    } else {
+        _state->update_num_bytes_scan_from_source(s.size);
     }
     return Status::OK();
 }
@@ -195,7 +197,7 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
                 return st;
             }
 
-            _curr_reader = std::make_unique<ScannerCSVReader>(file, _parse_options);
+            _curr_reader = std::make_unique<ScannerCSVReader>(file, _state, _parse_options);
             _curr_reader->set_counter(_counter);
             if (_scan_range.ranges[_curr_file_index].size > 0 &&
                 _scan_range.ranges[_curr_file_index].format_type == TFileFormatType::FORMAT_CSV_PLAIN) {

--- a/be/src/exec/csv_scanner.h
+++ b/be/src/exec/csv_scanner.h
@@ -47,9 +47,11 @@ public:
 private:
     class ScannerCSVReader : public CSVReader {
     public:
-        ScannerCSVReader(std::shared_ptr<SequentialFile> file, const CSVParseOptions& parse_options)
+        ScannerCSVReader(std::shared_ptr<SequentialFile> file, RuntimeState* state,
+                         const CSVParseOptions& parse_options)
                 : CSVReader(parse_options) {
             _file = std::move(file);
+            _state = state;
         }
 
         void set_counter(ScannerCounter* counter) { _counter = counter; }
@@ -61,6 +63,7 @@ private:
     private:
         std::shared_ptr<SequentialFile> _file;
         ScannerCounter* _counter = nullptr;
+        RuntimeState* _state = nullptr;
     };
 
     ChunkPtr _create_chunk(const std::vector<SlotDescriptor*>& slots);

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -705,6 +705,8 @@ Status JsonReader::_read_and_parse_json() {
         SCOPED_RAW_TIMER(&_counter->file_read_ns);
         ASSIGN_OR_RETURN(_parser_buf, stream_file->pipe()->read());
 
+        _state->update_num_bytes_scan_from_source(_parser_buf->remaining());
+
         if (_parser_buf->capacity < _parser_buf->remaining() + simdjson::SIMDJSON_PADDING) {
             // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
             // Hence, a re-allocation is needed if the space is not enough.

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -643,6 +643,10 @@ Status OlapScanNode::_start_scan_thread(RuntimeState* state) {
             scanner_params.skip_aggregation = _olap_scan_node.is_preaggregation;
             scanner_params.need_agg_finalize = true;
             scanner_params.unused_output_columns = &_unused_output_columns;
+            // one scan range has multi tablet_scanners, so only the first scanner need to update scan range
+            if (i == 0) {
+                scanner_params.update_num_scan_range = true;
+            }
             auto* scanner = _pool->add(new TabletScanner(this));
             RETURN_IF_ERROR(scanner->init(state, scanner_params));
             // Assume all scanners have the same schema.

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -183,6 +183,7 @@ Status ORCScanner::_next_orc_batch(ChunkPtr* result) {
 
 Status ORCScanner::_open_next_orc_reader() {
     while (true) {
+        _state->update_num_bytes_scan_from_source(_last_file_size);
         if (_next_range >= _scan_range.ranges.size()) {
             return Status::EndOfFile("no more file to be read");
         }
@@ -198,6 +199,7 @@ Status ORCScanner::_open_next_orc_reader() {
         ASSIGN_OR_RETURN(uint64_t file_size, file->get_size());
         auto inStream = std::make_unique<ORCFileStream>(file, file_size, _counter);
         _next_range++;
+        _last_file_size = file_size;
         _orc_reader->set_read_chunk_size(_max_chunk_size);
         _orc_reader->set_current_file_name(file_name);
         st = _orc_reader->init(std::move(inStream));

--- a/be/src/exec/orc_scanner.h
+++ b/be/src/exec/orc_scanner.h
@@ -57,6 +57,7 @@ private:
     int _next_range;
     int _error_counter;
     bool _status_eof;
+    int64_t _last_file_size = 0;
 
     std::unique_ptr<OrcChunkReader> _orc_reader;
     std::vector<SlotDescriptor*> _orc_slot_descriptors;

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -91,6 +91,8 @@ Status ParquetReaderWrap::init_parquet_reader(const std::vector<SlotDescriptor*>
             LOG(INFO) << "Ignore the parquet file because of unexpected nullptr FileMetaData";
             return Status::EndOfFile("Unexpected nullptr FileMetaData");
         }
+
+        _num_rows = _file_metadata->num_rows();
         // initial members
         _total_groups = _file_metadata->num_row_groups();
         if (_total_groups == 0) {
@@ -260,6 +262,10 @@ ParquetChunkReader::ParquetChunkReader(std::shared_ptr<ParquetReaderWrap>&& parq
 
 ParquetChunkReader::~ParquetChunkReader() {
     _parquet_reader->close();
+}
+
+int64_t ParquetChunkReader::total_num_rows() const {
+    return _parquet_reader->num_rows();
 }
 
 Status ParquetChunkReader::next_batch(RecordBatchPtr* batch) {

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -69,6 +69,7 @@ public:
     Status init_parquet_reader(const std::vector<SlotDescriptor*>& tuple_slot_descs, const std::string& timezone);
     Status read_record_batch(const std::vector<SlotDescriptor*>& tuple_slot_descs, bool* eof);
     const std::shared_ptr<arrow::RecordBatch>& get_batch();
+    int64_t num_rows() { return _num_rows; }
 
 private:
     Status column_indices(const std::vector<SlotDescriptor*>& tuple_slot_descs);
@@ -76,6 +77,7 @@ private:
     Status next_selected_row_group();
 
     const int32_t _num_of_columns_from_file;
+    int64_t _num_rows = 0;
     parquet::ReaderProperties _properties;
     std::shared_ptr<arrow::io::RandomAccessFile> _parquet;
 
@@ -111,6 +113,7 @@ public:
                        const std::vector<SlotDescriptor*>& src_slot_descs, std::string time_zone);
     ~ParquetChunkReader();
     Status next_batch(RecordBatchPtr* batch);
+    int64_t total_num_rows() const;
 
 private:
     std::shared_ptr<ParquetReaderWrap> _parquet_reader;

--- a/be/src/exec/parquet_scanner.h
+++ b/be/src/exec/parquet_scanner.h
@@ -80,6 +80,11 @@ private:
     ObjectPool _pool;
     Filter _chunk_filter;
     ArrowConvertContext _conv_ctx;
+    int64_t _last_file_size = 0;
+    int64_t _last_range_size = 0;
+    int64_t _last_file_scan_rows = 0;
+    int64_t _last_file_scan_bytes = 0;
+    int64_t _next_batch_counter = 0;
 };
 
 } // namespace starrocks

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -43,6 +43,7 @@ Status TabletScanner::init(RuntimeState* runtime_state, const TabletScannerParam
     _runtime_state = runtime_state;
     _skip_aggregation = params.skip_aggregation;
     _need_agg_finalize = params.need_agg_finalize;
+    _update_num_scan_range = params.update_num_scan_range;
 
     RETURN_IF_ERROR(Expr::clone_if_not_exists(runtime_state, &_pool, *params.conjunct_ctxs, &_conjunct_ctxs));
     RETURN_IF_ERROR(_get_tablet(params.scan_range));

--- a/be/src/exec/tablet_scanner.h
+++ b/be/src/exec/tablet_scanner.h
@@ -42,6 +42,7 @@ struct TabletScannerParams {
 
     bool skip_aggregation = false;
     bool need_agg_finalize = true;
+    bool update_num_scan_range = false;
 };
 
 class TabletScanner {
@@ -95,6 +96,7 @@ private:
     bool _skip_aggregation = false;
     bool _need_agg_finalize = false;
     bool _has_update_counter = false;
+    bool _update_num_scan_range = false;
 
     TabletReaderParams _params;
     std::shared_ptr<TabletReader> _reader;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -266,6 +266,8 @@ public:
 
     int64_t num_rows_load_unselected() const noexcept { return _num_rows_load_unselected.load(); }
 
+    int64_t num_bytes_scan_from_source() const noexcept { return _num_bytes_scan_from_source.load(); }
+
     void update_num_bytes_load_from_source(int64_t bytes_load) { _num_bytes_load_from_source.fetch_add(bytes_load); }
 
     void update_num_rows_load_from_source(int64_t num_rows) { _num_rows_load_total_from_source.fetch_add(num_rows); }
@@ -278,6 +280,8 @@ public:
 
     void update_num_rows_load_unselected(int64_t num_rows) { _num_rows_load_unselected.fetch_add(num_rows); }
 
+    void update_num_bytes_scan_from_source(int64_t scan_bytes) { _num_bytes_scan_from_source.fetch_add(scan_bytes); }
+
     void update_report_load_status(TReportExecStatusParams* load_params) {
         load_params->__set_loaded_rows(num_rows_load_sink());
         load_params->__set_sink_load_bytes(num_bytes_load_sink());
@@ -285,6 +289,7 @@ public:
         load_params->__set_source_load_bytes(num_bytes_load_from_source());
         load_params->__set_filtered_rows(num_rows_load_filtered());
         load_params->__set_unselected_rows(num_rows_load_unselected());
+        load_params->__set_source_scan_bytes(num_bytes_scan_from_source());
     }
 
     void set_per_fragment_instance_idx(int idx) { _per_fragment_instance_idx = idx; }
@@ -468,8 +473,9 @@ private:
     std::atomic<int64_t> _num_rows_load_sink{0};  // total rows sink to storage
     std::atomic<int64_t> _num_bytes_load_sink{0}; // total bytes sink to storage
 
-    std::atomic<int64_t> _num_rows_load_filtered{0};   // unqualified rows
-    std::atomic<int64_t> _num_rows_load_unselected{0}; // rows filtered by predicates
+    std::atomic<int64_t> _num_rows_load_filtered{0};     // unqualified rows
+    std::atomic<int64_t> _num_rows_load_unselected{0};   // rows filtered by predicates
+    std::atomic<int64_t> _num_bytes_scan_from_source{0}; // total bytes scan from source node
 
     std::atomic<int64_t> _num_print_error_rows{0};
     std::atomic<int64_t> _num_log_rejected_rows{0}; // rejected rows

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -277,6 +277,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 UUID uuid = UUID.randomUUID();
                 TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
                 task.init(loadId, attachment.getFileStatusByTable(aggKey), attachment.getFileNumByTable(aggKey));
+                // update total loading task scan range num
                 idToTasks.put(task.getSignature(), task);
                 // idToTasks contains previous LoadPendingTasks, so idToTasks is just used to save all tasks.
                 // use newLoadingTasks to save new created loading tasks and submit them later.
@@ -444,8 +445,13 @@ public class BrokerLoadJob extends BulkLoadJob {
         try {
             super.updateProgess(params);
             if (!loadingStatus.getLoadStatistic().getLoadFinish()) {
-                progress = (int) ((double) loadingStatus.getLoadStatistic().totalSourceLoadBytes() /
-                        loadingStatus.getLoadStatistic().totalFileSize() * 100);
+                if (jobType == EtlJobType.BROKER) {
+                    progress = (int) ((double) loadingStatus.getLoadStatistic().sourceScanBytes() /
+                            loadingStatus.getLoadStatistic().totalFileSize() * 100);
+                } else {
+                    progress = (int) ((double) loadingStatus.getLoadStatistic().totalSourceLoadBytes() /
+                            loadingStatus.getLoadStatistic().totalFileSize() * 100);
+                }
                 if (progress >= 100) {
                     progress = 99;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -257,6 +257,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         loadingStatus.setLoadFileInfo(fileNum, fileSize);
     }
 
+    public void updateScanRangeNum(long scanRangeNum) {
+        loadingStatus.updateScanRangeNum(scanRangeNum);
+    }
+
     public TUniqueId getRequestId() {
         return requestId;
     }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -554,6 +554,8 @@ struct TReportExecStatusParams {
   24: optional string rejected_record_path
 
   25: optional list<Types.TSinkCommitInfo> sink_commit_infos
+
+  26: optional i64 source_scan_bytes
 }
 
 struct TFeResult {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The previous implementation of load progress used the `load chunk size` divided by the `total file_size`. This calculation is very inaccurate, especially for formats with built-in compression such as parquet. 
Therefore, we consider dividing the actual `read file_size` by the `total file_size`. For parquet, since the actual read file_size cannot be obtained accurately due to the use of a third-party library, it is estimated based on the ratio of the number of rows read to the total number of rows.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
