### PR TITLE
[BugFix] ASAN BE crashed when delete rows from primary key table

### DIFF
--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -298,6 +298,7 @@ Status RowsetWriter::_flush_delete_file(const SegmentPB& segment_pb, butil::IOBu
     }
     RETURN_IF_ERROR(wfile->close());
 
+    _delfile_idxes.emplace_back(_num_segment + _num_delfile);
     _num_delfile++;
     _num_rows_del += segment_pb.delete_num_rows();
 

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -298,6 +298,8 @@ Status RowsetWriter::_flush_delete_file(const SegmentPB& segment_pb, butil::IOBu
     }
     RETURN_IF_ERROR(wfile->close());
 
+    // _delfile_idxes keep the idx for every delete file, so we need to add the idx to _delfile_idxes if we create a
+    // new delete file
     _delfile_idxes.emplace_back(_num_segment + _num_delfile);
     _num_delfile++;
     _num_rows_del += segment_pb.delete_num_rows();
@@ -535,6 +537,8 @@ Status HorizontalRowsetWriter::flush_chunk_with_deletes(const Chunk& upserts, co
             seg_info->set_delete_data_size(content.size());
             seg_info->set_delete_path(wfile->filename());
         }
+        // _delfile_idxes keep the idx for every delete file, so we need to add the idx to _delfile_idxes if we create a
+        // new delete file
         _delfile_idxes.emplace_back(_num_segment + _num_delfile);
         _num_delfile++;
         _num_rows_del += deletes.size();


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/22362

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Fix ASAN BE maybe crash when we delete rows from primary key table and the reason is this pr(https://github.com/StarRocks/starrocks/pull/21132) only update `_num_delfile` but not update `_delfile_idxes` when we do a pure delete, so the following check `DCHECK(_delfile_idxes.size() == _num_delfile);` fail.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
