### PR TITLE
[BugFix] Fix some cancel problem in spiller

### DIFF
--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -240,6 +240,12 @@ AggregatorParamsPtr convert_to_aggregator_params(const TPlanNode& tnode);
 class Aggregator : public pipeline::ContextWithDependency {
 public:
     static constexpr auto MAX_CHUNK_BUFFER_SIZE = 1024;
+#ifdef NDEBUG
+    static constexpr size_t two_level_memory_threshold = 33554432; // 32M, L3 Cache
+#else
+    static constexpr size_t two_level_memory_threshold = 64;
+#endif
+
     Aggregator(AggregatorParamsPtr params);
 
     ~Aggregator() noexcept override {
@@ -275,7 +281,8 @@ public:
     const int64_t hash_map_memory_usage() const { return _hash_map_variant.reserved_memory_usage(mem_pool()); }
     const int64_t hash_set_memory_usage() const { return _hash_set_variant.reserved_memory_usage(mem_pool()); }
 
-    TStreamingPreaggregationMode::type streaming_preaggregation_mode() { return _streaming_preaggregation_mode; }
+    TStreamingPreaggregationMode::type& streaming_preaggregation_mode() { return _streaming_preaggregation_mode; }
+    TStreamingPreaggregationMode::type streaming_preaggregation_mode() const { return _streaming_preaggregation_mode; }
     const AggHashMapVariant& hash_map_variant() { return _hash_map_variant; }
     const AggHashSetVariant& hash_set_variant() { return _hash_set_variant; }
     std::any& it_hash() { return _it_hash; }
@@ -361,13 +368,6 @@ public:
         return _spiller == nullptr || _spiller->spilled_append_rows() == _spiller->restore_read_rows();
     }
 
-#ifdef NDEBUG
-    static constexpr size_t two_level_memory_threshold = 33554432; // 32M, L3 Cache
-    static constexpr size_t streaming_hash_table_size_threshold = 10000000;
-#else
-    static constexpr size_t two_level_memory_threshold = 64;
-    static constexpr size_t streaming_hash_table_size_threshold = 4;
-#endif
     HashTableKeyAllocator _state_allocator;
 
 protected:

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -466,7 +466,7 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
 
     if (runtime_state()->enable_spill() &&
         std::is_same_v<HashJoinBuilderFactory, SpillableHashJoinBuildOperatorFactory>) {
-        context->interpolate_spill_process(build_side_spill_channel_factory, num_right_partitions);
+        context->interpolate_spill_process(id(), build_side_spill_channel_factory, num_right_partitions);
     }
 
     auto* pool = context->fragment_context()->runtime_state()->obj_pool();

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -46,6 +46,8 @@ public:
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
+    void mark_need_spill() override;
+
 private:
     // Invoked by push_chunk if current mode is TStreamingPreaggregationMode::FORCE_STREAMING
     Status _push_chunk_by_force_streaming(const ChunkPtr& chunk);
@@ -66,7 +68,7 @@ private:
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;
-    AggrAutoState _auto_state;
+    AggrAutoState _auto_state{};
     AggrAutoContext _auto_context;
 };
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
@@ -40,7 +40,9 @@ public:
 
     Status prepare(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
-    bool pending_finish() const override { return _aggregator->has_pending_data(); }
+    bool pending_finish() const override {
+        return _aggregator->has_pending_data() || _aggregator->has_pending_restore();
+    }
 
 private:
     Status _spill_all_inputs(RuntimeState* state, const ChunkPtr& chunk);

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -56,7 +56,6 @@ bool SpillableAggregateBlockingSourceOperator::is_finished() const {
 Status SpillableAggregateBlockingSourceOperator::set_finished(RuntimeState* state) {
     _is_finished = true;
     RETURN_IF_ERROR(AggregateBlockingSourceOperator::set_finished(state));
-    _aggregator->spiller()->set_finished();
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -172,6 +172,7 @@ Status SpillableHashJoinBuildOperator::push_chunk(RuntimeState* state, const Chu
 }
 
 void SpillableHashJoinBuildOperator::mark_need_spill() {
+    HashJoinBuildOperator::mark_need_spill();
     if (!_is_finished) {
         _join_builder->set_spill_strategy(spill::SpillStrategy::SPILL_ALL);
     }

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
@@ -45,7 +45,9 @@ public:
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
-    bool pending_finish() const override { return _join_builder->spiller()->has_pending_data(); }
+    bool pending_finish() const override {
+        return _join_builder->spiller()->has_pending_data() || !_join_builder->spiller()->restore_finished();
+    }
 
     void mark_need_spill() override;
 

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -176,15 +176,15 @@ OpFactories PipelineBuilderContext::_do_maybe_interpolate_local_shuffle_exchange
     return {std::move(local_shuffle_source)};
 }
 
-void PipelineBuilderContext::interpolate_spill_process(const SpillProcessChannelFactoryPtr& spill_channel_factory,
+void PipelineBuilderContext::interpolate_spill_process(size_t plan_node_id,
+                                                       const SpillProcessChannelFactoryPtr& spill_channel_factory,
                                                        size_t dop) {
     OpFactories spill_process_operators;
-    auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto spill_process_factory = std::make_shared<SpillProcessOperatorFactory>(
-            next_operator_id(), "spill-process", pseudo_plan_node_id, spill_channel_factory);
+    auto spill_process_factory = std::make_shared<SpillProcessOperatorFactory>(next_operator_id(), "spill-process",
+                                                                               plan_node_id, spill_channel_factory);
     spill_process_factory->set_degree_of_parallelism(dop);
     spill_process_operators.emplace_back(std::move(spill_process_factory));
-    auto noop_sink_factory = std::make_shared<NoopSinkOperatorFactory>(next_operator_id(), next_pseudo_plan_node_id());
+    auto noop_sink_factory = std::make_shared<NoopSinkOperatorFactory>(next_operator_id(), plan_node_id);
     spill_process_operators.emplace_back(std::move(noop_sink_factory));
     add_pipeline(std::move(spill_process_operators));
 }

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -63,7 +63,8 @@ public:
     OpFactories maybe_interpolate_local_shuffle_exchange(RuntimeState* state, OpFactories& pred_operators,
                                                          const PartitionExprsGenerator& self_partition_exprs_generator);
 
-    void interpolate_spill_process(const SpillProcessChannelFactoryPtr& channel_factory, size_t dop);
+    void interpolate_spill_process(size_t plan_node_id, const SpillProcessChannelFactoryPtr& channel_factory,
+                                   size_t dop);
 
     // Uses local exchange to gather the output chunks of multiple predecessor pipelines
     // into a new pipeline, which the successor operator belongs to.

--- a/be/src/exec/pipeline/sort/sort_context.cpp
+++ b/be/src/exec/pipeline/sort/sort_context.cpp
@@ -56,13 +56,7 @@ bool SortContext::is_partition_ready() const {
     });
 }
 
-void SortContext::cancel() {
-    for (const auto& sorter : _chunks_sorter_partitions) {
-        if (sorter) {
-            sorter->cancel();
-        }
-    }
-}
+void SortContext::cancel() {}
 
 StatusOr<ChunkPtr> SortContext::pull_chunk() {
     _init_merger();

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -214,6 +214,9 @@ StatusOr<ChunkUniquePtr> UnorderedInputStream::get_next(SerdeContext& ctx) {
             // move to the next block
             continue;
         }
+        if (res.status().ok() && res.value()->is_empty()) {
+            continue;
+        }
         if (!res.status().is_end_of_file()) {
             return res;
         }

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -57,6 +57,8 @@ public:
 
     bool restore_finished() const { return _running_restore_tasks == 0; }
 
+    bool has_restore_task() const { return _running_restore_tasks > 0; }
+
 protected:
     Spiller* _spiller;
     std::atomic_uint64_t _running_restore_tasks{};

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -123,7 +123,12 @@ public:
 
     bool restore_finished() const { return _reader->restore_finished(); }
 
-    void cancel() { _writer->cancel(); }
+    bool is_cancel() { return _is_cancel; }
+
+    void cancel() {
+        _is_cancel = true;
+        _writer->cancel();
+    }
 
     void set_finished() { cancel(); }
 
@@ -175,5 +180,7 @@ private:
     std::shared_ptr<spill::Serde> _serde;
     spill::BlockManager* _block_manager = nullptr;
     std::shared_ptr<spill::BlockGroup> _block_group;
+
+    std::atomic_bool _is_cancel = false;
 };
 } // namespace starrocks::spill

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -123,7 +123,7 @@ public:
 
     bool restore_finished() const { return _reader->restore_finished(); }
 
-    bool is_cancel() { return _is_cancel; }
+    bool is_cancel() const { return _is_cancel; }
 
     void cancel() {
         _is_cancel = true;

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -296,7 +296,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
 
     // spill process operator
     if (runtime_state()->enable_spill() && _limit < 0 && !is_partition_topn) {
-        context->interpolate_spill_process(spill_channel_factory, degree_of_parallelism);
+        context->interpolate_spill_process(id(), spill_channel_factory, degree_of_parallelism);
     }
 
     // create context factory


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：


## Problem Summary(Required) ：
problem 1. 
now XXXSinkOperator ans XXXSourceOperator share the same spiller
if SinkOperator is running with spill
```
template <class TaskExecutor, class MemGuard>
Status RawSpillerWriter::spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&& executor, MemGuard&& guard) {
    if (_mem_table == nullptr) {
        _mem_table = _acquire_mem_table_from_pool();
    }
    >>> runing here
    RETURN_IF_ERROR(_mem_table->append(chunk));

    if (_mem_table->is_full()) {
        return flush(state, std::forward<TaskExecutor>(executor), std::forward<MemGuard>(guard));
    }

    return Status::OK();
}
```
when source operator call cancel. the _mem_table will be reset it will cause some problem

problem 2:
if Source Operator is finished. and closed. at this time. SinkOperator call set_finishing. the set_flush_all_call_back will be called and submit a task. but at this time sink operator pending finish is not true.
```
    Status set_flush_all_call_back(const FlushAllCallBack& callback, RuntimeState* state, IOTaskExecutor& executor,
                                   const MemTrackerGuard& guard) {
        auto flush_call_back = [this, callback, state, &executor, guard]() {
            RETURN_IF_ERROR(callback());
            if (spilled()) {
                RETURN_IF_ERROR(_acquire_input_stream(state));
                RETURN_IF_ERROR(trigger_restore(state, executor, guard));
            }
            return Status::OK();
        };
        return _writer->set_flush_all_call_back(flush_call_back);
    }
```

possiable stack:
```
*** Aborted at 1681279903 (unix time) try "date -d @1681279903" if you are using GNU date ***
PC: @          0x36302a0 starrocks::spill::RawSpillerWriter::spill<>()
*** SIGSEGV (@0x18) received by PID 559052 (TID 0x7f83d5fde640) from PID 24; stack trace: ***
    @          0x68527ba google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f85527bb520 (unknown)
    @          0x36302a0 starrocks::spill::RawSpillerWriter::spill<>()
    @          0x3631d55 starrocks::spill::Spiller::spill<>()
    @          0x362c600 starrocks::SpillableChunksSorterFullSort::update()
    @          0x38d3737 starrocks::pipeline::PartitionSortSinkOperator::push_chunk()
    @          0x3906032 starrocks::pipeline::SpillablePartitionSortSinkOperator::push_chunk()
    @          0x39202f4 starrocks::pipeline::PipelineDriver::process()
    @          0x390f0e0 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x59eaa3b starrocks::ThreadPool::dispatch_thread()
    @          0x59e51ba starrocks::Thread::supervise_thread()
    @     0x7f855280db43 (unknown)
    @     0x7f855289fa00 (unknown)
    @                0x0 (unknown)

*** Aborted at 1681216315 (unix time) try "date -d @1681216315" if you are using GNU date ***
PC: @          0x4da8b45 starrocks::ColumnVisitorMutableAdapter<>::visit()
*** SIGSEGV (@0x0) received by PID 3340 (TID 0x7fbc61cc7700) from PID 0; stack trace: ***
    @          0x65b8612 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fbcca6db630 (unknown)
    @          0x4da8b45 starrocks::ColumnVisitorMutableAdapter<>::visit()
    @          0x32c2bfc starrocks::ColumnFactory<>::accept_mutable()
    @          0x4da8528 starrocks::serde::ColumnArraySerde::deserialize()
    @          0x3b47ccc starrocks::spill::ColumnarSerde::deserialize()
    @          0x3b4a53d starrocks::spill::UnorderedInputStream::get_next()
    @          0x3b4c0ab starrocks::spill::BufferedInputStream::prefetch()
    @          0x3b48b67 starrocks::spill::OrderedInputStream::prefetch()
    @          0x3a569ca _ZNSt17_Function_handlerIFvvEZN9starrocks5spill13SpillerReader15trigger_restoreIRNS2_14IOTaskExecutorERKNS2_15MemTrackerGuardEEENS1_6StatusEPNS1_12RuntimeStateEOT_OT0_EUlvE_E9_M_invokeERKSt9_Any_data
    @          0x562d3c0 starrocks::PriorityThreadPool::work_thread()
    @          0x65696a7 thread_proxy
    @     0x7fbcca6d3ea5 start_thread
    @     0x7fbcca3fcb0d __clone
    @                0x0 (unknown)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
