### PR TITLE
[BugFix] NPE when drop database (#22116)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -355,8 +355,13 @@ public class TaskManager {
         if (dbName == null) {
             taskList.addAll(nameToTaskMap.values());
         } else {
-            taskList.addAll(nameToTaskMap.values().stream()
-                    .filter(u -> u.getDbName().equals(dbName)).collect(Collectors.toList()));
+            for (Map.Entry<String, Task> entry : nameToTaskMap.entrySet()) {
+                Task task = entry.getValue();
+
+                if (task.getDbName() != null && task.getDbName().equals(dbName)) {
+                    taskList.add(task);
+                }
+            }
         }
         return taskList;
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22116

## Problem Summary(Required) ：
Problem:
In the task framework, some task may have null database name. If we drop a database, sr will check all tasks whether it is belong to this database. But the dbName comparison will get NPE problem because some task has not been set dbName.

Solution:
Check the dbName first.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
