### PR TITLE
[Enhancement] Optimize tablet scheduler for large pending tablets case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -75,7 +75,6 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         VERSION_INCOMPLETE, // alive replica num is enough, but version is missing.
         REPLICA_RELOCATING, // replica is healthy, but is under relocating (e.g. BE is decommission).
         REDUNDANT, // too much replicas.
-        REPLICA_MISSING_IN_CLUSTER, // not enough healthy replicas in correct cluster.
         FORCE_REDUNDANT, // some replica is missing or bad, but there is no other backends for repair,
         // at least one replica has to be deleted first to make room for new replica.
         COLOCATE_MISMATCH, // replicas do not all locate in right colocate backends set.
@@ -610,10 +609,8 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             }
         }
 
-        // 4. healthy replicas in cluster are not enough
-        if (availableInCluster < replicationNum) {
-            return Pair.create(TabletStatus.REPLICA_MISSING_IN_CLUSTER, TabletSchedCtx.Priority.LOW);
-        } else if (replicas.size() > replicationNum) {
+        // 4. replica redundant
+        if (replicas.size() > replicationNum) {
             // we set REDUNDANT as VERY_HIGH, because delete redundant replicas can free the space quickly.
             return createRedundantSchedCtx(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
                     needFurtherRepairReplica);

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1069,7 +1069,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     }
 
     /**
-     * try to upgrade the priority if this tablet has not been scheduled by long time
+     * try to upgrade the priority if this tablet has not been scheduled for a long time
      */
     public boolean adjustPriority(TabletSchedulerStat stat) {
         long currentTime = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -84,28 +84,6 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     private static final Logger LOG = LogManager.getLogger(TabletSchedCtx.class);
 
     /*
-     * SCHED_FAILED_COUNTER_THRESHOLD:
-     *    threshold of times a tablet failed to be scheduled
-     *
-     * MIN_ADJUST_PRIORITY_INTERVAL_MS:
-     *    min interval time of adjusting a tablet's priority
-     *
-     * MAX_NOT_BEING_SCHEDULED_INTERVAL_MS:
-     *    max gap time of a tablet NOT being scheduled.
-     *
-     * These 3 params is for adjusting priority.
-     * If a tablet being scheduled failed for more than SCHED_FAILED_COUNTER_THRESHOLD times, its priority
-     * will be downgraded. And the interval between adjustment is larger than MIN_ADJUST_PRIORITY_INTERVAL_MS,
-     * to avoid being downgraded too soon.
-     * And if a tablet is not being scheduled longer than MAX_NOT_BEING_SCHEDULED_INTERVAL_MS, its priority
-     * will be upgraded, to avoid starvation.
-     *
-     */
-    private static final int SCHED_FAILED_COUNTER_THRESHOLD = 5;
-    private static final long MIN_ADJUST_PRIORITY_INTERVAL_MS = 5 * 60 * 1000L; // 5 min
-    private static final long MAX_NOT_BEING_SCHEDULED_INTERVAL_MS = 30 * 60 * 1000L; // 30 min
-
-    /*
      *  A clone task timeout is between Config.min_clone_task_timeout_sec and Config.max_clone_task_timeout_sec,
      *  estimated by tablet size / MIN_CLONE_SPEED_MB_PER_SECOND.
      */
@@ -770,7 +748,6 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         return tablet.deleteReplicaByBackendId(replica.getBackendId());
     }
 
-    // database lock should be held.
     public CloneTask createCloneReplicaAndTask() throws SchedException {
         Backend srcBe = infoService.getBackend(srcReplica.getBackendId());
         if (srcBe == null) {
@@ -805,74 +782,90 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
         // if this is a balance task, or this is a repair task with REPLICA_MISSING/REPLICA_RELOCATING or REPLICA_MISSING_IN_CLUSTER,
         // we create a new replica with state CLONE
-        if (tabletStatus == TabletStatus.REPLICA_MISSING || tabletStatus == TabletStatus.REPLICA_MISSING_IN_CLUSTER
-                || tabletStatus == TabletStatus.REPLICA_RELOCATING || tabletStatus == TabletStatus.COLOCATE_MISMATCH
-                || (type == Type.BALANCE && !cloneTask.isLocal())) {
-            Replica cloneReplica = new Replica(
-                    GlobalStateMgr.getCurrentState().getNextId(), destBackendId,
-                    -1 /* version */, schemaHash,
-                    -1 /* data size */, -1 /* row count */,
-                    ReplicaState.CLONE,
-                    committedVersion,
-                    -1 /* last success version */);
+        Database db = GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(dbId);
+        if (db == null || !db.writeLockAndCheckExist()) {
+            throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " not exist");
+        }
+        try {
+            if (tabletStatus == TabletStatus.REPLICA_MISSING
+                    || tabletStatus == TabletStatus.REPLICA_RELOCATING
+                    || tabletStatus == TabletStatus.COLOCATE_MISMATCH
+                    || (type == Type.BALANCE && !cloneTask.isLocal())) {
+                Replica cloneReplica = new Replica(
+                        GlobalStateMgr.getCurrentState().getNextId(), destBackendId,
+                        -1 /* version */, schemaHash,
+                        -1 /* data size */, -1 /* row count */,
+                        ReplicaState.CLONE,
+                        committedVersion,
+                        -1 /* last success version */);
 
-            // addReplica() method will add this replica to tablet inverted index too.
-            tablet.addReplica(cloneReplica);
-        } else if (tabletStatus == TabletStatus.VERSION_INCOMPLETE) {
-            Preconditions.checkState(type == Type.REPAIR, type);
-            // double check
-            Replica replica = tablet.getReplicaByBackendId(destBackendId);
-            if (replica == null) {
-                throw new SchedException(Status.UNRECOVERABLE, "dest replica does not exist on BE " + destBackendId);
-            }
+                // addReplica() method will add this replica to tablet inverted index too.
+                tablet.addReplica(cloneReplica);
+            } else if (tabletStatus == TabletStatus.VERSION_INCOMPLETE) {
+                Preconditions.checkState(type == Type.REPAIR, type);
+                // double check
+                Replica replica = tablet.getReplicaByBackendId(destBackendId);
+                if (replica == null) {
+                    throw new SchedException(Status.UNRECOVERABLE, "dest replica does not exist on BE " + destBackendId);
+                }
 
-            if (replica.getPathHash() != destPathHash) {
-                throw new SchedException(Status.UNRECOVERABLE, "dest replica's path hash is changed. "
-                        + "current: " + replica.getPathHash() + ", scheduled: " + destPathHash);
+                if (replica.getPathHash() != destPathHash) {
+                    throw new SchedException(Status.UNRECOVERABLE, "dest replica's path hash is changed. "
+                            + "current: " + replica.getPathHash() + ", scheduled: " + destPathHash);
+                }
+            } else if (type == Type.BALANCE && cloneTask.isLocal()) {
+                if (tabletStatus != TabletStatus.HEALTHY) {
+                    throw new SchedException(Status.SCHEDULE_RETRY, "tablet " + tabletId + " is not healthy");
+                }
             }
-        } else if (type == Type.BALANCE && cloneTask.isLocal()) {
-            if (tabletStatus != TabletStatus.HEALTHY) {
-                throw new SchedException(Status.SCHEDULE_RETRY, "tablet " + tabletId + " is not healthy");
-            }
+        } finally {
+            db.writeUnlock();
         }
 
         this.state = State.RUNNING;
         return cloneTask;
     }
 
-    public CreateReplicaTask createEmptyReplicaAndTask() {
+    public CreateReplicaTask createEmptyReplicaAndTask() throws SchedException {
         // only create this task if force recovery is true
         LOG.warn("tablet {} has only one replica {} on backend {}"
                         + " and it is lost. create an empty replica to recover it on backend {}",
                 tabletId, tablet.getSingleReplica(), tablet.getSingleReplica().getBackendId(), destBackendId);
 
         final GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(
-                globalStateMgr.getDbIncludeRecycleBin(dbId),
-                tblId);
-        MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
-        CreateReplicaTask createReplicaTask = new CreateReplicaTask(destBackendId, dbId,
-                tblId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
-                indexMeta.getSchemaHash(), visibleVersion,
-                indexMeta.getKeysType(),
-                TStorageType.COLUMN,
-                TStorageMedium.HDD, indexMeta.getSchema(), olapTable.getCopiedBfColumns(), olapTable.getBfFpp(), null,
-                olapTable.getCopiedIndexes(),
-                olapTable.isInMemory(),
-                olapTable.enablePersistentIndex(),
-                olapTable.getPartitionInfo().getTabletType(partitionId),
-                olapTable.getCompressionType(), indexMeta.getSortKeyIdxes());
-        createReplicaTask.setIsRecoverTask(true);
-        taskTimeoutMs = Config.tablet_sched_min_clone_task_timeout_sec * 1000;
+        Database db = globalStateMgr.getDbIncludeRecycleBin(dbId);
+        if (db == null || !db.writeLockAndCheckExist()) {
+            throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " not exist");
+        }
+        try {
+            OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(
+                    globalStateMgr.getDbIncludeRecycleBin(dbId),
+                    tblId);
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+            CreateReplicaTask createReplicaTask = new CreateReplicaTask(destBackendId, dbId,
+                    tblId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
+                    indexMeta.getSchemaHash(), visibleVersion,
+                    indexMeta.getKeysType(),
+                    TStorageType.COLUMN,
+                    TStorageMedium.HDD, indexMeta.getSchema(), olapTable.getCopiedBfColumns(), olapTable.getBfFpp(), null,
+                    olapTable.getCopiedIndexes(),
+                    olapTable.isInMemory(),
+                    olapTable.enablePersistentIndex(),
+                    olapTable.getPartitionInfo().getTabletType(partitionId),
+                    olapTable.getCompressionType(), indexMeta.getSortKeyIdxes());
+            createReplicaTask.setIsRecoverTask(true);
+            taskTimeoutMs = Config.tablet_sched_min_clone_task_timeout_sec * 1000;
 
-        Replica emptyReplica =
-                new Replica(tablet.getSingleReplica().getId(), destBackendId, ReplicaState.NORMAL, visibleVersion,
-                        indexMeta.getSchemaHash());
-        // addReplica() method will add this replica to tablet inverted index too.
-        tablet.addReplica(emptyReplica);
-
-        state = State.RUNNING;
-        return createReplicaTask;
+            Replica emptyReplica =
+                    new Replica(tablet.getSingleReplica().getId(), destBackendId, ReplicaState.NORMAL, visibleVersion,
+                            indexMeta.getSchemaHash());
+            // addReplica() method will add this replica to tablet inverted index too.
+            tablet.addReplica(emptyReplica);
+            state = State.RUNNING;
+            return createReplicaTask;
+        } finally {
+            db.writeUnlock();
+        }
     }
 
     // timeout is between MIN_CLONE_TASK_TIMEOUT_MS and MAX_CLONE_TASK_TIMEOUT_MS
@@ -1073,73 +1066,6 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         }
         return String.format("version:%d min_readable_version:%d", reportedTablet.getVersion(),
                 reportedTablet.getMin_readable_version());
-    }
-
-    /*
-     * we try to adjust the priority based on schedule history
-     * 1. If failed counter is larger than FAILED_COUNTER_THRESHOLD, which means this tablet is being scheduled
-     *    at least FAILED_TIME_THRESHOLD times and all are failed. So we downgrade its priority.
-     *    Also reset the failedCounter, or it will be downgraded forever.
-     *
-     * 2. Else, if it has been a long time since last time the tablet being scheduled, we upgrade its
-     *    priority to let it more available to be scheduled.
-     *
-     * The time gap between adjustment should be larger than MIN_ADJUST_PRIORITY_INTERVAL_MS, to avoid
-     * being downgraded too fast.
-     *
-     * eg:
-     *    A tablet has been scheduled for 5 times and all were failed. its priority will be downgraded. And if it is
-     *    scheduled for 5 times and all are failed again, it will be downgraded again, until to the LOW.
-     *    And then, because of LOW, this tablet can not be scheduled for a long time, and it will be upgraded
-     *    to NORMAL, if still not being scheduled, it will be upgraded up to VERY_HIGH.
-     *
-     * return true if dynamic priority changed
-     */
-    public boolean adjustPriority(TabletSchedulerStat stat) {
-        long currentTime = System.currentTimeMillis();
-        if (lastAdjustPrioTime == 0) {
-            // skip the first time we adjust this priority
-            lastAdjustPrioTime = currentTime;
-            return false;
-        } else {
-            if (currentTime - lastAdjustPrioTime < MIN_ADJUST_PRIORITY_INTERVAL_MS) {
-                return false;
-            }
-        }
-
-        boolean isDowngrade = false;
-        boolean isUpgrade = false;
-
-        if (failedSchedCounter > SCHED_FAILED_COUNTER_THRESHOLD) {
-            isDowngrade = true;
-        } else {
-            long lastTime = lastSchedTime == 0 ? createTime : lastSchedTime;
-            if (currentTime - lastTime > MAX_NOT_BEING_SCHEDULED_INTERVAL_MS) {
-                isUpgrade = true;
-            }
-        }
-
-        Priority originDynamicPriority = dynamicPriority;
-        if (isDowngrade) {
-            dynamicPriority = dynamicPriority.adjust(origPriority, false /* downgrade */);
-            failedSchedCounter = 0;
-            if (originDynamicPriority != dynamicPriority) {
-                LOG.debug("downgrade dynamic priority from {} to {}, origin: {}, tablet: {}",
-                        originDynamicPriority.name(), dynamicPriority.name(), origPriority.name(), tabletId);
-                stat.counterTabletPrioDowngraded.incrementAndGet();
-                return true;
-            }
-        } else if (isUpgrade) {
-            dynamicPriority = dynamicPriority.adjust(origPriority, true /* upgrade */);
-            // no need to set lastSchedTime, lastSchedTime is set each time we schedule this tablet
-            if (originDynamicPriority != dynamicPriority) {
-                LOG.debug("upgrade dynamic priority from {} to {}, origin: {}, tablet: {}",
-                        originDynamicPriority.name(), dynamicPriority.name(), origPriority.name(), tabletId);
-                stat.counterTabletPrioUpgraded.incrementAndGet();
-                return true;
-            }
-        }
-        return false;
     }
 
     public boolean isTimeout() {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
@@ -97,8 +97,6 @@ public class TabletSchedulerStat {
      */
     @StatField("num of tablet priority upgraded")
     public AtomicLong counterTabletPrioUpgraded = new AtomicLong(0L);
-    @StatField("num of tablet priority downgraded")
-    public AtomicLong counterTabletPrioDowngraded = new AtomicLong(0L);
 
     /*
      * Clone task related
@@ -210,17 +208,5 @@ public class TabletSchedulerStat {
 
         snapshot();
         return sb.toString();
-    }
-
-    // for test
-    public static void main(String[] args) {
-        TabletSchedulerStat stat = new TabletSchedulerStat();
-
-        stat.counterCloneTask.addAndGet(300);
-        System.out.println(stat.incrementalBrief());
-
-        stat.counterCloneTask.addAndGet(3);
-        stat.counterTabletChecked.incrementAndGet();
-        System.out.println(stat.incrementalBrief());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1170,6 +1170,14 @@ public class Config extends ConfigBase {
     public static long tablet_sched_storage_cooldown_second = -1L; // won't cool down by default
 
     /**
+     * If the tablet in scheduler queue has not been scheduled for tablet_sched_max_not_being_scheduled_interval_ms,
+     * its priority will upgrade.
+     * default is 30min
+     */
+    @ConfField(mutable = true)
+    public static long tablet_sched_max_not_being_scheduled_interval_ms = 30 * 60 * 1000;
+
+    /**
      * enable replicated storage as default table engine
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1172,10 +1172,10 @@ public class Config extends ConfigBase {
     /**
      * If the tablet in scheduler queue has not been scheduled for tablet_sched_max_not_being_scheduled_interval_ms,
      * its priority will upgrade.
-     * default is 30min
+     * default is 15min
      */
     @ConfField(mutable = true)
-    public static long tablet_sched_max_not_being_scheduled_interval_ms = 30 * 60 * 1000;
+    public static long tablet_sched_max_not_being_scheduled_interval_ms = 15 * 60 * 1000;
 
     /**
      * enable replicated storage as default table engine


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now, there are some bad cases in the logic of tablet scheduler when the number of tablets to be repaired is large: the priority of tablet will be downgraded if there is not enough resource(be path slot), and the tablet in low priority will never be scheduled if there are new tablets to repair continuously, because the new tablets will be put to the head of schedule queue. The tablet in low priority can be upgraded to high priority, but the time interval is very big, it's 30 mins.
To cover this bad case:
1. do not downgrade the priority of tablet if there is not enough resource, because the resource should be allocated to the selected tablet before first.
2. schedule all the tablet in queue one time, because the tablet on the head and tablet on the tail may use different be resource.
3. since the number of tablet to schedule in one batch is increased, we should optimize the granularity of db lock: use db read lock to check existence of meta, and use db write lock when add or drop replica.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
