### PR TITLE
[BugFix] set INIT phase when building a new limitOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
@@ -148,7 +148,7 @@ public class PruneGroupByKeysRule extends TransformationRule {
                 // like `select 'a','b' from table group by 'c','d'`,
                 // we can remove agg node and rewrite it to `select 'a','b' from table limit 1`
                 OptExpression result = OptExpression.create(
-                        new LogicalLimitOperator(1, 0, LogicalLimitOperator.Phase.GLOBAL),
+                        new LogicalLimitOperator(1, 0, LogicalLimitOperator.Phase.INIT),
                         OptExpression.create(
                                 projectOperator, input.getInputs().get(0).getInputs()));
                 return Lists.newArrayList(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2621,7 +2621,7 @@ public class PlanFragmentBuilder {
         @Override
         public PlanFragment visitPhysicalLimit(OptExpression optExpression, ExecPlan context) {
             // PhysicalLimit use for enforce gather property, Enforcer will produce more PhysicalDistribution, there
-            // don't need do anything.
+            // don't need to do anything.
             return visit(optExpression.inputAt(0), context);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2286,4 +2286,19 @@ public class AggregateTest extends PlanTestBase {
                 "  |  output: sum(4: expr)");
         connectContext.getSessionVariable().setNewPlanerAggStage(oldValue);
     }
+
+    @Test
+    public void testDistinctConst() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "SELECT DISTINCT 16 col0 FROM t0 AS cor0 LEFT JOIN t1 AS cor1 ON NULL IS NULL";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "6:Project\n" +
+                "  |  <slot 7> : 16\n" +
+                "  |  limit: 1");
+        sql = "SELECT DISTINCT 61 AS col0 FROM t0 AS cor0 LEFT JOIN t1 AS cor1 ON NOT NULL IS NOT NULL, t0 AS cor2;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "11:Project\n" +
+                "  |  <slot 10> : 61\n" +
+                "  |  limit: 1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -140,11 +140,13 @@ public class NestLoopJoinTest extends PlanTestBase {
                 " on substr(cast(sub1.v7 as string), 1) = substr(cast(sub2.v10 as string), 1)";
         assertPlanContains(sql, "13:Project\n" +
                 "  |  <slot 20> : 1\n" +
+                "  |  limit: 1\n" +
                 "  |  \n" +
                 "  12:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 14: substr = 15: substr");
+                "  |  equal join conjunct: 14: substr = 15: substr\n" +
+                "  |  limit: 1");
 
         // RIGHT ANTI JOIN + AGGREGATE count(*)
         sql = "select count(*) from (select t2.id_char, t2.id_varchar " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -232,8 +232,9 @@ public class SubqueryTest extends PlanTestBase {
                     ")IS NULL";
 
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  18:Project\n" +
+            assertContains(plan, "18:Project\n" +
                     "  |  <slot 15> : 1\n" +
+                    "  |  limit: 1\n" +
                     "  |  \n" +
                     "  17:NESTLOOP JOIN\n" +
                     "  |  join op: INNER JOIN\n" +
@@ -251,8 +252,9 @@ public class SubqueryTest extends PlanTestBase {
                     "IS NULL";
 
             String plan = getFragmentPlan(sql);
-            assertContains(plan, "  18:Project\n" +
+            assertContains(plan, "18:Project\n" +
                     "  |  <slot 15> : 1\n" +
+                    "  |  limit: 1\n" +
                     "  |  \n" +
                     "  17:NESTLOOP JOIN\n" +
                     "  |  join op: INNER JOIN\n" +


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21609

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When remove the agg of a distinct count sql, the new added limit operator should be init phase then this limit can be correctly split and pushed down.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
