### PR TITLE
[BugFix] avoid scan operator hanging

### DIFF
--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -167,12 +167,6 @@ pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::Pipelin
 
     // port from olap scan node. to control chunk buffer usage, we can control memory consumption to avoid OOM.
     size_t max_buffer_capacity = pipeline::ScanOperator::max_buffer_capacity() * dop;
-
-    if (_limit != -1) {
-        size_t max_chunks = std::max<size_t>(_limit / (runtime_state()->chunk_size()), 1);
-        max_buffer_capacity = std::min(max_buffer_capacity, max_chunks);
-    }
-
     size_t default_buffer_capacity = std::min<size_t>(max_buffer_capacity, _estimated_max_concurrent_chunks());
     pipeline::ChunkBufferLimiterPtr buffer_limiter = std::make_unique<pipeline::DynamicChunkBufferLimiter>(
             max_buffer_capacity, default_buffer_capacity, mem_limit, runtime_state()->chunk_size());


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

I think the max capacity of chunk buffer should be capped by `limit / chunk size`, but I don't why it does not work.

If I add follwoing code (introduced in this pr https://github.com/StarRocks/starrocks/pull/21879)

```
    if (_limit != -1) {
        size_t max_chunks = std::max<size_t>(_limit / (runtime_state()->chunk_size()), 1);
        max_buffer_capacity = std::min(max_buffer_capacity, max_chunks);
    }
```

the scan operator will hang once in a while with high probability.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
