### PR TITLE
[Feature] Introduce safe mode for starrocks cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2190,6 +2190,18 @@ public class Config extends ConfigBase {
     public static long binlog_max_size = Long.MAX_VALUE; // no limit
 
     /**
+     * Enable check if the cluster is under safe mode or not
+     **/
+    @ConfField(mutable = true)
+    public static boolean enable_safe_mode_check = true;
+
+    /**
+     * The safe mode checker thread work interval
+     */
+    @ConfField(mutable = true)
+    public static long safe_mode_checker_interval_sec = 5;
+
+    /**
      * Enable auto create tablet when creating table and add partition
      **/
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/healthchecker/SafeModeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/healthchecker/SafeModeChecker.java
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/http/rest/HealthAction.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.starrocks.healthchecker;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.LeaderDaemon;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public class SafeModeChecker extends LeaderDaemon {
+    private static final Logger LOG = LogManager.getLogger(SafeModeChecker.class);
+
+    public SafeModeChecker() {
+        super("safe mode checker", Config.safe_mode_checker_interval_sec * 1000);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        // update interval
+        if (getInterval() != Config.safe_mode_checker_interval_sec * 1000) {
+            setInterval(Config.safe_mode_checker_interval_sec * 1000);
+        }
+
+        checkInternal();
+    }
+
+    @VisibleForTesting
+    protected boolean checkInternal() {
+        List<Backend> backendList = GlobalStateMgr.getCurrentSystemInfo().getBackends();
+        for (Backend be : backendList) {
+            // We assume that the cluster is always in balance, once we find that
+            // the left space of one disk less than min(0.9 * disk_capacity, 50GB),
+            // we should enter safe mode
+            if (be.isAlive()) {
+                for (DiskInfo diskInfo : be.getDisks().values()) {
+                    double safeModeCheckDiskCapacity = Math.min(
+                            0.9 * diskInfo.getTotalCapacityB(), 53687091200L);
+                    if (diskInfo.getAvailableCapacityB() < safeModeCheckDiskCapacity) {
+                        if (!GlobalStateMgr.getCurrentState().isSafeMode()) {
+                            String warnMsg = String.format(
+                                    "The cluster is entering safe mode since left disk space of %d" +
+                                            " is %d. The load jobs will fail with exception.",
+                                    be.getId(),
+                                    diskInfo.getAvailableCapacityB());
+                            LOG.warn(warnMsg);
+
+                            // set safe mode flag to disable load jobs
+                            GlobalStateMgr.getCurrentState().setSafeMode(true);
+
+                            // abort all running transactions
+                            try {
+                                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                                        .abortAllRunningTransactions();
+                            } catch (Exception e) {
+                                LOG.error("Abort transactions failed with exceptions!", e);
+                            }
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // cluster state is healthy, exit safe mode
+        if (GlobalStateMgr.getCurrentState().isSafeMode()) {
+            LOG.info("The cluster exit safe mode");
+            GlobalStateMgr.getCurrentState().setSafeMode(false);
+        }
+        return false;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -37,6 +37,7 @@ package com.starrocks.metric;
 import com.starrocks.common.Config;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
+import com.starrocks.server.GlobalStateMgr;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -145,5 +146,7 @@ public class MetricCalculator extends TimerTask {
         if (Config.enable_routine_load_lag_metrics)  {
             MetricRepo.updateRoutineLoadProcessMetrics();
         }
+
+        MetricRepo.GAUGE_SAFE_MODE.setValue(GlobalStateMgr.getCurrentState().isSafeMode() ? 1 : 0);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -145,6 +145,9 @@ public final class MetricRepo {
 
     public static List<GaugeMetricImpl<Long>> GAUGE_ROUTINE_LOAD_LAGS;
 
+    // Currently, we use gauge for safe mode metrics, since we do not have unTyped metrics till now
+    public static GaugeMetricImpl<Integer> GAUGE_SAFE_MODE;
+
     private static final ScheduledThreadPoolExecutor METRIC_TIMER =
             ThreadPoolManager.newDaemonScheduledThreadPool(1, "Metric-Timer-Pool", true);
     private static final MetricCalculator METRIC_CALCULATOR = new MetricCalculator();
@@ -340,6 +343,11 @@ public final class MetricRepo {
         GAUGE_QUERY_LATENCY_P999.addLabel(new MetricLabel("type", "999_quantile"));
         GAUGE_QUERY_LATENCY_P999.setValue(0.0);
         STARROCKS_METRIC_REGISTER.addMetric(GAUGE_QUERY_LATENCY_P999);
+
+        GAUGE_SAFE_MODE = new GaugeMetricImpl<>("safe_mode", MetricUnit.NOUNIT, "safe mode flag");
+        GAUGE_SAFE_MODE.addLabel(new MetricLabel("type", "safe_mode"));
+        GAUGE_SAFE_MODE.setValue(0);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_SAFE_MODE);
 
         // 2. counter
         COUNTER_REQUEST_ALL = new LongCounterMetric("request_total", MetricUnit.REQUESTS, "total request");

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1228,6 +1228,12 @@ public class DatabaseTransactionMgr {
         abortTransaction(transactionId, reason, null);
     }
 
+    public void abortAllRunningTransaction() throws UserException {
+        for (Map.Entry<Long, TransactionState> entry : idToRunningTransactionState.entrySet()) {
+            abortTransaction(entry.getKey(), "The cluster is under safe mode!", null);
+        }
+    }
+
     public void abortTransaction(long transactionId, String reason, TxnCommitAttachment txnCommitAttachment)
             throws UserException {
         abortTransaction(transactionId, true, reason, txnCommitAttachment, Lists.newArrayList());

--- a/fe/fe-core/src/test/java/com/starrocks/healthchecker/SafeModeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/healthchecker/SafeModeCheckerTest.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.healthchecker;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.DiskInfo;
+import com.starrocks.common.DdlException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SafeModeCheckerTest {
+
+    private SafeModeChecker safeModeChecker = new SafeModeChecker();
+    @Mocked GlobalStateMgr globalStateMgr;
+
+    Backend be = new Backend(-1000L, "", 0);
+
+    @Before
+    public void setUp() {
+        globalStateMgr.getClusterInfo().addBackend(be);
+        ImmutableMap<String, DiskInfo> disksRef;
+        DiskInfo diskInfo = new DiskInfo("");
+        diskInfo.setTotalCapacityB(100);
+        diskInfo.setAvailableCapacityB(5);
+        disksRef = ImmutableMap.of("", diskInfo);
+        be.setDisks(disksRef);
+        be.setAlive(true);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                GlobalStateMgr.getCurrentSystemInfo().getBackends();
+                minTimes = 0;
+                result = be;
+            }
+        };
+    }
+
+    @After
+    public void tearDown() throws DdlException {
+        GlobalStateMgr.getCurrentState().getClusterInfo().dropBackend(be);
+        GlobalStateMgr.getCurrentState().setSafeMode(false);
+    }
+
+    @Test
+    public void testSafeMode() {
+        assertEquals(true, safeModeChecker.checkInternal());
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In this pr, we introduced safe mode for StarRocks cluster.

does not consider trash now
introduce a fe config enable_safe_mode_check(default value is true)
The detailed explanation is as follows:

When the usage of one disk left space is less than Math.min(0.9 * diskInfo.getTotalCapacityB(), 53687091200L), it enters safe mode and does not allow any new load transactions to come in.
Other design tradeoffs:

We did not use the edit log to store the safe mode information but kept it directly in the memory of the FE leader node. Because the introduction of an edit log may face compatibility issues and some other corner cases related to FE metadata.

When we keep the safe mode state in the memory, if the leader is switched or restarted, startLeaderOnlyDaemonThreads will first execute a heartbeat task to obtain the status of the be node, and then execute the logic of the safe mode checker task. This ensures that there are no load jobs even if we restart FE or the leader switched.

If heartbeat task or safe mode checker was not executed, theoretically load manager will also not be available, so there will be no load jobs too.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
