### PR TITLE
[Enhancement] Optimize the mem usage of ordinal index when there is a lot of small segment files

### DIFF
--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -109,9 +109,6 @@ public:
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     int32_t num_data_pages() const { return _num_pages; }
 
-    // REQUIRES: the index data has been successfully `load()`ed into memory.
-    size_t num_rows() const { return _ordinals.back() - _ordinals.front(); }
-
     bool loaded() const { return invoked(_load_once); }
 
 private:
@@ -120,7 +117,7 @@ private:
     void _reset();
 
     size_t _mem_usage() const {
-        return sizeof(OrdinalIndexReader) + _ordinals.size() * sizeof(ordinal_t) + _pages.size() * sizeof(PagePointer);
+        return sizeof(OrdinalIndexReader) + (_num_pages + 1) * sizeof(ordinal_t) + _num_pages * sizeof(PagePointer);
     }
 
     Status _do_load(const IndexReadOptions& opts, const OrdinalIndexPB& meta, ordinal_t num_values);
@@ -129,9 +126,9 @@ private:
     // valid after load
     int _num_pages = 0;
     // _ordinals[i] = first ordinal of the i-th data page,
-    std::vector<ordinal_t> _ordinals;
+    std::unique_ptr<ordinal_t[]> _ordinals;
     // _pages[i] = page pointer to the i-th data page
-    std::vector<PagePointer> _pages;
+    std::unique_ptr<PagePointer[]> _pages;
 };
 
 class OrdinalPageIndexIterator {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

std::vector<> will use 24 bytes, std::unique_ptr only use 8 bytes. If there is a lot of tablets or columns, the pr will save a lot of memory.

If there is 100000 small tablet, and one tablet have 400 columns, the memory usage will reduce from 3.6G to 2.0G.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
