### PR TITLE
[Enhancement] Provide instructions on how to modify mem_limit for a resource group

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -141,7 +141,7 @@ void WorkGroup::init() {
     _memory_limit_bytes = _memory_limit == ABSENT_MEMORY_LIMIT
                                   ? ExecEnv::GetInstance()->query_pool_mem_tracker()->limit()
                                   : ExecEnv::GetInstance()->query_pool_mem_tracker()->limit() * _memory_limit;
-    _mem_tracker = std::make_shared<starrocks::MemTracker>(_memory_limit_bytes, _name,
+    _mem_tracker = std::make_shared<starrocks::MemTracker>(MemTracker::RESOURCE_GROUP, _memory_limit_bytes, _name,
                                                            ExecEnv::GetInstance()->query_pool_mem_tracker());
     _driver_sched_entity.set_queue(std::make_unique<pipeline::QuerySharedDriverQueue>());
     _scan_sched_entity.set_queue(workgroup::create_scan_task_queue());

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -165,6 +165,15 @@ std::string MemTracker::err_msg(const std::string& msg) const {
     case MemTracker::SCHEMA_CHANGE_TASK:
         str << "You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change]";
         break;
+    case MemTracker::RESOURCE_GROUP:
+        // TODO: make default_wg configuable.
+        if (label() == "default_wg") {
+            str << "Mem usage has exceed the limit of query pool";
+        } else {
+            str << "Mem usage has exceed the limit of the resource group [" << label() << "]. "
+                << "You can change the limit by modify [mem_limit] of this group";
+        }
+        break;
     default:
         break;
     }

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -91,7 +91,7 @@ public:
         int64_t peak_consumption = 0;
     };
 
-    enum Type { NO_SET, PROCESS, QUERY_POOL, QUERY, LOAD, CONSISTENCY, COMPACTION, SCHEMA_CHANGE_TASK };
+    enum Type { NO_SET, PROCESS, QUERY_POOL, QUERY, LOAD, CONSISTENCY, COMPACTION, SCHEMA_CHANGE_TASK, RESOURCE_GROUP };
 
     /// 'byte_limit' < 0 means no limit
     /// 'label' is the label used in the usage string (LogUsage())

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -532,10 +532,10 @@ private:
             break;                                                                                                  \
         case MemTracker::RESOURCE_GROUP:                                                                            \
             /* TODO: make default_wg configuable. */                                                                \
-            if (label() == "default_wg") {                                                                          \
+            if (tracker->label() == "default_wg") {                                                                 \
                 str << "Mem usage has exceed the limit of query pool";                                              \
             } else {                                                                                                \
-                str << "Mem usage has exceed the limit of the resource group [" << label() << "]. "                 \
+                str << "Mem usage has exceed the limit of the resource group [" << tracker->label() << "]. "        \
                     << "You can change the limit by modify [mem_limit] of this group";                              \
             }                                                                                                       \
             break;                                                                                                  \

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -530,6 +530,15 @@ private:
         case MemTracker::SCHEMA_CHANGE_TASK:                                                                        \
             str << "You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change]"; \
             break;                                                                                                  \
+        case MemTracker::RESOURCE_GROUP:                                                                            \
+            /* TODO: make default_wg configuable. */                                                                \
+            if (label() == "default_wg") {                                                                          \
+                str << "Mem usage has exceed the limit of query pool";                                              \
+            } else {                                                                                                \
+                str << "Mem usage has exceed the limit of the resource group [" << label() << "]. "                 \
+                    << "You can change the limit by modify [mem_limit] of this group";                              \
+            }                                                                                                       \
+            break;                                                                                                  \
         default:                                                                                                    \
             break;                                                                                                  \
         }                                                                                                           \


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the memory exceeds limit of a workgroup, it returns `Memory of rg1 exceed limit. Used: 48768571277, Limit: 48768455281.` to the user, which is hard to know what to do next.

After this PR:
For `default_wg`, it returns:
```
Memory of default_wg exceed limit. Used: 48768571277, Limit: 48768455281.
Mem usage has exceed the limit of query pool
```

For the other groups, it returns:
```
Memory of rg1 exceed limit. Used: 48768571277, Limit: 48768455281.
Mem usage has exceed the limit of the resource group [rg1]. 
You can change the limit by modify [mem_limit] of this group.
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
