### PR TITLE
[BugFix] forbid creating mv in information_schema db

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/InfoSchemaDb.java
@@ -71,6 +71,11 @@ public class InfoSchemaDb extends Database {
     }
 
     @Override
+    public boolean createMaterializedWithLock(MaterializedView materializedView, boolean isReplay) {
+        return false;
+    }
+
+    @Override
     public void write(DataOutput out) throws IOException {
         // Do nothing
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/InfoSchemaDbTest.java
@@ -45,6 +45,7 @@ public class InfoSchemaDbTest {
         Database db = new InfoSchemaDb();
 
         Assert.assertFalse(db.createTable(null));
+        Assert.assertFalse(db.createMaterializedWithLock(null, false));
         Assert.assertFalse(db.createTableWithLock(null, false));
         db.dropTable("authors");
         db.dropTableWithLock("authors");


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
information_schema is a special db,  no real table in it , no state change  in fe meta ,  so creating mv in information_schema db can cause some strange problem about meta.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
