### PR TITLE
[BugFix] Fix null flag comparison for intra-chunks

### DIFF
--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -50,10 +50,9 @@ public:
         ColumnSelfComparator comparator(ptr, _cmp_vector, column.immutable_null_column_data());
         RETURN_IF_ERROR(column.data_column()->accept(&comparator));
 
-        const auto& data_column = column.data_column();
         // NOTE
         if (!_first_column->empty()) {
-            _cmp_vector[0] |= _first_column->compare_at(0, 0, *data_column, 1) != 0;
+            _cmp_vector[0] |= _first_column->compare_at(0, 0, column, 1) != 0;
         } else {
             _cmp_vector[0] |= 1;
         }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22437

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the previous chunk and the current chunk have some same keys, we compare the nullable previous column with the current data column, `_first_column->compare_at(column.data_column, 1)`.

If the value of this key is null, `_first_column->compare_at(column.data_column, 1)` will return false, which causes the new `column` is considers as a new key.

```
[...., null, null] [null, 1, ....]
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
