### PR TITLE
[BugFix] Fix BE coredump when deserialize avro failed

### DIFF
--- a/be/src/exec/avro_scanner.cpp
+++ b/be/src/exec/avro_scanner.cpp
@@ -276,7 +276,6 @@ Status AvroScanner::_parse_avro(Chunk* chunk, const std::shared_ptr<SequentialFi
         }
         data = reinterpret_cast<uint8_t*>(_parser_buf->ptr);
         length = _parser_buf->remaining();
-        DeferOp op([&] { avro_value_decref(&avro_value); });
         serdes_schema_t* schema;
         serdes_err_t err =
                 serdes_deserialize_avro(_serdes, &avro_value, &schema, data, length, _err_buf, sizeof(_err_buf));
@@ -287,6 +286,7 @@ Status AvroScanner::_parse_avro(Chunk* chunk, const std::shared_ptr<SequentialFi
             _state->append_error_msg_to_file("", err_msg);
             return Status::InternalError("serdes deserialize avro failed");
         }
+        DeferOp op([&] { avro_value_decref(&avro_value); });
 #endif
         size_t chunk_row_num = chunk->num_rows();
         Status st = Status::OK();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21707

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If the deserialization of the avro data fails, the BE will also attempt to destroy the avro_value_t object, causing a coredump. This PR fixes this problem.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
