### PR TITLE
[Enhancement] Improve cloud native tablet read io statistics (#21826)

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -392,7 +392,7 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_rows_read_counter, _num_rows_read);
 
     COUNTER_UPDATE(_io_timer, _reader->stats().io_ns);
-    COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read);
+    COUNTER_UPDATE(_read_compressed_counter, _reader->stats().compressed_bytes_read_request);
     COUNTER_UPDATE(_decompress_timer, _reader->stats().decompress_ns);
     COUNTER_UPDATE(_read_uncompressed_counter, _reader->stats().uncompressed_bytes_read);
     COUNTER_UPDATE(_bytes_read_counter, _reader->stats().bytes_read);

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -262,11 +262,30 @@ struct OlapReaderStatistics {
 
     int64_t runtime_stats_filtered = 0;
 
-    // for lake tablet
-    int64_t io_ns_from_local_disk = 0;
-    int64_t compressed_bytes_from_local_disk = 0;
+    // ------ for lake tablet ------
     int64_t pages_from_local_disk = 0;
+
+    int64_t compressed_bytes_read_local_disk = 0;
+    int64_t compressed_bytes_read_remote = 0;
+    // bytes read requested from be, same as compressed_bytes_read for local tablet
+    int64_t compressed_bytes_read_request = 0;
+
+    int64_t io_count = 0;
+    int64_t io_count_local_disk = 0;
+    int64_t io_count_remote = 0;
+    int64_t io_count_request = 0;
+
+    int64_t io_ns_local_disk = 0;
+    int64_t io_ns_remote = 0;
+    // ------ for lake tablet ------
 };
+
+const char* const kBytesReadLocalDisk = "bytes_read_local_disk";
+const char* const kBytesReadRemote = "bytes_read_remote";
+const char* const kIOCountLocalDisk = "io_count_local_disk";
+const char* const kIOCountRemote = "io_count_remote";
+const char* const kIONsLocalDisk = "io_ns_local_disk";
+const char* const kIONsRemote = "io_ns_remote";
 
 typedef uint32_t ColumnId;
 // Column unique id set

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -168,14 +168,13 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     {
         SCOPED_RAW_TIMER(&opts.stats->io_ns);
         if (opts.read_file->is_cache_hit()) {
-            SCOPED_RAW_TIMER(&opts.stats->io_ns_from_local_disk);
             RETURN_IF_ERROR(opts.read_file->read_at_fully(opts.page_pointer.offset, page_slice.data, page_slice.size));
-            opts.stats->compressed_bytes_from_local_disk += page_size;
             ++opts.stats->pages_from_local_disk;
         } else {
             RETURN_IF_ERROR(opts.read_file->read_at_fully(opts.page_pointer.offset, page_slice.data, page_slice.size));
         }
-        opts.stats->compressed_bytes_read += page_size;
+        opts.stats->compressed_bytes_read_request += page_size;
+        ++opts.stats->io_count_request;
     }
 
     if (opts.verify_checksum) {


### PR DESCRIPTION
Use more accurate io statistics from starlet.

```
- IOStatistics: 2s379ms
   - CompressedBytesReadLocalDisk: 0.00   // compressed bytes actually read from local disk
   - CompressedBytesReadRemote: 40.00 MB  // compressed bytes actually read from remote
   - CompressedBytesReadRequest: 36.76 MB // compressed bytes read requested by BE
   - CompressedBytesReadTotal: 40.00 MB   // compressed bytes actually read total
   - IOCountLocalDisk: 0
   - IOCountRemote: 320
   - IOCountRequest: 3.7K (3700)
   - IOCountTotal: 320
   - IOTimeLocalDisk: 0ns
   - IOTimeRemote: 2s189ms
   - IOTimeTotal: 2s379ms
   - PagesCountLocalDisk: 0
   - PagesCountMemory: 0
   - PagesCountRemote: 3.7K (3700)
   - PagesCountTotal: 3.7K (3700)
```

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
