### PR TITLE
[Doc] fixed one typo - s of word select is missing in Architecture.md

### DIFF
--- a/docs/introduction/Architecture.md
+++ b/docs/introduction/Architecture.md
@@ -10,7 +10,7 @@ The following figure shows the architecture of StarRocks.
 
 ## FE and BE
 
-FEs are responsible for metadata management, client connection management, query planning, and query scheduling. Each FE stores and maintains a complete copy of metadata in its memory, which guarantees indiscriminate services among the FEs. FEs can work as leaders, followers, and observers. Followers can elect a leader according to the Paxos-like BDB JE protocol. BDB JE is short for Berkeley DB Java Edition.
+FEs are responsible for metadata management, client connection management, query planning, and query scheduling. Each FE stores and maintains a complete copy of metadata in its memory, which guarantees indiscriminate services among the FEs. FEs can work as leaders, followers, and observers. Followers can select a leader according to the Paxos-like BDB JE protocol. BDB JE is short for Berkeley DB Java Edition.
 
 - Leader
   - The leader FE is elected from follower FEs. To perform leader election, more than half of the follower FEs in the cluster must be active. When the leader FE fails, follower FEs will start another round of leader election.


### PR DESCRIPTION
fixed one spelling mistake, s letter is missing.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
one typo - s of word select is missing in Architecture.md

## Problem Summary(Required) ：
one typo - s of word select is missing in Architecture.md

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
- [ ] 3.0
- [ ] 2.5
- [ ] 2.4
- [ ] 2.3
