### PR TITLE
[Enhancement] Choose big size tablet in high priority to balance cluster disk

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -503,7 +503,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                 for (Pair<Long, Long> partitionMVId : hState.sortedPartitions) {
                     List<Long> hPartitionTablets = hState.partitionTablets.get(partitionMVId);
                     List<Long> lPartitionTablets = lState.partitionTablets.computeIfAbsent(partitionMVId,
-                            pmId -> new ArrayList<>());
+                            pmId -> new LinkedList<>());
                     int replicaTotalCnt = partitionReplicaCnt.getOrDefault(partitionMVId.first, 0);
                     int slotOfHighBE = hPartitionTablets.size() - (replicaTotalCnt / beStats.size());
                     int slotOfLowBE = ((replicaTotalCnt + beStats.size() - 1) / beStats.size())

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -18,7 +18,6 @@ package com.starrocks.clone;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
@@ -772,13 +771,13 @@ public class DiskAndTabletLoadReBalancerTest {
         Assert.assertEquals((Integer) 4, hState.pathSortIndex.get(pathHash14));
         Assert.assertEquals(10 * tabletDataSize, hState.usedCapacity);
 
-        List<Long> highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        List<Long> highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(1, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId1, highLoadPaths.get(0));
 
         // change threshold to 0.3, tabletId2 will be chosen
         Config.tablet_sched_balance_load_score_threshold = 0.3;
-        highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(2, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId1, highLoadPaths.get(0));
         Assert.assertEquals((Long) tabletId2, highLoadPaths.get(1));
@@ -795,7 +794,7 @@ public class DiskAndTabletLoadReBalancerTest {
         Assert.assertEquals((Integer) 2, hState.pathSortIndex.get(pathHash13));
         Assert.assertEquals(6 * tabletDataSize, hState.usedCapacity);
         // only tabletId2 will be chosen
-        highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(1, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId2, highLoadPaths.get(0));
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Choose the big size tablet to balance cluster disk, so that the cluster can reach to the balance state faster, and easier to retain the balanced distribution of tablet.

Sort the partitions by average tablet size in desc order for the same skew , and sort the tablet in every partition by size in desc order.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
