### PR TITLE
[Enhancement] adjust the transaction publish thread pool size strategy

### DIFF
--- a/be/src/agent/agent_common.h
+++ b/be/src/agent/agent_common.h
@@ -86,6 +86,8 @@ struct AgentTaskRequestWithoutReqBody {
     int64_t recv_time;
 };
 
+const int MIN_TRANSACTION_PUBLISH_WORKER_COUNT = 8;
+
 using CreateTabletAgentTaskRequest = AgentTaskRequestWithReqBody<TCreateTabletReq>;
 using DropTabletAgentTaskRequest = AgentTaskRequestWithReqBody<TDropTabletReq>;
 using PushReqAgentTaskRequest = AgentTaskRequestWithReqBody<TPushReq>;

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -151,12 +151,23 @@ void AgentServer::Impl::init_or_die() {
         CHECK(st.ok()) << st;                                                            \
     } while (false)
 
-        // The ideal queue size of threadpool should be larger than the maximum number of tablet of a partition.
-        // But it seems that there's no limit for the number of tablets of a partition.
-        // Since a large queue size brings a little overhead, a big one is chosen here.
-        BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version", config::transaction_publish_version_worker_count,
-                                       config::transaction_publish_version_worker_count,
-                                       DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE, _thread_pool_publish_version);
+// The ideal queue size of threadpool should be larger than the maximum number of tablet of a partition.
+// But it seems that there's no limit for the number of tablets of a partition.
+// Since a large queue size brings a little overhead, a big one is chosen here.
+#ifdef BE_TEST
+        BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version", 1, 1, DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE,
+                                       _thread_pool_publish_version);
+#else
+        int max_publish_version_worker_count = config::transaction_publish_version_worker_count;
+        if (max_publish_version_worker_count <= 0) {
+            max_publish_version_worker_count = CpuInfo::num_cores() / 2;
+        }
+        max_publish_version_worker_count =
+                std::max(max_publish_version_worker_count, MIN_TRANSACTION_PUBLISH_WORKER_COUNT);
+        BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version", MIN_TRANSACTION_PUBLISH_WORKER_COUNT,
+                                       max_publish_version_worker_count, DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE,
+                                       _thread_pool_publish_version);
+#endif
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("drop", config::drop_tablet_worker_count, config::drop_tablet_worker_count,
                                        std::numeric_limits<int>::max(), _thread_pool_drop);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -109,12 +109,8 @@ CONF_Int32(push_worker_count_normal_priority, "3");
 // The count of thread to high priority batch load.
 CONF_Int32(push_worker_count_high_priority, "3");
 
-#ifdef BE_TEST
-CONF_Int32(transaction_publish_version_worker_count, "1");
-#else
 // The count of thread to publish version per transaction
-CONF_Int32(transaction_publish_version_worker_count, "8");
-#endif
+CONF_mInt32(transaction_publish_version_worker_count, "0");
 
 // The count of thread to clear transaction task.
 CONF_Int32(clear_transaction_task_worker_count, "1");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -41,6 +41,8 @@
 #include <mutex>
 #include <string>
 
+#include "agent/agent_common.h"
+#include "agent/agent_server.h"
 #include "common/configbase.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -107,6 +109,11 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
 #if defined(USE_STAROS) && !defined(BE_TEST)
             _exec_env->lake_update_manager()->update_primary_index_memory_limit(config::update_memory_limit_percent);
 #endif
+        });
+        _config_callback.emplace("transaction_publish_version_worker_count", [&]() {
+            auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::PUBLISH_VERSION);
+            thread_pool->update_max_threads(
+                    std::max(MIN_TRANSACTION_PUBLISH_WORKER_COUNT, config::transaction_publish_version_worker_count));
         });
     });
 

--- a/docs/administration/Configuration.md
+++ b/docs/administration/Configuration.md
@@ -399,7 +399,7 @@ BE static parameters are as follows.
 | drop_tablet_worker_count | 3 | N/A | The number of threads used to drop a tablet. |
 | push_worker_count_normal_priority | 3 | N/A | The number of threads used to handle a load task with NORMAL priority. |
 | push_worker_count_high_priority | 3 | N/A | The number of threads used to handle a load task with HIGH priority. |
-| transaction_publish_version_worker_count | 8 | N/A | The number of threads used to publish a version. |
+| transaction_publish_version_worker_count | 0 | N/A | The max number of threads used to publish a version. When it's value is less than or equal to 0, it will default to half of the number of cores.  |
 | clear_transaction_task_worker_count | 1 | N/A | The number of threads used for clearing transaction. |
 | alter_tablet_worker_count | 3 | N/A | The number of threads used for schema change. |
 | clone_worker_count | 3 | N/A | The number of threads used for clone. |


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21367

## Problem Summary(Required) ：
In the current implementation, the transaction publish thread pool adopts a fixed number of threads strategy, with the number of threads being set to the configuration item `transaction_publish_version_worker_count=8`. However, this may cause problems because the default 8 threads may not be sufficient when the import concurrency is high, and can only be adjusted manually by analyzing and adjusting the number of threads.

Therefore, here comes a more friendly strategy, which is to take advantage of the dynamic thread pool by setting the minimum number of transaction publish threads to 8, and the maximum number of threads to half of the machine's cpu count by default. At the same time, it allows dynamic adjustment of the thread pool's maximum threads through an HTTP interface.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
