### PR TITLE
[Enhancement] Improve the tablet scheduler logic  (#20785)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -301,10 +301,10 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             throws SchedException {
         TabletScheduler.PathSlot srcBePathSlot = backendsWorkingSlots.get(beId);
         if (srcBePathSlot == null) {
-            throw new SchedException(SchedException.Status.UNRECOVERABLE, "working slots not exist for src be");
+            throw new SchedException(SchedException.Status.UNRECOVERABLE, "working slots not exist for be: " + beId);
         }
         if (srcBePathSlot.takeSlot(pathHash) == -1) {
-            throw new SchedException(SchedException.Status.SCHEDULE_FAILED, "path busy, wait for next round");
+            throw new SchedException(SchedException.Status.SCHEDULE_RETRY, "path busy, wait for next round");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/SchedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/SchedException.java
@@ -25,8 +25,7 @@ public class SchedException extends Exception {
     private static final long serialVersionUID = 4233856721704062083L;
 
     public enum Status {
-        SCHEDULE_FAILED, // failed to schedule the tablet, this should only happen in scheduling pending tablets.
-        RUNNING_FAILED, // failed to running the clone task, this should only happen in handling running tablets.
+        SCHEDULE_RETRY, // there are some resource unavailable or wait for something to happen, retry for the next schedule round
         UNRECOVERABLE, // unable to go on, the tablet should be removed from tablet scheduler.
         FINISHED // schedule is done, remove the tablet from tablet scheduler with status FINISHED
     }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
@@ -6,7 +6,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Random;
@@ -32,8 +31,6 @@ public class DecommissionTest {
         PseudoCluster.getInstance().shutdown(false);
     }
 
-    //TODO: this ut will fail when the system load is high.
-    @Ignore
     @Test
     public void testDecommission() throws Exception {
         PseudoCluster cluster = PseudoCluster.getInstance();


### PR DESCRIPTION
There are 4 schedule state `SCHEDULE_FAILED, RUNNING_FAILED, UNRECOVERABLE, FINISHED` in the tablet scheduler. For the state: SCHEDULE_FAILED and RUNNING_FAILED, the scheduler will retry schedule that tablet(10 times for balance, endless for repair), but at most cases, retry will fail again, for example: there is no healthy replica or the data on backend is disrupted. 

1. Change the schedule state to UNRECOVERABLE in some cases. 
2. Merge `SCHEDULE_FAILED` and `RUNNING_FAILED` to `SCHEDULE_RETRY`.