### PR TITLE
[Feature] adjust iceberg table sink dop

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -30,6 +30,7 @@ import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION_DEFAULT;
 
 public class IcebergTableSink extends DataSink {
+    public final static int ICEBERG_SINK_MAX_DOP = 32;
     protected final TupleDescriptor desc;
     private final long targetTableId;
     private final String fileFormat;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -151,6 +151,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     private TCacheParam cacheParam = null;
     private boolean hasOlapTableSink = false;
+    private boolean hasIcebergTableSink = false;
     private boolean forceSetTableSinkDop = false;
     private boolean forceAssignScanRangesPerDriverSeq = false;
 
@@ -258,6 +259,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public void setHasOlapTableSink() {
         this.hasOlapTableSink = true;
+    }
+
+    public boolean hasIcebergTableSink() {
+        return this.hasIcebergTableSink;
+    }
+
+    public void setHasIcebergTableSink() {
+        this.hasIcebergTableSink = true;
     }
 
     public boolean forceSetTableSinkDop() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -46,7 +46,6 @@ import com.starrocks.planner.JoinNode;
 import com.starrocks.planner.MultiCastDataSink;
 import com.starrocks.planner.MultiCastPlanFragment;
 import com.starrocks.planner.OlapScanNode;
-import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNode;
@@ -1744,9 +1743,9 @@ public class CoordinatorPreprocessor {
                 if (forceSetTableSinkDop) {
                     DataSink dataSink = fragment.getSink();
                     int dop = fragment.getPipelineDop();
-                    if (dataSink instanceof OlapTableSink) {
+                    if (!(dataSink instanceof IcebergTableSink)) {
                         curTableSinkDop = dop;
-                    } else if (dataSink instanceof IcebergTableSink) {
+                    } else {
                         int sessionVarSinkDop = ConnectContext.get().getSessionVariable().getPipelineSinkDop();
                         if (sessionVarSinkDop > 0) {
                             curTableSinkDop = Math.min(dop, sessionVarSinkDop);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1695,9 +1695,9 @@ public class CoordinatorPreprocessor {
                 if (forceSetTableSinkDop) {
                     DataSink dataSink = fragment.getSink();
                     int dop = fragment.getPipelineDop();
-                    if (dataSink instanceof OlapTableSink) {
+                    if (!(dataSink instanceof IcebergTableSink)) {
                         curTableSinkDop = dop;
-                    } else if (dataSink instanceof IcebergTableSink) {
+                    } else {
                         int sessionVarSinkDop = ConnectContext.get().getSessionVariable().getPipelineSinkDop();
                         if (sessionVarSinkDop > 0) {
                             curTableSinkDop = Math.min(dop, sessionVarSinkDop);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -418,7 +418,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             .add(DISABLE_BUCKET_JOIN)
             .add(CBO_ENABLE_REPLICATED_JOIN)
             .add(FOREIGN_KEY_CHECKS)
-            .add(PIPELINE_SINK_DOP)
             .add("enable_cbo")
             .add("enable_vectorized_engine")
             .add("vectorized_engine_enable")
@@ -657,6 +656,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_DOP)
     private int pipelineDop = 0;
+
+    @VariableMgr.VarAttr(name = PIPELINE_SINK_DOP)
+    private int pipelineSinkDop = 0;
 
     /*
      * The maximum pipeline dop limit which only takes effect when pipeline_dop=0.
@@ -1577,6 +1579,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineDop() {
         return this.pipelineDop;
+    }
+
+    public int getPipelineSinkDop() {
+        return pipelineSinkDop;
+    }
+
+    public void setPipelineSinkDop(int pipelineSinkDop) {
+        this.pipelineSinkDop = pipelineSinkDop;
     }
 
     public void setMaxPipelineDop(int maxPipelineDop) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/21502

In the first milestone of iceberg table sink, we want to support users manually config the sink dop. it mainly to used to increase concurrency and reducing small files by user. If user doesn't configure, we will use the current sink dop default value.  the default value is `min(32, default_dop_by_cores)`.  32 is an empirical value for accessing S3, which is a turning point for the IO concurrency. 
Session variable `pipeline_sink_dop` has been deprecated currently. In this patch, we cancel the deprecation. It only be used in iceberg table sink. We didn't modify any logic of the olap table sink.

We will make adaptive adjustments to the Iceberg sink DOP in the next milestone.



## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
