### PR TITLE
[BugFix] QueryState#errorMessage may be null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -94,6 +94,7 @@ import com.starrocks.thrift.TTabletCommitInfo;
 import com.starrocks.thrift.TTabletFailInfo;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUnit;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -1398,7 +1399,7 @@ public class Coordinator {
     }
 
     private void cancelInternal(PPlanFragmentCancelReason cancelReason) {
-        if (connectContext.getState().getErrorMessage().isEmpty()) {
+        if (StringUtils.isEmpty(connectContext.getState().getErrorMessage())) {
             connectContext.getState().setError(cancelReason.toString());
         }
         if (null != receiver) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -110,7 +110,7 @@ public class QueryState {
 
     public void setError(String errorMsg) {
         this.stateType = MysqlStateType.ERR;
-        this.errorMessage = errorMsg;
+        this.setMsg(errorMsg);
     }
 
     public boolean isError() {
@@ -126,7 +126,7 @@ public class QueryState {
     }
 
     public void setMsg(String msg) {
-        this.errorMessage = msg;
+        this.errorMessage = msg == null ? "" : msg;
     }
 
     public void setErrType(ErrType errType) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes Noop.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We use `getState().setError(e.getMessage())` to set the error message, which could be null.
More worse, we use `getState().getErrorMessage().isEmpty()` to check, which will throw a NPE.

```
java.lang.NullPointerException: null
        at com.starrocks.qe.Coordinator.cancelInternal(Coordinator.java:1388) ~[fe-log.jar:?]
        at com.starrocks.qe.Coordinator.getNext(Coordinator.java:1342) ~[fe-log.jar:?]
        at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:784) ~[fe-log.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:458) ~[fe-log.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:348) ~[fe-log.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:462) ~[fe-log.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:728) ~[fe-log.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[fe-log.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_322]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_322]
        at java.lang.Thread.run(Thread.java:750) [?:1.8.0_322]

2023-04-17 22:36:48,751 WARN (starrocks-mysql-nio-pool-109|45140) [QueryState.setError():121] [DEBUG] setError
        at com.starrocks.qe.QueryState.setError(QueryState.java:120) ~[fe-log.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:559) ~[fe-log.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:348) ~[fe-log.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:462) ~[fe-log.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:728) ~[fe-log.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[fe-log.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_322]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_322]
        at java.lang.Thread.run(Thread.java:750) [?:1.8.0_322]
````

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
