### PR TITLE
[BugFix] ignore varchar length when compare array<varchar> types

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -294,7 +294,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         }
         if (type1.isArrayType() || type2.isArrayType()) {
             // Must both be array
-            if (!type1.equals(type2)) {
+            if (!type1.matchesType(type2)) {
                 return Type.INVALID;
             }
             return type1;

--- a/test/sql/test_array/R/test_array
+++ b/test/sql/test_array/R/test_array
@@ -77,3 +77,55 @@ select c4 > c5 from array_data_type;
 0
 1
 -- !result
+-- name: testArrayVarchar
+CREATE TABLE array_data_type_1
+    (c1 int,
+    c2  array<datetime>,
+    c3  array<float>,
+    c4  array<varchar(10)>,
+    c5  array<varchar(20)>,
+    c6  array<array<varchar(10)>>)
+    PRIMARY KEY(c1)
+    DISTRIBUTED BY HASH(c1)
+    buckets 1
+    PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into array_data_type_1 values
+(1, ['2020-11-11', '2021-11-11', '2022-01-01'], [1.23, 1.35, 2.7894], ['a', 'b'], ['sss', 'eee', 'fff'], [['a', 'b']]),
+(2, ['2020-01-11', null, '2022-11-01'], [2.23, 2.35, 3.7894], ['aa', null], ['ssss', 'eeee', null], [['a', null], null]),
+(3, null, null, null, null, null);
+-- result:
+-- !result
+select * from array_data_type_1 where c4 != ['a'] or c6 = [['a', 'b']];
+-- result:
+1	["2020-11-11 00:00:00","2021-11-11 00:00:00","2022-01-01 00:00:00"]	[1.23,1.35,2.7894]	["a","b"]	["sss","eee","fff"]	[["a","b"]]
+2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
+-- !result
+select * from array_data_type_1 where c4 = ['a'] or c6 != [['a', 'b']];
+-- result:
+2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
+-- !result
+select * from array_data_type_1 where c4 = cast(c4 as array<char(10)>);
+-- result:
+1	["2020-11-11 00:00:00","2021-11-11 00:00:00","2022-01-01 00:00:00"]	[1.23,1.35,2.7894]	["a","b"]	["sss","eee","fff"]	[["a","b"]]
+2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
+-- !result
+select * from array_data_type_1 where c5 = c4 or c6 = [['a']];
+-- result:
+-- !result
+select * from array_data_type_1 where array_map((x) -> concat(x, 'a'), c5) = c4;
+-- result:
+-- !result
+select c6[0] = ['a'] from array_data_type_1;
+-- result:
+None
+None
+None
+-- !result
+select c6[0] > array_map((x) -> concat(x, 'a'), c5) from array_data_type_1;
+-- result:
+None
+None
+None
+-- !result

--- a/test/sql/test_array/T/test_array
+++ b/test/sql/test_array/T/test_array
@@ -33,3 +33,29 @@ insert into array_data_type (c1, c2, c3, c4,c5) values
 
 select c4 = c5 from array_data_type;
 select c4 > c5 from array_data_type;
+
+-- name: testArrayVarchar
+CREATE TABLE array_data_type_1
+    (c1 int,
+    c2  array<datetime>,
+    c3  array<float>,
+    c4  array<varchar(10)>,
+    c5  array<varchar(20)>,
+    c6  array<array<varchar(10)>>)
+    PRIMARY KEY(c1)
+    DISTRIBUTED BY HASH(c1)
+    buckets 1
+    PROPERTIES ("replication_num" = "1");
+
+insert into array_data_type_1 values
+(1, ['2020-11-11', '2021-11-11', '2022-01-01'], [1.23, 1.35, 2.7894], ['a', 'b'], ['sss', 'eee', 'fff'], [['a', 'b']]),
+(2, ['2020-01-11', null, '2022-11-01'], [2.23, 2.35, 3.7894], ['aa', null], ['ssss', 'eeee', null], [['a', null], null]),
+(3, null, null, null, null, null);
+
+select * from array_data_type_1 where c4 != ['a'] or c6 = [['a', 'b']];
+select * from array_data_type_1 where c4 = ['a'] or c6 != [['a', 'b']];
+select * from array_data_type_1 where c4 = cast(c4 as array<char(10)>);
+select * from array_data_type_1 where c5 = c4 or c6 = [['a']];
+select * from array_data_type_1 where array_map((x) -> concat(x, 'a'), c5) = c4;
+select c6[0] = ['a'] from array_data_type_1;
+select c6[0] > array_map((x) -> concat(x, 'a'), c5) from array_data_type_1;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22341

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
const `['a']` is defined as `array<varchar>` while a array of vachar column is defiend as `array<varchar(10)>` with length required, and their elements have different length which prevent the comparision. This pr remove this limitation.  

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
