### PR TITLE
[BugFix] Cast exception when compare two columns (#22134)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -651,15 +651,18 @@ public class Column implements Writable {
             return false;
         }
 
-        if (this.getStrLen() != other.getStrLen()) {
-            return false;
+        if (this.getType().isScalarType() && other.getType().isScalarType()) {
+            if (this.getStrLen() != other.getStrLen()) {
+                return false;
+            }
+            if (this.getPrecision() != other.getPrecision()) {
+                return false;
+            }
+            if (this.getScale() != other.getScale()) {
+                return false;
+            }
         }
-        if (this.getPrecision() != other.getPrecision()) {
-            return false;
-        }
-        if (this.getScale() != other.getScale()) {
-            return false;
-        }
+
         if (this.isMaterializedColumn() && !other.isMaterializedColumn()) {
             return false;
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22134

## Problem Summary(Required) ：
Problem:
In Column definition, we can use equals method to compare two column obj. In this function, sr will compare strlen, precision and scale for ScalarType. But when doing the comparison, the code will not check the column type whether it is the ScalarType or not. If it is not the ScalarType, we will get the cast exception and fail.

Solution:
check the type is ScalarType or not.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
