### PR TITLE
[BugFix] Different column types in different chunks

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -195,6 +195,14 @@ public:
         return NullableColumn::create(src_column, NullColumn::create(src_column->size(), 0));
     }
 
+    static ColumnPtr cast_to_non_nullable_column_force(const ColumnPtr& src_column) {
+        if (!src_column->is_nullable()) {
+            return src_column;
+        }
+        auto* nullable_column = as_raw_column<NullableColumn>(src_column);
+        return nullable_column->data_column();
+    }
+
     // Move the source column according to the specific dest type and nullable.
     static ColumnPtr move_column(const TypeDescriptor& dst_type_desc, bool dst_nullable, const ColumnPtr& src_column,
                                  int num_rows) {

--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -204,11 +204,10 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::ChunkPtr& src, star
                     filter[i] = 0;
                     _error_counter++;
 
-                    std::stringstream error_msg;
-                    error_msg << "Value '" << src_col->debug_item(i) << "' is out of range. "
-                              << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
-
                     if (_state->enable_log_rejected_record()) {
+                        std::stringstream error_msg;
+                        error_msg << "Value '" << src_col->debug_item(i) << "' is out of range. "
+                                  << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
                         // TODO(meegoo): support other file format
                         _state->append_rejected_record_to_file(src->rebuild_csv_row(i, ","), error_msg.str(),
                                                                src->source_filename());
@@ -216,6 +215,9 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::ChunkPtr& src, star
 
                     // avoid print too many debug log
                     if (!_state->has_reached_max_error_msg_num()) {
+                        std::stringstream error_msg;
+                        error_msg << "Value '" << src_col->debug_item(i) << "' is out of range. "
+                                  << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
                         _state->append_error_msg_to_file(src->debug_row(i), error_msg.str());
                     }
                 }
@@ -229,14 +231,15 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::ChunkPtr& src, star
                 if (nulls[i]) {
                     filter[i] = 0;
 
-                    std::stringstream error_msg;
-                    error_msg << "NULL value in non-nullable column '" << slot->col_name() << "'";
-
                     if (!_state->has_reached_max_error_msg_num()) {
+                        std::stringstream error_msg;
+                        error_msg << "NULL value in non-nullable column '" << slot->col_name() << "'";
                         _state->append_error_msg_to_file(cast->debug_row(i), error_msg.str());
                     }
 
                     if (_state->enable_log_rejected_record()) {
+                        std::stringstream error_msg;
+                        error_msg << "NULL value in non-nullable column '" << slot->col_name() << "'";
                         _state->append_rejected_record_to_file(cast->rebuild_csv_row(i, ","), error_msg.str(),
                                                                cast->source_filename());
                     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/22342

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The column type like datetime is cast from varchar in the file scanner.
cast_from_string_to_datetime_fn would build a column as nullable when there're nulls in the column, while it would build a column as non-nullable when there's no null in the column. So, the column types of different chunks may be different.
The exchange node gets the chunk schema according to the first chunk it receives and then parses the chunk according to the schema. In this way, the exchange node cannot handle the variable column type.
This PR corrects the columns returned by the cast_from_string_to_datetime_fn according to the actual schema.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
