### PR TITLE
[BugFix] Ensure show materialized views's result set not null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -208,6 +208,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -599,14 +600,18 @@ public class ShowExecutor {
             // task_id
             resultRow.add(String.valueOf(taskStatus.getTaskId()));
             // task_name
-            resultRow.add(taskStatus.getTaskName());
+            resultRow.add(Strings.nullToEmpty(taskStatus.getTaskName()));
             // last_refresh_start_time
             resultRow.add(String.valueOf(TimeUtils.longToTimeString(taskStatus.getCreateTime())));
             // last_refresh_finished_time
             resultRow.add(String.valueOf(TimeUtils.longToTimeString(taskStatus.getFinishTime())));
             // last_refresh_duration(s)
-            resultRow.add(DebugUtil.DECIMAL_FORMAT_SCALE_3
-                    .format((taskStatus.getFinishTime() - taskStatus.getCreateTime()) / 1000D));
+            if (taskStatus.getFinishTime() > taskStatus.getCreateTime()) {
+                resultRow.add(DebugUtil.DECIMAL_FORMAT_SCALE_3
+                        .format((taskStatus.getFinishTime() - taskStatus.getCreateTime()) / 1000D));
+            } else {
+                resultRow.add("0.000");
+            }
             // last_refresh_state
             resultRow.add(String.valueOf(taskStatus.getState()));
 
@@ -614,22 +619,19 @@ public class ShowExecutor {
             // force refresh
             resultRow.add(extraMessage.isForceRefresh() ? "true" : "false");
             // last_refresh partition start
-            resultRow.add(extraMessage.getPartitionStart());
+            resultRow.add(Strings.nullToEmpty(extraMessage.getPartitionStart()));
             // last_refresh partition end
-            resultRow.add(extraMessage.getPartitionEnd());
+            resultRow.add(Strings.nullToEmpty(extraMessage.getPartitionEnd()));
             // last_refresh base table refresh map
-            resultRow.add(extraMessage.getBasePartitionsToRefreshMapString());
+            resultRow.add(Strings.nullToEmpty(extraMessage.getBasePartitionsToRefreshMapString()));
             // last_refresh mv partitions
-            resultRow.add(extraMessage.getMvPartitionsToRefreshString());
-
+            resultRow.add(Strings.nullToEmpty(extraMessage.getMvPartitionsToRefreshString()));
             // last_refresh_code
             resultRow.add(String.valueOf(taskStatus.getErrorCode()));
             // last_refresh_reason
-            resultRow.add(taskStatus.getErrorMessage());
+            resultRow.add(Strings.nullToEmpty(taskStatus.getErrorMessage()));
         } else {
-            for (int i = 0; i < 13; i++) {
-                resultRow.add("");
-            }
+            resultRow.addAll(Collections.nCopies(13, ""));
         }
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes #19336

## Problem Summary(Required) ：

Because `resultRows` is required string and can not be nullable, so must keep not-null for ShowMaterializedViews.
```
struct TShowResultSet {
    1: required TShowResultSetMetaData metaData;
    2: required list<list<string>> resultRows;
}
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
