### PR TITLE
[Enhancement] isFullyCompatible support all types

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
@@ -240,7 +240,7 @@ public class CastExpr extends Expr {
     @Override
     public boolean isNullable() {
         Expr fromExpr = getChild(0);
-        if (ScalarType.isFullyCompatible(fromExpr.getType(), getType())) {
+        if (fromExpr.getType().isFullyCompatible(getType())) {
             return fromExpr.isNullable();
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
@@ -85,6 +85,20 @@ public class ArrayType extends Type {
     }
 
     @Override
+    public boolean isFullyCompatible(Type other) {
+        if (!other.isArrayType()) {
+            return false;
+        }
+
+        if (equals(other)) {
+            return true;
+        }
+
+        ArrayType t = (ArrayType) other;
+        return itemType.isFullyCompatible(t.getItemType());
+    }
+
+    @Override
     protected String prettyPrint(int lpad) {
         String leftPadding = Strings.repeat(" ", lpad);
         if (!itemType.isStructType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -170,6 +170,20 @@ public class MapType extends Type {
     }
 
     @Override
+    public boolean isFullyCompatible(Type other) {
+        if (!other.isMapType()) {
+            return false;
+        }
+
+        if (equals(other)) {
+            return true;
+        }
+
+        MapType t = (MapType) other;
+        return keyType.isFullyCompatible(t.getKeyType()) && valueType.isFullyCompatible(t.getValueType());
+    }
+
+    @Override
     public MapType clone() {
         MapType clone = (MapType) super.clone();
         clone.keyType = this.keyType.clone();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PseudoType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PseudoType.java
@@ -42,6 +42,11 @@ public class PseudoType extends Type {
     }
 
     @Override
+    public boolean isFullyCompatible(Type other) {
+        return matchesType(other);
+    }
+
+    @Override
     protected String toSql(int depth) {
         return toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -468,56 +468,6 @@ public class ScalarType extends Type implements Cloneable {
     }
 
     /**
-     * Returns true if t2 can be fully compatible with t1.
-     * fully compatible means that all possible values of t1 can be represented by t2,
-     * and no null values will be produced if we cast t1 as t2.
-     * This is closely related to the implementation by BE.
-     * @TODO: the currently implementation is conservative, we can add more rules later.
-     */
-    public static boolean isFullyCompatible(Type t1, Type t2) {
-        if (t1.isScalarType() && t2.isScalarType()) {
-            return isFullyCompatible((ScalarType) t1, (ScalarType) t2);
-        }
-        if (t1.isArrayType() && t2.isArrayType()) {
-            return isFullyCompatible(((ArrayType) t1).getItemType(), ((ArrayType) t2).getItemType());
-        }
-        return false;
-    }
-
-    public static boolean isFullyCompatible(ScalarType t1, ScalarType t2) {
-        // same type
-        if (t1.equals(t2)) {
-            return true;
-        }
-        if (t1.isBoolean()) {
-            return t2.isIntegerType() || t2.isLargeIntType() || t2.isStringType() || t2.isNumericType();
-        }
-        if (t1.isIntegerType() || t1.isLargeIntType()) {
-            if (t2.isIntegerType() || t2.isLargeIntType()) {
-                return t1.ordinal() < t2.ordinal();
-            }
-            if (t2.isStringType()) {
-                return true;
-            }
-            return false;
-        }
-        if (t1.isDecimalV3()) {
-            if (t2.isDecimalV3()) {
-                return t2.precision >= t1.precision && t2.scale >= t1.scale;
-            }
-            if (t2.isStringType() || t2.isFloatingPointType()) {
-                return true;
-            }
-            return false;
-        }
-        // both string
-        if (t1.isStringType() && t2.isStringType()) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * Returns true t1 can be implicitly cast to t2, false otherwise.
      * If strict is true, only consider casts that result in no loss of precision.
      */
@@ -665,6 +615,45 @@ public class ScalarType extends Type implements Cloneable {
                 break;
             }
         }
+    }
+
+    @Override
+    public boolean isFullyCompatible(Type other) {
+        if (!other.isScalarType()) {
+            return false;
+        }
+
+        if (this.equals(other)) {
+            return true;
+        }
+
+        ScalarType t = (ScalarType) other;
+        if (isBoolean()) {
+            return t.isIntegerType() || t.isLargeIntType() || t.isStringType() || t.isNumericType();
+        }
+        if (isIntegerType() || isLargeIntType()) {
+            if (t.isIntegerType() || t.isLargeIntType()) {
+                return ordinal() < t.ordinal();
+            }
+            if (t.isStringType()) {
+                return true;
+            }
+            return false;
+        }
+        if (isDecimalV3()) {
+            if (t.isDecimalV3()) {
+                return t.precision >= precision && t.scale >= scale;
+            }
+            if (t.isStringType() || t.isFloatingPointType()) {
+                return true;
+            }
+            return false;
+        }
+        // both string
+        if (isStringType() && t.isStringType()) {
+            return true;
+        }
+        return false;
     }
 
     public int decimalPrecision() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -245,6 +245,28 @@ public class StructType extends Type {
     }
 
     @Override
+    public boolean isFullyCompatible(Type other) {
+        if (!other.isStructType()) {
+            return false;
+        }
+
+        if (equals(other)) {
+            return true;
+        }
+
+        StructType t = (StructType) other;
+        if (fields.size() != t.fields.size()) {
+            return false;
+        }
+        for (int i = 0; i < fields.size(); i++) {
+            if (!fields.get(i).getType().isFullyCompatible(t.fields.get(i).getType())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
     public StructType clone() {
         ArrayList<StructField> structFields = new ArrayList<>(fields.size());
         for (StructField field : fields) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -975,6 +975,15 @@ public abstract class Type implements Cloneable {
     public abstract void toThrift(TTypeDesc container);
 
     /**
+     * Returns true if the other can be fully compatible with this type.
+     * fully compatible means that all possible values of this type can be represented by the other type,
+     * and no null values will be produced if we cast this as the other.
+     * This is closely related to the implementation by BE.
+     * @TODO: the currently implementation is conservative, we can add more rules later.
+     */
+    public abstract boolean isFullyCompatible(Type other);
+
+    /**
      * Returns true if this type is equal to t, or if t is a wildcard variant of this
      * type. Subclasses should override this as appropriate. The default implementation
      * here is to avoid special-casing logic in callers for concrete types.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -102,6 +102,7 @@ public class TypeManager {
             if (!fieldCommon.isValid()) {
                 return Type.INVALID;
             }
+            fieldTypes.add(fieldCommon);
         }
         // TODO(alvin): needed to assign field names for this struct type
         return new StructType(fieldTypes);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CastOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CastOperator.java
@@ -16,7 +16,6 @@
 package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 
 import java.util.Objects;
@@ -45,7 +44,7 @@ public class CastOperator extends CallOperator {
     @Override
     public boolean isNullable() {
         ScalarOperator fromOperator = getChild(0);
-        if (ScalarType.isFullyCompatible(fromOperator.getType(), getType())) {
+        if (fromOperator.getType().isFullyCompatible(getType())) {
             return fromOperator.isNullable();
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
@@ -272,7 +272,7 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
                 // if toType is fully compatible with fromType,
                 // and we can find related aggregate function signature,
                 // just remove the cast
-                if (ScalarType.isFullyCompatible(fromType, toType)) {
+                if (fromType.isFullyCompatible(toType)) {
                     AggregateFunction possibleAggregateFunction = AggregateFunction.createBuiltin(
                             FunctionSet.SUM, Lists.newArrayList(fromType), toType, toType,
                             false, true, false);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
@@ -186,43 +186,41 @@ public class ScalarTypeTest {
         // integer to integer
         for (int i = 0; i < integerTypes.size(); i++) {
             for (int j = 0; j < integerTypes.size(); j++) {
-                Assert.assertEquals(
-                        ScalarType.isFullyCompatible(integerTypes.get(i), integerTypes.get(j)), i <= j);
+                Assert.assertEquals(i <= j, integerTypes.get(i).isFullyCompatible(integerTypes.get(j)));
             }
         }
         // integer to string
         for (int i = 0; i < integerTypes.size(); i++) {
             for (int j = 0; j < stringTypes.size(); j++) {
-                Assert.assertTrue(ScalarType.isFullyCompatible(integerTypes.get(i), stringTypes.get(j)));
+                Assert.assertTrue(integerTypes.get(i).isFullyCompatible(stringTypes.get(j)));
             }
         }
         // decimal to decimal
         for (int i = 0; i < decimalTypes.size(); i++) {
             for (int j = 0; j < decimalTypes.size(); j++) {
-                Assert.assertEquals(
-                        ScalarType.isFullyCompatible(decimalTypes.get(i), decimalTypes.get(j)), i <= j);
+                Assert.assertEquals(i <= j, decimalTypes.get(i).isFullyCompatible(decimalTypes.get(j)));
             }
         }
         // decimal to float
         for (int i = 0; i < decimalTypes.size(); i++) {
-            Assert.assertTrue(ScalarType.isFullyCompatible(decimalTypes.get(i), ScalarType.FLOAT));
-            Assert.assertTrue(ScalarType.isFullyCompatible(decimalTypes.get(i), ScalarType.DOUBLE));
+            Assert.assertTrue(decimalTypes.get(i).isFullyCompatible(ScalarType.FLOAT));
+            Assert.assertTrue(decimalTypes.get(i).isFullyCompatible(ScalarType.DOUBLE));
         }
         // decimal to string
         for (int i = 0; i < decimalTypes.size(); i++) {
             for (int j = 0; j < stringTypes.size(); j++) {
-                Assert.assertTrue(ScalarType.isFullyCompatible(decimalTypes.get(i), stringTypes.get(j)));
+                Assert.assertTrue(decimalTypes.get(i).isFullyCompatible(stringTypes.get(j)));
             }
         }
         // string to string
         for (int i = 0; i < stringTypes.size(); i++) {
             for (int j = 0; j < stringTypes.size(); j++) {
-                Assert.assertTrue(ScalarType.isFullyCompatible(stringTypes.get(i), stringTypes.get(j)));
+                Assert.assertTrue(stringTypes.get(i).isFullyCompatible(stringTypes.get(j)));
             }
         }
 
         // complex types
-        Assert.assertFalse(ScalarType.isFullyCompatible(ScalarType.JSON, ScalarType.INT));
-        Assert.assertFalse(ScalarType.isFullyCompatible(ScalarType.JSON, ScalarType.VARCHAR));
+        Assert.assertFalse(ScalarType.JSON.isFullyCompatible(ScalarType.INT));
+        Assert.assertFalse(ScalarType.JSON.isFullyCompatible(ScalarType.VARCHAR));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -31,6 +31,12 @@ public class StructTypePlanTest extends PlanTestBase {
         starRocksAssert.withTable("create table test(c0 INT, " +
                 "c1 struct<a int, b array<struct<a int, b int>>>," +
                 "c2 struct<a int, b int>," +
+                "c3 struct<a int, b int, c struct<a int, b int>, d array<int>>) " +
+                "duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+        starRocksAssert.withTable("create table test1(c0 INT, " +
+                "c1 struct<a int, b array<struct<a int, b int>>>," +
+                "c2 struct<a int, b int>," +
                 "c2_0 struct<a int, b varchar(10)>, " +
                 "c3 struct<a int, b int, c struct<a int, b int>, d array<int>>) " +
                 "duplicate key(c0) distributed by hash(c0) buckets 1 " +
@@ -45,14 +51,14 @@ public class StructTypePlanTest extends PlanTestBase {
 
     @Test
     public void testStruct() throws Exception {
-        String sql = "select * from test union all select * from test";
+        String sql = "select * from test1 union all select * from test1";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "0:UNION\n" +
                 "  |  \n" +
                 "  |----6:EXCHANGE\n" +
                 "  |    \n" +
                 "  3:EXCHANGE");
-        sql = "select c2 from test union all select c2_0 from test";
+        sql = "select c2 from test1 union all select c2_0 from test1";
         plan = getFragmentPlan(sql);
         assertContains(plan, "2:Project\n" +
                 "  |  <slot 6> : CAST(3: c2 AS STRUCT<col0 int(11), col1 varchar(10)>)\n" +


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When check the type of its children output with the type of the setOperation output, we need ensure the setOperation output col is compaitble with the children output col , in other words, all possible values of children output col can be represented in the setOperation output col. So I extend `isFullyCompatible()` to all types.

Also fix a small bug when `getCommonStructType()`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
