### PR TITLE
[Enhancement] Add hint to insert into error msg if thrift server pool is exhausted

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -606,12 +606,6 @@ public class Config extends ConfigBase {
     public static int thrift_backlog_num = 1024;
 
     /**
-     * Define thrift server's server model, default is TThreadPoolServer model
-     */
-    @ConfField
-    public static String thrift_server_type = ThriftServer.THREAD_POOL;
-
-    /**
      * the timeout for thrift rpc call
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -172,7 +172,7 @@ public enum ErrorCode {
     ERR_NO_ALTER_OPERATION(5023, new byte[] {'H', 'Y', '0', '0', '0'},
             "No operation in alter statement"),
     ERR_QUERY_TIMEOUT(5024, new byte[] {'H', 'Y', '0', '0', '0'},
-            "Query timeout. Increase the query_timeout session variable and retry"),
+            "Query timeout. %s"),
     ERR_FAILED_WHEN_INSERT(5025, new byte[] {'H', 'Y', '0', '0', '0'}, "Failed when INSERT execute"),
     ERR_UNSUPPORTED_TYPE_IN_CTAS(5026, new byte[] {'H', 'Y', '0', '0', '0'},
             "Unsupported type '%s' in create table as select statement"),

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
@@ -25,9 +25,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TServer;
-import org.apache.thrift.server.TSimpleServer;
-import org.apache.thrift.server.TThreadedSelectorServer;
-import org.apache.thrift.transport.TNonblockingServerSocket;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportException;
 
@@ -38,71 +35,17 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 public class ThriftServer {
     private static final Logger LOG = LogManager.getLogger(ThriftServer.class);
-    private ThriftServerType type;
     private int port;
     private TProcessor processor;
     private TServer server;
     private Thread serverThread;
     private Set<TNetworkAddress> connects;
-
-    public static final String SIMPLE = "SIMPLE";
-    public static final String THREADED = "THREADED";
-    public static final String THREAD_POOL = "THREAD_POOL";
-
-    public enum ThriftServerType {
-        // TSimplerServer
-        SIMPLE(ThriftServer.SIMPLE),
-        // TThreadedSelectorServer
-        THREADED(ThriftServer.THREADED),
-        // TThreadPoolServer
-        THREAD_POOL(ThriftServer.THREAD_POOL);
-
-        private final String value;
-
-        ThriftServerType(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public static ThriftServerType getThriftServerType(String value) {
-            for (ThriftServerType val : ThriftServerType.values()) {
-                if (val.getValue().equalsIgnoreCase(value)) {
-                    return val;
-                }
-            }
-            return ThriftServerType.THREAD_POOL;
-        }
-    }
+    private static ThreadPoolExecutor executor;
 
     public ThriftServer(int port, TProcessor processor) {
         this.port = port;
         this.processor = processor;
         this.connects = Sets.newConcurrentHashSet();
-        this.type = ThriftServerType.getThriftServerType(Config.thrift_server_type);
-    }
-
-    public ThriftServerType getType() {
-        return type;
-    }
-
-    private void createSimpleServer() throws TTransportException {
-        TServer.Args args = new TServer.Args(new TServerSocket(port)).protocolFactory(
-                new TBinaryProtocol.Factory()).processor(processor);
-        server = new TSimpleServer(args);
-    }
-
-    private void createThreadedServer() throws TTransportException {
-        TThreadedSelectorServer.Args args =
-                new TThreadedSelectorServer.Args(new TNonblockingServerSocket(port, Config.thrift_client_timeout_ms))
-                        .protocolFactory(
-                                new TBinaryProtocol.Factory()).processor(processor);
-        ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager
-                .newDaemonCacheThreadPool(Config.thrift_server_max_worker_threads, "thrift-server-pool", true);
-        args.executorService(threadPoolExecutor);
-        server = new TThreadedSelectorServer(args);
     }
 
     private void createThreadPoolServer() throws TTransportException {
@@ -122,6 +65,7 @@ public class ThriftServer {
         // if not used for ThreadPoolManager.KEEP_ALIVE_TIME
         threadPoolExecutor.allowCoreThreadTimeOut(true);
         serverArgs.executorService(threadPoolExecutor);
+        executor = threadPoolExecutor;
         server = new SRTThreadPoolServer(serverArgs);
 
         GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(() -> {
@@ -134,16 +78,7 @@ public class ThriftServer {
 
     public void start() throws IOException {
         try {
-            switch (type) {
-                case SIMPLE:
-                    createSimpleServer();
-                    break;
-                case THREADED:
-                    createThreadedServer();
-                    break;
-                default:
-                    createThreadPoolServer();
-            }
+            createThreadPoolServer();
         } catch (TTransportException ex) {
             LOG.warn("create thrift server failed.", ex);
             throw new IOException("create thrift server failed.", ex);
@@ -182,5 +117,9 @@ public class ThriftServer {
 
     public void removeConnect(TNetworkAddress clientAddress) {
         connects.remove(clientAddress);
+    }
+
+    public static ThreadPoolExecutor getExecutor() {
+        return executor;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerEventProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServerEventProcessor.java
@@ -41,7 +41,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.server.ServerContext;
 import org.apache.thrift.server.TServerEventHandler;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 
@@ -70,35 +69,16 @@ public class ThriftServerEventProcessor implements TServerEventHandler {
     @Override
     public ServerContext createContext(TProtocol input, TProtocol output) {
         // param input is class org.apache.thrift.protocol.TBinaryProtocol
-        TSocket tSocket = null;
         TTransport transport = input.getTransport();
+        Preconditions.checkState(transport instanceof TSocket);
 
-        switch (thriftServer.getType()) {
-            case THREADED:
-                // class org.apache.thrift.transport.TFramedTransport
-                Preconditions.checkState(transport instanceof TFramedTransport);
-                TFramedTransport framedTransport = (TFramedTransport) transport;
-                // NOTE: we need patch code in TNonblockingServer, we don't use for now.
-                //  see https://issues.apache.org/jira/browse/THRIFT-1053
-                break;
-            case SIMPLE:
-            case THREAD_POOL:
-                // org.apache.thrift.transport.TSocket
-                Preconditions.checkState(transport instanceof TSocket);
-                tSocket = (TSocket) transport;
-                break;
-        }
-        if (tSocket == null) {
-            LOG.warn("fail to get client socket. server type: {}", thriftServer.getType());
-            return null;
-        }
+        TSocket tSocket = (TSocket) transport;
         SocketAddress socketAddress = tSocket.getSocket().getRemoteSocketAddress();
         InetSocketAddress inetSocketAddress = null;
         if (socketAddress instanceof InetSocketAddress) {
             inetSocketAddress = (InetSocketAddress) socketAddress;
         } else {
-            LOG.warn("fail to get client socket address. server type: {}",
-                    thriftServer.getType());
+            LOG.warn("fail to get client socket address");
             return null;
         }
         TNetworkAddress clientAddress = new TNetworkAddress(
@@ -131,9 +111,9 @@ public class ThriftServerEventProcessor implements TServerEventHandler {
             return;
         }
 
+        Preconditions.checkState(serverContext instanceof ThriftServerContext);
         ThriftServerContext thriftServerContext = (ThriftServerContext) serverContext;
         TNetworkAddress clientAddress = thriftServerContext.getClient();
-        Preconditions.checkState(serverContext instanceof ThriftServerContext);
         connectionContext.set(new ThriftServerContext(clientAddress));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1578,7 +1578,8 @@ public class Coordinator {
                 return true;
             }
 
-            if (ThriftServer.getExecutor().getPoolSize() >= Config.thrift_server_max_worker_threads) {
+            if (ThriftServer.getExecutor() != null
+                    && ThriftServer.getExecutor().getPoolSize() >= Config.thrift_server_max_worker_threads) {
                 thriftServerHighLoad = true;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1448,7 +1448,16 @@ public class StmtExecutor {
                     ErrorReport.reportDdlException(ErrorCode.ERR_QUERY_EXCEPTION);
                 } else {
                     coord.cancel();
-                    ErrorReport.reportDdlException(ErrorCode.ERR_QUERY_TIMEOUT);
+                    if (coord.isThriftServerHighLoad()) {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_QUERY_TIMEOUT,
+                                "Please check the thrift-server-pool metrics, " +
+                                        "if the pool size reaches thrift_server_max_worker_threads(default is 4096), " +
+                                        "you can set the config to a higher value in fe.conf, " +
+                                        "or set parallel_fragment_exec_instance_num to a lower value in session variable");
+                    } else {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_QUERY_TIMEOUT,
+                                "Increase the query_timeout session variable and retry");
+                    }
                 }
             }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Check the thrift server pool size when waiting for the fragments to finish. If the thrift server pool size is bigger than the max thrift server worker, the timeout reason maybe the rejection of request by thrift server.

BTW, remove the unused thrift server type.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
