### PR TITLE
[Enhancement] Add broker load error in retrying

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/BrokerUtil.java
@@ -120,7 +120,8 @@ public class BrokerUtil {
             }
         } catch (TException e) {
             LOG.warn("Broker list path exception, path={}, address={}, exception={}", path, address, e);
-            throw new UserException("Broker list path exception. path=" + path + ", broker=" + address);
+            throw new UserException("Broker list path exception. path=" + path +
+                    ", broker=" + address + " exception: " + e.getMessage());
         } finally {
             returnClient(client, address, failed);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -252,6 +252,9 @@ public abstract class BulkLoadJob extends LoadJob {
                 logFinalOperation();
                 return;
             } else {
+                failMsg.setMsg("Still retrying, error: " + failMsg.getMsg());
+                unprotectUpdateFailMsg(failMsg);
+
                 // retry task
                 idToTasks.remove(loadTask.getSignature());
                 if (loadTask instanceof LoadLoadingTask) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -697,6 +697,15 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         unprotectReadEndOperation((LoadJobFinalOperation) txnState.getTxnCommitAttachment(), false);
     }
 
+    /**
+     * This method will update job failMsg without edit log and lock
+     *
+     * @param failMsg
+     */
+    public void unprotectUpdateFailMsg(FailMsg failMsg) {
+        this.failMsg = failMsg;
+    }
+
     public List<Comparable> getShowInfo() throws DdlException {
         readLock();
         try {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The broker load job would retry for 3 times if the plan stage get any problem, but the error message would not be shown until until the job is canceled. 
To make it simpler to find out the problem, This PR adds the error message in the process of retrying to the result of `show load`.
![8lZWOjXia7](https://user-images.githubusercontent.com/16649269/233242625-3ad6a99b-ef04-4538-b4c5-59d142e02319.jpg)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
