### PR TITLE
[Enhancement] Support query single sync MV by using hint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -641,6 +641,25 @@ public class Database extends MetaObject implements Writable {
         return null;
     }
 
+    public Pair<Table, MaterializedIndex> getMaterializedViewIndex(String mvName) {
+        // TODO: add an index to speed it up.
+        for (Table table : idToTable.values()) {
+            if (table instanceof OlapTable) {
+                OlapTable olapTable = (OlapTable) table;
+                for (MaterializedIndex mvIndex : olapTable.getVisibleIndex()) {
+                    String indexName = olapTable.getIndexNameById(mvIndex.getId());
+                    if (indexName == null) {
+                        continue;
+                    }
+                    if (indexName.equals(mvName)) {
+                        return Pair.create(table, mvIndex);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * This is a thread-safe method when idToTable is a concurrent hash map
      *

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -18,12 +18,14 @@ package com.starrocks.connector;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.ast.AddPartitionClause;
@@ -93,6 +95,17 @@ public interface ConnectorMetadata {
      * @return a Table instance
      */
     default Table getTable(String dbName, String tblName) {
+        return null;
+    }
+
+    /**
+     * Get Table descriptor and materialized index for the materialized view index specific by `dbName`.`tblName`
+     *
+     * @param dbName  - the string represents the database name
+     * @param tblName - the string represents the table name
+     * @return a Table instance
+     */
+    default Pair<Table, MaterializedIndex> getMaterializedViewIndex(String dbName, String tblName) {
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -355,6 +355,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE = "enable_materialized_view_rewrite";
     public static final String ENABLE_MATERIALIZED_VIEW_UNION_REWRITE = "enable_materialized_view_union_rewrite";
 
+    public static final String ENABLE_SYNC_MATERIALIZED_VIEW_REWRITE = "enable_sync_materialized_view_rewrite";
     public static final String ENABLE_RULE_BASED_MATERIALIZED_VIEW_REWRITE =
             "enable_rule_based_materialized_view_rewrite";
 
@@ -986,6 +987,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE)
     private boolean enableMaterializedViewRewrite = true;
+
+    @VarAttr(name = ENABLE_SYNC_MATERIALIZED_VIEW_REWRITE)
+    private boolean enableSyncMaterializedViewRewrite = true;
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_UNION_REWRITE)
     private boolean enableMaterializedViewUnionRewrite = true;
@@ -1916,6 +1920,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableMaterializedViewUnionRewrite(boolean enableMaterializedViewUnionRewrite) {
         this.enableMaterializedViewUnionRewrite = enableMaterializedViewUnionRewrite;
+    }
+
+    public boolean isEnableSyncMaterializedViewRewrite() {
+        return enableSyncMaterializedViewRewrite;
+    }
+
+    public void setEnableSyncMaterializedViewRewrite(boolean enableSyncMaterializedViewRewrite) {
+        this.enableSyncMaterializedViewRewrite = enableSyncMaterializedViewRewrite;
     }
 
     // 1 means the mvs directly based on base table

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2376,6 +2376,15 @@ public class LocalMetastore implements ConnectorMetadata {
     }
 
     @Override
+    public Pair<Table, MaterializedIndex> getMaterializedViewIndex(String dbName, String indexName) {
+        Database database = getDb(dbName);
+        if (database == null) {
+            return null;
+        }
+        return database.getMaterializedViewIndex(indexName);
+    }
+
+    @Override
     public Database getDb(String name) {
         if (name == null) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
@@ -28,6 +29,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
@@ -213,6 +215,13 @@ public class MetadataMgr {
             connectorTblMetaInfoMgr.setTableInfoForConnectorTable(catalogName, dbName, connectorTable);
         }
         return connectorTable;
+    }
+
+    public Pair<Table, MaterializedIndex> getMaterializedViewIndex(String catalogName, String dbName, String tblName) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        Pair<Table, MaterializedIndex> materializedIndex =
+                connectorMetadata.map(metadata -> metadata.getMaterializedViewIndex(dbName, tblName)).orElse(null);
+        return materializedIndex;
     }
 
     public List<String> listPartitionNames(String catalogName, String dbName, String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
@@ -31,7 +31,8 @@ public class TableRelation extends Relation {
 
     public enum TableHint {
         _META_,
-        _BINLOG_
+        _BINLOG_,
+        _SYNC_MV_
     }
 
     private final TableName name;
@@ -151,6 +152,9 @@ public class TableRelation extends Relation {
 
     public boolean isBinlogQuery() {
         return tableHints.contains(TableHint._BINLOG_) && table.isOlapTable();
+    }
+    public boolean isSyncMVQuery() {
+        return tableHints.contains(TableHint._SYNC_MV_);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
@@ -85,8 +85,9 @@ public class TableRelation extends Relation {
         this.partitionNames = partitionNames;
     }
 
-    public boolean getHasHintsPartitionNames() {
-        return partitionNames != null;
+    // Check whether the table has some table hints, some rules should not be applied.
+    public boolean hasTableHints() {
+        return partitionNames != null || isSyncMVQuery() ||  (tabletIds != null && !tabletIds.isEmpty());
     }
 
     public List<Long> getTabletIds() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -229,6 +229,7 @@ public class MvRewritePreprocessor {
                 mv.getBaseIndexId(),
                 selectPartitionIds,
                 partitionNames,
+                false,
                 selectTabletIds,
                 Lists.newArrayList());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -302,6 +302,7 @@ public class Optimizer {
         }
 
         if (sessionVariable.isEnableSyncMaterializedViewRewrite()) {
+            // Add a config to decide whether to rewrite sync mv.
             tree = new MaterializedViewRule().transform(tree, context).get(0);
             deriveLogicalProperty(tree);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -301,8 +301,10 @@ public class Optimizer {
             }
         }
 
-        tree = new MaterializedViewRule().transform(tree, context).get(0);
-        deriveLogicalProperty(tree);
+        if (sessionVariable.isEnableSyncMaterializedViewRewrite()) {
+            tree = new MaterializedViewRule().transform(tree, context).get(0);
+            deriveLogicalProperty(tree);
+        }
 
         ruleRewriteIterative(tree, rootTaskContext, RuleSetType.MULTI_DISTINCT_REWRITE);
         ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PUSH_DOWN_PREDICATE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -33,13 +33,13 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class LogicalOlapScanOperator extends LogicalScanOperator {
-    private HashDistributionSpec hashDistributionSpec;
-    private long selectedIndexId;
-    private List<Long> selectedPartitionId;
-    private PartitionNames partitionNames;
-    private boolean hasHintsPartitionNames;
-    private List<Long> selectedTabletId;
-    private List<Long> hintsTabletIds;
+    private final HashDistributionSpec hashDistributionSpec;
+    private final long selectedIndexId;
+    private final List<Long> selectedPartitionId;
+    private final PartitionNames partitionNames;
+    private final boolean hasTableHints;
+    private final List<Long> selectedTabletId;
+    private final List<Long> hintsTabletIds;
 
     private List<ScalarOperator> prunedPartitionPredicates;
 
@@ -73,7 +73,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
             long selectedIndexId,
             List<Long> selectedPartitionId,
             PartitionNames partitionNames,
-            boolean hasHintsPartitionNames,
+            boolean hasTableHints,
             List<Long> selectedTabletId,
             List<Long> hintsTabletIds) {
         super(OperatorType.LOGICAL_OLAP_SCAN, table, colRefToColumnMetaMap, columnMetaToColRefMap, limit, predicate,
@@ -84,7 +84,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         this.selectedIndexId = selectedIndexId;
         this.selectedPartitionId = selectedPartitionId;
         this.partitionNames = partitionNames;
-        this.hasHintsPartitionNames = hasHintsPartitionNames;
+        this.hasTableHints = hasTableHints;
         this.selectedTabletId = selectedTabletId;
         this.hintsTabletIds = hintsTabletIds;
         this.prunedPartitionPredicates = Lists.newArrayList();
@@ -106,8 +106,20 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
                 selectedIndexId, selectedPartitionId, partitionNames, false, selectedTabletId, hintsTabletIds);
     }
 
-    private LogicalOlapScanOperator() {
-        super(OperatorType.LOGICAL_OLAP_SCAN);
+    private LogicalOlapScanOperator(Builder builder) {
+        super(OperatorType.LOGICAL_OLAP_SCAN, builder.table,
+                builder.colRefToColumnMetaMap, builder.columnMetaToColRefMap,
+                builder.getLimit(),
+                builder.getPredicate(),
+                builder.getProjection());
+        this.hashDistributionSpec = builder.hashDistributionSpec;
+        this.selectedIndexId = builder.selectedIndexId;
+        this.selectedPartitionId = builder.selectedPartitionId;
+        this.partitionNames = builder.partitionNames;
+        this.hasTableHints = builder.hasTableHints;
+        this.selectedTabletId = builder.selectedTabletId;
+        this.hintsTabletIds = builder.hintsTabletIds;
+        this.prunedPartitionPredicates = builder.prunedPartitionPredicates;
     }
 
     public HashDistributionSpec getDistributionSpec() {
@@ -134,8 +146,8 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         return hintsTabletIds;
     }
 
-    public boolean hasTabletOrPartitionHints() {
-        return (hintsTabletIds != null && !hintsTabletIds.isEmpty()) || hasHintsPartitionNames;
+    public boolean hasTableHints() {
+        return hasTableHints;
     }
 
     public List<ScalarOperator> getPrunedPartitionPredicates() {
@@ -174,6 +186,17 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
 
     public static class Builder
             extends LogicalScanOperator.Builder<LogicalOlapScanOperator, LogicalOlapScanOperator.Builder> {
+        private HashDistributionSpec hashDistributionSpec;
+        private long selectedIndexId;
+        private List<Long> selectedPartitionId;
+        private PartitionNames partitionNames;
+
+        private boolean hasTableHints;
+        private List<Long> selectedTabletId;
+        private List<Long> hintsTabletIds;
+
+        private List<ScalarOperator> prunedPartitionPredicates;
+
         @Override
         protected LogicalOlapScanOperator newInstance() {
             return new LogicalOlapScanOperator();
@@ -183,14 +206,14 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         public Builder withOperator(LogicalOlapScanOperator scanOperator) {
             super.withOperator(scanOperator);
 
-            builder.hashDistributionSpec = scanOperator.hashDistributionSpec;
-            builder.selectedIndexId = scanOperator.selectedIndexId;
-            builder.selectedPartitionId = scanOperator.selectedPartitionId;
-            builder.partitionNames = scanOperator.partitionNames;
-            builder.hasHintsPartitionNames = scanOperator.hasHintsPartitionNames;
-            builder.selectedTabletId = scanOperator.selectedTabletId;
-            builder.hintsTabletIds = scanOperator.hintsTabletIds;
-            builder.prunedPartitionPredicates = scanOperator.prunedPartitionPredicates;
+            this.hashDistributionSpec = scanOperator.hashDistributionSpec;
+            this.selectedIndexId = scanOperator.selectedIndexId;
+            this.selectedPartitionId = scanOperator.selectedPartitionId;
+            this.partitionNames = scanOperator.partitionNames;
+            this.hasTableHints = scanOperator.hasTableHints;
+            this.selectedTabletId = scanOperator.selectedTabletId;
+            this.hintsTabletIds = scanOperator.hintsTabletIds;
+            this.prunedPartitionPredicates = scanOperator.prunedPartitionPredicates;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -59,6 +59,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
                 ((OlapTable) table).getBaseIndexId(),
                 null,
                 null,
+                false,
                 Lists.newArrayList(),
                 Lists.newArrayList());
     }
@@ -88,22 +89,6 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         this.selectedTabletId = selectedTabletId;
         this.hintsTabletIds = hintsTabletIds;
         this.prunedPartitionPredicates = Lists.newArrayList();
-    }
-
-    public LogicalOlapScanOperator(
-            Table table,
-            Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
-            Map<Column, ColumnRefOperator> columnMetaToColRefMap,
-            HashDistributionSpec hashDistributionSpec,
-            long limit,
-            ScalarOperator predicate,
-            long selectedIndexId,
-            List<Long> selectedPartitionId,
-            PartitionNames partitionNames,
-            List<Long> selectedTabletId,
-            List<Long> hintsTabletIds) {
-        this(table, colRefToColumnMetaMap, columnMetaToColRefMap, hashDistributionSpec, limit, predicate,
-                selectedIndexId, selectedPartitionId, partitionNames, false, selectedTabletId, hintsTabletIds);
     }
 
     private LogicalOlapScanOperator(Builder builder) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -33,13 +33,13 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class LogicalOlapScanOperator extends LogicalScanOperator {
-    private final HashDistributionSpec hashDistributionSpec;
-    private final long selectedIndexId;
-    private final List<Long> selectedPartitionId;
-    private final PartitionNames partitionNames;
-    private final boolean hasTableHints;
-    private final List<Long> selectedTabletId;
-    private final List<Long> hintsTabletIds;
+    private HashDistributionSpec hashDistributionSpec;
+    private long selectedIndexId;
+    private List<Long> selectedPartitionId;
+    private PartitionNames partitionNames;
+    private boolean hasTableHints;
+    private List<Long> selectedTabletId;
+    private List<Long> hintsTabletIds;
 
     private List<ScalarOperator> prunedPartitionPredicates;
 
@@ -91,20 +91,8 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         this.prunedPartitionPredicates = Lists.newArrayList();
     }
 
-    private LogicalOlapScanOperator(Builder builder) {
-        super(OperatorType.LOGICAL_OLAP_SCAN, builder.table,
-                builder.colRefToColumnMetaMap, builder.columnMetaToColRefMap,
-                builder.getLimit(),
-                builder.getPredicate(),
-                builder.getProjection());
-        this.hashDistributionSpec = builder.hashDistributionSpec;
-        this.selectedIndexId = builder.selectedIndexId;
-        this.selectedPartitionId = builder.selectedPartitionId;
-        this.partitionNames = builder.partitionNames;
-        this.hasTableHints = builder.hasTableHints;
-        this.selectedTabletId = builder.selectedTabletId;
-        this.hintsTabletIds = builder.hintsTabletIds;
-        this.prunedPartitionPredicates = builder.prunedPartitionPredicates;
+    private LogicalOlapScanOperator() {
+        super(OperatorType.LOGICAL_OLAP_SCAN);
     }
 
     public HashDistributionSpec getDistributionSpec() {
@@ -171,17 +159,6 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
 
     public static class Builder
             extends LogicalScanOperator.Builder<LogicalOlapScanOperator, LogicalOlapScanOperator.Builder> {
-        private HashDistributionSpec hashDistributionSpec;
-        private long selectedIndexId;
-        private List<Long> selectedPartitionId;
-        private PartitionNames partitionNames;
-
-        private boolean hasTableHints;
-        private List<Long> selectedTabletId;
-        private List<Long> hintsTabletIds;
-
-        private List<ScalarOperator> prunedPartitionPredicates;
-
         @Override
         protected LogicalOlapScanOperator newInstance() {
             return new LogicalOlapScanOperator();
@@ -191,14 +168,14 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         public Builder withOperator(LogicalOlapScanOperator scanOperator) {
             super.withOperator(scanOperator);
 
-            this.hashDistributionSpec = scanOperator.hashDistributionSpec;
-            this.selectedIndexId = scanOperator.selectedIndexId;
-            this.selectedPartitionId = scanOperator.selectedPartitionId;
-            this.partitionNames = scanOperator.partitionNames;
-            this.hasTableHints = scanOperator.hasTableHints;
-            this.selectedTabletId = scanOperator.selectedTabletId;
-            this.hintsTabletIds = scanOperator.hintsTabletIds;
-            this.prunedPartitionPredicates = scanOperator.prunedPartitionPredicates;
+            builder.hashDistributionSpec = scanOperator.hashDistributionSpec;
+            builder.selectedIndexId = scanOperator.selectedIndexId;
+            builder.selectedPartitionId = scanOperator.selectedPartitionId;
+            builder.partitionNames = scanOperator.partitionNames;
+            builder.hasTableHints = scanOperator.hasTableHints;
+            builder.selectedTabletId = scanOperator.selectedTabletId;
+            builder.hintsTabletIds = scanOperator.hintsTabletIds;
+            builder.prunedPartitionPredicates = scanOperator.prunedPartitionPredicates;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/BestIndexRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/BestIndexRewriter.java
@@ -58,6 +58,7 @@ public class BestIndexRewriter extends OptExpressionVisitor<OptExpression, Long>
                     bestIndex,
                     olapScanOperator.getSelectedPartitionId(),
                     olapScanOperator.getPartitionNames(),
+                    olapScanOperator.hasTableHints(),
                     olapScanOperator.getSelectedTabletId(),
                     olapScanOperator.getHintsTabletIds());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVProjectAggProjectScanRewrite.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVProjectAggProjectScanRewrite.java
@@ -16,6 +16,7 @@
 package com.starrocks.sql.optimizer.rule.mv;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.AggregateType;
@@ -116,19 +117,9 @@ public class MVProjectAggProjectScanRewrite {
             columnRefOperatorColumnMap.put(rewriteContext.mvColumnRef, rewriteContext.mvColumn);
         }
 
-        LogicalOlapScanOperator newScanOperator = new LogicalOlapScanOperator(
-                olapScanOperator.getTable(),
-                columnRefOperatorColumnMap,
-                olapScanOperator.getColumnMetaToColRefMap(),
-                olapScanOperator.getDistributionSpec(),
-                olapScanOperator.getLimit(),
-                olapScanOperator.getPredicate(),
-                olapScanOperator.getSelectedIndexId(),
-                olapScanOperator.getSelectedPartitionId(),
-                olapScanOperator.getPartitionNames(),
-                olapScanOperator.getSelectedTabletId(),
-                olapScanOperator.getHintsTabletIds());
-
+        LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
+        LogicalOlapScanOperator newScanOperator = builder.withOperator(olapScanOperator)
+                .setColRefToColumnMetaMap(ImmutableMap.copyOf(columnRefOperatorColumnMap)).build();
         optExpression.setChild(0, OptExpression.create(newScanOperator));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.rule.mv;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
@@ -98,19 +99,10 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
             columnRefOperatorColumnMap.remove(context.queryColumnRef);
             columnRefOperatorColumnMap.put(context.mvColumnRef, context.mvColumn);
 
-            LogicalOlapScanOperator newScanOperator = new LogicalOlapScanOperator(
-                    olapScanOperator.getTable(),
-                    columnRefOperatorColumnMap,
-                    olapScanOperator.getColumnMetaToColRefMap(),
-                    olapScanOperator.getDistributionSpec(),
-                    olapScanOperator.getLimit(),
-                    olapScanOperator.getPredicate(),
-                    olapScanOperator.getSelectedIndexId(),
-                    olapScanOperator.getSelectedPartitionId(),
-                    olapScanOperator.getPartitionNames(),
-                    olapScanOperator.getSelectedTabletId(),
-                    olapScanOperator.getHintsTabletIds());
 
+            LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
+            LogicalOlapScanOperator newScanOperator = builder.withOperator(olapScanOperator)
+                    .setColRefToColumnMetaMap(ImmutableMap.copyOf(columnRefOperatorColumnMap)).build();
             optExpression = OptExpression.create(newScanOperator, optExpression.getInputs());
         }
         return optExpression;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -118,7 +118,7 @@ public class MaterializedViewRule extends Rule {
 
         init(optExpression);
 
-        if (scanOperators.stream().anyMatch(LogicalOlapScanOperator::hasTabletOrPartitionHints)) {
+        if (scanOperators.stream().anyMatch(LogicalOlapScanOperator::hasTableHints)) {
             return Lists.newArrayList(optExpression);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -74,19 +75,10 @@ public class PruneScanColumnRule extends TransformationRule {
                     .collect(Collectors.toMap(identity(), scanOperator.getColRefToColumnMetaMap()::get));
             if (scanOperator instanceof LogicalOlapScanOperator) {
                 LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
-                LogicalOlapScanOperator newScanOperator = new LogicalOlapScanOperator(
-                        olapScanOperator.getTable(),
-                        newColumnRefMap,
-                        olapScanOperator.getColumnMetaToColRefMap(),
-                        olapScanOperator.getDistributionSpec(),
-                        olapScanOperator.getLimit(),
-                        olapScanOperator.getPredicate(),
-                        olapScanOperator.getSelectedIndexId(),
-                        olapScanOperator.getSelectedPartitionId(),
-                        olapScanOperator.getPartitionNames(),
-                        olapScanOperator.getSelectedTabletId(),
-                        olapScanOperator.getHintsTabletIds());
 
+                LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
+                LogicalOlapScanOperator newScanOperator = builder.withOperator(olapScanOperator)
+                        .setColRefToColumnMetaMap(ImmutableMap.copyOf(newColumnRefMap)).build();
                 return Lists.newArrayList(new OptExpression(newScanOperator));
             } else {
                 LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(scanOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -49,7 +49,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
     private boolean checkOlapScanWithoutTabletOrPartitionHints(OptExpression input) {
         if (input.getOp() instanceof LogicalOlapScanOperator) {
             LogicalOlapScanOperator scan = input.getOp().cast();
-            if (scan.hasTabletOrPartitionHints()) {
+            if (scan.hasTableHints()) {
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -470,7 +470,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
                         ((OlapTable) node.getTable()).getBaseIndexId(),
                         null,
                         node.getPartitionNames(),
-                        node.getHasHintsPartitionNames(),
+                        node.hasTableHints(),
                         Lists.newArrayList(),
                         node.getTabletIds());
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRuleTest.java
@@ -39,7 +39,7 @@ public class OlapScanImplementationRuleTest {
         LogicalOlapScanOperator logical = new LogicalOlapScanOperator(table, Maps.newHashMap(), Maps.newHashMap(),
                 null, -1, ConstantOperator.createBoolean(true),
                 1, Lists.newArrayList(1L, 2L, 3L), null,
-                Lists.newArrayList(4L), null);
+                false, Lists.newArrayList(4L), null);
 
         List<OptExpression> output =
                 new OlapScanImplementationRule().transform(new OptExpression(logical), new OptimizerContext(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
@@ -146,7 +146,7 @@ public class DistributionPrunerRuleTest {
                         inPredicateOperator2, inPredicateOperator3, inPredicateOperator4);
         LogicalOlapScanOperator operator =
                 new LogicalOlapScanOperator(olapTable, scanColumnMap, Maps.newHashMap(), null, -1, predicate,
-                        1, Lists.newArrayList(1L), null, Lists.newArrayList(), Lists.newArrayList());
+                        1, Lists.newArrayList(1L), null, false, Lists.newArrayList(), Lists.newArrayList());
         operator.setPredicate(null);
 
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -381,7 +381,7 @@ public class PartitionPruneRuleTest {
         LogicalOlapScanOperator operator =
                 new LogicalOlapScanOperator(olapTable, scanColumnMap, columnMetaToColRefMap,
                         null, -1, null, olapTable.getBaseIndexId(),
-                        null, partitionNames, Lists.newArrayList(), Lists.newArrayList());
+                        null, partitionNames, false, Lists.newArrayList(), Lists.newArrayList());
 
         Partition part1 = new Partition(10001L, "p1", null, null);
         Partition part2 = new Partition(10002L, "p2", null, null);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -250,6 +250,7 @@ public class StatisticsCalculatorTest {
                     ((OlapTable) table).getBaseIndexId(),
                     partitionIds,
                     null,
+                    false,
                     Lists.newArrayList(),
                     Lists.newArrayList());
 
@@ -312,6 +313,7 @@ public class StatisticsCalculatorTest {
                         ((OlapTable) table).getBaseIndexId(),
                         partitionIds,
                         null,
+                        false,
                         Lists.newArrayList(),
                         Lists.newArrayList());
 
@@ -367,6 +369,7 @@ public class StatisticsCalculatorTest {
                         ((OlapTable) table).getBaseIndexId(),
                         partitionIds,
                         null,
+                        false,
                         Lists.newArrayList(),
                         Lists.newArrayList());
 
@@ -394,6 +397,7 @@ public class StatisticsCalculatorTest {
                         null, -1, null, ((OlapTable) table).getBaseIndexId(),
                         partitionIds,
                         null,
+                        false,
                         Lists.newArrayList(),
                         Lists.newArrayList());
         olapScanOperator.setPredicate(new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GE,
@@ -452,6 +456,7 @@ public class StatisticsCalculatorTest {
                         ((OlapTable) table).getBaseIndexId(),
                         partitionIds,
                         null,
+                        false,
                         Lists.newArrayList(),
                         Lists.newArrayList());
 
@@ -481,6 +486,7 @@ public class StatisticsCalculatorTest {
                         ((OlapTable) table).getBaseIndexId(),
                         partitionIds,
                         null,
+                        false,
                         Lists.newArrayList(),
                         Lists.newArrayList());
         olapScanOperator.setPredicate(new BinaryPredicateOperator(BinaryPredicateOperator.BinaryType.GE,


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required) ：
Single Sync MV cannot be queried for now,  it's hard to check what's wrong with it.

Fix:
- https://github.com/StarRocks/starrocks/issues/22401
- https://github.com/StarRocks/starrocks/issues/22352

Updates:
- Support to query single sync mv by using hint.
- Change MV's column to alias name for better query.(Note: only affects the new MVs).
- Add a config to control whether to support to rewrite Single Sync MV.

```
CREATE DATABASE test_materialized_view;
USE test_materialized_view;

CREATE TABLE `test_materialized_view_tbl1` (
  `k1` tinyint(4) NULL DEFAULT "0",
  `k2` varchar(64) NULL DEFAULT "",
  `k3` bigint NULL DEFAULT "0",
  `k4` varchar(64) NULL DEFAULT ""
) ENGINE=OLAP 
DUPLICATE KEY(`k1`, `k2`)
DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 3
PROPERTIES (
"replication_num" = "1"
);
insert into test_materialized_view_tbl1 values (1, 'a', 1, 'aa'), (1, 'b', 2, 'bb'), (3, NULL, NULL, NULL);

CREATE MATERIALIZED VIEW test_materialized_view_tbl1_mv1 as select k1, k2, sum(k3) as sum_k3, count(k4) as count_k4 from test_materialized_view_tbl1 group by k1, k2;

select sleep(20);

select * from test_materialized_view_tbl1_mv1 [_SYNC_MV_] order by k1, k2;
select sum_k3 from test_materialized_view_tbl1_mv1 [_SYNC_MV_] order by k1, k2;
select count_k4, sum_k3 from test_materialized_view_tbl1_mv1 [_SYNC_MV_] order by k1, k2;
select k2, count_k4, sum_k3 from test_materialized_view_tbl1_mv1 [_SYNC_MV_] order by k1, k2;
select count(1) from test_materialized_view_tbl1_mv1 [_SYNC_MV_];
```

TODO: 
- Original Sync MV's column will not use alias as the MV table's column, I will refine this later.

eg:
```
CREATE MATERIALIZED VIEW test_materialized_view_tbl1_mv1 as select k1, k2, sum(k3) as sum_k3, count(k4) as count_k4 from test_materialized_view_tbl1 group by k1, k2;


mysql> select * from test_materialized_view_tbl1_mv1 [_SYNC_MV_] order by k1, k2;
+------+------+------+-------------+
| k1   | k2   | k3   | mv_count_k4 |
+------+------+------+-------------+
|    1 | a    |    1 |           1 |
|    1 | b    |    2 |           1 |
|    3 | NULL | NULL |           0 |
+------+------+------+-------------+
3 rows in set (0.01 sec)
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
