### PR TITLE
[Refactor] Remove PageDecoderOptions from page decoder

### DIFF
--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -176,12 +176,8 @@ bool BinaryDictPageBuilder::is_valid_global_dict(const GlobalDictMap* global_dic
 }
 
 template <LogicalType Type>
-BinaryDictPageDecoder<Type>::BinaryDictPageDecoder(Slice data, const PageDecoderOptions& options)
-        : _data(data),
-          _options(options),
-          _data_page_decoder(nullptr),
-          _parsed(false),
-          _encoding_type(UNKNOWN_ENCODING) {}
+BinaryDictPageDecoder<Type>::BinaryDictPageDecoder(Slice data)
+        : _data(data), _data_page_decoder(nullptr), _parsed(false), _encoding_type(UNKNOWN_ENCODING) {}
 
 template <LogicalType Type>
 Status BinaryDictPageDecoder<Type>::init() {
@@ -196,10 +192,10 @@ Status BinaryDictPageDecoder<Type>::init() {
     if (_encoding_type == DICT_ENCODING) {
         // copy the codewords into a temporary buffer first
         // And then copy the strings corresponding to the codewords to the destination buffer
-        _data_page_decoder = std::make_unique<BitShufflePageDecoder<TYPE_INT>>(_data, _options);
+        _data_page_decoder = std::make_unique<BitShufflePageDecoder<TYPE_INT>>(_data);
     } else if (_encoding_type == PLAIN_ENCODING) {
         DCHECK_EQ(_encoding_type, PLAIN_ENCODING);
-        _data_page_decoder.reset(new BinaryPlainPageDecoder<Type>(_data, _options));
+        _data_page_decoder.reset(new BinaryPlainPageDecoder<Type>(_data));
     } else {
         LOG(WARNING) << "invalid encoding type:" << _encoding_type;
         return Status::Corruption(strings::Substitute("invalid encoding type:$0", _encoding_type));

--- a/be/src/storage/rowset/binary_dict_page.h
+++ b/be/src/storage/rowset/binary_dict_page.h
@@ -123,7 +123,7 @@ private:
 template <LogicalType Type>
 class BinaryDictPageDecoder final : public PageDecoder {
 public:
-    BinaryDictPageDecoder(Slice data, const PageDecoderOptions& options);
+    BinaryDictPageDecoder(Slice data);
 
     Status init() override;
 
@@ -147,7 +147,6 @@ public:
 
 private:
     Slice _data;
-    PageDecoderOptions _options;
     std::unique_ptr<PageDecoder> _data_page_decoder;
     const BinaryPlainPageDecoder<Type>* _dict_decoder = nullptr;
     bool _parsed;

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -181,10 +181,8 @@ private:
 template <LogicalType Type>
 class BinaryPlainPageDecoder final : public PageDecoder {
 public:
-    explicit BinaryPlainPageDecoder(Slice data) : BinaryPlainPageDecoder(data, PageDecoderOptions()) {}
-
-    BinaryPlainPageDecoder(Slice data, const PageDecoderOptions& options)
-            : _data(data), _options(options), _parsed(false), _num_elems(0), _offsets_pos(0), _cur_idx(0) {}
+    explicit BinaryPlainPageDecoder(Slice data)
+            : _data(data), _parsed(false), _num_elems(0), _offsets_pos(0), _cur_idx(0) {}
 
     Status init() override {
         RETURN_IF(_parsed, Status::OK());
@@ -279,7 +277,6 @@ private:
     }
 
     Slice _data;
-    PageDecoderOptions _options;
     bool _parsed;
 
     uint32_t _num_elems;

--- a/be/src/storage/rowset/binary_prefix_page.h
+++ b/be/src/storage/rowset/binary_prefix_page.h
@@ -119,7 +119,7 @@ private:
 template <LogicalType Type>
 class BinaryPrefixPageDecoder final : public PageDecoder {
 public:
-    BinaryPrefixPageDecoder(Slice data, const PageDecoderOptions& options) : _data(data) {}
+    BinaryPrefixPageDecoder(Slice data) : _data(data) {}
 
     Status init() override;
 

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -239,7 +239,7 @@ private:
 template <LogicalType Type>
 class BitShufflePageDecoder final : public PageDecoder {
 public:
-    BitShufflePageDecoder(Slice data, const PageDecoderOptions& options) : _data(data), _options(options) {}
+    BitShufflePageDecoder(Slice data) : _data(data) {}
 
     Status init() override {
         CHECK(!_parsed);
@@ -368,7 +368,6 @@ private:
     enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
 
     Slice _data;
-    PageDecoderOptions _options;
     uint32_t _num_elements{0};
     size_t _compressed_size{0};
     size_t _num_element_after_padding{0};

--- a/be/src/storage/rowset/encoding_info.cpp
+++ b/be/src/storage/rowset/encoding_info.cpp
@@ -63,8 +63,8 @@ struct TypeEncodingTraits<type, PLAIN_ENCODING, CppType> {
         *builder = new PlainPageBuilder<type>(opts);
         return Status::OK();
     }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
-        *decoder = new PlainPageDecoder<type>(data, opts);
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new PlainPageDecoder<type>(data);
         return Status::OK();
     }
 };
@@ -75,8 +75,8 @@ struct TypeEncodingTraits<type, PLAIN_ENCODING, Slice> {
         *builder = new BinaryPlainPageBuilder(opts);
         return Status::OK();
     }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
-        *decoder = new BinaryPlainPageDecoder<type>(data, opts);
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new BinaryPlainPageDecoder<type>(data);
         return Status::OK();
     }
 };
@@ -88,8 +88,8 @@ struct TypeEncodingTraits<type, BIT_SHUFFLE, CppType,
         *builder = new BitshufflePageBuilder<type>(opts);
         return Status::OK();
     }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
-        *decoder = new BitShufflePageDecoder<type>(data, opts);
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new BitShufflePageDecoder<type>(data);
         return Status::OK();
     }
 };
@@ -100,8 +100,8 @@ struct TypeEncodingTraits<TYPE_BOOLEAN, RLE, bool> {
         *builder = new RlePageBuilder<TYPE_BOOLEAN>(opts);
         return Status::OK();
     }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
-        *decoder = new RlePageDecoder<TYPE_BOOLEAN>(data, opts);
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new RlePageDecoder<TYPE_BOOLEAN>(data);
         return Status::OK();
     }
 };
@@ -112,8 +112,8 @@ struct TypeEncodingTraits<type, DICT_ENCODING, Slice> {
         *builder = new BinaryDictPageBuilder(opts);
         return Status::OK();
     }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
-        *decoder = new BinaryDictPageDecoder<type>(data, opts);
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new BinaryDictPageDecoder<type>(data);
         return Status::OK();
     }
 };
@@ -124,8 +124,8 @@ struct TypeEncodingTraits<TYPE_DATE_V1, FOR_ENCODING, typename CppTypeTraits<TYP
         *builder = new FrameOfReferencePageBuilder<TYPE_DATE_V1>(opts);
         return Status::OK();
     }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
-        *decoder = new FrameOfReferencePageDecoder<TYPE_DATE_V1>(data, opts);
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new FrameOfReferencePageDecoder<TYPE_DATE_V1>(data);
         return Status::OK();
     }
 };
@@ -137,8 +137,8 @@ struct TypeEncodingTraits<type, FOR_ENCODING, CppType,
         *builder = new FrameOfReferencePageBuilder<type>(opts);
         return Status::OK();
     }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
-        *decoder = new FrameOfReferencePageDecoder<type>(data, opts);
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new FrameOfReferencePageDecoder<type>(data);
         return Status::OK();
     }
 };
@@ -149,8 +149,8 @@ struct TypeEncodingTraits<type, PREFIX_ENCODING, Slice> {
         *builder = new BinaryPrefixPageBuilder(opts);
         return Status::OK();
     }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) {
-        *decoder = new BinaryPrefixPageDecoder<type>(data, opts);
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new BinaryPrefixPageDecoder<type>(data);
         return Status::OK();
     }
 };

--- a/be/src/storage/rowset/encoding_info.h
+++ b/be/src/storage/rowset/encoding_info.h
@@ -47,7 +47,6 @@ class TypeInfo;
 class PageBuilder;
 class PageDecoder;
 class PageBuilderOptions;
-class PageDecoderOptions;
 
 class EncodingInfo {
 public:
@@ -61,8 +60,8 @@ public:
     Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) const {
         return _create_builder_func(opts, builder);
     }
-    Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts, PageDecoder** decoder) const {
-        return _create_decoder_func(data, opts, decoder);
+    Status create_page_decoder(const Slice& data, PageDecoder** decoder) const {
+        return _create_decoder_func(data, decoder);
     }
     LogicalType type() const { return _type; }
     EncodingTypePB encoding() const { return _encoding; }
@@ -76,7 +75,7 @@ private:
     using CreateBuilderFunc = std::function<Status(const PageBuilderOptions&, PageBuilder**)>;
     CreateBuilderFunc _create_builder_func;
 
-    using CreateDecoderFunc = std::function<Status(const Slice&, const PageDecoderOptions& opts, PageDecoder**)>;
+    using CreateDecoderFunc = std::function<Status(const Slice&, PageDecoder**)>;
     CreateDecoderFunc _create_decoder_func;
 
     LogicalType _type;

--- a/be/src/storage/rowset/frame_of_reference_page.h
+++ b/be/src/storage/rowset/frame_of_reference_page.h
@@ -115,10 +115,7 @@ private:
 template <LogicalType Type>
 class FrameOfReferencePageDecoder final : public PageDecoder {
 public:
-    FrameOfReferencePageDecoder(Slice data, const PageDecoderOptions& options)
-            : _data(data),
-
-              _decoder((uint8_t*)_data.data, _data.size) {}
+    FrameOfReferencePageDecoder(Slice data) : _data(data), _decoder((uint8_t*)_data.data, _data.size) {}
 
     ~FrameOfReferencePageDecoder() override = default;
 

--- a/be/src/storage/rowset/options.h
+++ b/be/src/storage/rowset/options.h
@@ -51,12 +51,6 @@ public:
     uint32_t dict_page_size = DEFAULT_PAGE_SIZE;
 };
 
-class PageDecoderOptions {
-public:
-    PageHandle* page_handle = nullptr;
-    bool enable_direct_copy = false;
-};
-
 class IndexReadOptions {
 public:
     FileSystem* fs = nullptr;

--- a/be/src/storage/rowset/parsed_page.cpp
+++ b/be/src/storage/rowset/parsed_page.cpp
@@ -322,8 +322,7 @@ Status parse_page_v1(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
 
     Slice data_slice(body.data, body.size - null_size);
     PageDecoder* decoder = nullptr;
-    PageDecoderOptions opts;
-    RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, opts, &decoder));
+    RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, &decoder));
     page->_data_decoder.reset(decoder);
     RETURN_IF_ERROR(page->_data_decoder->init());
 
@@ -378,10 +377,7 @@ Status parse_page_v2(std::unique_ptr<ParsedPage>* result, PageHandle handle, con
 
     Slice data_slice(body.data, body.size - null_size);
     PageDecoder* decoder = nullptr;
-    PageDecoderOptions opts;
-    opts.page_handle = &(page->_page_handle);
-    opts.enable_direct_copy = true;
-    RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, opts, &decoder));
+    RETURN_IF_ERROR(encoding->create_page_decoder(data_slice, &decoder));
     page->_data_decoder.reset(decoder);
     RETURN_IF_ERROR(page->_data_decoder->init());
 

--- a/be/src/storage/rowset/plain_page.h
+++ b/be/src/storage/rowset/plain_page.h
@@ -124,7 +124,7 @@ private:
 template <LogicalType Type>
 class PlainPageDecoder : public PageDecoder {
 public:
-    PlainPageDecoder(Slice data, const PageDecoderOptions& options) : _data(data), _options(options) {}
+    PlainPageDecoder(Slice data) : _data(data) {}
 
     Status init() override {
         CHECK(!_parsed);
@@ -247,7 +247,6 @@ public:
 
 private:
     Slice _data;
-    PageDecoderOptions _options;
     bool _parsed{false};
     uint32_t _num_elems{0};
     uint32_t _cur_idx{0};

--- a/be/src/storage/rowset/rle_page.h
+++ b/be/src/storage/rowset/rle_page.h
@@ -161,7 +161,7 @@ private:
 template <LogicalType Type>
 class RlePageDecoder final : public PageDecoder {
 public:
-    RlePageDecoder(Slice slice, const PageDecoderOptions& options) : _data(slice), _options(options) {}
+    RlePageDecoder(Slice slice) : _data(slice) {}
 
     Status init() override {
         CHECK(!_parsed);
@@ -247,7 +247,6 @@ private:
     enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
 
     Slice _data;
-    PageDecoderOptions _options;
     bool _parsed{false};
     uint32_t _num_elements{0};
     uint32_t _cur_index{0};

--- a/be/test/storage/rowset/binary_dict_page_test.cpp
+++ b/be/test/storage/rowset/binary_dict_page_test.cpp
@@ -81,9 +81,7 @@ public:
 
         // construct dict page
         OwnedSlice dict_slice = page_builder.get_dictionary_page()->build();
-        PageDecoderOptions dict_decoder_options;
-        auto dict_page_decoder =
-                std::make_unique<BinaryPlainPageDecoder<TYPE_VARCHAR>>(dict_slice.slice(), dict_decoder_options);
+        auto dict_page_decoder = std::make_unique<BinaryPlainPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
         status = dict_page_decoder->init();
         ASSERT_TRUE(status.ok());
         // because every slice is unique
@@ -100,8 +98,7 @@ public:
         Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
         ASSERT_TRUE(st.ok());
 
-        PageDecoderOptions decoder_options;
-        BinaryDictPageDecoder<TYPE_VARCHAR> page_decoder(encoded_data, decoder_options);
+        BinaryDictPageDecoder<TYPE_VARCHAR> page_decoder(encoded_data);
         page_decoder.set_dict_decoder(dict_page_decoder.get());
 
         status = page_decoder.init();
@@ -198,9 +195,7 @@ public:
         for (int i = 0; i < 100; ++i) {
             int slice_index = random() % results.size();
             //int slice_index = 1;
-            PageDecoderOptions dict_decoder_options;
-            auto dict_page_decoder =
-                    std::make_unique<BinaryPlainPageDecoder<TYPE_VARCHAR>>(dict_slice.slice(), dict_decoder_options);
+            auto dict_page_decoder = std::make_unique<BinaryPlainPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
             status = dict_page_decoder->init();
             ASSERT_TRUE(status.ok());
 
@@ -215,8 +210,7 @@ public:
             Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
             ASSERT_TRUE(st.ok());
 
-            PageDecoderOptions decoder_options;
-            BinaryDictPageDecoder<TYPE_VARCHAR> page_decoder(encoded_data, decoder_options);
+            BinaryDictPageDecoder<TYPE_VARCHAR> page_decoder(encoded_data);
             status = page_decoder.init();
             page_decoder.set_dict_decoder(dict_page_decoder.get());
             ASSERT_TRUE(status.ok());

--- a/be/test/storage/rowset/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/binary_plain_page_test.cpp
@@ -81,8 +81,7 @@ public:
         page_builder.get_last_value(&last_value);
         ASSERT_EQ(slices[count - 1], last_value);
 
-        PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(owned_slice.slice(), decoder_options);
+        PageDecoderType page_decoder(owned_slice.slice());
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
 

--- a/be/test/storage/rowset/binary_prefix_page_test.cpp
+++ b/be/test/storage/rowset/binary_prefix_page_test.cpp
@@ -68,9 +68,7 @@ public:
 
         OwnedSlice dict_slice = page_builder.finish()->build();
 
-        PageDecoderOptions dict_decoder_options;
-        auto page_decoder =
-                std::make_unique<BinaryPrefixPageDecoder<TYPE_VARCHAR>>(dict_slice.slice(), dict_decoder_options);
+        auto page_decoder = std::make_unique<BinaryPrefixPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
         Status ret = page_decoder->init();
         ASSERT_TRUE(ret.ok());
 
@@ -111,9 +109,7 @@ public:
         page_builder.get_last_value(&last_value);
         ASSERT_EQ(slices[count - 1], last_value);
 
-        PageDecoderOptions dict_decoder_options;
-        auto page_decoder =
-                std::make_unique<BinaryPrefixPageDecoder<TYPE_VARCHAR>>(dict_slice.slice(), dict_decoder_options);
+        auto page_decoder = std::make_unique<BinaryPrefixPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
         Status ret = page_decoder->init();
         ASSERT_TRUE(ret.ok());
         // because every slice is unique

--- a/be/test/storage/rowset/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/bitshuffle_page_test.cpp
@@ -95,8 +95,7 @@ public:
         Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::BIT_SHUFFLE, &page, &encoded_data);
         ASSERT_TRUE(st.ok());
 
-        PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(encoded_data, decoder_options);
+        PageDecoderType page_decoder(encoded_data);
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, page_decoder.current_index());
@@ -156,8 +155,7 @@ public:
             ASSERT_TRUE(st.ok());
 
             // read whole the page
-            PageDecoderOptions decoder_options;
-            PageDecoderType page_decoder(encoded_data, decoder_options);
+            PageDecoderType page_decoder(encoded_data);
             Status status = page_decoder.init();
             ASSERT_TRUE(status.ok());
             ASSERT_EQ(0, page_decoder.current_index());
@@ -178,8 +176,7 @@ public:
 
         {
             // read half of the page
-            PageDecoderOptions decoder_options;
-            PageDecoderType page_decoder(encoded_data, decoder_options);
+            PageDecoderType page_decoder(encoded_data);
             Status status = page_decoder.init();
             ASSERT_TRUE(status.ok());
             ASSERT_EQ(0, page_decoder.current_index());
@@ -200,8 +197,7 @@ public:
 
         {
             // read range data of page
-            PageDecoderOptions decoder_options;
-            PageDecoderType page_decoder(encoded_data, decoder_options);
+            PageDecoderType page_decoder(encoded_data);
             Status status = page_decoder.init();
             ASSERT_TRUE(status.ok());
             ASSERT_EQ(0, page_decoder.current_index());
@@ -255,8 +251,7 @@ public:
         Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::BIT_SHUFFLE, &page, &encoded_data);
         ASSERT_TRUE(st.ok());
 
-        PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(encoded_data, decoder_options);
+        PageDecoderType page_decoder(encoded_data);
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, page_decoder.current_index());

--- a/be/test/storage/rowset/frame_of_reference_page_test.cpp
+++ b/be/test/storage/rowset/frame_of_reference_page_test.cpp
@@ -50,7 +50,6 @@
 #include "util/logging.h"
 
 using starrocks::PageBuilderOptions;
-using starrocks::PageDecoderOptions;
 using starrocks::operator<<;
 
 namespace starrocks {
@@ -81,8 +80,7 @@ public:
         LOG(INFO) << "FrameOfReference Encoded size for " << size << " values: " << s.slice().size
                   << ", original size:" << size * sizeof(CppType);
 
-        PageDecoderOptions decoder_options;
-        PageDecoderType for_page_decoder(s.slice(), decoder_options);
+        PageDecoderType for_page_decoder(s.slice());
         Status status = for_page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, for_page_decoder.current_index());
@@ -124,8 +122,7 @@ public:
         LOG(INFO) << "FrameOfReference Encoded size for " << size << " values: " << s.slice().size
                   << ", original size:" << size * sizeof(CppType);
 
-        PageDecoderOptions decoder_options;
-        PageDecoderType for_page_decoder(s.slice(), decoder_options);
+        PageDecoderType for_page_decoder(s.slice());
         Status status = for_page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, for_page_decoder.current_index());

--- a/be/test/storage/rowset/plain_page_test.cpp
+++ b/be/test/storage/rowset/plain_page_test.cpp
@@ -91,8 +91,7 @@ public:
         page_builder.get_last_value(&last_value);
         ASSERT_EQ(src[size - 1], last_value);
 
-        PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s.slice(), decoder_options);
+        PageDecoderType page_decoder(s.slice());
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
 
@@ -158,8 +157,7 @@ public:
         size = page_builder.add(reinterpret_cast<const uint8_t*>(src), size);
         OwnedSlice s = page_builder.finish()->build();
 
-        PageDecoderOptions decoder_options;
-        PageDecoderType page_decoder(s.slice(), decoder_options);
+        PageDecoderType page_decoder(s.slice());
         Status status = page_decoder.init();
 
         ASSERT_TRUE(status.ok());

--- a/be/test/storage/rowset/rle_page_test.cpp
+++ b/be/test/storage/rowset/rle_page_test.cpp
@@ -49,7 +49,6 @@
 #include "util/logging.h"
 
 using starrocks::PageBuilderOptions;
-using starrocks::PageDecoderOptions;
 
 namespace starrocks {
 
@@ -92,8 +91,7 @@ public:
         typedef typename TypeTraits<Type>::CppType CppType;
         OwnedSlice s = rle_encode<Type>(src, size);
 
-        PageDecoderOptions decodeder_options;
-        RlePageDecoder<Type> rle_page_decoder(s.slice(), decodeder_options);
+        RlePageDecoder<Type> rle_page_decoder(s.slice());
         Status status = rle_page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, rle_page_decoder.current_index());
@@ -128,8 +126,7 @@ public:
         typedef typename TypeTraits<Type>::CppType CppType;
         OwnedSlice s = rle_encode<Type>(src, size);
 
-        PageDecoderOptions decodeder_options;
-        RlePageDecoder<Type> rle_page_decoder(s.slice(), decodeder_options);
+        RlePageDecoder<Type> rle_page_decoder(s.slice());
         Status status = rle_page_decoder.init();
         ASSERT_TRUE(status.ok());
         ASSERT_EQ(0, rle_page_decoder.current_index());


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

`PageDecoderOptions` is useless, remove it.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
