### PR TITLE
[BugFix] make wait for version timeout smaller than exec_plan_fragment rpc timeout (backport #18838)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2030,7 +2030,7 @@ Status TabletUpdates::get_applied_rowsets(int64_t version, std::vector<RowsetSha
                            _tablet.tablet_id(), _error_msg));
     }
     // TODO(cbl): optimize: following code lock _lock twice, should make it just lock once
-    RETURN_IF_ERROR(_wait_for_version(EditVersion(version, 0), 60000));
+    RETURN_IF_ERROR(_wait_for_version(EditVersion(version, 0), 55000));
     std::lock_guard rl(_lock);
     if (_edit_version_infos.empty()) {
         string msg = Substitute("tablet deleted when get_applied_rowsets tablet:$0", _tablet.tablet_id());


### PR DESCRIPTION
…t rpc timeout (backport #18838)

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
