### PR TITLE
[Enhancement] add sv `runtime_filter_early_return_selectivity`

### DIFF
--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -503,7 +503,7 @@ void RuntimeFilterProbeCollector::update_selectivity(Chunk* chunk, RuntimeBloomF
         auto true_count = SIMD::count_nonzero(selection);
         eval_context.run_filter_nums += 1;
         double selectivity = true_count * 1.0 / chunk_size;
-        if (selectivity <= 0.5) {                    // useful filter
+        if (selectivity <= 0.5) {                          // useful filter
             if (selectivity < _early_return_selectivity) { // very useful filter, could early return
                 seletivity_map.clear();
                 seletivity_map.emplace(selectivity, rf_desc);

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -354,9 +354,9 @@ Status RuntimeFilterProbeCollector::prepare(RuntimeState* state, const RowDescri
         RETURN_IF_ERROR(rf_desc->prepare(state, row_desc, profile));
     }
     if (state != nullptr) {
-        TQueryOptions& options = state->query_options();
-        if (options.__isset.runtime_filter_early_return_ratio) {
-            _early_return_ratio = options.runtime_filter_early_return_ratio;
+        const TQueryOptions& options = state->query_options();
+        if (options.__isset.runtime_filter_early_return_selectivity) {
+            _early_return_selectivity = options.runtime_filter_early_return_selectivity;
         }
     }
     return Status::OK();
@@ -504,7 +504,7 @@ void RuntimeFilterProbeCollector::update_selectivity(Chunk* chunk, RuntimeBloomF
         eval_context.run_filter_nums += 1;
         double selectivity = true_count * 1.0 / chunk_size;
         if (selectivity <= 0.5) {                    // useful filter
-            if (selectivity < _early_return_ratio) { // very useful filter, could early return
+            if (selectivity < _early_return_selectivity) { // very useful filter, could early return
                 seletivity_map.clear();
                 seletivity_map.emplace(selectivity, rf_desc);
                 chunk->filter(selection);

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -353,6 +353,12 @@ Status RuntimeFilterProbeCollector::prepare(RuntimeState* state, const RowDescri
         RuntimeFilterProbeDescriptor* rf_desc = it.second;
         RETURN_IF_ERROR(rf_desc->prepare(state, row_desc, profile));
     }
+    if (state != nullptr) {
+        TQueryOptions& options = state->query_options();
+        if (options.__isset.runtime_filter_early_return_ratio) {
+            _early_return_ratio = options.runtime_filter_early_return_ratio;
+        }
+    }
     return Status::OK();
 }
 Status RuntimeFilterProbeCollector::open(RuntimeState* state) {
@@ -497,8 +503,8 @@ void RuntimeFilterProbeCollector::update_selectivity(Chunk* chunk, RuntimeBloomF
         auto true_count = SIMD::count_nonzero(selection);
         eval_context.run_filter_nums += 1;
         double selectivity = true_count * 1.0 / chunk_size;
-        if (selectivity <= 0.5) {     // useful filter
-            if (selectivity < 0.05) { // very useful filter, could early return
+        if (selectivity <= 0.5) {                    // useful filter
+            if (selectivity < _early_return_ratio) { // very useful filter, could early return
                 seletivity_map.clear();
                 seletivity_map.emplace(selectivity, rf_desc);
                 chunk->filter(selection);

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -251,6 +251,7 @@ private:
     std::map<int32_t, RuntimeFilterProbeDescriptor*> _descriptors;
     int _wait_timeout_ms = 0;
     long _scan_wait_timeout_ms = 0L;
+    double _early_return_ratio = 0.05;
     RuntimeProfile* _runtime_profile = nullptr;
     RuntimeBloomFilterEvalContext _eval_context;
     int _plan_node_id = -1;

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -251,7 +251,7 @@ private:
     std::map<int32_t, RuntimeFilterProbeDescriptor*> _descriptors;
     int _wait_timeout_ms = 0;
     long _scan_wait_timeout_ms = 0L;
-    double _early_return_ratio = 0.05;
+    double _early_return_selectivity = 0.05;
     RuntimeProfile* _runtime_profile = nullptr;
     RuntimeBloomFilterEvalContext _eval_context;
     int _plan_node_id = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1014,11 +1014,7 @@ public class CoordinatorPreprocessor {
     void computeScanRangeAssignment() throws Exception {
         SessionVariable sv = connectContext.getSessionVariable();
 
-        queryOptions.setUse_scan_block_cache(sv.getUseScanBlockCache());
-        queryOptions.setEnable_populate_block_cache(sv.getEnablePopulateBlockCache());
-        queryOptions.setHudi_mor_force_jni_reader(sv.getHudiMORForceJNIReader());
-        queryOptions.setIo_tasks_per_scan_operator(sv.getIoTasksPerScanOperator());
-        queryOptions.setConnector_io_tasks_per_scan_operator(sv.getConnectorIoTasksPerScanOperator());
+
 
         // set scan ranges/locations for scan nodes
         for (ScanNode scanNode : scanNodes) {
@@ -1556,6 +1552,7 @@ public class CoordinatorPreprocessor {
                                 sessionVariable.getAdaptiveDopMaxOutputAmplificationFactor());
                     }
                 }
+
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -276,6 +276,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String GLOBAL_RUNTIME_FILTER_PROBE_MIN_SIZE = "global_runtime_filter_probe_min_size";
     public static final String GLOBAL_RUNTIME_FILTER_PROBE_MIN_SELECTIVITY =
             "global_runtime_filter_probe_min_selectivity";
+    public static final String RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY = "runtime_filter_early_return_selectivity";
 
     public static final String ENABLE_COLUMN_EXPR_PREDICATE = "enable_column_expr_predicate";
     public static final String ENABLE_EXCHANGE_PASS_THROUGH = "enable_exchange_pass_through";
@@ -684,7 +685,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = SPILL_OPERATOR_MAX_BYTES, flag = VariableMgr.INVISIBLE)
     private long spillOperatorMaxBytes = 1024L * 1024 * 1000;
 
-
     @VariableMgr.VarAttr(name = FORWARD_TO_LEADER, alias = FORWARD_TO_MASTER)
     private boolean forwardToLeader = false;
 
@@ -793,6 +793,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long globalRuntimeFilterProbeMinSize = 100L * 1024L;
     @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_PROBE_MIN_SELECTIVITY, flag = VariableMgr.INVISIBLE)
     private float globalRuntimeFilterProbeMinSelectivity = 0.5f;
+    @VariableMgr.VarAttr(name = RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY, flag = VariableMgr.INVISIBLE)
+    private float runtimeFilterEarlyReturnSelectivity = 0.05f;
 
     //In order to be compatible with the logic of the old planner,
     //When the column name is the same as the alias name,
@@ -910,18 +912,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = HUDI_MOR_FORCE_JNI_READER)
     private boolean hudiMORForceJNIReader = false;
-
-    public boolean getUseScanBlockCache() {
-        return useScanBlockCache;
-    }
-
-    public int getIoTasksPerScanOperator() {
-        return ioTasksPerScanOperator;
-    }
-
-    public int getConnectorIoTasksPerScanOperator() {
-        return connectorIoTasksPerScanOperator;
-    }
 
     @VarAttr(name = ENABLE_QUERY_CACHE)
     private boolean enableQueryCache = false;
@@ -1069,10 +1059,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableDistinctColumnBucketization() {
         return enableDistinctColumnBucketization;
-    }
-
-    public boolean getEnablePopulateBlockCache() {
-        return enablePopulateBlockCache;
     }
 
     public boolean getHudiMORForceJNIReader() {
@@ -2046,8 +2032,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setSpill_mode(TSpillMode.valueOf(spillMode.toUpperCase()));
         tResult.setEnable_query_debug_trace(enableQueryDebugTrace);
         tResult.setEnable_pipeline_query_statistic(enablePipelineQueryStatistic);
+        tResult.setRuntime_filter_early_return_selectivity(runtimeFilterEarlyReturnSelectivity);
 
         tResult.setAllow_throw_exception((sqlMode & SqlModeHelper.MODE_ALLOW_THROW_EXCEPTION) != 0);
+
+        tResult.setUse_scan_block_cache(useScanBlockCache);
+        tResult.setEnable_populate_block_cache(enablePopulateBlockCache);
+        tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);
+        tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);
+        tResult.setConnector_io_tasks_per_scan_operator(connectorIoTasksPerScanOperator);
         return tResult;
     }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -187,6 +187,7 @@ struct TQueryOptions {
   
   86: optional i32 io_tasks_per_scan_operator = 4;
   87: optional i32 connector_io_tasks_per_scan_operator = 16;
+  88: optional double runtime_filter_early_return_ratio = 0.05;
 }
 
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -187,7 +187,7 @@ struct TQueryOptions {
   
   86: optional i32 io_tasks_per_scan_operator = 4;
   87: optional i32 connector_io_tasks_per_scan_operator = 16;
-  88: optional double runtime_filter_early_return_ratio = 0.05;
+  88: optional double runtime_filter_early_return_selectivity = 0.05;
 }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We found a customer case that there are two runtime filters:
1. the first one has filter ratio (0.03)
2. but the second has filter ratio like 4e-6

Since we have code like following, we will skip the second(but better) runtime filter.

```cpp
        if (selectivity <= 0.5) {                    // useful filter
            if (selectivity < 0.05) { // very useful filter, could early return
                seletivity_map.clear();
                seletivity_map.emplace(selectivity, rf_desc);
                chunk->filter(selection);
                return;
            }
```

And since this sv is rarely used, I'd like to put it invisible.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
