### PR TITLE
[BugFix] Fix mv with partition predicate rewrite bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -83,6 +83,10 @@ public class BaseTableInfo {
         return this.catalogName;
     }
 
+    public boolean isExternalTable() {
+        return catalogName != null && !catalogName.equalsIgnoreCase(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+    }
+
     public String getDbName() {
         return this.dbName != null ? this.dbName : getDb().getFullName();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -481,7 +481,8 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
             BasePartitionInfo basePartitionInfo = versionEntry.getValue();
             if (basePartitionInfo == null
                     || basePartitionInfo.getId() != basePartition.getId()
-                    || basePartition.getVisibleVersion() > basePartitionInfo.getVersion()) {
+                    || (basePartitionInfo.getVersion() != -1
+                    && basePartition.getVisibleVersion() > basePartitionInfo.getVersion())) {
                 result.add(basePartitionName);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -417,8 +417,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                     currentVersionMap.get(baseTableInfo);
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = tableEntry.getValue();
             currentTablePartitionInfo.putAll(partitionInfoMap);
-            Set<String> partitionNames = Sets.newHashSet(PartitionUtil.getPartitionNames(baseTableInfo.getTable()));
             // remove partition info of not-exist partition for snapshot table from version map
+            Set<String> partitionNames = Sets.newHashSet(PartitionUtil.getPartitionNames(baseTableInfo.getTable()));
             currentTablePartitionInfo.keySet().removeIf(partitionName ->
                     !partitionNames.contains(partitionName));
         }
@@ -893,24 +893,6 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         }
         return false;
     }
-
-    /*
-    private Map<Long, Map<String, MaterializedView.BasePartitionInfo>> getSourceTablePartitionInfos(ExecPlan execPlan) {
-        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> selectedBasePartitionInfos = Maps.newHashMap();
-        List<ScanNode> scanNodes = execPlan.getScanNodes();
-        for (ScanNode scanNode : scanNodes) {
-            if (scanNode instanceof OlapScanNode) {
-                OlapScanNode olapScanNode = (OlapScanNode) scanNode;
-                Map<String, MaterializedView.BasePartitionInfo> selectedPartitionIdVersions =
-                        getSelectedPartitionInfos(olapScanNode);
-                OlapTable olapTable = olapScanNode.getOlapTable();
-                selectedBasePartitionInfos.put(olapTable.getId(), selectedPartitionIdVersions);
-            }
-        }
-        return selectedBasePartitionInfos;
-    }
-
-     */
 
     private Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> getSourceTableInfoPartitionInfos(
             ExecPlan execPlan) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -417,13 +417,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                     currentVersionMap.get(baseTableInfo);
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = tableEntry.getValue();
             currentTablePartitionInfo.putAll(partitionInfoMap);
-            List<String> partitionNames = PartitionUtil.getPartitionNames(baseTableInfo.getTable());
-            for (String partitionName : partitionNames) {
-                MaterializedView.BasePartitionInfo invalidPartitionInfo =
-                        new MaterializedView.BasePartitionInfo(-1, -1);
-                currentTablePartitionInfo.putIfAbsent(partitionName, invalidPartitionInfo);
-            }
-
+            Set<String> partitionNames = Sets.newHashSet(PartitionUtil.getPartitionNames(baseTableInfo.getTable()));
             // remove partition info of not-exist partition for snapshot table from version map
             currentTablePartitionInfo.keySet().removeIf(partitionName ->
                     !partitionNames.contains(partitionName));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -927,9 +927,9 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                 selectedBasePartitionInfos.put(baseTableInfoOptional.get(), selectedPartitionIdVersions);
             } else if (scanNode instanceof OlapScanNode) {
                 OlapScanNode olapScanNode = (OlapScanNode) scanNode;
-                Table olapTable = olapScanNode.getOlapTable();
+                OlapTable olapTable = olapScanNode.getOlapTable();
                 Optional<BaseTableInfo> baseTableInfoOptional = materializedView.getBaseTableInfos().stream().filter(
-                        baseTableInfo -> baseTableInfo.getTableIdentifier().equals(olapTable.getTableIdentifier())).
+                        baseTableInfo -> baseTableInfo.getTableIdentifier().equals(String.valueOf(olapTable.getId()))).
                         findAny();
                 if (!baseTableInfoOptional.isPresent()) {
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -345,7 +345,11 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         // update version map of materialized view
         for (Map.Entry<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> tableEntry
                 : changedTablePartitionInfos.entrySet()) {
-            Long tableId = tableEntry.getKey().getTableId();
+            BaseTableInfo baseTableInfo = tableEntry.getKey();
+            if (baseTableInfo.isExternalTable()) {
+                continue;
+            }
+            Long tableId = baseTableInfo.getTableId();
             if (partitionTable != null && tableId != partitionTable.getId()) {
                 continue;
             }
@@ -400,6 +404,9 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         for (Map.Entry<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> tableEntry
                 : changedTablePartitionInfos.entrySet()) {
             BaseTableInfo baseTableInfo = tableEntry.getKey();
+            if (!baseTableInfo.isExternalTable()) {
+                continue;
+            }
             if (partitionTableInfo != null && !partitionTableInfo.equals(baseTableInfo)) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -417,9 +417,14 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                     currentVersionMap.get(baseTableInfo);
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = tableEntry.getValue();
             currentTablePartitionInfo.putAll(partitionInfoMap);
+            List<String> partitionNames = PartitionUtil.getPartitionNames(baseTableInfo.getTable());
+            for (String partitionName : partitionNames) {
+                MaterializedView.BasePartitionInfo invalidPartitionInfo =
+                        new MaterializedView.BasePartitionInfo(-1, -1);
+                currentTablePartitionInfo.putIfAbsent(partitionName, invalidPartitionInfo);
+            }
 
             // remove partition info of not-exist partition for snapshot table from version map
-            Set<String> partitionNames = Sets.newHashSet(PartitionUtil.getPartitionNames(baseTableInfo.getTable()));
             currentTablePartitionInfo.keySet().removeIf(partitionName ->
                     !partitionNames.contains(partitionName));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2081,28 +2081,4 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             testRewriteFail(mv, query);
         }
     }
-
-    @Test
-    public void testMvRewrite() throws Exception {
-
-        String mv = "SELECT `lineorder`.`lo_orderkey`, `lineorder`.`lo_linenumber`, `lineorder`.`lo_custkey`," +
-                " `lineorder`.`lo_partkey`, `lineorder`.`lo_suppkey`, `lineorder`.`lo_orderdate`," +
-                " `lineorder`.`lo_orderpriority`, `lineorder`.`lo_shippriority`, `lineorder`.`lo_quantity`," +
-                " `lineorder`.`lo_extendedprice`, `lineorder`.`lo_ordtotalprice`, `lineorder`.`lo_discount`," +
-                " `lineorder`.`lo_revenue`, `lineorder`.`lo_supplycost`, `lineorder`.`lo_tax`, `lineorder`.`lo_commitdate`," +
-                " `lineorder`.`lo_shipmode`, `dates`.`d_datekey`, `dates`.`d_date`, `dates`.`d_dayofweek`," +
-                " `dates`.`d_month`, `dates`.`d_year`, `dates`.`d_yearmonthnum`, `dates`.`d_yearmonth`," +
-                " `dates`.`d_daynuminweek`, `dates`.`d_daynuminmonth`, `dates`.`d_daynuminyear`," +
-                " `dates`.`d_monthnuminyear`, `dates`.`d_weeknuminyear`, `dates`.`d_sellingseason`," +
-                " `dates`.`d_lastdayinweekfl`, `dates`.`d_lastdayinmonthfl`, `dates`.`d_holidayfl`," +
-                " `dates`.`d_weekdayfl`\n" +
-                "FROM `lineorder`" +
-                " LEFT OUTER JOIN `dates` ON `lineorder`.`lo_orderdate` = `dates`.`d_datekey`\n" +
-                "WHERE `lineorder`.`lo_orderdate` = 19961001;";
-
-        String query = "select sum(lo_linenumber) from `lineorder`" +
-                " LEFT OUTER JOIN `dates`" +
-                " ON `lineorder`.`lo_orderdate` = `dates`.`d_datekey` WHERE `lineorder`.`lo_orderdate` = 19961001;";
-        testRewriteOK(mv, query);
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2081,4 +2081,28 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             testRewriteFail(mv, query);
         }
     }
+
+    @Test
+    public void testMvRewrite() throws Exception {
+
+        String mv = "SELECT `lineorder`.`lo_orderkey`, `lineorder`.`lo_linenumber`, `lineorder`.`lo_custkey`," +
+                " `lineorder`.`lo_partkey`, `lineorder`.`lo_suppkey`, `lineorder`.`lo_orderdate`," +
+                " `lineorder`.`lo_orderpriority`, `lineorder`.`lo_shippriority`, `lineorder`.`lo_quantity`," +
+                " `lineorder`.`lo_extendedprice`, `lineorder`.`lo_ordtotalprice`, `lineorder`.`lo_discount`," +
+                " `lineorder`.`lo_revenue`, `lineorder`.`lo_supplycost`, `lineorder`.`lo_tax`, `lineorder`.`lo_commitdate`," +
+                " `lineorder`.`lo_shipmode`, `dates`.`d_datekey`, `dates`.`d_date`, `dates`.`d_dayofweek`," +
+                " `dates`.`d_month`, `dates`.`d_year`, `dates`.`d_yearmonthnum`, `dates`.`d_yearmonth`," +
+                " `dates`.`d_daynuminweek`, `dates`.`d_daynuminmonth`, `dates`.`d_daynuminyear`," +
+                " `dates`.`d_monthnuminyear`, `dates`.`d_weeknuminyear`, `dates`.`d_sellingseason`," +
+                " `dates`.`d_lastdayinweekfl`, `dates`.`d_lastdayinmonthfl`, `dates`.`d_holidayfl`," +
+                " `dates`.`d_weekdayfl`\n" +
+                "FROM `lineorder`" +
+                " LEFT OUTER JOIN `dates` ON `lineorder`.`lo_orderdate` = `dates`.`d_datekey`\n" +
+                "WHERE `lineorder`.`lo_orderdate` = 19961001;";
+
+        String query = "select sum(lo_linenumber) from `lineorder`" +
+                " LEFT OUTER JOIN `dates`" +
+                " ON `lineorder`.`lo_orderdate` = `dates`.`d_datekey` WHERE `lineorder`.`lo_orderdate` = 19961001;";
+        testRewriteOK(mv, query);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -2501,4 +2501,15 @@ public class MvRewriteOptimizationTest {
             starRocksAssert.dropMaterializedView("partial_mv_13");
         }
     }
+
+    @Test
+    public void testNonpartitionedMvWithPartitionPredicate() throws Exception {
+        createAndRefreshMv("test", "mv_with_partition_predicate_1",
+                "create materialized view mv_with_partition_predicate_1 distributed by hash(`k1`)" +
+                        " as select k1, v1 from t1 where k1 = 3;");
+        String query = "select k1, v1 from t1 where k1 = 3;";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "mv_with_partition_predicate_1");
+        starRocksAssert.dropMaterializedView("mv_with_partition_predicate_1");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22088 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Fix mv with partition predicate rewrite bug. The reason is that the version map of mv is not correct because of partition prune. Fix it by adding pruned partitions into version map with special version(-1) and filtered when query.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
