### PR TITLE
[BugFix] Fix schema change hang when FE meets runtime exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -554,9 +554,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             LOG.info("schema change tasks not finished. job: {}", jobId);
             List<AgentTask> tasks = schemaChangeBatchTask.getUnfinishedTasks(2000);
             for (AgentTask task : tasks) {
-                if (task.getFailedTimes() >= 3) {
-                    throw new AlterCancelException(
-                            "schema change task failed after try three times: " + task.getErrorMsg());
+                if (task.isFailed() || task.getFailedTimes() >= 3) {
+                    throw new AlterCancelException("schema change task failed: " + task.getErrorMsg());
                 }
             }
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTask.java
@@ -57,6 +57,7 @@ public abstract class AgentTask {
     // some of are not.
     // so whether the task is finished depends on caller's logic, not the value of this member.
     protected boolean isFinished = false;
+    protected boolean isFailed = false;
     protected long createTime;
     protected String traceParent;
 
@@ -155,6 +156,14 @@ public abstract class AgentTask {
 
     public boolean isFinished() {
         return isFinished;
+    }
+
+    public boolean isFailed() {
+        return isFailed;
+    }
+
+    public void setFailed(boolean isFailed) {
+        this.isFailed = isFailed;
     }
 
     public boolean shouldResend(long currentTimeMillis) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -189,7 +189,7 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
      *      So the replica's version should be larger than X. So we don't need to modify the replica version
      *      because its already looks like normal.
      */
-    public void handleFinishAlterTask() throws MetaNotFoundException {
+    public void handleFinishAlterTask() throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getDb(getDbId());
         if (db == null) {
             throw new MetaNotFoundException("database " + getDbId() + " does not exist");
@@ -257,8 +257,11 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
     public void run() {
         try {
             handleFinishAlterTask();
-        } catch (MetaNotFoundException e) {
-            LOG.warn("failed to handle finish alter task: {}, {}", getSignature(), e.getMessage());
+        } catch (Exception e) {
+            String errMsg = "failed to handle finish alter task: " + getSignature() + ", " + e.getMessage();
+            LOG.warn(errMsg);
+            setErrorMsg(errMsg);
+            setFailed(true);
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
If FE got a runtime exception when handle an alter task finish request, the alter task cannot finished normally and will hang the whole alter job until timeout.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
