### PR TITLE
[Enhancement] Add randomness when choosing low replica num backend

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -52,6 +52,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.clone.TabletSchedCtx.Priority;
 import com.starrocks.clone.TabletScheduler.AddResult;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.server.GlobalStateMgr;
@@ -1072,29 +1073,32 @@ public class ColocateTableBalancer extends FrontendDaemon {
             }
         }
 
-        return backendToReplicaNum
-                .entrySet()
-                .stream()
-                .sorted((entry1, entry2) -> {
-                    if (!entry1.getValue().equals(entry2.getValue())) {
-                        return (int) (entry2.getValue() - entry1.getValue());
-                    }
-                    BackendLoadStatistic beStat1 = statistic.getBackendLoadStatistic(entry1.getKey());
-                    BackendLoadStatistic beStat2 = statistic.getBackendLoadStatistic(entry2.getKey());
-                    if (beStat1 == null || beStat2 == null) {
-                        return 0;
-                    }
-                    double loadScore1 = beStat1.getMixLoadScore();
-                    double loadScore2 = beStat2.getMixLoadScore();
-                    if (Math.abs(loadScore1 - loadScore2) < 1e-6) {
-                        return 0;
-                    } else if (loadScore2 > loadScore1) {
-                        return 1;
-                    } else {
-                        return -1;
-                    }
-                })
-                .collect(Collectors.toList());
+        List<Map.Entry<Long, Long>> entries = new ArrayList<>(backendToReplicaNum.entrySet());
+        if (!FeConstants.runningUnitTest) {
+            // to randomize the relative order of entries with the same number of replicas
+            Collections.shuffle(entries);
+        }
+        entries.sort((entry1, entry2) -> {
+            if (!entry1.getValue().equals(entry2.getValue())) {
+                return (int) (entry2.getValue() - entry1.getValue());
+            }
+            BackendLoadStatistic beStat1 = statistic.getBackendLoadStatistic(entry1.getKey());
+            BackendLoadStatistic beStat2 = statistic.getBackendLoadStatistic(entry2.getKey());
+            if (beStat1 == null || beStat2 == null) {
+                return 0;
+            }
+            double loadScore1 = beStat1.getMixLoadScore();
+            double loadScore2 = beStat2.getMixLoadScore();
+            if (Math.abs(loadScore1 - loadScore2) < 1e-6) {
+                return 0;
+            } else if (loadScore2 > loadScore1) {
+                return 1;
+            } else {
+                return -1;
+            }
+        });
+
+        return entries;
     }
 
     /*

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -52,6 +52,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -186,6 +187,7 @@ public class ColocateTableBalancerTest {
 
         // 1. balance an imbalanced group
         // [[1, 2, 3], [4, 1, 2], [3, 4, 1], [2, 3, 4], [1, 2, 3]]
+        FeConstants.runningUnitTest = true;
         ColocateTableIndex colocateTableIndex = createColocateIndex(groupId,
                 Lists.newArrayList(1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), 3);
         Deencapsulation.setField(colocateTableIndex, "group2Schema", group2Schema);
@@ -1050,6 +1052,8 @@ public class ColocateTableBalancerTest {
                 result = "192.168.0.115";
             }
         };
+
+        FeConstants.runningUnitTest = true;
 
         GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
         GroupId groupId = new GroupId(10005, 10006);


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://starrocks.atlassian.net/browse/SR-17135

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Randomize the relative order of entries with the same number of replicas, so that when adding multi new backends, it won't cause the replicas accumulated on the same backend.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
