### PR TITLE
[Enhancement] Choose big size tablet in high priority to balance cluster disk

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -5,7 +5,6 @@ package com.starrocks.clone;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
@@ -759,13 +758,13 @@ public class DiskAndTabletLoadReBalancerTest {
         Assert.assertEquals((Integer) 4, hState.pathSortIndex.get(pathHash14));
         Assert.assertEquals(10 * tabletDataSize, hState.usedCapacity);
 
-        List<Long> highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        List<Long> highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(1, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId1, highLoadPaths.get(0));
 
         // change threshold to 0.3, tabletId2 will be chosen
         Config.tablet_sched_balance_load_score_threshold = 0.3;
-        highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(2, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId1, highLoadPaths.get(0));
         Assert.assertEquals((Long) tabletId2, highLoadPaths.get(1));
@@ -782,7 +781,7 @@ public class DiskAndTabletLoadReBalancerTest {
         Assert.assertEquals((Integer) 2, hState.pathSortIndex.get(pathHash13));
         Assert.assertEquals(6 * tabletDataSize, hState.usedCapacity);
         // only tabletId2 will be chosen
-        highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(1, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId2, highLoadPaths.get(0));
 


### PR DESCRIPTION
Choose the big size tablet to balance cluster disk, so that the cluster can reach to the balance state faster, and easier to retain the balanced distribution of tablet.

Sort the partitions by average tablet size in desc order for the same skew , and sort the tablet in every partition by size in desc order.

Signed-off-by: gengjun-git <gengjun@starrocks.com>
