### PR TITLE
[BugFix] Fix Be crash in ASAN mode if load a unapplied rowset from disk

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -267,6 +267,7 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
         stats->num_rows = rowset->num_rows();
         stats->byte_size = rowset->data_disk_size();
         stats->num_dels = 0;
+        // the unapplied rowsets have no delete vector yet, so we only need to check the applied rowsets
         if (unapplied_rowsets.find(rsid) == unapplied_rowsets.end()) {
             for (int i = 0; i < rowset->num_segments(); i++) {
                 auto itr = del_vector_cardinality_by_rssid.find(rsid + i);
@@ -275,7 +276,7 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
                 } else {
                     std::string msg = strings::Substitute("delvec not found for rowset $0 segment $1", rsid, i);
                     LOG(ERROR) << msg;
-                    DCHECK(false);
+                    return Status::InternalError(msg);
                 }
             }
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/2343

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The following code in `TabletUpdates`
```
    for (auto& [rsid, rowset] : _rowsets) {
        auto stats = std::make_unique<RowsetStats>();
        stats->num_segments = rowset->num_segments();
        stats->num_rows = rowset->num_rows();
        stats->byte_size = rowset->data_disk_size();
        stats->num_dels = 0;
        for (int i = 0; i < rowset->num_segments(); i++) {
            auto itr = del_vector_cardinality_by_rssid.find(rsid + i);
            if (itr != del_vector_cardinality_by_rssid.end() && itr->second != -1) {
                stats->num_dels += itr->second;
            } else {
                std::string msg = strings::Substitute("delvec not found for rowset $0 segment $1", rsid, i);
                LOG(ERROR) << msg;
                DCHECK(false); // BE will crash in this line if we find a unapplied rowset 
            }
        }
        DCHECK_LE(stats->num_dels, stats->num_rows) << " tabletid:" << _tablet.tablet_id() << " rowset:" << rsid;
        _calc_compaction_score(stats.get());
        std::lock_guard lg(_rowset_stats_lock);
        _rowset_stats.emplace(rsid, std::move(stats));
    }
```
The `del_vector_cardinality_by_rssid` keep the all applied rowset and `_rowsets` keep the all commited rowset.  So if a rowset already commit but not apply, we can not find the rowset in `del_vector_cardinality_by_rssid` because this rowset does not have delete vector and this will cause BE crash in ASAN mode.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
