### PR TITLE
[Enhancement] Introduce the SyncPoint from RocksDB into StarRocks (#2…

### DIFF
--- a/be/src/testutil/CMakeLists.txt
+++ b/be/src/testutil/CMakeLists.txt
@@ -20,5 +20,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/testutil")
 add_library(TestUtil
     desc_tbl_builder.cc
     function_utils.cpp
+    sync_point.cc
+    sync_point_impl.cc
 )
 

--- a/be/src/testutil/sync_point.cc
+++ b/be/src/testutil/sync_point.cc
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The code in this file was modified from the RocksDB project at the following URL:
+// https://github.com/facebook/rocksdb/blob/fb63d9b4ee26afc81810bd5398bda4f2b351b26b/test_util/sync_point.cc
+//
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "testutil/sync_point.h"
+
+#include <fcntl.h>
+
+#include "testutil/sync_point_impl.h"
+
+std::vector<std::string> starrocks_kill_exclude_prefixes;
+
+#ifndef NDEBUG
+namespace starrocks {
+
+SyncPoint* SyncPoint::GetInstance() {
+    static SyncPoint sync_point;
+    return &sync_point;
+}
+
+SyncPoint::SyncPoint() : impl_(new Data) {}
+
+SyncPoint::~SyncPoint() {
+    delete impl_;
+}
+
+void SyncPoint::LoadDependency(const std::vector<SyncPointPair>& dependencies) {
+    impl_->LoadDependency(dependencies);
+}
+
+void SyncPoint::LoadDependencyAndMarkers(const std::vector<SyncPointPair>& dependencies,
+                                         const std::vector<SyncPointPair>& markers) {
+    impl_->LoadDependencyAndMarkers(dependencies, markers);
+}
+
+void SyncPoint::SetCallBack(const std::string& point, const std::function<void(void*)>& callback) {
+    impl_->SetCallBack(point, callback);
+}
+
+void SyncPoint::ClearCallBack(const std::string& point) {
+    impl_->ClearCallBack(point);
+}
+
+void SyncPoint::ClearAllCallBacks() {
+    impl_->ClearAllCallBacks();
+}
+
+void SyncPoint::EnableProcessing() {
+    impl_->EnableProcessing();
+}
+
+void SyncPoint::DisableProcessing() {
+    impl_->DisableProcessing();
+}
+
+void SyncPoint::ClearTrace() {
+    impl_->ClearTrace();
+}
+
+void SyncPoint::Process(const std::string_view& point, void* cb_arg) {
+    impl_->Process(point, cb_arg);
+}
+
+} // namespace starrocks
+#endif // NDEBUG

--- a/be/src/testutil/sync_point.h
+++ b/be/src/testutil/sync_point.h
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The code in this file was modified from the RocksDB project at the following URL:
+// https://github.com/facebook/rocksdb/blob/fb63d9b4ee26afc81810bd5398bda4f2b351b26b/test_util/sync_point.h
+//
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+#pragma once
+
+#include <assert.h>
+
+#include <functional>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "util/slice.h"
+
+#ifdef NDEBUG
+// empty in release build
+#define TEST_KILL_RANDOM_WITH_WEIGHT(kill_point, starrock_skill_odds_weight)
+#define TEST_KILL_RANDOM(kill_point)
+#else
+
+namespace starrocks {
+
+// To avoid crashing always at some frequently executed codepaths (during
+// kill random test), use this factor to reduce odds
+#define REDUCE_ODDS 2
+#define REDUCE_ODDS2 4
+
+// A class used to pass when a kill point is reached.
+struct KillPoint {
+public:
+    // This is only set from db_stress.cc and for testing only.
+    // If non-zero, kill at various points in source code with probability 1/this
+    int starrock_skill_odds = 0;
+    // If kill point has a prefix on this list, will skip killing.
+    std::vector<std::string> starrockskill_exclude_prefixes;
+    // Kill the process with probability 1/odds for testing.
+    void TestKillRandom(std::string kill_point, int odds, const std::string& srcfile, int srcline);
+
+    static KillPoint* GetInstance();
+};
+
+#define TEST_KILL_RANDOM_WITH_WEIGHT(kill_point, starrock_skill_odds_weight) \
+    { KillPoint::GetInstance()->TestKillRandom(kill_point, starrock_skill_odds_weight, __FILE__, __LINE__); }
+#define TEST_KILL_RANDOM(kill_point) TEST_KILL_RANDOM_WITH_WEIGHT(kill_point, 1)
+} // namespace starrocks
+
+#endif
+
+#ifdef NDEBUG
+#define TEST_SYNC_POINT(x)
+#define TEST_IDX_SYNC_POINT(x, index)
+#define TEST_SYNC_POINT_CALLBACK(x, y)
+#define INIT_SYNC_POINT_SINGLETONS()
+#else
+
+namespace starrocks {
+
+// This class provides facility to reproduce race conditions deterministically
+// in unit tests.
+// Developer could specify sync points in the codebase via TEST_SYNC_POINT.
+// Each sync point represents a position in the execution stream of a thread.
+// In the unit test, 'Happens After' relationship among sync points could be
+// setup via SyncPoint::LoadDependency, to reproduce a desired interleave of
+// threads execution.
+
+class SyncPoint {
+public:
+    static SyncPoint* GetInstance();
+
+    SyncPoint(const SyncPoint&) = delete;
+    SyncPoint& operator=(const SyncPoint&) = delete;
+    ~SyncPoint();
+
+    struct SyncPointPair {
+        std::string predecessor;
+        std::string successor;
+    };
+
+    // call once at the beginning of a test to setup the dependency between
+    // sync points
+    void LoadDependency(const std::vector<SyncPointPair>& dependencies);
+
+    // call once at the beginning of a test to setup the dependency between
+    // sync points and setup markers indicating the successor is only enabled
+    // when it is processed on the same thread as the predecessor.
+    // When adding a marker, it implicitly adds a dependency for the marker pair.
+    void LoadDependencyAndMarkers(const std::vector<SyncPointPair>& dependencies,
+                                  const std::vector<SyncPointPair>& markers);
+
+    // The argument to the callback is passed through from
+    // TEST_SYNC_POINT_CALLBACK(); nullptr if TEST_SYNC_POINT or
+    // TEST_IDX_SYNC_POINT was used.
+    void SetCallBack(const std::string& point, const std::function<void(void*)>& callback);
+
+    // Clear callback function by point
+    void ClearCallBack(const std::string& point);
+
+    // Clear all call back functions.
+    void ClearAllCallBacks();
+
+    // enable sync point processing (disabled on startup)
+    void EnableProcessing();
+
+    // disable sync point processing
+    void DisableProcessing();
+
+    // remove the execution trace of all sync points
+    void ClearTrace();
+
+    // triggered by TEST_SYNC_POINT, blocking execution until all predecessors
+    // are executed.
+    // And/or call registered callback function, with argument `cb_arg`
+    void Process(const std::string_view& point, void* cb_arg = nullptr);
+
+    // template gets length of const string at compile time,
+    //  avoiding strlen() at runtime
+    template <size_t kLen>
+    void Process(const char (&point)[kLen], void* cb_arg = nullptr) {
+        static_assert(kLen > 0, "Must not be empty");
+        assert(point[kLen - 1] == '\0');
+        Process(std::string_view(point, kLen - 1), cb_arg);
+    }
+
+    // TODO: it might be useful to provide a function that blocks until all
+    // sync points are cleared.
+
+    // We want this to be public so we can
+    // subclass the implementation
+    struct Data;
+
+private:
+    // Singleton
+    SyncPoint();
+    Data* impl_;
+};
+
+} // namespace starrocks
+
+// Use TEST_SYNC_POINT to specify sync points inside code base.
+// Sync points can have happens-after dependency on other sync points,
+// configured at runtime via SyncPoint::LoadDependency. This could be
+// utilized to re-produce race conditions between threads.
+// See TransactionLogIteratorRace in db_test.cc for an example use case.
+// TEST_SYNC_POINT is no op in release build.
+#define TEST_SYNC_POINT(x) starrocks::SyncPoint::GetInstance()->Process(x)
+#define TEST_IDX_SYNC_POINT(x, index) starrocks::SyncPoint::GetInstance()->Process(x + std::to_string(index))
+#define TEST_SYNC_POINT_CALLBACK(x, y) starrocks::SyncPoint::GetInstance()->Process(x, y)
+#define INIT_SYNC_POINT_SINGLETONS() (void)starrocks::SyncPoint::GetInstance();
+#endif // NDEBUG
+
+// Callback sync point for any read IO errors that should be ignored by
+// the fault injection framework
+// Disable in release mode
+#ifdef NDEBUG
+#define IGNORE_STATUS_IF_ERROR(_status_)
+#else
+#define IGNORE_STATUS_IF_ERROR(_status_)                  \
+    {                                                     \
+        if (!_status_.ok()) {                             \
+            TEST_SYNC_POINT("FaultInjectionIgnoreError"); \
+        }                                                 \
+    }
+#endif // NDEBUG

--- a/be/src/testutil/sync_point_impl.cc
+++ b/be/src/testutil/sync_point_impl.cc
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The code in this file was modified from the RocksDB project at the following URL:
+// https://github.com/facebook/rocksdb/blob/fb63d9b4ee26afc81810bd5398bda4f2b351b26b/test_util/sync_point_impl.cc
+//
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include "testutil/sync_point_impl.h"
+
+#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef NDEBUG
+namespace starrocks {
+KillPoint* KillPoint::GetInstance() {
+    static KillPoint kp;
+    return &kp;
+}
+
+void KillPoint::TestKillRandom(std::string kill_point, int odds_weight, const std::string& srcfile, int srcline) {
+    if (starrock_skill_odds <= 0) {
+        return;
+    }
+    int odds = starrock_skill_odds * odds_weight;
+    for (auto& p : starrockskill_exclude_prefixes) {
+        if (kill_point.substr(0, p.length()) == p) {
+            return;
+        }
+    }
+
+    assert(odds > 0);
+    if (odds % 7 == 0) {
+        // class Random uses multiplier 16807, which is 7^5. If odds are
+        // multiplier of 7, there might be limited values generated.
+        odds++;
+    }
+    auto* r = Random::GetTLSInstance();
+    bool crash = r->OneIn(odds);
+    if (crash) {
+        fprintf(stdout, "Crashing at %s:%d\n", srcfile.c_str(), srcline);
+        fflush(stdout);
+        kill(getpid(), SIGTERM);
+    }
+}
+
+void SyncPoint::Data::LoadDependency(const std::vector<SyncPointPair>& dependencies) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    successors_.clear();
+    predecessors_.clear();
+    cleared_points_.clear();
+    for (const auto& dependency : dependencies) {
+        successors_[dependency.predecessor].push_back(dependency.successor);
+        predecessors_[dependency.successor].push_back(dependency.predecessor);
+    }
+    cv_.notify_all();
+}
+
+void SyncPoint::Data::LoadDependencyAndMarkers(const std::vector<SyncPointPair>& dependencies,
+                                               const std::vector<SyncPointPair>& markers) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    successors_.clear();
+    predecessors_.clear();
+    cleared_points_.clear();
+    markers_.clear();
+    marked_thread_id_.clear();
+    for (const auto& dependency : dependencies) {
+        successors_[dependency.predecessor].push_back(dependency.successor);
+        predecessors_[dependency.successor].push_back(dependency.predecessor);
+    }
+    for (const auto& marker : markers) {
+        successors_[marker.predecessor].push_back(marker.successor);
+        predecessors_[marker.successor].push_back(marker.predecessor);
+        markers_[marker.predecessor].push_back(marker.successor);
+    }
+    cv_.notify_all();
+}
+
+bool SyncPoint::Data::PredecessorsAllCleared(const std::string& point) {
+    for (const auto& pred : predecessors_[point]) {
+        if (cleared_points_.count(pred) == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void SyncPoint::Data::ClearCallBack(const std::string& point) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (num_callbacks_running_ > 0) {
+        cv_.wait(lock);
+    }
+    callbacks_.erase(point);
+}
+
+void SyncPoint::Data::ClearAllCallBacks() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (num_callbacks_running_ > 0) {
+        cv_.wait(lock);
+    }
+    callbacks_.clear();
+}
+
+void SyncPoint::Data::Process(const std::string_view& point, void* cb_arg) {
+    if (!enabled_) {
+        return;
+    }
+
+    // Must convert to std::string for remaining work.  Take
+    //  heap hit.
+    std::string point_string(point);
+    std::unique_lock<std::mutex> lock(mutex_);
+    auto thread_id = std::this_thread::get_id();
+
+    auto marker_iter = markers_.find(point_string);
+    if (marker_iter != markers_.end()) {
+        for (auto& marked_point : marker_iter->second) {
+            marked_thread_id_.emplace(marked_point, thread_id);
+        }
+    }
+
+    if (DisabledByMarker(point_string, thread_id)) {
+        return;
+    }
+
+    while (!PredecessorsAllCleared(point_string)) {
+        cv_.wait(lock);
+        if (DisabledByMarker(point_string, thread_id)) {
+            return;
+        }
+    }
+
+    auto callback_pair = callbacks_.find(point_string);
+    if (callback_pair != callbacks_.end()) {
+        num_callbacks_running_++;
+        mutex_.unlock();
+        callback_pair->second(cb_arg);
+        mutex_.lock();
+        num_callbacks_running_--;
+    }
+    cleared_points_.insert(point_string);
+    cv_.notify_all();
+}
+} // namespace starrocks
+#endif

--- a/be/src/testutil/sync_point_impl.h
+++ b/be/src/testutil/sync_point_impl.h
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The code in this file was modified from the RocksDB project at the following URL:
+// https://github.com/facebook/rocksdb/blob/fb63d9b4ee26afc81810bd5398bda4f2b351b26b/test_util/sync_point_impl.h
+//
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#include <assert.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "testutil/sync_point.h"
+#include "util/random.h"
+
+#pragma once
+
+#ifndef NDEBUG
+namespace starrocks {
+
+struct SyncPoint::Data {
+    Data() : enabled_(false) {}
+    // Enable proper deletion by subclasses
+    virtual ~Data() {}
+    // successor/predecessor map loaded from LoadDependency
+    std::unordered_map<std::string, std::vector<std::string>> successors_;
+    std::unordered_map<std::string, std::vector<std::string>> predecessors_;
+    std::unordered_map<std::string, std::function<void(void*)>> callbacks_;
+    std::unordered_map<std::string, std::vector<std::string>> markers_;
+    std::unordered_map<std::string, std::thread::id> marked_thread_id_;
+
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    // sync points that have been passed through
+    std::unordered_set<std::string> cleared_points_;
+    std::atomic<bool> enabled_;
+    int num_callbacks_running_ = 0;
+
+    void LoadDependency(const std::vector<SyncPointPair>& dependencies);
+    void LoadDependencyAndMarkers(const std::vector<SyncPointPair>& dependencies,
+                                  const std::vector<SyncPointPair>& markers);
+    bool PredecessorsAllCleared(const std::string& point);
+    void SetCallBack(const std::string& point, const std::function<void(void*)>& callback) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        callbacks_[point] = callback;
+    }
+
+    void ClearCallBack(const std::string& point);
+    void ClearAllCallBacks();
+    void EnableProcessing() { enabled_ = true; }
+    void DisableProcessing() { enabled_ = false; }
+    void ClearTrace() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cleared_points_.clear();
+    }
+    bool DisabledByMarker(const std::string& point, std::thread::id thread_id) {
+        auto marked_point_iter = marked_thread_id_.find(point);
+        return marked_point_iter != marked_thread_id_.end() && thread_id != marked_point_iter->second;
+    }
+    void Process(const std::string_view& point, void* cb_arg);
+};
+} // namespace starrocks
+#endif // NDEBUG

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -95,6 +95,7 @@ set(UTIL_FILES
   lru_cache.cpp
   tdigest.cpp
   debug/query_trace_impl.cpp
+  random.cc
 )
 
 add_library(Util STATIC

--- a/be/src/util/random.cc
+++ b/be/src/util/random.cc
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+
+#include "util/random.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <thread>
+#include <utility>
+
+#include "common/compiler_util.h"
+
+#define STORAGE_DECL static thread_local
+
+namespace starrocks {
+
+Random* Random::GetTLSInstance() {
+    STORAGE_DECL Random* tls_instance;
+    STORAGE_DECL std::aligned_storage<sizeof(Random)>::type tls_instance_bytes;
+
+    auto rv = tls_instance;
+    if (UNLIKELY(rv == nullptr)) {
+        size_t seed = std::hash<std::thread::id>()(std::this_thread::get_id());
+        rv = new (&tls_instance_bytes) Random((uint32_t)seed);
+        tls_instance = rv;
+    }
+    return rv;
+}
+
+std::string Random::HumanReadableString(int len) {
+    std::string ret;
+    ret.resize(len);
+    for (int i = 0; i < len; ++i) {
+        ret[i] = static_cast<char>('a' + Uniform(26));
+    }
+    return ret;
+}
+
+std::string Random::RandomString(int len) {
+    std::string ret;
+    ret.resize(len);
+    for (int i = 0; i < len; i++) {
+        ret[i] = static_cast<char>(' ' + Uniform(95)); // ' ' .. '~'
+    }
+    return ret;
+}
+
+std::string Random::RandomBinaryString(int len) {
+    std::string ret;
+    ret.resize(len);
+    for (int i = 0; i < len; i++) {
+        ret[i] = static_cast<char>(Uniform(CHAR_MAX));
+    }
+    return ret;
+}
+
+} // namespace starrocks

--- a/be/src/util/random.h
+++ b/be/src/util/random.h
@@ -1,23 +1,31 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
 
 #pragma once
+#include <stdint.h>
 
-#include <cstdint>
+#include <algorithm>
+#include <random>
 
 namespace starrocks {
 
@@ -26,18 +34,26 @@ namespace starrocks {
 // package.
 class Random {
 private:
+    enum : uint32_t {
+        M = 2147483647L // 2^31-1
+    };
+    enum : uint64_t {
+        A = 16807 // bits 14, 8, 7, 5, 2, 1, 0
+    };
+
     uint32_t seed_;
 
+    static uint32_t GoodSeed(uint32_t s) { return (s & M) != 0 ? (s & M) : 1; }
+
 public:
-    explicit Random(uint32_t s) : seed_(s & 0x7fffffffu) {
-        // Avoid bad seeds.
-        if (seed_ == 0 || seed_ == 2147483647L) {
-            seed_ = 1;
-        }
-    }
+    // This is the largest value that can be returned from Next()
+    enum : uint32_t { kMaxNext = M };
+
+    explicit Random(uint32_t s) : seed_(GoodSeed(s)) {}
+
+    void Reset(uint32_t s) { seed_ = GoodSeed(s); }
+
     uint32_t Next() {
-        static const uint32_t M = 2147483647L; // 2^31-1
-        static const uint64_t A = 16807;       // bits 14, 8, 7, 5, 2, 1, 0
         // We are computing
         //       seed_ = (seed_ * A) % M,    where M = 2^31-1
         //
@@ -56,18 +72,121 @@ public:
         }
         return seed_;
     }
+
+    uint64_t Next64() { return (uint64_t{Next()} << 32) | Next(); }
+
     // Returns a uniformly distributed value in the range [0..n-1]
     // REQUIRES: n > 0
     uint32_t Uniform(int n) { return Next() % n; }
 
     // Randomly returns true ~"1/n" of the time, and false otherwise.
     // REQUIRES: n > 0
-    bool OneIn(int n) { return (Next() % n) == 0; }
+    bool OneIn(int n) { return Uniform(n) == 0; }
+
+    // "Optional" one-in-n, where 0 or negative always returns false
+    // (may or may not consume a random value)
+    bool OneInOpt(int n) { return n > 0 && OneIn(n); }
+
+    // Returns random bool that is true for the given percentage of
+    // calls on average. Zero or less is always false and 100 or more
+    // is always true (may or may not consume a random value)
+    bool PercentTrue(int percentage) { return static_cast<int>(Uniform(100)) < percentage; }
 
     // Skewed: pick "base" uniformly from range [0,max_log] and then
     // return "base" random bits.  The effect is to pick a number in the
     // range [0,2^max_log-1] with exponential bias towards smaller numbers.
     uint32_t Skewed(int max_log) { return Uniform(1 << Uniform(max_log + 1)); }
+
+    // Returns a random string of length "len"
+    std::string RandomString(int len);
+
+    // Generates a random string of len bytes using human-readable characters
+    std::string HumanReadableString(int len);
+
+    // Generates a random binary data
+    std::string RandomBinaryString(int len);
+
+    // Returns a Random instance for use by the current thread without
+    // additional locking
+    static Random* GetTLSInstance();
 };
+
+// A good 32-bit random number generator based on std::mt19937.
+// This exists in part to avoid compiler variance in warning about coercing
+// uint_fast32_t from mt19937 to uint32_t.
+class Random32 {
+private:
+    std::mt19937 generator_;
+
+public:
+    explicit Random32(uint32_t s) : generator_(s) {}
+
+    // Generates the next random number
+    uint32_t Next() { return static_cast<uint32_t>(generator_()); }
+
+    // Returns a uniformly distributed value in the range [0..n-1]
+    // REQUIRES: n > 0
+    uint32_t Uniform(uint32_t n) {
+        return static_cast<uint32_t>(std::uniform_int_distribution<std::mt19937::result_type>(0, n - 1)(generator_));
+    }
+
+    // Returns an *almost* uniformly distributed value in the range [0..n-1].
+    // Much faster than Uniform().
+    // REQUIRES: n > 0
+    uint32_t Uniformish(uint32_t n) {
+        // fastrange (without the header)
+        return static_cast<uint32_t>((uint64_t(generator_()) * uint64_t(n)) >> 32);
+    }
+
+    // Randomly returns true ~"1/n" of the time, and false otherwise.
+    // REQUIRES: n > 0
+    bool OneIn(uint32_t n) { return Uniform(n) == 0; }
+
+    // Skewed: pick "base" uniformly from range [0,max_log] and then
+    // return "base" random bits.  The effect is to pick a number in the
+    // range [0,2^max_log-1] with exponential bias towards smaller numbers.
+    uint32_t Skewed(int max_log) { return Uniform(uint32_t{1} << Uniform(max_log + 1)); }
+
+    // Reset the seed of the generator to the given value
+    void Seed(uint32_t new_seed) { generator_.seed(new_seed); }
+};
+
+// A good 64-bit random number generator based on std::mt19937_64
+class Random64 {
+private:
+    std::mt19937_64 generator_;
+
+public:
+    explicit Random64(uint64_t s) : generator_(s) {}
+
+    // Generates the next random number
+    uint64_t Next() { return generator_(); }
+
+    // Returns a uniformly distributed value in the range [0..n-1]
+    // REQUIRES: n > 0
+    uint64_t Uniform(uint64_t n) { return std::uniform_int_distribution<uint64_t>(0, n - 1)(generator_); }
+
+    // Randomly returns true ~"1/n" of the time, and false otherwise.
+    // REQUIRES: n > 0
+    bool OneIn(uint64_t n) { return Uniform(n) == 0; }
+
+    // Skewed: pick "base" uniformly from range [0,max_log] and then
+    // return "base" random bits.  The effect is to pick a number in the
+    // range [0,2^max_log-1] with exponential bias towards smaller numbers.
+    uint64_t Skewed(int max_log) { return Uniform(uint64_t(1) << Uniform(max_log + 1)); }
+};
+
+// A seeded replacement for removed std::random_shuffle
+template <class RandomIt>
+void RandomShuffle(RandomIt first, RandomIt last, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::shuffle(first, last, rng);
+}
+
+// A replacement for removed std::random_shuffle
+template <class RandomIt>
+void RandomShuffle(RandomIt first, RandomIt last) {
+    RandomShuffle(first, last, std::random_device{}());
+}
 
 } // namespace starrocks


### PR DESCRIPTION
…2247)

The SyncPoint class provides facility to reproduce race conditions deterministically in unit tests.

In order to reduce the introduced dependencies, I removed the DynamicBloom used in SyncPoint to reduce mutex lock, which may sacrifice some performance

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
