### PR TITLE
[Enhancement] Add system table be_cloud_native_compactions

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -130,6 +130,7 @@ set(EXEC_FILES
     schema_scanner/schema_fe_tablet_schedules_scanner.cpp
     schema_scanner/schema_be_compactions_scanner.cpp
     schema_scanner/schema_be_bvars_scanner.cpp
+    schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
     schema_scanner/schema_helper.cpp
     jdbc_scanner.cpp
     sorting/compare_column.cpp

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -16,6 +16,7 @@
 
 #include "column/type_traits.h"
 #include "exec/schema_scanner/schema_be_bvars_scanner.h"
+#include "exec/schema_scanner/schema_be_cloud_native_compactions_scanner.h"
 #include "exec/schema_scanner/schema_be_compactions_scanner.h"
 #include "exec/schema_scanner/schema_be_configs_scanner.h"
 #include "exec/schema_scanner/schema_be_logs_scanner.h"
@@ -147,6 +148,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaBeCompactionsScanner>();
     case TSchemaTableType::SCH_BE_BVARS:
         return std::make_unique<SchemaBeBvarsScanner>();
+    case TSchemaTableType::SCH_BE_CLOUD_NATIVE_COMPACTIONS:
+        return std::make_unique<SchemaBeCloudNativeCompactionsScanner>();
     default:
         return std::make_unique<SchemaDummyScanner>();
     }

--- a/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
@@ -1,0 +1,156 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_be_cloud_native_compactions_scanner.h"
+
+#include "agent/master_info.h"
+#include "exec/schema_scanner/schema_helper.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/datetime_value.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "runtime/string_value.h"
+#include "storage/compaction_manager.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/storage_engine.h"
+#include "types/logical_type.h"
+#include "util/metrics.h"
+#include "util/starrocks_metrics.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaBeCloudNativeCompactionsScanner::_s_columns[] = {
+        {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"TXN_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"TABLET_ID", TYPE_BIGINT, sizeof(int64_t), false},
+        {"VERSION", TYPE_BIGINT, sizeof(int64_t), false},
+        {"SKIPPED", TYPE_BOOLEAN, sizeof(bool), false},
+        {"RUNS", TYPE_INT, sizeof(int), false},
+        {"START_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
+        {"FINISH_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
+        {"PROGRESS", TYPE_INT, sizeof(int32_t), false},
+        {"Status", TYPE_VARCHAR, sizeof(StringValue), false}};
+
+SchemaBeCloudNativeCompactionsScanner::SchemaBeCloudNativeCompactionsScanner()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeCloudNativeCompactionsScanner::~SchemaBeCloudNativeCompactionsScanner() = default;
+
+Status SchemaBeCloudNativeCompactionsScanner::start(RuntimeState* state) {
+    auto o_id = get_backend_id();
+    _be_id = o_id.has_value() ? o_id.value() : -1;
+    _infos.clear();
+    _cur_idx = 0;
+    _ctz = state->timezone_obj();
+    _chunk_size = state->chunk_size();
+    if (UNLIKELY(_chunk_size <= 0)) {
+        return Status::InternalError("RuntimeState::chunk_size() cannot be zero or negative");
+    }
+    auto tablet_manager = ExecEnv::GetInstance()->lake_tablet_manager();
+    if (tablet_manager != nullptr) {
+        tablet_manager->compaction_scheduler()->list_tasks(&_infos);
+    }
+    return Status::OK();
+}
+
+Status SchemaBeCloudNativeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
+    const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
+    const auto end = std::min<size_t>(_infos.size(), _cur_idx + _chunk_size);
+    for (; _cur_idx < end; _cur_idx++) {
+        auto& info = _infos[_cur_idx];
+        for (const auto& [slot_id, index] : slot_id_to_index_map) {
+            if (slot_id < 1 || slot_id > 10) {
+                return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
+            }
+            ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
+            switch (slot_id) {
+            case 1: {
+                // be id
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&_be_id);
+                break;
+            }
+            case 2: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.txn_id);
+                break;
+            }
+            case 3: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.tablet_id);
+                break;
+            }
+            case 4: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.version);
+                break;
+            }
+            case 5: {
+                fill_column_with_slot<TYPE_BOOLEAN>(column.get(), (void*)&info.skipped);
+                break;
+            }
+            case 6: {
+                fill_column_with_slot<TYPE_INT>(column.get(), (void*)&info.runs);
+                break;
+            }
+            case 7: {
+                if (info.start_time > 0) {
+                    DateTimeValue ts;
+                    ts.from_unixtime(info.start_time, _ctz);
+                    fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&ts);
+                } else {
+                    fill_data_column_with_null(column.get());
+                }
+                break;
+            }
+            case 8: {
+                if (info.finish_time > 0) {
+                    DateTimeValue ts;
+                    ts.from_unixtime(info.finish_time, _ctz);
+                    fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&ts);
+                } else {
+                    fill_data_column_with_null(column.get());
+                }
+                break;
+            }
+            case 9: {
+                fill_column_with_slot<TYPE_INT>(column.get(), (void*)&info.progress);
+                break;
+            }
+            case 10: {
+                auto s = info.status.to_string();
+                Slice v(s);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaBeCloudNativeCompactionsScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("call this before initial.");
+    }
+    if (_cur_idx >= _infos.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    if (nullptr == chunk || nullptr == eos) {
+        return Status::InternalError("invalid parameter.");
+    }
+    *eos = false;
+    return fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
@@ -40,7 +40,7 @@ SchemaScanner::ColumnDesc SchemaBeCloudNativeCompactionsScanner::_s_columns[] = 
         {"START_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"FINISH_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"PROGRESS", TYPE_INT, sizeof(int32_t), false},
-        {"Status", TYPE_VARCHAR, sizeof(StringValue), false}};
+        {"STATUS", TYPE_VARCHAR, sizeof(StringValue), false}};
 
 SchemaBeCloudNativeCompactionsScanner::SchemaBeCloudNativeCompactionsScanner()
         : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}

--- a/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.h
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cctz/time_zone.h>
+
+#include <cstdint>
+
+#include "exec/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "storage/lake/compaction_scheduler.h"
+
+namespace starrocks {
+
+class SchemaBeCloudNativeCompactionsScanner : public SchemaScanner {
+public:
+    SchemaBeCloudNativeCompactionsScanner();
+    ~SchemaBeCloudNativeCompactionsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    static SchemaScanner::ColumnDesc _s_columns[];
+
+    Status fill_chunk(ChunkPtr* chunk);
+
+    int64_t _be_id{0};
+    std::vector<lake::CompactionTaskInfo> _infos;
+    size_t _cur_idx{0};
+    int _chunk_size;
+    cctz::time_zone _ctz;
+};
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaTable.java
@@ -750,6 +750,22 @@ public class SchemaTable extends Table {
                                     .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN), false)
                                     .column("DESC", ScalarType.createVarchar(NAME_CHAR_LEN), false)
                                     .build()))
+                    .put("be_cloud_native_compactions", new SchemaTable(
+                            SystemId.BE_CLOUD_NATIVE_COMPACTIONS,
+                            "be_cloud_native_compactions",
+                            TableType.SCHEMA,
+                            builder()
+                                    .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TXN_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("SKIPPED", ScalarType.createType(PrimitiveType.BOOLEAN))
+                                    .column("RUNS", ScalarType.createType(PrimitiveType.INT))
+                                    .column("START_TIME", ScalarType.createType(PrimitiveType.DATETIME))
+                                    .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
+                                    .column("PROGRESS", ScalarType.createType(PrimitiveType.INT))
+                                    .column("STATUS", ScalarType.createType(PrimitiveType.VARCHAR))
+                                    .build()))
                     .build();
 
     public static class Builder {
@@ -857,7 +873,9 @@ public class SchemaTable extends Table {
         SCH_BE_COMPACTIONS("BE_COMPACTIONS", "BE_COMPACTIONS", TSchemaTableType.SCH_BE_COMPACTIONS),
         SCH_BE_THREADS("BE_THREADS", "BE_THREADS", TSchemaTableType.SCH_BE_THREADS),
         SCH_BE_LOGS("BE_LOGS", "BE_LOGS", TSchemaTableType.SCH_BE_LOGS),
-        SCH_BE_BVARS("BE_BVARS", "BE_BVARS", TSchemaTableType.SCH_BE_BVARS);
+        SCH_BE_BVARS("BE_BVARS", "BE_BVARS", TSchemaTableType.SCH_BE_BVARS),
+        SCH_BE_CLOUD_NATIVE_COMPACTIONS("BE_CLOUD_NATIVE_COMPACTIONS", "BE_CLOUD_NATIVE_COMPACTIONS",
+                TSchemaTableType.SCH_BE_CLOUD_NATIVE_COMPACTIONS);
 
         private final String description;
         private final String tableName;

--- a/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/SystemId.java
@@ -93,4 +93,6 @@ public class SystemId {
     public static final long BE_LOGS_ID = 37L;
 
     public static final long BE_BVARS_ID = 38L;
+
+    public static final long BE_CLOUD_NATIVE_COMPACTIONS = 39L;
 }

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -148,7 +148,7 @@ enum TSchemaTableType {
     SCH_BE_THREADS,
     SCH_BE_LOGS,
     SCH_BE_BVARS,
-    SCH_BE_CLOUD_NATIVE_COMPACTIONS
+    SCH_BE_CLOUD_NATIVE_COMPACTIONS,
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -148,6 +148,7 @@ enum TSchemaTableType {
     SCH_BE_THREADS,
     SCH_BE_LOGS,
     SCH_BE_BVARS,
+    SCH_BE_CLOUD_NATIVE_COMPACTIONS
 }
 
 enum THdfsCompression {


### PR DESCRIPTION
```
StarRocks> select * from information_schema.be_cloud_native_compactions;
+-------+--------+-----------+---------+---------+------+---------------------+---------------------+----------+--------+
| BE_ID | TXN_ID | TABLET_ID | VERSION | SKIPPED | RUNS | START_TIME          | FINISH_TIME         | PROGRESS | STATUS |
+-------+--------+-----------+---------+---------+------+---------------------+---------------------+----------+--------+
| 12021 |  18045 |     25021 |      97 |       0 |    1 | 2023-04-13 17:27:15 | 2023-04-13 17:27:15 |      100 | OK     |
| 12021 |  18045 |     25022 |      97 |       0 |    2 | 2023-04-13 17:27:15 | NULL                |       25 | OK     |
| 12021 |  18045 |     25023 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
| 12021 |  18045 |     25024 |      97 |       0 |    1 | 2023-04-13 17:27:15 | NULL                |        0 | OK     |
| 12021 |  18045 |     25025 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
| 12021 |  18045 |     25026 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
| 12021 |  18045 |     25027 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
| 12021 |  18045 |     25028 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
| 12021 |  18045 |     25029 |      97 |       0 |    1 | 2023-04-13 17:27:15 | NULL                |       33 | OK     |
| 12021 |  18045 |     25030 |      97 |       0 |    1 | 2023-04-13 17:27:15 | NULL                |        0 | OK     |
| 12021 |  18045 |     25031 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
| 12021 |  18045 |     25032 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
| 12021 |  18045 |     25033 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
| 12021 |  18045 |     25034 |      97 |       0 |    2 | 2023-04-13 17:27:15 | 2023-04-13 17:27:20 |      100 | OK     |
+-------+--------+-----------+---------+---------+------+---------------------+---------------------+----------+--------+
```

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
