### PR TITLE
[Enhancement] Populate the block cache with the 'overwrite' option to avoid checking the existence by reading the block.

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -72,7 +72,7 @@ Status BlockCache::init(const CacheOptions& options) {
 }
 
 Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* buffer,
-                               size_t ttl_seconds) {
+                               size_t ttl_seconds, bool overwrite) {
     if (offset % _block_size != 0) {
         LOG(WARNING) << "write block key: " << cache_key << " with invalid args, offset: " << offset;
         return Status::InvalidArgument(strings::Substitute("offset must be aligned by block size $0", _block_size));
@@ -86,7 +86,7 @@ Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, size_t s
 
     size_t index = offset / _block_size;
     std::string block_key = fmt::format("{}/{}", cache_key, index);
-    return _kv_cache->write_cache(block_key, buffer, size, ttl_seconds);
+    return _kv_cache->write_cache(block_key, buffer, size, ttl_seconds, overwrite);
 }
 
 StatusOr<size_t> BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* buffer) {

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -30,8 +30,8 @@ public:
     Status init(const CacheOptions& options);
 
     // Write data to cache, the offset must be aligned by block size
-    Status write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* buffer,
-                       size_t ttl_seconds = 0);
+    Status write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* buffer, size_t ttl_seconds = 0,
+                       bool overwrite = true);
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned. The offset and size must be aligned by block size.

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -53,7 +53,12 @@ Status CacheLibWrapper::init(const CacheOptions& options) {
     return Status::OK();
 }
 
-Status CacheLibWrapper::write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds) {
+Status CacheLibWrapper::write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
+                                    bool overwrite) {
+    //  Simulate the behavior of skipping if exists
+    if (!overwrite && _cache->find(key)) {
+        return Status::AlreadyExist("the cache item already exists");
+    }
     // TODO: check size for chain item
     auto handle = _cache->allocate(_default_pool, key, size);
     if (!handle) {

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -44,7 +44,8 @@ public:
 
     Status init(const CacheOptions& options) override;
 
-    Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds) override;
+    Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
+                       bool overwrite) override;
 
     StatusOr<size_t> read_cache(const std::string& key, char* value, size_t off, size_t size) override;
 

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -27,7 +27,8 @@ public:
     virtual Status init(const CacheOptions& options) = 0;
 
     // Write data to cache
-    virtual Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds) = 0;
+    virtual Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
+                               bool overwrite) = 0;
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned.

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -50,11 +50,16 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     return to_status(_cache->init(opt));
 }
 
-Status StarCacheWrapper::write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds) {
+Status StarCacheWrapper::write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
+                                     bool overwrite) {
     butil::IOBuf buf;
     // Don't free the buffer passed by users
     buf.append_user_data((void*)value, size, empty_deleter);
-    return to_status(_cache->set(key, buf));
+
+    starcache::WriteOptions options;
+    options.ttl_seconds = ttl_seconds;
+    options.overwrite = overwrite;
+    return to_status(_cache->set(key, buf, &options));
 }
 
 StatusOr<size_t> StarCacheWrapper::read_cache(const std::string& key, char* value, size_t off, size_t size) {

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -27,7 +27,8 @@ public:
 
     Status init(const CacheOptions& options) override;
 
-    Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds) override;
+    Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
+                       bool overwrite) override;
 
     StatusOr<size_t> read_cache(const std::string& key, char* value, size_t off, size_t size) override;
 
@@ -59,6 +60,8 @@ inline Status to_status(const butil::Status& st) {
         return Status::InvalidArgument(st.error_str());
     case EIO:
         return Status::IOError(st.error_str());
+    case ENOMEM:
+        return Status::MemoryLimitExceeded(st.error_str());
     default:
         return Status::InternalError(st.error_str());
     }

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -892,7 +892,7 @@ CONF_Bool(block_cache_enable, "false");
 CONF_Int64(block_cache_disk_size, "0");
 CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
 CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
-CONF_Int64(block_cache_block_size, "1048576");  // 1MB
+CONF_Int64(block_cache_block_size, "262144");   // 256K
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 CONF_Bool(block_cache_checksum_enable, "false");
 // Maximum number of concurrent inserts we allow globally for block cache.


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When populating block cache from zero copy buffer, we read the block from cache first (ignore the read data) to check whether the block already exists in the cache. Only if not exists, we populate the block to cache. This behavior results an extra read procedure, which may cause the memory copy, disk io and meta operation overhead.

Now, we support a `overwrite` option in starcache submodule, to control whether overwrite the old data if the cache object already exists in the cache. So, we can populate the block cache with the overwrite (false) directly without reading it first to achieve the same purpose.

### Perf Test：
The first query time for the ssb-100g:

Query | read+write | write with overwrite
-- | -- | --
Q01 | 5023 | 4592
Q02 | 1831 | 1811
Q03 | 1722 | 1705
Q04 | 13141 | 9260
Q05 | 2944 | 2934
Q06 | 2859 | 2845
Q07 | 7430 | 5462
Q08 | 3101 | 3043
Q09 | 2790 | 2767
Q10 | 2491 | 2458
Q11 | 7721 | 6946
Q12 | 4143 | 4094
Q13 | 4026 | 3991

Because some queries (like Q02, Q03) only read data from cache (that was populated by previous queries), they will not populate the block cache, so there is not much time optimization with the overwrite option for them.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
