### PR TITLE
[BugFix]Parallel stream load NullPointerException

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -413,7 +413,7 @@ public class LoadPlanner {
             // 4. Olap table sink
             OlapTable olapTable = (OlapTable) destTable;
             boolean enableAutomaticPartition;
-            if (fileGroups.stream().anyMatch(BrokerFileGroup::isSpecifyPartition)) {
+            if (fileGroups != null && fileGroups.stream().anyMatch(BrokerFileGroup::isSpecifyPartition)) {
                 enableAutomaticPartition = false;
             } else {
                 enableAutomaticPartition = olapTable.supportedAutomaticPartition();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Only broker load has `fileGroups`. If parallel stream load is used, a null pointer exception will be thrown at LoadPlanner#plan.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
