### PR TITLE
[BugFix] hashCode and equals of LiteralExpr should be consistent

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BoolLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BoolLiteral.java
@@ -47,6 +47,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Objects;
 
 public class BoolLiteral extends LiteralExpr {
     private boolean value;
@@ -174,7 +175,7 @@ public class BoolLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Boolean.hashCode(value);
+        return Objects.hash(super.hashCode(), value);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
@@ -388,7 +388,8 @@ public class IntLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), value);
+        // IntLiteral(0) equals to LargeIntLiteral(0), so their hash codes must equal.
+        return Objects.hash(getLongValue());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LargeIntLiteral.java
@@ -258,7 +258,8 @@ public class LargeIntLiteral extends LiteralExpr {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), value);
+        // IntLiteral(0) equals to LargeIntLiteral(0), so their hash codes must equal.
+        return Objects.hash(getLongValue());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
@@ -210,7 +210,11 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
         if ((obj instanceof StringLiteral && !(this instanceof StringLiteral))
                 || (this instanceof StringLiteral && !(obj instanceof StringLiteral))
                 || (obj instanceof DecimalLiteral && !(this instanceof DecimalLiteral))
-                || (this instanceof DecimalLiteral && !(obj instanceof DecimalLiteral))) {
+                || (this instanceof DecimalLiteral && !(obj instanceof DecimalLiteral))
+                || (obj instanceof BoolLiteral && !(this instanceof BoolLiteral))
+                || (this instanceof BoolLiteral && !(obj instanceof BoolLiteral))
+                || (obj instanceof FloatLiteral && !(this instanceof FloatLiteral))
+                || (this instanceof FloatLiteral && !(obj instanceof FloatLiteral))) {
             return false;
         }
         return this.compareLiteral(((LiteralExpr) obj)) == 0;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
@@ -18,9 +18,13 @@ package com.starrocks.analysis;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectRelation;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -32,13 +36,13 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ExprHashCodeTest {
+public class ExprHashCodeTest {
 
     private Set<Expr> exprSet = Sets.newHashSet();
 
     @ParameterizedTest
     @MethodSource("generateExprStream")
-    void testExprHashCode(Expr expr) {
+    public void testExprHashCode(Expr expr) {
         assertTrue(exprSet.add(expr));
     }
 
@@ -64,5 +68,71 @@ class ExprHashCodeTest {
                 decimalLiteral, functionCallExpr, likePredicate, existsPredicate, predicate, compoundPredicate,
                 arithmeticExpr, analyticExpr);
         return exprList.stream().map(e -> Arguments.of(e));
+    }
+
+    @Test
+    public void testNumericLiteral() throws AnalysisException {
+        List<Expr> floatLiterals = ImmutableList.of(
+                new FloatLiteral(0.0d),
+                new FloatLiteral(1.0d),
+                new FloatLiteral(1.1d),
+                new FloatLiteral(2.0d),
+                new FloatLiteral(2.1d)
+        );
+        List<Expr> intLiterals = ImmutableList.of(
+                new IntLiteral(0),
+                new IntLiteral(1),
+                new IntLiteral(2)
+        );
+        List<Expr> largeIntLiterals = ImmutableList.of(
+                new LargeIntLiteral("0"),
+                new LargeIntLiteral("1"),
+                new LargeIntLiteral("2")
+        );
+        List<Expr> boolLiterals = ImmutableList.of(
+                new BoolLiteral(false),
+                new BoolLiteral(true)
+        );
+
+        List<Expr> allLiterals = ImmutableList.<Expr>builder()
+                .addAll(floatLiterals)
+                .addAll(intLiterals)
+                .addAll(largeIntLiterals)
+                .addAll(boolLiterals)
+                .build();
+
+        // FloatLiteral doesn't equal to IntLiteral/LargeIntLiteral/BoolLiteral.
+        Streams.forEachPair(floatLiterals.stream(), allLiterals.stream(), (x, y) -> {
+            if (x == y) {
+                Assertions.assertEquals(x, y);;
+            } else {
+                Assertions.assertNotEquals(x, y);
+            }
+        });
+
+        // IntLiteral/LargeIntLiteral doesn't equal to FloatLiteral/BoolLiteral.
+        // IntLiteral can equal to LargeIntLiteral.
+        Streams.forEachPair(intLiterals.stream(), largeIntLiterals.stream(), Assertions::assertEquals);
+        Streams.forEachPair(largeIntLiterals.stream(), intLiterals.stream(), Assertions::assertEquals);
+        Streams.forEachPair(intLiterals.stream(), Streams.concat(floatLiterals.stream(), boolLiterals.stream()),
+                Assertions::assertNotEquals);
+        Streams.forEachPair(largeIntLiterals.stream(), Streams.concat(floatLiterals.stream(), boolLiterals.stream()),
+                Assertions::assertNotEquals);
+
+        // BoolLiteral doesn't equal to FloatLiteral/IntLiteral/LargeIntLiteral.
+        Streams.forEachPair(boolLiterals.stream(), allLiterals.stream(), (x, y) -> {
+            if (x == y) {
+                Assertions.assertEquals(x, y);;
+            } else {
+                Assertions.assertNotEquals(x, y);
+            }
+        });
+
+        // When two numeric literal equal, the hash code of them must equal.
+        Streams.forEachPair(allLiterals.stream(), allLiterals.stream(), (x, y) -> {
+            if (x.equals(y)) {
+                Assertions.assertEquals(x.hashCode(), y.hashCode());
+            }
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -17,6 +17,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.parser.ParsingException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -347,5 +348,61 @@ public class ConstantExpressionTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  1:Project\n" +
                 "  |  <slot 2> : uuid()\n" +
                 "  |  <slot 3> : uuid()"));
+    }
+
+    @Test
+    public void testNumericLiteralComparison() throws Exception {
+        String sql;
+        String plan;
+
+        final long prevSqlMode = connectContext.getSessionVariable().getSqlMode();
+        try {
+            connectContext.getSessionVariable().setSqlMode(prevSqlMode | SqlModeHelper.MODE_DOUBLE_LITERAL);
+
+            sql = "SELECT percentile_approx(2.25, false), percentile_approx(2.25, 0), percentile_approx(2.25, 0.)";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:Project\n" +
+                    "  |  <slot 2> : 2: percentile_approx\n" +
+                    "  |  <slot 3> : 2: percentile_approx\n" +
+                    "  |  <slot 4> : 2: percentile_approx\n" +
+                    "  |  \n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  output: percentile_approx(2.25, 0.0)\n" +
+                    "  |  group by: ");
+
+            sql = "SELECT COUNT(CASE WHEN 1 THEN 1 END), COUNT(CASE WHEN TRUE THEN 1 END), " +
+                    "COUNT(CASE WHEN 1.0 THEN 1 END), COUNT(CASE WHEN CAST(1 AS LARGEINT) THEN 1 END)";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:Project\n" +
+                    "  |  <slot 2> : 2: count\n" +
+                    "  |  <slot 3> : 2: count\n" +
+                    "  |  <slot 4> : 4: count\n" +
+                    "  |  <slot 5> : 2: count\n" +
+                    "  |  \n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  output: count(1), count(if(CAST(1.0 AS BOOLEAN), 1, NULL))\n" +
+                    "  |  group by: ");
+
+            sql = "SELECT 1, TRUE, 0, FALSE, 1.1, 1, 1.1, TRUE, FALSE, 0";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  1:Project\n" +
+                    "  |  <slot 7> : 1\n" +
+                    "  |  <slot 8> : 1.1\n" +
+                    "  |  <slot 9> : TRUE\n" +
+                    "  |  <slot 10> : FALSE\n" +
+                    "  |  <slot 11> : 0");
+
+            sql = "SELECT TRUE, 1, FALSE, 0, 1.1, 1, 1.1, TRUE, FALSE, 0";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "  1:Project\n" +
+                    "  |  <slot 7> : 1\n" +
+                    "  |  <slot 8> : 1.1\n" +
+                    "  |  <slot 9> : TRUE\n" +
+                    "  |  <slot 10> : FALSE\n" +
+                    "  |  <slot 11> : 0");
+
+        } finally {
+            connectContext.getSessionVariable().setSqlMode(prevSqlMode);
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22001.

## Problem Summary(Required) ：
### Root Cause
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
As for `BoolLiteral`, `IntLiteral`, `LargeIntLiteral`, `FloatLiteral`, `equals()` and `hashCode` aren't consisten:
- When `equals()` returns true, their hash codes are not equal sometimes. For example, `BoolLiteral(0)`/`IntLiteral(0)`/`LargeIntLiteral(0)`/`FloatLiteral(0)`.

We sometimes directly use `equals` to compare two literal expressions, and sometimes consider `hashCode`.
- During `SelectAnalyzer#analyzeAggregations`, `ArrayList#contains` is used here, which directly uses `equals()`.
- During `SqlToScalarOperatorTranslator#translate`, `HashMap#contains` is used here, which firstly uses `hashCode()`.

### Solution
We should make `hashCode` and `equals` of `LiteralExpr` be consistent.
- For `equals`: only `IntLiteral` and `LargeIntLiteral` could compare each other. That is, `BoolLiteral(0).equals(IntLiteral(0))` returns false.
- For `hashCode`, make `IntLiteral` and `LargeIntLiteral` just return `getLongValue().hashCode()`, because `super.hashCode()` considers `type`, which of `IntLiteral` and `LargeIntLiteral` is `INT` and `LARGEINT`, respectively.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
