### PR TITLE
[BugFix] Fix BE decommission failed after drop database force

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -269,7 +269,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
      * if we can erase this instance, we should check if anyone enable erase later.
      * Only used by main loop.
      */
-    private synchronized boolean canErase(long id, long currentTimeMs) {
+    private synchronized boolean timeExpired(long id, long currentTimeMs) {
         long latencyMs = currentTimeMs - idToRecycleTime.get(id);
         long expireMs = max(Config.catalog_trash_expire_second * 1000L, MIN_ERASE_LATENCY);
         if (enableEraseLater.contains(id)) {
@@ -277,6 +277,38 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             expireMs += LATE_RECYCLE_INTERVAL_SECONDS * 1000L;
         }
         return latencyMs > expireMs;
+    }
+
+
+    private synchronized boolean canEraseTable(RecycleTableInfo tableInfo, long currentTimeMs) {
+        if (timeExpired(tableInfo.getTable().getId(), currentTimeMs)) {
+            return true;
+        }
+
+        // database is force dropped, the table can not be recovered, erase it.
+        if (GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(tableInfo.getDbId()) == null) {
+            return true;
+        }
+        return false;
+    }
+
+    private synchronized boolean canErasePartition(RecyclePartitionInfo partitionInfo, long currentTimeMs) {
+        if (timeExpired(partitionInfo.getPartition().getId(), currentTimeMs)) {
+            return true;
+        }
+
+        // database is force dropped, the partition can not be recovered, erase it.
+        Database database = GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(partitionInfo.getDbId());
+        if (database == null) {
+            return true;
+        }
+
+        // table is force dropped, the partition can not be recovered, erase it.
+        if (GlobalStateMgr.getCurrentState().getTableIncludeRecycleBin(database, partitionInfo.getTableId()) == null) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -307,7 +339,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             Map.Entry<Long, RecycleDatabaseInfo> entry = dbIter.next();
             RecycleDatabaseInfo dbInfo = entry.getValue();
             Database db = dbInfo.getDb();
-            if (canErase(db.getId(), currentTimeMs)) {
+            if (timeExpired(db.getId(), currentTimeMs)) {
                 // erase db
                 dbIter.remove();
                 removeRecycleMarkers(entry.getKey());
@@ -357,7 +389,10 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
                 Table table = tableInfo.getTable();
                 long tableId = table.getId();
 
-                if (canErase(tableId, currentTimeMs)) {
+                // 1. time expired
+                // 2. the db have been dropped force, this table can never be recovered
+                if (canEraseTable(tableInfo, currentTimeMs)
+                        || GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(tableInfo.dbId) == null) {
                     tableToRemove.add(tableInfo);
                     currentEraseOpCnt++;
                     if (currentEraseOpCnt >= MAX_ERASE_OPERATIONS_PER_CYCLE) {
@@ -429,7 +464,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             Partition partition = partitionInfo.getPartition();
 
             long partitionId = entry.getKey();
-            if (canErase(partitionId, currentTimeMs)) {
+            if (canErasePartition(partitionInfo, currentTimeMs)) {
                 GlobalStateMgr.getCurrentState().onErasePartition(partition);
                 // erase partition
                 iterator.remove();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -386,11 +386,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         for (Map<Long, RecycleTableInfo> tableEntry : idToTableInfo.rowMap().values()) {
             for (Map.Entry<Long, RecycleTableInfo> entry : tableEntry.entrySet()) {
                 RecycleTableInfo tableInfo = entry.getValue();
-                Table table = tableInfo.getTable();
-                long tableId = table.getId();
 
-                // 1. time expired
-                // 2. the db have been dropped force, this table can never be recovered
                 if (canEraseTable(tableInfo, currentTimeMs)
                         || GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(tableInfo.dbId) == null) {
                     tableToRemove.add(tableInfo);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10918

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
If database is dropped force, the table or partition of that database in the recycle bin will never be reached by TabletChecker, so the tablets of those table or partition cannot be relocated.
To fix this bug, erase table if database has been dropped force, erase partition if table or database has been dropped force.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
