### PR TITLE
[Feature] support flat_map to named struct

### DIFF
--- a/be/src/exprs/map_functions.h
+++ b/be/src/exprs/map_functions.h
@@ -38,6 +38,8 @@ public:
 
     DEFINE_VECTORIZED_FN(map_filter);
 
+    DEFINE_VECTORIZED_FN(flat_map);
+
 private:
     static void _filter_map_items(const MapColumn* src_column, const ColumnPtr raw_filter, MapColumn* dest_column,
                                   NullColumn* dest_null_map);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -412,6 +412,8 @@ public class FunctionSet {
     public static final String TRANSFORM_VALUES = "transform_values";
     public static final String TRANSFORM_KEYS = "transform_keys";
 
+    public static final String FLAT_MAP = "flat_map";
+
     // Struct functions:
     public static final String ROW = "row";
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -178,6 +178,13 @@ public class PolymorphicFunctionAnalyzer {
         }
     }
 
+    private static class FlatMapDeduce implements java.util.function.Function<Type[], Type> {
+        @Override
+        public Type apply(Type[] types) {
+            MapType mapType = (MapType) types[0];
+            return new StructType(Arrays.asList(mapType.getValueType()));
+        }
+    }
     private static final ImmutableMap<String, java.util.function.Function<Type[], Type>> DEDUCE_RETURN_TYPE_FUNCTIONS
             = ImmutableMap.<String, java.util.function.Function<Type[], Type>>builder()
             .put("map_keys", new MapKeysDeduce())
@@ -186,6 +193,7 @@ public class PolymorphicFunctionAnalyzer {
             .put("row", new RowDeduce())
             .put("map_apply", new MapApplyDeduce())
             .put("map_filter", new MapFilterDeduce())
+            .put("flat_map", new FlatMapDeduce())
             .build();
 
     private static Function resolveByDeducingReturnType(Function fn, Type[] inputArgTypes) {

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -938,6 +938,7 @@ vectorized_functions = [
     [170003, 'map_from_arrays', 'ANY_MAP', ['ANY_ARRAY', 'ANY_ARRAY'], 'MapFunctions::map_from_arrays'],
     [170004, 'map_apply', 'ANY_MAP', ['FUNCTION', 'ANY_MAP'], 'nullptr'],
     [170005, 'map_filter', 'ANY_MAP',  ['ANY_MAP', 'ARRAY_BOOLEAN'], 'MapFunctions::map_filter'],
+    [170006, 'flat_map', 'ANY_STRUCT', ['ANY_MAP'], 'MapFunctions::flat_map'],
 
     # struct functions
     # [170500, 'row', 'ANY_STRUCT', ['ANY_ELEMENT', "..."], 'StructFunctions::row'],


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
flat map to named struct
```
mysql> select a, b , flat_map(b) from tmap;
+------+---------------------+--------------------------------------------+
| a    | b                   | flat_map(b)                                |
+------+---------------------+--------------------------------------------+
|    3 | {"zf":2,"bb":3}     | {"'bb'":3,"'bbb'":null,"'zf'":2}           |
|    3 | {"zf":2,"bb":3}     | {"'bb'":3,"'bbb'":null,"'zf'":2}           |
|    5 | {"bbb":33}          | {"'bb'":null,"'bbb'":33,"'zf'":null}       |
|    5 | {"bbb":33}          | {"'bb'":null,"'bbb'":33,"'zf'":null}       |
|    5 | {}                  | {"'bb'":null,"'bbb'":null,"'zf'":null}     |
|    6 | NULL                | NULL                                       |
|    6 | NULL                | NULL                                       |
|    1 | {"a":2,"b":3,"c":4} | {"'a'":2,"'b'":3,"'c'":4,"NULL":null}      |
|    2 | {"a":22,null:23}    | {"'a'":22,"'b'":null,"'c'":null,"NULL":23} |
|    4 | NULL                | NULL                                       |
|    4 | NULL                | NULL                                       |
|    3 | {"zf":2,"bb":3}     | {"'bb'":3,"'bbb'":null,"'zf'":2}           |
|    5 | {"bbb":33}          | {"'bb'":null,"'bbb'":33,"'zf'":null}       |
|    5 | {}                  | {"'bb'":null,"'bbb'":null,"'zf'":null}     |
|    6 | NULL                | NULL                                       |
|    6 | NULL                | NULL                                       |
|    1 | {"a":2,"b":3,"c":4} | {"'a'":2,"'b'":3,"'c'":4,"NULL":null}      |
|    2 | {"a":22,null:23}    | {"'a'":22,"'b'":null,"'c'":null,"NULL":23} |
|    4 | NULL                | NULL                                       |
+------+---------------------+--------------------------------------------+
```
as they are evaluated in 4 different chunks, so the names in the struct are different.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
