### PR TITLE
[BugFix] Fix mv may not completely refresh when create with property partition_refresh_number.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -340,6 +340,9 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         for (Map.Entry<Long, Map<String, MaterializedView.BasePartitionInfo>> tableEntry
                 : changedTablePartitionInfos.entrySet()) {
             Long tableId = tableEntry.getKey();
+            if (mvContext.hasNextBatchPartition() && tableId != materializedView.getId()) {
+                continue;
+            }
             if (!currentVersionMap.containsKey(tableId)) {
                 currentVersionMap.put(tableId, Maps.newHashMap());
             }
@@ -373,6 +376,9 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         for (Map.Entry<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> tableEntry
                 : changedTablePartitionInfos.entrySet()) {
             BaseTableInfo baseTableInfo = tableEntry.getKey();
+            if (mvContext.hasNextBatchPartition() && baseTableInfo.getTableId() != materializedView.getId()) {
+                continue;
+            }
             if (!currentVersionMap.containsKey(baseTableInfo)) {
                 currentVersionMap.put(baseTableInfo, Maps.newHashMap());
             }


### PR DESCRIPTION

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21419

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->


Metadata for other tables only refresh when last task execute success.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
