### PR TITLE
[Enhancement] support implicit cast to boolean in predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -404,6 +404,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SQL_QUOTE_SHOW_CREATE = "sql_quote_show_create";
 
+    public static final String ENABLE_STRICT_TYPE = "enable_strict_type";
+
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1093,6 +1096,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableShowAllVariables(boolean enableShowAllVariables) {
         this.enableShowAllVariables = enableShowAllVariables;
     }
+
+    @VarAttr(name = ENABLE_STRICT_TYPE, flag = VariableMgr.INVISIBLE)
+    private boolean enableStrictType = false;
 
     public int getStatisticCollectParallelism() {
         return statisticCollectParallelism;
@@ -1968,6 +1974,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean getHDFSBackendSelectorScanRangeShuffle() {
         return hdfsBackendSelectorScanRangeShuffle;
+    }
+
+    public boolean isEnableStrictType() {
+        return enableStrictType;
+    }
+
+    public void setEnableStrictType(boolean val) {
+        this.enableStrictType = val;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -520,18 +520,17 @@ public class ExpressionAnalyzer {
 
         @Override
         public Void visitCompoundPredicate(CompoundPredicate node, Scope scope) {
+            node.setType(Type.BOOLEAN);
             for (int i = 0; i < node.getChildren().size(); i++) {
-                Type type = node.getChild(i).getType();
-                if (!type.isBoolean() && !type.isNull()) {
-                    String msg = String.format("Operand '%s' part of predicate " +
-                                    "'%s' should return type 'BOOLEAN' but returns type '%s'",
-                            AstToStringBuilder.toString(node), AstToStringBuilder.toString(node.getChild(i)),
-                            type.toSql());
-                    throw new SemanticException(msg, node.getChild(i).getPos());
+                Expr child = node.getChild(i);
+                if (child.getType().isBoolean() || child.getType().isNull()) {
+                    // do nothing
+                } else if (!session.getSessionVariable().isEnableStrictType() && Type.canCastTo(child.getType(), Type.BOOLEAN)) {
+                    node.getChildren().set(i, new CastExpr(Type.BOOLEAN, child));
+                } else {
+                    throw new SemanticException(child.toSql() + " can not be converted to boolean type.");
                 }
             }
-
-            node.setType(Type.BOOLEAN);
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -147,11 +147,11 @@ public class AnalyzeSingleTest {
         analyzeSuccess("select v1 from t0 where v1 = 1");
         analyzeSuccess("select v1 from t0 where v2 = 1 and v3 = 5");
         analyzeSuccess("select v1 from t0 where v1 = v2");
+        analyzeSuccess("select v1 from t0 where v2");
 
         analyzeFail("select v1 from t0 where sum(v2) > 1");
         analyzeFail("select v1 from t0 where error = 5");
         analyzeFail("select v1 from t0 where error = v1");
-        analyzeFail("select v1 from t0 where v2");
     }
 
     @Test
@@ -465,8 +465,7 @@ public class AnalyzeSingleTest {
     @Test
     public void testSqlMode() {
         ConnectContext connectContext = getConnectContext();
-        analyzeFail("select 'a' || 'b' from t0",
-                "Operand ''a' OR 'b'' part of predicate ''a'' should return type 'BOOLEAN'");
+        analyzeSuccess("select 'a' || 'b' from t0");
 
         StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse("select true || false from t0",
                 connectContext.getSessionVariable().getSqlMode()).get(0);
@@ -496,8 +495,7 @@ public class AnalyzeSingleTest {
                 "SELECT * FROM test.tall WHERE (test.tall.ta LIKE (concat('h', 'a', 'i'))) OR TRUE",
                 AstToStringBuilder.toString(statementBase));
 
-        analyzeFail("select * from  tall where ta like concat(\"h\", \"a\", \"i\")||'%'",
-                "LIKE (concat('h', 'a', 'i'))) OR '%'' part of predicate ''%'' should return type 'BOOLEAN'");
+        analyzeSuccess("select * from  tall where ta like concat(\"h\", \"a\", \"i\")||'%'");
 
         connectContext.getSessionVariable().setSqlMode(SqlModeHelper.MODE_SORT_NULLS_LAST);
         statementBase = SqlParser.parse("select * from  tall order by ta",


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
select * from tbl where case col1 when 'a' then 1 else false end and case col2 when 'a' then 1 else false end;
should success to execute.
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Currently, we support some implicit conversion capabilities, such as binary predicates, where we will convert the left and right operands to a common type that is compatible with both. However, in compound predicates, each operand must be a Boolean type. To gradually unify the behavior of implicit conversions, this pr perform implicit conversions on the children of compound predicates from bottom to top and add casts to expressions that can be cast to Boolean in the where clause. The reason for not modifying in the plan phase is that the analyze phase can more easily determine whether an expression is an expression in the where clause. For example, in select 1 from tbl where 1, the analyze phase can easily only change where 1 to where cast(1 as boolean) but do noting to select 1.

A session variable ENABLE_STRICT_TYPE has been added to control the behavior of strict type requirement, defaulting to false. Currently, it only controls the behavior of implicit type conversion in compound predicates and where clauses. In the future, it should be expanded to have the ability to control implicit type conversion universally.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
