### PR TITLE
[Enhancement] support implicit cast to boolean in predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -232,6 +232,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String STATISTIC_COLLECT_PARALLEL = "statistic_collect_parallel";
 
+    public static final String ENABLE_STRICT_TYPE = "enable_strict_type";
+
     // Limitations
     // mem limit can't smaller than bufferpool's default page size
     public static final int MIN_EXEC_MEM_LIMIT = 2097152;
@@ -593,6 +595,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = STATISTIC_COLLECT_PARALLEL)
     private int statisticCollectParallelism = 1;
+
+    @VarAttr(name = ENABLE_STRICT_TYPE, flag = VariableMgr.INVISIBLE)
+    private boolean enableStrictType = false;
 
     public int getStatisticCollectParallelism() {
         return statisticCollectParallelism;
@@ -1060,6 +1065,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableOptimizerTraceLog() {
         return enableOptimizerTraceLog;
+    }
+
+    public boolean isEnableStrictType() {
+        return enableStrictType;
+    }
+
+    public void setEnableStrictType(boolean val) {
+        this.enableStrictType = val;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -212,7 +212,7 @@ public class ExpressionAnalyzer {
             node.setType(Type.BOOLEAN);
             for (int i = 0; i < node.getChildren().size(); i++) {
                 Expr child = node.getChild(i);
-                if (child.getType().matchesType(Type.BOOLEAN) || child.getType().isNull()) {
+                if (child.getType().isBoolean() || child.getType().isNull()) {
                     // do nothing
                 } else if (!session.getSessionVariable().isEnableStrictType() && Type.canCastTo(child.getType(), Type.BOOLEAN)) {
                     node.getChildren().set(i, new CastExpr(Type.BOOLEAN, child));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -209,16 +209,17 @@ public class ExpressionAnalyzer {
 
         @Override
         public Void visitCompoundPredicate(CompoundPredicate node, Scope scope) {
+            node.setType(Type.BOOLEAN);
             for (int i = 0; i < node.getChildren().size(); i++) {
-                Type type = node.getChild(i).getType();
-                if (!type.isBoolean() && !type.isNull()) {
-                    throw new SemanticException("Operand '%s' part of predicate " +
-                            "'%s' should return type 'BOOLEAN' but returns type '%s'.",
-                            AST2SQL.toString(node), AST2SQL.toString(node.getChild(i)), type.toSql());
+                Expr child = node.getChild(i);
+                if (child.getType().matchesType(Type.BOOLEAN) || child.getType().isNull()) {
+                    // do nothing
+                } else if (!session.getSessionVariable().isEnableStrictType() && Type.canCastTo(child.getType(), Type.BOOLEAN)) {
+                    node.getChildren().set(i, new CastExpr(Type.BOOLEAN, child));
+                } else {
+                    throw new SemanticException(child.toSql() + " can not be converted to boolean type.");
                 }
             }
-
-            node.setType(Type.BOOLEAN);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -342,7 +342,7 @@ public class SelectAnalyzer {
         AnalyzerUtils.verifyNoGroupingFunctions(predicate, "WHERE");
 
 
-        if (predicate.getType().matchesType(Type.BOOLEAN) || predicate.getType().isNull()) {
+        if (predicate.getType().isBoolean() || predicate.getType().isNull()) {
             // do nothing
         } else if (!session.getSessionVariable().isEnableStrictType() && Type.canCastTo(predicate.getType(), Type.BOOLEAN)) {
             predicate = new CastExpr(Type.BOOLEAN, predicate);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.starrocks.analysis.AnalyticExpr;
+import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.GroupByClause;
@@ -340,8 +341,13 @@ public class SelectAnalyzer {
         AnalyzerUtils.verifyNoWindowFunctions(predicate, "WHERE");
         AnalyzerUtils.verifyNoGroupingFunctions(predicate, "WHERE");
 
-        if (!predicate.getType().matchesType(Type.BOOLEAN) && !predicate.getType().matchesType(Type.NULL)) {
-            throw new SemanticException("WHERE clause must evaluate to a boolean: actual type %s", predicate.getType());
+
+        if (predicate.getType().matchesType(Type.BOOLEAN) || predicate.getType().isNull()) {
+            // do nothing
+        } else if (!session.getSessionVariable().isEnableStrictType() && Type.canCastTo(predicate.getType(), Type.BOOLEAN)) {
+            predicate = new CastExpr(Type.BOOLEAN, predicate);
+        } else {
+            throw new SemanticException("WHERE clause %s can not be converted to boolean type", predicate.toSql());
         }
 
         analyzeState.setPredicate(predicate);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -119,11 +119,11 @@ public class AnalyzeSingleTest {
         analyzeSuccess("select v1 from t0 where v1 = 1");
         analyzeSuccess("select v1 from t0 where v2 = 1 and v3 = 5");
         analyzeSuccess("select v1 from t0 where v1 = v2");
+        analyzeSuccess("select v1 from t0 where v2");
 
         analyzeFail("select v1 from t0 where sum(v2) > 1");
         analyzeFail("select v1 from t0 where error = 5");
         analyzeFail("select v1 from t0 where error = v1");
-        analyzeFail("select v1 from t0 where v2");
     }
 
     @Test
@@ -453,8 +453,7 @@ public class AnalyzeSingleTest {
     @Test
     public void testSqlMode() {
         ConnectContext connectContext = getConnectContext();
-        analyzeFail("select 'a' || 'b' from t0",
-                "Operand ''a' OR 'b'' part of predicate ''a'' should return type 'BOOLEAN'");
+        analyzeSuccess("select 'a' || 'b' from t0");
 
         StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse("select true || false from t0",
                 connectContext.getSessionVariable().getSqlMode()).get(0);
@@ -484,8 +483,7 @@ public class AnalyzeSingleTest {
                 "SELECT * FROM default_cluster:test.tall WHERE (ta LIKE (concat('h', 'a', 'i'))) OR TRUE",
                 AST2SQL.toString(statementBase));
 
-        analyzeFail("select * from  tall where ta like concat(\"h\", \"a\", \"i\")||'%'",
-                "LIKE (concat('h', 'a', 'i'))) OR '%'' part of predicate ''%'' should return type 'BOOLEAN'");
+        analyzeSuccess("select * from  tall where ta like concat(\"h\", \"a\", \"i\")||'%'");
 
         connectContext.getSessionVariable().setSqlMode(SqlModeHelper.MODE_SORT_NULLS_LAST);
         statementBase = SqlParser.parse("select * from  tall order by ta",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ImplicitCastTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ImplicitCastTest.java
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ImplicitCastTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @ParameterizedTest
+    @MethodSource("predicateImplicitCastSql")
+    @Order(1)
+    public void testPredicateImplicitCast(Pair<String, String> pair) throws Exception {
+        connectContext.getSessionVariable().setEnableStrictType(false);
+        String plan = getFragmentPlan(pair.first);
+        assertContains(plan, pair.second);
+        connectContext.getSessionVariable().setEnableStrictType(true);
+        try {
+            getFragmentPlan(pair.first);
+        } catch (Exception e) {
+            assertContains(e.getMessage(), "can not be converted to boolean type");
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsupportedImplicitCastSql")
+    @Order(2)
+    public void testUnsupportedImplicitCast(String sql) throws Exception {
+        connectContext.getSessionVariable().setEnableStrictType(false);
+        try {
+            getFragmentPlan(sql);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            assertContains(e.getMessage(), "can not be converted to boolean type");
+        }
+    }
+
+    private static Stream<Arguments> predicateImplicitCastSql() {
+        List<Pair<String, String>> sqlList = Lists.newArrayList();
+        sqlList.add(Pair.create("select 1 from t1 where 1", "PREDICATES: TRUE"));
+        sqlList.add(Pair.create("select 1 from t1 where 100", "PREDICATES: CAST(100 AS BOOLEAN)"));
+        sqlList.add(Pair.create("select 1 from t1 where 2.3456", "PREDICATES: CAST(2.3456 AS BOOLEAN)"));
+        sqlList.add(Pair.create("select 1 from t1 where '2020-02-02'", "PREDICATES: CAST('2020-02-02' AS BOOLEAN)"));
+        sqlList.add(Pair.create("select 1 from t1 where '2.3456'", "PREDICATES: CAST('2.3456' AS BOOLEAN)"));
+        sqlList.add(Pair.create("select 1 from t1 where '0'", "0:EMPTYSET"));
+        sqlList.add(Pair.create("select 1 and 'a' is null from t1 where 1 and 'a' is null", "0:EMPTYSET"));
+        sqlList.add(Pair.create("select 1 or 'a' is null from t1 where 1 or 'a' is null", "PREDICATES: TRUE"));
+        sqlList.add(Pair.create("select case v1 when 'a' then 1 else 0 end from t0 where case v1 when 'a' then 1 else 0 end",
+                "CAST(if(CAST(1: v1 AS VARCHAR) = 'a', 1, 0) AS BOOLEAN)"));
+        sqlList.add(Pair.create("select * from t0 where case v1 when 'a' then 1 else 0 end " +
+                "and case v2 when 'a' then 2 else 0 end",
+                "PREDICATES: CAST(if(CAST(1: v1 AS VARCHAR) = 'a', 1, 0) AS BOOLEAN), " +
+                        "CAST(if(CAST(2: v2 AS VARCHAR) = 'a', 2, 0) AS BOOLEAN)"));
+        sqlList.add(Pair.create("select * from tarray where v3[1] and case v1 when 1 then 1 else 0 end and v2",
+                "PREDICATES: CAST(3: v3[1] AS BOOLEAN), CAST(if(1: v1 = 1, 1, 0) AS BOOLEAN), CAST(2: v2 AS BOOLEAN)"));
+        sqlList.add(Pair.create("select * from bitmap_table where BITMAP_COUNT(id2)",
+                "CAST(bitmap_count(2: id2) AS BOOLEAN)"));
+        return sqlList.stream().map(e -> Arguments.of(e));
+    }
+
+    private static Stream<Arguments> unsupportedImplicitCastSql() {
+        List<String> sqlList = Lists.newArrayList();
+        sqlList.add("select * from tarray where v3");
+        sqlList.add("select * from bitmap_table where id2");
+        sqlList.add("select * from tarray where v3 and 1");
+        sqlList.add("select * from bitmap_table where id2 or abs(1) < abs(2)");
+        sqlList.add("select * from test_agg where h1");
+        return sqlList.stream().map(e -> Arguments.of(e));
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
`select * from tbl where case col1 when 'a' then 1 else false end and case col2 when 'a' then 1 else false end;`
should success to execute.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, we support some implicit conversion capabilities, such as binary predicates, where we will convert the left and right operands to a common type that is compatible with both. However, in compound predicates, each operand must be a Boolean type. To gradually unify the behavior of implicit conversions, this pr perform implicit conversions on the children of compound predicates from bottom to top and add casts to expressions that can be cast to Boolean in the where clause. The reason for not modifying in the plan phase is that the analyze phase can more easily determine whether an expression is an expression in the where clause. For example, in `select 1 from tbl where 1`, the analyze phase can easily only change `where 1` to `where cast(1 as boolean)` but do noting to `select 1`.

A session variable `ENABLE_STRICT_TYPE` has been added to control the behavior of strict type requirement, defaulting to false. Currently, it only controls the behavior of implicit type conversion in compound predicates and where clauses. In the future, it should be expanded to have the ability to control implicit type conversion universally.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
