### PR TITLE
[Enhancement] Support concat function for array type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -23,7 +23,6 @@ import com.starrocks.analysis.CaseWhenClause;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IntLiteral;
-import com.starrocks.sql.ast.ArrayExpr;
 
 import java.util.List;
 import java.util.Map;
@@ -108,10 +107,6 @@ public class Trino2SRFunctionCallTransformer {
                 ImmutableList.of(new FunctionCallExpr("array_concat", ImmutableList.of(
                         new PlaceholderExpr(1, Expr.class), new PlaceholderExpr(2, Expr.class)
                 )))));
-
-        // 2. concat -> array_concat
-        registerFunctionTransformerWithVarArgs("concat", "array_concat",
-                ImmutableList.of(ArrayExpr.class));
 
         // 3. contains -> array_contains
         registerFunctionTransformer("contains", 2, "array_contains",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -974,11 +974,15 @@ public class ExpressionAnalyzer {
                                 Lists.newArrayList(node.getChild(i))));
                     }
                 }
-                argumentTypes = node.getChildren().stream().map(Expr::getType).toArray(Type[]::new);
 
-                fn = Expr.getBuiltinFunction(FunctionSet.ARRAY_CONCAT, argumentTypes,
-                        Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                argumentTypes = node.getChildren().stream().map(Expr::getType).toArray(Type[]::new);
                 node.resetFnName(null, FunctionSet.ARRAY_CONCAT);
+                if (DecimalV3FunctionAnalyzer.argumentTypeContainDecimalV3(FunctionSet.ARRAY_CONCAT, argumentTypes)) {
+                    fn = DecimalV3FunctionAnalyzer.getDecimalV3Function(session, node, argumentTypes);
+                } else {
+                    fn = Expr.getBuiltinFunction(FunctionSet.ARRAY_CONCAT, argumentTypes,
+                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                }
             } else if (DecimalV3FunctionAnalyzer.argumentTypeContainDecimalV3(fnName, argumentTypes)) {
                 // Since the priority of decimal version is higher than double version (according functionId),
                 // and in `Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF` mode, `Expr.getBuiltinFunction` always

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1000,7 +1000,7 @@ public class ExpressionAnalyzer {
             } else if (FunctionSet.ARRAY_GENERATE.equals(fnName)) {
                 fn = getArrayGenerateFunction(node);
                 argumentTypes = node.getChildren().stream().map(Expr::getType).toArray(Type[]::new);
-            }  else {
+            } else {
                 fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -59,6 +59,16 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select concat(array[1,2,3], array[4,5,6]) from test_array";
         assertPlanContains(sql, "array_concat([1,2,3], [4,5,6])");
 
+        sql = "select concat(c1, c2) from test_array";
+        assertPlanContains(sql, "array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR>))");
+
+        sql = "select concat(c1, c2, array[1,2], array[3,4]) from test_array";
+        assertPlanContains(sql, "array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR>), CAST([1,2] AS ARRAY<VARCHAR>), " +
+                "CAST([3,4] AS ARRAY<VARCHAR>)");
+
+        sql = "select concat(c2, 2) from test_array";
+        assertPlanContains(sql, "array_concat(3: c2, CAST([2] AS ARRAY<INT>))");
+
         sql = "select contains(array[1,2,3], 1)";
         assertPlanContains(sql, "array_contains([1,2,3], 1)");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -76,13 +76,26 @@ public class ArrayTypeTest extends PlanTestBase {
 
         sql = "select concat(i_1, s_1, d_1) from adec";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "array_concat(CAST(2: i_1 AS ARRAY<VARCHAR>), 3: s_1, CAST(4: d_1 AS ARRAY<VARCHAR>))");
+        assertContains(plan, "array_concat(CAST(2: i_1 AS ARRAY<VARCHAR(65533)>), 3: s_1, " +
+                "CAST(4: d_1 AS ARRAY<VARCHAR(65533)>))");
+
+        sql = "select concat(d_1, d_2) from adec";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "array_concat(CAST(4: d_1 AS ARRAY<DECIMAL128(27,3)>), " +
+                "CAST(5: d_2 AS ARRAY<DECIMAL128(27,3)>))");
+
+        sql = "select concat(d_1, d_2, d_3, d_4, d_5, d_6) from adec";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "array_concat(CAST(4: d_1 AS ARRAY<DOUBLE>), CAST(5: d_2 AS ARRAY<DOUBLE>), " +
+                "CAST(6: d_3 AS ARRAY<DOUBLE>), CAST(7: d_4 AS ARRAY<DOUBLE>), CAST(8: d_5 AS ARRAY<DOUBLE>), " +
+                "CAST(9: d_6 AS ARRAY<DOUBLE>))");
 
         sql = "select concat(i_1, s_1, d_1, d_2, d_3, d_4, d_5, d_6) from adec";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "array_concat(CAST(2: i_1 AS ARRAY<VARCHAR>), 3: s_1, CAST(4: d_1 AS ARRAY<VARCHAR>), " +
-                "CAST(5: d_2 AS ARRAY<VARCHAR>), CAST(6: d_3 AS ARRAY<VARCHAR>), CAST(7: d_4 AS ARRAY<VARCHAR>), " +
-                "CAST(8: d_5 AS ARRAY<VARCHAR>), CAST(9: d_6 AS ARRAY<VARCHAR>)");
+        assertContains(plan, "array_concat(CAST(2: i_1 AS ARRAY<VARCHAR(65533)>), 3: s_1, " +
+                "CAST(4: d_1 AS ARRAY<VARCHAR(65533)>), CAST(5: d_2 AS ARRAY<VARCHAR(65533)>), " +
+                "CAST(6: d_3 AS ARRAY<VARCHAR(65533)>), CAST(7: d_4 AS ARRAY<VARCHAR(65533)>), " +
+                "CAST(8: d_5 AS ARRAY<VARCHAR(65533)>), CAST(9: d_6 AS ARRAY<VARCHAR(65533)>))");
 
         sql = "select concat(v1, [1,2,3], s_1) from adec";
         plan = getFragmentPlan(sql);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22201

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For trino parser on starrocks, function conversion can be performed at the syntax level, However, for some conversions, it cannot convert when need to know the argument type, such like `select concat(c1, c2)`, parser can not get the type of c1 and c2, it can not decide to use `concat` or `array_concat` in SR.
So, we need to do it in SR anlyze stage:
when **concat** function arguments have array type, use **array_concat** to replace it

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
