### PR TITLE
[BugFix] Fix complex cte lose property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -410,6 +410,7 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
         Preconditions.checkState(childrenOutputProperties.size() == 2);
         PhysicalPropertySet output = childrenOutputProperties.get(1).copy();
         CTEProperty cteProperty = childrenOutputProperties.get(1).getCteProperty().removeCTE(node.getCteId());
+        cteProperty.merge(childrenOutputProperties.get(0).getCteProperty());
         output.setCteProperty(cteProperty);
         return output;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

like sql:
```
with x1 as (select * from v1),
     x2 as (select * from x1)

select * from x2 join x2
```        

```
        NoCTE(cteid = x1)
             |
      CTEAnchor(cteie = x2)     // lose output CTE-x1's property
      /                 \
CTEConsume(x1)          Join
                    /           \
            CTEConsume(x2)  CTEConsume(x2)
```



## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
