### PR TITLE
[Enhancement] import 2.5 enhancement #11380 port ORCHdfsFileStream to OrcScanner to…

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -12,7 +12,6 @@
 
 namespace starrocks::vectorized {
 
-
 class OrcRowReaderFilter : public orc::RowReaderFilter {
 public:
     OrcRowReaderFilter(const HdfsScannerParams& scanner_params, const HdfsScannerContext& scanner_ctx,

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -174,6 +174,8 @@ static inline size_t remove_trailing_spaces(const char* s, size_t size) {
 
 bool OrcRowReaderFilter::filterOnPickStringDictionary(
         const std::unordered_map<uint64_t, orc::StringDictionary*>& sdicts) {
+    _dict_filter_eval_cache.clear();
+
     if (sdicts.empty()) return false;
 
     if (!_init_use_dict_filter_slots) {
@@ -190,8 +192,6 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
         }
         _init_use_dict_filter_slots = true;
     }
-
-    _dict_filter_eval_cache.clear();
 
     for (auto& p : _use_dict_filter_slots) {
         SlotDescriptor* slot_desc = p.first;

--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -486,4 +486,5 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
     // todo: build predicate hook and ranges hook.
     return Status::OK();
 }
+
 } // namespace starrocks::vectorized

--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -20,13 +20,11 @@ namespace starrocks::vectorized {
 
 class ORCFileStream : public ORCHdfsFileStream {
 public:
-    ORCFileStream(std::shared_ptr <RandomAccessFile> file, uint64_t length,
-                  starrocks::vectorized::ScannerCounter *counter)
+    ORCFileStream(std::shared_ptr<RandomAccessFile> file, uint64_t length,
+                  starrocks::vectorized::ScannerCounter* counter)
             : ORCHdfsFileStream(file.get(), length), _file(std::move(file)), _counter(counter) {}
 
     ~ORCFileStream() override { _file.reset(); }
-
-
 
     /**
      * Read length bytes from the file starting at offset into
@@ -39,7 +37,6 @@ public:
         SCOPED_RAW_TIMER(&_counter->file_read_ns);
         ORCHdfsFileStream::read(buf, length, offset);
     }
-
 
 private:
     std::shared_ptr<RandomAccessFile> _file;

--- a/be/src/exec/vectorized/orc_scanner.cpp
+++ b/be/src/exec/vectorized/orc_scanner.cpp
@@ -193,7 +193,8 @@ Status ORCScanner::_open_next_orc_reader() {
             return st;
         }
         const std::string& file_name = file->filename();
-        auto inStream = std::make_unique<ORCFileStream>(file, _counter);
+        ASSIGN_OR_RETURN(uint64_t file_size, file->get_size());
+        auto inStream = std::make_unique<ORCFileStream>(file, file_size, _counter);
         _next_range++;
         _orc_reader->set_read_chunk_size(_max_chunk_size);
         _orc_reader->set_current_file_name(file_name);

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -2219,4 +2219,48 @@ int OrcChunkReader::get_column_id_by_name(const std::string& name) const {
     return -1;
 }
 
+void ORCHdfsFileStream::prepareCache(orc::InputStream::PrepareCacheScope scope, uint64_t offset, uint64_t length) {
+    const size_t cache_max_size = config::orc_file_cache_max_size;
+    if (length > cache_max_size) return;
+    if (canUseCacheBuffer(offset, length)) return;
+
+    // If this stripe is small, probably other stripes are also small
+    // we combine those reads into one, and try to read several stripes in one shot.
+    if (scope == orc::InputStream::PrepareCacheScope::READ_FULL_STRIPE) {
+        length = std::min(_length - offset, cache_max_size);
+    }
+
+    _cache_buffer.resize(length);
+    _cache_offset = offset;
+    doRead(_cache_buffer.data(), length, offset);
+}
+
+bool ORCHdfsFileStream::canUseCacheBuffer(uint64_t offset, uint64_t length) {
+    if ((_cache_buffer.size() != 0) && (offset >= _cache_offset) &&
+        ((offset + length) <= (_cache_offset + _cache_buffer.size()))) {
+        return true;
+    }
+    return false;
+}
+
+void ORCHdfsFileStream::read(void* buf, uint64_t length, uint64_t offset) {
+    if (canUseCacheBuffer(offset, length)) {
+        size_t idx = offset - _cache_offset;
+        memcpy(buf, _cache_buffer.data() + idx, length);
+    } else {
+        doRead(buf, length, offset);
+    }
+}
+
+void ORCHdfsFileStream::doRead(void* buf, uint64_t length, uint64_t offset) {
+    if (buf == nullptr) {
+        throw orc::ParseError("Buffer is null");
+    }
+    Status status = _file->read_at_fully(offset, buf, length);
+    if (!status.ok()) {
+        auto msg = strings::Substitute("Failed to read $0: $1", _file->filename(), status.to_string());
+        throw orc::ParseError(msg);
+    }
+}
+
 } // namespace starrocks::vectorized

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -10,10 +10,10 @@
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/vectorized/runtime_filter_bank.h"
-#include "runtime/descriptors.h"
-#include "runtime/types.h"
 #include "fs/fs.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/descriptors.h"
+#include "runtime/types.h"
 
 namespace orc {
 namespace proto {
@@ -24,7 +24,7 @@ class ColumnStatistics;
 namespace starrocks {
 class RuntimeState;
 class RandomAccessFile;
-}
+} // namespace starrocks
 namespace starrocks::vectorized {
 
 using FillColumnFunction = void (*)(orc::ColumnVectorBatch* cvb, ColumnPtr& col, int from, int size,
@@ -208,19 +208,11 @@ public:
 
     void prepareCache(orc::InputStream::PrepareCacheScope scope, uint64_t offset, uint64_t length) override;
 
-
-
     bool canUseCacheBuffer(uint64_t offset, uint64_t length);
-
-
 
     void read(void* buf, uint64_t length, uint64_t offset) override;
 
-
-
     void doRead(void* buf, uint64_t length, uint64_t offset);
-
-
 
     const std::string& getName() const override { return _file->filename(); }
 


### PR DESCRIPTION
… 2.3

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Fixes #https://github.com/StarRocks/starrocks/issues/11329

import 2.5 enhancement #11380 port ORCHdfsFileStream to OrcScanner to 2.3 

“Class ORCHdfsFileStream has capability to do pre-read and io coalesce functionalities. However OrcScanner does not use it, which makes broker load extremly slow and do a lot of random IO.
With this enhancement, case2 can be cutdown from 35s -> 5/6s.”

