### PR TITLE
[BugFix] Fix wrong schema when hash join enable auto-spill 

### DIFF
--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -17,7 +17,10 @@
 #include <column/chunk.h>
 #include <runtime/descriptors.h>
 
+#include <memory>
+
 #include "column/vectorized_fwd.h"
+#include "common/statusor.h"
 #include "exec/hash_join_node.h"
 #include "serde/column_array_serde.h"
 #include "simd/simd.h"
@@ -502,6 +505,22 @@ void JoinHashTable::append_chunk(RuntimeState* state, const ChunkPtr& chunk, con
     }
 
     _table_items->row_count += chunk->num_rows();
+}
+
+StatusOr<ChunkPtr> JoinHashTable::convert_to_serialize_format(const ChunkPtr& chunk) const {
+    ChunkPtr output = std::make_shared<Chunk>();
+    //
+    for (size_t i = 0; i < _table_items->build_column_count; i++) {
+        SlotDescriptor* slot = _table_items->build_slots[i].slot;
+        const ColumnPtr& column = chunk->get_column_by_slot_id(slot->id());
+        output->append_column(column, slot->id());
+    }
+
+    if (_need_create_tuple_columns) {
+        return Status::NotSupported("unreachable path");
+    }
+
+    return output;
 }
 
 void JoinHashTable::remove_duplicate_index(Filter* filter) {

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -507,7 +507,7 @@ void JoinHashTable::append_chunk(RuntimeState* state, const ChunkPtr& chunk, con
     _table_items->row_count += chunk->num_rows();
 }
 
-StatusOr<ChunkPtr> JoinHashTable::convert_to_serialize_format(const ChunkPtr& chunk) const {
+StatusOr<ChunkPtr> JoinHashTable::convert_to_spill_schema(const ChunkPtr& chunk) const {
     ChunkPtr output = std::make_shared<Chunk>();
     //
     for (size_t i = 0; i < _table_items->build_column_count; i++) {

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -696,6 +696,8 @@ public:
     Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);
 
     void append_chunk(RuntimeState* state, const ChunkPtr& chunk, const Columns& key_columns);
+    // convert input column to serialize format for spill
+    StatusOr<ChunkPtr> convert_to_serialize_format(const ChunkPtr& chunk) const;
 
     const ChunkPtr& get_build_chunk() const { return _table_items->build_chunk; }
     Columns& get_key_columns() { return _table_items->key_columns; }

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -696,8 +696,8 @@ public:
     Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);
 
     void append_chunk(RuntimeState* state, const ChunkPtr& chunk, const Columns& key_columns);
-    // convert input column to serialize format for spill
-    StatusOr<ChunkPtr> convert_to_serialize_format(const ChunkPtr& chunk) const;
+    // convert input column to spill schema order
+    StatusOr<ChunkPtr> convert_to_spill_schema(const ChunkPtr& chunk) const;
 
     const ChunkPtr& get_build_chunk() const { return _table_items->build_chunk; }
     Columns& get_key_columns() { return _table_items->key_columns; }

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -54,6 +54,7 @@ bool SpillableHashJoinBuildOperator::need_input() const {
 
 Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
     if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
+        _join_builder->spill_channel()->set_finishing();
         return HashJoinBuildOperator::set_finishing(state);
     }
 
@@ -159,7 +160,7 @@ Status SpillableHashJoinBuildOperator::push_chunk(RuntimeState* state, const Chu
     // TODO: materialize chunk (const/nullable)
 
     auto& ht = _join_builder->hash_join_builder()->hash_table();
-    ASSIGN_OR_RETURN(auto spill_chunk, ht.convert_to_serialize_format(chunk));
+    ASSIGN_OR_RETURN(auto spill_chunk, ht.convert_to_spill_schema(chunk));
     RETURN_IF_ERROR(append_hash_columns(spill_chunk));
 
     RETURN_IF_ERROR(_join_builder->append_chunk_to_spill_buffer(state, spill_chunk));

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -158,9 +158,11 @@ Status SpillableHashJoinBuildOperator::push_chunk(RuntimeState* state, const Chu
 
     // TODO: materialize chunk (const/nullable)
 
-    RETURN_IF_ERROR(append_hash_columns(chunk));
+    auto& ht = _join_builder->hash_join_builder()->hash_table();
+    ASSIGN_OR_RETURN(auto spill_chunk, ht.convert_to_serialize_format(chunk));
+    RETURN_IF_ERROR(append_hash_columns(spill_chunk));
 
-    RETURN_IF_ERROR(_join_builder->append_chunk_to_spill_buffer(state, chunk));
+    RETURN_IF_ERROR(_join_builder->append_chunk_to_spill_buffer(state, spill_chunk));
 
     if (_is_first_time_spill) {
         _is_first_time_spill = false;
@@ -185,7 +187,7 @@ std::function<StatusOr<ChunkPtr>()> SpillableHashJoinBuildOperator::_convert_has
     _hash_table_build_chunk_slice.reset(build_chunk);
     _hash_table_build_chunk_slice.skip(kHashJoinKeyColumnOffset);
 
-    return [this]() mutable -> StatusOr<ChunkPtr> {
+    return [this]() -> StatusOr<ChunkPtr> {
         if (_hash_table_build_chunk_slice.empty()) {
             _join_builder->hash_join_builder()->reset(_join_builder->hash_table_param());
             return Status::EndOfFile("eos");

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -50,6 +50,7 @@ Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
     if (state->is_cancelled()) {
         _is_finished = true;
         _chunks_sorter->cancel();
+        _chunks_sorter->spill_channel()->set_finishing();
         return Status::Cancelled("runtime state is cancelled");
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #
```
*** Aborted at 1681819387 (unix time) try "date -d @1681819387" if you are using GNU date ***
PC: @          0x32701b0 starrocks::BinaryColumnBase<>::append_selective()
*** SIGSEGV (@0x58) received by PID 861673 (TID 0x7fb9c1428640) from PID 88; stack trace: ***
    @          0x691fd5a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fbb13bbb520 (unknown)
    @          0x32701b0 starrocks::BinaryColumnBase<>::append_selective()
    @          0x31e7dea starrocks::Chunk::append_selective()
    @          0x3a718be starrocks::spill::UnorderedMemTable::append_selective()
    @          0x3670b04 _ZN9starrocks5spill24PartitionedSpillerWriter22process_partition_dataIZNS1_5spillIRNS0_14IOTaskExecutorERNS0_15MemTrackerGuardEEENS_6StatusEPNS_12RuntimeStateERKSt10shared_ptrINS_5ChunkEEOT_OT0_EUlPNS0_16SpilledPartitionERKSt6vectorIjSaIjEEiiE_EEvSF_SQ_SH_
    @          0x3670e11 starrocks::spill::PartitionedSpillerWriter::spill<>()
    @          0x36711ca starrocks::spill::Spiller::spill<>()
    @          0x35653fd starrocks::HashJoiner::append_spill_task()
    @          0x39e4fb0 starrocks::pipeline::SpillableHashJoinBuildOperator::push_chunk()
    @          0x3984ed4 starrocks::pipeline::PipelineDriver::process()
    @          0x3973c30 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x5a8e2db starrocks::ThreadPool::dispatch_thread()
    @          0x5a88a2a starrocks::Thread::supervise_thread()
    @     0x7fbb13c0db43 (unknown)
    @     0x7fbb13c9fa00 (unknown)
    @                0x0 (unknown)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
