### PR TITLE
[BugFix] Find correct index of window_size for window_funnel

### DIFF
--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -92,14 +92,35 @@ struct WindowFunnelState {
         TimestampType last_timestamp = -1;
     };
     using TimestampVector = std::vector<TimestampTypePair>;
-    int64_t window_size;
+
+    // `window_size` is guaranteed to be non-negative by the analyzer in FE,
+    // so use -1 to indicate `window_size` hasn't been initialized.
+    static constexpr int64_t ABSENT_WINDOW_SIZE = -1;
+
+    int64_t window_size = ABSENT_WINDOW_SIZE;
     mutable int32_t mode = 0;
     uint8_t events_size;
     bool sorted = true;
     char buffer[reserve_list_size * sizeof(TimestampEvent)];
     stack_memory_resource mr;
     mutable std::pmr::vector<TimestampEvent> events_list;
+
     WindowFunnelState() : mr(buffer, sizeof(buffer)), events_list(&mr) { events_list.reserve(reserve_list_size); }
+
+    void init_once(FunctionContext* ctx) {
+        if (window_size != ABSENT_WINDOW_SIZE) {
+            return;
+        }
+
+        // `agg_expr_ctxs` is different between update and merge mode of the AggregationOperator.
+        // - update mode: [InitLiteral(BIGINT), SlotRef(DATE/DATETIME), IntLiteral(INT), SlotRef(Array<BOOLEAN>)]
+        // - merge mode: [SlotRef(ARRAY<BIGINT>), InitLiteral(BIGINT), IntLiteral(INT)]
+        // Therefore, the index of `window_size` is 0 or 1.
+        size_t window_size_col_index = ctx->get_constant_column(0) != nullptr ? 0 : 1;
+        window_size = ColumnHelper::get_const_value<TYPE_BIGINT>(ctx->get_constant_column(window_size_col_index));
+
+        mode = ColumnHelper::get_const_value<TYPE_INT>(ctx->get_constant_column(2));
+    }
 
     void sort() const { std::stable_sort(std::begin(events_list), std::end(events_list)); }
 
@@ -124,8 +145,6 @@ struct WindowFunnelState {
         }
 
         std::vector<TimestampEvent> other_list;
-        window_size = ColumnHelper::get_const_value<TYPE_BIGINT>(ctx->get_constant_column(1));
-        mode = ColumnHelper::get_const_value<TYPE_INT>(ctx->get_constant_column(2));
 
         events_size = (uint8_t)array[0];
         bool other_sorted = (uint8_t)array[1];
@@ -419,8 +438,7 @@ public:
                 size_t row_num) const override {
         DCHECK(columns[2]->is_constant());
 
-        this->data(state).window_size = down_cast<const Int64Column*>(columns[0])->get_data()[0];
-        this->data(state).mode = ColumnHelper::get_const_value<TYPE_INT>(columns[2]);
+        this->data(state).init_once(ctx);
 
         // get timestamp
         TimeType tv;
@@ -481,6 +499,9 @@ public:
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_array());
         DCHECK(!column->is_nullable());
+
+        this->data(state).init_once(ctx);
+
         const auto* input_column = down_cast<const ArrayColumn*>(column);
         const auto& offsets = input_column->offsets().get_data();
         const auto& elements = input_column->elements();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -234,6 +234,11 @@ public class FunctionAnalyzer {
             } else {
                 throw new SemanticException("window argument must be numerical type", windowArg.getPos());
             }
+
+            Expr timeExpr = functionCallExpr.getChild(1);
+            if (timeExpr.isConstant()) {
+                throw new SemanticException("time arg must be column", timeExpr.getPos());
+            }
         }
 
         if (fnName.getFunction().equals(FunctionSet.MAX_BY) || fnName.getFunction().equals(FunctionSet.MIN_BY)) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -227,4 +227,39 @@ public class AnalyzeAggregateTest {
         analyzeSuccess("select percentile_disc(tj,0.5) from tall group by tb");
     }
 
+    @Test
+    public void testWindowFunnelFunction() {
+        // For the argument `window_size`.
+        analyzeFail("SELECT window_funnel(-1, ti, 0, [ta='a', ta='b']) FROM tall",
+                "window argument must >= 0");
+        analyzeFail("SELECT window_funnel('VARCHAR', ti, 0, [ta='a', ta='b']) FROM tall",
+                "window argument must be numerical type");
+        analyzeFail("SELECT window_funnel(tc, ti, 0, [ta='a', ta='b']) FROM tall",
+                "window argument must be numerical type");
+
+        // For the argument `mode`.
+        analyzeFail("SELECT window_funnel(1, ti, -1, [ta='a', ta='b']) FROM tall",
+                "mode argument's range must be [0-7]");
+        analyzeFail("SELECT window_funnel(1, ti, 8, [ta='a', ta='b']) FROM tall",
+                "mode argument's range must be [0-7]");
+        analyzeFail("SELECT window_funnel(1, ti, 'VARCHAR', [ta='a', ta='b']) FROM tall",
+                "mode argument must be numerical type");
+        analyzeFail("SELECT window_funnel(1, ti, ta, [ta='a', ta='b']) FROM tall",
+                "mode argument must be numerical type");
+
+        // For the argument `time`.
+        analyzeFail("SELECT window_funnel(1, '2022-01-01', 0, [ta='a', ta='b']) FROM tall",
+                "time arg must be column");
+
+        // For the argument `condition`.
+        analyzeFail("SELECT window_funnel(1, ti, 0, ti) FROM tall",
+                "No matching function with signature");
+
+        // Successful statements.
+        analyzeSuccess("SELECT window_funnel(0, ti, 0, [ta='a', ta='b']) FROM tall");
+        analyzeSuccess("SELECT window_funnel(1, ti, 0, [ta='a', ta='b']) FROM tall");
+        analyzeSuccess("SELECT window_funnel(1, ta, 0, [ta='a', ta='b']) FROM tall");
+        analyzeSuccess("SELECT window_funnel(1, ta, 0, [true, true, false]) FROM tall");
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -926,34 +926,6 @@ public class AggregateTest extends PlanTestBase {
         FeConstants.runningUnitTest = false;
     }
 
-    public void testWindowFunnelWithInvalidModeWindow() throws Exception {
-        FeConstants.runningUnitTest = true;
-        expectedException.expect(SemanticException.class);
-        expectedException.expectMessage("mode argument's range must be [0-7]");
-        String sql =
-                "select L_ORDERKEY,window_funnel(1800, L_SHIPDATE, 8, [L_PARTKEY = 1]) from lineitem_partition_colocate" +
-                        " group by L_ORDERKEY;";
-        try {
-            getFragmentPlan(sql);
-        } finally {
-            FeConstants.runningUnitTest = false;
-        }
-    }
-
-    @Test
-    public void testWindowFunnelWithNonDecimalWindow() throws Exception {
-        FeConstants.runningUnitTest = true;
-        expectedException.expect(SemanticException.class);
-        expectedException.expectMessage("window argument must be numerical type");
-        String sql = "select L_ORDERKEY,window_funnel('varchar', L_SHIPDATE, 3, [L_PARTKEY = 1]) " +
-                "from lineitem_partition_colocate group by L_ORDERKEY;";
-        try {
-            getFragmentPlan(sql);
-        } finally {
-            FeConstants.runningUnitTest = false;
-        }
-    }
-
     @Test
     public void testLocalAggregateWithMultiStage() throws Exception {
         FeConstants.runningUnitTest = true;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21474.




## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`agg_expr_ctxs` of `window_funnel` is different between the **update** and **merge** mode of the AggregationOperator.
- **update** mode: [InitLiteral(BIGINT), SlotRef(DATE/DATETIME), IntLiteral(INT), SlotRef(Array<BOOLEAN>)]
- **merge** mode: [SlotRef(ARRAY<BIGINT>), InitLiteral(BIGINT), IntLiteral(INT)]

Therefore, the index of `window_size` is 0 or 1, 
- `WindowFunnelAggregateFunction::update` considers it as 0,
- `WindowFunnelAggregateFunction::merge` considers it as 1.

However, when enabling query cache, the `update` mode AggregateOperator could accepts intermediate input chunk, which also invokes `WindowFunnelAggregateFunction::merge` and consider the index of `window_size` is 1.


---

Besides, the second argument of `window_funnel` should be constrained to the non-constant column. Otherwise, `agg_expr_ctxs` of **merge** mode will be [SlotRef(ARRAY<BIGINT>), InitLiteral(BIGINT), **InitLiteral(Date/Int)** IntLiteral(INT)], which is hard to find the correct index of `window_size` and `window_mode`.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
