### PR TITLE
[BugFix] Fix cast decimal type error for trino parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -939,9 +939,15 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
 
     private Type getGenericDataType(GenericDataType dataType) {
         int length = -1;
+        int precision = -1;
+        int scale = -1;
         String typeName = dataType.getName().getValue().toLowerCase();
         if (!dataType.getArguments().isEmpty() && dataType.getArguments().get(0) instanceof NumericParameter) {
             length = Integer.parseInt(((NumericParameter) dataType.getArguments().get(0)).getValue());
+            precision = length;
+            if (dataType.getArguments().size() > 1 && dataType.getArguments().get(1) instanceof NumericParameter) {
+                scale = Integer.parseInt(((NumericParameter) dataType.getArguments().get(1)).getValue());
+            }
         }
         if (typeName.equals("varchar")) {
             ScalarType type = ScalarType.createVarcharType(length);
@@ -955,6 +961,16 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
                 type.setAssignedStrLenInColDefinition();
             }
             return type;
+        } else if (typeName.equals("decimal")) {
+            if (precision != -1) {
+                if (scale != -1) {
+                    return ScalarType.createUnifiedDecimalType(precision, scale);
+                }
+                return ScalarType.createUnifiedDecimalType(precision, 0);
+            }
+            return ScalarType.createUnifiedDecimalType(38, 0);
+        } else if (typeName.contains("decimal")) {
+            throw new SemanticException("Unknown type: %s", typeName);
         } else {
             // this contains datetime/date/numeric type
             return ScalarType.createType(typeName);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -101,6 +101,33 @@ public class TrinoQueryTest extends TrinoTestBase {
     }
 
     @Test
+    public void testDecimal() throws Exception {
+        String sql = "select cast(tj as decimal32) from tall";
+        analyzeFail(sql, "Unknown type: decimal32");
+
+        sql = "select cast(tj as decimal64) from tall";
+        analyzeFail(sql, "Unknown type: decimal64");
+
+        sql = "select cast(tj as decimal128) from tall";
+        analyzeFail(sql, "Unknown type: decimal128");
+
+        sql = "select cast(tj as decimal) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(10: tj AS DECIMAL128(38,0))");
+
+        sql = "select cast(tj as decimal(10, 2)) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(10: tj AS DECIMAL64(10,2))");
+
+        sql = "select cast(tj as decimal(10)) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(10: tj AS DECIMAL64(10,0))");
+
+        sql = "select cast(tj as decimal(28, 2)) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(10: tj AS DECIMAL128(28,2))");
+
+        sql = "select cast(tj as decimal(28)) from tall";
+        assertPlanContains(sql, "<slot 11> : CAST(10: tj AS DECIMAL128(28,0))");
+    }
+
+    @Test
     public void testSelectLiteral() throws Exception {
         String sql = "select date '1998-12-01'";
         assertPlanContains(sql, "<slot 2> : '1998-12-01'");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#14825

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
trino do not support decimal32/decimal64/decimal128, only support decimal with precision and scale


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
