### PR TITLE
[BugFix] Clear bucketColumns if not all OlapScanNode use it 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -71,6 +71,8 @@ public class FeConstants {
     public static int checkpoint_interval_second = 60; // 1 minutes
     // set to true to skip some step when running FE unit test
     public static boolean runningUnitTest = false;
+    // Set this flag to false to suppress showing local shuffle columns in verbose explain, when running FE unit tests.
+    public static boolean showLocalShuffleColumnsInExplain = true;
     // set to true when replay from query dump
     public static boolean isReplayFromQueryDump = false;
     // default scheduler interval is 10 seconds

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -721,6 +721,13 @@ public class OlapScanNode extends ScanNode {
                             .append(String.format("Pruned type: %d <-> [%s]\n", slotDescriptor.getId().asInt(), type));
                 }
             }
+
+            if (!bucketColumns.isEmpty()) {
+                output.append(prefix).append("LocalShuffleColumns:\n");
+                for (ColumnRefOperator col : bucketColumns) {
+                    output.append(prefix).append("- ").append(col.toString()).append("\n");
+                }
+            }
         }
 
         return output.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -68,6 +68,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.lake.LakeTablet;
@@ -722,7 +723,7 @@ public class OlapScanNode extends ScanNode {
                 }
             }
 
-            if (!bucketColumns.isEmpty()) {
+            if (!bucketColumns.isEmpty() && FeConstants.showLocalShuffleColumnsInExplain) {
                 output.append(prefix).append("LocalShuffleColumns:\n");
                 for (ColumnRefOperator col : bucketColumns) {
                     output.append(prefix).append("- ").append(col.toString()).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -58,6 +58,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -651,14 +652,23 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.cacheParam = cacheParam;
     }
 
-    public PlanNode getLeftMostLeafNode() {
-        PlanNode node = planRoot;
-        while (!node.getChildren().isEmpty()) {
+    public List<OlapScanNode> collectOlapScanNodes() {
+        List<OlapScanNode> olapScanNodes = Lists.newArrayList();
+        Queue<PlanNode> queue = Lists.newLinkedList();
+        queue.add(planRoot);
+        while (!queue.isEmpty()) {
+            PlanNode node = queue.poll();
+
             if (node instanceof ExchangeNode) {
-                break;
+                continue;
             }
-            node = node.getChild(0);
+            if (node instanceof OlapScanNode) {
+                olapScanNodes.add((OlapScanNode) node);
+            }
+
+            queue.addAll(node.getChildren());
         }
-        return node;
+
+        return olapScanNodes;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -315,9 +315,7 @@ public class PlanFragmentBuilder {
         }
         Collections.reverse(fragments);
 
-        for (PlanFragment fragment : fragments) {
-            maybeClearOlapScanNodePartitions(fragment);
-        }
+        fragments.forEach(PlanFragmentBuilder::maybeClearOlapScanNodePartitions);
 
         // compute local_rf_waiting_set for each PlanNode.
         // when enable_pipeline_engine=true and enable_global_runtime_filter=false, we should clear

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -315,6 +315,10 @@ public class PlanFragmentBuilder {
         }
         Collections.reverse(fragments);
 
+        for (PlanFragment fragment : fragments) {
+            maybeClearOlapScanNodePartitions(fragment);
+        }
+
         // compute local_rf_waiting_set for each PlanNode.
         // when enable_pipeline_engine=true and enable_global_runtime_filter=false, we should clear
         // runtime filters from PlanNode.
@@ -340,6 +344,50 @@ public class PlanFragmentBuilder {
         }
 
         return execPlan;
+    }
+
+    private static void maybeClearOlapScanNodePartitions(PlanFragment fragment) {
+        List<OlapScanNode> olapScanNodes = fragment.collectOlapScanNodes();
+        long numNodesWithBucketColumns = olapScanNodes.stream().filter(node -> !node.getBucketColumns().isEmpty()).count();
+        // Either all OlapScanNode use bucketColumns for local shuffle, or none of them do.
+        // Therefore, clear bucketColumns if only some of them contain bucketColumns.
+        boolean needClear = numNodesWithBucketColumns > 0 && numNodesWithBucketColumns < olapScanNodes.size();
+        if (needClear) {
+            clearOlapScanNodePartitions(fragment.getPlanRoot());
+        }
+    }
+
+    /**
+     * Clear partitionExprs of OlapScanNode (the bucket keys to pass to BE).
+     * <p>
+     * When partitionExprs of OlapScanNode are passed to BE, the post operators will use them as
+     * local shuffle partition exprs.
+     * Otherwise, the operators will use the original partition exprs (group by keys or join on keys).
+     * <p>
+     * The bucket keys can satisfy the required hash property of blocking aggregation except two scenarios:
+     * - OlapScanNode only has one tablet after pruned.
+     * - It is executed on the single BE.
+     * As for these two scenarios, which will generate ScanNode(k1)->LocalShuffle(c1)->BlockingAgg(c1),
+     * partitionExprs of OlapScanNode must be cleared to make BE use group by keys not bucket keys as
+     * local shuffle partition exprs.
+     *
+     * @param root The root node of the fragment which need to check whether to clear bucket keys of OlapScanNode.
+     */
+    private static void clearOlapScanNodePartitions(PlanNode root) {
+        if (root instanceof OlapScanNode) {
+            OlapScanNode scanNode = (OlapScanNode) root;
+            scanNode.setBucketExprs(Lists.newArrayList());
+            scanNode.setBucketColumns(Lists.newArrayList());
+            return;
+        }
+
+        if (root instanceof ExchangeNode) {
+            return;
+        }
+
+        for (PlanNode child : root.getChildren()) {
+            clearOlapScanNodePartitions(child);
+        }
     }
 
     private static class PhysicalPlanTranslator extends OptExpressionVisitor<PlanFragment, ExecPlan> {
@@ -1482,39 +1530,6 @@ public class PlanFragmentBuilder {
             sourceFragment.clearDestination();
             sourceFragment.clearOutputPartition();
             return sourceFragment;
-        }
-
-        /**
-         * Clear partitionExprs of OlapScanNode (the bucket keys to pass to BE).
-         * <p>
-         * When partitionExprs of OlapScanNode are passed to BE, the post operators will use them as
-         * local shuffle partition exprs.
-         * Otherwise, the operators will use the original partition exprs (group by keys or join on keys).
-         * <p>
-         * The bucket keys can satisfy the required hash property of blocking aggregation except two scenarios:
-         * - OlapScanNode only has one tablet after pruned.
-         * - It is executed on the single BE.
-         * As for these two scenarios, which will generate ScanNode(k1)->LocalShuffle(c1)->BlockingAgg(c1),
-         * partitionExprs of OlapScanNode must be cleared to make BE use group by keys not bucket keys as
-         * local shuffle partition exprs.
-         *
-         * @param root The root node of the fragment which need to check whether to clear bucket keys of OlapScanNode.
-         */
-        private void clearOlapScanNodePartitions(PlanNode root) {
-            if (root instanceof OlapScanNode) {
-                OlapScanNode scanNode = (OlapScanNode) root;
-                scanNode.setBucketExprs(Lists.newArrayList());
-                scanNode.setBucketColumns(Lists.newArrayList());
-                return;
-            }
-
-            if (root instanceof ExchangeNode) {
-                return;
-            }
-
-            for (PlanNode child : root.getChildren()) {
-                clearOlapScanNodePartitions(child);
-            }
         }
 
         private static class AggregateExprInfo {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithCaseWhenTest.java
@@ -98,6 +98,9 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
+                                "     LocalShuffleColumns:\n" +
+                                "     - 1: region\n" +
+                                "     - 2: order_date\n" +
                                 "     cardinality: 1",
                 },
                 {"select * from test.t0 where \n" +
@@ -191,6 +194,9 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
+                                "     LocalShuffleColumns:\n" +
+                                "     - 1: region\n" +
+                                "     - 2: order_date\n" +
                                 "     cardinality: 1",
                 },
 
@@ -347,6 +353,9 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
+                                "     LocalShuffleColumns:\n" +
+                                "     - 1: region\n" +
+                                "     - 2: order_date\n" +
                                 "     cardinality: 1",
                 },
                 // Q21
@@ -376,6 +385,7 @@ public class SelectStmtWithCaseWhenTest {
         };
         for (String[] tc : testCases) {
             String sql = tc[0];
+            System.out.println(sql);
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
             Assert.assertTrue(plan, Stream.of(tc).skip(1).anyMatch(plan::contains));
         }
@@ -426,6 +436,9 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
+                                "     LocalShuffleColumns:\n" +
+                                "     - 1: region\n" +
+                                "     - 2: order_date\n" +
                                 "     cardinality: 1"},
                 {"in ('A','B','C','D','E','F')",
                         "  0:OlapScanNode\n" +
@@ -434,6 +447,9 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
+                                "     LocalShuffleColumns:\n" +
+                                "     - 1: region\n" +
+                                "     - 2: order_date\n" +
                                 "     cardinality: 1"},
                 {"not in ('A','B')",
                         "(4: ship_mode < 80) OR (4: ship_mode >= 90), [4: ship_mode, INT, false] < 90, " +
@@ -455,6 +471,9 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
+                                "     LocalShuffleColumns:\n" +
+                                "     - 1: region\n" +
+                                "     - 2: order_date\n" +
                                 "     cardinality: 1"},
         };
         for (String[] tc : testCases) {
@@ -483,6 +502,9 @@ public class SelectStmtWithCaseWhenTest {
                         "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                         "     tabletList=\n" +
                         "     actualRows=0, avgRowSize=4.0\n" +
+                        "     LocalShuffleColumns:\n" +
+                        "     - 1: region\n" +
+                        "     - 2: order_date\n" +
                         "     cardinality: 1"},
                 {"select * from test.t0 where if(region='USA', 1, 0) in (1)",
                         "[1: region, VARCHAR, false] = 'USA', 1: region = 'USA' IS NOT NULL"},
@@ -492,6 +514,9 @@ public class SelectStmtWithCaseWhenTest {
                         "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                         "     tabletList=\n" +
                         "     actualRows=0, avgRowSize=4.0\n" +
+                        "     LocalShuffleColumns:\n" +
+                        "     - 1: region\n" +
+                        "     - 2: order_date\n" +
                         "     cardinality: 1\n"},
                 {"select * from test.t0 where if(region='USA', 1, 0) in (2,3)", "0:EMPTYSET"},
                 {"select * from test.t0 where if(region='USA', 1, 0) not in (0)",
@@ -503,6 +528,9 @@ public class SelectStmtWithCaseWhenTest {
                         "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                         "     tabletList=\n" +
                         "     actualRows=0, avgRowSize=4.0\n" +
+                        "     LocalShuffleColumns:\n" +
+                        "     - 1: region\n" +
+                        "     - 2: order_date\n" +
                         "     cardinality: 1\n"},
                 {"select * from test.t0 where if(region='USA', 1, 0) is NULL", "0:EMPTYSET"},
                 {"select * from test.t0 where if(region='USA', 1, 0) is NOT NULL", "  0:OlapScanNode\n" +
@@ -511,6 +539,9 @@ public class SelectStmtWithCaseWhenTest {
                         "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                         "     tabletList=\n" +
                         "     actualRows=0, avgRowSize=4.0\n" +
+                        "     LocalShuffleColumns:\n" +
+                        "     - 1: region\n" +
+                        "     - 2: order_date\n" +
                         "     cardinality: 1\n"},
                 // Q14
                 {"select * from test.t0 where nullif('China', region) = 'China'",

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithCaseWhenTest.java
@@ -385,7 +385,6 @@ public class SelectStmtWithCaseWhenTest {
         };
         for (String[] tc : testCases) {
             String sql = tc[0];
-            System.out.println(sql);
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
             Assert.assertTrue(plan, Stream.of(tc).skip(1).anyMatch(plan::contains));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -19,7 +19,6 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.planner.AggregationNode;
-import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1420,23 +1420,15 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         sql = "select count(d_datekey), d_date from dates_n group by d_date";
         plan = getVerboseExplain(sql);
         assertNotContains(plan, "LocalShuffleColumns");
-        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
-                "  |  aggregate: count[([1: d_datekey, INT, true]); args: INT; result: BIGINT; args nullable: true; result nullable: false]\n" +
-                "  |  group by: [2: d_date, VARCHAR, true]\n" +
-                "  |  cardinality: 1278\n" +
-                "  |  \n" +
-                "  0:OlapScanNode");
+        assertContains(plan, "  1:AGGREGATE (update finalize)");
+        assertContains(plan, "  0:OlapScanNode");
 
         // dates_n only contains one tablet.
         sql = "select count(d_date), d_datekey from dates_n group by d_datekey";
         plan = getVerboseExplain(sql);
         assertNotContains(plan, "LocalShuffleColumns");
-        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
-                "  |  aggregate: count[([2: d_date, VARCHAR, true]); args: VARCHAR; result: BIGINT; args nullable: true; result nullable: false]\n" +
-                "  |  group by: [1: d_datekey, INT, true]\n" +
-                "  |  cardinality: 1278\n" +
-                "  |  \n" +
-                "  0:OlapScanNode");
+        assertContains(plan, "  1:AGGREGATE (update finalize)");
+        assertContains(plan, "  0:OlapScanNode");
 
         // dates_n only contains one tablet.
         //       HashJoin(Colocate)
@@ -1463,13 +1455,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         plan = getVerboseExplain(sql);
         assertContains(plan, "     LocalShuffleColumns:\n" +
                 "     - 1: LO_ORDERKEY");
-        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
-                "  |  aggregate: count[([36: P_TYPE, VARCHAR, false]); args: VARCHAR; result: BIGINT; args nullable: false; result nullable: false]\n" +
-                "  |  group by: [1: LO_ORDERKEY, INT, false]\n" +
-                "  |  cardinality: 300004609\n" +
-                "  |  \n" +
-                "  0:OlapScanNode");
-
-
+        assertContains(plan, "  1:AGGREGATE (update finalize)");
+        assertContains(plan, "  0:OlapScanNode");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -904,6 +904,8 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
                     "     tabletList=" + tabletIdsStrList.get(1) + "\n" +
                     "     actualRows=0, avgRowSize=4.0\n" +
+                    "     LocalShuffleColumns:\n" +
+                    "     - 5: v4\n" +
                     "     cardinality: 360000\n" +
                     "     probe runtime filters:\n" +
                     "     - filter_id = 0, probe_expr = (5: v4 + 2)");
@@ -914,6 +916,8 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
                     "     tabletList=" + tabletIdsStrList.get(0) + "\n" +
                     "     actualRows=0, avgRowSize=4.0\n" +
+                    "     LocalShuffleColumns:\n" +
+                    "     - 1: v1\n" +
                     "     cardinality: 360000\n" +
                     "     probe runtime filters:\n" +
                     "     - filter_id = 0, probe_expr = (1: v1 + 1)");
@@ -1039,6 +1043,8 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
                 "     tabletList=" + tabletIdsStrList.get(0) + "\n" +
                 "     actualRows=0, avgRowSize=1.0\n" +
+                "     LocalShuffleColumns:\n" +
+                "     - 1: v4\n" +
                 "     cardinality: 400000");
 
         assertContains(plan, "  5:EXCHANGE\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -67,6 +67,7 @@ public class ReplayFromDumpTest {
         connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
         starRocksAssert = new StarRocksAssert(connectContext);
         FeConstants.runningUnitTest = true;
+        FeConstants.showLocalShuffleColumnsInExplain = false;
     }
 
     @Before
@@ -78,6 +79,7 @@ public class ReplayFromDumpTest {
     @AfterClass
     public static void afterClass() throws Exception {
         connectContext.getSessionVariable().setEnableLocalShuffleAgg(true);
+        FeConstants.showLocalShuffleColumnsInExplain = true;
     }
 
     public String getModelContent(String filename, String model) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithCostTest.java
@@ -16,6 +16,7 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -25,8 +26,14 @@ public class TPCHPlanWithCostTest extends DistributedEnvPlanTestBase {
     public static void beforeClass() throws Exception {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
+        FeConstants.showLocalShuffleColumnsInExplain = false;
         connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
         connectContext.getSessionVariable().setEnableMultiColumnsOnGlobbalRuntimeFilter(true);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        FeConstants.showLocalShuffleColumnsInExplain = true;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.MockTPCHHistogramStatisticStorage;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -28,6 +29,7 @@ public class TPCHPlanWithHistogramCostTest extends DistributedEnvPlanTestBase {
     public static void beforeClass() throws Exception {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
+        FeConstants.showLocalShuffleColumnsInExplain = false;
         connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
@@ -56,6 +58,11 @@ public class TPCHPlanWithHistogramCostTest extends DistributedEnvPlanTestBase {
 
         OlapTable t7 = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem");
         setTableStatistics(t7, 6000000 * scale);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        FeConstants.showLocalShuffleColumnsInExplain = true;
     }
 
     @Test


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22462

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Constraint: Either all OlapScanNodes use `bucketColumns` for local shuffle, or none of them do. 

When meeting the blocking aggregation executed on the single tablet, we only clear `bucketColumns` of the sub-fragment from this agg node, not the entire fragment, which causes only some of `OlapScanNode` uses `bucketColumns`


```
        //             HashJoin(Colocate)
        //      /                         \
        // OlapScanNode(NOT CLEAR)       BlockingAgg
        //                                |
        //                             OlapScanNode(CLEAR)
```

Therefore, I add a new conservative strategy during the finalizeFragment phase: we examine each fragment and clear the `bucketColumns` if only some of OlapScanNodes within the fragment use `bucketColumns`. 


BTW, add `LocalShuffleColumns` to OlapScanNode in the verbose explain.
```
| PLAN FRAGMENT 1(F00)                                                                                                          |
|                                                                                                                               |
|   Input Partition: RANDOM                                                                                                     |
|   OutPut Partition: UNPARTITIONED                                                                                             |
|   OutPut Exchange Id: 01                                                                                                      |
|                                                                                                                               |
|   0:OlapScanNode                                                                                                              |
|      table: customer, rollup: customer                                                                                        |
|      preAggregation: on                                                                                                       |
|      partitionsRatio=1/1, tabletsRatio=12/12                                                                                  |
|      tabletList=10804,10806,10808,10810,10812,10814,10816,10818,10820,10822 ...                                               |
|      actualRows=3000000, avgRowSize=84.88014                                                                                  |
|      LocalShuffleColumns:                                                                                                           |
|      - 1: c_custkey                                                                                                           |
|      cardinality: 3000000                                                                                                     |
+-------------------------------------------------------------------------------------------------------------------------------+
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
