### PR TITLE
[Enhancement] Support time_slice input for date_trunc  partition column 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewPartitionFunctionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewPartitionFunctionChecker.java
@@ -1,0 +1,104 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
+
+import java.util.Map;
+
+import static com.starrocks.sql.common.TimeUnitUtils.TIME_MAP;
+
+public class MaterializedViewPartitionFunctionChecker {
+    @FunctionalInterface
+    public interface CheckPartitionFunction {
+        boolean check(Expr expr);
+    }
+
+    public static final Map<String, CheckPartitionFunction> FN_NAME_TO_PATTERN;
+
+    static {
+        FN_NAME_TO_PATTERN = Maps.newHashMap();
+        // can add some other functions
+        FN_NAME_TO_PATTERN.put("date_trunc", MaterializedViewPartitionFunctionChecker::checkDateTrunc);
+    }
+
+    public static boolean checkDateTrunc(Expr expr) {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return false;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        String fnNameString = fnExpr.getFnName().getFunction();
+        if (!fnNameString.equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
+            return false;
+        }
+
+        if (!(fnExpr.getChild(0) instanceof StringLiteral)) {
+            return false;
+        }
+        String fmt = ((StringLiteral) fnExpr.getChild(0)).getValue();
+        if (fmt.equalsIgnoreCase("week")) {
+            throw new SemanticException("The function date_trunc used by the materialized view for partition" +
+                    " does not support week formatting", expr.getPos());
+        }
+
+        Expr child1 = fnExpr.getChild(1);
+        if (child1 instanceof SlotRef) {
+            SlotRef slotRef = (SlotRef) child1;
+            PrimitiveType primitiveType = slotRef.getType().getPrimitiveType();
+            // must check slotRef type, because function analyze don't check it.
+            return primitiveType == PrimitiveType.DATETIME || primitiveType == PrimitiveType.DATE;
+        } else if (child1 instanceof FunctionCallExpr) {
+            // date_trunc('hour', time_slice(dt, 'minute'))
+            FunctionCallExpr funcExpr = (FunctionCallExpr) child1;
+            if (funcExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.TIME_SLICE)) {
+                if (funcExpr.getParams().exprs().size() != 4) {
+                    return false;
+                }
+
+                // TODO: support more functions which do not affect the mv's final partition.
+                Expr child0 = funcExpr.getChild(0);
+                if (!(child0 instanceof SlotRef)) {
+                    throw new SemanticException("1th child of the function time_slice used by the materialized view " +
+                            "only supports slot ref", expr.getPos());
+                }
+                // Check time_slice's input type valid
+                SlotRef slotRef = (SlotRef)  child0;
+                PrimitiveType primitiveType = slotRef.getType().getPrimitiveType();
+                if (primitiveType != PrimitiveType.DATETIME && primitiveType != PrimitiveType.DATE) {
+                    return false;
+                }
+                // Check time_slice's input
+                String timeSliceFloor = ((StringLiteral) funcExpr.getChild(3)).getValue();
+                if (!timeSliceFloor.equalsIgnoreCase("floor")) {
+                    return false;
+                }
+                // NOTE: Ensure time_slice's time unit is less than partition's time unit which
+                // will not affect the mv's final partition.
+                String timeSliceFmt = ((StringLiteral) funcExpr.getChild(2)).getValue();
+                if (TIME_MAP.containsKey(timeSliceFmt) && TIME_MAP.containsKey(fmt) &&
+                        TIME_MAP.get(timeSliceFmt) < TIME_MAP.get(fmt)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -60,19 +60,19 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.common.TimeUnitUtils.DAY;
+import static com.starrocks.sql.common.TimeUnitUtils.HOUR;
+import static com.starrocks.sql.common.TimeUnitUtils.MINUTE;
+import static com.starrocks.sql.common.TimeUnitUtils.MONTH;
+import static com.starrocks.sql.common.TimeUnitUtils.QUARTER;
+import static com.starrocks.sql.common.TimeUnitUtils.YEAR;
+
 /**
  * Process lower bound and upper bound for Expression Partition,
  * only support SlotRef and FunctionCallExpr
  */
 public class SyncPartitionUtils {
     private static final Logger LOG = LogManager.getLogger(SyncPartitionUtils.class);
-
-    public static final String MINUTE = "minute";
-    public static final String HOUR = "hour";
-    public static final String DAY = "day";
-    public static final String MONTH = "month";
-    public static final String QUARTER = "quarter";
-    public static final String YEAR = "year";
 
     private SyncPartitionUtils() throws IllegalAccessException {
         throw new IllegalAccessException("Utility class");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TimeUnitUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TimeUnitUtils.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.google.common.collect.ImmutableMap;
+
+public class TimeUnitUtils {
+
+    public static final String SECOND = "second";
+    public static final String MINUTE = "minute";
+    public static final String HOUR = "hour";
+    public static final String DAY = "day";
+    public static final String MONTH = "month";
+    public static final String QUARTER = "quarter";
+    public static final String YEAR = "year";
+
+    // "week" can not exist in timeMap due "month" not sure contains week
+    public static final ImmutableMap<String, Integer> TIME_MAP =
+            new ImmutableMap.Builder<String, Integer>()
+                    .put("second", 1)
+                    .put("minute", 2)
+                    .put("hour", 3)
+                    .put("day", 4)
+                    .put("month", 5)
+                    .put("quarter", 6)
+                    .put("year", 7)
+                    .build();
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -16,7 +16,6 @@
 package com.starrocks.sql.optimizer.operator;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.BoolLiteral;
@@ -58,6 +57,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static com.starrocks.sql.common.TimeUnitUtils.TIME_MAP;
+
 /**
  * Convert column predicate to partition column filter
  */
@@ -66,17 +67,6 @@ public class ColumnFilterConverter {
 
     private static final ColumnFilterVisitor COLUMN_FILTER_VISITOR = new ColumnFilterVisitor();
 
-    // "week" can not exist in timeMap due "month" not sure contains week
-    private static final ImmutableMap<String, Integer> TIME_MAP =
-            new ImmutableMap.Builder<String, Integer>()
-                    .put("second", 1)
-                    .put("minute", 2)
-                    .put("hour", 3)
-                    .put("day", 4)
-                    .put("month", 5)
-                    .put("quarter", 6)
-                    .put("year", 7)
-                    .build();
 
     public static Map<String, PartitionColumnFilter> convertColumnFilter(List<ScalarOperator> predicates) {
         return convertColumnFilter(predicates, null);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -2629,7 +2629,6 @@ public class CreateMaterializedViewTest {
             starRocksAssert.dropMaterializedView(mvName);
         }
     }
-
     @Test
     public void testExprAlias() throws Exception {
         testMVColumnAlias("c_1_9 + 1");
@@ -2711,6 +2710,65 @@ public class CreateMaterializedViewTest {
 
         starRocksAssert.dropTable("emps");
         starRocksAssert.dropTable("depts");
+	}
+
+    @Test
+    public void testCreateAsyncDateTruncAndTimeSLice() throws Exception {
+        LocalDateTime startTime = LocalDateTime.now().plusSeconds(3);
+        {
+            String sql = "create materialized view mv1\n" +
+                    "partition by date_trunc('month', k11)\n" +
+                    "distributed by hash(s2) buckets 10\n" +
+                    "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                    "') EVERY(INTERVAL 3 DAY)\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ")\n" +
+                    "as select time_slice(tb1.k1, interval 5 minute) as k11, k2 s2 from tbl1 tb1;";
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        }
+
+        {
+            String sql = "create materialized view mv1\n" +
+                    "partition by date_trunc('month', k11)\n" +
+                    "distributed by hash(s2) buckets 10\n" +
+                    "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                    "') EVERY(INTERVAL 3 DAY)\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ")\n" +
+                    "as select time_slice(tb1.k1, interval 5 year) as k11, k2 s2 from tbl1 tb1;";
+            Assert.assertThrows(AnalysisException.class,
+                    () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+        }
+
+        {
+            String sql = "create materialized view mv1\n" +
+                    "partition by date_trunc('month', k11)\n" +
+                    "distributed by hash(s2) buckets 10\n" +
+                    "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                    "') EVERY(INTERVAL 3 DAY)\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ")\n" +
+                    "as select time_slice(tb1.k1, interval 5 month) as k11, k2 s2 from tbl1 tb1;";
+            Assert.assertThrows(AnalysisException.class,
+                    () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+        }
+
+        {
+            String sql = "create materialized view mv1\n" +
+                    "partition by date_trunc('month', k11)\n" +
+                    "distributed by hash(s2) buckets 10\n" +
+                    "refresh async START('" + startTime.format(DateUtils.DATE_TIME_FORMATTER) +
+                    "') EVERY(INTERVAL 3 DAY)\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ")\n" +
+                    "as select time_slice(tb1.k1, interval 5 month, 'ceil') as k11, k2 s2 from tbl1 tb1;";
+            Assert.assertThrows(AnalysisException.class,
+                    () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+        }
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DropMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DropMaterializedViewStmtTest.java
@@ -42,8 +42,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.AnalysisException;
-import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
@@ -53,9 +51,7 @@ import com.starrocks.thrift.TStorageType;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -47,7 +47,7 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
 
     @Test
     public void testDistinct2() throws Exception {
-        String tableSQL = "CREATE TABLE `test_partition_expr_tbl1` (\n" +
+        String tableSQL = "CREATE TABLE `test_distinct2` (\n" +
                 "  `order_id` bigint(20) NOT NULL DEFAULT \"-1\" COMMENT \"\",\n" +
                 "  `dt` datetime NOT NULL DEFAULT \"1996-01-01 00:00:00\" COMMENT \"\",\n" +
                 "  `k1`bigint,\n" +
@@ -71,7 +71,7 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "\"replication_num\" = \"1\"" +
                 ");";
         starRocksAssert.withTable(tableSQL);
-        String mv = "CREATE MATERIALIZED VIEW `test_partition_expr_mv1`\n" +
+        String mv = "CREATE MATERIALIZED VIEW `test_distinct2_mv`\n" +
                 "COMMENT \"MATERIALIZED_VIEW\"\n" +
                 "PARTITION BY (date_trunc('hour', `dt`))\n" +
                 "DISTRIBUTED BY HASH(`dt`) BUCKETS 10\n" +
@@ -83,13 +83,13 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "k1, " +
                 "count(DISTINCT `order_id`) AS `order_num`, \n" +
                 "`dt`\n" +
-                "FROM `test_partition_expr_tbl1`\n" +
+                "FROM `test_distinct2`\n" +
                 "group by dt, k1;";
         starRocksAssert.withMaterializedView(mv);
         sql("select dt, count(distinct order_id) " +
                 "from test_partition_expr_tbl1 group by dt")
                 .nonMatch("test_partition_expr_mv1");
-        starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
+        starRocksAssert.dropMaterializedView("test_distinct2_mv");
     }
 
     @Test
@@ -177,5 +177,6 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "FROM `test_partition_expr_tbl1`\n" +
                 "WHERE `dt` >= '2023-04-10 17:00:00' and `dt` < '2023-04-10 18:00:00'\n" +
                 "group by ts").nonMatch("test_partition_expr_mv1");
+        starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -114,4 +114,68 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
         testRewriteOK(mv, "SELECT dt, count(DISTINCT id) from test_limit_1 where " +
                 "dt >= '2022-07-01' and dt <= '2022-10-01' group by dt limit 10");
     }
+
+    @Test
+    public void testPartitionColumnExpr1() throws Exception {
+        String tableSQL = "CREATE TABLE `test_partition_expr_tbl1` (\n" +
+                "  `order_id` bigint(20) NOT NULL DEFAULT \"-1\" COMMENT \"\",\n" +
+                "  `dt` datetime NOT NULL DEFAULT \"1996-01-01 00:00:00\" COMMENT \"\",\n" +
+                "  `value` varchar(256) NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`order_id`, `dt`)\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(\n" +
+                "PARTITION p2023041017 VALUES [(\"2023-04-10 17:00:00\"), (\"2023-04-10 18:00:00\")),\n" +
+                "PARTITION p2023041021 VALUES [(\"2023-04-10 21:00:00\"), (\"2023-04-10 22:00:00\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`order_id`) BUCKETS 9\n" +
+                "PROPERTIES (\n" +
+                "\"dynamic_partition.enable\" = \"true\",\n" +
+                "\"dynamic_partition.time_unit\" = \"HOUR\",\n" +
+                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                "\"dynamic_partition.start\" = \"-240\",\n" +
+                "\"dynamic_partition.end\" = \"2\",\n" +
+                "\"dynamic_partition.prefix\" = \"p\",\n" +
+                "\"dynamic_partition.buckets\" = \"9\"," +
+                "\"replication_num\" = \"1\"" +
+                ");";
+        starRocksAssert.withTable(tableSQL);
+        String mv = "CREATE MATERIALIZED VIEW `test_partition_expr_mv1`\n" +
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "PARTITION BY (date_trunc('hour', ds))\n" +
+                "DISTRIBUTED BY HASH(`order_num`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ")\n" +
+                "AS\n" +
+                "SELECT \n" +
+                "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                "time_slice(`dt`, INTERVAL 5 minute) AS ds\n" +
+                "FROM `test_partition_expr_tbl1`\n" +
+                "group by ds;";
+        starRocksAssert.withMaterializedView(mv);
+
+        sql("SELECT \n" +
+                "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                "time_slice(`dt`, INTERVAL 5 minute) AS ds \n" +
+                "FROM `test_partition_expr_tbl1`\n" +
+                "WHERE time_slice(`dt`, INTERVAL 5 minute) BETWEEN '2023-04-11' AND '2023-04-12'\n" +
+                "group by ds")
+                .match("test_partition_expr_mv1");
+
+        sql("SELECT \n" +
+                "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                "time_slice(`dt`, INTERVAL 5 minute) AS `ts`\n" +
+                "FROM `test_partition_expr_tbl1`\n" +
+                "WHERE time_slice(dt, interval 5 minute) >= '2023-04-10 17:00:00' and time_slice(dt, interval 5 minute) < '2023-04-10 18:00:00'\n" +
+                "group by ts")
+                .match("test_partition_expr_mv1");
+
+        sql("SELECT \n" +
+                "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                "time_slice(`dt`, INTERVAL 5 minute) AS `ts`\n" +
+                "FROM `test_partition_expr_tbl1`\n" +
+                "WHERE `dt` >= '2023-04-10 17:00:00' and `dt` < '2023-04-10 18:00:00'\n" +
+                "group by ts").nonMatch("test_partition_expr_mv1");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
-  support another special case: `date_trunc` partition column for `time_slice` input which will not affect the final output partition.

eg:
```
create materialized view mv1
partition by date_trunc('month', k11)
distributed by hash(s2) buckets 10
refresh async START('2023-04-18 00:00:00') EVERY(INTERVAL 3 DAY)
PROPERTIES (
"replication_num" = "1"
)
as select time_slice(tb1.k1, interval 5 minute) as k11, k2 s2 from tbl1 tb1;
```


Futher:
- After `automatic partitioning`, we may support more non-slot ref inputs for partition columns.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
