### PR TITLE
[Feature] Support JSON type in ElasticSearch's external table and catalog

### DIFF
--- a/be/src/exec/es/es_scroll_parser.h
+++ b/be/src/exec/es/es_scroll_parser.h
@@ -76,6 +76,9 @@ private:
     Status _append_array_val(const rapidjson::Value& col, const TypeDescriptor& type_desc, Column* column,
                              bool pure_doc_value);
 
+    Status _append_json_val(const rapidjson::Value& col, const TypeDescriptor& type_desc, Column* column,
+                            bool pure_doc_value);
+
     Status _append_array_val_from_docvalue(const rapidjson::Value& val, const TypeDescriptor& child_type_desc,
                                            Column* column);
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
@@ -20,7 +20,6 @@ import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadata;
-import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -84,11 +83,12 @@ public class ElasticsearchMetadata
             esTable.syncTableMetaData(esRestClient);
             return esTable;
         } catch (NoSuchElementException e) {
-            LOG.error("Unknown index {}", tableName);
-            throw new StarRocksConnectorException("Unknown index " + tableName);
+            LOG.error(String.format("Unknown index {%s}", tableName), e);
+            return null;
         } catch (Exception e) {
             LOG.error("transform to EsTable Error", e);
-            throw new StarRocksConnectorException(e.getMessage());
+            return null;
         }
+
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsUtil.java
@@ -125,8 +125,8 @@ public class EsUtil {
         }
         for (String columnName : properties.keySet()) {
             JSONObject columnAttr = (JSONObject) properties.get(columnName);
-            //default set string.
-            Type type = Type.STRING;
+            // default set json.
+            Type type = Type.JSON;
             if (columnAttr.has("type")) {
                 type = convertType(columnAttr.get("type").toString());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
@@ -14,32 +14,18 @@
 
 package com.starrocks.connector.elasticsearch;
 
-import com.starrocks.common.ExceptionChecker;
-import com.starrocks.connector.exception.StarRocksConnectorException;
-import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.NoSuchElementException;
 
 public class ElasticsearchMetadataTest {
 
     @Test
     public void testGetTable(@Mocked EsRestClient client) {
-        new Expectations() {
-            {
-                client.getMapping("not_exist_index");
-                result = new NoSuchElementException();
-            }
-        };
-
         ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
-        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
-                "Unknown index not_exist_index",
-                () -> metadata.getTable("default_db", "not_exist_index"));
-
+        Assert.assertNull(metadata.getTable("default_db", "not_exist_index"));
         Assert.assertNull(metadata.getTable("aaaa", "tbl"));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

We support json in es now!

```sql
CREATE EXTERNAL TABLE es_json
(
    user json,
    message string
)
ENGINE=ELASTICSEARCH
PROPERTIES 
(
    "hosts" = "http://127.0.0.1:9200",
    "index" = "student",
    "type" = "_doc"
);
```

If you are using the catalog, like the below:
```sql
CREATE EXTERNAL CATALOG es_catalog
PROPERTIES (
    "type"="es",
    "es.type"="_doc",
    "hosts"="http://127.0.0.1:9200"
);
```
It will mapping JSON type automatically.


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
