### PR TITLE
[BugFix] fix the bug of output profile to BE log

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -1020,7 +1020,7 @@ void RuntimeProfile::print_child_counters(const std::string& prefix, const std::
             DCHECK(iter != counter_map.end());
             auto value = iter->second.first->value();
             auto display_threshold = iter->second.first->display_threshold();
-            if (display_threshold > 0 && value > display_threshold) {
+            if (display_threshold == 0 || (display_threshold > 0 && value > display_threshold)) {
                 stream << prefix << "   - " << iter->first << ": "
                        << PrettyPrinter::print(iter->second.first->value(), iter->second.first->type()) << std::endl;
                 RuntimeProfile::print_child_counters(prefix + "  ", child_counter, counter_map, child_counter_map, s);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Before the pr

```
I0413 10:25:38.301513 50940 plan_fragment_executor.cpp:427] Fragment 631010f1-d9a2-11ed-93cc-eaf78f209815:(Active: 39s462ms, non-child: 0.00%)
  DataStreamSender (dst_id=5, dst_fragments=[631010f1d9a211ed-93cceaf78f209816]):(Active: 425.423us, non-child: 0.00%)
     - PartType: UNPARTITIONED
  AGGREGATION_NODE (id=4):(Active: 39s461ms, non-child: 0.00%)
     - AggregateFunctions: count(9: lo_quantity)
    AGGREGATION_NODE (id=3):(Active: 39s461ms, non-child: 0.00%)
       - GroupingKeys: 9: lo_quantity
      EXCHANGE_NODE (id=2):(Active: 39s461ms, non-child: 100.00%)
```

after the pr

```
I0413 10:57:03.197690 89772 plan_fragment_executor.cpp:427] Fragment c5cdf0f6-d9a6-11ed-93cc-eaf78f209814:(Active: 40s695ms, non-child: 0.00%)
   - MemoryLimit: 18.63 GB
   - PeakMemoryUsage: 0
   - RowsProduced: 50
  DataStreamSender (dst_id=2, dst_fragments=[c5cdf0f6d9a611ed-93cceaf78f209815]):(Active: 1.367ms, non-child: 0.00%)
     - PartType: HASH_PARTITIONED
     - BytesSent: 212.00 B
     - CompressTime: 18.845us
     - IgnoreRows: 0
     - OverallThroughput: 151.39 KB/sec
     - SendRequestTime: 433.195us
     - SerializeChunkTime: 88.300us
     - ShuffleDispatchTime: 0.000ns
     - ShuffleHashTime: 0.000ns
     - UncompressedBytes: 212.00 B
     - WaitResponseTime: 630.418us
  AGGREGATION_NODE (id=1):(Active: 40s694ms, non-child: 94.34%)
     - GroupingKeys: 9: lo_quantity
     - AggComputeTime: 37s823ms
     - ExprComputeTime: 132.815ms
     - ExprReleaseTime: 109.097ms
     - GetResultsTime: 100.175us
     - HashTableSize: 50
     - InputRowCount: 144.00M
     - PassThroughRowCount: 0
     - PeakMemoryUsage: 348.00 B
     - ResultAggAppendTime: 0.000ns
     - ResultGroupByAppendTime: 7.084us
     - ResultIteratorTime: 0.000ns
     - RowsReturned: 0
     - RowsReturnedRate: 0
     - StreamingTime: 0.000ns
    OLAP_SCAN_NODE (id=0):(Active: 2s300ms, non-child: 0.00%)
       - Table: lineorder
       - Rollup: lineorder
       - BytesRead: 549.31 MB
       - IOTaskCount : 192
       - NumDiskAccess: 0
       - PeakMemoryUsage: 0
       - RowsRead: 144.00M
       - RowsReturned: 144.00M
       - RowsReturnedRate: 62.60 M/sec
       - ScanConcurrency : 1
       - ScanTime: 3s201ms
       - ScannerThreadsInvoluntaryContextSwitches: 0
       - ScannerThreadsTotalWallClockTime: 0.000ns
         - MaterializeTupleTime(*): 0.000ns
         - ScannerThreadsSysTime: 0.000ns
         - ScannerThreadsUserTime: 0.000ns
       - ScannerThreadsVoluntaryContextSwitches: 0
       - TabletCount : 192
       - TotalRawReadTime(*): 0.000ns
       - TotalReadThroughput: 238.79 MB/sec
```

For most indicators, the display_threshold is 0, which will cause the proflie not output to be log.

The bug is introduced by this PR: https://github.com/StarRocks/starrocks/pull/16602.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
