### PR TITLE
[Enhancement] Improve cloud native tablet read io statistics

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -137,16 +137,25 @@ private:
 
     // IO statistics
     RuntimeProfile::Counter* _io_statistics_timer = nullptr;
-    RuntimeProfile::Counter* _pages_from_memory_counter = nullptr;
-    RuntimeProfile::Counter* _pages_from_local_disk_counter = nullptr;
-    RuntimeProfile::Counter* _pages_from_remote_counter = nullptr;
-    RuntimeProfile::Counter* _pages_total_counter = nullptr;
-    RuntimeProfile::Counter* _io_from_local_disk_timer = nullptr;
-    RuntimeProfile::Counter* _io_from_remote_timer = nullptr;
-    RuntimeProfile::Counter* _io_total_timer = nullptr;
-    RuntimeProfile::Counter* _compressed_bytes_from_local_disk_counter = nullptr;
-    RuntimeProfile::Counter* _compressed_bytes_from_remote_counter = nullptr;
-    RuntimeProfile::Counter* _compressed_bytes_total_counter = nullptr;
+    // Page count
+    RuntimeProfile::Counter* _pages_count_memory_counter = nullptr;
+    RuntimeProfile::Counter* _pages_count_local_disk_counter = nullptr;
+    RuntimeProfile::Counter* _pages_count_remote_counter = nullptr;
+    RuntimeProfile::Counter* _pages_count_total_counter = nullptr;
+    // Compressed bytes read
+    RuntimeProfile::Counter* _compressed_bytes_read_local_disk_counter = nullptr;
+    RuntimeProfile::Counter* _compressed_bytes_read_remote_counter = nullptr;
+    RuntimeProfile::Counter* _compressed_bytes_read_total_counter = nullptr;
+    RuntimeProfile::Counter* _compressed_bytes_read_request_counter = nullptr;
+    // IO count
+    RuntimeProfile::Counter* _io_count_local_disk_counter = nullptr;
+    RuntimeProfile::Counter* _io_count_remote_counter = nullptr;
+    RuntimeProfile::Counter* _io_count_total_counter = nullptr;
+    RuntimeProfile::Counter* _io_count_request_counter = nullptr;
+    // IO time
+    RuntimeProfile::Counter* _io_ns_local_disk_timer = nullptr;
+    RuntimeProfile::Counter* _io_ns_remote_timer = nullptr;
+    RuntimeProfile::Counter* _io_ns_total_timer = nullptr;
 };
 
 // ================================
@@ -235,6 +244,8 @@ Status LakeDataSource::open(RuntimeState* state) {
 
 void LakeDataSource::close(RuntimeState* state) {
     if (_reader) {
+        // close reader to update statistics before update counters
+        _reader->close();
         update_counter();
     }
     if (_prj_iter) {
@@ -527,30 +538,31 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     // IO statistics
     // IOTime
     _io_timer = ADD_TIMER(_runtime_profile, "IOTime");
-
     _io_statistics_timer = ADD_TIMER(_runtime_profile, "IOStatistics");
-
-    // Page
-    _pages_from_memory_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "PagesReadFromMemory", TUnit::UNIT, "IOStatistics");
-    _pages_from_local_disk_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "PagesReadFromLocalDisk", TUnit::UNIT, "IOStatistics");
-    _pages_from_remote_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "PagesReadFromRemote", TUnit::UNIT, "IOStatistics");
-    _pages_total_counter = ADD_CHILD_COUNTER(_runtime_profile, "PagesReadTotal", TUnit::UNIT, "IOStatistics");
-
-    // IO time
-    _io_from_local_disk_timer = ADD_CHILD_TIMER(_runtime_profile, "IOTimeFromLocalDisk", "IOStatistics");
-    _io_from_remote_timer = ADD_CHILD_TIMER(_runtime_profile, "IOTimeFromRemote", "IOStatistics");
-    _io_total_timer = ADD_CHILD_TIMER(_runtime_profile, "IOTimeTotal", "IOStatistics");
-
+    // Page count
+    _pages_count_memory_counter = ADD_CHILD_COUNTER(_runtime_profile, "PagesCountMemory", TUnit::UNIT, "IOStatistics");
+    _pages_count_local_disk_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "PagesCountLocalDisk", TUnit::UNIT, "IOStatistics");
+    _pages_count_remote_counter = ADD_CHILD_COUNTER(_runtime_profile, "PagesCountRemote", TUnit::UNIT, "IOStatistics");
+    _pages_count_total_counter = ADD_CHILD_COUNTER(_runtime_profile, "PagesCountTotal", TUnit::UNIT, "IOStatistics");
     // Compressed bytes read
-    _compressed_bytes_from_local_disk_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "CompressedBytesReadFromLocalDisk", TUnit::BYTES, "IOStatistics");
-    _compressed_bytes_from_remote_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "CompressedBytesReadFromRemote", TUnit::BYTES, "IOStatistics");
-    _compressed_bytes_total_counter =
+    _compressed_bytes_read_local_disk_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "CompressedBytesReadLocalDisk", TUnit::BYTES, "IOStatistics");
+    _compressed_bytes_read_remote_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "CompressedBytesReadRemote", TUnit::BYTES, "IOStatistics");
+    _compressed_bytes_read_total_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "CompressedBytesReadTotal", TUnit::BYTES, "IOStatistics");
+    _compressed_bytes_read_request_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "CompressedBytesReadRequest", TUnit::BYTES, "IOStatistics");
+    // IO count
+    _io_count_local_disk_counter = ADD_CHILD_COUNTER(_runtime_profile, "IOCountLocalDisk", TUnit::UNIT, "IOStatistics");
+    _io_count_remote_counter = ADD_CHILD_COUNTER(_runtime_profile, "IOCountRemote", TUnit::UNIT, "IOStatistics");
+    _io_count_total_counter = ADD_CHILD_COUNTER(_runtime_profile, "IOCountTotal", TUnit::UNIT, "IOStatistics");
+    _io_count_request_counter = ADD_CHILD_COUNTER(_runtime_profile, "IOCountRequest", TUnit::UNIT, "IOStatistics");
+    // IO time
+    _io_ns_local_disk_timer = ADD_CHILD_TIMER(_runtime_profile, "IOTimeLocalDisk", "IOStatistics");
+    _io_ns_remote_timer = ADD_CHILD_TIMER(_runtime_profile, "IOTimeRemote", "IOStatistics");
+    _io_ns_total_timer = ADD_CHILD_TIMER(_runtime_profile, "IOTimeTotal", "IOStatistics");
 }
 
 void LakeDataSource::update_realtime_counter(Chunk* chunk) {
@@ -628,23 +640,25 @@ void LakeDataSource::update_counter() {
     int64_t pages_total = _reader->stats().total_pages_num;
     int64_t pages_from_memory = _reader->stats().cached_pages_num;
     int64_t pages_from_local_disk = _reader->stats().pages_from_local_disk;
-    COUNTER_UPDATE(_pages_from_memory_counter, pages_from_memory);
-    COUNTER_UPDATE(_pages_from_local_disk_counter, pages_from_local_disk);
-    COUNTER_UPDATE(_pages_from_remote_counter, pages_total - pages_from_memory - pages_from_local_disk);
-    COUNTER_UPDATE(_pages_total_counter, pages_total);
+    COUNTER_UPDATE(_pages_count_memory_counter, pages_from_memory);
+    COUNTER_UPDATE(_pages_count_local_disk_counter, pages_from_local_disk);
+    COUNTER_UPDATE(_pages_count_remote_counter, pages_total - pages_from_memory - pages_from_local_disk);
+    COUNTER_UPDATE(_pages_count_total_counter, pages_total);
 
-    int64_t io_ns = _reader->stats().io_ns;
-    int64_t io_ns_from_local_disk = _reader->stats().io_ns_from_local_disk;
-    COUNTER_UPDATE(_io_from_local_disk_timer, io_ns_from_local_disk);
-    COUNTER_UPDATE(_io_from_remote_timer, io_ns - io_ns_from_local_disk);
-    COUNTER_UPDATE(_io_total_timer, io_ns);
-    COUNTER_UPDATE(_io_statistics_timer, io_ns);
+    COUNTER_UPDATE(_compressed_bytes_read_local_disk_counter, _reader->stats().compressed_bytes_read_local_disk);
+    COUNTER_UPDATE(_compressed_bytes_read_remote_counter, _reader->stats().compressed_bytes_read_remote);
+    COUNTER_UPDATE(_compressed_bytes_read_total_counter, _reader->stats().compressed_bytes_read);
+    COUNTER_UPDATE(_compressed_bytes_read_request_counter, _reader->stats().compressed_bytes_read_request);
 
-    int64_t compressed_bytes_read = _reader->stats().compressed_bytes_read;
-    int64_t compressed_bytes_from_local_disk = _reader->stats().compressed_bytes_from_local_disk;
-    COUNTER_UPDATE(_compressed_bytes_from_local_disk_counter, compressed_bytes_from_local_disk);
-    COUNTER_UPDATE(_compressed_bytes_from_remote_counter, compressed_bytes_read - compressed_bytes_from_local_disk);
-    COUNTER_UPDATE(_compressed_bytes_total_counter, compressed_bytes_read);
+    COUNTER_UPDATE(_io_count_local_disk_counter, _reader->stats().io_count_local_disk);
+    COUNTER_UPDATE(_io_count_remote_counter, _reader->stats().io_count_remote);
+    COUNTER_UPDATE(_io_count_total_counter, _reader->stats().io_count);
+    COUNTER_UPDATE(_io_count_request_counter, _reader->stats().io_count_request);
+
+    COUNTER_UPDATE(_io_ns_local_disk_timer, _reader->stats().io_ns_local_disk);
+    COUNTER_UPDATE(_io_ns_remote_timer, _reader->stats().io_ns_remote);
+    COUNTER_UPDATE(_io_ns_total_timer, _reader->stats().io_ns);
+    COUNTER_UPDATE(_io_statistics_timer, _reader->stats().io_ns);
 }
 
 // ================================

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -393,7 +393,7 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_rows_read_counter, _num_rows_read);
 
     COUNTER_UPDATE(_io_timer, _reader->stats().io_ns);
-    COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read);
+    COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read_request);
     COUNTER_UPDATE(_decompress_timer, _reader->stats().decompress_ns);
     COUNTER_UPDATE(_read_uncompressed_counter, _reader->stats().uncompressed_bytes_read);
     COUNTER_UPDATE(_bytes_read_counter, _reader->stats().bytes_read);

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -263,11 +263,30 @@ struct OlapReaderStatistics {
 
     int64_t runtime_stats_filtered = 0;
 
-    // for lake tablet
-    int64_t io_ns_from_local_disk = 0;
-    int64_t compressed_bytes_from_local_disk = 0;
+    // ------ for lake tablet ------
     int64_t pages_from_local_disk = 0;
+
+    int64_t compressed_bytes_read_local_disk = 0;
+    int64_t compressed_bytes_read_remote = 0;
+    // bytes read requested from be, same as compressed_bytes_read for local tablet
+    int64_t compressed_bytes_read_request = 0;
+
+    int64_t io_count = 0;
+    int64_t io_count_local_disk = 0;
+    int64_t io_count_remote = 0;
+    int64_t io_count_request = 0;
+
+    int64_t io_ns_local_disk = 0;
+    int64_t io_ns_remote = 0;
+    // ------ for lake tablet ------
 };
+
+const char* const kBytesReadLocalDisk = "bytes_read_local_disk";
+const char* const kBytesReadRemote = "bytes_read_remote";
+const char* const kIOCountLocalDisk = "io_count_local_disk";
+const char* const kIOCountRemote = "io_count_remote";
+const char* const kIONsLocalDisk = "io_ns_local_disk";
+const char* const kIONsRemote = "io_ns_remote";
 
 typedef uint32_t ColumnId;
 typedef int32_t ColumnUID;

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -168,14 +168,13 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     {
         SCOPED_RAW_TIMER(&opts.stats->io_ns);
         if (opts.read_file->is_cache_hit()) {
-            SCOPED_RAW_TIMER(&opts.stats->io_ns_from_local_disk);
             RETURN_IF_ERROR(opts.read_file->read_at_fully(opts.page_pointer.offset, page_slice.data, page_slice.size));
-            opts.stats->compressed_bytes_from_local_disk += page_size;
             ++opts.stats->pages_from_local_disk;
         } else {
             RETURN_IF_ERROR(opts.read_file->read_at_fully(opts.page_pointer.offset, page_slice.data, page_slice.size));
         }
-        opts.stats->compressed_bytes_read += page_size;
+        opts.stats->compressed_bytes_read_request += page_size;
+        ++opts.stats->io_count_request;
     }
 
     if (opts.verify_checksum) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -253,6 +253,8 @@ private:
     // `ucid` means unique column id, use it for searching delta column group.
     Status _init_column_iterator_by_cid(const ColumnId cid, const ColumnUID ucid, bool check_dict_enc);
 
+    void _update_stats(RandomAccessFile* rfile);
+
 private:
     using RawColumnIterators = std::vector<std::unique_ptr<ColumnIterator>>;
     using ColumnDecoders = std::vector<ColumnDecoder>;
@@ -1614,6 +1616,42 @@ Status SegmentIterator::_get_row_ranges_by_rowid_range() {
     return Status::OK();
 }
 
+// Currently, update stats is only used for lake tablet, and numeric statistics is nullptr for local tablet.
+void SegmentIterator::_update_stats(RandomAccessFile* rfile) {
+    auto stats_or = rfile->get_numeric_statistics();
+    if (!stats_or.ok()) {
+        LOG(WARNING) << "failed to get statistics: " << stats_or.status();
+        return;
+    }
+
+    std::unique_ptr<io::NumericStatistics> stats = std::move(stats_or).value();
+    if (stats == nullptr || stats->size() == 0) {
+        return;
+    }
+
+    for (int64_t i = 0, sz = stats->size(); i < sz; ++i) {
+        auto&& name = stats->name(i);
+        auto&& value = stats->value(i);
+        if (name == kBytesReadLocalDisk) {
+            _opts.stats->compressed_bytes_read_local_disk += value;
+            _opts.stats->compressed_bytes_read += value;
+        } else if (name == kBytesReadRemote) {
+            _opts.stats->compressed_bytes_read_remote += value;
+            _opts.stats->compressed_bytes_read += value;
+        } else if (name == kIOCountLocalDisk) {
+            _opts.stats->io_count_local_disk += value;
+            _opts.stats->io_count += value;
+        } else if (name == kIOCountRemote) {
+            _opts.stats->io_count_remote += value;
+            _opts.stats->io_count += value;
+        } else if (name == kIONsLocalDisk) {
+            _opts.stats->io_ns_local_disk += value;
+        } else if (name == kIONsRemote) {
+            _opts.stats->io_ns_remote += value;
+        }
+    }
+}
+
 void SegmentIterator::close() {
     if (_del_vec) {
         _del_vec.reset();
@@ -1626,6 +1664,8 @@ void SegmentIterator::close() {
     _column_decoders.clear();
 
     for (auto& [cid, rfile] : _column_files) {
+        // update statistics before reset column file
+        _update_stats(rfile.get());
         rfile.reset();
     }
 


### PR DESCRIPTION

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Use more accurate io statistics from starlet.

```
- IOStatistics: 2s379ms
   - CompressedBytesReadLocalDisk: 0.00   // compressed bytes actually read from local disk
   - CompressedBytesReadRemote: 40.00 MB  // compressed bytes actually read from remote
   - CompressedBytesReadRequest: 36.76 MB // compressed bytes read requested by BE
   - CompressedBytesReadTotal: 40.00 MB   // compressed bytes actually read total
   - IOCountLocalDisk: 0
   - IOCountRemote: 320
   - IOCountRequest: 3.7K (3700)
   - IOCountTotal: 320
   - IOTimeLocalDisk: 0ns
   - IOTimeRemote: 2s189ms
   - IOTimeTotal: 2s379ms
   - PagesCountLocalDisk: 0
   - PagesCountMemory: 0
   - PagesCountRemote: 3.7K (3700)
   - PagesCountTotal: 3.7K (3700)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
