### PR TITLE
[Feature] Don't use hive partition file cache when executing "insert into target_table select from hive table"

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -49,10 +49,18 @@ public class RemoteFileOperations {
     }
 
     public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions) {
-        return getRemoteFiles(partitions, Optional.empty());
+        return getRemoteFiles(partitions, Optional.empty(), true);
+    }
+
+    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, boolean useCache) {
+        return getRemoteFiles(partitions, Optional.empty(), useCache);
     }
 
     public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, Optional<String> hudiTableLocation) {
+        return getRemoteFiles(partitions, hudiTableLocation, true);
+    }
+
+    public List<RemoteFileInfo> getRemoteFiles(List<Partition> partitions, Optional<String> hudiTableLocation, boolean useCache) {
         Map<RemotePathKey, Partition> pathKeyToPartition = Maps.newHashMap();
         for (Partition partition : partitions) {
             RemotePathKey key = RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation);
@@ -60,7 +68,7 @@ public class RemoteFileOperations {
         }
 
         int cacheMissSize = partitions.size();
-        if (enableCatalogLevelCache) {
+        if (enableCatalogLevelCache && useCache) {
             cacheMissSize = cacheMissSize - remoteFileIO.getPresentRemoteFiles(
                     Lists.newArrayList(pathKeyToPartition.keySet())).size();
         }
@@ -75,7 +83,7 @@ public class RemoteFileOperations {
             for (Partition partition : partitions) {
                 RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation);
                 Future<Map<RemotePathKey, List<RemoteFileDesc>>> future = executor.submit(() ->
-                        remoteFileIO.getRemoteFiles(pathKey));
+                        remoteFileIO.getRemoteFiles(pathKey, useCache));
                 futures.add(future);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveMetaStoreTable;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
@@ -129,7 +130,13 @@ public class HiveMetadata implements ConnectorMetadata {
                 }
             }
         }
-        return fileOps.getRemoteFiles(partitions.build());
+
+        boolean useRemoteFileCache = true;
+        if (table instanceof HiveTable) {
+            useRemoteFileCache = ((HiveTable) table).isUseMetadataCache();
+        }
+
+        return fileOps.getRemoteFiles(partitions.build(), useRemoteFileCache);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -72,6 +72,9 @@ public interface IHiveMetastore {
     default void invalidatePartition(HivePartitionName partitionName) {
     }
 
+    default void invalidatePartitionKeys(HiveTableName tableName) {
+    }
+
     default long getCurrentEventId() {
         return -1;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -296,6 +296,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
 
+    public static final String ENABLE_HIVE_METADATA_CACHE_WITH_INSERT = "enable_hive_metadata_cache_with_insert";
+
     public static final String DEFAULT_TABLE_COMPRESSION = "default_table_compression";
 
     // In most cases, the partition statistics obtained from the hive metastore are empty.
@@ -858,6 +860,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_HIVE_COLUMN_STATS)
     private boolean enableHiveColumnStats = true;
 
+    @VariableMgr.VarAttr(name = ENABLE_HIVE_METADATA_CACHE_WITH_INSERT)
+    private boolean enableHiveMetadataCacheWithInsert = false;
+
     @VariableMgr.VarAttr(name = HIVE_PARTITION_STATS_SAMPLE_SIZE)
     private int hivePartitionStatsSampleSize = 3000;
 
@@ -1166,6 +1171,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableHiveColumnStats(boolean enableHiveColumnStats) {
         this.enableHiveColumnStats = enableHiveColumnStats;
+    }
+
+    public boolean isEnableHiveMetadataCacheWithInsert() {
+        return enableHiveMetadataCacheWithInsert;
+    }
+
+    public void setEnableHiveMetadataCacheWithInsert(boolean enableHiveMetadataCacheWithInsert) {
+        this.enableHiveMetadataCacheWithInsert = enableHiveMetadataCacheWithInsert;
     }
 
     public int getHivePartitionStatsSampleSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -418,6 +418,10 @@ public class AnalyzerUtils {
         new AnalyzerUtils.OlapTableCollector(olapTables).visit(statementBase);
     }
 
+    public static void collectSpecifyExternalTables(StatementBase statementBase, List<Table> tables, Predicate<Table> filter) {
+        new ExternalTableCollector(tables, filter).visit(statementBase);
+    }
+
     public static Map<TableName, SubqueryRelation> collectAllSubQueryRelation(QueryStatement queryStatement) {
         Map<TableName, SubqueryRelation> subQueryRelations = Maps.newHashMap();
         new AnalyzerUtils.SubQueryRelationCollector(subQueryRelations).visit(queryStatement);
@@ -507,6 +511,25 @@ public class AnalyzerUtils {
                 // Only copy the necessary olap table meta to avoid the lock when plan query
                 OlapTable copied = table.copyOnlyForQuery();
                 node.setTable(copied);
+            }
+            return null;
+        }
+    }
+
+    private static class ExternalTableCollector extends TableCollector {
+        List<Table> tables;
+        Predicate<Table> predicate;
+
+        public ExternalTableCollector(List<Table> tables, Predicate<Table> filter) {
+            this.tables = tables;
+            this.predicate = filter;
+        }
+
+        @Override
+        public Void visitTable(TableRelation node, Void context) {
+            Table table = node.getTable();
+            if (predicate.test(table)) {
+                tables.add(table);
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -22,6 +22,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
@@ -50,6 +51,11 @@ public class InsertAnalyzer {
     public static void analyze(InsertStmt insertStmt, ConnectContext session) {
         QueryRelation query = insertStmt.getQueryStatement().getQueryRelation();
         new QueryAnalyzer(session).analyze(insertStmt.getQueryStatement());
+
+        List<Table> tables = new ArrayList<>();
+        AnalyzerUtils.collectSpecifyExternalTables(insertStmt.getQueryStatement(), tables, Table::isHiveTable);
+        tables.stream().map(table -> (HiveTable) table)
+                .forEach(table -> table.useMetadataCache(false));
 
         /*
          *  Target table


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
For "insert into target_table select from hive_table" in StarRocks, the query result may not be correct if the cached file information for the Hive partition has expired. This can cause incorrect data to be inserted. This error will occur after the user side appends the file to the existing partition. To prevent this issue, we disabled the Hive metadata cache when the hiveTable is used as a queryRelation in the insert statement.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
