### PR TITLE
[BugFix] use default_db as es connector default database

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
@@ -37,7 +37,7 @@ public class ElasticsearchMetadata
 
     private final EsRestClient esRestClient;
     private final Map<String, String> properties;
-    public static final String DEFAULT_DB = "default";
+    public static final String DEFAULT_DB = "default_db";
     public static final long DEFAULT_DB_ID = 1L;
 
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
`default` is keyword.  it will fail when we execute "use default" in the es connector. so we should use other word as es connector default database
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
