### PR TITLE
[BugFix] Fix the problem of updating GroupExpression's op or inputs without re-inserting it

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -339,7 +339,8 @@ public class Memo {
         GroupExpression initGroupExpression = group.getFirstLogicalExpression();
         // This remove must be successful, otherwise GroupExpression::op or GroupExpression::inputs
         // may be updated without re-inserted.
-        Preconditions.checkNotNull(groupExpressions.remove(initGroupExpression));
+        Preconditions.checkNotNull(groupExpressions.remove(initGroupExpression),
+                "GroupExpression has been updated without re-inserting");
 
         Preconditions.checkState(group.isValidInitState());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer;
 
 import com.google.common.base.Preconditions;
@@ -338,7 +337,9 @@ public class Memo {
 
     private void removeGroupInitLogicExpression(Group group) {
         GroupExpression initGroupExpression = group.getFirstLogicalExpression();
-        groupExpressions.remove(initGroupExpression);
+        // This remove must be successful, otherwise GroupExpression::op or GroupExpression::inputs
+        // may be updated without re-inserted.
+        Preconditions.checkNotNull(groupExpressions.remove(initGroupExpression));
 
         Preconditions.checkState(group.isValidInitState());
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`PruneUnionColumnsRule` updates the `LogicalUnionOperator` directly without creating a new OptExpression. This may cause problems in branch 2.2-2.4, where `Memo` is initialized before logical rewrite and GroupExpression is used as hash key.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
