### PR TITLE
[Enhancement] Skip the starcache installation when building starrocks BE

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -310,6 +310,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DWITH_BENCH=${WITH_BENCH} \
                     -DWITH_CACHELIB=${WITH_CACHELIB} \
                     -DSTARCACHE_THIRDPARTY_DIR=${STARROCKS_THIRDPARTY}/installed \
+                    -DSTARCACHE_SKIP_INSTALL=ON \
                     -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
                     -DgRPC_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/grpc \
                     -Dprometheus-cpp_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/prometheus-cpp \
@@ -328,6 +329,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DWITH_COMPRESS=${WITH_COMPRESS} \
                     -DWITH_CACHELIB=${WITH_CACHELIB} \
                     -DSTARCACHE_THIRDPARTY_DIR=${STARROCKS_THIRDPARTY}/installed \
+                    -DSTARCACHE_SKIP_INSTALL=ON \
                     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  ..
     fi
     time ${BUILD_SYSTEM} -j${PARALLEL}

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -151,6 +151,7 @@ if [ "${USE_STAROS}" == "ON"  ]; then
               -DUSE_STAROS=${USE_STAROS} -DWITH_GCOV=${WITH_GCOV} \
               -DWITH_CACHELIB=${WITH_CACHELIB} \
               -DSTARCACHE_THIRDPARTY_DIR=${STARROCKS_THIRDPARTY}/installed \
+              -DSTARCACHE_SKIP_INSTALL=ON \
               -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
               -DgRPC_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/grpc \
               -Dprometheus-cpp_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/prometheus-cpp \
@@ -165,6 +166,7 @@ else
               -DWITH_GCOV=${WITH_GCOV} \
               -DWITH_CACHELIB=${WITH_CACHELIB} \
               -DSTARCACHE_THIRDPARTY_DIR=${STARROCKS_THIRDPARTY}/installed \
+              -DSTARCACHE_SKIP_INSTALL=ON \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
 fi
 ${BUILD_SYSTEM} -j${PARALLEL}


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now, starcache is imported as a submodule, and we build it as a subdirectory of starrocks BE sources. So, the starcache installation is unnecessary. We set the `STARCACHE_SKIP_INSTALL` option to skip it.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
