### PR TITLE
[Enhancement] Support some string function transform for trino parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -64,6 +64,7 @@ public class Trino2SRFunctionCallTransformer {
         registerAggregateFunctionTransformer();
         registerArrayFunctionTransformer();
         registerDateFunctionTransformer();
+        registerStringFunctionTransformer();
         // todo: support more function transform
     }
 
@@ -146,6 +147,18 @@ public class Trino2SRFunctionCallTransformer {
         // doy -> dayofyear
         registerFunctionTransformer("doy", 1, "dayofyear",
                 ImmutableList.of(Expr.class));
+    }
+
+    private static void registerStringFunctionTransformer() {
+        // chr -> char
+        registerFunctionTransformer("chr", 1, "char", ImmutableList.of(Expr.class));
+
+        // codepoint -> ascii
+        registerFunctionTransformer("codepoint", 1, "ascii", ImmutableList.of(Expr.class));
+
+        // strpos -> locate
+        registerFunctionTransformer("strpos", 2, new FunctionCallExpr("locate",
+                ImmutableList.of(new PlaceholderExpr(2, Expr.class), new PlaceholderExpr(1, Expr.class))));
     }
 
     private static void registerFunctionTransformer(String trinoFnName, int trinoFnArgNums, String starRocksFnName,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -117,4 +117,19 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select doy(date '2022-03-06');";
         assertPlanContains(sql, "dayofyear('2022-03-06 00:00:00')");
     }
+
+    @Test
+    public void testStringFnTransform() throws Exception {
+        String sql = "select chr(56)";
+        assertPlanContains(sql, "char(56)");
+
+        sql = "select codepoint('a')";
+        assertPlanContains(sql, "ascii('a')");
+
+        sql = "select position('aa' in 'bccaab');";
+        assertPlanContains(sql, "locate('aa', 'bccaab')");
+
+        sql = "select strpos('bccaab', 'aa');";
+        assertPlanContains(sql, "locate('aa', 'bccaab')");
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#14825 
#23014

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support trino function `chr`, `codepoint`,`strpos` transform to sr function
when use trino parser, it will transdorm `chr` to `char`, such like `select chr(56)` will transform to `select char(56)`;

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
