### PR TITLE
[Enhancement] Support creating mv:  the refresh start time is before current time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.scheduler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -137,12 +138,8 @@ public class TaskManager {
             long period = TimeUtils.convertTimeUnitValueToSecond(taskSchedule.getPeriod(),
                     taskSchedule.getTimeUnit());
             LocalDateTime startTime = Utils.getDatetimeFromLong(taskSchedule.getStartTime());
-            Duration duration = Duration.between(LocalDateTime.now(), startTime);
-            long initialDelay = duration.getSeconds();
-            // if startTime < now, start scheduling from the next period
-            if (initialDelay < 0) {
-                initialDelay = ((initialDelay % period) + period) % period;
-            }
+            LocalDateTime scheduleTime = LocalDateTime.now();
+            long initialDelay = getInitialDelayTime(period, startTime, scheduleTime);
             // Tasks that run automatically have the lowest priority,
             // but are automatically merged if they are found to be merge-able.
             ExecuteOption option = new ExecuteOption(Constants.TaskRunPriority.LOWEST.value(),
@@ -151,6 +148,19 @@ public class TaskManager {
                             executeTask(task.getName(), option), initialDelay,
                     period, TimeUnit.SECONDS);
             periodFutureMap.put(task.getId(), future);
+        }
+    }
+
+    @VisibleForTesting
+    static long getInitialDelayTime(long period, LocalDateTime startTime,
+                                    LocalDateTime scheduleTime) {
+        Duration duration = Duration.between(scheduleTime, startTime);
+        long initialDelay = duration.getSeconds();
+        // if startTime < now, start scheduling from the next period
+        if (initialDelay < 0) {
+            return ((initialDelay % period) + period) % period;
+        } else {
+            return initialDelay;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -121,9 +121,6 @@ public interface ParserErrorMsg {
     @BaseMessage("Binary literal can only contain hexadecimal digits and an even number of digits")
     String invalidBinaryFormat();
 
-    @BaseMessage("Refresh start time must be after current time")
-    String invalidStartTime();
-
     @BaseMessage("Invalid map format, which should be key:value")
     String invalidMapFormat();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5947,9 +5947,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                     dateTimeFormatter = DateUtils.probeFormat(stringLiteral.getStringValue());
                     LocalDateTime tempStartTime = DateUtils.
                             parseStringWithDefaultHSM(stringLiteral.getStringValue(), dateTimeFormatter);
-                    if (tempStartTime.isBefore(LocalDateTime.now())) {
-                        throw new ParsingException(PARSER_ERROR_MSG.invalidStartTime(), timePos);
-                    }
                     startTime = tempStartTime;
                     defineStartTime = true;
                 } catch (AnalysisException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1298,9 +1298,13 @@ public class CreateMaterializedViewTest {
                 ") " +
                 "as select tbl1.k1 ss, k2 from tbl1;";
         try {
-            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            CreateMaterializedViewStatement createMaterializedViewStatement =
+                    (CreateMaterializedViewStatement) statementBase;
+            RefreshSchemeDesc refreshSchemeDesc = createMaterializedViewStatement.getRefreshSchemeDesc();
+            Assert.assertEquals(MaterializedView.RefreshType.ASYNC, refreshSchemeDesc.getType());
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains("Refresh start time must be after current time"));
+            Assert.fail(e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -48,8 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.PriorityBlockingQueue;
 
-import static com.starrocks.sql.optimizer.Utils.getDatetimeFromLong;
-
 public class TaskManagerTest {
 
     private static final Logger LOG = LogManager.getLogger(TaskManagerTest.class);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -16,8 +16,10 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.Queues;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -39,9 +41,14 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.PriorityBlockingQueue;
+
+import static com.starrocks.sql.optimizer.Utils.getDatetimeFromLong;
 
 public class TaskManagerTest {
 
@@ -395,4 +402,20 @@ public class TaskManagerTest {
 
     }
 
+    private LocalDateTime parseLocalDateTime(String str) throws Exception {
+        Date date = TimeUtils.parseDate(str, PrimitiveType.DATETIME);
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+    }
+
+    @Test
+    public void testGetInitialDelayTime() throws Exception {
+        Assert.assertEquals(50, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:50"),
+                parseLocalDateTime("2023-04-18 20:00:00")));
+        Assert.assertEquals(30, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
+                parseLocalDateTime("2023-04-18 20:00:00")));
+        Assert.assertEquals(20, TaskManager.getInitialDelayTime(60, parseLocalDateTime("2023-04-18 19:08:30"),
+                parseLocalDateTime("2023-04-18 20:00:10")));
+        Assert.assertEquals(0, TaskManager.getInitialDelayTime(20, parseLocalDateTime("2023-04-18 19:08:30"),
+                parseLocalDateTime("2023-04-18 21:00:10")));
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
- `Refresh start time must be after current time` is always a trouble for users to define a timestamp which must be after the current time, we can support the refresh time after the current time just by using the nearest period from the defined start time.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
