### PR TITLE
[BugFix] Table UUID should only be related with original information of the table in connector mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
@@ -45,13 +45,14 @@ public class DeltaLakeTable extends Table {
     public static final String PARTITION_NULL_VALUE = "null";
 
     public DeltaLakeTable(long id, String catalogName, String dbName, String tableName, List<Column> schema,
-                          List<String> partitionNames, DeltaLog deltaLog) {
+                          List<String> partitionNames, DeltaLog deltaLog, long createTime) {
         super(id, tableName, TableType.DELTALAKE, schema);
         this.catalogName = catalogName;
         this.dbName = dbName;
         this.tableName = tableName;
         this.partColumnNames = partitionNames;
         this.deltaLog = deltaLog;
+        this.createTime = createTime;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -130,6 +130,9 @@ public class EsTable extends Table {
 
     // record the latest and recently exception when sync ES table metadata (mapping, shard location)
     private Throwable lastMetaDataSyncException = null;
+    // used for catalog to identify the remote table.
+    private String catalogName = null;
+    private String dbName = null;
 
     public EsTable() {
         super(TableType.ELASTICSEARCH);
@@ -139,6 +142,15 @@ public class EsTable extends Table {
                    PartitionInfo partitionInfo) throws DdlException {
         super(id, name, TableType.ELASTICSEARCH, schema);
         this.partitionInfo = partitionInfo;
+        validate(properties);
+    }
+
+    public EsTable(long id, String catalogName, String dbName, String name, List<Column> schema, Map<String, String> properties,
+                    PartitionInfo partitionInfo) throws DdlException {
+        super(id, name, TableType.ELASTICSEARCH, schema);
+        this.partitionInfo = partitionInfo;
+        this.catalogName = catalogName;
+        this.dbName = dbName;
         validate(properties);
     }
 
@@ -316,6 +328,16 @@ public class EsTable extends Table {
                 fullSchema.size(), 0, getName(), "");
         tTableDescriptor.setEsTable(tEsTable);
         return tTableDescriptor;
+    }
+
+    // TODO, identify the remote table that created after deleted
+    @Override
+    public String getUUID() {
+        if (!Strings.isNullOrEmpty(catalogName)) {
+            return String.join(".", catalogName, dbName, name);
+        } else {
+            return Long.toString(id);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -113,7 +113,8 @@ public class IcebergTable extends Table {
     @Override
     public String getUUID() {
         if (CatalogMgr.isExternalCatalog(catalogName)) {
-            return String.join(".", catalogName, remoteDbName, remoteTableName, Long.toString(createTime));
+            return String.join(".", catalogName, remoteDbName, remoteTableName,
+                    ((BaseTable) getNativeTable()).operations().current().uuid());
         } else {
             return Long.toString(id);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -45,6 +45,7 @@ public class JDBCTable extends Table {
     private String jdbcTable;
     private Map<String, String> properties;
     private String dbName;
+    private String catalogName;
 
     public JDBCTable() {
         super(TableType.JDBC);
@@ -55,10 +56,11 @@ public class JDBCTable extends Table {
         validate(properties);
     }
 
-    public JDBCTable(long id, String name, List<Column> schema, String dbName,
+    public JDBCTable(long id, String name, List<Column> schema, String dbName, String catalogName,
                      Map<String, String> properties) throws DdlException {
         super(id, name, TableType.JDBC, schema);
         this.dbName = dbName;
+        this.catalogName = catalogName;
         validate(properties);
     }
 
@@ -105,6 +107,16 @@ public class JDBCTable extends Table {
         }
         if (resource.getType() != ResourceType.JDBC) {
             throw new DdlException("resource [" + resourceName + "] is not jdbc resource");
+        }
+    }
+
+    // TODO, identify the remote table that created after deleted
+    @Override
+    public String getUUID() {
+        if (!Strings.isNullOrEmpty(catalogName)) {
+            return String.join(".", catalogName, dbName, name);
+        } else {
+            return Long.toString(id);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -67,7 +67,8 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
             }
             HiveTable hiveTable = (HiveTable) table;
             String path = hiveTable.getTableLocation();
-            return DeltaUtils.convertDeltaToSRTable(catalogName, dbName, tblName, path, configuration);
+            long createTime = table.getCreateTime();
+            return DeltaUtils.convertDeltaToSRTable(catalogName, dbName, tblName, path, configuration, createTime);
         } catch (Exception e) {
             LOG.warn(e.getMessage());
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -39,7 +39,7 @@ public class DeltaUtils {
     private static final Logger LOG = LogManager.getLogger(DeltaUtils.class);
 
     public static DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
-                                                       Configuration configuration) {
+                                                       Configuration configuration, long createTime) {
         DeltaLog deltaLog = DeltaLog.forTable(configuration, path);
 
         if (!deltaLog.tableExists()) {
@@ -70,7 +70,7 @@ public class DeltaUtils {
         }
 
         return new DeltaLakeTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalog, dbName, tblName,
-                fullSchema, metadata.getPartitionColumns(), deltaLog);
+                fullSchema, metadata.getPartitionColumns(), deltaLog, createTime);
     }
 
     public static RemoteFileInputFormat getRemoteFileFormat(String format) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchConnector.java
@@ -44,7 +44,7 @@ public class ElasticsearchConnector
     public ConnectorMetadata getMetadata() {
         if (metadata == null) {
             try {
-                metadata = new ElasticsearchMetadata(esRestClient, esConfig.getProperties());
+                metadata = new ElasticsearchMetadata(esRestClient, esConfig.getProperties(), catalogName);
             } catch (StarRocksConnectorException e) {
                 LOG.error("Failed to create elasticsearch metadata on [catalog : {}]", catalogName, e);
                 throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
@@ -38,13 +38,15 @@ public class ElasticsearchMetadata
 
     private final EsRestClient esRestClient;
     private final Map<String, String> properties;
+    private final String catalogName;
     public static final String DEFAULT_DB = "default_db";
     public static final long DEFAULT_DB_ID = 1L;
 
 
-    public ElasticsearchMetadata(EsRestClient esRestClient, Map<String, String> properties) {
+    public ElasticsearchMetadata(EsRestClient esRestClient, Map<String, String> properties, String catalogName) {
         this.esRestClient = esRestClient;
         this.properties = properties;
+        this.catalogName = catalogName;
     }
 
     @Override
@@ -67,17 +69,17 @@ public class ElasticsearchMetadata
         if (!DEFAULT_DB.equalsIgnoreCase(dbName)) {
             return null;
         }
-        return toEsTable(esRestClient, properties, tblName);
+        return toEsTable(esRestClient, properties, tblName, dbName, catalogName);
     }
 
     public static EsTable toEsTable(EsRestClient esRestClient,
                                     Map<String, String> properties,
-                                    String tableName) {
+                                    String tableName, String dbName, String catalogName) {
         try {
             List<Column> columns = EsUtil.convertColumnSchema(esRestClient, tableName);
             properties.put(EsTable.INDEX, tableName);
             EsTable esTable = new EsTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(),
-                    tableName, columns, properties, new SinglePartitionInfo());
+                    catalogName, dbName, tableName, columns, properties, new SinglePartitionInfo());
             esTable.setComment("created by external es catalog");
             esTable.syncTableMetaData(esRestClient);
             return esTable;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCConnector.java
@@ -91,7 +91,7 @@ public class JDBCConnector implements Connector {
     public ConnectorMetadata getMetadata() {
         if (metadata == null) {
             try {
-                metadata = new JDBCMetadata(properties);
+                metadata = new JDBCMetadata(properties, catalogName);
             } catch (StarRocksConnectorException e) {
                 LOG.error("Failed to create jdbc metadata on [catalog : {}]", catalogName, e);
                 throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -40,10 +40,12 @@ public class JDBCMetadata implements ConnectorMetadata {
     private static Logger LOG = LogManager.getLogger(JDBCMetadata.class);
 
     private Map<String, String> properties;
+    private String catalogName;
     private JDBCSchemaResolver schemaResolver;
 
-    public JDBCMetadata(Map<String, String> properties) {
+    public JDBCMetadata(Map<String, String> properties, String catalogName) {
         this.properties = properties;
+        this.catalogName = catalogName;
         try {
             Class.forName(properties.get(JDBCResource.DRIVER_CLASS));
         } catch (ClassNotFoundException e) {
@@ -112,7 +114,7 @@ public class JDBCMetadata implements ConnectorMetadata {
                 return null;
             }
             return schemaResolver.getTable(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(),
-                    tblName, fullSchema, dbName, properties);
+                    tblName, fullSchema, dbName, catalogName, properties);
         } catch (SQLException | DdlException e) {
             LOG.warn(e.getMessage());
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -58,9 +58,9 @@ public abstract class JDBCSchemaResolver {
         return connection.getMetaData().getColumns(dbName, null, tblName, "%");
     }
 
-    public Table getTable(long id, String name, List<Column> schema, String dbName,
+    public Table getTable(long id, String name, List<Column> schema, String dbName, String catalogName,
                           Map<String, String> properties) throws DdlException {
-        return new JDBCTable(id, name, schema, dbName, properties);
+        return new JDBCTable(id, name, schema, dbName, catalogName, properties);
     }
 
     public List<Column> convertToSRTable(ResultSet columnSet) throws SQLException {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -46,9 +46,9 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
     }
 
     @Override
-    public Table getTable(long id, String name, List<Column> schema, String dbName,
+    public Table getTable(long id, String name, List<Column> schema, String dbName, String catalogName,
                           Map<String, String> properties) throws DdlException {
-        return new JDBCTable(id, dbName + "." + name, schema, "", properties);
+        return new JDBCTable(id, dbName + "." + name, schema, "", catalogName, properties);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadataTest.java
@@ -35,7 +35,7 @@ public class ElasticsearchMetadataTest {
             }
         };
 
-        ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>());
+        ElasticsearchMetadata metadata = new ElasticsearchMetadata(client, new HashMap<>(), "catalog");
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
                 "Unknown index not_exist_index",
                 () -> metadata.getTable("default_db", "not_exist_index"));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -99,7 +99,7 @@ public class JDBCMetadataTest {
     @Test
     public void testListDatabaseNames() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties);
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("test");
             Assert.assertEquals(expectResult, result);
@@ -111,7 +111,7 @@ public class JDBCMetadataTest {
     @Test
     public void testGetDb() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties);
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
@@ -122,7 +122,7 @@ public class JDBCMetadataTest {
     @Test
     public void testListTableNames() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties);
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -134,7 +134,7 @@ public class JDBCMetadataTest {
     @Test
     public void testGetTable() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties);
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -86,7 +86,7 @@ public class PostgresSchemaResolverTest {
             }
         };
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties);
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("postgres", "template1", "test");
             Assert.assertEquals(expectResult, result);
@@ -109,7 +109,7 @@ public class PostgresSchemaResolverTest {
             }
         };
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties);
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
@@ -136,7 +136,7 @@ public class PostgresSchemaResolverTest {
             }
         };
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties);
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -163,7 +163,7 @@ public class PostgresSchemaResolverTest {
             }
         };
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties);
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
         } catch (Exception e) {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

we use uuid to identify the external table. in catalog scenario,
tableid and table createtime changed offenly in deferent queries,
we should use external table's catalog, remote dbname, remote
tablename to identify the external table. To deal with that table
created after deleted, we also use the original table's createtime.
for iceberg table, we can use native uuid instread of createtime.

TODO: for jdbctable estable we can't identify the table created
 after deleted.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
