### PR TITLE
[Feature] Recover binlog when loading tablets

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -722,7 +722,9 @@ void run_update_meta_info_task(const std::shared_ptr<UpdateTabletMetaInfoAgentTa
                     }
                 }
 
-                tablet->set_binlog_config(tablet_meta_info.binlog_config);
+                BinlogConfig binlog_config;
+                binlog_config.update(tablet_meta_info.binlog_config);
+                tablet->update_binlog_config(binlog_config);
                 break;
             case TTabletMetaType::ENABLE_PERSISTENT_INDEX:
                 LOG(INFO) << "update tablet:" << tablet->tablet_id()

--- a/be/src/storage/binlog_file_reader.cpp
+++ b/be/src/storage/binlog_file_reader.cpp
@@ -445,6 +445,7 @@ StatusOr<BinlogFileMetaPBPtr> BinlogFileReader::load_meta_by_scan_pages(int64_t 
         file_meta->set_end_version(page_header->version());
         file_meta->set_end_seq_id(page_header->end_seq_id());
         file_meta->set_end_timestamp_in_us(page_header->timestamp_in_us());
+        file_meta->set_version_eof(page_header->end_of_version());
 
         for (auto rowset_id : page_header->rowsets()) {
             rowsets.insert(rowset_id);

--- a/be/src/storage/binlog_file_reader.h
+++ b/be/src/storage/binlog_file_reader.h
@@ -49,8 +49,8 @@ struct PageContext {
     PageContentPB page_content;
 };
 
-// Used to filter useless data when loading binlog file
-class BinlogFileLoadFilter {
+// Used to filter invalid pages when loading the file meta
+class BinlogFileDataFilter {
 public:
     virtual bool is_valid_seq(int64_t version, int64_t seq_id) = 0;
 
@@ -89,26 +89,40 @@ public:
     // on it's state across two next().
     LogEntryInfo* log_entry();
 
-    static Status page_file_header(RandomAccessFile* read_file, int64_t file_size, BinlogFileHeaderPB* file_header,
-                                   int64_t* read_file_size);
+    static Status parse_file_header(RandomAccessFile* read_file, int64_t file_size, BinlogFileHeaderPB* file_header,
+                                    int64_t* read_file_size);
 
     static Status parse_file_footer(RandomAccessFile* read_file, int64_t file_size, BinlogFileMetaPB* file_meta);
 
     static Status parse_page_header(RandomAccessFile* read_file, int64_t file_size, int64_t file_pos,
                                     int64_t page_index, PageHeaderPB* page_header_pb, int64_t* read_file_size);
 
-    // Scan the pages in the binlog file to load file meta. Return Status::OK() if there is valid data
-    // matching the filter. Returns Status::NotFound() if there is no valid data. Other status will be
-    // returned if errors happens, such as I/O error.
-    static Status scan_pages_to_load(int64_t file_id, RandomAccessFile* read_file, int64_t file_size,
-                                     BinlogFileLoadFilter* filter, BinlogFileMetaPB* file_meta);
+    // Load the file meta by scanning pages. Scan from the beginning of the file until to the first
+    // page that is corrupted, or filtered by the filter, and construct the file meta according to
+    // those scanned pages. Returns Status::OK() and the file meta if there is valid data. Returns
+    // Status::NotFound() if there is no valid data. Other status will be returned if unexpected
+    // error happens.
+    //
+    // Why is it possible to have corrupted, or filtered pages?
+    // A binlog file is appendable and can be shared by multiple ingestion. Considering a possible
+    // process to fail to generate binlog for an ingestion
+    // 1. the file already contains binlog for some successful ingestion
+    // 2. a new ingestion comes, and appends a page to the binlog file, but not committed (fsync)
+    // 4. BE exits because of core dump, or temporary disk error, the ingestion fails to publish,
+    //    and the appended page is useless, but there is no chance to truncate it
+    // 5. restart BE, and load binlog file meta by scanning pages
+    // In this case, the last page can be
+    // 1. corrupted because there may be only part of data written to the disk
+    // 2. persisted successfully, but should be filtered because failed to publish
+    // So stop to scan pages until meeting the first corrupted or filtered page.
+    static StatusOr<BinlogFileMetaPBPtr> load_meta_by_scan_pages(int64_t file_id, RandomAccessFile* read_file, int64_t file_size,
+                                                       BinlogFileDataFilter* filter);
 
-    // Load the file meta from the binlog file. This method first try to get the file meta from the
-    // file footer. If the footer not exists, will scan pages to get the file meta. Return Status::OK()
-    // if there is valid data matching the filter. Returns Status::NotFound() if there is no valid data.
-    // Other status will be returned if errors happens, such as I/O error.
-    static StatusOr<std::shared_ptr<BinlogFileMetaPB>> load(int64_t file_id, std::string& file_path,
-                                                            BinlogFileLoadFilter* filter);
+    // Load the file meta from the binlog file. First try to get the file meta from the file footer.
+    // If the footer not exists, or is invalid, scan pages to get the file meta. Returns Status::OK()
+    // and the file meta if there is valid data. Returns Status::NotFound() if there is no valid data.
+    // Other status will be returned if unexpected error happens.
+    static StatusOr<BinlogFileMetaPBPtr> load_meta(int64_t file_id, std::string& file_path, BinlogFileDataFilter* filter);
 
 private:
     Status _seek(int64_t version, int64_t seq_id);

--- a/be/src/storage/binlog_file_reader.h
+++ b/be/src/storage/binlog_file_reader.h
@@ -49,14 +49,6 @@ struct PageContext {
     PageContentPB page_content;
 };
 
-// Used to filter invalid pages when loading the file meta
-class BinlogFileDataFilter {
-public:
-    virtual bool is_valid_seq(int64_t version, int64_t seq_id) = 0;
-
-    virtual bool is_valid_rowset(int64_t rowset_version) = 0;
-};
-
 // Read log entries in the binlog file.
 //
 // How to use
@@ -98,12 +90,12 @@ public:
                                     int64_t page_index, PageHeaderPB* page_header_pb, int64_t* read_file_size);
 
     // Load the file meta by scanning pages. Scan from the beginning of the file until to the first
-    // page that is corrupted, or filtered by the filter, and construct the file meta according to
-    // those scanned pages. Returns Status::OK() and the file meta if there is valid data. Returns
-    // Status::NotFound() if there is no valid data. Other status will be returned if unexpected
-    // error happens.
+    // page that is corrupted, or is no less than the parameter *maxLsnExclusive*, and construct the
+    // file meta according to those scanned pages. Returns Status::OK() and the file meta if there
+    // is valid data. Returns Status::NotFound() if there is no valid data. Other status will be
+    // returned if unexpected error happens.
     //
-    // Why is it possible to have corrupted, or filtered pages?
+    // Why is it possible to have corrupted pages, and need to filter pages by maxLsnExclusive?
     // A binlog file is appendable and can be shared by multiple ingestion. Considering a possible
     // process to fail to generate binlog for an ingestion
     // 1. the file already contains binlog for some successful ingestion
@@ -113,16 +105,16 @@ public:
     // 5. restart BE, and load binlog file meta by scanning pages
     // In this case, the last page can be
     // 1. corrupted because there may be only part of data written to the disk
-    // 2. persisted successfully, but should be filtered because failed to publish
+    // 2. persisted successfully, but should be filtered by maxLsnExclusive because failed to publish
     // So stop to scan pages until meeting the first corrupted or filtered page.
-    static StatusOr<BinlogFileMetaPBPtr> load_meta_by_scan_pages(int64_t file_id, RandomAccessFile* read_file, int64_t file_size,
-                                                       BinlogFileDataFilter* filter);
+    static StatusOr<BinlogFileMetaPBPtr> load_meta_by_scan_pages(int64_t file_id, RandomAccessFile* read_file,
+                                                                 int64_t file_size, BinlogLsn& maxLsnExclusive);
 
     // Load the file meta from the binlog file. First try to get the file meta from the file footer.
     // If the footer not exists, or is invalid, scan pages to get the file meta. Returns Status::OK()
     // and the file meta if there is valid data. Returns Status::NotFound() if there is no valid data.
     // Other status will be returned if unexpected error happens.
-    static StatusOr<BinlogFileMetaPBPtr> load_meta(int64_t file_id, std::string& file_path, BinlogFileDataFilter* filter);
+    static StatusOr<BinlogFileMetaPBPtr> load_meta(int64_t file_id, std::string& file_path, BinlogLsn& maxLsnExclusive);
 
 private:
     Status _seek(int64_t version, int64_t seq_id);

--- a/be/src/storage/binlog_file_reader.h
+++ b/be/src/storage/binlog_file_reader.h
@@ -90,12 +90,12 @@ public:
                                     int64_t page_index, PageHeaderPB* page_header_pb, int64_t* read_file_size);
 
     // Load the file meta by scanning pages. Scan from the beginning of the file until to the first
-    // page that is corrupted, or is no less than the parameter *maxLsnExclusive*, and construct the
+    // page that is corrupted, or is no less than the parameter *max_lsn_exclusive*, and construct the
     // file meta according to those scanned pages. Returns Status::OK() and the file meta if there
     // is valid data. Returns Status::NotFound() if there is no valid data. Other status will be
     // returned if unexpected error happens.
     //
-    // Why is it possible to have corrupted pages, and need to filter pages by maxLsnExclusive?
+    // Why is it possible to have corrupted pages, and need to filter pages by max_lsn_exclusive?
     // A binlog file is appendable and can be shared by multiple ingestion. Considering a possible
     // process to fail to generate binlog for an ingestion
     // 1. the file already contains binlog for some successful ingestion
@@ -105,16 +105,17 @@ public:
     // 5. restart BE, and load binlog file meta by scanning pages
     // In this case, the last page can be
     // 1. corrupted because there may be only part of data written to the disk
-    // 2. persisted successfully, but should be filtered by maxLsnExclusive because failed to publish
+    // 2. persisted successfully, but should be filtered by max_lsn_exclusive because failed to publish
     // So stop to scan pages until meeting the first corrupted or filtered page.
     static StatusOr<BinlogFileMetaPBPtr> load_meta_by_scan_pages(int64_t file_id, RandomAccessFile* read_file,
-                                                                 int64_t file_size, BinlogLsn& maxLsnExclusive);
+                                                                 int64_t file_size, BinlogLsn& max_lsn_exclusive);
 
     // Load the file meta from the binlog file. First try to get the file meta from the file footer.
     // If the footer not exists, or is invalid, scan pages to get the file meta. Returns Status::OK()
     // and the file meta if there is valid data. Returns Status::NotFound() if there is no valid data.
     // Other status will be returned if unexpected error happens.
-    static StatusOr<BinlogFileMetaPBPtr> load_meta(int64_t file_id, std::string& file_path, BinlogLsn& maxLsnExclusive);
+    static StatusOr<BinlogFileMetaPBPtr> load_meta(int64_t file_id, std::string& file_path,
+                                                   BinlogLsn& max_lsn_exclusive);
 
 private:
     Status _seek(int64_t version, int64_t seq_id);

--- a/be/src/storage/binlog_file_writer.cpp
+++ b/be/src/storage/binlog_file_writer.cpp
@@ -295,6 +295,7 @@ Status BinlogFileWriter::commit(bool end_of_version) {
     file_meta->set_end_version(version_context->version);
     file_meta->set_end_seq_id(page_context->end_seq_id);
     file_meta->set_end_timestamp_in_us(version_context->change_event_timestamp_in_us);
+    file_meta->set_version_eof(end_of_version);
     file_meta->set_num_pages(file_meta->num_pages() + version_context->num_pages);
     file_meta->set_file_size(_file->size());
     for (auto& rowset_id : version_context->rowsets) {

--- a/be/src/storage/binlog_file_writer.cpp
+++ b/be/src/storage/binlog_file_writer.cpp
@@ -526,6 +526,10 @@ void BinlogFileWriter::_reset_pending_context() {
     _pending_page_context->page_content.Clear();
 }
 
+Status BinlogFileWriter::force_flush_page(bool end_version) {
+    return _flush_page(end_version);
+}
+
 StatusOr<std::shared_ptr<BinlogFileWriter>> BinlogFileWriter::reopen(int64_t file_id, const std::string& file_path,
                                                                      int32_t page_size,
                                                                      CompressionTypePB compression_type,

--- a/be/src/storage/binlog_file_writer.h
+++ b/be/src/storage/binlog_file_writer.h
@@ -202,14 +202,16 @@ public:
 
     void copy_file_meta(BinlogFileMetaPB* new_file_meta) { new_file_meta->CopyFrom(*_file_meta.get()); }
 
-    // For testing
-    std::unordered_set<int64_t>& rowsets() { return _rowsets; }
-
     // Reopen an existed binlog file to append data. The writer will be reset
     // to the state described by *previous_meta*.
     static StatusOr<std::shared_ptr<BinlogFileWriter>> reopen(int64_t file_id, const std::string& file_path,
                                                               int32_t page_size, CompressionTypePB compression_type,
                                                               BinlogFileMetaPB* previous_meta);
+
+    // For testing
+    std::unordered_set<int64_t>& rowsets() { return _rowsets; }
+
+    Status force_flush_page(bool end_version);
 
 private:
     Status _check_state(WriterState expect_state);

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -81,20 +81,8 @@ Status BinlogManager::init(BinlogLsn min_valid_lsn, std::vector<int64_t>& sorted
                 "version: {}",
                 _tablet_id, min_valid_lsn.to_string(), sorted_valid_versions.size(), num_versions_recovered,
                 *version_it);
-        LOG(ERROR) << err_msg;
-        if (VLOG_IS_ON(3)) {
-            std::stringstream ss;
-            ss << "detail of valid versions for tablet: " << _tablet_id << ", [";
-            auto it = sorted_valid_versions.begin();
-            ss << *it;
-            it++;
-            while (it != sorted_valid_versions.end()) {
-                ss << ", " << *it;
-                it++;
-            }
-            ss << "]";
-            VLOG(3) << ss.str();
-        }
+        LOG(ERROR) << err_msg << ". Details of valid versions for tablet: "
+                   << fmt::format("{}", fmt::join(sorted_valid_versions, ", "));
         _init_failure.store(true);
         return Status::InternalError(err_msg);
     }
@@ -123,6 +111,8 @@ Status BinlogManager::init(BinlogLsn min_valid_lsn, std::vector<int64_t>& sorted
     }
     LOG(INFO) << "Init binlog successfully, tablet: " << _tablet_id
               << ", num valid versions: " << sorted_valid_versions.size() << version_details;
+    VLOG(3) << "Details of recovered versions for tablet: " << _tablet_id
+            << ", versions: " << fmt::format("{}", fmt::join(sorted_valid_versions, ", "));
 
     return Status::OK();
 }

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -43,7 +43,7 @@ BinlogManager::~BinlogManager() {
     }
 }
 
-Status BinlogManager::init(BinlogLsn min_valid_lsn, std::list<int64_t>& sorted_valid_versions) {
+Status BinlogManager::init(BinlogLsn min_valid_lsn, std::vector<int64_t>& sorted_valid_versions) {
     // 1. list all of binlog files
     std::list<int64_t> binlog_file_ids;
     Status status = BinlogUtil::list_binlog_file_ids(_path, &binlog_file_ids);

--- a/be/src/storage/binlog_manager.cpp
+++ b/be/src/storage/binlog_manager.cpp
@@ -43,7 +43,7 @@ BinlogManager::~BinlogManager() {
     }
 }
 
-Status BinlogManager::init(BinlogLsn min_lsn, std::set<int64_t> versions) {
+Status BinlogManager::init(BinlogLsn min_lsn, std::list<int64_t> sortedValidVersions) {
     std::set<int64_t> binlog_file_ids;
     Status status = BinlogUtil::list_binlog_file_ids(_path, &binlog_file_ids);
     if (!status.ok()) {
@@ -99,7 +99,7 @@ Status BinlogManager::init(BinlogLsn min_lsn, std::set<int64_t> versions) {
 
     // TODO don't print if versions is empty
     LOG(INFO) << "Init binlog manager successfully, tablet: " << _tablet_id << ", lsn " << min_lsn
-              << ", min version: " << *versions.begin() << ", max version: " << *versions.rbegin();
+              << ", min version: " << sortedValidVersions.front() << ", max version: " << sortedValidVersions.back();
     return Status::OK();
 }
 

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -93,21 +93,6 @@ private:
     Tablet& _tablet;
 };
 
-class BinlogFileLoadFilterImpl : public BinlogFileDataFilter {
-public:
-    BinlogFileLoadFilterImpl(int64_t max_version, int64_t max_seq_id, RowsetFetcher* rowset_fetcher);
-
-    bool is_valid_seq(int64_t version, int64_t seq_id) override;
-
-    bool is_valid_rowset(int64_t rowset_id) override;
-
-private:
-    // less than <_max_version, _max_seq_id>
-    int64_t _max_version;
-    int64_t _max_seq_id;
-    RowsetFetcher* _rowset_fetcher;
-};
-
 class BinlogRange {
 public:
     BinlogRange(int64_t start_version, int64_t start_seq_id, int64_t end_version, int64_t end_seq_id)

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -176,7 +176,7 @@ public:
 
     ~BinlogManager();
 
-    Status init(BinlogLsn min_lsn, std::set<int64_t> versions);
+    Status init(BinlogLsn min_lsn, std::list<int64_t> sortedValidVersions);
 
     //  The process of an ingestion is as following, and protected by Tablet#_meta_lock to ensure there is
     //  no concurrent ingestion for duplicate key table

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -176,7 +176,58 @@ public:
 
     ~BinlogManager();
 
-    Status init(BinlogLsn min_lsn, std::list<int64_t> sortedValidVersions);
+    // Initialize the binlog. It will load binlog files metas from disk, and recover the binlog.
+    // @param min_valid_lsn the minimum lsn of valid binlog
+    // @param sorted_valid_versions a list of versions of valid binlog. They are already sorted.
+    //
+    // Let's explain how to recovery the binlog by an example. Assume BE restarts after a crash. There are
+    // 6 binlog files under the directory, and their states are described in the following table
+    // +---------+----------+------------------------+---------------------------------------------------------------------------------------------------+
+    // | file id | should   | data                   | what happened before BE crashed                                                                   |
+    // |         | recovery |                        |                                                                                                   |
+    // +---------+----------+------------------------+---------------------------------------------------------------------------------------------------+
+    // | 1       | no       | version 1, seq 0-100   | expired, and invalid. rowset meta for v1 had been removed from TabletMetaPB#inc_rs_metas, but the |
+    // |         |          | version 2, seq 0-50    | binlog file was residual because BE crashed before deleting the file                              |
+    // +---------+----------+------------------------+---------------------------------------------------------------------------------------------------+
+    // | 2       | yes      | version 2, seq 51-100  | valid. TabletMetaPB#binlog_min_lsn recorded the minimum lsn (version 2, seq 51) when file 1 was   |
+    // |         |          | version 3, seq 0-99    | expired, and rowset metas for version 2 and 3 were still in TabletMetaPB#inc_rs_metas             |
+    // +---------+----------+------------------------+---------------------------------------------------------------------------------------------------+
+    // | 3       | yes      | version 3, seq 100-149 | valid. rowset metas for version 3 and 4 were in TabletMetaPB#inc_rs_metas                         |
+    // |         |          | version 4, seq 0-50    |                                                                                                   |
+    // +---------+----------+------------------------+---------------------------------------------------------------------------------------------------+
+    // | 4       | no       | version 5, seq 0-10    | invalid. when publishing version 5, temporary disk error happened after partial data was          |
+    // |         |          |                        | written into the binlog file, so the publish failed, and the file should be deleted, but          |
+    // |         |          |                        | the file also failed to delete because of disk error, and waited for gc (would support later)     |
+    // +---------+----------+------------------------+---------------------------------------------------------------------------------------------------+
+    // | 5       | yes      | version 5, seq 0-149   | valid. publish for version 5 was retried, and succeeded                                           |
+    // +---------+----------+------------------------+---------------------------------------------------------------------------------------------------+
+    // | 6       | no       | version 6, seq 0-50    | invalid. binlog for version 6 was partially written before BE crashed                             |
+    // +---------+----------+------------------------+---------------------------------------------------------------------------------------------------+
+    //
+    // the parameters for init() will be min_lsn = (2, 51), sorted_valid_versions = [2, 3, 4, 5], and they are constructed in Tablet#finish_load_rowsets()
+    // The steps to recover binlog are as follows
+    // 1. recover version 5:
+    //    1.1 load file 6, and the version of binlog is 6, which is bigger than 5, so discard file 6
+    //    1.2 load file 5, the version of all data is 5 which is expected, so recover file 5. The min
+    //        seq is 0 which indicates we find all binlog for version 5
+    // 2. recover version 4
+    //    2.1 load file 4, and the version of binlog is 5, which is bigger than 4, so discard file 4
+    //    2.2 load file 3, and the max version is 4, so the file is valid, and recover it. The min version
+    //        is 3 which indicates the binlog for version 4 is only in one file, and we find all data
+    // 3. recover version 3:
+    //    3.1 the min version of file 3 is 3, but the min seq is 100 (not 0), so only part of binlog for version 3
+    //        is in file 3, and we need to load more files
+    //    3.2 load file 2, and the max lsn (version 3, seq 99) is continuously with the min lsn (version 3, seq 100)
+    //        in file 3, and the min version is 2, which indicates file 2 contains left binlog for version 3, and
+    //        we find all data
+    // 4. recover version 2:
+    //    4.1 the min lsn of file 2 is (version 2, seq 51) which is equal to the min_valid_lsn, so we find all valid binlog
+    //        for version 2
+    // After recovery, file 1, 4 and 6 will be deleted.
+    // Core ideas for the recovery
+    // 1. use min_valid_lsn and sorted_valid_versions to decide what data is valid, and ensure the completeness
+    // 2. recover from the higher version to the lower so that remove duplicate data (such as version 5)
+    Status init(BinlogLsn min_valid_lsn, std::list<int64_t>& sorted_valid_versions);
 
     //  The process of an ingestion is as following, and protected by Tablet#_meta_lock to ensure there is
     //  no concurrent ingestion for duplicate key table
@@ -279,6 +330,12 @@ public:
     void close_active_writer();
 
 private:
+    Status _recover_version(int64_t version, BinlogLsn& min_lsn, std::list<int64_t>& file_ids,
+                            std::list<int64_t>::reverse_iterator& file_id_it,
+                            std::vector<BinlogFileMetaPBPtr>& recovered_file_metas,
+                            std::vector<int64_t>* useless_file_ids);
+    StatusOr<BinlogFileMetaPBPtr> _recover_file_meta_for_version(int64_t version, int64_t file_id,
+                                                                 BinlogFileMetaPB* last_file_meta);
     void _apply_build_result(BinlogBuildResult* result);
     void _check_wait_reader_binlog_files();
     bool _check_alive_binlog_files(int64_t current_second, int64_t binlog_ttl_second, int64_t binlog_max_size);
@@ -296,8 +353,9 @@ private:
     // If true, will decline to generate new binlog and read requests
     std::atomic<bool> _init_failure{false};
 
+    int64_t BINLOG_MIN_FILE_ID = 1;
     // file id for the next binlog file. Protected by Tablet#_meta_lock
-    std::atomic<int64_t> _next_file_id = 0;
+    std::atomic<int64_t> _next_file_id = BINLOG_MIN_FILE_ID;
     // the version of running ingestion. -1 indicates no ingestion.
     // Protected by Tablet#_meta_lock
     int64_t _ingestion_version = -1;

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -353,7 +353,7 @@ private:
     // If true, will decline to generate new binlog and read requests
     std::atomic<bool> _init_failure{false};
 
-    int64_t BINLOG_MIN_FILE_ID = 1;
+    static const int64_t BINLOG_MIN_FILE_ID = 1;
     // file id for the next binlog file. Protected by Tablet#_meta_lock
     std::atomic<int64_t> _next_file_id = BINLOG_MIN_FILE_ID;
     // the version of running ingestion. -1 indicates no ingestion.

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -63,7 +63,7 @@ struct BinlogConfig {
         binlog_config_pb->set_binlog_max_size(binlog_max_size);
     }
 
-    std::string to_string() {
+    std::string to_string() const {
         return strings::Substitute(
                 "BinlogConfig={version=$0, binlog_enable=$1, binlog_ttl_second=$2, binlog_max_size=$3}", version,
                 binlog_enable, binlog_ttl_second, binlog_max_size);

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -227,7 +227,7 @@ public:
     // Core ideas for the recovery
     // 1. use min_valid_lsn and sorted_valid_versions to decide what data is valid, and ensure the completeness
     // 2. recover from the higher version to the lower so that remove duplicate data (such as version 5)
-    Status init(BinlogLsn min_valid_lsn, std::list<int64_t>& sorted_valid_versions);
+    Status init(BinlogLsn min_valid_lsn, std::vector<int64_t>& sorted_valid_versions);
 
     //  The process of an ingestion is as following, and protected by Tablet#_meta_lock to ensure there is
     //  no concurrent ingestion for duplicate key table

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -191,7 +191,7 @@ public:
 
     ~BinlogManager();
 
-    Status init(int64_t min_version, int64_t max_version);
+    Status init(BinlogLsn min_lsn, std::set<int64_t> versions);
 
     //  The process of an ingestion is as following, and protected by Tablet#_meta_lock to ensure there is
     //  no concurrent ingestion for duplicate key table
@@ -273,7 +273,7 @@ public:
 
     BinlogFileWriter* active_binlog_writer() { return _active_binlog_writer.get(); }
 
-    std::map<int128_t, BinlogFilePtr>& alive_binlog_files() { return _alive_binlog_files; }
+    std::map<BinlogLsn, BinlogFilePtr>& alive_binlog_files() { return _alive_binlog_files; }
 
     std::unordered_map<int64_t, int32_t>& alive_rowset_count_map() { return _alive_rowset_count_map; }
 
@@ -326,7 +326,7 @@ private:
     // LSN(start_version, start_seq_id) of a binlog file to the file meta. A binlog file with a
     // smaller start LSN also has a smaller file id. The file with the biggest start LSN is the
     // meta of _active_binlog_writer if it's not null.
-    std::map<int128_t, BinlogFilePtr> _alive_binlog_files;
+    std::map<BinlogLsn, BinlogFilePtr> _alive_binlog_files;
     // Alive rowsets. Map from rowset id to the number of binlog files using it in _alive_binlog_files
     std::unordered_map<int64_t, int32_t> _alive_rowset_count_map;
     // Disk size for alive binlog files

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -191,7 +191,7 @@ public:
 
     ~BinlogManager();
 
-    Status init();
+    Status init(int64_t min_version, int64_t max_version);
 
     //  The process of an ingestion is as following, and protected by Tablet#_meta_lock to ensure there is
     //  no concurrent ingestion for duplicate key table
@@ -238,7 +238,8 @@ public:
     // because Tablet#_inc_rs_version_map may be visited. This method only updates metas
     // of binlog files that should be deleted, but not do the deletion which will be done
     // in delete_unused_binlog() later, so Tablet#_meta_lock will not be blocked too long.
-    void check_expire_and_capacity(int64_t current_second, int64_t binlog_ttl_second, int64_t binlog_max_size);
+    // Return true if there is expired or overcapacity binlog.
+    bool check_expire_and_capacity(int64_t current_second, int64_t binlog_ttl_second, int64_t binlog_max_size);
 
     // Whether the rowset is used by the binlog.
     bool is_rowset_used(int64_t rowset_id);
@@ -295,7 +296,7 @@ public:
 private:
     void _apply_build_result(BinlogBuildResult* result);
     void _check_wait_reader_binlog_files();
-    void _check_alive_binlog_files(int64_t current_second, int64_t binlog_ttl_second, int64_t binlog_max_size);
+    bool _check_alive_binlog_files(int64_t current_second, int64_t binlog_ttl_second, int64_t binlog_max_size);
     Status _check_init_failure();
 
     int64_t _tablet_id;

--- a/be/src/storage/binlog_manager.h
+++ b/be/src/storage/binlog_manager.h
@@ -93,7 +93,7 @@ private:
     Tablet& _tablet;
 };
 
-class BinlogFileLoadFilterImpl : public BinlogFileLoadFilter {
+class BinlogFileLoadFilterImpl : public BinlogFileDataFilter {
 public:
     BinlogFileLoadFilterImpl(int64_t max_version, int64_t max_seq_id, RowsetFetcher* rowset_fetcher);
 

--- a/be/src/storage/binlog_util.cpp
+++ b/be/src/storage/binlog_util.cpp
@@ -53,14 +53,14 @@ bool BinlogUtil::get_file_id_from_name(const std::string& file_name, int64_t* fi
     return true;
 }
 
-Status BinlogUtil::list_binlog_file_ids(std::string& binlog_dir, std::set<int64_t>* binlog_file_ids) {
+Status BinlogUtil::list_binlog_file_ids(std::string& binlog_dir, std::list<int64_t>* binlog_file_ids) {
     std::set<std::string> file_names;
     RETURN_IF_ERROR(fs::list_dirs_files(binlog_dir, nullptr, &file_names));
     int64_t file_id;
     for (auto& name : file_names) {
         bool ret = get_file_id_from_name(name, &file_id);
         if (ret) {
-            binlog_file_ids->emplace(file_id);
+            binlog_file_ids->push_back(file_id);
         }
     }
     return Status::OK();

--- a/be/src/storage/binlog_util.cpp
+++ b/be/src/storage/binlog_util.cpp
@@ -16,9 +16,14 @@
 
 #include <re2/re2.h>
 
+#include "fmt/format.h"
 #include "fs/fs_util.h"
 
 namespace starrocks {
+
+std::string BinlogLsn::to_string() const {
+    return fmt::format("[version={}, seq_id={}]", version(), seq_id());
+}
 
 std::string BinlogUtil::file_meta_to_string(BinlogFileMetaPB* file_meta) {
     std::stringstream ss;

--- a/be/src/storage/binlog_util.cpp
+++ b/be/src/storage/binlog_util.cpp
@@ -32,8 +32,21 @@ std::string BinlogUtil::file_meta_to_string(BinlogFileMetaPB* file_meta) {
        << ", start_seq_id: " << file_meta->start_seq_id()
        << ", start_timestamp_in_us: " << file_meta->start_timestamp_in_us()
        << ", end_version: " << file_meta->end_version() << ", end_seq_id: " << file_meta->end_seq_id()
-       << ", end_timestamp_in_us: " << file_meta->end_timestamp_in_us() << ", num_pages: " << file_meta->num_pages()
-       << ", file_size: " << file_meta->file_size() << "}";
+       << ", end_timestamp_in_us: " << file_meta->end_timestamp_in_us() << ", version_eof: " << file_meta->version_eof()
+       << ", num_pages: " << file_meta->num_pages() << ", file_size: " << file_meta->file_size() << "}";
+    return ss.str();
+}
+
+std::string BinlogUtil::page_header_to_string(PageHeaderPB* page_header) {
+    std::stringstream ss;
+    ss << "{page type: " << page_header->page_type() << ", compress type: " << page_header->compress_type()
+       << ", uncompressed size: " << page_header->uncompressed_size()
+       << ", compressed size: " << page_header->compressed_size() << ", crc: " << page_header->compressed_page_crc()
+       << ", version: " << page_header->version() << ", num log entries: " << page_header->num_log_entries()
+       << ", start seq id: " << page_header->start_seq_id() << ", end seq id: " << page_header->end_seq_id()
+       << ". timestamp in us: " << page_header->timestamp_in_us()
+       << ", end of version: " << page_header->end_of_version() << ", num rowsets: " << page_header->rowsets().size()
+       << "}";
     return ss.str();
 }
 

--- a/be/src/storage/binlog_util.h
+++ b/be/src/storage/binlog_util.h
@@ -25,13 +25,33 @@ namespace starrocks {
 
 using BinlogFileMetaPBPtr = std::shared_ptr<BinlogFileMetaPB>;
 
+// The log sequence number of the change event which is unique in all ingestion. It's a combination of
+// version(int64_t) and seq_id(int64_t). The version is the publish version of the ingestion to generate
+// the change event, and the seq_id is the sequence number of the change event in the ingestion.
+struct BinlogLsn {
+    uint128_t lsn = 0;
+
+    BinlogLsn(int64_t version, int64_t seq_id) : lsn((((uint128_t)version) << 64) | seq_id) {}
+    BinlogLsn() = default;
+
+    int64_t version() const { return (int64_t)(lsn >> 64); }
+    int64_t seq_id() const { return (int64_t)(lsn & 0xffffffffUL); }
+    bool operator!=(const BinlogLsn& rhs) const { return lsn != rhs.lsn; }
+    bool operator==(const BinlogLsn& rhs) const { return lsn == rhs.lsn; }
+    bool operator<(const BinlogLsn& rhs) const { return lsn < rhs.lsn; }
+    std::string to_string() const;
+    friend std::ostream& operator<<(std::ostream& os, const BinlogLsn& lsn);
+};
+
+inline std::ostream& operator<<(std::ostream& os, const BinlogLsn& lsn) {
+    return os << lsn.to_string();
+}
+
 class BinlogUtil {
 public:
     static std::string binlog_file_path(std::string& binlog_dir, int64_t file_id) {
         return strings::Substitute("$0/$1.binlog", binlog_dir, file_id);
     }
-
-    static int128_t get_lsn(int64_t version, int64_t seq_id) { return (((int128_t)version) << 64) | seq_id; }
 
     static std::string file_meta_to_string(BinlogFileMetaPB* file_meta);
 

--- a/be/src/storage/binlog_util.h
+++ b/be/src/storage/binlog_util.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <re2/re2.h>
+#include <list>
 
 #include "common/status.h"
 #include "gen_cpp/binlog.pb.h"
@@ -55,6 +55,8 @@ public:
     }
 
     static std::string file_meta_to_string(BinlogFileMetaPB* file_meta);
+
+    static std::string page_header_to_string(PageHeaderPB* page_header);
 
     static bool get_file_id_from_name(const std::string& file_name, int64_t* file_id);
 

--- a/be/src/storage/binlog_util.h
+++ b/be/src/storage/binlog_util.h
@@ -39,6 +39,7 @@ struct BinlogLsn {
     bool operator!=(const BinlogLsn& rhs) const { return lsn != rhs.lsn; }
     bool operator==(const BinlogLsn& rhs) const { return lsn == rhs.lsn; }
     bool operator<(const BinlogLsn& rhs) const { return lsn < rhs.lsn; }
+    bool operator<=(const BinlogLsn& rhs) const { return lsn <= rhs.lsn; }
     std::string to_string() const;
     friend std::ostream& operator<<(std::ostream& os, const BinlogLsn& lsn);
 };
@@ -57,7 +58,7 @@ public:
 
     static bool get_file_id_from_name(const std::string& file_name, int64_t* file_id);
 
-    static Status list_binlog_file_ids(std::string& binlog_dir, std::set<int64_t>* binlog_file_ids);
+    static Status list_binlog_file_ids(std::string& binlog_dir, std::list<int64_t>* binlog_file_ids);
 };
 
 } // namespace starrocks

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -389,8 +389,13 @@ Status DataDir::load() {
         if (tablet == nullptr) {
             continue;
         }
+        // ignore the failure, and this behaviour is the same as that when failed to load rowset above.
+        // For full data, FE will repair it by cloning data from other replicas. For binlog, there may
+        // be data loss, because there is no clone mechanism for binlog currently, and the application
+        // should deal with the case. For example, realtime MV can initialize with the newest full data
+        // to skip the lost binlog, and process the new binlog after that. The situation is similar with
+        // that the binlog is expired and deleted before the application processes it.
         Status st = tablet->finish_load_rowsets();
-        // ignore the failure, and this behaviour is same as that when failed to load rowset
         if (!st.ok()) {
             LOG(WARNING) << "Fail to finish loading rowsets, tablet id=" << tablet_id << ", status: " << st.to_string();
         }

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -421,6 +421,17 @@ Status Tablet::support_binlog() {
     return Status::InternalError("Not support binlog, keys type: " + KeysType_Name(keys_type()));
 }
 
+void Tablet::update_binlog_config(const BinlogConfig& new_config) {
+    std::shared_ptr<BinlogConfig> old_config = _tablet_meta->get_binlog_config();
+    if (old_config != nullptr && old_config->version >= new_config.version) {
+        VLOG(3) << "skip to update binlog config of tablet: " << tablet_id()
+                << ", current version: " << old_config->version << ", new version: " << new_config.version;
+        return;
+    }
+    _tablet_meta->set_binlog_config(new_config);
+    LOG(INFO) << "set binlog config of tablet: " << tablet_id() << ", " << new_config.to_string();
+}
+
 StatusOr<bool> Tablet::_prepare_binlog_if_needed(const RowsetSharedPtr& rowset, int64_t version) {
     auto config = _tablet_meta->get_binlog_config();
     if (config == nullptr || !config->binlog_enable) {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -283,7 +283,7 @@ Status Tablet::finish_load_rowsets() {
 
     // find valid versions
     BinlogLsn min_lsn = _tablet_meta->get_binlog_min_lsn();
-    std::list<int64_t> valid_versions;
+    std::vector<int64_t> valid_versions;
     for (auto& item : _inc_rs_version_map) {
         int64_t version = item.first.first;
         if (version < min_lsn.version()) {
@@ -291,7 +291,7 @@ Status Tablet::finish_load_rowsets() {
         }
         valid_versions.push_back(version);
     }
-    valid_versions.sort();
+    std::sort(valid_versions.begin(), valid_versions.end());
 
     // TabletMeta#binlog_min_lsn may be not accurate for the minimum version. Consider that when
     // enable binlog in Tablet#update_binlog_config, we don't know the first incremental version

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -293,9 +293,10 @@ Status Tablet::finish_load_rowsets() {
     }
     valid_versions.sort();
 
-    // TabletMeta#binlog_min_lsn is first set when enable binlog in Tablet#update_binlog_config,
-    // and we don't know the first incremental version for add_inc_rowset, and the data may be
-    // copied to this tablet via full clone, so the min_lsn may be smaller than the actual version
+    // TabletMeta#binlog_min_lsn may be not accurate for the minimum version. Consider that when
+    // enable binlog in Tablet#update_binlog_config, we don't know the first incremental version
+    // for add_inc_rowset, so just set the min version to (_tablet_meta->max_version + 1), and
+    // after some ingestion, the actual min version may be larger than it
     int64_t min_valid_version = valid_versions.empty() ? min_lsn.version() : valid_versions.front();
     if (min_valid_version > min_lsn.version()) {
         min_lsn = BinlogLsn(min_valid_version, 0);

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -317,7 +317,6 @@ private:
     StatusOr<bool> _prepare_binlog_if_needed(const RowsetSharedPtr& rowset, int64_t version);
     void _commit_binlog(int64_t version);
     void _abort_binlog(const RowsetSharedPtr& rowset, int64_t version);
-    void _delete_unused_binlog();
 
     friend class TabletUpdates;
     static const int64_t kInvalidCumulativePoint = -1;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -120,6 +120,11 @@ public:
     std::string schema_debug_string() const;
     std::string debug_string() const;
 
+    // Load incremental rowsets to the tablet in DataDir#load.
+    Status load_rowset(const RowsetSharedPtr& rowset);
+    // finish loading rowsets
+    Status finish_load_rowsets();
+
     // operation in rowsets
     Status add_rowset(const RowsetSharedPtr& rowset, bool need_persist = true);
     void modify_rowsets(const vector<RowsetSharedPtr>& to_add, const vector<RowsetSharedPtr>& to_delete,

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -275,7 +275,7 @@ public:
 
     Status support_binlog();
 
-    void set_binlog_config(TBinlogConfig binlog_config) { _tablet_meta->set_binlog_config(binlog_config); }
+    void update_binlog_config(const BinlogConfig& binlog_config);
 
     BinlogManager* binlog_manager() { return _binlog_manager == nullptr ? nullptr : _binlog_manager.get(); }
 

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -275,6 +275,8 @@ public:
 
     Status support_binlog();
 
+    // This will modify the TabletMeta, and save_meta() will be called outside
+    // to persist it. See run_update_meta_info_task() in agent_task.cpp
     void update_binlog_config(const BinlogConfig& binlog_config);
 
     BinlogManager* binlog_manager() { return _binlog_manager == nullptr ? nullptr : _binlog_manager.get(); }
@@ -317,6 +319,9 @@ private:
     StatusOr<bool> _prepare_binlog_if_needed(const RowsetSharedPtr& rowset, int64_t version);
     void _commit_binlog(int64_t version);
     void _abort_binlog(const RowsetSharedPtr& rowset, int64_t version);
+    // check whether there is useless binlog, and update the in-memory TabletMeta to the state after
+    // those binlog is deleted. Return true the meta has been changed, and needs to be persisted
+    bool _check_useless_binlog_and_update_meta(int64_t current_second);
 
     friend class TabletUpdates;
     static const int64_t kInvalidCumulativePoint = -1;

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -276,8 +276,9 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
         set_binlog_config(binlog_config);
     }
 
-    if (tablet_meta_pb.has_binlog_min_version()) {
-        _binlog_min_version = tablet_meta_pb.binlog_min_version();
+    if (tablet_meta_pb.has_binlog_min_lsn()) {
+        auto& lsnPb = tablet_meta_pb.binlog_min_lsn();
+        _binlog_min_lsn = BinlogLsn(lsnPb.version(), lsnPb.seq_id());
     }
 }
 

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -275,6 +275,10 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
         binlog_config.update(tablet_meta_pb.binlog_config());
         set_binlog_config(binlog_config);
     }
+
+    if (tablet_meta_pb.has_binlog_min_version()) {
+        _binlog_min_version = tablet_meta_pb.binlog_min_version();
+    }
 }
 
 void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
@@ -327,6 +331,10 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
 
     if (_binlog_config != nullptr) {
         _binlog_config->to_pb(tablet_meta_pb->mutable_binlog_config());
+    }
+
+    if (_binlog_min_version != -1) {
+        tablet_meta_pb->set_binlog_min_version(_binlog_min_version);
     }
 }
 

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -332,10 +332,9 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
 
     if (_binlog_config != nullptr) {
         _binlog_config->to_pb(tablet_meta_pb->mutable_binlog_config());
-    }
-
-    if (_binlog_min_version != -1) {
-        tablet_meta_pb->set_binlog_min_version(_binlog_min_version);
+        BinlogLsnPB* lsn = tablet_meta_pb->mutable_binlog_min_lsn();
+        lsn->set_version(_binlog_min_lsn.version());
+        lsn->set_seq_id(_binlog_min_lsn.seq_id());
     }
 }
 

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -196,28 +196,9 @@ public:
 
     std::shared_ptr<BinlogConfig> get_binlog_config() { return _binlog_config; }
 
-    void set_binlog_config(const TBinlogConfig& binlog_config) {
-        if (_binlog_config == nullptr) {
-            _binlog_config = std::make_shared<BinlogConfig>();
-        } else if (_binlog_config->version > binlog_config.version) {
-            LOG(WARNING) << "skip to update binlog config of tablet=, " << _tablet_id << " current version is "
-                         << _binlog_config->version << ", update version is " << binlog_config.version;
-            return;
-        }
-        _binlog_config->update(binlog_config);
-        LOG(INFO) << "Set binlog config of tablet=" << _tablet_id << " to " << _binlog_config->to_string();
-    }
-
-    void set_binlog_config(const BinlogConfig& binlog_config) {
-        if (_binlog_config == nullptr) {
-            _binlog_config = std::make_shared<BinlogConfig>();
-        } else if (_binlog_config->version > binlog_config.version) {
-            LOG(WARNING) << "skip to update binlog config of tablet=, " << _tablet_id << " current version is "
-                         << _binlog_config->version << ", update version is " << binlog_config.version;
-            return;
-        }
-        _binlog_config->update(binlog_config);
-        LOG(INFO) << "Set binlog config of tablet=" << _tablet_id << " to " << _binlog_config->to_string();
+    void set_binlog_config(const BinlogConfig& new_config) {
+        _binlog_config = std::make_shared<BinlogConfig>();
+        _binlog_config->update(new_config);
     }
 
 private:

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -201,6 +201,14 @@ public:
         _binlog_config->update(new_config);
     }
 
+    int64_t get_binlog_min_version() {
+        return _binlog_min_version;
+    }
+
+    void set_binlog_min_version(int64 min_version) {
+        _binlog_min_version = min_version;
+    }
+
 private:
     int64_t _mem_usage() const { return sizeof(TabletMeta); }
 
@@ -245,6 +253,7 @@ private:
     TabletUpdates* _updates = nullptr;
 
     std::shared_ptr<BinlogConfig> _binlog_config;
+    int64_t _binlog_min_version = -1;
 
     std::shared_mutex _meta_lock;
 };

--- a/be/test/storage/binlog_file_test.cpp
+++ b/be/test/storage/binlog_file_test.cpp
@@ -424,7 +424,8 @@ TEST_F(BinlogFileTest, test_random_begin_commit_abort) {
     ASSERT_EQ(versions[0].version, file_meta->start_version());
     ASSERT_EQ(0, file_meta->start_seq_id());
     ASSERT_EQ(versions.back().version, file_meta->end_version());
-    ASSERT_EQ(versions.back().num_entries * versions.back().num_rows_per_entry - 1, file_meta->end_seq_id());
+    ASSERT_EQ(std::max(versions.back().num_entries * versions.back().num_rows_per_entry - 1, (int64_t)0),
+              file_meta->end_seq_id());
     verify_dup_key_multiple_versions(versions, _binlog_file_dir, {file_meta});
 }
 

--- a/be/test/storage/binlog_file_test.cpp
+++ b/be/test/storage/binlog_file_test.cpp
@@ -425,9 +425,9 @@ TEST_F(BinlogFileTest, test_random_begin_commit_abort) {
 // TODO add tests for primary key
 TEST_F(BinlogFileTest, test_primary_key) {}
 
-class BinlogFileLoadFilterTest : public BinlogFileLoadFilter {
+class BinlogFileDataFilterTest : public BinlogFileDataFilter {
 public:
-    BinlogFileLoadFilterTest(int64_t max_version, int64_t max_seq_id, std::unordered_set<int64_t>* rowset_ids)
+    BinlogFileDataFilterTest(int64_t max_version, int64_t max_seq_id, std::unordered_set<int64_t>* rowset_ids)
             : _max_version(max_version), _max_seq_id(max_seq_id), _rowset_ids(rowset_ids) {}
 
     bool is_valid_seq(int64_t version, int64_t seq_id) override {
@@ -501,15 +501,15 @@ void BinlogFileTest::test_load(bool append_meta) {
 
         // filter by rowset id
         if (i + 1 < metas_for_each_page.size() && meta->end_version() < metas_for_each_page[i + 1]->end_version()) {
-            BinlogFileLoadFilterTest filter(INT64_MAX, INT64_MAX, &filter_rowset_ids);
-            auto status_or = BinlogFileReader::load(file_id, file_path, &filter);
+            BinlogFileDataFilterTest filter(INT64_MAX, INT64_MAX, &filter_rowset_ids);
+            auto status_or = BinlogFileReader::load_meta(file_id, file_path, &filter);
             ASSERT_OK(status_or.status());
             verify_file_meta(meta.get(), status_or.value());
         }
 
         // filter by seq id
-        BinlogFileLoadFilterTest filter(meta->end_version(), meta->end_seq_id() + 1, nullptr);
-        auto status_or = BinlogFileReader::load(file_id, file_path, &filter);
+        BinlogFileDataFilterTest filter(meta->end_version(), meta->end_seq_id() + 1, nullptr);
+        auto status_or = BinlogFileReader::load_meta(file_id, file_path, &filter);
         ASSERT_OK(status_or.status());
         verify_file_meta(meta.get(), status_or.value());
     }

--- a/be/test/storage/binlog_file_test.cpp
+++ b/be/test/storage/binlog_file_test.cpp
@@ -110,7 +110,7 @@ TEST_F(BinlogFileTest, test_basic_write_read) {
     ASSERT_OK(file_writer->commit(true));
 
     expect_file_meta.set_end_version(3);
-    expect_file_meta.set_end_seq_id(-1);
+    expect_file_meta.set_end_seq_id(0);
     expect_file_meta.set_end_timestamp_in_us(3);
     expect_file_meta.set_version_eof(true);
     expect_file_meta.set_num_pages(4);

--- a/be/test/storage/binlog_manager_test.cpp
+++ b/be/test/storage/binlog_manager_test.cpp
@@ -871,7 +871,7 @@ TEST_F(BinlogManagerTest, test_init) {
             std::rand(), _binlog_file_dir, 100 * 1024 * 1024, 1024 * 1024, LZ4_FRAME, rowset_fetcher);
 
     std::vector<BinlogFileMetaPBPtr> expect_metas;
-    std::list<int64_t> valid_versions;
+    std::vector<int64_t> valid_versions;
 
     // file1: all data is valid
     std::vector<PartialRowsetInfo> binlog_file_info_1;

--- a/be/test/storage/binlog_manager_test.cpp
+++ b/be/test/storage/binlog_manager_test.cpp
@@ -160,7 +160,7 @@ TEST_F(BinlogManagerTest, test_ingestion_commit) {
 
     std::shared_ptr<BinlogFileWriter> last_file_writer;
     std::shared_ptr<BinlogFileMetaPB> last_file_meta;
-    for (int64_t version = 1, next_file_id = 0; version < 1000; version++) {
+    for (int64_t version = 1, next_file_id = 1; version < 1000; version++) {
         rowset_fetcher->add_rowset(version, mock_rowset);
         ASSERT_EQ(next_file_id, binlog_manager->next_file_id());
         ASSERT_EQ(-1, binlog_manager->ingestion_version());

--- a/be/test/storage/binlog_test_base.cpp
+++ b/be/test/storage/binlog_test_base.cpp
@@ -140,7 +140,7 @@ void BinlogTestBase::verify_log_entry_info(const std::shared_ptr<TestLogEntryInf
 }
 
 void BinlogTestBase::verify_file_meta(BinlogFileMetaPB* expect_file_meta,
-                                      const std::shared_ptr<BinlogFileMetaPB>& actual_file_meta) {
+                                      std::shared_ptr<BinlogFileMetaPB>& actual_file_meta) {
     ASSERT_EQ(expect_file_meta->id(), actual_file_meta->id());
     ASSERT_EQ(expect_file_meta->start_version(), actual_file_meta->start_version());
     ASSERT_EQ(expect_file_meta->start_seq_id(), actual_file_meta->start_seq_id());

--- a/be/test/storage/binlog_test_base.cpp
+++ b/be/test/storage/binlog_test_base.cpp
@@ -148,6 +148,7 @@ void BinlogTestBase::verify_file_meta(BinlogFileMetaPB* expect_file_meta,
     ASSERT_EQ(expect_file_meta->end_version(), actual_file_meta->end_version());
     ASSERT_EQ(expect_file_meta->end_seq_id(), actual_file_meta->end_seq_id());
     ASSERT_EQ(expect_file_meta->end_timestamp_in_us(), actual_file_meta->end_timestamp_in_us());
+    ASSERT_EQ(expect_file_meta->version_eof(), actual_file_meta->version_eof());
     ASSERT_EQ(expect_file_meta->num_pages(), actual_file_meta->num_pages());
     ASSERT_EQ(expect_file_meta->file_size(), actual_file_meta->file_size());
 

--- a/be/test/storage/binlog_test_base.h
+++ b/be/test/storage/binlog_test_base.h
@@ -77,8 +77,7 @@ protected:
     void verify_file_id(FileIdPB* expect_file_id, FileIdPB* actual_file_id);
     void verify_log_entry(LogEntryPB* expect, LogEntryPB* actual);
     void verify_log_entry_info(const std::shared_ptr<TestLogEntryInfo>& expect, LogEntryInfo* actual);
-    void verify_file_meta(BinlogFileMetaPB* expect_file_meta,
-                          const std::shared_ptr<BinlogFileMetaPB>& actual_file_meta);
+    void verify_file_meta(BinlogFileMetaPB* expect_file_meta, std::shared_ptr<BinlogFileMetaPB>& actual_file_meta);
     void verify_seek_and_next(const std::string& file_path, const std::shared_ptr<BinlogFileMetaPB>& file_meta,
                               int64_t seek_version, int64_t seek_seq_id,
                               std::vector<std::shared_ptr<TestLogEntryInfo>>& expected, int expected_first_entry_index);

--- a/be/test/storage/tablet_binlog_test.cpp
+++ b/be/test/storage/tablet_binlog_test.cpp
@@ -201,6 +201,8 @@ TEST_F(TabletBinlogTest, test_publish_out_of_order) {
 }
 
 TEST_F(TabletBinlogTest, test_load) {
+    // verify load empty rowsets
+    ASSERT_OK(_tablet->finish_load_rowsets());
     std::vector<DupKeyVersionInfo> version_infos;
     ingest_random_binlog(_tablet, 2, 50, &version_infos);
     // simulate to checkpoint tablet meta

--- a/be/test/storage/tablet_binlog_test.cpp
+++ b/be/test/storage/tablet_binlog_test.cpp
@@ -162,7 +162,7 @@ TEST_F(TabletBinlogTest, test_generate_binlog) {
     std::vector<DupKeyVersionInfo> version_infos;
     ingest_random_binlog(_tablet, 2, 100, &version_infos);
     BinlogManager* binlog_manager = _tablet->binlog_manager();
-    std::map<int128_t, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
+    std::map<BinlogLsn, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
     std::vector<BinlogFileMetaPBPtr> file_metas;
     for (auto it : lsn_map) {
         file_metas.push_back(it.second->file_meta());
@@ -192,7 +192,7 @@ TEST_F(TabletBinlogTest, test_publish_out_of_order) {
     }
 
     BinlogManager* binlog_manager = _tablet->binlog_manager();
-    std::map<int128_t, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
+    std::map<BinlogLsn, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
     std::vector<BinlogFileMetaPBPtr> file_metas;
     for (auto it : lsn_map) {
         file_metas.push_back(it.second->file_meta());
@@ -227,7 +227,7 @@ TEST_F(TabletBinlogTest, test_load) {
     }
 
     BinlogManager* binlog_manager = load_tablet->binlog_manager();
-    std::map<int128_t, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
+    std::map<BinlogLsn, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
     std::vector<BinlogFileMetaPBPtr> file_metas;
     for (auto it : lsn_map) {
         file_metas.push_back(it.second->file_meta());

--- a/be/test/storage/tablet_binlog_test.cpp
+++ b/be/test/storage/tablet_binlog_test.cpp
@@ -107,12 +107,15 @@ public:
     }
 
 protected:
+    void ingest_random_binlog(TabletSharedPtr tablet, int64_t start_version, int64_t num_version,
+                              std::vector<DupKeyVersionInfo>* version_infos);
+
     TabletSharedPtr _tablet;
 };
 
-TEST_F(TabletBinlogTest, test_generate_binlog) {
-    std::vector<DupKeyVersionInfo> version_infos;
-    for (int32_t version = 2; version < 100; version++) {
+void TabletBinlogTest::ingest_random_binlog(TabletSharedPtr tablet, int64_t start_version, int64_t num_version,
+                                            std::vector<DupKeyVersionInfo>* version_infos) {
+    for (int32_t version = start_version; version < start_version + num_version; version++) {
         int32_t num_segments = std::rand() % 5;
         int32_t num_rows_per_segment = std::rand() % 100 + 1;
         std::vector<int32_t> segment_rows;
@@ -120,12 +123,16 @@ TEST_F(TabletBinlogTest, test_generate_binlog) {
             segment_rows.push_back(num_rows_per_segment);
         }
         RowsetSharedPtr rowset;
-        create_rowset(_tablet, segment_rows, &rowset);
-        ASSERT_OK(_tablet->add_inc_rowset(rowset, version));
+        create_rowset(tablet, segment_rows, &rowset);
+        ASSERT_OK(tablet->add_inc_rowset(rowset, version));
         int64_t timestamp = rowset->creation_time() * 1000000;
-        version_infos.push_back(DupKeyVersionInfo(version, num_segments, num_rows_per_segment, timestamp));
+        version_infos->push_back(DupKeyVersionInfo(version, num_segments, num_rows_per_segment, timestamp));
     }
+}
 
+TEST_F(TabletBinlogTest, test_generate_binlog) {
+    std::vector<DupKeyVersionInfo> version_infos;
+    ingest_random_binlog(_tablet, 2, 100, &version_infos);
     BinlogManager* binlog_manager = _tablet->binlog_manager();
     std::map<int128_t, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
     std::vector<BinlogFileMetaPBPtr> file_metas;
@@ -163,6 +170,41 @@ TEST_F(TabletBinlogTest, test_publish_out_of_order) {
         file_metas.push_back(it.second->file_meta());
     }
     verify_dup_key_multiple_versions(version_infos, _tablet->schema_hash_path(), file_metas);
+}
+
+TEST_F(TabletBinlogTest, test_load) {
+    std::vector<DupKeyVersionInfo> version_infos;
+    ingest_random_binlog(_tablet, 2, 50, &version_infos);
+    // simulate to checkpoint tablet meta
+    std::shared_ptr<TabletMetaPB> meta_checkpoint = std::make_shared<TabletMetaPB>();
+    _tablet->tablet_meta()->to_meta_pb(meta_checkpoint.get());
+    ingest_random_binlog(_tablet, 52, 50, &version_infos);
+
+    // simulate the process of loading tablet as DataDir#load
+    TabletMetaSharedPtr load_tablet_meta = TabletMeta::create();
+    load_tablet_meta->init_from_pb(meta_checkpoint.get());
+    auto load_tablet = Tablet::create_tablet_from_meta(load_tablet_meta, _tablet->data_dir());
+    ASSERT_OK(load_tablet->init());
+    for (int64_t version = 52; version < 102; version++) {
+        ASSERT_OK(load_tablet->load_rowset(_tablet->get_inc_rowset_by_version(Version(version, version))));
+    }
+    ASSERT_OK(load_tablet->finish_load_rowsets());
+
+    for (int64_t version = 2; version < 102; version++) {
+        RowsetSharedPtr raw_rowset = _tablet->get_inc_rowset_by_version(Version(version, version));
+        RowsetSharedPtr load_rowset = load_tablet->get_inc_rowset_by_version(Version(version, version));
+        ASSERT_TRUE(raw_rowset != nullptr);
+        ASSERT_TRUE(load_rowset != nullptr);
+        ASSERT_EQ(raw_rowset->rowset_id(), load_rowset->rowset_id());
+    }
+
+    BinlogManager* binlog_manager = load_tablet->binlog_manager();
+    std::map<int128_t, BinlogFilePtr>& lsn_map = binlog_manager->alive_binlog_files();
+    std::vector<BinlogFileMetaPBPtr> file_metas;
+    for (auto it : lsn_map) {
+        file_metas.push_back(it.second->file_meta());
+    }
+    verify_dup_key_multiple_versions(version_infos, load_tablet->schema_hash_path(), file_metas);
 }
 
 } // namespace starrocks

--- a/be/test/storage/tablet_meta_test.cpp
+++ b/be/test/storage/tablet_meta_test.cpp
@@ -231,32 +231,6 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_EQ(23724, binlog_config_ptr->binlog_max_size);
 }
 
-TEST(TabletMetaTest, test_config_binlog) {
-    TabletMetaSharedPtr tablet_meta = TabletMeta::create();
-    std::shared_ptr<BinlogConfig> binlog_config_ptr = tablet_meta->get_binlog_config();
-    ASSERT_TRUE(binlog_config_ptr == nullptr);
-
-    // test configuration with pb
-    BinlogConfig binlog_config;
-    binlog_config.update(3, true, 823, 984);
-    tablet_meta->set_binlog_config(binlog_config);
-    binlog_config_ptr = tablet_meta->get_binlog_config();
-    ASSERT_EQ(3, binlog_config_ptr->version);
-    ASSERT_TRUE(binlog_config_ptr->binlog_enable);
-    ASSERT_EQ(823, binlog_config_ptr->binlog_ttl_second);
-    ASSERT_EQ(984, binlog_config_ptr->binlog_max_size);
-
-    // test lower version would not override the configuration
-    BinlogConfig binlog_config1;
-    binlog_config1.update(2, true, 323, 475);
-    tablet_meta->set_binlog_config(binlog_config1);
-    binlog_config_ptr = tablet_meta->get_binlog_config();
-    ASSERT_EQ(3, binlog_config_ptr->version);
-    ASSERT_TRUE(binlog_config_ptr->binlog_enable);
-    ASSERT_EQ(823, binlog_config_ptr->binlog_ttl_second);
-    ASSERT_EQ(984, binlog_config_ptr->binlog_max_size);
-}
-
 TEST(TabletMetaTest, test_init_from_pb) {
     TabletMetaSharedPtr tablet_meta = TabletMeta::create();
     std::shared_ptr<BinlogConfig> binlog_config_ptr = tablet_meta->get_binlog_config();

--- a/gensrc/proto/binlog.proto
+++ b/gensrc/proto/binlog.proto
@@ -16,7 +16,6 @@ syntax = "proto2";
 
 package starrocks;
 
-import "olap_file.proto";
 import "types.proto";
 
 message FileIdPB {
@@ -125,4 +124,9 @@ message BinlogFileMetaPB {
     optional int64 file_size = 9;
     // rowsets that this binlog file uses
     repeated int64 rowsets = 10;
+}
+
+message BinlogLsnPB {
+    optional int64 version = 1;
+    optional int64 seq_id = 2;
 }

--- a/gensrc/proto/binlog.proto
+++ b/gensrc/proto/binlog.proto
@@ -117,13 +117,14 @@ message BinlogFileMetaPB {
     // the sequence number for the last change event in the file
     optional int64 end_seq_id = 6;
     // timestamp for the last change evnet in the file
-    optional int64 end_timestamp_in_us= 7;
+    optional int64 end_timestamp_in_us = 7;
+    optional bool version_eof = 8;
     // number of pages in this file
-    optional int64 num_pages = 8;
+    optional int64 num_pages = 9;
     // file size of the binlog file
-    optional int64 file_size = 9;
+    optional int64 file_size = 10;
     // rowsets that this binlog file uses
-    repeated int64 rowsets = 10;
+    repeated int64 rowsets = 11;
 }
 
 message BinlogLsnPB {

--- a/gensrc/proto/binlog.proto
+++ b/gensrc/proto/binlog.proto
@@ -15,6 +15,7 @@
 syntax = "proto2";
 
 package starrocks;
+option java_package = "com.starrocks.proto";
 
 import "types.proto";
 
@@ -118,6 +119,7 @@ message BinlogFileMetaPB {
     optional int64 end_seq_id = 6;
     // timestamp for the last change evnet in the file
     optional int64 end_timestamp_in_us = 7;
+    // whether this file is end of end_version
     optional bool version_eof = 8;
     // number of pages in this file
     optional int64 num_pages = 9;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -279,6 +279,7 @@ message TabletMetaPB {
     optional TabletUpdatesPB updates = 50;                        // used for new updatable tablet
     optional bool enable_persistent_index = 51 [default = false]; // used for persistent index in primary index
     optional BinlogConfigPB binlog_config = 52;
+    optional int64 binlog_min_version = 53;
 }
 
 message OLAPIndexHeaderMessage {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -38,6 +38,7 @@ syntax = "proto2";
 package starrocks;
 option java_package = "com.starrocks.proto";
 
+import "binlog.proto";
 import "olap_common.proto";
 import "tablet_schema.proto";
 import "types.proto";
@@ -279,7 +280,7 @@ message TabletMetaPB {
     optional TabletUpdatesPB updates = 50;                        // used for new updatable tablet
     optional bool enable_persistent_index = 51 [default = false]; // used for persistent index in primary index
     optional BinlogConfigPB binlog_config = 52;
-    optional int64 binlog_min_version = 53;
+    optional BinlogLsnPB binlog_min_lsn = 53;
 }
 
 message OLAPIndexHeaderMessage {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The feature to support the storage of binlog has several PRs
* Support to write/read binlog file
* Generate binlog when the ingestion is published
* Read binlog to generate change events
* Cleanup the binlog when expired or oversize
* Recover binlog when loading tablets

This is the fifth PR. Recover binlog when loading tablets. The core ideas are
* use `TabletMeta#_binlog_min_lsn` and `TabletMeta#_inc_rs_metas` to determine what binlog is  valid
    *  `TabletMeta#_binlog_min_lsn` will be updated when removing expired data
    *  `TabletMeta#_inc_rs_metas` will be updated when ingesting new data and removing expired data
* `BinlogManager#init()` loads binlog file metas, and prunes useless data according to the metas in the `TabletMeta` above. Refer to the code comment for the detail.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
