### PR TITLE
[Feature][Cherry-pick][Branch-3.0] Parse avro data directly (#19866)

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -14,6 +14,7 @@
 
 #include "connector/file_connector.h"
 
+#include "exec/avro_scanner.h"
 #include "exec/csv_scanner.h"
 #include "exec/exec_node.h"
 #include "exec/json_scanner.h"
@@ -75,9 +76,7 @@ Status FileDataSource::_create_scanner() {
     } else if (_scan_range.ranges[0].format_type == TFileFormatType::FORMAT_JSON) {
         _scanner = std::make_unique<JsonScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
     } else if (_scan_range.ranges[0].format_type == TFileFormatType::FORMAT_AVRO) {
-        // TODO(yangzaorang): we use json as an intermediate format to parse avro format, but there are
-        // performance issues here, and we could directly parse avro format data later.
-        _scanner = std::make_unique<JsonScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
+        _scanner = std::make_unique<AvroScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
     } else {
         _scanner = std::make_unique<CSVScanner>(_runtime_state, _runtime_profile, _scan_range, &_counter);
     }

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -92,6 +92,7 @@ set(EXEC_FILES
     hdfs_scanner_text.cpp
     json_scanner.cpp
     json_parser.cpp
+    avro_scanner.cpp
     project_node.cpp
     dict_decode_node.cpp
     repeat_node.cpp

--- a/be/src/exec/avro_scanner.cpp
+++ b/be/src/exec/avro_scanner.cpp
@@ -1,0 +1,721 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/avro_scanner.h"
+
+#include <fmt/format.h>
+#include <ryu/ryu.h>
+
+#include <algorithm>
+#include <boost/algorithm/string.hpp>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include "column/adaptive_nullable_column.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "exec/avro_scanner.h"
+#include "exec/json_parser.h"
+#include "exec/json_scanner.h"
+#include "exprs/cast_expr.h"
+#include "exprs/column_ref.h"
+#include "exprs/json_functions.h"
+#include "formats/avro/nullable_column.h"
+#include "fs/fs.h"
+#include "gutil/casts.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "runtime/stream_load/load_stream_mgr.h"
+#include "runtime/stream_load/stream_load_pipe.h"
+#include "runtime/types.h"
+#include "util/defer_op.h"
+#include "util/runtime_profile.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "libserdes/serdes-avro.h"
+#ifdef __cplusplus
+}
+#endif
+
+void replaceAll(std::string& str, const std::string& from, const std::string& to) {
+    if (from.empty()) return;
+    size_t start_pos = 0;
+    while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+    }
+}
+
+namespace starrocks {
+
+AvroScanner::AvroScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
+                         ScannerCounter* counter)
+        : FileScanner(state, profile, scan_range.params, counter),
+          _scan_range(scan_range),
+          _serdes(nullptr),
+          _closed(false) {}
+
+AvroScanner::AvroScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
+                         ScannerCounter* counter, const std::string schema_text)
+        : FileScanner(state, profile, scan_range.params, counter),
+          _scan_range(scan_range),
+          _schema_text(schema_text),
+          _closed(false) {}
+
+AvroScanner::~AvroScanner() {
+#if BE_TEST
+    avro_file_reader_close(_dbreader);
+#else
+    if (_serdes != nullptr) {
+        free(_serdes);
+    }
+#endif
+}
+
+// Previously, when parsing avro through JsonScanner, we used.*. to handle union data types,
+// but for the new implementation, we no longer need this pattern. For example, for the following
+// avro schema:
+// {
+//     "name": "raw_log",
+//     "type": ["null", {
+//         "fields": [{
+//             "name": "id",
+//             "type": "string"
+//         }, {
+//             "name": "data",
+//             "type": "string"
+//         }],
+//         "name": "logs",
+//         "type": "record"
+//     }]
+// }
+// If you want to select the id field, for the new implementation jsonpath can be written as $.id instead
+// of $.*.id. To ensure forward compatibility, we find the.*. pattern in the new implementation and replace
+// it with '.'. In addition, there is another case where the union is at the end of the path, where the pattern
+// is.*, in which case.* is removed.
+std::string AvroScanner::preprocess_jsonpaths(std::string jsonpaths) {
+    replaceAll(jsonpaths, ".*.", ".");
+    replaceAll(jsonpaths, ".*", "");
+    return jsonpaths;
+}
+
+Status AvroScanner::open() {
+    if (_scan_range.ranges.size() == 0) {
+        return Status::EndOfFile("EOF of reading protobuf file");
+    }
+    const TBrokerRangeDesc& range_desc = _scan_range.ranges[0];
+#if BE_TEST
+    if (avro_file_reader(range_desc.path.c_str(), &_dbreader)) {
+        auto err_msg = "Error opening file: " + std::string(avro_strerror());
+        return Status::InternalError(err_msg);
+    }
+#endif
+
+    RETURN_IF_ERROR(FileScanner::open());
+    RETURN_IF_ERROR(_construct_avro_types());
+    RETURN_IF_ERROR(_construct_cast_exprs());
+    if (_scan_range.ranges.empty()) {
+        return Status::OK();
+    }
+#ifndef BE_TEST
+    if (_serdes == nullptr) {
+        std::string confluent_schema_registry_url;
+        if (!_scan_range.params.__isset.confluent_schema_registry_url) {
+            return Status::InternalError("'confluent_schema_registry_url' not set");
+        } else {
+            confluent_schema_registry_url = _scan_range.params.confluent_schema_registry_url;
+        }
+
+        serdes_conf_t* sconf =
+                serdes_conf_new(NULL, 0, "schema.registry.url", confluent_schema_registry_url.c_str(), NULL);
+        _serdes = serdes_new(sconf, _err_buf, sizeof(_err_buf));
+        if (!_serdes) {
+            LOG(ERROR) << "failed to create serdes handle: " << _err_buf;
+            return Status::InternalError("failed to create serdes handle");
+        }
+    }
+#endif
+    if (range_desc.__isset.jsonpaths) {
+        std::string jsonpaths = preprocess_jsonpaths(range_desc.jsonpaths);
+        RETURN_IF_ERROR(JsonScanner::parse_json_paths(jsonpaths, &_json_paths));
+    }
+    Status st = create_sequential_file(range_desc, _scan_range.broker_addresses[0], _scan_range.params, &_file);
+    if (!st.ok()) {
+        LOG(WARNING) << "Failed to create sequential files: " << st.to_string();
+        return st;
+    }
+
+    for (const auto& desc : _src_slot_descriptors) {
+        if (desc == nullptr) {
+            continue;
+        }
+        _slot_desc_dict.emplace(desc->col_name(), desc);
+    }
+    _init_data_idx_to_slot_once = false;
+    return Status::OK();
+}
+
+void AvroScanner::_materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk) {
+    chunk->materialized_nullable();
+    for (int i = 0; i < chunk->num_columns(); i++) {
+        AdaptiveNullableColumn* adaptive_column =
+                down_cast<AdaptiveNullableColumn*>(chunk->get_column_by_index(i).get());
+        chunk->update_column_by_index(NullableColumn::create(adaptive_column->materialized_raw_data_column(),
+                                                             adaptive_column->materialized_raw_null_column()),
+                                      i);
+    }
+}
+
+Status AvroScanner::_create_src_chunk(ChunkPtr* chunk) {
+    SCOPED_RAW_TIMER(&_counter->init_chunk_ns);
+    *chunk = std::make_shared<Chunk>();
+    size_t slot_size = _src_slot_descriptors.size();
+    for (int column_pos = 0; column_pos < slot_size; ++column_pos) {
+        auto slot_desc = _src_slot_descriptors[column_pos];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+        auto column = ColumnHelper::create_column(_avro_types[column_pos], true, false, 0, true);
+        (*chunk)->append_column(column, slot_desc->id());
+    }
+
+    return Status::OK();
+}
+
+void AvroScanner::_report_error(const std::string& line, const std::string& err_msg) {
+    _state->append_error_msg_to_file(line, err_msg);
+}
+
+Status AvroScanner::_construct_row(const avro_value_t& avro_value, Chunk* chunk) {
+    size_t slot_size = _src_slot_descriptors.size();
+    size_t jsonpath_size = _json_paths.size();
+    for (size_t i = 0; i < slot_size; i++) {
+        if (_src_slot_descriptors[i] == nullptr) {
+            continue;
+        }
+        auto column = down_cast<NullableColumn*>(chunk->get_column_by_slot_id(_src_slot_descriptors[i]->id()).get());
+        if (UNLIKELY(i >= jsonpath_size)) {
+            column->append_nulls(1);
+            continue;
+        }
+        avro_value_t output_value;
+        auto st = _extract_field(avro_value, _json_paths[i], output_value);
+        if (LIKELY(st.ok())) {
+            RETURN_IF_ERROR(_construct_column(output_value, column, _src_slot_descriptors[i]->type(),
+                                              _src_slot_descriptors[i]->col_name()));
+        } else if (st.is_not_found()) {
+            column->append_nulls(1);
+        } else {
+            return st;
+        }
+    }
+    return Status::OK();
+}
+
+Status AvroScanner::_parse_avro(Chunk* chunk, const std::shared_ptr<SequentialFile>& file) {
+    const int capacity = _state->chunk_size();
+    DCHECK_EQ(0, chunk->num_rows());
+    for (size_t num_rows = chunk->num_rows(); num_rows < capacity; /**/) {
+        avro_value_t avro_value;
+#ifdef BE_TEST
+        // In general, we want to test component injection schemastr.
+        avro_schema_error_t error;
+        avro_schema_t schema = NULL;
+        int result = avro_schema_from_json(_schema_text.c_str(), _schema_text.size(), &schema, &error);
+        if (result != 0) {
+            auto err_msg = "parse schema from json error: " + std::string(avro_strerror());
+            return Status::InternalError(err_msg);
+        }
+        avro_value_iface_t* iface = avro_generic_class_from_schema(schema);
+        if (avro_generic_value_new(iface, &avro_value)) {
+            auto err_msg = "Cannot allocate new value instance: " + std::string(avro_strerror());
+            return Status::InternalError(err_msg);
+        }
+        DeferOp avro_deleter([&] {
+            avro_schema_decref(schema);
+            avro_value_iface_decref(iface);
+            avro_value_decref(&avro_value);
+        });
+        result = avro_file_reader_read_value(_dbreader, &avro_value);
+        if (result != 0) {
+            auto err_msg = "read avro value error: " + std::string(avro_strerror());
+            return Status::EndOfFile(err_msg);
+        }
+
+        char* avro_as_json = nullptr;
+        result = avro_value_to_json(&avro_value, 1, &avro_as_json);
+        if (result != 0) {
+            auto err_msg = "Unable to read value: " + std::string(avro_strerror());
+            return Status::InternalError(err_msg);
+        }
+        free(avro_as_json);
+#else
+        const uint8_t* data{};
+        size_t length = 0;
+        auto* stream_file = down_cast<StreamLoadPipeInputStream*>(file->stream().get());
+        {
+            SCOPED_RAW_TIMER(&_counter->file_read_ns);
+            ASSIGN_OR_RETURN(_parser_buf, stream_file->pipe()->read());
+        }
+        data = reinterpret_cast<uint8_t*>(_parser_buf->ptr);
+        length = _parser_buf->remaining();
+        DeferOp op([&] { avro_value_decref(&avro_value); });
+        serdes_schema_t* schema;
+        serdes_err_t err =
+                serdes_deserialize_avro(_serdes, &avro_value, &schema, data, length, _err_buf, sizeof(_err_buf));
+        if (err) {
+            auto err_msg = "serdes deserialize avro failed: " + std::string(_err_buf);
+            LOG(ERROR) << err_msg;
+            _counter->num_rows_filtered++;
+            _state->append_error_msg_to_file("", err_msg);
+            return Status::InternalError("serdes deserialize avro failed");
+        }
+#endif
+        size_t chunk_row_num = chunk->num_rows();
+        Status st = Status::OK();
+        if (!_json_paths.empty()) {
+            st = _construct_row(avro_value, chunk);
+        } else {
+            if (!_init_data_idx_to_slot_once) {
+                size_t element_count;
+                if (UNLIKELY(avro_value_get_size(&avro_value, &element_count) != 0)) {
+                    auto err_msg = "Cannot get record size: " + std::string(avro_strerror());
+                    return Status::InternalError(err_msg);
+                }
+                _data_idx_to_slot.assign(element_count, SlotInfo());
+                for (size_t i = 0; i < element_count; i++) {
+                    const char* field_name;
+                    avro_value_t element_value;
+                    if (UNLIKELY(avro_value_get_by_index(&avro_value, i, &element_value, &field_name) != 0)) {
+                        auto err_msg = "Cannot get value by index: " + std::string(avro_strerror());
+                        return Status::InternalError(err_msg);
+                    }
+                    _data_idx_to_fieldname.push_back(std::string(field_name));
+                }
+
+                _init_data_idx_to_slot_once = true;
+            }
+            st = _construct_row_without_jsonpath(avro_value, chunk);
+        }
+        if (!st.ok()) {
+            if (_counter->num_rows_filtered++ < MAX_ERROR_LINES_IN_FILE) {
+                // We would continue to construct row even if error is returned,
+                // hence the number of error appended to the file should be limited.
+                _state->append_error_msg_to_file("", st.to_string());
+                LOG(WARNING) << "failed to construct row: " << st;
+            }
+            // Before continuing to process other rows, we need to first clean the fail parsed row.
+            chunk->set_num_rows(chunk_row_num);
+            return st;
+        }
+        num_rows++;
+    }
+    return Status::OK();
+}
+
+Status AvroScanner::_construct_row_without_jsonpath(const avro_value_t& avro_value, Chunk* chunk) {
+    _found_columns.assign(chunk->num_columns(), false);
+    size_t element_count = _data_idx_to_fieldname.size();
+    avro_value_t element_value;
+    for (size_t i = 0; i < element_count; i++) {
+        if (UNLIKELY(avro_value_get_by_index(&avro_value, i, &element_value, NULL) != 0)) {
+            auto err_msg = "Cannot get value by index: " + std::string(avro_strerror());
+            return Status::InternalError(err_msg);
+        }
+        SlotInfo& slot_info = _data_idx_to_slot[i];
+        if (slot_info.id_ > -1) {
+            int column_index = chunk->get_index_by_slot_id(slot_info.id_);
+            _found_columns[column_index] = true;
+        } else if (slot_info.id_ == -1) {
+            continue;
+        } else if (UNLIKELY(slot_info.id_ < -1)) {
+            const std::string& key = _data_idx_to_fieldname[i];
+            // look up key in the slot dict.
+            auto itr = _slot_desc_dict.find(key);
+            if (itr == _slot_desc_dict.end()) {
+                slot_info.id_ = -1;
+                continue;
+            }
+            auto slot_desc = itr->second;
+            slot_info.id_ = slot_desc->id();
+            slot_info.type_ = slot_desc->type();
+            slot_info.key_ = key;
+            int column_index = chunk->get_index_by_slot_id(slot_info.id_);
+            _found_columns[column_index] = true;
+        }
+
+        auto& column = chunk->get_column_by_slot_id(slot_info.id_);
+        // construct column with value.
+        RETURN_IF_ERROR(_construct_column(element_value, column.get(), slot_info.type_, slot_info.key_));
+    }
+
+    for (int i = 0; i < _found_columns.size(); i++) {
+        if (UNLIKELY(!_found_columns[i])) {
+            auto& column = chunk->get_column_by_index(i);
+            column->append_nulls(1);
+        }
+    }
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> AvroScanner::get_next() {
+    SCOPED_RAW_TIMER(&_counter->total_ns);
+    ChunkPtr src_chunk;
+    RETURN_IF_ERROR(_create_src_chunk(&src_chunk));
+    const int chunk_capacity = _state->chunk_size();
+    src_chunk->reserve(chunk_capacity);
+    src_chunk->set_num_rows(0);
+    Status st = _parse_avro(src_chunk.get(), _file);
+    if (!st.ok() && !st.is_time_out() && !st.is_end_of_file()) {
+        return st;
+    }
+    if (src_chunk->num_rows() == 0) {
+        if (st.is_end_of_file()) {
+            return Status::EndOfFile("EOF of reading avro file, nothing read");
+        } else if (st.is_time_out()) {
+            // if timeout happens at the beginning of reading src_chunk, we return the error state
+            // else we will _materialize the lines read before timeout and return ok()
+            return st;
+        }
+    }
+    _materialize_src_chunk_adaptive_nullable_column(src_chunk);
+    ASSIGN_OR_RETURN(auto cast_chunk, _cast_chunk(src_chunk));
+    return materialize(src_chunk, cast_chunk);
+}
+
+StatusOr<ChunkPtr> AvroScanner::_cast_chunk(const starrocks::ChunkPtr& src_chunk) {
+    SCOPED_RAW_TIMER(&_counter->cast_chunk_ns);
+    ChunkPtr cast_chunk = std::make_shared<Chunk>();
+
+    size_t slot_size = _src_slot_descriptors.size();
+    for (int column_pos = 0; column_pos < slot_size; ++column_pos) {
+        auto slot = _src_slot_descriptors[column_pos];
+        if (slot == nullptr) {
+            continue;
+        }
+
+        ASSIGN_OR_RETURN(ColumnPtr col, _cast_exprs[column_pos]->evaluate_checked(nullptr, src_chunk.get()));
+        col = ColumnHelper::unfold_const_column(slot->type(), src_chunk->num_rows(), col);
+        cast_chunk->append_column(std::move(col), slot->id());
+    }
+
+    return cast_chunk;
+}
+
+Status AvroScanner::_construct_cast_exprs() {
+    size_t slot_size = _src_slot_descriptors.size();
+    _cast_exprs.resize(slot_size);
+    for (int column_pos = 0; column_pos < slot_size; ++column_pos) {
+        auto slot_desc = _src_slot_descriptors[column_pos];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+
+        auto& from_type = _avro_types[column_pos];
+        auto& to_type = slot_desc->type();
+        Expr* slot = _pool.add(new ColumnRef(slot_desc));
+
+        if (to_type.is_assignable(from_type)) {
+            _cast_exprs[column_pos] = slot;
+            continue;
+        }
+
+        VLOG(3) << strings::Substitute("The field name($0) cast STARROCKS($1) to STARROCKS($2).", slot_desc->col_name(),
+                                       from_type.debug_string(), to_type.debug_string());
+
+        Expr* cast = VectorizedCastExprFactory::from_type(from_type, to_type, slot, &_pool);
+
+        if (cast == nullptr) {
+            return Status::InternalError(strings::Substitute("Not support cast $0 to $1.", from_type.debug_string(),
+                                                             to_type.debug_string()));
+        }
+
+        _cast_exprs[column_pos] = cast;
+    }
+
+    return Status::OK();
+}
+
+Status AvroScanner::_construct_avro_types() {
+    size_t slot_size = _src_slot_descriptors.size();
+    _avro_types.resize(slot_size);
+    for (int column_pos = 0; column_pos < slot_size; ++column_pos) {
+        auto slot_desc = _src_slot_descriptors[column_pos];
+        if (slot_desc == nullptr) {
+            continue;
+        }
+
+        switch (slot_desc->type().type) {
+        case TYPE_ARRAY: {
+            TypeDescriptor json_type(TYPE_ARRAY);
+            TypeDescriptor* child_type = &json_type;
+
+            const TypeDescriptor* slot_type = &(slot_desc->type().children[0]);
+            while (slot_type->type == TYPE_ARRAY) {
+                slot_type = &(slot_type->children[0]);
+
+                child_type->children.emplace_back(TYPE_ARRAY);
+                child_type = &(child_type->children[0]);
+            }
+
+            // the json lib don't support get_int128_t(), so we load with BinaryColumn and then convert to LargeIntColumn
+            if (slot_type->type == TYPE_FLOAT || slot_type->type == TYPE_DOUBLE || slot_type->type == TYPE_BIGINT ||
+                slot_type->type == TYPE_INT || slot_type->type == TYPE_SMALLINT || slot_type->type == TYPE_TINYINT) {
+                // Treat these types as what they are.
+                child_type->children.emplace_back(slot_type->type);
+            } else if (slot_type->type == TYPE_VARCHAR) {
+                auto varchar_type = TypeDescriptor::create_varchar_type(slot_type->len);
+                child_type->children.emplace_back(varchar_type);
+            } else if (slot_type->type == TYPE_CHAR) {
+                auto char_type = TypeDescriptor::create_char_type(slot_type->len);
+                child_type->children.emplace_back(char_type);
+            } else if (slot_type->type == TYPE_JSON) {
+                child_type->children.emplace_back(TypeDescriptor::create_json_type());
+            } else {
+                // Treat other types as VARCHAR.
+                auto varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+                child_type->children.emplace_back(varchar_type);
+            }
+
+            _avro_types[column_pos] = std::move(json_type);
+            break;
+        }
+
+        // Treat these types as what they are.
+        case TYPE_FLOAT:
+        case TYPE_DOUBLE:
+        case TYPE_BIGINT:
+        case TYPE_INT:
+        case TYPE_BOOLEAN:
+        case TYPE_SMALLINT:
+        case TYPE_TINYINT: {
+            _avro_types[column_pos] = TypeDescriptor{slot_desc->type().type};
+            break;
+        }
+
+        case TYPE_CHAR: {
+            auto char_type = TypeDescriptor::create_char_type(slot_desc->type().len);
+            _avro_types[column_pos] = std::move(char_type);
+            break;
+        }
+
+        case TYPE_VARCHAR: {
+            auto varchar_type = TypeDescriptor::create_varchar_type(slot_desc->type().len);
+            _avro_types[column_pos] = std::move(varchar_type);
+            break;
+        }
+
+        case TYPE_JSON: {
+            _avro_types[column_pos] = TypeDescriptor::create_json_type();
+            break;
+        }
+
+        // Treat other types as VARCHAR.
+        default: {
+            auto varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+            _avro_types[column_pos] = std::move(varchar_type);
+            break;
+        }
+        }
+    }
+    return Status::OK();
+}
+
+void AvroScanner::close() {
+    if (!_closed) {
+        _file.reset();
+        _closed = true;
+    }
+    FileScanner::close();
+}
+
+Status AvroScanner::_get_array_element(avro_value_t* cur_value, size_t idx, avro_value_t* element) {
+    size_t element_count;
+    if (avro_value_get_size(cur_value, &element_count) != 0) {
+        auto err_msg = "Cannot get avro array size: " + std::string(avro_strerror());
+        return Status::InternalError(err_msg);
+    }
+    if (idx >= element_count) {
+        auto err_msg = "array idx greater than the avro array max size";
+        return Status::InternalError(err_msg);
+    }
+    if (avro_value_get_by_index(cur_value, idx, element, nullptr) != 0) {
+        auto err_msg = "Cannot get avro value from array: " + std::string(avro_strerror());
+        return Status::InternalError(err_msg);
+    }
+    return Status::OK();
+}
+
+bool construct_path_from_str(std::string path_str, std::vector<AvroPath>& paths) {
+    return false;
+}
+
+// This function handles the union data type, and the reason for using loops is that there is a nested case:
+//    [
+//         null,
+//         [
+//             null,
+//             [
+//                 null,
+//                 "string"
+//             ]
+//         ]
+//     ]
+// The whole logic is to return the deepest data, which could be null or some other data type.
+Status AvroScanner::_handle_union(avro_value_t input_value, avro_value_t& branch) {
+    while (avro_value_get_type(&input_value) == AVRO_UNION) {
+        int disc;
+        if (avro_value_get_discriminant(&input_value, &disc) != 0) {
+            auto err_msg = "Cannot get union discriminan: " + std::string(avro_strerror());
+            return Status::InternalError(err_msg);
+        }
+        if (avro_value_set_branch(&input_value, disc, &branch) != 0) {
+            auto err_msg = "Cannot set union branch: " + std::string(avro_strerror());
+            return Status::InternalError(err_msg);
+        }
+        if (avro_value_get_type(&branch) == AVRO_NULL) {
+            return Status::OK();
+        }
+        input_value = branch;
+    }
+    return Status::OK();
+}
+
+// This function extracts the corresponding field data from avro data according to
+// the corresponding path of each column, where:
+// input_value: input param
+// paths: input param
+// output_value: output param
+Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::vector<AvroPath>& paths,
+                                   avro_value_t& output_value) {
+    avro_value_t cur_value = input_value;
+
+    // Select the entire data
+    if (UNLIKELY(paths.size() == 1 && paths[0].key == "$" && paths[0].idx == -1)) {
+        // Remove union
+        if (avro_value_get_type(&cur_value) == AVRO_UNION) {
+            avro_value_t branch;
+            RETURN_IF_ERROR(_handle_union(cur_value, branch));
+            cur_value = branch;
+        }
+        output_value = cur_value;
+        return Status::OK();
+    }
+
+    // The starting point for our progression is an array, and we cannot use avro_value_get_by_name
+    // to get the value of the next field. We want the path pattern to look like this:
+    // {
+    //     key == "$"
+    //     idx = 0,1,2,3....
+    // }
+    if (UNLIKELY(avro_value_get_type(&cur_value) == AVRO_ARRAY)) {
+        if (paths[0].key != "$" || paths[0].idx < 0) {
+            auto err_msg = "The avro root type is an array, and you should select a specific array element.";
+            return Status::InternalError(err_msg);
+        }
+        avro_value_t element;
+        RETURN_IF_ERROR(_get_array_element(&cur_value, paths[0].idx, &element));
+        cur_value = element;
+    }
+
+    // paths[0] should be $, skip it
+    for (int i = 1; i < paths.size(); i++) {
+        // The union type is used to provide nullable semantics. For scenarios where AVRO imports,
+        // AVRO's union type can only be of this pattern:
+        // {
+        //      null,
+        //      Other Type
+        // }
+        // For each iteration, we first determine if the current avro type is union. If it is union,
+        // we continue to determine if it is null. If so, we stop the progression and return.
+        // If it is not null, the corresponding value is extracted and the progress continues.
+        if (UNLIKELY(avro_value_get_type(&cur_value) == AVRO_UNION)) {
+            avro_value_t branch;
+            RETURN_IF_ERROR(_handle_union(cur_value, branch));
+            cur_value = branch;
+            if (avro_value_get_type(&branch) == AVRO_NULL) {
+                output_value = cur_value;
+                return Status::OK();
+            }
+        }
+
+        if (UNLIKELY(avro_value_get_type(&cur_value) != AVRO_RECORD)) {
+            if (i == paths.size() - 1) {
+                break;
+            } else {
+                auto err_msg = "A non-record type was found during avro parsing. Please check the path you specified";
+                return Status::InternalError(err_msg);
+            }
+        }
+        avro_value_t next_value;
+        if (LIKELY(avro_value_get_by_name(&cur_value, paths[i].key.c_str(), &next_value, nullptr) == 0)) {
+            // For each path, we first need to determine whether the path has an array element operation
+            cur_value = next_value;
+            if (UNLIKELY(paths[i].idx != -1)) {
+                // In this case, you need to remove the union:
+                // $.event_params[2]
+                // {
+                //   "name": "event_params",
+                //   "type": ["null", {
+                //      "items": "string",
+                //      "type": "array"
+                //    }]
+                // }
+                if (avro_value_get_type(&cur_value) == AVRO_UNION) {
+                    avro_value_t branch;
+                    RETURN_IF_ERROR(_handle_union(cur_value, branch));
+                    cur_value = branch;
+                    if (avro_value_get_type(&branch) == AVRO_NULL) {
+                        output_value = cur_value;
+                        return Status::OK();
+                    }
+                }
+                // cur_value must be an array type, otherwise it is invalid
+                if (avro_value_get_type(&cur_value) != AVRO_ARRAY) {
+                    auto err_msg =
+                            "A non-array type was found during avro parsing. Please check the path you specified";
+                    return Status::InternalError(err_msg);
+                }
+                avro_value_t element;
+                RETURN_IF_ERROR(_get_array_element(&cur_value, paths[0].idx, &element));
+                cur_value = element;
+            }
+        } else {
+            // If no field can be found, end the parsing of the row and return not found.
+            auto msg = strings::Substitute("Cannot get field: $0. err msg: $1.", paths[i].key, avro_strerror());
+            return Status::NotFound(msg);
+        }
+    }
+    // Remove union
+    if (UNLIKELY(avro_value_get_type(&cur_value) == AVRO_UNION)) {
+        avro_value_t branch;
+        RETURN_IF_ERROR(_handle_union(cur_value, branch));
+        cur_value = branch;
+    }
+    output_value = cur_value;
+    return Status::OK();
+}
+
+Status AvroScanner::_construct_column(const avro_value_t& input_value, Column* column, const TypeDescriptor& type_desc,
+                                      const std::string& col_name) {
+    return add_adaptive_nullable_column(column, type_desc, col_name, input_value, !_strict_mode);
+}
+
+} // namespace starrocks

--- a/be/src/exec/avro_scanner.h
+++ b/be/src/exec/avro_scanner.h
@@ -1,0 +1,110 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string_view>
+
+#include "column/nullable_column.h"
+#include "common/compiler_util.h"
+#include "common/status.h"
+#include "exec/file_scanner.h"
+#include "exec/json_scanner.h"
+#include "exprs/json_functions.h"
+#include "fs/fs.h"
+#include "runtime/stream_load/load_stream_mgr.h"
+#include "util/raw_container.h"
+#include "util/slice.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "avro.h"
+#include "libserdes/serdes.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+using AvroPath = SimpleJsonPath;
+
+class AvroScanner final : public FileScanner {
+public:
+    AvroScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
+                ScannerCounter* counter);
+
+    // A new constructor is introduced for the single test.
+    AvroScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
+                ScannerCounter* counter, std::string schema_text);
+    ~AvroScanner() override;
+
+    // Open this scanner, will initialize information needed
+    Status open() override;
+
+    StatusOr<ChunkPtr> get_next() override;
+
+    // Close this scanner
+    void close() override;
+
+    static std::string preprocess_jsonpaths(std::string jsonpath);
+
+    struct SlotInfo {
+        SlotInfo() : id_(-2) {}
+        SlotId id_;
+        TypeDescriptor type_;
+        std::string key_;
+    };
+
+private:
+    Status _construct_avro_types();
+    Status _construct_cast_exprs();
+    StatusOr<ChunkPtr> _cast_chunk(const starrocks::ChunkPtr& src_chunk);
+    Status _create_src_chunk(ChunkPtr* chunk);
+    Status _parse_avro(Chunk* chunk, const std::shared_ptr<SequentialFile>& file);
+    void _report_error(const std::string& line, const std::string& err_msg);
+    Status _construct_row(const avro_value_t& avro_value, Chunk* chunk);
+    void _materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk);
+    Status _construct_column(const avro_value_t& input_value, Column* column, const TypeDescriptor& type_desc,
+                             const std::string& col_name);
+    Status _extract_field(const avro_value_t& input_value, const std::vector<AvroPath>& paths,
+                          avro_value_t& output_value);
+    Status _handle_union(avro_value_t input_value, avro_value_t& branch);
+    Status _get_array_element(avro_value_t* cur_value, size_t idx, avro_value_t* element);
+    std::string _preprocess_jsonpaths(std::string jsonpath);
+    Status _construct_row_without_jsonpath(const avro_value_t& avro_value, Chunk* chunk);
+
+    const TBrokerScanRange& _scan_range;
+    serdes_t* _serdes;
+    std::string _schema_text;
+    bool _closed;
+    char _err_buf[512];
+    std::vector<Column*> _column_raw_ptrs;
+    ByteBufferPtr _parser_buf;
+    std::vector<std::vector<AvroPath>> _json_paths;
+    std::vector<TypeDescriptor> _avro_types;
+    std::vector<Expr*> _cast_exprs;
+    ObjectPool _pool;
+    std::shared_ptr<SequentialFile> _file;
+    std::unordered_map<std::string_view, SlotDescriptor*> _slot_desc_dict;
+    std::vector<bool> _found_columns;
+    std::vector<SlotInfo> _data_idx_to_slot;
+    std::vector<std::string> _data_idx_to_fieldname;
+    bool _init_data_idx_to_slot_once;
+
+#if BE_TEST
+    avro_file_reader_t _dbreader;
+#endif
+};
+
+} // namespace starrocks

--- a/be/src/exec/file_scan_node.cpp
+++ b/be/src/exec/file_scan_node.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 
 #include "column/chunk.h"
+#include "exec/avro_scanner.h"
 #include "exec/csv_scanner.h"
 #include "exec/json_scanner.h"
 #include "exec/orc_scanner.h"
@@ -209,7 +210,7 @@ std::unique_ptr<FileScanner> FileScanNode::_create_scanner(const TBrokerScanRang
     } else if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_JSON) {
         return std::make_unique<JsonScanner>(runtime_state(), runtime_profile(), scan_range, counter);
     } else if (scan_range.ranges[0].format_type == TFileFormatType::FORMAT_AVRO) {
-        return std::make_unique<JsonScanner>(runtime_state(), runtime_profile(), scan_range, counter);
+        return std::make_unique<AvroScanner>(runtime_state(), runtime_profile(), scan_range, counter);
     } else {
         return std::make_unique<CSVScanner>(runtime_state(), runtime_profile(), scan_range, counter);
     }

--- a/be/src/exec/file_scanner.h
+++ b/be/src/exec/file_scanner.h
@@ -25,6 +25,8 @@ class RandomAccessFile;
 
 namespace starrocks {
 
+const int64_t MAX_ERROR_LINES_IN_FILE = 50;
+
 struct ScannerCounter {
     int64_t num_rows_filtered = 0;
     int64_t num_rows_unselected = 0;

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -40,7 +40,6 @@
 
 namespace starrocks {
 
-const int64_t MAX_ERROR_LINES_IN_FILE = 50;
 const int64_t MAX_ERROR_LOG_LENGTH = 64;
 
 JsonScanner::JsonScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
@@ -66,7 +65,7 @@ Status JsonScanner::open() {
     const TBrokerRangeDesc& range = _scan_range.ranges[0];
 
     if (range.__isset.jsonpaths) {
-        RETURN_IF_ERROR(_parse_json_paths(range.jsonpaths, &_json_paths));
+        RETURN_IF_ERROR(parse_json_paths(range.jsonpaths, &_json_paths));
     }
     if (range.__isset.json_root) {
         JsonFunctions::parse_json_paths(range.json_root, &_root_paths);
@@ -240,8 +239,7 @@ Status JsonScanner::_construct_cast_exprs() {
     return Status::OK();
 }
 
-Status JsonScanner::_parse_json_paths(const std::string& jsonpath,
-                                      std::vector<std::vector<SimpleJsonPath>>* path_vecs) {
+Status JsonScanner::parse_json_paths(const std::string& jsonpath, std::vector<std::vector<SimpleJsonPath>>* path_vecs) {
     try {
         simdjson::dom::parser parser;
         simdjson::dom::element elem = parser.parse(jsonpath.c_str(), jsonpath.length());

--- a/be/src/exec/json_scanner.h
+++ b/be/src/exec/json_scanner.h
@@ -44,11 +44,11 @@ public:
 
     // Close this scanner
     void close() override;
+    static Status parse_json_paths(const std::string& jsonpath, std::vector<std::vector<SimpleJsonPath>>* path_vecs);
 
 private:
     Status _construct_json_types();
     Status _construct_cast_exprs();
-    static Status _parse_json_paths(const std::string& jsonpath, std::vector<std::vector<SimpleJsonPath>>* path_vecs);
     Status _create_src_chunk(ChunkPtr* chunk);
     Status _open_next_reader();
     StatusOr<ChunkPtr> _cast_chunk(const ChunkPtr& src_chunk);

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -51,10 +51,8 @@ Status JsonFunctions::_get_parsed_paths(const std::vector<std::string>& path_exp
         auto& current = path_exprs[i];
 
         if (i == 0) {
-            if (current != "$") {
+            if (current.size() == 0 || current[0] != '$') {
                 parsed_paths->emplace_back("", -1, true);
-            } else {
-                parsed_paths->emplace_back("$", -1, true);
                 continue;
             }
         }

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -33,6 +33,9 @@ add_library(Formats STATIC
         json/nullable_column.cpp
         json/numeric_column.cpp
         json/binary_column.cpp
+        avro/nullable_column.cpp
+        avro/numeric_column.cpp
+        avro/binary_column.cpp
         orc/orc_chunk_reader.cpp
         orc/orc_input_stream.cpp
         orc/orc_mapping.cpp

--- a/be/src/formats/avro/binary_column.cpp
+++ b/be/src/formats/avro/binary_column.cpp
@@ -1,0 +1,270 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "binary_column.h"
+
+#include "column/binary_column.h"
+#include "column/json_column.h"
+#include "common/status.h"
+#include "gutil/strings/substitute.h"
+#include "util/defer_op.h"
+#include "util/json.h"
+
+namespace starrocks {
+
+static Status add_column_with_numeric_value(BinaryColumn* column, const TypeDescriptor& type_desc,
+                                            const std::string& name, const avro_value_t& value) {
+    switch (avro_value_get_type(&value)) {
+    case AVRO_INT32: {
+        int in;
+        if (avro_value_get_int(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get int value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        std::string sv = std::to_string(in);
+        if (UNLIKELY(type_desc.len < sv.size())) {
+            auto err_msg = strings::Substitute("Value length is beyond the capacity. column=$0, capacity=$1", name,
+                                               type_desc.len);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        column->append(Slice(sv));
+
+        return Status::OK();
+    }
+    case AVRO_INT64: {
+        int64_t in;
+        if (avro_value_get_long(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get int64 value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        std::string sv = std::to_string(in);
+        if (UNLIKELY(type_desc.len < sv.size())) {
+            auto err_msg = strings::Substitute("Value length is beyond the capacity. column=$0, capacity=$1", name,
+                                               type_desc.len);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        column->append(Slice(sv));
+
+        return Status::OK();
+    }
+    case AVRO_FLOAT: {
+        float in;
+        if (avro_value_get_float(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get float value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        std::string sv = std::to_string(in);
+        if (UNLIKELY(type_desc.len < sv.size())) {
+            auto err_msg = strings::Substitute("Value length is beyond the capacity. column=$0, capacity=$1", name,
+                                               type_desc.len);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        column->append(Slice(sv));
+
+        return Status::OK();
+    }
+
+    case AVRO_DOUBLE: {
+        double in;
+        if (avro_value_get_double(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get double value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        std::string sv = std::to_string(in);
+        if (UNLIKELY(type_desc.len < sv.size())) {
+            auto err_msg = strings::Substitute("Value length is beyond the capacity. column=$0, capacity=$1", name,
+                                               type_desc.len);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        column->append(Slice(sv));
+
+        return Status::OK();
+    }
+
+    default: {
+        auto err_msg = strings::Substitute("Unsupported value type. column=$0", name);
+        return Status::InternalError(err_msg);
+    }
+    }
+    return Status::OK();
+}
+
+static Status add_column_with_string_value(BinaryColumn* column, const TypeDescriptor& type_desc,
+                                           const std::string& name, const avro_value_t& value) {
+    switch (avro_value_get_type(&value)) {
+    case AVRO_STRING: {
+        const char* in;
+        size_t size;
+        if (UNLIKELY(avro_value_get_string(&value, &in, &size) != 0)) {
+            auto err_msg = strings::Substitute("Get string value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        --size;
+        if (UNLIKELY(type_desc.len < size)) {
+            auto err_msg = strings::Substitute("Value length is beyond the capacity. column=$0, capacity=$1", name,
+                                               type_desc.len);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        column->append(Slice{in, size});
+        return Status::OK();
+    }
+
+    case AVRO_ENUM: {
+        avro_schema_t enum_schema;
+        int symbol_value;
+        const char* symbol_name;
+        if (UNLIKELY(avro_value_get_enum(&value, &symbol_value) != 0)) {
+            auto err_msg = strings::Substitute("Get enum value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        enum_schema = avro_value_get_schema(&value);
+        symbol_name = avro_schema_enum_get(enum_schema, symbol_value);
+
+        column->append(Slice(symbol_name));
+        return Status::OK();
+    }
+
+    case AVRO_FIXED: {
+        const char* in;
+        size_t size;
+        if (UNLIKELY(avro_value_get_fixed(&value, (const void**)&in, &size) != 0)) {
+            auto err_msg = strings::Substitute("Get fixed value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        if (UNLIKELY(type_desc.len < size)) {
+            auto err_msg = strings::Substitute("Value length is beyond the capacity. column=$0, capacity=$1", name,
+                                               type_desc.len);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        column->append(Slice{in, size});
+        return Status::OK();
+    }
+
+    case AVRO_BYTES: {
+        const char* in;
+        size_t size;
+        if (UNLIKELY(avro_value_get_bytes(&value, (const void**)&in, &size) != 0)) {
+            auto err_msg = strings::Substitute("Get bytes value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        if (UNLIKELY(type_desc.len < size)) {
+            auto err_msg = strings::Substitute("Value length is beyond the capacity. column=$0, capacity=$1", name,
+                                               type_desc.len);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        column->append(Slice{in, size});
+        return Status::OK();
+    }
+
+    default: {
+        auto err_msg = strings::Substitute("Unsupported value type. column=$0", name);
+        return Status::InternalError(err_msg);
+    }
+    }
+    return Status::OK();
+}
+
+static Status add_column_with_boolean_value(BinaryColumn* column, const TypeDescriptor& type_desc,
+                                            const std::string& name, const avro_value_t& value) {
+    int in;
+    if (avro_value_get_boolean(&value, &in) != 0) {
+        auto err_msg = strings::Substitute("Get boolean value error. column=$0", name);
+        return Status::InvalidArgument(err_msg);
+    }
+    if (in == 1) {
+        column->append(Slice{"1"});
+    } else {
+        column->append(Slice{"0"});
+    }
+    return Status::OK();
+}
+
+static Status add_column_with_array_object_value(BinaryColumn* column, const TypeDescriptor& type_desc,
+                                                 const std::string& name, const avro_value_t& value) {
+    char* as_json;
+    if (avro_value_to_json(&value, 1, &as_json)) {
+        LOG(ERROR) << "avro to json failed: %s" << avro_strerror();
+        return Status::InternalError("avro to json failed");
+    }
+    column->append(Slice(as_json));
+    free(as_json);
+    return Status::OK();
+}
+
+Status add_binary_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                         const avro_value_t& value) {
+    auto binary_column = down_cast<BinaryColumn*>(column);
+
+    switch (avro_value_get_type(&value)) {
+    case AVRO_INT32:
+    case AVRO_INT64:
+    case AVRO_FLOAT:
+    case AVRO_DOUBLE: {
+        return add_column_with_numeric_value(binary_column, type_desc, name, value);
+    }
+
+    case AVRO_FIXED:
+    case AVRO_STRING:
+    case AVRO_ENUM:
+    case AVRO_BYTES: {
+        return add_column_with_string_value(binary_column, type_desc, name, value);
+    }
+
+    case AVRO_BOOLEAN: {
+        return add_column_with_boolean_value(binary_column, type_desc, name, value);
+    }
+
+    case AVRO_MAP:
+    case AVRO_ARRAY:
+    case AVRO_UNION:
+    case AVRO_RECORD: {
+        return add_column_with_array_object_value(binary_column, type_desc, name, value);
+    }
+
+    default: {
+        auto err_msg = strings::Substitute("Unsupported value type. Binary type is required. column=$0", name);
+        return Status::DataQualityError(err_msg);
+    }
+    }
+    return Status::OK();
+}
+
+Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                              const avro_value_t& value) {
+    auto json_column = down_cast<JsonColumn*>(column);
+    char* as_json;
+    if (avro_value_to_json(&value, 1, &as_json)) {
+        LOG(ERROR) << "avro to json failed: %s" << avro_strerror();
+        return Status::InternalError("avro to json failed");
+    }
+    DeferOp json_deleter([&] { free(as_json); });
+    JsonValue json_value;
+    Status s = JsonValue::parse(as_json, &json_value);
+    if (!s.ok()) {
+        return Status::InternalError("parse json failed");
+    }
+    json_column->append(std::move(json_value));
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/formats/avro/binary_column.h
+++ b/be/src/formats/avro/binary_column.h
@@ -1,0 +1,38 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "column/column.h"
+#include "common/status.h"
+#include "runtime/types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "avro.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+Status add_binary_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                         const avro_value_t& value);
+
+Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                              const avro_value_t& value);
+
+} // namespace starrocks

--- a/be/src/formats/avro/nullable_column.cpp
+++ b/be/src/formats/avro/nullable_column.cpp
@@ -1,0 +1,282 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nullable_column.h"
+
+#include "column/adaptive_nullable_column.h"
+#include "column/array_column.h"
+#include "column/nullable_column.h"
+#include "formats/json/binary_column.h"
+#include "gutil/strings/substitute.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+template <typename T>
+static Status add_adaptive_nullable_numeric_column(Column* column, const TypeDescriptor& type_desc,
+                                                   const std::string& name, const avro_value_t& value) {
+    auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+    if (avro_value_get_type(&value) == AVRO_NULL) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+    auto& data_column = nullable_column->begin_append_not_default_value();
+    RETURN_IF_ERROR(add_numeric_column<T>(data_column.get(), type_desc, name, value));
+    nullable_column->finish_append_one_not_default_value();
+    return Status::OK();
+}
+
+template Status add_adaptive_nullable_numeric_column<int64_t>(Column* column, const TypeDescriptor& type_desc,
+                                                              const std::string& name, const avro_value_t& value);
+template Status add_adaptive_nullable_numeric_column<int32_t>(Column* column, const TypeDescriptor& type_desc,
+                                                              const std::string& name, const avro_value_t& value);
+template Status add_adaptive_nullable_numeric_column<int16_t>(Column* column, const TypeDescriptor& type_desc,
+                                                              const std::string& name, const avro_value_t& value);
+template Status add_adaptive_nullable_numeric_column<int8_t>(Column* column, const TypeDescriptor& type_desc,
+                                                             const std::string& name, const avro_value_t& value);
+template Status add_adaptive_nullable_numeric_column<uint8_t>(Column* column, const TypeDescriptor& type_desc,
+                                                              const std::string& name, const avro_value_t& value);
+template Status add_adaptive_nullable_numeric_column<double>(Column* column, const TypeDescriptor& type_desc,
+                                                             const std::string& name, const avro_value_t& value);
+template Status add_adaptive_nullable_numeric_column<float>(Column* column, const TypeDescriptor& type_desc,
+                                                            const std::string& name, const avro_value_t& value);
+
+template <typename T>
+static Status add_nullable_numeric_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                          const avro_value_t& value) {
+    auto nullable_column = down_cast<NullableColumn*>(column);
+
+    auto& null_column = nullable_column->null_column();
+    auto& data_column = nullable_column->data_column();
+    if (avro_value_get_type(&value) == AVRO_NULL) {
+        data_column->append_default(1);
+        null_column->append(1);
+        return Status::OK();
+    }
+
+    RETURN_IF_ERROR(add_numeric_column<T>(data_column.get(), type_desc, name, value));
+
+    null_column->append(0);
+    return Status::OK();
+}
+
+static Status add_adpative_nullable_binary_column(Column* column, const TypeDescriptor& type_desc,
+                                                  const std::string& name, const avro_value_t& value) {
+    auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+    if (avro_value_get_type(&value) == AVRO_NULL) {
+        nullable_column->append_nulls(1);
+        return Status::OK();
+    }
+    auto& data_column = nullable_column->begin_append_not_default_value();
+
+    RETURN_IF_ERROR(add_binary_column(data_column.get(), type_desc, name, value));
+
+    nullable_column->finish_append_one_not_default_value();
+
+    return Status::OK();
+}
+
+static Status add_nullable_binary_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                         const avro_value_t& value) {
+    auto nullable_column = down_cast<NullableColumn*>(column);
+
+    auto& null_column = nullable_column->null_column();
+    auto& data_column = nullable_column->data_column();
+    if (avro_value_get_type(&value) == AVRO_NULL) {
+        nullable_column->append_nulls(1);
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(add_binary_column(data_column.get(), type_desc, name, value));
+    null_column->append(0);
+    return Status::OK();
+}
+
+static Status add_adpative_nullable_native_json_column(Column* column, const TypeDescriptor& type_desc,
+                                                       const std::string& name, const avro_value_t& value) {
+    auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+    if (avro_value_get_type(&value) == AVRO_NULL) {
+        nullable_column->append_nulls(1);
+        return Status::OK();
+    }
+    auto& data_column = nullable_column->begin_append_not_default_value();
+
+    RETURN_IF_ERROR(add_native_json_column(data_column.get(), type_desc, name, value));
+
+    nullable_column->finish_append_one_not_default_value();
+
+    return Status::OK();
+}
+
+static Status add_nullable_native_json_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                              const avro_value_t& value) {
+    auto nullable_column = down_cast<NullableColumn*>(column);
+
+    auto& null_column = nullable_column->null_column();
+    auto& data_column = nullable_column->data_column();
+    if (avro_value_get_type(&value) == AVRO_NULL) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(add_native_json_column(data_column.get(), type_desc, name, value));
+
+    null_column->append(0);
+    return Status::OK();
+}
+
+static Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                  const avro_value_t& value) {
+    switch (type_desc.type) {
+    case TYPE_BOOLEAN:
+        return add_nullable_numeric_column<int8_t>(column, type_desc, name, value);
+    case TYPE_BIGINT:
+        return add_nullable_numeric_column<int64_t>(column, type_desc, name, value);
+    case TYPE_INT:
+        return add_nullable_numeric_column<int32_t>(column, type_desc, name, value);
+    case TYPE_SMALLINT:
+        return add_nullable_numeric_column<int16_t>(column, type_desc, name, value);
+    case TYPE_TINYINT:
+        return add_nullable_numeric_column<int8_t>(column, type_desc, name, value);
+    case TYPE_DOUBLE:
+        return add_nullable_numeric_column<double>(column, type_desc, name, value);
+    case TYPE_FLOAT:
+        return add_nullable_numeric_column<float>(column, type_desc, name, value);
+    case TYPE_JSON:
+        return add_nullable_native_json_column(column, type_desc, name, value);
+    case TYPE_ARRAY: {
+        if (avro_value_get_type(&value) == AVRO_ARRAY) {
+            auto nullable_column = down_cast<NullableColumn*>(column);
+
+            auto array_column = down_cast<ArrayColumn*>(nullable_column->mutable_data_column());
+            auto null_column = nullable_column->null_column();
+
+            auto& elems_column = array_column->elements_column();
+            size_t n = 0;
+            if (avro_value_get_size(&value, &n) != 0) {
+                auto err_msg = strings::Substitute("Failed to get array size, column=$0", name);
+                return Status::InvalidArgument(err_msg);
+            }
+            for (int i = 0; i < n; i++) {
+                avro_value_t element;
+                if (avro_value_get_by_index(&value, i, &element, nullptr) != 0) {
+                    auto err_msg = strings::Substitute("Failed to get array element, column=$0", name);
+                    return Status::InvalidArgument(err_msg);
+                }
+                RETURN_IF_ERROR(add_nullable_column(elems_column.get(), type_desc.children[0], name, element));
+            }
+
+            auto offsets = array_column->offsets_column();
+            uint32_t sz = offsets->get_data().back() + n;
+            offsets->append_numbers(&sz, sizeof(sz));
+            null_column->append(0);
+
+            return Status::OK();
+        } else {
+            auto err_msg = strings::Substitute("Failed to parse value as array, column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+    }
+
+    default:
+        return add_nullable_binary_column(column, type_desc, name, value);
+    }
+}
+
+static Status add_adpative_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                           const avro_value_t& value) {
+    switch (type_desc.type) {
+    case TYPE_BOOLEAN:
+        return add_adaptive_nullable_numeric_column<uint8_t>(column, type_desc, name, value);
+    case TYPE_BIGINT:
+        return add_adaptive_nullable_numeric_column<int64_t>(column, type_desc, name, value);
+    case TYPE_INT:
+        return add_adaptive_nullable_numeric_column<int32_t>(column, type_desc, name, value);
+    case TYPE_SMALLINT:
+        return add_adaptive_nullable_numeric_column<int16_t>(column, type_desc, name, value);
+    case TYPE_TINYINT:
+        return add_adaptive_nullable_numeric_column<int8_t>(column, type_desc, name, value);
+    case TYPE_DOUBLE:
+        return add_adaptive_nullable_numeric_column<double>(column, type_desc, name, value);
+    case TYPE_FLOAT:
+        return add_adaptive_nullable_numeric_column<float>(column, type_desc, name, value);
+    case TYPE_JSON:
+        return add_adpative_nullable_native_json_column(column, type_desc, name, value);
+    case TYPE_ARRAY: {
+        if (avro_value_get_type(&value) == AVRO_ARRAY) {
+            auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+
+            auto array_column = down_cast<ArrayColumn*>(nullable_column->mutable_begin_append_not_default_value());
+
+            auto& elems_column = array_column->elements_column();
+            size_t n = 0;
+            if (avro_value_get_size(&value, &n) != 0) {
+                auto err_msg = strings::Substitute("Failed to get array size, column=$0", name);
+                return Status::InvalidArgument(err_msg);
+            }
+            for (int i = 0; i < n; i++) {
+                avro_value_t element;
+                if (avro_value_get_by_index(&value, i, &element, nullptr) != 0) {
+                    auto err_msg = strings::Substitute("Failed to get array element, column=$0", name);
+                    return Status::InvalidArgument(err_msg);
+                }
+                RETURN_IF_ERROR(add_nullable_column(elems_column.get(), type_desc.children[0], name, element));
+            }
+
+            auto offsets = array_column->offsets_column();
+            uint32_t sz = offsets->get_data().back() + n;
+            offsets->append_numbers(&sz, sizeof(sz));
+
+            nullable_column->finish_append_one_not_default_value();
+
+            return Status::OK();
+        } else {
+            auto err_msg = strings::Substitute("Failed to parse value as array, column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+    }
+    default:
+        return add_adpative_nullable_binary_column(column, type_desc, name, value);
+    }
+}
+
+Status add_adaptive_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                    const avro_value_t& value, bool invalid_as_null) {
+    if (avro_value_get_type(&value) == AVRO_NULL) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+
+    auto st = add_adpative_nullable_column(column, type_desc, name, value);
+    if (UNLIKELY(!st.ok() && invalid_as_null)) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+    return st;
+}
+
+Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                           const avro_value_t& value, bool invalid_as_null) {
+    if (avro_value_get_type(&value) == AVRO_NULL) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+
+    auto st = add_nullable_column(column, type_desc, name, value);
+    if (!st.ok() && invalid_as_null) {
+        column->append_nulls(1);
+        return Status::OK();
+    }
+    return st;
+}
+
+} // namespace starrocks

--- a/be/src/formats/avro/nullable_column.h
+++ b/be/src/formats/avro/nullable_column.h
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "binary_column.h"
+#include "column/column.h"
+#include "common/status.h"
+#include "numeric_column.h"
+#include "runtime/types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "avro.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                           const avro_value_t& value, bool invalid_as_null);
+
+Status add_adaptive_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                    const avro_value_t& value, bool invalid_as_null);
+} // namespace starrocks

--- a/be/src/formats/avro/numeric_column.cpp
+++ b/be/src/formats/avro/numeric_column.cpp
@@ -1,0 +1,220 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "numeric_column.h"
+
+#include "column/fixed_length_column.h"
+#include "gutil/strings/substitute.h"
+#include "util/string_parser.hpp"
+
+namespace starrocks {
+
+template <typename FromType, typename ToType>
+static inline bool checked_cast(const FromType& from, ToType* to) {
+    *to = static_cast<ToType>(from);
+
+    // NOTE: use lowest() because float and double needed.
+    DIAGNOSTIC_PUSH
+#if defined(__clang__)
+    DIAGNOSTIC_IGNORE("-Wimplicit-const-int-float-conversion")
+#endif
+    return (from < std::numeric_limits<ToType>::lowest() || from > std::numeric_limits<ToType>::max());
+    DIAGNOSTIC_POP
+}
+
+template <typename T>
+static Status add_column_with_numeric_value(FixedLengthColumn<T>* column, const TypeDescriptor& type_desc,
+                                            const std::string& name, const avro_value_t& value) {
+    switch (avro_value_get_type(&value)) {
+    case AVRO_INT32: {
+        int in;
+        if (avro_value_get_int(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get int value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        T out{};
+
+        if (!checked_cast(in, &out)) {
+            column->append_numbers(&out, sizeof(out));
+        } else {
+            auto err_msg = strings::Substitute("Value is overflow. column=$0, value=$1", name, in);
+            return Status::InvalidArgument(err_msg);
+        }
+        return Status::OK();
+    }
+    case AVRO_INT64: {
+        int64_t in;
+        if (avro_value_get_long(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get int64 value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        T out{};
+
+        if (!checked_cast(in, &out)) {
+            column->append_numbers(&out, sizeof(out));
+        } else {
+            auto err_msg = strings::Substitute("Value is overflow. column=$0, value=$1", name, in);
+            return Status::InvalidArgument(err_msg);
+        }
+        return Status::OK();
+    }
+    case AVRO_BOOLEAN: {
+        int in;
+        if (avro_value_get_boolean(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get boolean value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+        T out{};
+
+        if (!checked_cast(in, &out)) {
+            column->append_numbers(&out, sizeof(out));
+        } else {
+            auto err_msg = strings::Substitute("Value is overflow. column=$0, value=$1", name, in);
+            return Status::InvalidArgument(err_msg);
+        }
+        return Status::OK();
+    }
+
+    case AVRO_FLOAT: {
+        float in;
+        if (avro_value_get_float(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get float value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        T out{};
+
+        if (!checked_cast(in, &out)) {
+            column->append_numbers(&out, sizeof(out));
+        } else {
+            auto err_msg = strings::Substitute("Value is overflow. column=$0, value=$1", name, in);
+            return Status::InvalidArgument(err_msg);
+        }
+        return Status::OK();
+    }
+
+    case AVRO_DOUBLE: {
+        double in;
+        if (avro_value_get_double(&value, &in) != 0) {
+            auto err_msg = strings::Substitute("Get double value error. column=$0", name);
+            return Status::InvalidArgument(err_msg);
+        }
+
+        T out{};
+
+        if (!checked_cast(in, &out)) {
+            column->append_numbers(&out, sizeof(out));
+        } else {
+            auto err_msg = strings::Substitute("Value is overflow. column=$0, value=$1", name, in);
+            return Status::InvalidArgument(err_msg);
+        }
+        return Status::OK();
+    }
+
+    default: {
+        auto err_msg = strings::Substitute("Unsupported value type. column=$0", name);
+        return Status::DataQualityError(err_msg);
+    }
+    }
+    return Status::OK();
+}
+
+template <typename T>
+static Status add_column_with_string_value_numeric(FixedLengthColumn<T>* column, const TypeDescriptor& type_desc,
+                                                   const std::string& name, const avro_value_t& value) {
+    const char* in;
+    size_t size;
+    if (avro_value_get_string(&value, &in, &size) != 0) {
+        auto err_msg = strings::Substitute("Get string value error. column=$0", name);
+        return Status::InvalidArgument(err_msg);
+    }
+
+    // The size returned for a string object will include the NUL terminator,
+    // it will be one more than you’d get from calling strlen on the content.
+    // Please refer to this link: https://avro.apache.org/docs/1.11.1/api/c/
+    --size;
+
+    StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
+
+    T v{};
+    if constexpr (std::is_floating_point<T>::value) {
+        v = StringParser::string_to_float<T>(in, size, &parse_result);
+    } else {
+        v = StringParser::string_to_int<T>(in, size, &parse_result);
+    }
+
+    if (parse_result == StringParser::PARSE_SUCCESS) {
+        column->append_numbers(&v, sizeof(v));
+        return Status::OK();
+    } else {
+        // Attemp to parse the string as float.
+        auto d = StringParser::string_to_float<double>(in, size, &parse_result);
+        if (parse_result == StringParser::PARSE_SUCCESS) {
+            if (!checked_cast(d, &v)) {
+                column->append_numbers(&v, sizeof(v));
+                return Status::OK();
+            } else {
+                auto err_msg = strings::Substitute("Value is overflow. column=$0, value=$1", name, d);
+                return Status::InvalidArgument(err_msg);
+            }
+        }
+
+        std::string err_msg = strings::Substitute("Unable to cast string value to BIGINT. value=$0, column=$1",
+                                                  std::string(in, size), name);
+        return Status::InvalidArgument(err_msg);
+    }
+}
+
+template <typename T>
+Status add_numeric_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                          const avro_value_t& value) {
+    auto numeric_column = down_cast<FixedLengthColumn<T>*>(column);
+    avro_type_t type = avro_value_get_type(&value);
+    switch (type) {
+    case AVRO_INT32:
+    case AVRO_INT64:
+    case AVRO_FLOAT:
+    case AVRO_DOUBLE:
+    case AVRO_BOOLEAN: {
+        return add_column_with_numeric_value(numeric_column, type_desc, name, value);
+    }
+
+    case AVRO_STRING: {
+        return add_column_with_string_value_numeric(numeric_column, type_desc, name, value);
+    }
+
+    default: {
+        auto err_msg = strings::Substitute("Unsupported value type. Numeric type is required. column=$0", name);
+        return Status::InvalidArgument(err_msg);
+    }
+    }
+    return Status::OK();
+}
+
+template Status add_numeric_column<int64_t>(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                            const avro_value_t& value);
+template Status add_numeric_column<int32_t>(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                            const avro_value_t& value);
+template Status add_numeric_column<int16_t>(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                            const avro_value_t& value);
+template Status add_numeric_column<int8_t>(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                           const avro_value_t& value);
+template Status add_numeric_column<uint8_t>(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                            const avro_value_t& value);
+template Status add_numeric_column<double>(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                           const avro_value_t& value);
+template Status add_numeric_column<float>(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                          const avro_value_t& value);
+
+} // namespace starrocks

--- a/be/src/formats/avro/numeric_column.h
+++ b/be/src/formats/avro/numeric_column.h
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <limits>
+#include <string>
+
+#include "column/column.h"
+#include "common/status.h"
+#include "runtime/types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "avro.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+template <typename T>
+Status add_numeric_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                          const avro_value_t& value);
+
+} // namespace starrocks

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -40,14 +40,6 @@
 #include "runtime/stream_load/stream_load_context.h"
 #include "util/defer_op.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-#include "libserdes/serdes-avro.h"
-#ifdef __cplusplus
-}
-#endif
-
 namespace starrocks {
 
 Status KafkaDataConsumerGroup::assign_topic_partitions(StreamLoadContext* ctx) {
@@ -112,25 +104,6 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
             VLOG(1) << "submit a data consumer: " << consumer->id() << ", group id: " << _grp_id;
         }
     }
-
-    char errstr[512];
-
-    serdes_conf_t* sconf = nullptr;
-    serdes_t* serdes = nullptr;
-    if (ctx->format == TFileFormatType::FORMAT_AVRO) {
-        sconf = serdes_conf_new(NULL, 0, "schema.registry.url", ctx->kafka_info->confluent_schema_registry_url.c_str(),
-                                NULL);
-        serdes = serdes_new(sconf, errstr, sizeof(errstr));
-        if (!serdes) {
-            LOG(ERROR) << "failed to create serdes handle: " << errstr;
-            return Status::InternalError("failed to create serdes handle");
-        }
-    }
-    DeferOp serdesDeleter([&] {
-        if (serdes != nullptr) {
-            free(serdes);
-        }
-    });
 
     // consuming from queue and put data to stream load pipe
     int64_t left_time = ctx->max_interval_s * 1000;
@@ -239,32 +212,8 @@ Status KafkaDataConsumerGroup::start_all(StreamLoadContext* ctx) {
                 }
             } else {
                 Status st = Status::OK();
-                if (ctx->format == TFileFormatType::FORMAT_AVRO) {
-                    // We must ensure the msg len > 0.
-                    if (msg->len() > 0) {
-                        avro_value_t avro;
-                        serdes_schema_t* schema;
-                        serdes_err_t err = serdes_deserialize_avro(serdes, &avro, &schema, msg->payload(), msg->len(),
-                                                                   errstr, sizeof(errstr));
-                        if (err) {
-                            auto err_msg = strings::Substitute("serdes deserialize avro failed: $0", errstr);
-                            LOG(ERROR) << err_msg;
-                            return Status::InternalError(err_msg);
-                        }
-                        DeferOp op([&] { avro_value_decref(&avro); });
-                        char* as_json;
-                        if (avro_value_to_json(&avro, 1, &as_json)) {
-                            auto err_msg = strings::Substitute("avro to json failed: $0", avro_strerror());
-                            LOG(ERROR) << err_msg;
-                            return Status::InternalError(err_msg);
-                        }
-                        st = (kafka_pipe.get()->*append_data)(as_json, strlen(as_json), row_delimiter);
-                        free(as_json);
-                    }
-                } else {
-                    st = (kafka_pipe.get()->*append_data)(static_cast<const char*>(msg->payload()),
-                                                          static_cast<size_t>(msg->len()), row_delimiter);
-                }
+                st = (kafka_pipe.get()->*append_data)(static_cast<const char*>(msg->payload()),
+                                                      static_cast<size_t>(msg->len()), row_delimiter);
                 if (st.ok()) {
                     received_rows++;
                     left_bytes -= msg->len();

--- a/be/src/runtime/stream_load/stream_load_pipe.cpp
+++ b/be/src/runtime/stream_load/stream_load_pipe.cpp
@@ -89,7 +89,7 @@ StatusOr<ByteBufferPtr> StreamLoadPipe::read() {
 
     // cancelled
     if (_cancelled) {
-        return _err_st;
+        return Status::EndOfFile("all data has been read");
     }
 
     // finished

--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -570,6 +570,11 @@ inline int StringParser::StringParseTraits<int8_t>::max_ascii_len() {
 }
 
 template <>
+inline int StringParser::StringParseTraits<uint8_t>::max_ascii_len() {
+    return 3;
+}
+
+template <>
 inline int StringParser::StringParseTraits<int16_t>::max_ascii_len() {
     return 5;
 }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -134,6 +134,9 @@ set(EXEC_FILES
         ./formats/json/binary_column_test.cpp
         ./formats/json/numeric_column_test.cpp
         ./formats/json/nullable_column_test.cpp
+        ./formats/avro/binary_column_test.cpp
+        ./formats/avro/numeric_column_test.cpp
+        ./formats/avro/nullable_column_test.cpp
         ./formats/orc/orc_chunk_reader_test.cpp
         ./formats/orc/orc_lazy_load_test.cpp
         ./formats/orc/orc_test_util/MemoryOutputStream.cc

--- a/be/test/exec/avro_scanner_test.cpp
+++ b/be/test/exec/avro_scanner_test.cpp
@@ -1,0 +1,966 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/avro_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "fs/fs_util.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+#include "testutil/parallel_test.h"
+#include "util/defer_op.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "avro.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+struct AvroHelper {
+    avro_schema_t schema = NULL;
+    avro_value_iface_t* iface = NULL;
+    avro_value_t avro_val;
+    std::string schema_text;
+};
+
+class AvroScannerTest : public ::testing::Test {
+protected:
+    std::unique_ptr<AvroScanner> create_avro_scanner(const std::vector<TypeDescriptor>& types,
+                                                     const std::vector<TBrokerRangeDesc>& ranges,
+                                                     const std::vector<std::string>& col_names,
+                                                     const std::string& schema_text) {
+        /// Init DescriptorTable
+        TDescriptorTableBuilder desc_tbl_builder;
+        TTupleDescriptorBuilder tuple_desc_builder;
+        for (int i = 0; i < types.size(); ++i) {
+            TSlotDescriptorBuilder slot_desc_builder;
+            slot_desc_builder.type(types[i]).column_name(col_names[i]).length(types[i].len).nullable(true);
+            tuple_desc_builder.add_slot(slot_desc_builder.build());
+        }
+        tuple_desc_builder.build(&desc_tbl_builder);
+
+        DescriptorTbl* desc_tbl = nullptr;
+        Status st = DescriptorTbl::create(_state, &_pool, desc_tbl_builder.desc_tbl(), &desc_tbl,
+                                          config::vector_chunk_size);
+        CHECK(st.ok()) << st.to_string();
+
+        /// Init RuntimeState
+        _state->set_desc_tbl(desc_tbl);
+        _state->init_instance_mem_tracker();
+
+        /// TBrokerScanRangeParams
+        TBrokerScanRangeParams* params = _pool.add(new TBrokerScanRangeParams());
+        params->strict_mode = true;
+        params->dest_tuple_id = 0;
+        params->src_tuple_id = 0;
+        for (int i = 0; i < types.size(); i++) {
+            params->expr_of_dest_slot[i] = TExpr();
+            params->expr_of_dest_slot[i].nodes.emplace_back(TExprNode());
+            params->expr_of_dest_slot[i].nodes[0].__set_type(types[i].to_thrift());
+            params->expr_of_dest_slot[i].nodes[0].__set_node_type(TExprNodeType::SLOT_REF);
+            params->expr_of_dest_slot[i].nodes[0].__set_is_nullable(true);
+            params->expr_of_dest_slot[i].nodes[0].__set_slot_ref(TSlotRef());
+            params->expr_of_dest_slot[i].nodes[0].slot_ref.__set_slot_id(i);
+            params->expr_of_dest_slot[i].nodes[0].__set_type(types[i].to_thrift());
+        }
+
+        for (int i = 0; i < types.size(); i++) {
+            params->src_slot_ids.emplace_back(i);
+        }
+
+        TBrokerScanRange* broker_scan_range = _pool.add(new TBrokerScanRange());
+        broker_scan_range->params = *params;
+        broker_scan_range->ranges = ranges;
+        return std::make_unique<AvroScanner>(_state, _profile, *broker_scan_range, _counter, schema_text);
+    }
+
+    static void SetUpTestCase() {
+        ASSERT_TRUE(fs::create_directories("./be/test/exec/test_data/avro_scanner/tmp").ok());
+    }
+
+    static void TearDownTestCase() { ASSERT_TRUE(fs::remove_all("./be/test/exec/test_data/avro_scanner/tmp").ok()); }
+
+    void SetUp() override {
+        config::vector_chunk_size = 4096;
+        _profile = _pool.add(new RuntimeProfile("test"));
+        _counter = _pool.add(new ScannerCounter());
+        _state = _pool.add(new RuntimeState(TQueryGlobals()));
+        std::string starrocks_home = getenv("STARROCKS_HOME");
+    }
+
+    void TearDown() override {}
+
+    void init_avro_value(std::string schema_path, AvroHelper& avro_helper) {
+        std::ifstream infile_schema;
+        infile_schema.open(schema_path);
+        std::stringstream ss;
+        ss << infile_schema.rdbuf();
+        std::string schema_str(ss.str());
+        avro_schema_error_t error;
+        avro_helper.schema_text = schema_str;
+        int result = avro_schema_from_json(schema_str.c_str(), schema_str.size(), &avro_helper.schema, &error);
+        if (result != 0) {
+            std::cout << "parse schema from json error: " << avro_strerror() << std::endl;
+        }
+        EXPECT_EQ(0, result);
+        avro_helper.iface = avro_generic_class_from_schema(avro_helper.schema);
+        avro_generic_value_new(avro_helper.iface, &avro_helper.avro_val);
+    }
+
+    Status write_avro_data(AvroHelper& avro_helper, std::string data_path) {
+        avro_file_writer_t db;
+        int rval = avro_file_writer_create(data_path.c_str(), avro_helper.schema, &db);
+        if (rval) {
+            auto err_msg =
+                    strings::Substitute("There was an error creating $0 error message: $1", data_path, avro_strerror());
+            return Status::InternalError(err_msg);
+        }
+
+        if (avro_file_writer_append_value(db, &avro_helper.avro_val)) {
+            auto err_msg =
+                    strings::Substitute("Unable to write Person value to memory buffer\nMessage: $0", avro_strerror());
+            return Status::InternalError(err_msg);
+        }
+        avro_file_writer_flush(db);
+        avro_file_writer_close(db);
+        return Status::OK();
+    }
+
+private:
+    RuntimeProfile* _profile = nullptr;
+    ScannerCounter* _counter = nullptr;
+    RuntimeState* _state = nullptr;
+    ObjectPool _pool;
+};
+
+TEST_F(AvroScannerTest, test_basic_type) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_basic_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    avro_value_t string_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "stringtype", &string_value, NULL) == 0) {
+        avro_value_set_string(&string_value, "abcdefg");
+    }
+
+    avro_value_t enum_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "enumtype", &enum_value, NULL) == 0) {
+        avro_value_set_enum(&enum_value, 2);
+    }
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_basic_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(TYPE_BIGINT);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner =
+            create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "stringtype", "enumtype"},
+                                avro_helper.schema_text);
+
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(5, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+    EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+    EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+    EXPECT_EQ("abcdefg", chunk->get(0)[3].get_slice());
+    EXPECT_EQ("DIAMONDS", chunk->get(0)[4].get_slice());
+}
+
+TEST_F(AvroScannerTest, test_preprocess_jsonpaths) {
+    std::string jsonpaths =
+            R"(["$.decoded_logs.id", "$.decoded_logs.event_signature.*", "$.decoded_logs.event_params.*", "$.decoded_logs.raw_log.*.data"])";
+    std::string new_jsonpaths = AvroScanner::preprocess_jsonpaths(jsonpaths);
+    EXPECT_EQ(
+            R"(["$.decoded_logs.id", "$.decoded_logs.event_signature", "$.decoded_logs.event_params", "$.decoded_logs.raw_log.data"])",
+            new_jsonpaths);
+}
+
+TEST_F(AvroScannerTest, test_jsonpaths) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_nest_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    avro_value_t string_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "stringtype", &string_value, NULL) == 0) {
+        avro_value_set_string(&string_value, "abcdefg");
+    }
+
+    avro_value_t nest_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "nesttype", &nest_value, NULL) == 0) {
+        {
+            avro_value_t boolean_value;
+            if (avro_value_get_by_name(&nest_value, "booleantype", &boolean_value, NULL) == 0) {
+                avro_value_set_boolean(&boolean_value, false);
+            }
+
+            avro_value_t long_value;
+            if (avro_value_get_by_name(&nest_value, "longtype", &long_value, NULL) == 0) {
+                avro_value_set_long(&long_value, 4294967297);
+            }
+        }
+    }
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_nest_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(TYPE_BIGINT);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TYPE_BIGINT);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.booleantype", "$.longtype", "$.doubletype", "$.stringtype", "$.nesttype.longtype"])";
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner =
+            create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "stringtype", "longtype2"},
+                                avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(5, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+    EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+    EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+    EXPECT_EQ("abcdefg", chunk->get(0)[3].get_slice());
+    EXPECT_EQ(4294967297, chunk->get(0)[4].get_int64());
+}
+
+TEST_F(AvroScannerTest, test_json_type) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_nest_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    avro_value_t string_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "stringtype", &string_value, NULL) == 0) {
+        avro_value_set_string(&string_value, "abcdefg");
+    }
+
+    avro_value_t nest_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "nesttype", &nest_value, NULL) == 0) {
+        {
+            avro_value_t boolean_value;
+            if (avro_value_get_by_name(&nest_value, "booleantype", &boolean_value, NULL) == 0) {
+                avro_value_set_boolean(&boolean_value, false);
+            }
+
+            avro_value_t long_value;
+            if (avro_value_get_by_name(&nest_value, "longtype", &long_value, NULL) == 0) {
+                avro_value_set_long(&long_value, 4294967297);
+            }
+        }
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_nest_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(TYPE_BIGINT);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TYPE_JSON);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.jsonpaths = false;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner =
+            create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "stringtype", "nesttype"},
+                                avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(5, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+    EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+    EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+    EXPECT_EQ("abcdefg", chunk->get(0)[3].get_slice());
+    const JsonValue* json = chunk->get(0)[4].get_json();
+    EXPECT_EQ("{\"booleantype\": false, \"longtype\": 4294967297}", json->to_string_uncheck());
+}
+
+TEST_F(AvroScannerTest, test_union_type_null) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_union_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    avro_value_t union_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "uniontype", &union_value, NULL) == 0) {
+        avro_value_t null_value;
+        avro_value_set_branch(&union_value, 0, &null_value);
+        avro_value_set_null(&null_value);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_union_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(TYPE_BIGINT);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.strip_outer_array = false;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.booleantype", "$.longtype", "$.doubletype", "$.uniontype.*"])";
+    range.__isset.json_root = false;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "uniontype"},
+                                       avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+    EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+    EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+    EXPECT_TRUE(chunk->get(0)[3].is_null());
+}
+
+TEST_F(AvroScannerTest, test_union_type_basic) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_union_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    avro_value_t union_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "uniontype", &union_value, NULL) == 0) {
+        avro_value_t string_value;
+        avro_value_set_branch(&union_value, 1, &string_value);
+        avro_value_set_string(&string_value, "abcdefg");
+    }
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_union_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(TYPE_BIGINT);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.strip_outer_array = false;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.booleantype", "$.longtype", "$.doubletype", "$.uniontype.*"])";
+    range.__isset.json_root = false;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "uniontype"},
+                                       avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+    EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+    EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+    EXPECT_EQ("abcdefg", chunk->get(0)[3].get_slice());
+}
+
+TEST_F(AvroScannerTest, test_array) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_array_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    avro_value_t array_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "arraytype", &array_value, NULL) == 0) {
+        avro_value_t ele1;
+        avro_value_append(&array_value, &ele1, NULL);
+        avro_value_set_long(&ele1, 4294967297);
+
+        avro_value_t ele2;
+        avro_value_append(&array_value, &ele2, NULL);
+        avro_value_set_long(&ele2, 4294967298);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_array_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(TYPE_BIGINT);
+    types.emplace_back(TYPE_DOUBLE);
+    TypeDescriptor t(TYPE_ARRAY);
+    t.children.emplace_back(TYPE_BIGINT);
+    types.emplace_back(t);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.jsonpaths = false;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "arraytype"},
+                                       avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+    EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+    EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+    auto array = chunk->get(0)[3].get_array();
+    ASSERT_EQ(4294967297, array[0].get_int64());
+    ASSERT_EQ(4294967298, array[1].get_int64());
+}
+
+TEST_F(AvroScannerTest, test_complex_schema) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_complex_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t decoded_logs_value;
+    avro_value_set_branch(&avro_helper.avro_val, 1, &decoded_logs_value);
+    avro_value_t id_value;
+    if (avro_value_get_by_name(&decoded_logs_value, "id", &id_value, NULL) == 0) {
+        avro_value_set_string(&id_value, "12345");
+    }
+
+    avro_value_t event_signature_val;
+    if (avro_value_get_by_name(&decoded_logs_value, "eventsignature", &event_signature_val, NULL) == 0) {
+        avro_value_t null_vale;
+        avro_value_set_branch(&event_signature_val, 0, &null_vale);
+        avro_value_set_null(&null_vale);
+    }
+
+    avro_value_t event_params_val;
+    if (avro_value_get_by_name(&decoded_logs_value, "eventparams", &event_params_val, NULL) == 0) {
+        avro_value_t array_value;
+        avro_value_set_branch(&event_params_val, 1, &array_value);
+
+        avro_value_t ele1;
+        avro_value_append(&array_value, &ele1, NULL);
+        avro_value_set_string(&ele1, "abc");
+
+        avro_value_t ele2;
+        avro_value_append(&array_value, &ele2, NULL);
+        avro_value_set_string(&ele2, "def");
+    }
+
+    avro_value_t raw_log_val;
+    if (avro_value_get_by_name(&decoded_logs_value, "rawlog", &raw_log_val, NULL) == 0) {
+        avro_value_t record_value;
+        avro_value_set_branch(&raw_log_val, 1, &record_value);
+
+        avro_value_t id_value;
+        if (avro_value_get_by_name(&record_value, "id", &id_value, NULL) == 0) {
+            avro_value_set_string(&id_value, "iop");
+        }
+        avro_value_t data_value;
+        if (avro_value_get_by_name(&record_value, "data", &data_value, NULL) == 0) {
+            avro_value_set_string(&data_value, "klj");
+        }
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_complex_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    TypeDescriptor t(TYPE_ARRAY);
+    t.children.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(t);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.id", "$.eventsignature.*", "$.eventparams.*", "$.rawlog.*.data"])";
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"id", "eventsignature", "eventparams", "data"},
+                                       avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("12345", chunk->get(0)[0].get_slice());
+    EXPECT_TRUE(chunk->get(0)[1].is_null());
+    auto array = chunk->get(0)[2].get_array();
+    ASSERT_EQ("abc", array[0].get_slice());
+    ASSERT_EQ("def", array[1].get_slice());
+    EXPECT_EQ("klj", chunk->get(0)[3].get_slice());
+}
+
+TEST_F(AvroScannerTest, test_complex_schema_null_data) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_complex_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t decoded_logs_value;
+    avro_value_set_branch(&avro_helper.avro_val, 1, &decoded_logs_value);
+    avro_value_t id_value;
+    if (avro_value_get_by_name(&decoded_logs_value, "id", &id_value, NULL) == 0) {
+        avro_value_set_string(&id_value, "12345");
+    }
+
+    avro_value_t event_signature_val;
+    if (avro_value_get_by_name(&decoded_logs_value, "eventsignature", &event_signature_val, NULL) == 0) {
+        avro_value_t null_vale;
+        avro_value_set_branch(&event_signature_val, 0, &null_vale);
+        avro_value_set_null(&null_vale);
+    }
+
+    avro_value_t event_params_val;
+    if (avro_value_get_by_name(&decoded_logs_value, "eventparams", &event_params_val, NULL) == 0) {
+        avro_value_t array_value;
+        avro_value_set_branch(&event_params_val, 1, &array_value);
+
+        avro_value_t ele1;
+        avro_value_append(&array_value, &ele1, NULL);
+        avro_value_set_string(&ele1, "abc");
+
+        avro_value_t ele2;
+        avro_value_append(&array_value, &ele2, NULL);
+        avro_value_set_string(&ele2, "def");
+    }
+
+    avro_value_t raw_log_val;
+    if (avro_value_get_by_name(&decoded_logs_value, "rawlog", &raw_log_val, NULL) == 0) {
+        avro_value_t null_vale;
+        avro_value_set_branch(&raw_log_val, 0, &null_vale);
+        avro_value_set_null(&null_vale);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_complex_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    TypeDescriptor t(TYPE_ARRAY);
+    t.children.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(t);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.strip_outer_array = false;
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$.id", "$.eventsignature.*", "$.eventparams.*", "$.rawlog.*.data"])";
+    range.__isset.json_root = false;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {{"id", "eventsignature", "eventparams", "data"}},
+                                       avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("12345", chunk->get(0)[0].get_slice());
+    EXPECT_TRUE(chunk->get(0)[1].is_null());
+    auto array = chunk->get(0)[2].get_array();
+    ASSERT_EQ("abc", array[0].get_slice());
+    ASSERT_EQ("def", array[1].get_slice());
+    EXPECT_TRUE(chunk->get(0)[3].is_null());
+}
+
+TEST_F(AvroScannerTest, test_map_to_json) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_map_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    avro_value_t map_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "maptype", &map_value, NULL) == 0) {
+        avro_value_t ele1;
+        avro_value_add(&map_value, "ele1", &ele1, NULL, NULL);
+        avro_value_set_long(&ele1, 4294967297);
+
+        avro_value_t ele2;
+        avro_value_add(&map_value, "ele2", &ele2, NULL, NULL);
+        avro_value_set_long(&ele2, 4294967298);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_map_data.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(TYPE_BIGINT);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TYPE_JSON);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "maptype"},
+                                       avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(4, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+    EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+    EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+    const JsonValue* json = chunk->get(0)[3].get_json();
+    EXPECT_EQ("{\"ele1\": 4294967297, \"ele2\": 4294967298}", json->to_string_uncheck());
+}
+
+TEST_F(AvroScannerTest, test_root_array) {
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_root_array_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    {
+        avro_value_t ele;
+        avro_value_append(&avro_helper.avro_val, &ele, NULL);
+
+        avro_value_t boolean_value;
+        if (avro_value_get_by_name(&ele, "booleantype", &boolean_value, NULL) == 0) {
+            avro_value_set_boolean(&boolean_value, true);
+        }
+
+        avro_value_t long_value;
+        if (avro_value_get_by_name(&ele, "longtype", &long_value, NULL) == 0) {
+            avro_value_set_long(&long_value, 4294967296);
+        }
+
+        avro_value_t double_value;
+        if (avro_value_get_by_name(&ele, "doubletype", &double_value, NULL) == 0) {
+            avro_value_set_double(&double_value, 1.234567);
+        }
+
+        avro_value_t string_value;
+        if (avro_value_get_by_name(&ele, "stringtype", &string_value, NULL) == 0) {
+            avro_value_set_string(&string_value, "abcdefg");
+        }
+
+        avro_value_t enum_value;
+        if (avro_value_get_by_name(&ele, "enumtype", &enum_value, NULL) == 0) {
+            avro_value_set_enum(&enum_value, 2);
+        }
+    }
+
+    {
+        avro_value_t ele;
+        avro_value_append(&avro_helper.avro_val, &ele, NULL);
+
+        avro_value_t boolean_value;
+        if (avro_value_get_by_name(&ele, "booleantype", &boolean_value, NULL) == 0) {
+            avro_value_set_boolean(&boolean_value, true);
+        }
+
+        avro_value_t long_value;
+        if (avro_value_get_by_name(&ele, "longtype", &long_value, NULL) == 0) {
+            avro_value_set_long(&long_value, 429496);
+        }
+
+        avro_value_t double_value;
+        if (avro_value_get_by_name(&ele, "doubletype", &double_value, NULL) == 0) {
+            avro_value_set_double(&double_value, 1.23457);
+        }
+
+        avro_value_t string_value;
+        if (avro_value_get_by_name(&ele, "stringtype", &string_value, NULL) == 0) {
+            avro_value_set_string(&string_value, "aaafg");
+        }
+
+        avro_value_t enum_value;
+        if (avro_value_get_by_name(&ele, "enumtype", &enum_value, NULL) == 0) {
+            avro_value_set_enum(&enum_value, 1);
+        }
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_root_array_schema.json";
+    write_avro_data(avro_helper, data_path);
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(TYPE_BIGINT);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    range.__isset.jsonpaths = true;
+    range.jsonpaths = R"(["$[0].booleantype", "$[0].longtype", "$[0].doubletype", "$[0].stringtype", "$[0].enumtype"])";
+    ranges.emplace_back(range);
+
+    auto scanner =
+            create_avro_scanner(types, ranges, {"booleantype", "longtype", "doubletype", "stringtype", "enumtype"},
+                                avro_helper.schema_text);
+
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok());
+
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok());
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(5, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get(0)[0].get_int8());
+    EXPECT_EQ(4294967296, chunk->get(0)[1].get_int64());
+    EXPECT_FLOAT_EQ(1.234567, chunk->get(0)[2].get_double());
+    EXPECT_EQ("abcdefg", chunk->get(0)[3].get_slice());
+    EXPECT_EQ("DIAMONDS", chunk->get(0)[4].get_slice());
+}
+
+} // namespace starrocks

--- a/be/test/exec/test_data/avro_scanner/avro_array_schema.json
+++ b/be/test/exec/test_data/avro_scanner/avro_array_schema.json
@@ -1,0 +1,14 @@
+{
+    "type": "record",
+    "name": "nest",
+    "fields" : [
+        {"name": "booleantype", "type" : "boolean"},
+        {"name": "longtype", "type": "long"},
+        {"name": "doubletype", "type": "double"},
+        {"name": "arraytype", "type": {
+            "type": "array",
+            "items": "long",
+            "defalut": []
+        }}
+    ]
+}

--- a/be/test/exec/test_data/avro_scanner/avro_basic_schema.json
+++ b/be/test/exec/test_data/avro_scanner/avro_basic_schema.json
@@ -1,0 +1,11 @@
+{
+    "type": "record",
+    "name": "basic",
+    "fields" : [
+        {"name": "booleantype", "type" : "boolean"},
+        {"name": "longtype", "type": "long"},
+        {"name": "doubletype", "type": "double"},
+        {"name": "stringtype", "type": "string"},
+        {"name": "enumtype", "type": {"type": "enum", "name": "ThirdEnum", "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]}}  
+    ]
+}

--- a/be/test/exec/test_data/avro_scanner/avro_complex_schema.json
+++ b/be/test/exec/test_data/avro_scanner/avro_complex_schema.json
@@ -1,0 +1,31 @@
+["null", {
+	"doc": "{\"primaryKeys\":[\"id\"]}",
+	"fields": [{
+		"name": "id",
+		"type": "string"
+	}, {
+		"name": "eventsignature",
+		"type": ["null", "string"]
+	}, {
+		"name": "eventparams",
+		"type": ["null", {
+			"items": "string",
+			"type": "array"
+		}]
+	}, {
+		"name": "rawlog",
+		"type": ["null", {
+			"fields": [{
+				"name": "id",
+				"type": "string"
+			}, {
+				"name": "data",
+				"type": "string"
+			}],
+			"name": "logs",
+			"type": "record"
+		}]
+	}],
+	"name": "decodedlogs",
+	"type": "record"
+}]

--- a/be/test/exec/test_data/avro_scanner/avro_map_schema.json
+++ b/be/test/exec/test_data/avro_scanner/avro_map_schema.json
@@ -1,0 +1,14 @@
+{
+    "type": "record",
+    "name": "nest",
+    "fields" : [
+        {"name": "booleantype", "type" : "boolean"},
+        {"name": "longtype", "type": "long"},
+        {"name": "doubletype", "type": "double"},
+        {"name": "maptype", "type": {
+            "type": "map",
+            "values": "long",
+            "defalut": {}
+        }}
+    ]
+}

--- a/be/test/exec/test_data/avro_scanner/avro_nest_schema.json
+++ b/be/test/exec/test_data/avro_scanner/avro_nest_schema.json
@@ -1,0 +1,20 @@
+{
+    "type": "record",
+    "name": "nest",
+    "fields" : [
+        {"name": "booleantype", "type" : "boolean"},
+        {"name": "longtype", "type": "long"},
+        {"name": "doubletype", "type": "double"},
+        {"name": "stringtype", "type": "string"},
+        {"name": "nesttype", "type": 
+            {
+                "type": "record",
+                "name": "ThirdRecord",
+                "fields" : [
+                    {"name": "booleantype", "type" : "boolean"},
+                    {"name": "longtype", "type": "long"}
+                ]
+            }
+        }
+    ]
+}

--- a/be/test/exec/test_data/avro_scanner/avro_root_array_schema.json
+++ b/be/test/exec/test_data/avro_scanner/avro_root_array_schema.json
@@ -1,0 +1,14 @@
+{
+    "type": "array",
+    "items": {
+        "type": "record",
+        "name": "basic",
+        "fields" : [
+            {"name": "booleantype", "type" : "boolean"},
+            {"name": "longtype", "type": "long"},
+            {"name": "doubletype", "type": "double"},
+            {"name": "stringtype", "type": "string"},
+            {"name": "enumtype", "type": {"type": "enum", "name": "ThirdEnum", "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]}}  
+        ]
+    }
+}

--- a/be/test/exec/test_data/avro_scanner/avro_union_schema.json
+++ b/be/test/exec/test_data/avro_scanner/avro_union_schema.json
@@ -1,0 +1,10 @@
+{
+    "type": "record",
+    "name": "nest",
+    "fields" : [
+        {"name": "booleantype", "type" : "boolean"},
+        {"name": "longtype", "type": "long"},
+        {"name": "doubletype", "type": "double"},
+        {"name": "uniontype", "type": ["null", "string"]}
+    ]
+}

--- a/be/test/formats/avro/binary_column_test.cpp
+++ b/be/test/formats/avro/binary_column_test.cpp
@@ -1,0 +1,232 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/avro/binary_column.h"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
+#include "column/binary_column.h"
+#include "column/fixed_length_column.h"
+#include "runtime/types.h"
+#include "util/defer_op.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "avro.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+class AvroAddBinaryColumnTest : public ::testing::Test {};
+
+struct AvroHelper {
+    avro_schema_t schema = NULL;
+    avro_value_iface_t* iface = NULL;
+    avro_value_t avro_val;
+};
+
+static void init_avro_value(std::string schema_path, AvroHelper& avro_helper) {
+    std::ifstream infile_schema;
+    infile_schema.open(schema_path);
+    std::stringstream ss;
+    ss << infile_schema.rdbuf();
+    std::string schema_str(ss.str());
+    avro_schema_error_t error;
+    int result = avro_schema_from_json(schema_str.c_str(), schema_str.size(), &avro_helper.schema, &error);
+    if (result != 0) {
+        std::cout << "parse schema from json error: " << avro_strerror() << std::endl;
+    }
+    EXPECT_EQ(0, result);
+    avro_helper.iface = avro_generic_class_from_schema(avro_helper.schema);
+    avro_generic_value_new(avro_helper.iface, &avro_helper.avro_val);
+}
+
+TEST_F(AvroAddBinaryColumnTest, test_add_string) {
+    auto column = BinaryColumn::create();
+    TypeDescriptor t = TypeDescriptor::create_varchar_type(20);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_string_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_string(&avro_helper.avro_val, "3.14");
+
+    auto st = add_binary_column(column.get(), t, "f_string", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("['3.14']", column->debug_string());
+}
+
+TEST_F(AvroAddBinaryColumnTest, test_add_enum) {
+    auto column = BinaryColumn::create();
+    TypeDescriptor t = TypeDescriptor::create_varchar_type(20);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_enum_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_enum(&avro_helper.avro_val, 2);
+
+    auto st = add_binary_column(column.get(), t, "f_enum", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("['DIAMONDS']", column->debug_string());
+}
+
+TEST_F(AvroAddBinaryColumnTest, test_add_number) {
+    auto column = BinaryColumn::create();
+    TypeDescriptor t = TypeDescriptor::create_varchar_type(20);
+    std::string schema_path = "./be/test/formats/test_data/avro/single_float_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_float(&avro_helper.avro_val, 3.14);
+
+    auto st = add_binary_column(column.get(), t, "f_float", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("['3.140000']", column->debug_string());
+}
+
+TEST_F(AvroAddBinaryColumnTest, test_add_boolean) {
+    auto column = BinaryColumn::create();
+    TypeDescriptor t = TypeDescriptor::create_varchar_type(20);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_boolean_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_boolean(&avro_helper.avro_val, 1);
+
+    auto st = add_binary_column(column.get(), t, "f_boolean", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("['1']", column->debug_string());
+}
+
+TEST_F(AvroAddBinaryColumnTest, test_add_object) {
+    auto column = BinaryColumn::create();
+    TypeDescriptor t = TypeDescriptor::create_varchar_type(200);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_record_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "boolean_type", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "long_type", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "double_type", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    auto st = add_binary_column(column.get(), t, "f_object", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(R"(['{"boolean_type": true, "long_type": 4294967296, "double_type": 1.234567}'])",
+              column->debug_string());
+}
+
+TEST_F(AvroAddBinaryColumnTest, test_add_array) {
+    auto column = BinaryColumn::create();
+    TypeDescriptor t = TypeDescriptor::create_varchar_type(200);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_array_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t ele1;
+    avro_value_append(&avro_helper.avro_val, &ele1, NULL);
+    avro_value_set_long(&ele1, 4294967297);
+
+    avro_value_t ele2;
+    avro_value_append(&avro_helper.avro_val, &ele2, NULL);
+    avro_value_set_long(&ele2, 4294967298);
+
+    auto st = add_binary_column(column.get(), t, "f_array", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(R"(['[4294967297, 4294967298]'])", column->debug_string());
+}
+
+TEST_F(AvroAddBinaryColumnTest, test_add_map) {
+    auto column = BinaryColumn::create();
+    TypeDescriptor t = TypeDescriptor::create_varchar_type(200);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_map_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t ele1;
+    avro_value_add(&avro_helper.avro_val, "ele1", &ele1, NULL, NULL);
+    avro_value_set_long(&ele1, 4294967297);
+
+    avro_value_t ele2;
+    avro_value_add(&avro_helper.avro_val, "ele2", &ele2, NULL, NULL);
+    avro_value_set_long(&ele2, 4294967298);
+
+    auto st = add_binary_column(column.get(), t, "f_map", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(R"(['{"ele1": 4294967297, "ele2": 4294967298}'])", column->debug_string());
+}
+
+} // namespace starrocks

--- a/be/test/formats/avro/nullable_column_test.cpp
+++ b/be/test/formats/avro/nullable_column_test.cpp
@@ -1,0 +1,286 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/avro/nullable_column.h"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
+#include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "runtime/types.h"
+#include "util/defer_op.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "avro.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+class AvroAddNullableColumnTest : public ::testing::Test {};
+
+struct AvroHelper {
+    avro_schema_t schema = NULL;
+    avro_value_iface_t* iface = NULL;
+    avro_value_t avro_val;
+};
+
+static void init_avro_value(std::string schema_path, AvroHelper& avro_helper) {
+    std::ifstream infile_schema;
+    infile_schema.open(schema_path);
+    std::stringstream ss;
+    ss << infile_schema.rdbuf();
+    std::string schema_str(ss.str());
+    avro_schema_error_t error;
+    int result = avro_schema_from_json(schema_str.c_str(), schema_str.size(), &avro_helper.schema, &error);
+    if (result != 0) {
+        std::cout << "parse schema from json error: " << avro_strerror() << std::endl;
+    }
+    EXPECT_EQ(0, result);
+    avro_helper.iface = avro_generic_class_from_schema(avro_helper.schema);
+    avro_generic_value_new(avro_helper.iface, &avro_helper.avro_val);
+}
+
+TEST_F(AvroAddNullableColumnTest, test_add_numeric) {
+    TypeDescriptor t(TYPE_FLOAT);
+    auto column = ColumnHelper::create_column(t, true);
+    std::string schema_path = "./be/test/formats/test_data/avro/single_float_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_float(&avro_helper.avro_val, 3.14);
+
+    auto st = add_nullable_column(column.get(), t, "f_float", avro_helper.avro_val, false);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[3.14]", column->debug_string());
+}
+
+TEST_F(AvroAddNullableColumnTest, test_add_binary) {
+    TypeDescriptor t = TypeDescriptor::create_char_type(20);
+    auto column = ColumnHelper::create_column(t, true);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_float_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_float(&avro_helper.avro_val, 3.14);
+
+    auto st = add_nullable_column(column.get(), t, "f_float", avro_helper.avro_val, false);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("['3.140000']", column->debug_string());
+}
+
+TEST_F(AvroAddNullableColumnTest, test_record_json) {
+    TypeDescriptor t(TYPE_JSON);
+    auto column = ColumnHelper::create_column(t, true);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_record_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "boolean_type", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "long_type", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "double_type", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    auto st = add_nullable_column(column.get(), t, "f_json", avro_helper.avro_val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(R"([{"boolean_type": true, "double_type": 1.234567, "long_type": 4294967296}])", column->debug_string());
+}
+
+TEST_F(AvroAddNullableColumnTest, test_map_json) {
+    TypeDescriptor t(TYPE_JSON);
+    auto column = ColumnHelper::create_column(t, true);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_map_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t ele1;
+    avro_value_add(&avro_helper.avro_val, "ele1", &ele1, NULL, NULL);
+    avro_value_set_long(&ele1, 4294967297);
+
+    avro_value_t ele2;
+    avro_value_add(&avro_helper.avro_val, "ele2", &ele2, NULL, NULL);
+    avro_value_set_long(&ele2, 4294967298);
+
+    auto st = add_nullable_column(column.get(), t, "f_json", avro_helper.avro_val, false);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(R"([{"ele1": 4294967297, "ele2": 4294967298}])", column->debug_string());
+}
+
+TEST_F(AvroAddNullableColumnTest, test_add_multi_dimension_array) {
+    TypeDescriptor first_level(TYPE_ARRAY);
+    first_level.children.emplace_back(TYPE_ARRAY);
+    TypeDescriptor* second_level = &first_level.children[0];
+    second_level->children.emplace_back(TYPE_ARRAY);
+    TypeDescriptor* third_level = &second_level->children[0];
+    third_level->children.emplace_back(TYPE_BIGINT);
+
+    auto column = ColumnHelper::create_column(first_level, true);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/multi_dimension_array_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    {
+        {
+            avro_value_t array_2;
+            avro_value_append(&avro_helper.avro_val, &array_2, NULL);
+            {
+                {
+                    avro_value_t array_3;
+                    avro_value_append(&array_2, &array_3, NULL);
+
+                    avro_value_t ele;
+                    avro_value_append(&array_3, &ele, NULL);
+                    avro_value_set_long(&ele, 4294967297);
+
+                    avro_value_t ele2;
+                    avro_value_append(&array_3, &ele2, NULL);
+                    avro_value_set_long(&ele2, 4294967296);
+                }
+
+                {
+                    avro_value_t array_3;
+                    avro_value_append(&array_2, &array_3, NULL);
+
+                    avro_value_t ele;
+                    avro_value_append(&array_3, &ele, NULL);
+                    avro_value_set_long(&ele, 4294967295);
+                }
+            }
+        }
+
+        {
+            avro_value_t array_2;
+            avro_value_append(&avro_helper.avro_val, &array_2, NULL);
+            {
+                {
+                    avro_value_t array_3;
+                    avro_value_append(&array_2, &array_3, NULL);
+
+                    avro_value_t ele;
+                    avro_value_append(&array_3, &ele, NULL);
+                    avro_value_set_long(&ele, 4294967294);
+                }
+            }
+        }
+    }
+
+    auto st = add_nullable_column(column.get(), first_level, "f_array", avro_helper.avro_val, false);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[[[[4294967297,4294967296],[4294967295]],[[4294967294]]]]", column->debug_string());
+}
+
+TEST_F(AvroAddNullableColumnTest, test_add_invalid_as_null) {
+    TypeDescriptor t{TYPE_INT};
+    auto column = ColumnHelper::create_column(t, true);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_array_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t ele1;
+    avro_value_append(&avro_helper.avro_val, &ele1, NULL);
+    avro_value_set_long(&ele1, 4294967297);
+
+    avro_value_t ele2;
+    avro_value_append(&avro_helper.avro_val, &ele2, NULL);
+    avro_value_set_long(&ele2, 4294967298);
+
+    auto st = add_nullable_column(column.get(), t, "f_object", avro_helper.avro_val, true);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[NULL]", column->debug_string());
+}
+
+TEST_F(AvroAddNullableColumnTest, test_add_invalid) {
+    TypeDescriptor t{TYPE_INT};
+    auto column = ColumnHelper::create_column(t, true);
+
+    std::string schema_path = "./be/test/formats/test_data/avro/single_array_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t ele1;
+    avro_value_append(&avro_helper.avro_val, &ele1, NULL);
+    avro_value_set_long(&ele1, 4294967297);
+
+    avro_value_t ele2;
+    avro_value_append(&avro_helper.avro_val, &ele2, NULL);
+    avro_value_set_long(&ele2, 4294967298);
+
+    auto st = add_nullable_column(column.get(), t, "f_object", avro_helper.avro_val, false);
+    ASSERT_TRUE(st.is_invalid_argument());
+}
+
+} // namespace starrocks

--- a/be/test/formats/avro/numeric_column_test.cpp
+++ b/be/test/formats/avro/numeric_column_test.cpp
@@ -1,0 +1,189 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/avro/numeric_column.h"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
+#include "column/fixed_length_column.h"
+#include "runtime/types.h"
+#include "util/defer_op.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "avro.h"
+#ifdef __cplusplus
+}
+#endif
+
+namespace starrocks {
+
+class AvroAddNumericColumnTest : public ::testing::Test {};
+
+struct AvroHelper {
+    avro_schema_t schema = NULL;
+    avro_value_iface_t* iface = NULL;
+    avro_value_t avro_val;
+};
+
+static void init_avro_value(std::string schema_path, AvroHelper& avro_helper) {
+    std::ifstream infile_schema;
+    infile_schema.open(schema_path);
+    std::stringstream ss;
+    ss << infile_schema.rdbuf();
+    std::string schema_str(ss.str());
+    avro_schema_error_t error;
+    int result = avro_schema_from_json(schema_str.c_str(), schema_str.size(), &avro_helper.schema, &error);
+    if (result != 0) {
+        std::cout << "parse schema from json error: " << avro_strerror() << std::endl;
+    }
+    EXPECT_EQ(0, result);
+    avro_helper.iface = avro_generic_class_from_schema(avro_helper.schema);
+    avro_generic_value_new(avro_helper.iface, &avro_helper.avro_val);
+}
+
+TEST_F(AvroAddNumericColumnTest, test_add_number) {
+    auto column = FixedLengthColumn<float>::create();
+    TypeDescriptor t(TYPE_FLOAT);
+    std::string schema_path = "./be/test/formats/test_data/avro/single_float_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_float(&avro_helper.avro_val, 3.14);
+
+    auto st = add_numeric_column<float>(column.get(), t, "f_float", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[3.14]", column->debug_string());
+}
+
+TEST_F(AvroAddNumericColumnTest, test_add_string) {
+    auto column = FixedLengthColumn<float>::create();
+    TypeDescriptor t(TYPE_FLOAT);
+    std::string schema_path = "./be/test/formats/test_data/avro/single_string_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_string(&avro_helper.avro_val, "3.14");
+
+    auto st = add_numeric_column<float>(column.get(), t, "f_string", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[3.14]", column->debug_string());
+}
+
+TEST_F(AvroAddNumericColumnTest, test_add_boolean) {
+    auto column = FixedLengthColumn<int8_t>::create();
+    TypeDescriptor t(TYPE_BOOLEAN);
+    std::string schema_path = "./be/test/formats/test_data/avro/single_boolean_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_boolean(&avro_helper.avro_val, 1);
+
+    auto st = add_numeric_column<int8_t>(column.get(), t, "f_boolean", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[1]", column->debug_string());
+}
+
+TEST_F(AvroAddNumericColumnTest, test_add_invalid) {
+    auto column = FixedLengthColumn<float>::create();
+    TypeDescriptor t(TYPE_FLOAT);
+    std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_nest_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t boolean_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "booleantype", &boolean_value, NULL) == 0) {
+        avro_value_set_boolean(&boolean_value, true);
+    }
+
+    avro_value_t long_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "longtype", &long_value, NULL) == 0) {
+        avro_value_set_long(&long_value, 4294967296);
+    }
+
+    avro_value_t double_value;
+    if (avro_value_get_by_name(&avro_helper.avro_val, "doubletype", &double_value, NULL) == 0) {
+        avro_value_set_double(&double_value, 1.234567);
+    }
+
+    auto st = add_numeric_column<float>(column.get(), t, "fobject", avro_helper.avro_val);
+    ASSERT_TRUE(st.is_invalid_argument());
+}
+
+TEST_F(AvroAddNumericColumnTest, test_add_int_overflow) {
+    auto column = FixedLengthColumn<int32_t>::create();
+    TypeDescriptor t(TYPE_INT);
+    std::string schema_path = "./be/test/formats/test_data/avro/single_long_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_set_long(&avro_helper.avro_val, 2147483648);
+
+    auto st = add_numeric_column<int32_t>(column.get(), t, "f_bigint", avro_helper.avro_val);
+    ASSERT_TRUE(st.is_invalid_argument());
+}
+
+TEST_F(AvroAddNumericColumnTest, test_add_int64_lowerbound) {
+    auto column = FixedLengthColumn<int64_t>::create();
+    TypeDescriptor t(TYPE_BIGINT);
+    std::string schema_path = "./be/test/formats/test_data/avro/single_long_schema.json";
+    AvroHelper avro_helper;
+    init_avro_value(schema_path, avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+    avro_value_set_long(&avro_helper.avro_val, -9223372036854775808ULL);
+    auto st = add_numeric_column<int64_t>(column.get(), t, "f_int64", avro_helper.avro_val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("[-9223372036854775808]", column->debug_string());
+}
+
+} // namespace starrocks

--- a/be/test/formats/test_data/avro/multi_dimension_array_schema.json
+++ b/be/test/formats/test_data/avro/multi_dimension_array_schema.json
@@ -1,0 +1,10 @@
+{
+  "type" : "array",
+  "items" : {
+    "type" : "array",
+    "items" : {
+      "type" : "array",
+      "items" : "long"
+    }
+  }
+}

--- a/be/test/formats/test_data/avro/single_array_schema.json
+++ b/be/test/formats/test_data/avro/single_array_schema.json
@@ -1,0 +1,5 @@
+{
+    "type": "array",
+    "items": "long",
+    "defalut": []
+}

--- a/be/test/formats/test_data/avro/single_boolean_schema.json
+++ b/be/test/formats/test_data/avro/single_boolean_schema.json
@@ -1,0 +1,4 @@
+{
+    "type": "boolean",
+    "name": "boolean_type"
+}

--- a/be/test/formats/test_data/avro/single_enum_schema.json
+++ b/be/test/formats/test_data/avro/single_enum_schema.json
@@ -1,0 +1,1 @@
+{"type": "enum", "name": "ThirdEnum", "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]}

--- a/be/test/formats/test_data/avro/single_float_schema.json
+++ b/be/test/formats/test_data/avro/single_float_schema.json
@@ -1,0 +1,4 @@
+{
+    "type": "float",
+    "name": "float_type"
+}

--- a/be/test/formats/test_data/avro/single_long_schema.json
+++ b/be/test/formats/test_data/avro/single_long_schema.json
@@ -1,0 +1,4 @@
+{
+    "type": "long",
+    "name": "long_type"
+}

--- a/be/test/formats/test_data/avro/single_map_schema.json
+++ b/be/test/formats/test_data/avro/single_map_schema.json
@@ -1,0 +1,5 @@
+{
+    "type": "map",
+    "values": "long",
+    "defalut": {}
+}

--- a/be/test/formats/test_data/avro/single_record_schema.json
+++ b/be/test/formats/test_data/avro/single_record_schema.json
@@ -1,0 +1,9 @@
+{
+    "type": "record",
+    "name": "nest",
+    "fields" : [
+        {"name": "boolean_type", "type" : "boolean"},
+        {"name": "long_type", "type": "long"},
+        {"name": "double_type", "type": "double"}
+    ]
+}

--- a/be/test/formats/test_data/avro/single_string_schema.json
+++ b/be/test/formats/test_data/avro/single_string_schema.json
@@ -1,0 +1,4 @@
+{
+    "type": "string",
+    "name": "string_type"
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -206,6 +206,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     private static final String PROPS_JSONPATHS = "jsonpaths";
     private static final String PROPS_JSONROOT = "json_root";
 
+    private String confluentSchemaRegistryUrl;
+
     // for csv
     protected boolean trimspace = false;
     protected byte enclose = 0;
@@ -342,6 +344,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             } else {
                 jobProperties.put(PROPS_JSONPATHS, "");
             }
+            this.confluentSchemaRegistryUrl = stmt.getConfluentSchemaRegistryUrl();
         } else {
             throw new UserException("Invalid format type.");
         }
@@ -370,6 +373,14 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         if (routineLoadDesc.getPartitionNames() != null) {
             partitions = routineLoadDesc.getPartitionNames();
         }
+    }
+
+    public String getConfluentSchemaRegistryUrl() {
+        return confluentSchemaRegistryUrl;
+    }
+
+    public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
+        this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -77,6 +77,7 @@ public class StreamLoadInfo {
     private TCompressionType compressionType = TCompressionType.NO_COMPRESSION;
     private int loadParallelRequestNum = 0;
     private boolean enableReplicatedStorage = false;
+    private String confluentSchemaRegistryUrl;
 
     public StreamLoadInfo(TUniqueId id, long txnId, TFileType fileType, TFileFormatType formatType) {
         this.id = id;
@@ -95,6 +96,14 @@ public class StreamLoadInfo {
         this.jsonRoot = "";
         this.stripOuterArray = false;
         this.timeout = timeout;
+    }
+
+    public String getConfluentSchemaRegistryUrl() {
+        return confluentSchemaRegistryUrl;
+    }
+
+    public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
+        this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
     }
 
     public TUniqueId getId() {
@@ -427,6 +436,7 @@ public class StreamLoadInfo {
             compressionType = CompressionUtils.findTCompressionByName(
                     routineLoadJob.getSessionVariables().get(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE));
         }
+        confluentSchemaRegistryUrl = routineLoadJob.getConfluentSchemaRegistryUrl();
         trimSpace = routineLoadJob.isTrimspace();
         enclose = routineLoadJob.getEnclose();
         escape = routineLoadJob.getEscape();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -222,6 +222,9 @@ public class StreamLoadScanNode extends LoadScanNode {
         params.setEnclose(streamLoadInfo.getEnclose());
         params.setEscape(streamLoadInfo.getEscape());
         params.setStrict_mode(streamLoadInfo.isStrictMode());
+        if (streamLoadInfo.getConfluentSchemaRegistryUrl() != null) {
+            params.setConfluent_schema_registry_url(streamLoadInfo.getConfluentSchemaRegistryUrl());
+        }
         initColumns();
         initWhereExpr(streamLoadInfo.getWhereExpr(), analyzer);
     }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -254,6 +254,8 @@ struct TBrokerScanRangeParams {
     26: optional i8 enclose
     // escape character
     27: optional i8 escape
+    // confluent schema registry url for pb import
+    28: optional string confluent_schema_registry_url
 }
 
 // Broker scan range


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Previously, we used json to parse avro data #18265, but the performance is not good. This PR uses avro SDK to parse avro data directly.
The following is the test result by selecting the data of 10000000 lines before clickbench dataset. Note that this test does not include disk IO and data flopping.
+ JsonScanner: 109s
+ AvroScanner: 108s
+ AvroScanner-old: 826s


As you can see, this PR results in a nearly 8X improvement over the previous implementation.
In addition, we also tested the scenario of routine load importing avro data, which is a clickbench data set with a total of 99997497 lines of data.  The clusters tested are: single kafka broker + 5 partitions, single BE node, clickbench table 8 buckets, duplicate model. The test results are as follows:
- Avro: 36231 lines/s
- Json: 58753 lines/s

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3