### PR TITLE
[Tool] Set -Djdk.lang.processReaperUseDefaultStackSize=true

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -105,6 +105,11 @@ else
     fi
 fi
 
+# Appending the option to avoid "process heaper" stack overflow exceptions.
+# Tried to adding this option to LIBHDFS_OPTS only, but that doesn't work.
+export JAVA_OPTS="$JAVA_OPTS -Djdk.lang.processReaperUseDefaultStackSize=true"
+export JAVA_OPTS_FOR_JDK_9_AND_LATER="$JAVA_OPTS_FOR_JDK_9_AND_LATER -Djdk.lang.processReaperUseDefaultStackSize=true"
+
 # check java version and choose correct JAVA_OPTS
 JAVA_VERSION=$(jdk_version)
 final_java_opt=$JAVA_OPTS


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：

When using certain JVM modules (e.g. Hadoop Azure module) on BE, the "process reaper" throws a stack overflow error. This is because "process reaper" uses a lower stack size (32KB) by default.

```
Exception in thread "process reaper" java.lang.StackOverflowError
	at java.base/java.lang.invoke.MethodType.equals(MethodType.java:797)
	at java.base/java.lang.invoke.MethodType.equals(MethodType.java:792)
	at java.base/java.lang.invoke.MethodType$ConcurrentWeakInternSet$WeakEntry.equals(MethodType.java:1341)
	at java.base/java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:940)
	at java.base/java.lang.invoke.MethodType$ConcurrentWeakInternSet.get(MethodType.java:1279)
	at java.base/java.lang.invoke.MethodType.makeImpl(MethodType.java:300)
	at java.base/java.lang.invoke.MethodTypeForm.<init>(MethodTypeForm.java:204)
	at java.base/java.lang.invoke.MethodTypeForm.findForm(MethodTypeForm.java:320)
	at java.base/java.lang.invoke.MethodType.makeImpl(MethodType.java:315)
	at java.base/java.lang.invoke.MethodTypeForm.canonicalize(MethodTypeForm.java:355)
	at java.base/java.lang.invoke.MethodTypeForm.findForm(MethodTypeForm.java:317)
	at java.base/java.lang.invoke.MethodType.makeImpl(MethodType.java:315)
	at java.base/java.lang.invoke.MethodHandleNatives.varHandleOperationLinkerMethod(MethodHandleNatives.java:544)
	at java.base/java.lang.invoke.MethodHandleNatives.linkMethodImpl(MethodHandleNatives.java:462)
	at java.base/java.lang.invoke.MethodHandleNatives.linkMethod(MethodHandleNatives.java:450)
	at java.base/java.util.concurrent.CompletableFuture.completeValue(CompletableFuture.java:305)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2072)
	at java.base/java.lang.ProcessHandleImpl$1.run(ProcessHandleImpl.java:162)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829) 
```

References:

- https://bugs.openjdk.org/browse/JDK-8153057

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
