### PR TITLE
[BugFix] fix alter pk table reorder

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3165,6 +3165,7 @@ Status TabletUpdates::reorder_from(const std::shared_ptr<Tablet>& base_tablet, i
         total_bytes += rowset_meta_pb.total_disk_size();
         total_rows += rowset_meta_pb.num_rows();
         total_files += rowset_meta_pb.num_segments() + rowset_meta_pb.num_delete_files();
+        chunk_arr.clear();
     }
 
     TabletMetaPB meta_pb;

--- a/test/sql/test_ddl/R/test_alter_pk_reorder
+++ b/test/sql/test_ddl/R/test_alter_pk_reorder
@@ -1,0 +1,55 @@
+-- name: test_alter_pk_reorder
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 INTEGER,
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100,100,100,100,100);
+-- result:
+-- !result
+insert into tab1 values (200,200,200,200,200);
+-- result:
+-- !result
+insert into tab1 values (300,300,300,300,300);
+-- result:
+-- !result
+insert into tab1 values (400,400,400,400,400);
+-- result:
+-- !result
+insert into tab1 values (500,500,500,500,500);
+-- result:
+-- !result
+insert into tab1 values (600,600,600,600,600);
+-- result:
+-- !result
+alter table tab1 order by (k2,k1);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into tab1 values (700,700,700,700,700);
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	100	100	100	100
+200	200	200	200	200
+300	300	300	300	300
+400	400	400	400	400
+500	500	500	500	500
+600	600	600	600	600
+700	700	700	700	700
+-- !result

--- a/test/sql/test_ddl/T/test_alter_pk_reorder
+++ b/test/sql/test_ddl/T/test_alter_pk_reorder
@@ -1,0 +1,26 @@
+-- name: test_alter_pk_reorder
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 INTEGER,
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into tab1 values (100,100,100,100,100);
+insert into tab1 values (200,200,200,200,200);
+insert into tab1 values (300,300,300,300,300);
+insert into tab1 values (400,400,400,400,400);
+insert into tab1 values (500,500,500,500,500);
+insert into tab1 values (600,600,600,600,600);
+alter table tab1 order by (k2,k1);
+function: wait_alter_table_finish()
+insert into tab1 values (700,700,700,700,700);
+select * from tab1;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21987

## Problem Summary(Required) ：
In current `TabletUpdates::reorder_from`, each time we read chunk from old tablet's rowset, we will keep it in `chunk_arr`, and not clear it, so the next rowset will contain rows in last rowset in new tablet, which will cause row duplicate in new tablet.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
