### PR TITLE
[BugFix] Some_problem_when_backup_restore_using_local_path (21735)

### DIFF
--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -371,6 +371,18 @@ Status HdfsFileSystem::iterate_dir2(const std::string& dir, const std::function<
         } else {
             dir_size = dir.size() + 1;
         }
+
+        const std::string local_fs("file:/");
+        if (dir.compare(0, local_fs.length(), local_fs) == 0) {
+            std::string mName(fileinfo[i].mName);
+            std::size_t found = mName.rfind("/");
+            if (found == std::string::npos) {
+                return Status::InvalidArgument("parse path fail {}"_format(dir));
+            }
+
+            dir_size = found + 1;
+        }
+
         std::string_view name(fileinfo[i].mName + dir_size);
         DirEntry entry{.name = name,
                        .mtime = fileinfo[i].mLastMod,

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1134,10 +1134,19 @@ public class HdfsFsManager {
     public void renamePath(String srcPath, String destPath, Map<String, String> loadProperties) throws UserException {
         WildcardURI srcPathUri = new WildcardURI(srcPath);
         WildcardURI destPathUri = new WildcardURI(destPath);
-        if (!srcPathUri.getAuthority().trim().equals(destPathUri.getAuthority().trim())) {
-            throw new UserException(
-                    "only allow rename in same file system");
+
+        boolean srcAuthorityNull = (srcPathUri.getAuthority() == null);
+        boolean destAuthorityNull = (destPathUri.getAuthority() == null);
+        if (srcAuthorityNull != destAuthorityNull) {
+            throw new UserException("Different authority info between srcPath: " + srcPath +
+                                    " and destPath: " + destPath);
         }
+        if (!srcAuthorityNull && !destAuthorityNull &&
+                !srcPathUri.getAuthority().trim().equals(destPathUri.getAuthority().trim())) {
+            throw new UserException(
+                "only allow rename in same file system");
+        }
+
         HdfsFs fileSystem = getFileSystem(srcPath, loadProperties, null);
         Path srcfilePath = new Path(srcPathUri.getPath());
         Path destfilePath = new Path(destPathUri.getPath());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21735

## Problem Summary(Required) ：
Problem 1:
When fe upload the backup file, fe will check the authority information.
But if we use local path, authority is undefined and fe will get NPE problem.

Problem 2:
When we use local path for restore, BE will parse the wrong path for
the remote file and let the restore fail.

Solution:
1. check authority information.
2. fix the parse problem.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
