### PR TITLE
[Enhancement] Restrict max_block_rows_per_driver_seq to be positive

### DIFF
--- a/be/src/exec/pipeline/adaptive/collect_stats_context.cpp
+++ b/be/src/exec/pipeline/adaptive/collect_stats_context.cpp
@@ -219,7 +219,8 @@ bool RoundRobinState::is_upstream_finished(int32_t driver_seq) const {
 CollectStatsContext::CollectStatsContext(RuntimeState* const runtime_state, size_t max_dop,
                                          const AdaptiveDopParam& param)
         : _max_dop(max_dop),
-          _max_block_rows_per_driver_seq(param.max_block_rows_per_driver_seq),
+          _max_block_rows_per_driver_seq(param.max_block_rows_per_driver_seq > 0 ? param.max_block_rows_per_driver_seq
+                                                                                 : 1),
           _max_output_amplification_factor(param.max_output_amplification_factor),
           _buffer_chunk_queue_per_driver_seq(max_dop),
           _is_finishing_per_driver_seq(max_dop),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -185,6 +185,10 @@ public class SetStmtAnalyzer {
             }
         }
 
+        if (variable.equalsIgnoreCase(SessionVariable.ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ)) {
+            checkRangeLongVariable(resolvedExpression, SessionVariable.ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ, 1L, null);
+        }
+
         var.setResolvedExpression(resolvedExpression);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -244,4 +244,18 @@ public class AnalyzeSetVariableTest {
         sql = "SET GLOBAL TRANSACTION ISOLATION LEVEL SERIALIZABLE";
         analyzeSuccess(sql);
     }
+
+    @Test
+    public void testSetAdaptiveDopMaxBlockRowsPerDriverSeq() {
+        String sql;
+
+        sql = "SET runtime_adaptive_dop_max_block_rows_per_driver_seq = 0";
+        analyzeFail(sql);
+
+        sql = "SET runtime_adaptive_dop_max_block_rows_per_driver_seq = -1";
+        analyzeFail(sql);
+
+        sql = "SET runtime_adaptive_dop_max_block_rows_per_driver_seq = 1";
+        analyzeSuccess(sql);
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
DOP will be adjusted to `num_rows/max_block_rows_per_driver_seq`, where `max_block_rows_per_driver_seq` is a session variable. 
Therefore, restrict it to positive in both FE and BE.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
