### PR TITLE
[Feature] Support bitmap/hll/percentile rewrite in async MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
@@ -74,15 +74,19 @@ public class AggregateFunctionRewriter {
         if (aggFuncName.equals(FunctionSet.AVG)) {
             return true;
         }
+        // BITMAP
         if (aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct()) {
             return true;
         }
         if (aggFuncName.equals(FunctionSet.BITMAP_UNION_COUNT)) {
             return true;
         }
-        if (aggFuncName.equals(FunctionSet.APPROX_COUNT_DISTINCT) || aggFuncName.equals(FunctionSet.NDV)) {
+        // HLL
+        if (aggFuncName.equals(FunctionSet.APPROX_COUNT_DISTINCT) || aggFuncName.equals(FunctionSet.NDV) ||
+                aggFuncName.equals(FunctionSet.HLL_UNION_AGG) || aggFuncName.equals(FunctionSet.HLL_CARDINALITY)) {
             return true;
         }
+        // PERCENTILE
         if (aggFuncName.equals(FunctionSet.PERCENTILE_APPROX)) {
             return true;
         }
@@ -96,7 +100,8 @@ public class AggregateFunctionRewriter {
             return rewriteCountDistinct(aggFunc);
         } else if (aggFuncName.equals(FunctionSet.AVG)) {
             return rewriteAvg(aggFunc);
-        } else if (aggFuncName.equals(FunctionSet.APPROX_COUNT_DISTINCT) || aggFuncName.equals(FunctionSet.NDV)) {
+        } else if (aggFuncName.equals(FunctionSet.APPROX_COUNT_DISTINCT) || aggFuncName.equals(FunctionSet.NDV) ||
+                aggFuncName.equals(FunctionSet.HLL_UNION_AGG) || aggFuncName.equals(FunctionSet.HLL_CARDINALITY)) {
             return rewriteApproxCount(aggFunc);
         } else if (aggFuncName.equals(FunctionSet.PERCENTILE_APPROX)) {
             return rewritePercentile(aggFunc);
@@ -237,10 +242,10 @@ public class AggregateFunctionRewriter {
             newAggFunc = newColRef;
         }
 
-        CallOperator hllUnionAggOp = new CallOperator(FunctionSet.HLL_UNION_AGG,
+        CallOperator hllUnionAggOp = new CallOperator(FunctionSet.HLL_CARDINALITY,
                 aggFunc.getType(),
                 Lists.newArrayList(newAggFunc),
-                Expr.getBuiltinFunction(FunctionSet.HLL_UNION_AGG, new Type[] {Type.HLL},
+                Expr.getBuiltinFunction(FunctionSet.HLL_CARDINALITY, new Type[] {Type.HLL},
                         IS_IDENTICAL));
         return hllUnionAggOp;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
@@ -1,0 +1,195 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
+
+/**
+ * `AggregateFunctionRewriter` will try to rewrite some agg functions to some transformations so can be
+ * better to be rewritten.
+ * eg: AVG -> SUM / COUNT
+ * eg: COUNT(DISTINCT) -> BITMAP_COUNT(BITMAP_UNION(TO_BITMAP)))
+ */
+public class AggregateFunctionRewriter {
+    final ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
+    final ColumnRefFactory queryColumnRefFactory;
+
+    // new rewrite agg can reuse old agg functions if it has existed.
+    final Map<ColumnRefOperator, CallOperator> oldAggregations;
+
+    Map<ColumnRefOperator, CallOperator> newColumnRefToAggFuncMap;
+
+    public AggregateFunctionRewriter(ColumnRefFactory queryColumnRefFactory,
+                                     Map<ColumnRefOperator, CallOperator> oldAggregations) {
+        this.queryColumnRefFactory = queryColumnRefFactory;
+        this.oldAggregations = oldAggregations;
+    }
+
+    public AggregateFunctionRewriter(ColumnRefFactory queryColumnRefFactory,
+                                     Map<ColumnRefOperator, CallOperator> oldAggregations,
+                                     Map<ColumnRefOperator, CallOperator> newColumnRefToAggFuncMap) {
+        this.queryColumnRefFactory = queryColumnRefFactory;
+        this.oldAggregations = oldAggregations;
+        this.newColumnRefToAggFuncMap = newColumnRefToAggFuncMap;
+    }
+
+    public boolean canRewriteAggFunction(ScalarOperator op) {
+        if (!(op instanceof CallOperator)) {
+            return false;
+        }
+
+        CallOperator aggFunc = (CallOperator) op;
+        if (aggFunc.getFnName().equals(FunctionSet.AVG)) {
+            return true;
+        }
+        if (aggFunc.getFnName().equals(FunctionSet.COUNT) && aggFunc.isDistinct()) {
+            return true;
+        }
+        return false;
+    }
+
+    public CallOperator rewriteAggFunction(CallOperator aggFunc) {
+        if (aggFunc.getFnName().equals(FunctionSet.COUNT) && aggFunc.isDistinct()) {
+            return rewriteCountDistinct(aggFunc);
+        } else if (aggFunc.getFnName().equals(FunctionSet.AVG)) {
+            return rewriteAvg(aggFunc);
+        }
+
+        return null;
+    }
+
+    private Function findArithmeticFunction(Type[] argsType, String fnName) {
+        return Expr.getBuiltinFunction(fnName, argsType, IS_IDENTICAL);
+    }
+
+    private Pair<ColumnRefOperator, CallOperator> createNewCallOperator(Function newFn,
+                                                                        List<ScalarOperator> args) {
+        Preconditions.checkState(newFn != null);
+        CallOperator newCallOp = new CallOperator(newFn.functionName(), newFn.getReturnType(), args, newFn);
+        for (Map.Entry<ColumnRefOperator, CallOperator> entry : oldAggregations.entrySet()) {
+            if (entry.getValue().equals(newCallOp)) {
+                return Pair.create(entry.getKey(), newCallOp);
+            }
+        }
+        ColumnRefOperator newColRef =
+                queryColumnRefFactory.create(newCallOp, newCallOp.getType(), newCallOp.isNullable());
+        return Pair.create(newColRef, newCallOp);
+    }
+
+    private CallOperator rewriteAvg(CallOperator aggFunc) {
+        Type argType = aggFunc.getChild(0).getType();
+
+        // construct `sum` agg
+        Function sumFn = findArithmeticFunction(aggFunc.getFunction().getArgs(), FunctionSet.SUM);
+        Preconditions.checkState(sumFn != null);
+        Type sumReturnType;
+        if (argType.isDecimalV3()) {
+            sumReturnType =
+                    ScalarType.createDecimalV3NarrowestType(38, ((ScalarType) argType).getScalarScale());
+        } else {
+            sumReturnType = sumFn.getReturnType();
+        }
+        sumFn = sumFn.copy();
+        sumFn.setArgsType(aggFunc.getFunction().getArgs());
+        sumFn.setRetType(sumReturnType);
+        Pair<ColumnRefOperator, CallOperator> sumCallOp =
+                createNewCallOperator(sumFn, aggFunc.getChildren());
+
+        Function countFn = findArithmeticFunction(aggFunc.getFunction().getArgs(), FunctionSet.COUNT);
+        Pair<ColumnRefOperator, CallOperator> countCallOp = createNewCallOperator(countFn, aggFunc.getChildren());
+
+        // add sum/count into projection
+        CallOperator newAvg;
+        if (newColumnRefToAggFuncMap != null) {
+            newAvg = new CallOperator(FunctionSet.DIVIDE, aggFunc.getType(),
+                    Lists.newArrayList(sumCallOp.first, countCallOp.first));
+        } else {
+            newAvg = new CallOperator(FunctionSet.DIVIDE, aggFunc.getType(),
+                    Lists.newArrayList(sumCallOp.second, countCallOp.second));
+        }
+        if (argType.isDecimalV3()) {
+            // There is not need to apply ImplicitCastRule to divide operator of decimal types.
+            // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
+            ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
+            newAvg.getChildren().set(1, new CastOperator(decimal128p38s0, newAvg.getChild(1), true));
+        } else {
+            newAvg = (CallOperator) scalarRewriter.rewrite(newAvg, Lists.newArrayList(new ImplicitCastRule()));
+        }
+
+        // add sum/count agg into aggregations map
+        if (newColumnRefToAggFuncMap != null) {
+            newColumnRefToAggFuncMap.put(sumCallOp.first, sumCallOp.second);
+            newColumnRefToAggFuncMap.put(countCallOp.first, countCallOp.second);
+        }
+        return newAvg;
+    }
+
+    private CallOperator rewriteCountDistinct(CallOperator aggFunc) {
+        // What if bitmap_union aggregate table?
+        Type childType = aggFunc.getChild(0).getType();
+        List<ScalarOperator> aggChild = aggFunc.getChildren();
+        if (!childType.isBitmapType()) {
+            // add `to_bitmap` function for input
+            CallOperator toBitmapOp = new CallOperator(FunctionSet.TO_BITMAP,
+                    Type.BITMAP,
+                    aggFunc.getChildren(),
+                    Expr.getBuiltinFunction(FunctionSet.TO_BITMAP, new Type[] { Type.VARCHAR },
+                            IS_IDENTICAL));
+            toBitmapOp = (CallOperator) scalarRewriter.rewrite(toBitmapOp,
+                    Lists.newArrayList(new ImplicitCastRule()));
+            aggChild = Lists.newArrayList(toBitmapOp);
+        }
+
+        // rewrite count distinct to bitmap_count(bitmap_union(to_bitmap(x)));
+        CallOperator bitmapUnionOp = new CallOperator(FunctionSet.BITMAP_UNION,
+                Type.BITMAP,
+                aggChild,
+                Expr.getBuiltinFunction(FunctionSet.BITMAP_UNION, new Type[] {Type.BITMAP},
+                        IS_IDENTICAL));
+        List<ScalarOperator> newAggFunc = Lists.newArrayList(bitmapUnionOp);
+        if (newColumnRefToAggFuncMap != null) {
+            ColumnRefOperator newColRef =
+                    queryColumnRefFactory.create(bitmapUnionOp, bitmapUnionOp.getType(), bitmapUnionOp.isNullable());
+            newColumnRefToAggFuncMap.put(newColRef, bitmapUnionOp);
+            newAggFunc = Lists.newArrayList(newColRef);
+        }
+
+        CallOperator bitmapCountOp = new CallOperator(FunctionSet.BITMAP_COUNT,
+                aggFunc.getType(),
+                newAggFunc,
+                Expr.getBuiltinFunction(FunctionSet.BITMAP_COUNT, new Type[] {Type.BITMAP},
+                        IS_IDENTICAL));
+        return bitmapCountOp;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -23,9 +23,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
-import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
@@ -39,14 +37,11 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
-import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
-import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -57,6 +52,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
 
 /**
  * SPJG materialized view rewriter, based on
@@ -77,6 +74,9 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             .add(FunctionSet.MAX)
             .add(FunctionSet.MIN)
             .add(FunctionSet.APPROX_COUNT_DISTINCT)
+            .add(FunctionSet.BITMAP_UNION)
+            .add(FunctionSet.HLL_UNION)
+            .add(FunctionSet.PERCENTILE_UNION)
             .build();
 
     public AggregatedMaterializedViewRewriter(MvRewriteContext mvRewriteContext) {
@@ -126,7 +126,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         boolean isRollup = isRollupAggregate(mvGroupingKeys, queryGroupingKeys);
 
         // Cannot ROLLUP distinct
-        if (isRollup && !canRewriteForRollup(mvAggOp)) {
+        if (isRollup && mvAggOp.getAggregations().values().stream().anyMatch(callOp -> callOp.isDistinct())) {
             return null;
         }
 
@@ -152,12 +152,84 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                 }
                 mvOptExpr = OptExpression.create(new LogicalFilterOperator(rewrittenPred), mvOptExpr);
             }
-            return rewriteProjection(rewriteContext, queryExprToMvExprRewriter, mvOptExpr);
+            return rewriteProjection(rewriteContext, queryAggOp, queryExprToMvExprRewriter, mvOptExpr);
         }
     }
 
-    private boolean canRewriteForRollup(LogicalAggregationOperator aggOp) {
-        return aggOp.getAggregations().values().stream().noneMatch(callOp -> callOp.isDistinct());
+    protected OptExpression rewriteProjection(RewriteContext rewriteContext,
+                                              LogicalAggregationOperator queryAggregationOperator,
+                                              EquationRewriter queryExprToMvExprRewriter,
+                                              OptExpression mvOptExpr) {
+        Map<ColumnRefOperator, ScalarOperator> queryMap = MvUtils.getColumnRefMap(
+                rewriteContext.getQueryExpression(), rewriteContext.getQueryRefFactory());
+        ColumnRewriter columnRewriter = new ColumnRewriter(rewriteContext);
+
+        Map<ColumnRefOperator, CallOperator> oldAggregations = queryAggregationOperator.getAggregations();
+        Map<ColumnRefOperator, ScalarOperator> swappedQueryColumnMap = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : queryMap.entrySet()) {
+            ScalarOperator rewritten = rewriteContext.getQueryColumnRefRewriter().rewrite(entry.getValue().clone());
+            ScalarOperator swapped = columnRewriter.rewriteByQueryEc(rewritten);
+            swappedQueryColumnMap.put(entry.getKey(), swapped);
+        }
+
+        Map<ColumnRefOperator, ScalarOperator> newQueryProjection = Maps.newHashMap();
+        AggregateFunctionRewriter aggregateFunctionRewriter = new AggregateFunctionRewriter(rewriteContext.getQueryRefFactory(),
+                oldAggregations);
+        ColumnRefSet originalColumnSet = new ColumnRefSet(rewriteContext.getQueryColumnSet());
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : swappedQueryColumnMap.entrySet()) {
+            ScalarOperator scalarOp = entry.getValue();
+            ScalarOperator rewritten;
+            if (scalarOp instanceof CallOperator) {
+                rewritten = rewriteCallOperator((CallOperator) scalarOp,
+                        queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
+                        originalColumnSet, aggregateFunctionRewriter);
+            } else {
+                rewritten = rewriteScalarOperator(entry.getValue(),
+                        queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
+                        originalColumnSet);
+            }
+
+            if (rewritten == null) {
+                return null;
+            }
+            newQueryProjection.put(entry.getKey(), rewritten);
+        }
+        Projection newProjection = new Projection(newQueryProjection);
+        mvOptExpr.getOp().setProjection(newProjection);
+        return mvOptExpr;
+    }
+
+    private ScalarOperator rewriteCallOperator(CallOperator callOp,
+                                               EquationRewriter queryExprToMvExprRewriter,
+                                               Map<ColumnRefOperator, ColumnRefOperator> columnMapping,
+                                               ColumnRefSet originalColumnSet,
+                                               AggregateFunctionRewriter aggregateFunctionRewriter) {
+        ScalarOperator rewritten =
+                rewriteScalarOperator(callOp, queryExprToMvExprRewriter, columnMapping, originalColumnSet);
+        if (rewritten != null) {
+            return rewritten;
+        }
+
+        if (aggregateFunctionRewriter.canRewriteAggFunction(callOp)) {
+            callOp = aggregateFunctionRewriter.rewriteAggFunction(callOp);
+            rewritten = rewriteScalarOperator(callOp, queryExprToMvExprRewriter, columnMapping, originalColumnSet);
+        }
+        return rewritten;
+    }
+
+    private ScalarOperator rewriteScalarOperator(ScalarOperator scalarOp,
+                                                 EquationRewriter queryExprToMvExprRewriter,
+                                                 Map<ColumnRefOperator, ColumnRefOperator> columnMapping,
+                                                 ColumnRefSet originalColumnSet) {
+        ScalarOperator rewritten = replaceExprWithTarget(scalarOp, queryExprToMvExprRewriter, columnMapping);
+        if (rewritten == null) {
+            return null;
+        }
+        if (!isAllExprReplaced(rewritten, originalColumnSet)) {
+            // it means there is some column that can not be rewritten by outputs of mv
+            return null;
+        }
+        return rewritten;
     }
 
     // NOTE: this method is not exactly right to check whether it's a rollup aggregate:
@@ -245,7 +317,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             queryColumnRefToScalarMap.put(queryGroupKeys.get(i), newQueryGroupKeys.get(i));
         }
 
-        // rewrite query agg operator: rewrite avg to sum/ count
+        // rewrite agg func to be better for rollup.
         LogicalAggregationOperator rewrittenQueryAggOp =
                 rewriteAggregationOperatorByRules(rewriteContext.getQueryRefFactory(), queryAggOp);
         Map<ColumnRefOperator, ScalarOperator> queryAggregation = rewriteAggregations(
@@ -551,90 +623,44 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
     }
 
     private Function findArithmeticFunction(Type[] argsType, String fnName) {
-        return Expr.getBuiltinFunction(fnName, argsType, Function.CompareMode.IS_IDENTICAL);
+        return Expr.getBuiltinFunction(fnName, argsType, IS_IDENTICAL);
     }
 
     // Rewrite query agg operator by rule:
     //  - now only support rewrite avg to sum/ count
-    // TODO: maybe we can rewrite the whole query before MV's rewrite.
     private LogicalAggregationOperator rewriteAggregationOperatorByRules(
             ColumnRefFactory queryColumnRefFactory,
             LogicalAggregationOperator aggregationOperator) {
         Map<ColumnRefOperator, CallOperator> oldAggregations = aggregationOperator.getAggregations();
-        if (oldAggregations.values().stream().allMatch(x -> !x.getFnName().equals(FunctionSet.AVG))) {
+        final Map<ColumnRefOperator, CallOperator> newColumnRefToAggFuncMap = Maps.newHashMap();
+        final AggregateFunctionRewriter aggFuncRewriter = new AggregateFunctionRewriter(queryColumnRefFactory,
+                oldAggregations, newColumnRefToAggFuncMap);
+        if (!oldAggregations.values().stream().anyMatch(func ->
+                aggFuncRewriter.canRewriteAggFunction(func))) {
             return aggregationOperator;
         }
 
-        final Map<ColumnRefOperator, CallOperator> newAggMap = Maps.newHashMap();
-        final Map<ColumnRefOperator, ScalarOperator> projections = new HashMap<>();
-        final ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
+        final Map<ColumnRefOperator, ScalarOperator> newProjection = new HashMap<>();
         for (Map.Entry<ColumnRefOperator, CallOperator> aggEntry : oldAggregations.entrySet()) {
-            CallOperator oldFunctionCall = aggEntry.getValue();
-            if (oldFunctionCall.getFunction().getFunctionName().getFunction().equals(FunctionSet.AVG)) {
-                Type argType = oldFunctionCall.getChild(0).getType();
-
-                // construct `sum` agg
-                Function sumFn = findArithmeticFunction(oldFunctionCall.getFunction().getArgs(), FunctionSet.SUM);
-                Preconditions.checkState(sumFn != null);
-                Type sumReturnType;
-                if (argType.isDecimalV3()) {
-                    sumReturnType =
-                            ScalarType.createDecimalV3NarrowestType(38, ((ScalarType) argType).getScalarScale());
-                } else {
-                    sumReturnType = sumFn.getReturnType();
-                }
-                sumFn = sumFn.copy();
-                sumFn.setArgsType(oldFunctionCall.getFunction().getArgs());
-                sumFn.setRetType(sumReturnType);
-                Pair<ColumnRefOperator, CallOperator> sumCallOp =
-                        createNewCallOperator(queryColumnRefFactory, sumFn, oldFunctionCall.getChildren(), oldAggregations);
-
-                Function countFn = findArithmeticFunction(oldFunctionCall.getFunction().getArgs(), FunctionSet.COUNT);
-                Pair<ColumnRefOperator, CallOperator> countCallOp = createNewCallOperator(queryColumnRefFactory,
-                        countFn, oldFunctionCall.getChildren(), oldAggregations);
-
-                // add sum/count agg into aggregations map
-                newAggMap.put(sumCallOp.first, sumCallOp.second);
-                newAggMap.put(countCallOp.first, countCallOp.second);
-
-                // add sum/count into projection
-                CallOperator newAvg = new CallOperator(FunctionSet.DIVIDE, oldFunctionCall.getType(),
-                        Lists.newArrayList(sumCallOp.first, countCallOp.first));
-                if (argType.isDecimalV3()) {
-                    // There is not need to apply ImplicitCastRule to divide operator of decimal types.
-                    // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
-                    ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
-                    newAvg.getChildren().set(1, new CastOperator(decimal128p38s0, newAvg.getChild(1), true));
-                } else {
-                    newAvg = (CallOperator) scalarRewriter.rewrite(newAvg, Lists.newArrayList(new ImplicitCastRule()));
-                }
-                projections.put(aggEntry.getKey(), newAvg);
+            CallOperator aggFunc = aggEntry.getValue();
+            if (aggFuncRewriter.canRewriteAggFunction(aggFunc)) {
+                CallOperator newAggFunc = (CallOperator) aggFuncRewriter.rewriteAggFunction(aggFunc);
+                newProjection.put(aggEntry.getKey(), newAggFunc);
             } else {
-                projections.put(aggEntry.getKey(), aggEntry.getKey());
-                newAggMap.put(aggEntry.getKey(), aggEntry.getValue());
+                newProjection.put(aggEntry.getKey(), aggEntry.getKey());
+                newColumnRefToAggFuncMap.put(aggEntry.getKey(), aggEntry.getValue());
             }
         }
-
-        aggregationOperator.getGroupingKeys().forEach(c -> projections.put(c, c));
+        // Copy group by keys as projection
+        aggregationOperator.getGroupingKeys().forEach(c -> newProjection.put(c, c));
+        // Copy original projection mappings.
+        if (aggregationOperator.getProjection() != null) {
+            aggregationOperator.getProjection().getColumnRefMap().forEach((k, v) -> newProjection.put(k, v));
+        }
+        // Make a new logical agg with new projections.
         LogicalAggregationOperator newAggOp =
-                new LogicalAggregationOperator(AggType.GLOBAL, aggregationOperator.getGroupingKeys(), newAggMap);
-        newAggOp.setProjection(new Projection(projections));
+                new LogicalAggregationOperator(AggType.GLOBAL, aggregationOperator.getGroupingKeys(), newColumnRefToAggFuncMap);
+        newAggOp.setProjection(new Projection(newProjection));
         return newAggOp;
-    }
-
-    private Pair<ColumnRefOperator, CallOperator> createNewCallOperator(ColumnRefFactory queryColumnRefFactory,
-                                                                        Function newFn,
-                                                                        List<ScalarOperator> args,
-                                                                        Map<ColumnRefOperator, CallOperator> oldAggregations) {
-        Preconditions.checkState(newFn != null);
-        CallOperator newCallOp = new CallOperator(newFn.functionName(), newFn.getReturnType(), args, newFn);
-        for (Map.Entry<ColumnRefOperator, CallOperator> entry : oldAggregations.entrySet()) {
-            if (entry.getValue().equals(newCallOp)) {
-                return Pair.create(entry.getKey(), newCallOp);
-            }
-        }
-        ColumnRefOperator newColRef =
-                queryColumnRefFactory.create(newCallOp, newCallOp.getType(), newCallOp.isNullable());
-        return Pair.create(newColRef, newCallOp);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -357,6 +357,7 @@ public class StarRocksAssert {
 
         public void explainContains(String... keywords) throws Exception {
             String plan = explainQuery();
+            System.out.println(plan);
             Assert.assertTrue(plan, Stream.of(keywords).allMatch(plan::contains));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -357,7 +357,6 @@ public class StarRocksAssert {
 
         public void explainContains(String... keywords) throws Exception {
             String plan = explainQuery();
-            System.out.println(plan);
             Assert.assertTrue(plan, Stream.of(keywords).allMatch(plan::contains));
         }
 

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite
@@ -1,0 +1,365 @@
+-- name: test_materialized_view_rewrite
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'c', 3);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'd', 4);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'e', 5);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 2, 'e', 5);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 3, 'e', 6);
+-- result:
+-- !result
+create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
+-- result:
+-- !result
+select sleep(2);
+-- result:
+1
+-- !result
+set enable_materialized_view_rewrite = off;
+-- result:
+-- !result
+select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, bitmap_union_count(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+set enable_materialized_view_rewrite = on;
+-- result:
+-- !result
+select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, bitmap_union_count(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+drop materialized view user_tags_mv1;
+-- result:
+-- !result
+create materialized view user_tags_mv2  distributed by hash(user_id) as select user_id, time, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id, time;
+-- result:
+-- !result
+select sleep(2);
+-- result:
+1
+-- !result
+set enable_materialized_view_rewrite = on;
+-- result:
+-- !result
+explain logical select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, bitmap_union_count(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+drop materialized view user_tags_mv2;
+-- result:
+-- !result
+create materialized view user_tags_hll_mv1  distributed by hash(user_id) as select user_id, time, hll_union(hll_hash(tag_id)) a  from user_tags group by user_id, time;
+-- result:
+-- !result
+select sleep(2);
+-- result:
+1
+-- !result
+set enable_materialized_view_rewrite = off;
+-- result:
+-- !result
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+set enable_materialized_view_rewrite = on;
+-- result:
+-- !result
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+drop materialized view user_tags_hll_mv1;
+-- result:
+-- !result
+create materialized view user_tags_hll_mv2  distributed by hash(user_id) as select user_id, time, hll_union(hll_hash(tag_id)) from user_tags group by user_id, time;
+-- result:
+-- !result
+select sleep(2);
+-- result:
+1
+-- !result
+set enable_materialized_view_rewrite = on;
+-- result:
+-- !result
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+drop materialized view user_tags_hll_mv2;
+-- result:
+-- !result
+create materialized view user_tags_percential_mv1 distributed by hash(user_id) as select user_id, percentile_union(percentile_hash(tag_id)) from user_tags group by user_id order by user_id;
+-- result:
+-- !result
+select sleep(2);
+-- result:
+1
+-- !result
+set enable_materialized_view_rewrite = off;
+-- result:
+-- !result
+select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
+-- result:
+1	5.0
+2	5.0
+3	6.0
+-- !result
+select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
+-- result:
+1	1.0
+2	5.0
+3	6.0
+-- !result
+select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+-- result:
+1	1
+2	5
+3	6
+-- !result
+set enable_materialized_view_rewrite = on;
+-- result:
+-- !result
+select user_id, percentile_approx_raw(percentile_union(percentile_hash(tag_id)), 1) x from user_tags group by user_id order by user_id;
+-- result:
+1	5.0
+2	5.0
+3	6.0
+-- !result
+select user_id, percentile_approx_raw(percentile_union(percentile_hash(tag_id)), 1) x from user_tags group by user_id order by user_id;
+-- result:
+1	5.0
+2	5.0
+3	6.0
+-- !result
+select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
+-- result:
+1	1.0
+2	5.0
+3	6.0
+-- !result
+select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+-- result:
+1	1
+2	5
+3	6
+-- !result
+drop materialized view user_tags_percential_mv1;
+-- result:
+-- !result
+create materialized view user_tags_percential_mv2 distributed by hash(user_id) as select user_id, time, percentile_union(percentile_hash(tag_id)) from user_tags group by user_id, time;
+-- result:
+-- !result
+set enable_materialized_view_rewrite = on;
+-- result:
+-- !result
+select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
+-- result:
+1	5.0
+2	5.0
+3	6.0
+-- !result
+select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
+-- result:
+1	5.0
+2	5.0
+3	6.0
+-- !result
+select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
+-- result:
+1	1.0
+2	5.0
+3	6.0
+-- !result
+select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+-- result:
+1	1
+2	5
+3	6
+-- !result
+drop materialized view user_tags_percential_mv2;
+-- result:
+-- !result
+create materialized view user_tags_mv3  distributed by hash(user_id) as select user_id, tag_id from user_tags where user_id > 2;
+-- result:
+-- !result
+select sleep(2);
+-- result:
+1
+-- !result
+set enable_materialized_view_rewrite = off;
+-- result:
+-- !result
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+set enable_materialized_view_rewrite = on;
+-- result:
+-- !result
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+-- result:
+1	5
+2	1
+3	1
+-- !result
+drop materialized view user_tags_mv3;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite
@@ -1,0 +1,96 @@
+-- name: test_materialized_view_rewrite
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+insert into user_tags values('2023-04-13', 1, 'c', 3);
+insert into user_tags values('2023-04-13', 1, 'd', 4);
+insert into user_tags values('2023-04-13', 1, 'e', 5);
+insert into user_tags values('2023-04-13', 2, 'e', 5);
+insert into user_tags values('2023-04-13', 3, 'e', 6);
+
+-- TEST BITMAP: NO ROLLUP
+create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
+select sleep(2);
+set enable_materialized_view_rewrite = off;
+select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+select user_id, bitmap_union_count(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
+select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) x from user_tags group by user_id order by user_id;
+set enable_materialized_view_rewrite = on;
+-- explain logical select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+select user_id, bitmap_union_count(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
+select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) x from user_tags group by user_id order by user_id;
+drop materialized view user_tags_mv1;
+
+-- TEST BITMAP: ROLLUP
+create materialized view user_tags_mv2  distributed by hash(user_id) as select user_id, time, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id, time;
+select sleep(2);
+set enable_materialized_view_rewrite = on;
+explain logical select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
+select user_id, bitmap_union_count(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
+select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) x from user_tags group by user_id order by user_id;
+drop materialized view user_tags_mv2;
+
+-- TEST HLL: NO ROLLUP
+create materialized view user_tags_hll_mv1  distributed by hash(user_id) as select user_id, time, hll_union(hll_hash(tag_id)) a  from user_tags group by user_id, time;
+select sleep(2);
+set enable_materialized_view_rewrite = off;
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+set enable_materialized_view_rewrite = on;
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+drop materialized view user_tags_hll_mv1;
+
+-- TEST HLL: ROLLUP
+create materialized view user_tags_hll_mv2  distributed by hash(user_id) as select user_id, time, hll_union(hll_hash(tag_id)) from user_tags group by user_id, time;
+select sleep(2);
+set enable_materialized_view_rewrite = on;
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+drop materialized view user_tags_hll_mv2;
+
+-- TEST PERCENTILE: NO ROLLUP
+create materialized view user_tags_percential_mv1 distributed by hash(user_id) as select user_id, percentile_union(percentile_hash(tag_id)) from user_tags group by user_id order by user_id;
+select sleep(2);
+set enable_materialized_view_rewrite = off;
+select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
+select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
+select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+set enable_materialized_view_rewrite = on;
+select user_id, percentile_approx_raw(percentile_union(percentile_hash(tag_id)), 1) x from user_tags group by user_id order by user_id;
+select user_id, percentile_approx_raw(percentile_union(percentile_hash(tag_id)), 1) x from user_tags group by user_id order by user_id;
+select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
+select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+drop materialized view user_tags_percential_mv1;
+
+-- TEST PERCENTILE: ROLLUP
+create materialized view user_tags_percential_mv2 distributed by hash(user_id) as select user_id, time, percentile_union(percentile_hash(tag_id)) from user_tags group by user_id, time;
+set enable_materialized_view_rewrite = on;
+select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
+select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
+select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
+select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+drop materialized view user_tags_percential_mv2;
+
+-- TEST BITMAP : UNOION
+create materialized view user_tags_mv3  distributed by hash(user_id) as select user_id, tag_id from user_tags where user_id > 2;
+select sleep(2);
+set enable_materialized_view_rewrite = off;
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+set enable_materialized_view_rewrite = on;
+select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
+select user_id, hll_union_agg(hll_hash(tag_id)) x from user_tags group by user_id order by user_id;
+select user_id, hll_cardinality(hll_union(hll_hash(tag_id))) x from user_tags group by user_id order by user_id;
+drop materialized view user_tags_mv3;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21234

## Problem Summary(Required) ：
- Like Sync MV, SR can rewrite async mv: support bitmap/hll/percentile's mv rewrite.


```
String mv = "select user_id, time, bitmap_union(to_bitmap(tag_id % 10)) from user_tags group by user_id, time;";
// rewrite count distinct to bitmap_count(bitmap_union(to_bitmap(x)));
testRewriteOK(mv, "select user_id, count(distinct tag_id % 10) x from user_tags group by user_id;");
```

TODO:
- optimize rewritten plan : Convert `BITMAP_COUNT(BITMAP_UNION(TO_BITMAP)))` to `bitmap_union_count`;

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
