### PR TITLE
[Feature][Cherry-pick][Branch-2.5]  Support error rate for routine load (#21532)

### DIFF
--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -264,7 +264,11 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
     // the routine load task'txn has alreay began in FE.
     // so it need to rollback if encounter error.
     ctx->need_rollback = true;
-    ctx->max_filter_ratio = 1.0;
+    if (task.__isset.max_filter_ratio) {
+        ctx->max_filter_ratio = task.max_filter_ratio;
+    } else {
+        ctx->max_filter_ratio = 1.0;
+    }
 
     // set source related params
     switch (task.type) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -164,6 +164,9 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         } else {
             tRoutineLoadTask.setFormat(TFileFormatType.FORMAT_CSV_PLAIN);
         }
+        if (Math.abs(routineLoadJob.getMaxFilterRatio() - 1) > 0.001) {
+            tRoutineLoadTask.setMax_filter_ratio(routineLoadJob.getMaxFilterRatio());
+        }
         return tRoutineLoadTask;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
@@ -139,6 +139,9 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
         } else {
             tRoutineLoadTask.setFormat(TFileFormatType.FORMAT_CSV_PLAIN);
         }
+        if (Math.abs(routineLoadJob.getMaxFilterRatio() - 1) > 0.001) {
+            tRoutineLoadTask.setMax_filter_ratio(routineLoadJob.getMaxFilterRatio());
+        }
         return tRoutineLoadTask;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -158,6 +158,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     protected int desireTaskConcurrentNum; // optional
     protected JobState state = JobState.NEED_SCHEDULE;
     protected LoadDataSourceType dataSourceType;
+    protected double maxFilterRatio = 1;
     // max number of error data in max batch rows * 10
     // maxErrorNum / (maxBatchRows * 10) = max error rate of routine load job
     // if current error rate is more than max error rate, the job will be paused
@@ -279,6 +280,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         if (stmt.getMaxErrorNum() != -1) {
             this.maxErrorNum = stmt.getMaxErrorNum();
         }
+        this.maxFilterRatio = stmt.getMaxFilterRatio();
         if (stmt.getMaxBatchIntervalS() != -1) {
             this.taskSchedIntervalS = stmt.getMaxBatchIntervalS();
         }
@@ -488,6 +490,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     public RoutineLoadProgress getProgress() {
         return progress;
+    }
+
+    public double getMaxFilterRatio() {
+        return maxFilterRatio;
     }
 
     public long getMaxBatchRows() {
@@ -1010,6 +1016,17 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
         routineLoadTaskInfo.setTxnStatus(txnStatus);
 
+        if (TransactionState.TxnStatusChangeReason.fromString(txnStatusChangeReasonStr) == 
+                                            TransactionState.TxnStatusChangeReason.FILTERED_ROWS) {
+            updateState(JobState.PAUSED,
+                        new ErrorReason(InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR, txnStatusChangeReasonStr),
+                        false /* not replay */);
+            LOG.warn(
+                    "routine load task [job name {}, task id {}] aborted because of {}, change state to PAUSED",
+                     name, routineLoadTaskInfo.getId().toString(), txnStatusChangeReasonStr);
+            return;
+        }
+
         if (state == JobState.RUNNING) {
             if (txnStatus == TransactionStatus.ABORTED) {
                 RoutineLoadTaskInfo newRoutineLoadTaskInfo = unprotectRenewTask(
@@ -1347,6 +1364,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             jobProperties.put("rowDelimiter", rowDelimiter == null ? "\t" : rowDelimiter.toString());
         }
         jobProperties.put("maxErrorNum", String.valueOf(maxErrorNum));
+        jobProperties.put("maxFilterRatio", String.valueOf(maxFilterRatio));
         jobProperties.put("maxBatchIntervalS", String.valueOf(taskSchedIntervalS));
         jobProperties.put("maxBatchRows", String.valueOf(maxBatchRows));
         jobProperties.put("currentTaskConcurrentNum", String.valueOf(currentTaskConcurrentNum));
@@ -1604,6 +1622,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         if (copiedJobProperties.containsKey(CreateRoutineLoadStmt.MAX_ERROR_NUMBER_PROPERTY)) {
             this.maxErrorNum = Long.parseLong(
                     copiedJobProperties.remove(CreateRoutineLoadStmt.MAX_ERROR_NUMBER_PROPERTY));
+        }
+        if (copiedJobProperties.containsKey(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY)) {
+            this.maxFilterRatio = Double.parseDouble(
+                    copiedJobProperties.remove(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY));
         }
         if (copiedJobProperties.containsKey(CreateRoutineLoadStmt.MAX_BATCH_INTERVAL_SEC_PROPERTY)) {
             this.taskSchedIntervalS = Long.parseLong(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterRoutineLoadStmt.java
@@ -33,6 +33,7 @@ public class AlterRoutineLoadStmt extends DdlStmt {
     private static final ImmutableSet<String> CONFIGURABLE_PROPERTIES_SET = new ImmutableSet.Builder<String>()
             .add(CreateRoutineLoadStmt.DESIRED_CONCURRENT_NUMBER_PROPERTY)
             .add(CreateRoutineLoadStmt.MAX_ERROR_NUMBER_PROPERTY)
+            .add(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY)
             .add(CreateRoutineLoadStmt.MAX_BATCH_INTERVAL_SEC_PROPERTY)
             .add(CreateRoutineLoadStmt.MAX_BATCH_ROWS_PROPERTY)
             .add(CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY)
@@ -125,6 +126,22 @@ public class AlterRoutineLoadStmt extends DdlStmt {
                     CreateRoutineLoadStmt.MAX_ERROR_NUMBER_PROPERTY + " should >= 0");
             analyzedJobProperties.put(CreateRoutineLoadStmt.MAX_ERROR_NUMBER_PROPERTY,
                     String.valueOf(maxErrorNum));
+        }
+
+        if (jobProperties.containsKey(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY)) {
+            double maxFilterRatio;
+            try {
+                maxFilterRatio = Double.valueOf(jobProperties.get(
+                                    CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY));
+            } catch (NumberFormatException exception) {
+                throw new UserException("Incorrect format of max_filter_ratio", exception);
+            }
+            if (maxFilterRatio < 0.0 || maxFilterRatio > 1.0) {
+                throw new UserException(
+                    CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY + " must between 0.0 and 1.0.");
+            }
+            analyzedJobProperties.put(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY,
+                    String.valueOf(maxFilterRatio));
         }
 
         if (jobProperties.containsKey(CreateRoutineLoadStmt.MAX_BATCH_INTERVAL_SEC_PROPERTY)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -79,6 +79,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String DESIRED_CONCURRENT_NUMBER_PROPERTY = "desired_concurrent_number";
     // max error number in ten thousand records
     public static final String MAX_ERROR_NUMBER_PROPERTY = "max_error_number";
+    // The maximum error rate that can be tolerated in a batch of data. 
+    // If the error rate exceeds this, the job will be paused.
+    public static final String MAX_FILTER_RATIO_PROPERTY = "max_filter_ratio";
 
     public static final String MAX_BATCH_INTERVAL_SEC_PROPERTY = "max_batch_interval";
     public static final String MAX_BATCH_ROWS_PROPERTY = "max_batch_rows";
@@ -113,6 +116,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     private static final ImmutableSet<String> PROPERTIES_SET = new ImmutableSet.Builder<String>()
             .add(DESIRED_CONCURRENT_NUMBER_PROPERTY)
             .add(MAX_ERROR_NUMBER_PROPERTY)
+            .add(MAX_FILTER_RATIO_PROPERTY)
             .add(MAX_BATCH_INTERVAL_SEC_PROPERTY)
             .add(MAX_BATCH_ROWS_PROPERTY)
             .add(MAX_BATCH_SIZE_PROPERTY)
@@ -155,6 +159,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     private RoutineLoadDesc routineLoadDesc;
     private int desiredConcurrentNum = 1;
     private long maxErrorNum = -1;
+    private double maxFilterRatio = 1;
     private long maxBatchIntervalS = -1;
     private long maxBatchRows = -1;
     private boolean strictMode = true;
@@ -254,6 +259,10 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     public long getMaxErrorNum() {
         return maxErrorNum;
+    }
+
+    public double getMaxFilterRatio() {
+        return maxFilterRatio;
     }
 
     public long getMaxBatchIntervalS() {
@@ -433,6 +442,18 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         maxErrorNum = Util.getLongPropertyOrDefault(jobProperties.get(MAX_ERROR_NUMBER_PROPERTY),
                 RoutineLoadJob.DEFAULT_MAX_ERROR_NUM, MAX_ERROR_NUMBER_PRED,
                 MAX_ERROR_NUMBER_PROPERTY + " should >= 0");
+
+        if (jobProperties.containsKey(MAX_FILTER_RATIO_PROPERTY)) {
+            String maxFilterRatioStr = jobProperties.get(MAX_FILTER_RATIO_PROPERTY);
+            try {
+                maxFilterRatio = Double.valueOf(maxFilterRatioStr);
+            } catch (NumberFormatException exception) {
+                throw new UserException("Incorrect format of max_filter_ratio", exception);
+            }
+            if (maxFilterRatio < 0.0 || maxFilterRatio > 1.0) {
+                throw new UserException(MAX_FILTER_RATIO_PROPERTY + " must between 0.0 and 1.0.");
+            }
+        }
 
         maxBatchIntervalS = Util.getLongPropertyOrDefault(jobProperties.get(MAX_BATCH_INTERVAL_SEC_PROPERTY),
                 RoutineLoadJob.DEFAULT_TASK_SCHED_INTERVAL_SECOND, MAX_BATCH_INTERVAL_PRED,

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -124,7 +124,8 @@ public class TransactionState implements Writable {
         TIMEOUT,
         OFFSET_OUT_OF_RANGE,
         PAUSE,
-        NO_PARTITIONS;
+        NO_PARTITIONS,
+        FILTERED_ROWS;
 
         public static TxnStatusChangeReason fromString(String reasonString) {
             if (Strings.isNullOrEmpty(reasonString)) {
@@ -146,6 +147,8 @@ public class TransactionState implements Writable {
                     return "Offset out of range";
                 case NO_PARTITIONS:
                     return "all partitions have no load data";
+                case FILTERED_ROWS:
+                    return "too many filtered rows";
                 default:
                     return this.name();
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
@@ -85,6 +85,7 @@ public class AlterRoutineLoadStmtTest {
                 + "(\n"
                 + "\"max_batch_rows\"=\"200000\",\n"
                 + "\"max_error_number\"=\"1\",\n"
+                + "\"max_filter_ratio\"=\"0.3\",\n"
                 + "\"desired_concurrent_number\"=\"3\",\n"
                 + "\"max_batch_interval\" = \"21\",\n"
                 + "\"strict_mode\" = \"false\",\n"
@@ -100,9 +101,12 @@ public class AlterRoutineLoadStmtTest {
         AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt)stmts.get(0);
         AlterRoutineLoadAnalyzer.analyze(stmt, connectContext);
 
-        Assert.assertEquals(6, stmt.getAnalyzedJobProperties().size());
+        Assert.assertEquals(7, stmt.getAnalyzedJobProperties().size());
         Assert.assertTrue(
                 stmt.getAnalyzedJobProperties().containsKey(CreateRoutineLoadStmt.MAX_ERROR_NUMBER_PROPERTY));
+        Assert.assertTrue(
+            stmt.getAnalyzedJobProperties().containsKey(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY));
+        Assert.assertEquals("0.3", stmt.getAnalyzedJobProperties().get(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY));
         Assert.assertTrue(
                 stmt.getAnalyzedJobProperties().containsKey(CreateRoutineLoadStmt.MAX_BATCH_ROWS_PROPERTY));
         Assert.assertTrue(stmt.hasDataSourceProperty());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -85,6 +85,7 @@ public class CreateRoutineLoadStmtTest {
                 + "(\n"
                 + "\"desired_concurrent_number\"=\"3\",\n"
                 + "\"max_batch_interval\" = \"20\",\n"
+                + "\"max_filter_ratio\" = \"0.12\",\n"
                 + "\"strict_mode\" = \"false\",\n"
                 + "\"timezone\" = \"Asia/Shanghai\"\n"
                 + ")\n"
@@ -108,6 +109,7 @@ public class CreateRoutineLoadStmtTest {
         Assert.assertEquals("kafkahost1:9092,kafkahost2:9092", createRoutineLoadStmt.getKafkaBrokerList());
         Assert.assertEquals("topictest", createRoutineLoadStmt.getKafkaTopic());
         Assert.assertEquals("Asia/Shanghai", createRoutineLoadStmt.getTimezone());
+        Assert.assertEquals(0.12, createRoutineLoadStmt.getMaxFilterRatio(), 0.01);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -267,6 +267,7 @@ public class RoutineLoadJobTest {
         String desiredConcurrentNumber = "3";
         String maxBatchInterval = "60";
         String maxErrorNumber = "10000";
+        String maxFilterRatio = "0.3";
         String maxBatchRows = "200000";
         String strictMode = "true";
         String timeZone = "UTC";
@@ -278,6 +279,7 @@ public class RoutineLoadJobTest {
                 "   \"desired_concurrent_number\" = \"" + desiredConcurrentNumber + "\"," +
                 "   \"max_batch_interval\" = \"" + maxBatchInterval + "\"," +
                 "   \"max_error_number\" = \"" + maxErrorNumber + "\"," +
+                "   \"max_filter_ratio\" = \"" + maxFilterRatio + "\"," +
                 "   \"max_batch_rows\" = \"" + maxBatchRows + "\"," +
                 "   \"strict_mode\" = \"" + strictMode + "\"," +
                 "   \"timezone\" = \"" + timeZone + "\"," +
@@ -294,6 +296,8 @@ public class RoutineLoadJobTest {
                 (long) Deencapsulation.getField(routineLoadJob, "taskSchedIntervalS"));
         Assert.assertEquals(Long.parseLong(maxErrorNumber),
                 (long) Deencapsulation.getField(routineLoadJob, "maxErrorNum"));
+        Assert.assertEquals(Double.parseDouble(maxFilterRatio),
+                (double) Deencapsulation.getField(routineLoadJob, "maxFilterRatio"), 0.01);
         Assert.assertEquals(Long.parseLong(maxBatchRows),
                 (long) Deencapsulation.getField(routineLoadJob, "maxBatchRows"));
         Assert.assertEquals(Boolean.parseBoolean(strictMode), routineLoadJob.isStrictMode());

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -76,6 +76,7 @@ struct TRoutineLoadTask {
     13: optional InternalService.TExecPlanFragmentParams params
     14: optional PlanNodes.TFileFormatType format
     15: optional TPulsarLoadInfo pulsar_load_info
+    16: optional double max_filter_ratio
 }
 
 struct TKafkaMetaProxyRequest {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For routine load, the value is max_error_number (The upper limit of the number of error data lines allowed in the error detection window. When the number of error rows exceeds this value, the import job stops and you need to perform a SHOW ROUTINE LOAD, checking the message in Kafka and correcting the error, based on the ErrorLogUrls. The default value is 0, which means that error lines are not allowed. The error row does not include data filtered out by the WHERE clause.)

For stream load, however, the max_filter_ratio is to specify the maximum fault tolerance of the import job, that is, the maximum proportion of data rows filtered out due to unqualified data quality that the import job can tolerate. Value range: 0 to 1. Default value: 0.

The two import models have different setting for error data tolerance. This PR allows routine load to support fault tolerance in the same way that stream load does. You can specify the max_filter_ratio property when creating an routine load task:
```
CREATE ROUTINE LOAD dbyzr.aaa ON clickbench
COLUMNS(...)
PROPERTIES
(
    "desired_concurrent_number"="5",
    "format" ="json",
    "max_filter_ratio" = "0.3" 
)
FROM KAFKA
(
	...
);
```
When importing a batch of data, the task will be paused if the proportion of incorrect data exceeds max_filter_ratio.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3