### PR TITLE
[Enhancement] Optimize the mem usage of ordinal index when there is a lot of small segment files (#22195

### DIFF
--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -21,7 +21,7 @@
 
 #include "storage/rowset/ordinal_page_index.h"
 
-#include <bthread/sys_futex.h>
+#include <memory>
 
 #include "common/logging.h"
 #include "env/env.h"
@@ -90,9 +90,11 @@ Status OrdinalIndexReader::_do_load(fs::BlockManager* fs, const std::string& fil
     if (meta.root_page().is_root_data_page()) {
         // only one data page, no index page
         _num_pages = 1;
-        _ordinals.push_back(0);
-        _ordinals.push_back(num_values);
-        _pages.emplace_back(meta.root_page().root_page());
+        _ordinals = std::make_unique<ordinal_t[]>(2);
+        _ordinals[0] = 0;
+        _ordinals[1] = num_values;
+        _pages = std::make_unique<PagePointer[]>(1);
+        _pages[0] = meta.root_page().root_page();
         return Status::OK();
     }
     // need to read index page
@@ -119,8 +121,8 @@ Status OrdinalIndexReader::_do_load(fs::BlockManager* fs, const std::string& fil
     RETURN_IF_ERROR(reader.parse(body, footer.index_page_footer()));
 
     _num_pages = reader.count();
-    _ordinals.resize(_num_pages + 1);
-    _pages.resize(_num_pages);
+    _ordinals = std::make_unique<ordinal_t[]>(_num_pages + 1);
+    _pages = std::make_unique<PagePointer[]>(_num_pages);
     for (int i = 0; i < _num_pages; i++) {
         Slice key = reader.get_key(i);
         ordinal_t ordinal = 0;
@@ -136,8 +138,8 @@ Status OrdinalIndexReader::_do_load(fs::BlockManager* fs, const std::string& fil
 
 void OrdinalIndexReader::_reset() {
     _num_pages = 0;
-    std::vector<ordinal_t>{}.swap(_ordinals);
-    std::vector<PagePointer>{}.swap(_pages);
+    _ordinals.reset();
+    _pages.reset();
 }
 
 OrdinalPageIndexIterator OrdinalIndexReader::seek_at_or_before(ordinal_t ordinal) {

--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -98,9 +98,6 @@ public:
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     int32_t num_data_pages() const { return _num_pages; }
 
-    // REQUIRES: the index data has been successfully `load()`ed into memory.
-    size_t num_rows() const { return _ordinals.back() - _ordinals.front(); }
-
     bool loaded() const { return invoked(_load_once); }
 
 private:
@@ -115,7 +112,7 @@ private:
     void _reset();
 
     size_t _mem_usage() const {
-        return sizeof(OrdinalIndexReader) + _ordinals.size() * sizeof(ordinal_t) + _pages.size() * sizeof(PagePointer);
+        return sizeof(OrdinalIndexReader) + (_num_pages + 1) * sizeof(ordinal_t) + _num_pages * sizeof(PagePointer);
     }
 
     Status _do_load(fs::BlockManager* fs, const std::string& filename, const OrdinalIndexPB& meta, ordinal_t num_values,
@@ -125,9 +122,9 @@ private:
     // valid after load
     int _num_pages = 0;
     // _ordinals[i] = first ordinal of the i-th data page,
-    std::vector<ordinal_t> _ordinals;
+    std::unique_ptr<ordinal_t[]> _ordinals;
     // _pages[i] = page pointer to the i-th data page
-    std::vector<PagePointer> _pages;
+    std::unique_ptr<PagePointer[]> _pages;
 };
 
 class OrdinalPageIndexIterator {


### PR DESCRIPTION
cherry-pick #22195 

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
