### PR TITLE
[Cherry-pick][branch-3.0][BugFix] remove function contains_sequence transformer for trino parser (#21733)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -117,11 +117,7 @@ public class Trino2SRFunctionCallTransformer {
         registerFunctionTransformer("contains", 2, "array_contains",
                 ImmutableList.of(Expr.class, Expr.class));
 
-        // 4. contains_sequence -> array_contains_all
-        registerFunctionTransformer("contains_sequence", 2, "array_contains_all",
-                ImmutableList.of(Expr.class, Expr.class));
-
-        // 5. slice -> array_slice
+        // 4. slice -> array_slice
         registerFunctionTransformer("slice", 3, "array_slice",
                 ImmutableList.of(Expr.class, Expr.class, Expr.class));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -62,12 +62,6 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select contains(array[1,2,3], 1)";
         assertPlanContains(sql, "array_contains(ARRAY<tinyint(4)>[1,2,3], 1)");
 
-        sql = "select contains_sequence(c1, array['1','2']) from test_array";
-        assertPlanContains(sql, "array_contains_all(2: c1, ARRAY<varchar>['1','2'])");
-
-        sql = "select contains_sequence(c1, array['1','2']) from test_array";
-        assertPlanContains(sql, "array_contains_all(2: c1, ARRAY<varchar>['1','2'])");
-
         sql = "select slice(array[1,2,3,4], 2, 2)";
         assertPlanContains(sql, "array_slice(ARRAY<tinyint(4)>[1,2,3,4], 2, 2)");
     }


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
