### PR TITLE
[Feature] support key partition exchanger for external table sink

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -123,6 +123,19 @@ PartitionExchanger::PartitionExchanger(const std::shared_ptr<LocalExchangeMemory
           _part_type(part_type),
           _partition_exprs(partition_expr_ctxs) {}
 
+KeyPartitionExchanger::KeyPartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+                                             LocalExchangeSourceOperatorFactory* source,
+                                             const std::vector<ExprContext*>& partition_expr_ctxs,
+                                             const size_t num_sinks)
+        : LocalExchanger(strings::Substitute("KeyPartition($0)"), memory_manager, source),
+          _source(source),
+          _partition_expr_ctxs(partition_expr_ctxs) {
+    _channel_partitions_columns.reserve(num_sinks);
+    for (int i = 0; i < num_sinks; ++i) {
+        _channel_partitions_columns.emplace_back(_partition_expr_ctxs.size());
+    }
+}
+
 void PartitionExchanger::incr_sinker() {
     LocalExchanger::incr_sinker();
     _partitioners.emplace_back(std::make_unique<ShufflePartitioner>(_source, _part_type, _partition_exprs));
@@ -156,6 +169,51 @@ Status PartitionExchanger::accept(const ChunkPtr& chunk, const int32_t sink_driv
     std::shared_ptr<std::vector<uint32_t>> partition_row_indexes = std::make_shared<std::vector<uint32_t>>(num_rows);
     RETURN_IF_ERROR(partitioner->partition_chunk(chunk, num_partitions, *partition_row_indexes));
     RETURN_IF_ERROR(partitioner->send_chunk(chunk, std::move(partition_row_indexes)));
+    return Status::OK();
+}
+
+Status KeyPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t sink_driver_sequence) {
+    size_t num_rows = chunk->num_rows();
+    size_t source_op_cnt = _source->get_sources().size();
+
+    if (num_rows == 0) {
+        return Status::OK();
+    }
+
+    auto& partitions_columns = _channel_partitions_columns[sink_driver_sequence];
+    for (size_t i = 0; i < partitions_columns.size(); ++i) {
+        ASSIGN_OR_RETURN(partitions_columns[i], _partition_expr_ctxs[i]->evaluate(chunk.get()))
+        DCHECK(partitions_columns[i] != nullptr);
+    }
+
+    Partition2RowIndexes partition_row_indexes;
+    for (int i = 0; i < num_rows; ++i) {
+        auto partition_key = std::make_shared<PartitionKey>(std::make_shared<Columns>(partitions_columns), i);
+        if (partition_row_indexes.find(partition_key) == partition_row_indexes.end()) {
+            partition_row_indexes.emplace(std::move(partition_key), std::make_shared<std::vector<uint32_t>>(1, i));
+        } else {
+            partition_row_indexes.at(partition_key)->emplace_back(i);
+        }
+    }
+
+    for (auto& i : partition_row_indexes) {
+        RowIndexPtr indexes = i.second;
+        std::vector<uint32_t> hash_values(indexes->at(0) + 1, HashUtil::FNV_SEED);
+        for (const ColumnPtr& column : partitions_columns) {
+            column->fnv_hash(&hash_values[0], indexes->at(0), indexes->at(0) + 1);
+        }
+
+        uint32_t shuffle_channel_id = hash_values[indexes->at(0)] % source_op_cnt;
+
+        size_t memory_usage(0);
+        for (unsigned int row_index : *indexes) {
+            memory_usage += chunk->bytes_usage(row_index, 1);
+        }
+
+        RETURN_IF_ERROR(_source->get_sources()[shuffle_channel_id]->add_chunk(
+                chunk, std::move(indexes), 0, indexes->size(), partitions_columns, _partition_expr_ctxs, memory_usage));
+    }
+
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -187,8 +187,9 @@ Status KeyPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t sink_d
     }
 
     Partition2RowIndexes partition_row_indexes;
+    auto partition_columns_ptr = std::make_shared<Columns>(partitions_columns);
     for (int i = 0; i < num_rows; ++i) {
-        auto partition_key = std::make_shared<PartitionKey>(std::make_shared<Columns>(partitions_columns), i);
+        auto partition_key = std::make_shared<PartitionKey>(partition_columns_ptr, i);
         auto partition_row_index = partition_row_indexes.find(partition_key);
         if (partition_row_index == partition_row_indexes.end()) {
             partition_row_indexes.emplace(std::move(partition_key), std::make_shared<std::vector<uint32_t>>(1, i));

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -199,11 +199,10 @@ Status KeyPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t sink_d
     }
 
     std::vector<uint32_t> hash_values(chunk->num_rows());
-    for (auto& partition_row_index : partition_row_indexes) {
-        RowIndexPtr indexes = partition_row_index.second;
+    for (auto& [_, indexes] : partition_row_indexes) {
         hash_values[(*indexes)[0]] = HashUtil::FNV_SEED;
         for (const ColumnPtr& column : partitions_columns) {
-            column->fnv_hash(&hash_values[0], (*indexes)[0], (*indexes)[1]);
+            column->fnv_hash(&hash_values[0], (*indexes)[0], (*indexes)[0] + 1);
         }
 
         uint32_t shuffle_channel_id = hash_values[(*indexes)[0]] % source_op_cnt;

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -196,9 +196,10 @@ Status KeyPartitionExchanger::accept(const ChunkPtr& chunk, const int32_t sink_d
         }
     }
 
+    std::vector<uint32_t> hash_values(chunk->num_rows());
     for (auto& i : partition_row_indexes) {
         RowIndexPtr indexes = i.second;
-        std::vector<uint32_t> hash_values(indexes->at(0) + 1, HashUtil::FNV_SEED);
+        hash_values[indexes->at(0)] = HashUtil::FNV_SEED;
         for (const ColumnPtr& column : partitions_columns) {
             column->fnv_hash(&hash_values[0], indexes->at(0), indexes->at(0) + 1);
         }

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -50,22 +50,63 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, std::shared_ptr<st
     return Status::OK();
 }
 
+Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes,
+                                              uint32_t from, uint32_t size, Columns& partition_columns,
+                                              const std::vector<ExprContext*>& partition_expr_ctxs,
+                                              size_t memory_usage) {
+    std::lock_guard<std::mutex> l(_chunk_lock);
+    if (_is_finished) {
+        return Status::OK();
+    }
+
+    auto partition_key = std::make_shared<PartitionKey>(std::make_shared<Columns>(partition_columns), indexes->at(0));
+    if (_partitions.find(partition_key) == _partitions.end()) {
+        ChunkPtr one_row_chunk = chunk->clone_empty_with_slot();
+        one_row_chunk->append_selective(*chunk, indexes.get()->data(), 0, 1);
+
+        Columns one_row_partitions_columns(partition_expr_ctxs.size());
+        for (size_t i = 0; i < partition_expr_ctxs.size(); ++i) {
+            ASSIGN_OR_RETURN(one_row_partitions_columns[i], partition_expr_ctxs[i]->evaluate(one_row_chunk.get()));
+            DCHECK(one_row_partitions_columns[i] != nullptr);
+        }
+
+        auto copied_partition_key =
+                std::make_shared<PartitionKey>(std::make_shared<Columns>(one_row_partitions_columns), 0);
+
+        auto queue = std::make_shared<std::queue<PartitionChunk>>();
+        queue->emplace(std::move(chunk), std::move(indexes), from, size, memory_usage);
+        PendingPartitionChunks pendingPartitionChunks(std::move(queue), size, memory_usage);
+        _partitions.emplace(std::move(copied_partition_key), std::move(pendingPartitionChunks));
+    } else {
+        PendingPartitionChunks& chunks = _partitions.at(partition_key);
+        chunks.partition_chunk_queue->emplace(std::move(chunk), std::move(indexes), from, size, memory_usage);
+        chunks.partition_row_nums += size;
+        chunks.memory_usage += memory_usage;
+    }
+
+    _local_memory_usage += memory_usage;
+    _memory_manager->update_memory_usage(memory_usage);
+
+    return Status::OK();
+}
+
 bool LocalExchangeSourceOperator::is_finished() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
-    if (_full_chunk_queue.empty() && !_partition_rows_num) {
+    if (_full_chunk_queue.empty() && !_partition_rows_num && _key_partition_pending_chunk_empty()) {
         if (UNLIKELY(_local_memory_usage != 0)) {
             throw std::runtime_error("_local_memory_usage should be 0 as there is no rows left.");
         }
     }
 
-    return _is_finished && _full_chunk_queue.empty() && !_partition_rows_num;
+    return _is_finished && _full_chunk_queue.empty() && !_partition_rows_num && _key_partition_pending_chunk_empty();
 }
 
 bool LocalExchangeSourceOperator::has_output() const {
     std::lock_guard<std::mutex> l(_chunk_lock);
 
     return !_full_chunk_queue.empty() || _partition_rows_num >= _factory->runtime_state()->chunk_size() ||
-           (_is_finished && _partition_rows_num > 0) || _local_buffer_almost_full();
+           _key_partition_max_rows() >= _factory->runtime_state()->chunk_size() ||
+           (_is_finished && (_partition_rows_num > 0 || _key_partition_max_rows() > 0)) || _local_buffer_almost_full();
 }
 
 Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
@@ -75,6 +116,8 @@ Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     { [[maybe_unused]] typeof(_full_chunk_queue) tmp = std::move(_full_chunk_queue); }
     // clear _partition_chunk_queue
     { [[maybe_unused]] typeof(_partition_chunk_queue) tmp = std::move(_partition_chunk_queue); }
+    // clear _key_partition_pending_chunks
+    { [[maybe_unused]] typeof(_partitions) tmp = std::move(_partitions); }
     // Subtract the number of rows of buffered chunks from row_count of _memory_manager and make it unblocked.
     _memory_manager->update_memory_usage(-_local_memory_usage);
     _partition_rows_num = 0;
@@ -84,8 +127,10 @@ Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
 
 StatusOr<ChunkPtr> LocalExchangeSourceOperator::pull_chunk(RuntimeState* state) {
     ChunkPtr chunk = _pull_passthrough_chunk(state);
-    if (chunk == nullptr) {
+    if (chunk == nullptr && _key_partition_pending_chunk_empty()) {
         chunk = _pull_shuffle_chunk(state);
+    } else if (chunk == nullptr && !_key_partition_pending_chunk_empty()) {
+        chunk = _pull_key_partition_chunk(state);
     }
     return std::move(chunk);
 }
@@ -137,6 +182,63 @@ ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
                                 partition_chunk.size);
     }
     return chunk;
+}
+
+ChunkPtr LocalExchangeSourceOperator::_pull_key_partition_chunk(RuntimeState* state) {
+    std::vector<PartitionChunk> selected_partition_chunks;
+    size_t rows_num = 0;
+    size_t memory_usage = 0;
+
+    {
+        std::lock_guard<std::mutex> l(_chunk_lock);
+
+        PendingPartitionChunks& pendingPartitionChunks = _max_row_partition_chunks();
+
+        DCHECK(!pendingPartitionChunks.partition_chunk_queue->empty());
+
+        while (!pendingPartitionChunks.partition_chunk_queue->empty() &&
+               rows_num + pendingPartitionChunks.partition_chunk_queue->front().size <= state->chunk_size()) {
+            rows_num += pendingPartitionChunks.partition_chunk_queue->front().size;
+            memory_usage += pendingPartitionChunks.partition_chunk_queue->front().memory_usage;
+
+            selected_partition_chunks.emplace_back(std::move(pendingPartitionChunks.partition_chunk_queue->front()));
+            pendingPartitionChunks.partition_chunk_queue->pop();
+        }
+
+        pendingPartitionChunks.partition_row_nums -= rows_num;
+        pendingPartitionChunks.memory_usage -= memory_usage;
+        _local_memory_usage -= memory_usage;
+        _memory_manager->update_memory_usage(-memory_usage);
+    }
+
+    // Unlock during merging partition chunks into a full chunk.
+    ChunkPtr chunk = selected_partition_chunks[0].chunk->clone_empty_with_slot();
+    chunk->reserve(rows_num);
+    for (const auto& partition_chunk : selected_partition_chunks) {
+        chunk->append_selective(*partition_chunk.chunk, partition_chunk.indexes->data(), partition_chunk.from,
+                                partition_chunk.size);
+    }
+
+    return chunk;
+}
+
+int64_t LocalExchangeSourceOperator::_key_partition_max_rows() const {
+    int64_t max_rows = 0;
+    if (!_partitions.empty()) {
+        for (const auto& partition : _partitions) {
+            max_rows = std::max(partition.second.partition_row_nums, max_rows);
+        }
+    }
+    return max_rows;
+}
+
+LocalExchangeSourceOperator::PendingPartitionChunks& LocalExchangeSourceOperator::_max_row_partition_chunks() {
+    using it_type = decltype(_partitions)::value_type;
+    auto max_it = std::max_element(_partitions.begin(), _partitions.end(), [](const it_type& lhs, const it_type& rhs) {
+        return lhs.second.partition_row_nums < rhs.second.partition_row_nums;
+    });
+
+    return max_it->second;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -22,6 +22,37 @@
 #include "exec/pipeline/source_operator.h"
 
 namespace starrocks::pipeline {
+
+struct PartitionKey {
+    PartitionKey() = default;
+
+    PartitionKey(std::shared_ptr<Columns> columns_, uint32_t index_) : columns(std::move(columns_)), index(index_) {}
+
+    std::shared_ptr<Columns> columns;
+    uint32_t index = 0;
+};
+
+using PartitionKeyPtr = std::shared_ptr<PartitionKey>;
+
+struct PartitionKeyComparator {
+    bool operator()(const std::shared_ptr<PartitionKey>& lhs, const std::shared_ptr<PartitionKey>& rhs) const {
+        if (lhs->columns == nullptr) {
+            return false;
+        } else if (rhs->columns == nullptr) {
+            return true;
+        }
+        DCHECK_EQ(lhs->columns->size(), rhs->columns->size());
+        for (size_t i = 0; i < lhs->columns->size(); ++i) {
+            int cmp = (*lhs->columns)[i]->compare_at(lhs->index, rhs->index, *(*rhs->columns)[i], -1);
+            if (cmp != 0) {
+                return cmp < 0;
+            }
+        }
+        // equal, return false
+        return false;
+    }
+};
+
 class LocalExchangeSourceOperator final : public SourceOperator {
     class PartitionChunk {
     public:
@@ -44,6 +75,18 @@ class LocalExchangeSourceOperator final : public SourceOperator {
         const size_t memory_usage;
     };
 
+    struct PendingPartitionChunks {
+        PendingPartitionChunks(std::shared_ptr<std::queue<PartitionChunk>> partition_chunk_queue_, uint32_t index_,
+                               size_t memory_usage_)
+                : partition_chunk_queue(std::move(partition_chunk_queue_)),
+                  partition_row_nums(index_),
+                  memory_usage(memory_usage_) {}
+
+        std::shared_ptr<std::queue<PartitionChunk>> partition_chunk_queue;
+        int64_t partition_row_nums;
+        size_t memory_usage;
+    };
+
 public:
     LocalExchangeSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                                 const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager)
@@ -53,6 +96,10 @@ public:
     Status add_chunk(ChunkPtr chunk);
 
     Status add_chunk(ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes, uint32_t from, uint32_t size,
+                     size_t memory_bytes);
+
+    Status add_chunk(ChunkPtr chunk, std::shared_ptr<std::vector<uint32_t>> indexes, uint32_t from, uint32_t size,
+                     Columns& partition_columns, const std::vector<ExprContext*>& _partition_expr_ctxs,
                      size_t memory_bytes);
 
     bool has_output() const override;
@@ -87,8 +134,23 @@ private:
 
     ChunkPtr _pull_shuffle_chunk(RuntimeState* state);
 
+    ChunkPtr _pull_key_partition_chunk(RuntimeState* state);
+
+    int64_t _key_partition_max_rows() const;
+
+    PendingPartitionChunks& _max_row_partition_chunks();
+
     bool _local_buffer_almost_full() const {
         return _local_memory_usage >= _memory_manager->get_memory_limit_per_driver() * 0.8;
+    }
+
+    bool _key_partition_pending_chunk_empty() const {
+        for (const auto& pending_chunks : _partitions) {
+            if (!pending_chunks.second.partition_chunk_queue->empty()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     bool _is_finished = false;
@@ -100,6 +162,7 @@ private:
     // TODO(KKS): make it lock free
     mutable std::mutex _chunk_lock;
     const std::shared_ptr<LocalExchangeMemoryManager>& _memory_manager;
+    std::map<PartitionKeyPtr, PendingPartitionChunks, PartitionKeyComparator> _partitions;
 
     // STREAM MV
     bool _is_epoch_finished = false;

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -76,13 +76,12 @@ class LocalExchangeSourceOperator final : public SourceOperator {
     };
 
     struct PendingPartitionChunks {
-        PendingPartitionChunks(std::shared_ptr<std::queue<PartitionChunk>> partition_chunk_queue_, uint32_t index_,
-                               size_t memory_usage_)
+        PendingPartitionChunks(std::queue<PartitionChunk> partition_chunk_queue_, uint32_t index_, size_t memory_usage_)
                 : partition_chunk_queue(std::move(partition_chunk_queue_)),
                   partition_row_nums(index_),
                   memory_usage(memory_usage_) {}
 
-        std::shared_ptr<std::queue<PartitionChunk>> partition_chunk_queue;
+        std::queue<PartitionChunk> partition_chunk_queue;
         int64_t partition_row_nums;
         size_t memory_usage;
     };
@@ -146,7 +145,7 @@ private:
 
     bool _key_partition_pending_chunk_empty() const {
         for (const auto& pending_chunks : _partitions) {
-            if (!pending_chunks.second.partition_chunk_queue->empty()) {
+            if (!pending_chunks.second.partition_chunk_queue.empty()) {
                 return false;
             }
         }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/21502

When writing data to an Iceberg partitioned table with an insert statement, values for the same partition column should be written to the same file.  And an iceberg sink operator could include multiple partitioned writers. In order to reduce small files, the partitions processed by each pipeline driver are orthogonal. If I use the current `PartitionExchanger`,  each chunk accepted by an iceberg_sink_operator may contain rows of multiple partitions. So I need to perform a second shuffle.  This result memory copy and lower performance. 

In summary, supporting lake partition exchange is mainly to ensure that the partition column values of each chunk which iceberg_sink_operator accepted are the same.  and it only once shuffle when iceberg table sink writes to multiple partitions.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
