### PR TITLE
[Refactor] Refactor error log when create primary table using ORDER BY

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -3063,7 +3063,12 @@ public class GlobalStateMgr {
                 throw new DdlException("Empty schema");
             }
             if (shortKeyColumnCount == 0) {
-                throw new DdlException("Data type of first column cannot be " + indexColumns.get(0).getType());
+                if (sortKeyIdxes.size() > 0) {
+                    throw new DdlException("Data type of first sort column cannot be " + 
+                            indexColumns.get(sortKeyIdxes.get(0)).getType());
+                } else {
+                    throw new DdlException("Data type of first column cannot be " + indexColumns.get(0).getType());
+                }
             }
         } // end calc shortKeyColumnCount
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/21416

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The OLAP table must has at least one short key and the float and double should not be short key, so the float and double could not be the first sort column in OLAP table.

If we separate primary keys and sort keys and the first sort key column type is float/double, the error log is inaccurate.

i.e.
we try to create a table with the following sql
```
CREATE TABLE `primary_table1` (
    `k1` date NOT NULL,
    `k2` datetime NOT NULL,
    `k3` varchar(20) NOT NULL,
    `k4` varchar(20) NOT NULL,
    `k5` boolean NOT NULL,
    `v1` tinyint NULL,
    `v2` smallint NULL,
    `v3` int NULL,
    `v4` bigint NULL,
    `v5` largeint NULL,
    `v6` float NULL,
    `v7` double NULL,
    `v8` decimal(27,9) NULL
)
PRIMARY KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3
ORDER BY(`v7`, `v5`, `v6`, `v8`, `v1`, `v2`, `v3`, `v4`, `k1`, `k2`, `k3`, `k4`, `k5`)
PROPERTIES (
    "replication_num" = "3",
    "enable_persistent_index" = "true",
    "storage_format" = "v2"
);
```
we will get the error log
```
ERROR 1064 (HY000): Unexpected exception: Data type of first column cannot be DATE
```

However, the true reason is the column `v7` type is double which cannot be the first column of short key but not the `k1` column type is error, so the error log after this pr is 

```
ERROR 1064 (HY000): Unexpected exception: Data type of first sort column cannot be DOUBLE
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
