### PR TITLE
[Enhancement] Choose big size tablet in high priority to balance cluster disk

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -46,7 +46,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -501,9 +501,9 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             for (int round = 1; round <= 2; round++) {
                 PARTITION:
                 for (Pair<Long, Long> partitionMVId : hState.sortedPartitions) {
-                    Set<Long> hPartitionTablets = hState.partitionTablets.get(partitionMVId);
-                    Set<Long> lPartitionTablets = lState.partitionTablets.computeIfAbsent(partitionMVId,
-                            pmId -> new HashSet<>());
+                    List<Long> hPartitionTablets = hState.partitionTablets.get(partitionMVId);
+                    List<Long> lPartitionTablets = lState.partitionTablets.computeIfAbsent(partitionMVId,
+                            pmId -> new LinkedList<>());
                     int replicaTotalCnt = partitionReplicaCnt.getOrDefault(partitionMVId.first, 0);
                     int slotOfHighBE = hPartitionTablets.size() - (replicaTotalCnt / beStats.size());
                     int slotOfLowBE = ((replicaTotalCnt + beStats.size() - 1) / beStats.size())
@@ -1642,6 +1642,10 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                                                        int backendCnt,
                                                        boolean sortPartition) {
         Map<Pair<Long, Long>, Set<Long>> partitionTablets = getPartitionTablets(backendId, medium, -1L);
+        Map<Pair<Long, Long>, List<Long>> partitionTabletList = new HashMap<>();
+        for (Map.Entry<Pair<Long, Long>, Set<Long>> entry : partitionTablets.entrySet()) {
+            partitionTabletList.put(entry.getKey(), new LinkedList<>(entry.getValue()));
+        }
         Map<Pair<Long, Long>, Double> partitionAvgReplicaSize = getPartitionAvgReplicaSize(backendId, partitionTablets);
         List<Pair<Long, Long>> partitions = new ArrayList<>(partitionTablets.keySet());
         if (sortPartition) {
@@ -1658,13 +1662,25 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                     return Double.compare(partitionAvgReplicaSize.get(p2), partitionAvgReplicaSize.get(p1));
                 }
             });
+
+            for (List<Long> tabletList : partitionTabletList.values()) {
+                if (tabletList.size() <= 1) {
+                    continue;
+                }
+                tabletList.sort((t1, t2) -> {
+                    Replica replica1 = invertedIndex.getReplica(t1, backendId);
+                    Replica replica2 = invertedIndex.getReplica(t2, backendId);
+                    return Long.compare(replica2 == null ? 0L : replica2.getDataSize(),
+                            replica1 == null ? 0L : replica1.getDataSize());
+                });
+            }
         }
 
         BackendBalanceState backendBalanceState = new BackendBalanceState(backendId,
                 backendLoadStatistic,
                 invertedIndex,
                 medium,
-                partitionTablets,
+                partitionTabletList,
                 partitions);
         backendBalanceState.init();
         return backendBalanceState;
@@ -1789,7 +1805,8 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         List<Pair<Long, Long>> sortedPartitions;
         TabletInvertedIndex tabletInvertedIndex;
         // <partitionId, mvId> => tablets in that partition
-        Map<Pair<Long, Long>, Set<Long>> partitionTablets;
+        // tablets is sorted by data size in desc order for the BE in high load group
+        Map<Pair<Long, Long>, List<Long>> partitionTablets;
         // total data used capacity
         long usedCapacity;
         // pathHash => usedCapacity
@@ -1806,7 +1823,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                             BackendLoadStatistic statistic,
                             TabletInvertedIndex tabletInvertedIndex,
                             TStorageMedium medium,
-                            Map<Pair<Long, Long>, Set<Long>> partitionTablets,
+                            Map<Pair<Long, Long>, List<Long>> partitionTablets,
                             List<Pair<Long, Long>> partitions) {
             this.backendId = backendId;
             this.statistic = statistic;
@@ -1860,7 +1877,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         }
 
         // used for high load group
-        public List<Long> getTabletsInHighLoadPath(Set<Long> tablets) {
+        public List<Long> getTabletsInHighLoadPath(List<Long> tablets) {
             double avgUsedPercent = pathUsedCapacity.values().stream().mapToLong(Long::longValue).sum()
                     / (double) statistic.getTotalCapacityB(medium);
             // find the last high load index, we only choose tablet in the high load paths

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -18,7 +18,6 @@ package com.starrocks.clone;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
@@ -772,13 +771,13 @@ public class DiskAndTabletLoadReBalancerTest {
         Assert.assertEquals((Integer) 4, hState.pathSortIndex.get(pathHash14));
         Assert.assertEquals(10 * tabletDataSize, hState.usedCapacity);
 
-        List<Long> highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        List<Long> highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(1, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId1, highLoadPaths.get(0));
 
         // change threshold to 0.3, tabletId2 will be chosen
         Config.tablet_sched_balance_load_score_threshold = 0.3;
-        highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(2, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId1, highLoadPaths.get(0));
         Assert.assertEquals((Long) tabletId2, highLoadPaths.get(1));
@@ -795,7 +794,7 @@ public class DiskAndTabletLoadReBalancerTest {
         Assert.assertEquals((Integer) 2, hState.pathSortIndex.get(pathHash13));
         Assert.assertEquals(6 * tabletDataSize, hState.usedCapacity);
         // only tabletId2 will be chosen
-        highLoadPaths = hState.getTabletsInHighLoadPath(Sets.newHashSet(tabletId1, tabletId2));
+        highLoadPaths = hState.getTabletsInHighLoadPath(Lists.newArrayList(tabletId1, tabletId2));
         Assert.assertEquals(1, highLoadPaths.size());
         Assert.assertEquals((Long) tabletId2, highLoadPaths.get(0));
 


### PR DESCRIPTION
Choose the big size tablet to balance cluster disk, so that the cluster can reach to the balance state faster, and easier to retain the balanced distribution of tablet.

Sort the partitions by average tablet size in desc order for the same skew , and sort the tablet in every partition by size in desc order.

Signed-off-by: gengjun-git <gengjun@starrocks.com>
