### PR TITLE
[BugFix] MergeLimitDirectRule prohibits RewriteMultiDistinctByCTERule from taking effects

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitDirectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitDirectRule.java
@@ -19,13 +19,17 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class MergeLimitDirectRule extends TransformationRule {
     public static final MergeLimitDirectRule AGGREGATE = new MergeLimitDirectRule(OperatorType.LOGICAL_AGGR);
@@ -55,7 +59,19 @@ public class MergeLimitDirectRule extends TransformationRule {
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
-        return limit.isLocal();
+        Operator op = input.inputAt(0).getOp();
+        // Merging limit into AggregateOperator with multi distinct aggregations prohibits
+        // RewriteMultiDistinctByCTERule from transform such a AggregateOperator into MulticastSink+HashJoin or
+        // MulticastSink+NestLoopJoin Plan.
+        if (op instanceof LogicalAggregationOperator) {
+            LogicalAggregationOperator aggOp = op.cast();
+            List<CallOperator> distinctAggOperatorList = aggOp.getAggregations().values().stream()
+                    .filter(CallOperator::isDistinct).collect(Collectors.toList());
+            boolean hasMultiColumns = distinctAggOperatorList.stream().anyMatch(f -> f.getChildren().size() > 1);
+            return (!hasMultiColumns || distinctAggOperatorList.size() > 1) && limit.isLocal();
+        } else {
+            return limit.isLocal();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -349,7 +349,13 @@ public class SelectStmtTest {
         String[] sqlList = {
                 "select count(distinct k1, k2), count(distinct k3) from db1.tbl1 limit 1",
                 "select * from (select count(distinct k1, k2), count(distinct k3) from db1.tbl1) t1 limit 1",
-                "with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1) select * from t1 limit 1",
+                "with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1) " +
+                        "select * from t1 limit 1",
+                "select count(distinct k1, k2), count(distinct k3) from db1.tbl1 group by k4 limit 1",
+                "select * from (select count(distinct k1, k2), count(distinct k3) from db1.tbl1 group by k4, k3) t1" +
+                        " limit 1",
+                "with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1 " +
+                        "group by k2, k3, k4) select * from t1 limit 1",
         };
         boolean cboCteReuse = starRocksAssert.getCtx().getSessionVariable().isCboCteReuse();
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -343,4 +343,27 @@ public class SelectStmtTest {
             Assert.fail("Should not throw an exception");
         }
     }
+
+    @Test
+    public void testMultiDistinctMultiColumnWithLimit() throws Exception {
+        String[] sqlList = {
+                "select count(distinct k1, k2), count(distinct k3) from db1.tbl1 limit 1",
+                "select * from (select count(distinct k1, k2), count(distinct k3) from db1.tbl1) t1 limit 1",
+                "with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1) select * from t1 limit 1",
+        };
+        boolean cboCteReuse = starRocksAssert.getCtx().getSessionVariable().isCboCteReuse();
+        try {
+            starRocksAssert.getCtx().getSessionVariable().setCboCteReuse(true);
+            for (String sql : sqlList) {
+                UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            }
+            starRocksAssert.getCtx().getSessionVariable().setCboCteReuse(false);
+            for (String sql : sqlList) {
+                UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            }
+
+        } finally {
+            starRocksAssert.getCtx().getSessionVariable().setCboCteReuse(cboCteReuse);
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/StarRocks/starrocks/issues/21777
MergeLimitDirectRule merges limit into AggregateOperator with multi distinct aggregations among which there are at least one aggregation's argument is multicolumn. for an example "select count(distinct a,b), count(distint c) from t limit 10 ".

RewriteMultiDistinctByCTERule  fails to break such a AggregationOperator into MulticastSink+Join(HashJoin for group-by agg, NestLoopJoin for non-group-by agg).

Later SplitAggRule fails to tackle with this AggregationOeprator.
```java
    private void checkDistinctAgg(List<CallOperator> distinctAggCallOperator) {
        List<ScalarOperator> distinctChild0 = distinctAggCallOperator.get(0).getChildren();
        for (int i = 1; i < distinctAggCallOperator.size(); ++i) {
            List<ScalarOperator> distinctChildI = distinctAggCallOperator.get(i).getChildren();
            if (!distinctChild0.equals(distinctChildI)) {
                throw new StarRocksPlannerException("The query contains multi count distinct or " +
                        "sum distinct, each can't have multi columns.", ErrorType.USER_ERROR);
            }
        }
    }
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
