### PR TITLE
[Enhancement] Support parallel merge (3)

### DIFF
--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -141,6 +141,8 @@ public:
 
     virtual bool has_pending_data() { return false; }
 
+    bool has_output() { return spiller() == nullptr || !spiller()->spilled() || spiller()->has_output_data(); }
+
     const std::shared_ptr<spill::Spiller>& spiller() const { return _spiller; }
 
     size_t revocable_mem_bytes() const { return _revocable_mem_bytes; }

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -269,7 +269,7 @@ Status ChunksSorterFullSort::get_next(ChunkPtr* chunk, bool* eos) {
     }
     size_t chunk_size = _state->chunk_size();
     SortedRun& run = _merged_runs.front();
-    *chunk = run.steal_chunk(false, chunk_size).first;
+    *chunk = run.steal_chunk(chunk_size);
     if (*chunk != nullptr) {
         if (!_early_materialized_slots.empty()) {
             *chunk = _late_materialize(*chunk);

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -269,7 +269,7 @@ Status ChunksSorterFullSort::get_next(ChunkPtr* chunk, bool* eos) {
     }
     size_t chunk_size = _state->chunk_size();
     SortedRun& run = _merged_runs.front();
-    *chunk = run.steal_chunk(chunk_size);
+    *chunk = run.steal_chunk(false, chunk_size).first;
     if (*chunk != nullptr) {
         if (!_early_materialized_slots.empty()) {
             *chunk = _late_materialize(*chunk);

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
@@ -34,7 +34,7 @@ bool ExchangeParallelMergeSourceOperator::has_output() const {
     if (_is_finished) {
         return false;
     }
-    if (_merger->is_current_stage_finished(_driver_sequence)) {
+    if (_merger->is_current_stage_finished(_driver_sequence, false)) {
         return false;
     }
     if (_merger->is_pending(_driver_sequence)) {
@@ -44,11 +44,7 @@ bool ExchangeParallelMergeSourceOperator::has_output() const {
 }
 
 bool ExchangeParallelMergeSourceOperator::is_finished() const {
-    if (_limit < 0) {
-        return _is_finished;
-    } else {
-        return _num_rows_returned >= _limit || _is_finished;
-    }
+    return _is_finished;
 }
 
 Status ExchangeParallelMergeSourceOperator::set_finishing(RuntimeState* state) {
@@ -59,7 +55,7 @@ Status ExchangeParallelMergeSourceOperator::set_finishing(RuntimeState* state) {
 }
 
 StatusOr<ChunkPtr> ExchangeParallelMergeSourceOperator::pull_chunk(RuntimeState* state) {
-    auto chunk = _merger->try_get_next(_driver_sequence);
+    ChunkPtr chunk = _merger->try_get_next(_driver_sequence);
 
     if (_merger->is_finished()) {
         _is_finished = true;
@@ -80,7 +76,7 @@ OperatorPtr ExchangeParallelMergeSourceOperatorFactory::create(int32_t degree_of
     ++_stream_recvr_cnt;
     return std::make_shared<ExchangeParallelMergeSourceOperator>(this, _id, _plan_node_id, driver_sequence, _num_sender,
                                                                  _row_desc, _sort_exec_exprs, _is_asc_order,
-                                                                 _nulls_first, _offset, _limit);
+                                                                 _nulls_first);
 }
 
 void ExchangeParallelMergeSourceOperatorFactory::close(RuntimeState* state) {
@@ -107,7 +103,7 @@ merge_path::MergePathCascadeMerger* ExchangeParallelMergeSourceOperatorFactory::
         SortDescs sort_descs(_is_asc_order, _nulls_first);
         _merger = std::make_unique<merge_path::MergePathCascadeMerger>(
                 state->chunk_size(), degree_of_parallelism(), _sort_exec_exprs->lhs_ordering_expr_ctxs(), sort_descs,
-                _row_desc.tuple_descriptors()[0], _offset, _limit, chunk_providers);
+                _row_desc.tuple_descriptors()[0], TTopNType::ROW_NUMBER, _offset, _limit, chunk_providers);
     }
     return _merger.get();
 }

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.h
@@ -55,21 +55,21 @@ public:
     ExchangeParallelMergeSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
                                         int32_t driver_sequence, int32_t num_sender, const RowDescriptor& row_desc,
                                         SortExecExprs* sort_exec_exprs, const std::vector<bool>& is_asc_order,
-                                        const std::vector<bool>& nulls_first, int64_t offset, int64_t limit)
+                                        const std::vector<bool>& nulls_first)
             : SourceOperator(factory, id, "global_parallel_merge_source", plan_node_id, driver_sequence),
               _num_sender(num_sender),
               _row_desc(row_desc),
               _sort_exec_exprs(sort_exec_exprs),
               _is_asc_order(is_asc_order),
-              _nulls_first(nulls_first),
-              _offset(offset),
-              _limit(limit) {}
+              _nulls_first(nulls_first) {}
 
     ~ExchangeParallelMergeSourceOperator() override = default;
 
     Status prepare(RuntimeState* state) override;
 
     bool has_output() const override;
+
+    bool is_mutable() const override { return true; }
 
     bool is_finished() const override;
 
@@ -86,11 +86,6 @@ private:
     const std::vector<bool>& _nulls_first;
 
     std::atomic<bool> _is_finished{false};
-
-    int64_t _num_rows_returned = 0;
-    int64_t _num_rows_input = 0;
-    int64_t _offset;
-    int64_t _limit;
 
     DataStreamRecvr* _stream_recvr;
     merge_path::MergePathCascadeMerger* _merger;
@@ -126,13 +121,13 @@ public:
     SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }
 
 private:
-    int32_t _num_sender;
+    const int32_t _num_sender;
     const RowDescriptor& _row_desc;
     SortExecExprs* _sort_exec_exprs;
     const std::vector<bool>& _is_asc_order;
     const std::vector<bool>& _nulls_first;
-    int64_t _offset;
-    int64_t _limit;
+    const int64_t _offset;
+    const int64_t _limit;
 
     std::shared_ptr<DataStreamRecvr> _stream_recvr;
     std::atomic<int64_t> _stream_recvr_cnt = 0;

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -54,7 +54,7 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _schedule_counter = ADD_COUNTER(_runtime_profile, "ScheduleCount", TUnit::UNIT);
     _yield_by_time_limit_counter = ADD_COUNTER(_runtime_profile, "YieldByTimeLimit", TUnit::UNIT);
     _yield_by_preempt_counter = ADD_COUNTER(_runtime_profile, "YieldByPreempt", TUnit::UNIT);
-    _yield_by_mutable_wait_counter = ADD_COUNTER(_runtime_profile, "YieldByMutableWait", TUnit::UNIT);
+    _yield_by_local_wait_counter = ADD_COUNTER(_runtime_profile, "YieldByLocalWait", TUnit::UNIT);
     _block_by_precondition_counter = ADD_COUNTER(_runtime_profile, "BlockByPrecondition", TUnit::UNIT);
     _block_by_output_full_counter = ADD_COUNTER(_runtime_profile, "BlockByOutputFull", TUnit::UNIT);
     _block_by_input_empty_counter = ADD_COUNTER(_runtime_profile, "BlockByInputEmpty", TUnit::UNIT);
@@ -352,14 +352,14 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
             // yield when total chunks moved or time spent on-core for evaluation
             // exceed the designated thresholds.
             if (time_spent >= YIELD_MAX_TIME_SPENT ||
-                driver_acct().get_accumulated_mutable_time_spent() >= YIELD_MAX_TIME_SPENT) {
+                driver_acct().get_accumulated_local_wait_time_spent() >= YIELD_MAX_TIME_SPENT) {
                 should_yield = true;
                 COUNTER_UPDATE(_yield_by_time_limit_counter, 1);
                 break;
             }
             if (_workgroup != nullptr &&
                 (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT ||
-                 driver_acct().get_accumulated_mutable_time_spent() > YIELD_PREEMPT_MAX_TIME_SPENT) &&
+                 driver_acct().get_accumulated_local_wait_time_spent() > YIELD_PREEMPT_MAX_TIME_SPENT) &&
                 _workgroup->driver_sched_entity()->in_queue()->should_yield(this, time_spent)) {
                 should_yield = true;
                 COUNTER_UPDATE(_yield_by_preempt_counter, 1);
@@ -391,8 +391,8 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 COUNTER_UPDATE(_block_by_output_full_counter, 1);
             } else if (!source_operator()->is_finished() && !source_operator()->has_output()) {
                 if (source_operator()->is_mutable()) {
-                    set_driver_state(DriverState::MUTABLE_WAITING);
-                    COUNTER_UPDATE(_yield_by_mutable_wait_counter, 1);
+                    set_driver_state(DriverState::LOCAL_WAITING);
+                    COUNTER_UPDATE(_yield_by_local_wait_counter, 1);
                 } else {
                     set_driver_state(DriverState::INPUT_EMPTY);
                     COUNTER_UPDATE(_block_by_input_empty_counter, 1);

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -52,9 +52,9 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
 
     _schedule_timer = ADD_TIMER(_runtime_profile, "ScheduleTime");
     _schedule_counter = ADD_COUNTER(_runtime_profile, "ScheduleCount", TUnit::UNIT);
-    _yield_by_time_limit_counter =
-            ADD_COUNTER_SKIP_MERGE(_runtime_profile, "YieldByTimeLimit", TUnit::UNIT, TCounterMergeType::SKIP_ALL);
+    _yield_by_time_limit_counter = ADD_COUNTER(_runtime_profile, "YieldByTimeLimit", TUnit::UNIT);
     _yield_by_preempt_counter = ADD_COUNTER(_runtime_profile, "YieldByPreempt", TUnit::UNIT);
+    _yield_by_mutable_wait_counter = ADD_COUNTER(_runtime_profile, "YieldByMutableWait", TUnit::UNIT);
     _block_by_precondition_counter = ADD_COUNTER(_runtime_profile, "BlockByPrecondition", TUnit::UNIT);
     _block_by_output_full_counter = ADD_COUNTER(_runtime_profile, "BlockByOutputFull", TUnit::UNIT);
     _block_by_input_empty_counter = ADD_COUNTER(_runtime_profile, "BlockByInputEmpty", TUnit::UNIT);
@@ -351,12 +351,15 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
             }
             // yield when total chunks moved or time spent on-core for evaluation
             // exceed the designated thresholds.
-            if (time_spent >= YIELD_MAX_TIME_SPENT) {
+            if (time_spent >= YIELD_MAX_TIME_SPENT ||
+                driver_acct().get_accumulated_mutable_time_spent() >= YIELD_MAX_TIME_SPENT) {
                 should_yield = true;
                 COUNTER_UPDATE(_yield_by_time_limit_counter, 1);
                 break;
             }
-            if (_workgroup != nullptr && time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
+            if (_workgroup != nullptr &&
+                (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT ||
+                 driver_acct().get_accumulated_mutable_time_spent() > YIELD_PREEMPT_MAX_TIME_SPENT) &&
                 _workgroup->driver_sched_entity()->in_queue()->should_yield(this, time_spent)) {
                 should_yield = true;
                 COUNTER_UPDATE(_yield_by_preempt_counter, 1);
@@ -387,8 +390,13 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 set_driver_state(DriverState::OUTPUT_FULL);
                 COUNTER_UPDATE(_block_by_output_full_counter, 1);
             } else if (!source_operator()->is_finished() && !source_operator()->has_output()) {
-                set_driver_state(DriverState::INPUT_EMPTY);
-                COUNTER_UPDATE(_block_by_input_empty_counter, 1);
+                if (source_operator()->is_mutable()) {
+                    set_driver_state(DriverState::MUTABLE_WAITING);
+                    COUNTER_UPDATE(_yield_by_mutable_wait_counter, 1);
+                } else {
+                    set_driver_state(DriverState::INPUT_EMPTY);
+                    COUNTER_UPDATE(_block_by_input_empty_counter, 1);
+                }
             } else {
                 set_driver_state(DriverState::READY);
             }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -351,15 +351,15 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
             }
             // yield when total chunks moved or time spent on-core for evaluation
             // exceed the designated thresholds.
-            if (time_spent >= YIELD_MAX_TIME_SPENT ||
-                driver_acct().get_accumulated_local_wait_time_spent() >= YIELD_MAX_TIME_SPENT) {
+            if (time_spent >= YIELD_MAX_TIME_SPENT_NS ||
+                driver_acct().get_accumulated_local_wait_time_spent() >= YIELD_MAX_TIME_SPENT_NS) {
                 should_yield = true;
                 COUNTER_UPDATE(_yield_by_time_limit_counter, 1);
                 break;
             }
             if (_workgroup != nullptr &&
-                (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT ||
-                 driver_acct().get_accumulated_local_wait_time_spent() > YIELD_PREEMPT_MAX_TIME_SPENT) &&
+                (time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT_NS ||
+                 driver_acct().get_accumulated_local_wait_time_spent() > YIELD_PREEMPT_MAX_TIME_SPENT_NS) &&
                 _workgroup->driver_sched_entity()->in_queue()->should_yield(this, time_spent)) {
                 should_yield = true;
                 COUNTER_UPDATE(_yield_by_preempt_counter, 1);

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -125,6 +125,7 @@ public:
         this->accumulated_time_spent += time_spent;
         this->accumulated_local_wait_time_spent += time_spent;
     }
+    // This method must be invoked when adding back to ready queue or pending queue.
     void clean_local_queue_infos() {
         this->accumulated_local_wait_time_spent = 0;
         this->enter_local_queue_timestamp = 0;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -443,10 +443,10 @@ protected:
               _driver_id(0) {}
 
     // Yield PipelineDriver when maximum time in nano-seconds has spent in current execution round.
-    static constexpr int64_t YIELD_MAX_TIME_SPENT = 100'000'000L;
+    static constexpr int64_t YIELD_MAX_TIME_SPENT_NS = 100'000'000L;
     // Yield PipelineDriver when maximum time in nano-seconds has spent in current execution round,
     // if it runs in the worker thread owned by other workgroup, which has running drivers.
-    static constexpr int64_t YIELD_PREEMPT_MAX_TIME_SPENT = 5'000'000L;
+    static constexpr int64_t YIELD_PREEMPT_MAX_TIME_SPENT_NS = 5'000'000L;
 
     // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.
     bool _check_fragment_is_canceled(RuntimeState* runtime_state);

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -229,7 +229,7 @@ StatusOr<DriverRawPtr> GlobalDriverExecutor::_get_next_driver(std::queue<DriverR
             if (driver->source_operator()->has_output()) {
                 return driver;
             } else {
-                if (driver->driver_acct().get_local_queue_time_spent() > LOCAL_MAX_WAIT_TIME_SPENT) {
+                if (driver->driver_acct().get_local_queue_time_spent() > LOCAL_MAX_WAIT_TIME_SPENT_NS) {
                     driver->driver_acct().clean_local_queue_infos();
                     driver->set_driver_state(DriverState::INPUT_EMPTY);
                     _blocked_driver_poller->add_blocked_driver(driver);

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -184,6 +184,7 @@ void GlobalDriverExecutor::_worker_thread() {
             switch (driver_state) {
             case READY:
             case RUNNING: {
+                driver->driver_acct().clean_local_queue_infos();
                 this->_driver_queue->put_back_from_executor(driver);
                 break;
             }
@@ -208,7 +209,6 @@ void GlobalDriverExecutor::_worker_thread() {
             case PENDING_FINISH:
             case EPOCH_PENDING_FINISH:
             case PRECONDITION_BLOCK: {
-                driver->driver_acct().clean_local_queue_infos();
                 _blocked_driver_poller->add_blocked_driver(driver);
                 break;
             }
@@ -230,7 +230,6 @@ StatusOr<DriverRawPtr> GlobalDriverExecutor::_get_next_driver(std::queue<DriverR
                 return driver;
             } else {
                 if (driver->driver_acct().get_local_queue_time_spent() > LOCAL_MAX_WAIT_TIME_SPENT_NS) {
-                    driver->driver_acct().clean_local_queue_infos();
                     driver->set_driver_state(DriverState::INPUT_EMPTY);
                     _blocked_driver_poller->add_blocked_driver(driver);
                 } else {

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -84,6 +84,7 @@ public:
 private:
     using Base = FactoryMethod<DriverExecutor, GlobalDriverExecutor>;
     void _worker_thread();
+    StatusOr<DriverRawPtr> _get_next_driver(std::queue<DriverRawPtr>& local_mutable_driver_queue);
     void _finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
     void _update_profile_by_level(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool done);
     void _remove_non_core_metrics(QueryContext* query_ctx, std::vector<RuntimeProfile*>& driver_profiles);
@@ -91,6 +92,9 @@ private:
     void _finalize_epoch(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
 
 private:
+    // The maximum duration that a driver could stay in _mutable_driver_queue
+    static constexpr int64_t MUTABLE_MAX_WAIT_TIME_SPENT = 1'000'000L;
+
     LimitSetter _num_threads_setter;
     std::unique_ptr<DriverQueue> _driver_queue;
     // _thread_pool must be placed after _driver_queue, because worker threads in _thread_pool use _driver_queue.

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -84,7 +84,7 @@ public:
 private:
     using Base = FactoryMethod<DriverExecutor, GlobalDriverExecutor>;
     void _worker_thread();
-    StatusOr<DriverRawPtr> _get_next_driver(std::queue<DriverRawPtr>& local_mutable_driver_queue);
+    StatusOr<DriverRawPtr> _get_next_driver(std::queue<DriverRawPtr>& local_driver_queue);
     void _finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
     void _update_profile_by_level(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool done);
     void _remove_non_core_metrics(QueryContext* query_ctx, std::vector<RuntimeProfile*>& driver_profiles);
@@ -92,8 +92,8 @@ private:
     void _finalize_epoch(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
 
 private:
-    // The maximum duration that a driver could stay in _mutable_driver_queue
-    static constexpr int64_t MUTABLE_MAX_WAIT_TIME_SPENT = 1'000'000L;
+    // The maximum duration that a driver could stay in local_driver_queue
+    static constexpr int64_t LOCAL_MAX_WAIT_TIME_SPENT = 1'000'000L;
 
     LimitSetter _num_threads_setter;
     std::unique_ptr<DriverQueue> _driver_queue;

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -93,7 +93,7 @@ private:
 
 private:
     // The maximum duration that a driver could stay in local_driver_queue
-    static constexpr int64_t LOCAL_MAX_WAIT_TIME_SPENT = 1'000'000L;
+    static constexpr int64_t LOCAL_MAX_WAIT_TIME_SPENT_NS = 1'000'000L;
 
     LimitSetter _num_threads_setter;
     std::unique_ptr<DriverQueue> _driver_queue;

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -173,6 +173,7 @@ void PipelineDriverPoller::add_blocked_driver(const DriverRawPtr driver) {
     std::unique_lock<std::mutex> lock(_global_mutex);
     _blocked_drivers.push_back(driver);
     driver->_pending_timer_sw->reset();
+    driver->driver_acct().clean_local_queue_infos();
     _cond.notify_one();
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_queue.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_queue.cpp
@@ -261,6 +261,9 @@ StatusOr<DriverRawPtr> WorkGroupDriverQueue::take(const bool block) {
                 continue;
             }
 
+            if (!block) {
+                return nullptr;
+            }
             // All the ready tasks are throttled, so wait until the new period or a new task comes.
             _cv.wait_for(lock, std::chrono::nanoseconds(sleep_ns));
         }

--- a/be/src/exec/pipeline/pipeline_driver_queue.h
+++ b/be/src/exec/pipeline/pipeline_driver_queue.h
@@ -35,7 +35,7 @@ public:
     // *from_executor* means that the executor thread puts the driver back to the queue.
     virtual void put_back_from_executor(const DriverRawPtr driver) = 0;
 
-    virtual StatusOr<DriverRawPtr> take() = 0;
+    virtual StatusOr<DriverRawPtr> take(const bool block) = 0;
     virtual void cancel(DriverRawPtr driver) = 0;
 
     // Update statistics of the driver's workgroup,
@@ -78,7 +78,7 @@ public:
 
     void put(const DriverRawPtr driver);
     void cancel(const DriverRawPtr driver);
-    DriverRawPtr take();
+    DriverRawPtr take(const bool block);
     inline bool empty() const { return num_drivers == 0; }
 
     inline size_t size() const { return num_drivers; }
@@ -109,7 +109,7 @@ public:
     void update_statistics(const DriverRawPtr driver) override;
 
     // Return cancelled status, if the queue is closed.
-    StatusOr<DriverRawPtr> take() override;
+    StatusOr<DriverRawPtr> take(const bool block) override;
 
     void cancel(DriverRawPtr driver) override;
 
@@ -163,7 +163,7 @@ public:
     // Return cancelled status, if the queue is closed.
     // Firstly, select the work group with the minimum vruntime.
     // Secondly, select the proper driver from the driver queue of this work group.
-    StatusOr<DriverRawPtr> take() override;
+    StatusOr<DriverRawPtr> take(const bool block) override;
 
     void cancel(DriverRawPtr driver) override;
 

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
@@ -82,8 +82,7 @@ OperatorPtr LocalParallelMergeSortSourceOperatorFactory::create(int32_t degree_o
 
     auto chunk_provider_factory = [](ChunksSorter* chunks_sorter) {
         return ([chunks_sorter](bool only_check_if_has_data, ChunkPtr* chunk, bool* eos) {
-            if (chunks_sorter->spiller() != nullptr && chunks_sorter->spiller()->spilled() &&
-                !chunks_sorter->spiller()->has_output_data()) {
+            if (!chunks_sorter->has_output()) {
                 return false;
             }
             if (!only_check_if_has_data) {

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
@@ -26,30 +26,13 @@ namespace starrocks::pipeline {
 Status LocalParallelMergeSortSourceOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     _sort_context->ref();
-    _merger->bind_profile(_driver_sequence, _unique_metrics.get());
+    _merger->bind_profile(_merge_parallel_id, _unique_metrics.get());
     return Status::OK();
 }
 
 void LocalParallelMergeSortSourceOperator::close(RuntimeState* state) {
     _sort_context->unref(state);
     Operator::close(state);
-}
-
-StatusOr<ChunkPtr> LocalParallelMergeSortSourceOperator::pull_chunk(RuntimeState* state) {
-    ChunkPtr chunk = _merger->try_get_next(_driver_sequence);
-
-    if (_merger->is_finished()) {
-        _is_finished = true;
-    }
-
-    return chunk;
-}
-
-Status LocalParallelMergeSortSourceOperator::set_finished(RuntimeState* state) {
-    if (_driver_sequence == 0) {
-        return _sort_context->set_finished();
-    }
-    return Status::OK();
 }
 
 bool LocalParallelMergeSortSourceOperator::has_output() const {
@@ -59,7 +42,10 @@ bool LocalParallelMergeSortSourceOperator::has_output() const {
     if (_is_finished) {
         return false;
     }
-    if (_merger->is_current_stage_finished(_driver_sequence)) {
+    if (_merger->is_current_stage_finished(_merge_parallel_id, false)) {
+        return false;
+    }
+    if (_merger->is_pending(_merge_parallel_id)) {
         return false;
     }
     return true;
@@ -67,6 +53,21 @@ bool LocalParallelMergeSortSourceOperator::has_output() const {
 
 bool LocalParallelMergeSortSourceOperator::is_finished() const {
     return _is_finished;
+}
+
+StatusOr<ChunkPtr> LocalParallelMergeSortSourceOperator::pull_chunk(RuntimeState* state) {
+    ChunkPtr chunk = _merger->try_get_next(_merge_parallel_id);
+
+    if (_merger->is_finished()) {
+        _is_finished = true;
+    }
+
+    return chunk;
+}
+
+Status LocalParallelMergeSortSourceOperator::set_finished(RuntimeState* state) {
+    _sort_context->cancel();
+    return _sort_context->set_finished();
 }
 
 Status LocalParallelMergeSortSourceOperatorFactory::prepare(RuntimeState* state) {
@@ -79,26 +80,46 @@ OperatorPtr LocalParallelMergeSortSourceOperatorFactory::create(int32_t degree_o
                                                                 int32_t driver_sequence) {
     auto sort_context = _sort_context_factory->create(driver_sequence);
 
-    if (_merger == nullptr) {
-        std::vector<merge_path::MergePathChunkProvider> chunk_providers;
-        for (int i = 0; i < degree_of_parallelism; i++) {
-            auto* chunks_sorter = sort_context->get_chunks_sorter(i);
-            DCHECK(chunks_sorter != nullptr);
-            chunk_providers.emplace_back([chunks_sorter](bool only_check_if_has_data, ChunkPtr* chunk, bool* eos) {
-                if (only_check_if_has_data) {
-                    return true;
-                }
+    auto chunk_provider_factory = [](ChunksSorter* chunks_sorter) {
+        return ([chunks_sorter](bool only_check_if_has_data, ChunkPtr* chunk, bool* eos) {
+            if (chunks_sorter->spiller() != nullptr && chunks_sorter->spiller()->spilled() &&
+                !chunks_sorter->spiller()->has_output_data()) {
+                return false;
+            }
+            if (!only_check_if_has_data) {
                 chunks_sorter->get_next(chunk, eos);
-                return true;
-            });
-        }
-        _merger = std::make_unique<merge_path::MergePathCascadeMerger>(
-                _state->chunk_size(), degree_of_parallelism, sort_context->sort_exprs(), sort_context->sort_descs(),
-                _tuple_desc, sort_context->offset(), sort_context->limit(), chunk_providers);
-    }
+            }
+            return true;
+        });
+    };
 
-    return std::make_shared<LocalParallelMergeSortSourceOperator>(this, _id, _plan_node_id, driver_sequence,
-                                                                  sort_context.get(), _merger.get());
+    if (_is_gathered) {
+        if (_mergers.empty()) {
+            std::vector<merge_path::MergePathChunkProvider> chunk_providers;
+            for (int i = 0; i < degree_of_parallelism; i++) {
+                auto* chunks_sorter = sort_context->get_chunks_sorter(i);
+                DCHECK(chunks_sorter != nullptr);
+                chunk_providers.emplace_back(chunk_provider_factory(chunks_sorter));
+            }
+            _mergers.push_back(std::make_unique<merge_path::MergePathCascadeMerger>(
+                    _state->chunk_size(), degree_of_parallelism, sort_context->sort_exprs(), sort_context->sort_descs(),
+                    _tuple_desc, sort_context->topn_type(), sort_context->offset(), sort_context->limit(),
+                    chunk_providers));
+        }
+        return std::make_shared<LocalParallelMergeSortSourceOperator>(
+                this, _id, _plan_node_id, driver_sequence, sort_context.get(), _is_gathered, _mergers[0].get());
+    } else {
+        std::vector<merge_path::MergePathChunkProvider> chunk_providers;
+        auto* chunks_sorter = sort_context->get_chunks_sorter(0);
+        DCHECK(chunks_sorter != nullptr);
+        chunk_providers.emplace_back(chunk_provider_factory(chunks_sorter));
+        _mergers.push_back(std::make_unique<merge_path::MergePathCascadeMerger>(
+                _state->chunk_size(), 1, sort_context->sort_exprs(), sort_context->sort_descs(), _tuple_desc,
+                sort_context->topn_type(), sort_context->offset(), sort_context->limit(), chunk_providers));
+        return std::make_shared<LocalParallelMergeSortSourceOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                                      sort_context.get(), _is_gathered,
+                                                                      _mergers[driver_sequence].get());
+    }
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -57,6 +57,7 @@ public:
         DCHECK_LT(driver_sequence, _chunks_sorter_partitions.size());
         return _chunks_sorter_partitions[driver_sequence].get();
     }
+    TTopNType::type topn_type() const { return _topn_type; }
     int64_t offset() const { return _offset; }
     int64_t limit() const { return _limit; }
     const std::vector<ExprContext*>& sort_exprs() const { return _sort_exprs; }

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -127,6 +127,11 @@ public:
 
     bool need_input() const override { return false; }
 
+    // Return true if the output of `has_output` shift frequently between true and false.
+    // We need to avoid this kind of mutable pipeline being moved frequently between ready queue and pending queue,
+    // which will lead to drastic performance deduction (the "ScheduleTime" in profile will be super high).
+    virtual bool is_mutable() const { return false; }
+
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override {
         return Status::InternalError("Shouldn't push chunk to source operator");
     }

--- a/be/src/exec/pipeline/stream_pipeline_driver.cpp
+++ b/be/src/exec/pipeline/stream_pipeline_driver.cpp
@@ -130,12 +130,12 @@ StatusOr<DriverState> StreamPipelineDriver::process(RuntimeState* runtime_state,
 
             // yield when total chunks moved or time spent on-core for evaluation
             // exceed the designated thresholds.
-            if (time_spent >= YIELD_MAX_TIME_SPENT) {
+            if (time_spent >= YIELD_MAX_TIME_SPENT_NS) {
                 should_yield = true;
                 COUNTER_UPDATE(_yield_by_time_limit_counter, 1);
                 break;
             }
-            if (_workgroup != nullptr && time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT &&
+            if (_workgroup != nullptr && time_spent >= YIELD_PREEMPT_MAX_TIME_SPENT_NS &&
                 _workgroup->driver_sched_entity()->in_queue()->should_yield(this, time_spent)) {
                 should_yield = true;
                 COUNTER_UPDATE(_yield_by_preempt_counter, 1);

--- a/be/src/exec/sorting/merge.h
+++ b/be/src/exec/sorting/merge.h
@@ -85,7 +85,8 @@ struct SortedRun {
 
     // Steal part of chunk, skip the first `skipped_rows` rows and take the next `size` rows, avoid copy if possible
     // After steal out, this run will not reference the chunk anymore
-    std::pair<ChunkPtr, Columns> steal_chunk(bool steal_orderby, size_t size, size_t skipped_rows = 0);
+    ChunkPtr steal_chunk(size_t size, size_t skipped_rows = 0) { return steal(false, size, skipped_rows).first; }
+    std::pair<ChunkPtr, Columns> steal(bool steal_orderby, size_t size, size_t skipped_rows);
 
     int compare_row(const SortDescs& desc, const SortedRun& rhs, size_t lhs_row, size_t rhs_row) const;
 

--- a/be/src/exec/sorting/merge.h
+++ b/be/src/exec/sorting/merge.h
@@ -85,7 +85,7 @@ struct SortedRun {
 
     // Steal part of chunk, skip the first `skipped_rows` rows and take the next `size` rows, avoid copy if possible
     // After steal out, this run will not reference the chunk anymore
-    ChunkPtr steal_chunk(size_t size, size_t skipped_rows = 0);
+    std::pair<ChunkPtr, Columns> steal_chunk(bool steal_orderby, size_t size, size_t skipped_rows = 0);
 
     int compare_row(const SortDescs& desc, const SortedRun& rhs, size_t lhs_row, size_t rhs_row) const;
 

--- a/be/src/exec/sorting/merge_column.cpp
+++ b/be/src/exec/sorting/merge_column.cpp
@@ -340,7 +340,7 @@ ChunkUniquePtr SortedRun::clone_slice() const {
     }
 }
 
-std::pair<ChunkPtr, Columns> SortedRun::steal_chunk(bool steal_orderby, size_t size, size_t skipped_rows) {
+std::pair<ChunkPtr, Columns> SortedRun::steal(bool steal_orderby, size_t size, size_t skipped_rows) {
     if (empty()) {
         return {};
     }

--- a/be/src/exec/sorting/merge_path.cpp
+++ b/be/src/exec/sorting/merge_path.cpp
@@ -1035,7 +1035,7 @@ void MergePathCascadeMerger::_split_chunk(const int32_t parallel_idx) {
 
     size_t remain_size = big_run.num_rows();
     while (remain_size > 0) {
-        auto pair = big_run.steal_chunk(_late_materialization, _chunk_size);
+        auto pair = big_run.steal(_late_materialization, _chunk_size, 0);
         ChunkPtr chunk = pair.first;
         Columns orderby = std::move(pair.second);
         DCHECK(chunk != nullptr);

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -330,9 +330,10 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
     SourceOperatorFactoryPtr source_operator;
 
     source_operator = std::make_shared<SourceFactory>(context->next_operator_id(), id(), context_factory);
-    if (enable_parallel_merge) {
+    if (!is_partition_topn && enable_parallel_merge) {
         down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())
                 ->set_tuple_desc(_materialized_tuple_desc);
+        down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())->set_is_gathered(need_merge);
     }
 
     ops_sink_with_sort.emplace_back(std::move(sink_operator));
@@ -368,8 +369,8 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
     // need_merge = true means gather is needed for multiple streams of data
     // need_merge = false means gather is no longer needed
     bool need_merge = _analytic_partition_exprs.empty();
-    bool enable_parallel_merge = !is_partition_topn && need_merge && _tnode.sort_node.__isset.enable_parallel_merge &&
-                                 _tnode.sort_node.enable_parallel_merge;
+    bool enable_parallel_merge =
+            _tnode.sort_node.__isset.enable_parallel_merge && _tnode.sort_node.enable_parallel_merge;
 
     OpFactories operators_source_with_sort;
 
@@ -380,18 +381,11 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
                                                                                 enable_parallel_merge);
     } else {
         if (runtime_state()->enable_spill() && _limit < 0) {
-            if (need_merge) {
-                if (enable_parallel_merge) {
-                    operators_source_with_sort =
-                            _decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,
-                                                   LocalParallelMergeSortSourceOperatorFactory>(
-                                    context, is_partition_topn, need_merge, enable_parallel_merge);
-                } else {
-                    operators_source_with_sort =
-                            _decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,
-                                                   LocalMergeSortSourceOperatorFactory>(
-                                    context, is_partition_topn, need_merge, enable_parallel_merge);
-                }
+            if (enable_parallel_merge) {
+                operators_source_with_sort =
+                        _decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,
+                                               LocalParallelMergeSortSourceOperatorFactory>(
+                                context, is_partition_topn, need_merge, enable_parallel_merge);
             } else {
                 operators_source_with_sort =
                         _decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,
@@ -399,18 +393,11 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
                                                                                     need_merge, enable_parallel_merge);
             }
         } else {
-            if (need_merge) {
-                if (enable_parallel_merge) {
-                    operators_source_with_sort =
-                            _decompose_to_pipeline<SortContextFactory, PartitionSortSinkOperatorFactory,
-                                                   LocalParallelMergeSortSourceOperatorFactory>(
-                                    context, is_partition_topn, need_merge, enable_parallel_merge);
-                } else {
-                    operators_source_with_sort =
-                            _decompose_to_pipeline<SortContextFactory, PartitionSortSinkOperatorFactory,
-                                                   LocalMergeSortSourceOperatorFactory>(
-                                    context, is_partition_topn, need_merge, enable_parallel_merge);
-                }
+            if (enable_parallel_merge) {
+                operators_source_with_sort =
+                        _decompose_to_pipeline<SortContextFactory, PartitionSortSinkOperatorFactory,
+                                               LocalParallelMergeSortSourceOperatorFactory>(
+                                context, is_partition_topn, need_merge, enable_parallel_merge);
             } else {
                 operators_source_with_sort =
                         _decompose_to_pipeline<SortContextFactory, PartitionSortSinkOperatorFactory,

--- a/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
+++ b/be/test/exec/pipeline/pipeline_driver_queue_test.cpp
@@ -82,7 +82,7 @@ PARALLEL_TEST(QuerySharedDriverQueueTest, test_basic) {
 
     // Take drivers from queue.
     for (auto* out_driver : out_drivers) {
-        auto maybe_driver = queue.take();
+        auto maybe_driver = queue.take(true);
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(out_driver, maybe_driver.value());
     }
@@ -124,7 +124,7 @@ PARALLEL_TEST(QuerySharedDriverQueueTest, test_cancel) {
 
     for (size_t i = 0; i < out_drivers.size(); i++) {
         ops_before_get[i]();
-        auto maybe_driver = queue.take();
+        auto maybe_driver = queue.take(true);
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(out_drivers[i], maybe_driver.value());
     }
@@ -139,7 +139,7 @@ PARALLEL_TEST(QuerySharedDriverQueueTest, test_take_block) {
     _set_driver_level(driver1.get(), 1);
 
     auto consumer_thread = std::make_shared<std::thread>([&queue, &driver1] {
-        auto maybe_driver = queue.take();
+        auto maybe_driver = queue.take(true);
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(driver1.get(), maybe_driver.value());
     });
@@ -155,7 +155,7 @@ PARALLEL_TEST(QuerySharedDriverQueueTest, test_take_close) {
     QuerySharedDriverQueue queue;
 
     auto consumer_thread = std::make_shared<std::thread>([&queue] {
-        auto maybe_driver = queue.take();
+        auto maybe_driver = queue.take(true);
         ASSERT_TRUE(maybe_driver.status().is_cancelled());
     });
 
@@ -263,7 +263,7 @@ TEST_F(WorkGroupDriverQueueTest, test_basic) {
 
     // Take drivers from queue.
     for (auto* out_driver : out_drivers) {
-        auto maybe_driver = queue.take();
+        auto maybe_driver = queue.take(true);
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(out_driver, maybe_driver.value());
     }
@@ -279,7 +279,7 @@ TEST_F(WorkGroupDriverQueueTest, test_take_block) {
     driver1->set_workgroup(_wg1);
 
     auto consumer_thread = std::make_shared<std::thread>([&queue, &driver1] {
-        auto maybe_driver = queue.take();
+        auto maybe_driver = queue.take(true);
         ASSERT_TRUE(maybe_driver.ok());
         ASSERT_EQ(driver1.get(), maybe_driver.value());
     });
@@ -295,7 +295,7 @@ TEST_F(WorkGroupDriverQueueTest, test_take_close) {
     WorkGroupDriverQueue queue;
 
     auto consumer_thread = std::make_shared<std::thread>([&queue] {
-        auto maybe_driver = queue.take();
+        auto maybe_driver = queue.take(true);
         ASSERT_TRUE(maybe_driver.status().is_cancelled());
     });
 

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -257,7 +257,7 @@ TEST(SortingTest, steal_chunk) {
         SortedRun run(chunk, chunk->columns());
         ChunkPtr sum = chunk->clone_empty();
         while (!run.empty()) {
-            ChunkPtr stealed = run.steal_chunk(false, chunk_size).first;
+            ChunkPtr stealed = run.steal_chunk(chunk_size);
             sum->append(*stealed);
         }
         ASSERT_EQ(chunk->num_rows(), sum->num_rows());

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -257,7 +257,7 @@ TEST(SortingTest, steal_chunk) {
         SortedRun run(chunk, chunk->columns());
         ChunkPtr sum = chunk->clone_empty();
         while (!run.empty()) {
-            ChunkPtr stealed = run.steal_chunk(chunk_size);
+            ChunkPtr stealed = run.steal_chunk(false, chunk_size).first;
             sum->append(*stealed);
         }
         ASSERT_EQ(chunk->num_rows(), sum->num_rows());
@@ -499,12 +499,14 @@ static void test_merge_path(const size_t num_cols, const size_t left_start, cons
     for (size_t processor_idx = 0; processor_idx < processor_num; processor_idx++) {
         ChunkPtr dest_chunk = primitive_dest_chunk->clone_empty_with_slot();
         Columns dest_orderby;
+        std::vector<int32_t> orderby_indexes;
         for (size_t col = 0; col < num_cols; col++) {
             auto column = ColumnHelper::create_column(type_desc, false);
             dest_orderby.push_back(std::move(column));
+            orderby_indexes.push_back(-1);
         }
         SortedRun dest_run(std::move(dest_chunk), std::move(dest_orderby));
-        dests.emplace_back(std::move(dest_run), dest_num_rows);
+        dests.emplace_back(std::move(dest_run), std::move(orderby_indexes), dest_num_rows);
     }
 
     std::vector<std::thread> threads;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Background

Please refer to https://github.com/StarRocks/starrocks/issues/20534 for details.

This is a continuation work of https://github.com/StarRocks/starrocks/pull/18525 and https://github.com/StarRocks/starrocks/pull/21205

## Enhancement

### Change the parallelism distribution strategy

Before this pr, the distribution strategy is like this: considering that there're 3 `MergeNode` and 8 parallelism, the 8 parallelism will be mapped with the 3 `MergeNode`, which is, 2 nodes eachs get 3 parallelism, and 1 node gets the remaining 2 parallelism.
* MergeNode1: 1 - 3
* MergeNode2: 4 - 6
* MergeNode3: 7 - 8

After this pr, the distribution strategy is like this: Still the above situation, each node gets the all 8 parallelism
* MergeNode1: 1 - 8
* MergeNode2: 1 - 8
* MergeNode3: 1 - 8

The differences of the above two strategies lie in two aspects:
1. Each parallelism process 1 node vs. Each parallelism process more than 1 nodes.
2. Each parallelism may have different workloads vs. Each parallelism have exactly the same workloads. Given that each MergeNode has same amount of data to process.

### Extend the schedule strategy

Given that `LocalParallelMergeSortSourceOperator` and `ExchangeParallelMergeSourceOperator` are a little bit mutable, which means its `has_output` may change frequently between true and false.

The current schedule framework cannot process this kind of pipeline well. Because this merits may lead to the driver being frequently moved between ready_queue and pending_queue, which will result in significant `ScheduleTime` in profile.

If we can keep those `mutable` drivers at worker's local queue for a while, the high schedule penalty can be diminished to large extend. So I introduced a new driver state called `MUTABLE_WAITING` to meet this requirement.

* If the driver stays in the local mutable queue for more than 1ms(defined by `GlobalDriverExecutor::MUTABLE_MAX_WAIT_TIME_SPENT`), it can be put into the poller's queue.
* The execution time is still projected to the same yield time constraints which are defined by `PipelineDriver::YIELD_MAX_TIME_SPENT` and `PipelineDriver::YIELD_PREEMPT_MAX_TIME_SPENT`.

### Other changes

1. Adjust the auto late materialization stratrgy by increasing the decay factor.
2. Avoid append column-ref order by columns twice.

## Experiment

### Test Info

#### Config

* `Session Variable`
    * `cbo_enable_low_cardinality_optimize = false`. We need to test string orderby cases, and this optimization will change string to int so I disable it.

#### Test Set

TPCH-100g

#### Dimension

1. different orderby column type
1. different cardinality of orderby column
1. different orderby column number
1. different non-orderby output column number
1. multi-core machines
1. mass cluster, with more than 20 backend nodes

#### Case

```sql
-- 1 Order By Type
-- Q1.1 order by decimal
select sum(wv) from (
    select *,
    rank() over(order by l_quantity) as wv
    from lineitem
) a;
-- Q1.2 order by int
select sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q1.3 order by varchar
select sum(wv) from (
    select *,
    rank() over(order by l_shipmode) as wv
    from lineitem
) a;
-- Q1.4 order by date
select sum(wv) from (
    select *,
    rank() over(order by l_commitdate) as wv
    from lineitem
) a;

-- 2 Order By Cardinality
-- Q2.1 low cardinality
select sum(wv) from (
    select *,
    rank() over(order by l_linenumber) as wv
    from lineitem
) a;
-- Q2.2 middle cardinality
select sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q2.3 high cardinality
select sum(wv) from (
    select *,
    rank() over(order by l_orderkey) as wv
    from lineitem
) a;

-- Q3 Order By Columns
-- Q3.1 order by 2 columns
select sum(wv) from (
    select *,
    rank() over(order by l_linenumber, l_quantity) as wv
    from lineitem
) a;
-- Q3.2 order by 3 columns
select sum(wv) from (
    select *,
    rank() over(order by l_linenumber, l_quantity, l_discount) as wv
    from lineitem
) a;
-- Q3.3 order by 4 columns
select sum(wv) from (
    select *,
    rank() over(order by l_linenumber, l_quantity, l_discount, l_tax) as wv
    from lineitem
) a;
-- Q3.4 order by 5 columns
select sum(wv) from (
    select *,
    rank() over(order by l_linenumber, l_quantity, l_discount, l_tax, l_returnflag) as wv
    from lineitem
) a;
-- Q3.5 order by 6 columns
select sum(wv) from (
    select *,
    rank() over(order by l_linenumber, l_quantity, l_discount, l_tax, l_returnflag, l_linestatus) as wv
    from lineitem
) a;
-- Q3.6 order by 7 columns
select sum(wv) from (
    select *,
    rank() over(order by l_linenumber, l_quantity, l_discount, l_tax, l_returnflag, l_linestatus, l_shipinstruct) as wv
    from lineitem
) a;
-- Q3.7 order by 8 columns
select sum(wv) from (
    select *,
    rank() over(order by l_linenumber, l_quantity, l_discount, l_tax, l_returnflag, l_linestatus, l_shipinstruct, l_shipmode) as wv
    from lineitem
) a;

-- Q4 Output Non-Order by Columns
-- Q4.1 
select sum(l_linenumber), sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q4.2
select sum(l_linenumber), sum(l_quantity), sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q4.3
select sum(l_linenumber), sum(l_quantity), sum(l_discount), sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q4.4
select sum(l_linenumber), sum(l_quantity), sum(l_discount), sum(l_tax), sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q4.5
select sum(l_linenumber), sum(l_quantity), sum(l_discount), sum(l_tax), sum(l_returnflag), sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q4.6
select sum(l_linenumber), sum(l_quantity), sum(l_discount), sum(l_tax), sum(l_returnflag), sum(l_linestatus), sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q4.7
select sum(l_linenumber), sum(l_quantity), sum(l_discount), sum(l_tax), sum(l_returnflag), sum(l_linestatus), sum(l_shipinstruct), sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
-- Q4.8
select sum(l_linenumber), sum(l_quantity), sum(l_discount), sum(l_tax), sum(l_returnflag), sum(l_linestatus), sum(l_shipinstruct), sum(l_shipmode), sum(wv) from (
    select *,
    rank() over(order by l_suppkey) as wv
    from lineitem
) a;
```

### Result

#### Orderby Column Type

Cluster specification: 3be/1fe, each with 16c/64g

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="6">Time(enable_parallel_merge=false)</th>
    <th colspan="6">Time(enable_parallel_merge=true)</th>
    <th rowspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q1.1</td>
    <td>54.037s</td>
    <td>37.255s</td>
    <td>30.298s</td>
    <td>25.414s</td>
    <td>26.273s</td>
    <td>23.849s</td>
    <td>48.762s</td>
    <td>26.031s</td>
    <td>19.701s</td>
    <td>15.811s</td>
    <td>15.34s</td>
    <td>12.221s</td>
    <td>1.11, 1.43, 1.54, 1.61, 1.71, 1.95</td>
  </tr>
  <tr>
    <td>Q1.2</td>
    <td>54.478s</td>
    <td>33.7s</td>
    <td>24.143s</td>
    <td>20.121s</td>
    <td>18.664s</td>
    <td>17.822s</td>
    <td>54.901s</td>
    <td>29.181s</td>
    <td>18.572s</td>
    <td>13.332s</td>
    <td>11.99s</td>
    <td>10.645s</td>
    <td>0.99, 1.15, 1.3, 1.51, 1.56, 1.67</td>
  </tr>
  <tr>
    <td>Q1.3</td>
    <td>88.874s</td>
    <td>59.628s</td>
    <td>45.904s</td>
    <td>47.042s</td>
    <td>44.765s</td>
    <td>48.455s</td>
    <td>74.331s</td>
    <td>38.065s</td>
    <td>24.206s</td>
    <td>19.213s</td>
    <td>17.871s</td>
    <td>14.537s</td>
    <td>1.2, 1.57, 1.9, 2.45, 2.5, 3.33</td>
  </tr>
  <tr>
    <td>Q1.4</td>
    <td>34.604s</td>
    <td>23.922s</td>
    <td>18.678s</td>
    <td>15.408s</td>
    <td>14.967s</td>
    <td>14.518s</td>
    <td>32.607s</td>
    <td>18.496s</td>
    <td>12.505s</td>
    <td>10.465s</td>
    <td>9.687s</td>
    <td>8.147s</td>
    <td>1.06, 1.29, 1.49, 1.47, 1.55, 1.78</td>
  </tr>
</table>


#### Orderby Column Cardinality

Cluster specification: 3be/1fe, each with 16c/64g

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="6">Time(enable_parallel_merge=false)</th>
    <th colspan="6">Time(enable_parallel_merge=true)</th>
    <th rowspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q2.1</td>
    <td>30.161s</td>
    <td>21.746s</td>
    <td>17.488s</td>
    <td>15.903s</td>
    <td>15.932s</td>
    <td>16.369s</td>
    <td>26.726s</td>
    <td>16.462s</td>
    <td>12.683s</td>
    <td>10.173s</td>
    <td>9.916s</td>
    <td>8.9s</td>
    <td>1.13, 1.32, 1.38, 1.56, 1.61, 1.84</td>
  </tr>
  <tr>
    <td>Q2.2</td>
    <td>52.665s</td>
    <td>35.562s</td>
    <td>25.031s</td>
    <td>20.46s</td>
    <td>19.378s</td>
    <td>18.25s</td>
    <td>53.194s</td>
    <td>29.496s</td>
    <td>18.897s</td>
    <td>13.853s</td>
    <td>12.728s</td>
    <td>10.638s</td>
    <td>0.99, 1.21, 1.32, 1.48, 1.52, 1.72</td>
  </tr>
  <tr>
    <td>Q2.3</td>
    <td>76.358s</td>
    <td>54.834s</td>
    <td>44.607s</td>
    <td>38.273s</td>
    <td>39.622s</td>
    <td>38.127s</td>
    <td>84.804s</td>
    <td>39.262s</td>
    <td>29.755s</td>
    <td>25.692s</td>
    <td>23.86s</td>
    <td>22.206s</td>
    <td>0.9, 1.4, 1.5, 1.49, 1.66, 1.72</td>
  </tr>
</table>

#### Orderby Column Number

Cluster specification: 3be/1fe, each with 16c/64g

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="6">Time(enable_parallel_merge=false)</th>
    <th colspan="6">Time(enable_parallel_merge=true)</th>
    <th rowspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q3.1</td>
    <td>78.423s</td>
    <td>54.155s</td>
    <td>41.886s</td>
    <td>38.799s</td>
    <td>35.745s</td>
    <td>35.51s</td>
    <td>71.787s</td>
    <td>39.655s</td>
    <td>28.709s</td>
    <td>22.257s</td>
    <td>21.994s</td>
    <td>16.988s</td>
    <td>1.09, 1.37, 1.46, 1.74, 1.63, 2.09</td>
  </tr>
  <tr>
    <td>Q3.2</td>
    <td>115.93s</td>
    <td>85.36s</td>
    <td>68.548s</td>
    <td>62.716s</td>
    <td>59.202s</td>
    <td>57.178s</td>
    <td>108.701s</td>
    <td>56.703s</td>
    <td>41.76s</td>
    <td>38.046s</td>
    <td>35.426s</td>
    <td>29.12s</td>
    <td>1.07, 1.51, 1.64, 1.65, 1.67, 1.96</td>
  </tr>
  <tr>
    <td>Q3.3</td>
    <td>166.56s</td>
    <td>120.376s</td>
    <td>95.746s</td>
    <td>83.232s</td>
    <td>84.097s</td>
    <td>81.164s</td>
    <td>146.202s</td>
    <td>86.85s</td>
    <td>60.467s</td>
    <td>51.61s</td>
    <td>47.816s</td>
    <td>39.74s</td>
    <td>1.14, 1.39, 1.58, 1.61, 1.76, 2.04</td>
  </tr>
</table>

#### Non-Orderby Column Number

Cluster specification: 3be/1fe, each with 16c/64g

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="6">Time(enable_parallel_merge=false)</th>
    <th colspan="6">Time(enable_parallel_merge=true)</th>
    <th rowspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q4.1</td>
    <td>67.284s</td>
    <td>41.339s</td>
    <td>29.052s</td>
    <td>24.382s</td>
    <td>24.675s</td>
    <td>22.482s</td>
    <td>64.212s</td>
    <td>34.36s</td>
    <td>20.837s</td>
    <td>15.042s</td>
    <td>13.622s</td>
    <td>12.065s</td>
    <td>1.05, 1.2, 1.39, 1.62, 1.81, 1.86</td>
  </tr>
  <tr>
    <td>Q4.2</td>
    <td>81.673s</td>
    <td>54.223s</td>
    <td>38.953s</td>
    <td>32.063s</td>
    <td>29.49s</td>
    <td>29.974s</td>
    <td>77.907s</td>
    <td>42.988s</td>
    <td>24.567s</td>
    <td>18.246s</td>
    <td>16.668s</td>
    <td>15.641s</td>
    <td>1.05, 1.26, 1.59, 1.76, 1.77, 1.92</td>
  </tr>
  <tr>
    <td>Q4.3</td>
    <td>99.18s</td>
    <td>66.831s</td>
    <td>47.221s</td>
    <td>38.976s</td>
    <td>37.425s</td>
    <td>36.039s</td>
    <td>93.624s</td>
    <td>53.667s</td>
    <td>31.008s</td>
    <td>23.988s</td>
    <td>20.435s</td>
    <td>20.115s</td>
    <td>1.06, 1.25, 1.52, 1.62, 1.83, 1.79</td>
  </tr>
  <tr>
    <td>Q4.4</td>
    <td>119.348s</td>
    <td>74.391s</td>
    <td>52.699s</td>
    <td>43.344s</td>
    <td>44.357s</td>
    <td>40.426s</td>
    <td>115.326s</td>
    <td>60.089s</td>
    <td>36.389s</td>
    <td>27.076s</td>
    <td>26.049s</td>
    <td>23.384s</td>
    <td>1.03, 1.24, 1.45, 1.6, 1.7, 1.73</td>
  </tr>
  <tr>
    <td>Q4.5</td>
    <td>172.409s</td>
    <td>108.09s</td>
    <td>77.894s</td>
    <td>63.778s</td>
    <td>58.14s</td>
    <td>60.618s</td>
    <td>151.492s</td>
    <td>77.386s</td>
    <td>50.713s</td>
    <td>38.91s</td>
    <td>37.134s</td>
    <td>36.417s</td>
    <td>1.14, 1.4, 1.54, 1.64, 1.57, 1.66</td>
  </tr>
  <tr>
    <td>Q4.6</td>
    <td>197.193s</td>
    <td>137.865s</td>
    <td>99.361s</td>
    <td>82.31s</td>
    <td>80.203s</td>
    <td>77.049s</td>
    <td>167.078s</td>
    <td>104.803s</td>
    <td>69.104s</td>
    <td>53.163s</td>
    <td>48.836s</td>
    <td>47.554s</td>
    <td>1.18, 1.32, 1.44, 1.55, 1.64, 1.62</td>
  </tr>
  <tr>
    <td>Q4.7</td>
    <td>324.195s</td>
    <td>199.466s</td>
    <td>142.855s</td>
    <td>117.494s</td>
    <td>121.573s</td>
    <td>108.716s</td>
    <td>280.954s</td>
    <td>146.744s</td>
    <td>101.526s</td>
    <td>78.042s</td>
    <td>77.103s</td>
    <td>76.939s</td>
    <td>1.15, 1.36, 1.41, 1.51, 1.58, 1.41</td>
  </tr>
  <tr>
    <td>Q4.8</td>
    <td>412.315s</td>
    <td>244.594s</td>
    <td>187.414s</td>
    <td>154.444s</td>
    <td>141.136s</td>
    <td>143.828s</td>
    <td>314.523s</td>
    <td>206.164s</td>
    <td>133.679s</td>
    <td>103.602s</td>
    <td>99.954s</td>
    <td>96.166s</td>
    <td>1.31, 1.19, 1.4, 1.49, 1.41, 1.5</td>
  </tr>
</table>

#### Mass Cluster

Cluster specification: 21be/1fe, each with 16c/64g

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="6">Time(enable_parallel_merge=false)</th>
    <th colspan="6">Time(enable_parallel_merge=true)</th>
    <th rowspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
    <th>dop=1</th>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q2.1</td>
    <td>21.885s</td>
    <td>21.029s</td>
    <td>21.197s</td>
    <td>22.085s</td>
    <td>20.766s</td>
    <td>20.131s</td>
    <td>17.376s</td>
    <td>11.488s</td>
    <td>9.448s</td>
    <td>7.971s</td>
    <td>8.424s</td>
    <td>8.793s</td>
    <td>1.26, 1.83, 2.24, 2.77, 2.47, 2.29</td>
  </tr>
  <tr>
    <td>Q2.3</td>
    <td>60.726s</td>
    <td>59.432s</td>
    <td>59.404s</td>
    <td>57.64s</td>
    <td>57.095s</td>
    <td>57.431s</td>
    <td>82.82s</td>
    <td>40.264s</td>
    <td>27.916s</td>
    <td>21.169s</td>
    <td>21.976s</td>
    <td>22.875s</td>
    <td>0.73, 1.48, 2.13, 2.72, 2.6, 2.51</td>
  </tr>
  <tr>
    <td>Q3.3</td>
    <td>123.122s</td>
    <td>127.489s</td>
    <td>124.624s</td>
    <td>113.806s</td>
    <td>115.307s</td>
    <td>122.999s</td>
    <td>88.386s</td>
    <td>51.493s</td>
    <td>40.089s</td>
    <td>35.247s</td>
    <td>30.464s</td>
    <td>33.316s</td>
    <td>1.39, 2.48, 3.11, 3.23, 3.79, 3.69</td>
  </tr>
  <tr>
    <td>Q4.8</td>
    <td>348.817s</td>
    <td>299.656s</td>
    <td>291.368s</td>
    <td>286.804s</td>
    <td>329.078s</td>
    <td>284.017s</td>
    <td>116.315s</td>
    <td>84.495s</td>
    <td>78.484s</td>
    <td>75.579s</td>
    <td>81.208s</td>
    <td>84.406s</td>
    <td>3.0, 3.55, 3.71, 3.79, 4.05, 3.36</td>
  </tr>
</table>

#### Multi-Core Machine

Cluster specification: 3be/1fe, each with 64c/128g

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="9">Time(enable_parallel_merge=false)</th>
    <th colspan="9">Time(enable_parallel_merge=true)</th>
    <th rowspan="2" width="160px">Performance Ratio</th>
  </tr>
  <tr>
    <th>dop=1</th>
    <th>dop=8</th>
    <th>dop=16</th>
    <th>dop=24</th>
    <th>dop=32</th>
    <th>dop=40</th>
    <th>dop=48</th>
    <th>dop=56</th>
    <th>dop=64</th>
    <th>dop=1</th>
    <th>dop=8</th>
    <th>dop=16</th>
    <th>dop=24</th>
    <th>dop=32</th>
    <th>dop=40</th>
    <th>dop=48</th>
    <th>dop=56</th>
    <th>dop=64</th>
  </tr>
  <tr>
    <td>Q2.1</td>
    <td>30.986s</td>
    <td>19.536s</td>
    <td>18.732s</td>
    <td>18.324s</td>
    <td>20.51s</td>
    <td>21.323s</td>
    <td>20.515s</td>
    <td>22.691s</td>
    <td>23.424s</td>
    <td>32.218s</td>
    <td>12.77s</td>
    <td>14.527s</td>
    <td>14.319s</td>
    <td>11.726s</td>
    <td>15.925s</td>
    <td>15.134s</td>
    <td>12.694s</td>
    <td>16.392s</td>
    <td>0.96, 1.53, 1.29, 1.28, 1.75, 1.34, 1.36, 1.79, 1.43</td>
  </tr>
  <tr>
    <td>Q2.3</td>
    <td>84.546s</td>
    <td>45.694s</td>
    <td>43.054s</td>
    <td>43.433s</td>
    <td>41.788s</td>
    <td>43.075s</td>
    <td>43.3s</td>
    <td>42.869s</td>
    <td>42.224s</td>
    <td>94.683s</td>
    <td>29.487s</td>
    <td>26.952s</td>
    <td>29.43s</td>
    <td>28.515s</td>
    <td>27.674s</td>
    <td>28.749s</td>
    <td>29.046s</td>
    <td>27.474s</td>
    <td>0.89, 1.55, 1.6, 1.48, 1.47, 1.56, 1.51, 1.48, 1.54</td>
  </tr>
  <tr>
    <td>Q3.7</td>
    <td>578.138s</td>
    <td>272.879s</td>
    <td>249.732s</td>
    <td>255.631s</td>
    <td>248.239s</td>
    <td>251.253s</td>
    <td>250.762s</td>
    <td>242.977s</td>
    <td>247.695s</td>
    <td>558.22s</td>
    <td>141.09s</td>
    <td>125.202s</td>
    <td>124.013s</td>
    <td>122.453s</td>
    <td>124.713s</td>
    <td>121.544s</td>
    <td>123.222s</td>
    <td>126.733s</td>
    <td>1.04, 1.93, 1.99, 2.06, 2.03, 2.01, 2.06, 1.97, 1.95</td>
  </tr>
  <tr>
    <td>Q4.8</td>
    <td>419.283s</td>
    <td>171.977s</td>
    <td>156.015s</td>
    <td>150.71s</td>
    <td>152.259s</td>
    <td>156.658s</td>
    <td>158.085s</td>
    <td>164.667s</td>
    <td>168.94s</td>
    <td>365.67s</td>
    <td>107.304s</td>
    <td>98.665s</td>
    <td>102.958s</td>
    <td>92.81s</td>
    <td>99.644s</td>
    <td>99.097s</td>
    <td>95.121s</td>
    <td>100.93s</td>
    <td>1.15, 1.6, 1.58, 1.46, 1.64, 1.57, 1.6, 1.73, 1.67</td>
  </tr>
</table>

#### StreamBatchSize

Cluster specification: 3be/1fe, each with 16c/64g

There're many threads working on the same MergeNode, and each parallelism must process a certain amount of data for sake of performance. Given the pipeline's chunk_size, and a factor, each parallelism handles as many as `factor * chunk_size` rows of data for one merge operation.

So the stream batch size goes to `factor * chunk_size * dop`, which means each MergeNode of the merge tree can buffer at most `factor * chunk_size * dop` rows of data.

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="5">Time(factor = 0.5)</th>
  </tr>
  <tr>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q2.1</td>
    <td>29.778s</td>
    <td>21.988s</td>
    <td>18.347s</td>
    <td>17.064s</td>
    <td>17.019s</td>
  </tr>
  <tr>
    <td>Q2.3</td>
    <td>49.389s</td>
    <td>36.185s</td>
    <td>30.836s</td>
    <td>28.866s</td>
    <td>29.524s</td>
  </tr>
  <tr>
    <td>Q3.3</td>
    <td>92.975s</td>
    <td>66.858s</td>
    <td>56.303s</td>
    <td>57.06s</td>
    <td>55.959s</td>
  </tr>
  <tr>
    <td>Q4.5</td>
    <td>95.276s</td>
    <td>62.019s</td>
    <td>48.525s</td>
    <td>46.834s</td>
    <td>45.943s</td>
  </tr>
</table>


<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="5">Time(factor = 1)</th>
  </tr>
  <tr>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q2.1</td>
    <td>18.74s</td>
    <td>13.762s</td>
    <td>11.556s</td>
    <td>12.271s</td>
    <td>12.16s</td>
  </tr>
  <tr>
    <td>Q2.3</td>
    <td>41.355s</td>
    <td>29.492s</td>
    <td>27.401s</td>
    <td>25.994s</td>
    <td>25.056s</td>
  </tr>
  <tr>
    <td>Q3.3</td>
    <td>80.755s</td>
    <td>64.586s</td>
    <td>52.572s</td>
    <td>50.248s</td>
    <td>51.618s</td>
  </tr>
  <tr>
    <td>Q4.5</td>
    <td>77.895s</td>
    <td>53.189s</td>
    <td>40.131s</td>
    <td>38.477s</td>
    <td>37.808s</td>
  </tr>
</table>

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="5">Time(factor = 2)</th>
  </tr>
  <tr>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q2.1</td>
    <td>15.966s</td>
    <td>12.54s</td>
    <td>10.518s</td>
    <td>10.513s</td>
    <td>11.325s</td>
  </tr>
  <tr>
    <td>Q2.3</td>
    <td>36.429s</td>
    <td>29.764s</td>
    <td>25.144s</td>
    <td>25.711s</td>
    <td>24.569s</td>
  </tr>
  <tr>
    <td>Q3.3</td>
    <td>79.674s</td>
    <td>59.586s</td>
    <td>54.215s</td>
    <td>49.794s</td>
    <td>47.517s</td>
  </tr>
  <tr>
    <td>Q4.5</td>
    <td>79.11s</td>
    <td>50.191s</td>
    <td>39.696s</td>
    <td>37.558s</td>
    <td>37.419s</td>
  </tr>
</table>

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="5">Time(factor = 4)</th>
  </tr>
  <tr>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q2.1</td>
    <td>16.462s</td>
    <td>12.683s</td>
    <td>10.173s</td>
    <td>9.916s</td>
    <td>8.9s</td>
  </tr>
  <tr>
    <td>Q2.3</td>
    <td>39.262s</td>
    <td>29.755s</td>
    <td>25.692s</td>
    <td>23.86s</td>
    <td>22.206s</td>
  </tr>
  <tr>
    <td>Q3.3</td>
    <td>86.85s</td>
    <td>60.467s</td>
    <td>51.61s</td>
    <td>47.816s</td>
    <td>39.74s</td>
  </tr>
  <tr>
    <td>Q4.5</td>
    <td>77.386s</td>
    <td>50.713s</td>
    <td>38.91s</td>
    <td>37.134s</td>
    <td>36.417s</td>
  </tr>
</table>

<table>
  <tr>
    <th rowspan="2">Query</th>
    <th colspan="5">Time(factor = 8)</th>
  </tr>
  <tr>
    <th>dop=2</th>
    <th>dop=4</th>
    <th>dop=8</th>
    <th>dop=12</th>
    <th>dop=16</th>
  </tr>
  <tr>
    <td>Q2.1</td>
    <td>13.722s</td>
    <td>11.161s</td>
    <td>10.346s</td>
    <td>9.806s</td>
    <td>10.473s</td>
  </tr>
  <tr>
    <td>Q2.3</td>
    <td>36.32s</td>
    <td>28.979s</td>
    <td>25.21s</td>
    <td>23.445s</td>
    <td>25.284s</td>
  </tr>
  <tr>
    <td>Q3.3</td>
    <td>82.042s</td>
    <td>60.236s</td>
    <td>49.505s</td>
    <td>49.596s</td>
    <td>49.029s</td>
  </tr>
  <tr>
    <td>Q4.5</td>
    <td>76.846s</td>
    <td>48.326s</td>
    <td>37.503s</td>
    <td>36.428s</td>
    <td>35.313s</td>
  </tr>
</table>

### Conclusion

Across all test cases:

1. For cases of dop=1, there's no performance deduction.
1. For cases of dop>1, parall merge outperforms the non-parallel merge for 1-4 times in terms of total query time.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
