### PR TITLE
[BugFix] Write short index page using sort key if table separate primary keys and sort keys

### DIFF
--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -315,11 +315,7 @@ Status SegmentWriter::append_chunk(const Chunk& chunk) {
                 size_t keys = _tablet_schema->num_short_key_columns();
                 SeekTuple tuple(*chunk.schema(), chunk.get(i).datums());
                 std::string encoded_key;
-                if (!_tablet_schema->sort_key_idxes().empty()) {
-                    encoded_key = tuple.short_key_encode(keys, _tablet_schema->sort_key_idxes(), 0);
-                } else {
-                    encoded_key = tuple.short_key_encode(keys, 0);
-                }
+                encoded_key = tuple.short_key_encode(keys, _tablet_schema->sort_key_idxes(), 0);
                 RETURN_IF_ERROR(_index_builder->add_item(encoded_key));
             }
             ++_num_rows_written;

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -314,7 +314,12 @@ Status SegmentWriter::append_chunk(const Chunk& chunk) {
             if ((_num_rows_written % _opts.num_rows_per_block) == 0) {
                 size_t keys = _tablet_schema->num_short_key_columns();
                 SeekTuple tuple(*chunk.schema(), chunk.get(i).datums());
-                std::string encoded_key = tuple.short_key_encode(keys, 0);
+                std::string encoded_key;
+                if (!_tablet_schema->sort_key_idxes().empty()) {
+                    encoded_key = tuple.short_key_encode(keys, _tablet_schema->sort_key_idxes(), 0);
+                } else {
+                    encoded_key = tuple.short_key_encode(keys, 0);
+                }
                 RETURN_IF_ERROR(_index_builder->add_item(encoded_key));
             }
             ++_num_rows_written;

--- a/be/src/storage/seek_tuple.h
+++ b/be/src/storage/seek_tuple.h
@@ -87,7 +87,7 @@ inline std::string SeekTuple::short_key_encode(size_t num_short_keys, std::vecto
                                                uint8_t padding) const {
     std::string output;
     DCHECK(num_short_keys <= sort_key_idxes.size());
-    size_t n = std::min(num_short_keys, std::min(sort_key_idxes.size(), _values.size()));
+    size_t n = std::min(num_short_keys, _values.size());
     size_t val_num = _values.size();
     for (auto i = 0; i < n; i++) {
         if (sort_key_idxes[i] >= val_num || _values[sort_key_idxes[i]].is_null()) {

--- a/be/src/storage/seek_tuple.h
+++ b/be/src/storage/seek_tuple.h
@@ -86,7 +86,6 @@ inline std::string SeekTuple::short_key_encode(size_t num_short_keys, uint8_t pa
 inline std::string SeekTuple::short_key_encode(size_t num_short_keys, std::vector<uint32_t> sort_key_idxes,
                                                uint8_t padding) const {
     std::string output;
-    LOG(INFO) << "num_short_keys is " << num_short_keys << ", sort_key_idxes size is " << sort_key_idxes.size();
     DCHECK(num_short_keys <= sort_key_idxes.size());
     size_t n = std::min(num_short_keys, std::min(sort_key_idxes.size(), _values.size()));
     size_t val_num = _values.size();

--- a/be/src/storage/seek_tuple.h
+++ b/be/src/storage/seek_tuple.h
@@ -83,17 +83,19 @@ inline std::string SeekTuple::short_key_encode(size_t num_short_keys, uint8_t pa
     return output;
 }
 
-inline std::string SeekTuple::short_key_encode(size_t num_short_keys, std::vector<uint32_t> short_key_idxes,
+inline std::string SeekTuple::short_key_encode(size_t num_short_keys, std::vector<uint32_t> sort_key_idxes,
                                                uint8_t padding) const {
     std::string output;
-    size_t n = std::min(num_short_keys, std::min(short_key_idxes.size(), _values.size()));
+    LOG(INFO) << "num_short_keys is " << num_short_keys << ", sort_key_idxes size is " << sort_key_idxes.size();
+    DCHECK(num_short_keys <= sort_key_idxes.size());
+    size_t n = std::min(num_short_keys, std::min(sort_key_idxes.size(), _values.size()));
     size_t val_num = _values.size();
     for (auto i = 0; i < n; i++) {
-        if (short_key_idxes[i] >= val_num || _values[short_key_idxes[i]].is_null()) {
+        if (sort_key_idxes[i] >= val_num || _values[sort_key_idxes[i]].is_null()) {
             output.push_back(KEY_NULL_FIRST_MARKER);
         } else {
             output.push_back(KEY_NORMAL_MARKER);
-            _schema.field(short_key_idxes[i])->encode_ascending(_values[short_key_idxes[i]], &output);
+            _schema.field(sort_key_idxes[i])->encode_ascending(_values[sort_key_idxes[i]], &output);
         }
     }
     if (_values.size() < num_short_keys) {

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -406,6 +406,7 @@ Status TabletReader::_to_seek_tuple(const TabletSchema& tablet_schema, const Ola
     values.reserve(input.size());
     const auto& sort_key_idxes = tablet_schema.sort_key_idxes();
     DCHECK(sort_key_idxes.empty() || sort_key_idxes.size() >= input.size());
+
     if (sort_key_idxes.size() > 0) {
         for (int i = 0; i < input.size(); i++) {
             schema.append_sort_key_idx(i);

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -408,8 +408,8 @@ Status TabletReader::_to_seek_tuple(const TabletSchema& tablet_schema, const Ola
     DCHECK(sort_key_idxes.empty() || sort_key_idxes.size() >= input.size());
 
     if (sort_key_idxes.size() > 0) {
-        for (int i = 0; i < input.size(); i++) {
-            schema.append_sort_key_idx(i);
+        for (auto idx : sort_key_idxes) {
+            schema.append_sort_key_idx(idx);
         }
     }
     for (size_t i = 0; i < input.size(); i++) {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1129,7 +1129,7 @@ TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
     request.__set_version(1);
     request.__set_version_hash(0);
     request.tablet_schema.schema_hash = schema_hash;
-    request.tablet_schema.short_key_column_count = 6;
+    request.tablet_schema.short_key_column_count = 1;
     request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
     request.tablet_schema.storage_type = TStorageType::COLUMN;
 

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -95,7 +95,7 @@ public:
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
-        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 

--- a/be/test/storage/rowset_column_update_state_test.cpp
+++ b/be/test/storage/rowset_column_update_state_test.cpp
@@ -94,7 +94,7 @@ public:
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
-        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -139,7 +139,7 @@ public:
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
-        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -94,7 +94,7 @@ public:
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
-        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -400,7 +400,7 @@ public:
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
-        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 
@@ -439,7 +439,7 @@ public:
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
-        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -86,7 +86,7 @@ public:
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
-        request.tablet_schema.short_key_column_count = 6;
+        request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/KeysDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/KeysDesc.java
@@ -189,7 +189,7 @@ public class KeysDesc implements ParseNode, Writable {
         }
     }
 
-    public void checkColumnDefs(List<ColumnDef> cols) {
+    public void checkColumnDefs(List<ColumnDef> cols, List<Integer> sortKeyIdxes) {
         if (type == null) {
             throw new SemanticException("Keys type is null.");
         }
@@ -236,6 +236,16 @@ public class KeysDesc implements ParseNode, Writable {
                     throw new SemanticException(type.name() + " table should not specify aggregate type for "
                             + "non-key column[%s]", cols.get(i).getName());
                 }
+            }
+        }
+
+        for (int i = 0; i < sortKeyIdxes.size(); i++) {
+            String name = cols.get(sortKeyIdxes.get(i)).getName();
+            ColumnDef cd = cols.get(sortKeyIdxes.get(i));
+            Type t = cd.getType();
+            if (!(t.isBoolean() || t.isIntegerType() || t.isLargeint() || t.isVarchar() || t.isDate() ||
+                    t.isDatetime())) {
+                throw new SemanticException("sort key column[" + name + "] type not supported: " + t.toSql());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -737,19 +737,21 @@ public class OlapScanNode extends ScanNode {
         List<TPrimitiveType> keyColumnTypes = new ArrayList<TPrimitiveType>();
         if (selectedIndexId != -1) {
             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(selectedIndexId);
-            if (KeysType.PRIMARY_KEYS == olapTable.getKeysType() && indexMeta.getSortKeyIdxes() != null) {
-                for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
-                    Column col = indexMeta.getSchema().get(sortKeyIdx);
-                    keyColumnNames.add(col.getName());
-                    keyColumnTypes.add(col.getPrimitiveType().toThrift());
-                }
-            } else {
-                for (Column col : olapTable.getSchemaByIndexId(selectedIndexId)) {
-                    if (!col.isKey()) {
-                        break;
+            if (indexMeta != null) {
+                if (KeysType.PRIMARY_KEYS == olapTable.getKeysType() && indexMeta.getSortKeyIdxes() != null) {
+                    for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
+                        Column col = indexMeta.getSchema().get(sortKeyIdx);
+                        keyColumnNames.add(col.getName());
+                        keyColumnTypes.add(col.getPrimitiveType().toThrift());
                     }
-                    keyColumnNames.add(col.getName());
-                    keyColumnTypes.add(col.getPrimitiveType().toThrift());
+                } else {
+                    for (Column col : olapTable.getSchemaByIndexId(selectedIndexId)) {
+                        if (!col.isKey()) {
+                            break;
+                        }
+                        keyColumnNames.add(col.getName());
+                        keyColumnTypes.add(col.getPrimitiveType().toThrift());
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -146,6 +146,7 @@ public class CreateTableAnalyzer {
         statement.setCharsetName(analyzeCharsetName(statement.getCharsetName()).toLowerCase());
 
         KeysDesc keysDesc = statement.getKeysDesc();
+        List<Integer> sortKeyIdxes = Lists.newArrayList();
         if (statement.getSortKeys() != null) {
             if (keysDesc == null || keysDesc.getKeysType() != KeysType.PRIMARY_KEYS) {
                 NodePosition keysPos = NodePosition.ZERO;
@@ -153,6 +154,17 @@ public class CreateTableAnalyzer {
                     keysPos = keysDesc.getPos();
                 }
                 throw new SemanticException("only primary key support sort key", keysPos);
+            } else {
+                List<String> columnNames = 
+                            statement.getColumnDefs().stream().map(ColumnDef::getName).collect(Collectors.toList());
+                
+                for (String column : statement.getSortKeys()) {
+                    int idx = columnNames.indexOf(column);
+                    if (idx == -1) {
+                        throw new SemanticException("Invalid column '%s' not exists in all columns. '%s', '%s'", column);
+                    }
+                    sortKeyIdxes.add(idx);
+                }
             }
         }
         List<ColumnDef> columnDefs = statement.getColumnDefs();
@@ -225,7 +237,7 @@ public class CreateTableAnalyzer {
             }
 
             keysDesc.analyze(columnDefs);
-            keysDesc.checkColumnDefs(columnDefs);
+            keysDesc.checkColumnDefs(columnDefs, sortKeyIdxes);
             for (int i = 0; i < keysDesc.keysColumnSize(); ++i) {
                 columnDefs.get(i).setIsKey(true);
             }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/21375 https://github.com/StarRocks/starrocks/issues/21372

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

If primary key table separate primary key and sort key, we will write data in the order of  sort keys. However, we still use primary keys to generate the short key index,  so we may get error scan range and get error result when we execute query.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
