### PR TITLE
[BugFix] AUTO_INCREMENT insert/load error when table has nullable column (#21846)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1968,9 +1968,9 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
         // update_column for auto increment column.
         if (_has_auto_increment && _auto_increment_slot_id == desc->id() && column_ptr->is_nullable()) {
             auto* nullable = down_cast<NullableColumn*>(column_ptr.get());
-            // If _null_expr_in_auto_increment == true, it means that user specify a null value in auto
-            // increment column, we abort the entire chunk and append a single error msg. Because be know
-            // nothing about whether this row is specified by the user as null or setted during planning.
+            // If nullable->has_null() && _null_expr_in_auto_increment == true, it means that user specify a
+            // null value in auto increment column, we abort the entire chunk and append a single error msg.
+            // Because be know nothing about whether this row is specified by the user as null or setted during planning.
             if (nullable->has_null() && _null_expr_in_auto_increment) {
                 std::stringstream ss;
                 ss << "NULL value in auto increment column '" << desc->col_name() << "'";

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -360,7 +360,9 @@ public class FileScanNode extends LoadScanNode {
                     } else if (defaultValueType == Column.DefaultValueType.NULL) {
                         if (column.isAllowNull() || column.isAutoIncrement()) {
                             expr = NullLiteral.create(column.getType());
-                            nullExprInAutoIncrement = false;
+                            if (column.isAutoIncrement()) {
+                                nullExprInAutoIncrement = false;
+                            }
                         } else {
                             throw new UserException("Unknown slot ref("
                                     + destSlotDesc.getColumn().getName() + ") in source file");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -292,7 +292,9 @@ public class StreamLoadScanNode extends LoadScanNode {
                     } else if (defaultValueType == Column.DefaultValueType.NULL) {
                         if (column.isAllowNull() || column.isAutoIncrement()) {
                             expr = NullLiteral.create(column.getType());
-                            nullExprInAutoIncrement = false;
+                            if (column.isAutoIncrement()) {
+                                nullExprInAutoIncrement = false;
+                            }
                         } else {
                             throw new AnalysisException("column has no source field, column=" + column.getName());
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -110,8 +110,7 @@ public class UpdatePlanner {
                 OlapTable olapTable = (OlapTable) table;
                 DataSink dataSink =
                         new OlapTableSink(olapTable, olapTuple, partitionIds, olapTable.writeQuorum(),
-                                olapTable.enableReplicatedStorage(), updateStmt.nullExprInAutoIncrement(),
-                                olapTable.supportedAutomaticPartition());
+                                olapTable.enableReplicatedStorage(), false, olapTable.supportedAutomaticPartition());
                 if (updateStmt.usePartialUpdate()) {
                     // using column mode partial update in UPDATE stmt
                     ((OlapTableSink) dataSink).setPartialUpdateMode(TPartialUpdateMode.COLUMN_MODE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
@@ -34,8 +34,6 @@ public class UpdateStmt extends DmlStmt {
     private Table table;
     private QueryStatement queryStatement;
 
-    private boolean nullExprInAutoIncrement;
-
     private boolean usePartialUpdate;
 
     public UpdateStmt(TableName tableName, List<ColumnAssignment> assignments, List<Relation> fromRelations,
@@ -51,7 +49,6 @@ public class UpdateStmt extends DmlStmt {
         this.fromRelations = fromRelations;
         this.wherePredicate = wherePredicate;
         this.commonTableExpressions = commonTableExpressions;
-        this.nullExprInAutoIncrement = true;
         this.assignmentColumns = Sets.newHashSet();
         for (ColumnAssignment each : assignments) {
             this.assignmentColumns.add(each.getColumn());
@@ -66,14 +63,6 @@ public class UpdateStmt extends DmlStmt {
     @Override
     public TableName getTableName() {
         return tableName;
-    }
-
-    public void setNullExprInAutoIncrement(boolean nullExprInAutoIncrement) {
-        this.nullExprInAutoIncrement = nullExprInAutoIncrement;
-    }
-
-    public boolean nullExprInAutoIncrement() {
-        return nullExprInAutoIncrement;
     }
 
     public List<ColumnAssignment> getAssignments() {

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -69,6 +69,51 @@ DROP TABLE t;
 DROP DATABASE test_create_table_normal_auto_increment;
 -- result:
 -- !result
+-- name: test_table_with_null
+CREATE DATABASE test_table_with_null;
+-- result:
+-- !result
+USE test_table_with_null;
+-- result:
+-- !result
+SET enable_insert_strict = false;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("empty_load_as_error" = "false");
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL AUTO_INCREMENT, job1 BIGINT NULL, job2 BIGINT NULL) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t (id, name, job1, job2) VALUES (1,DEFAULT,NULL,2);
+-- result:
+-- !result
+SELECT * FROM t;
+-- result:
+1	1	None	2
+-- !result
+INSERT INTO t (id, name, job1, job2) VALUES (1,NULL,NULL,2);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: AUTO_INCREMENT column: name must not be NULL.')
+-- !result
+INSERT INTO t VALUES (1,NULL,NULL,2);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: AUTO_INCREMENT column: name must not be NULL.')
+-- !result
+UPDATE t SET name = NULL where id = 1;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: AUTO_INCREMENT column: name must not be NULL.')
+-- !result
+SELECT * FROM t;
+-- result:
+1	1	None	2
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+DROP DATABASE test_table_with_null;
+-- result:
+-- !result
 -- name: test_update
 CREATE DATABASE test_update_auto_increment;
 -- result:

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -163,3 +163,25 @@ function: wait_alter_table_finish()
 
 DROP TABLE t;
 DROP DATABASE test_schema_change_auto_increment;
+
+-- name: test_table_with_null
+CREATE DATABASE test_table_with_null;
+USE test_table_with_null;
+
+SET enable_insert_strict = false;
+ADMIN SET FRONTEND CONFIG ("empty_load_as_error" = "false");
+
+CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL AUTO_INCREMENT, job1 BIGINT NULL, job2 BIGINT NULL) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+
+INSERT INTO t (id, name, job1, job2) VALUES (1,DEFAULT,NULL,2);
+SELECT * FROM t;
+
+INSERT INTO t (id, name, job1, job2) VALUES (1,NULL,NULL,2);
+INSERT INTO t VALUES (1,NULL,NULL,2);
+
+UPDATE t SET name = NULL where id = 1;
+
+SELECT * FROM t;
+
+DROP TABLE t;
+DROP DATABASE test_table_with_null;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21846

## Problem Summary(Required) ：
Problem:
Currently, we use nullExprInAutoIncrement to represent that if user specify null expression for auto increment column. But there is some bug for the nullExprInAutoIncrement

Insert:
If the table with auto increment column and other nullable column, the nullExprInAutoIncrement will be set even though the auto increment column is not set by null if user set null to the nullable column. This will cause insertion failure.

Load:
If the table with auto increment column and other nullable column. If user specify the NULL value for auto increment column explictly, and miss the nullable column, the load will be successfully finished but not cancel.This is unexpected behavior.

Solution:
1. Fix the nullExprInAutoIncrement problem.
2. refactor the code, throw exception when Insert/Update has nullExprInAutoIncrement == true

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
