### PR TITLE
[BugFix] Fix wrong check in lowcardinality complex string function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.tree;
 
 import com.google.common.base.Preconditions;
@@ -106,9 +105,8 @@ public class DictMappingRewriter {
                     hasApplied = hasApplied || context.hasAppliedOperator;
                     disableApplied = disableApplied || context.hasUnsupportedOperator;
                 }
-                Preconditions.checkState(hasApplied);
-                if (!disableApplied) {
-                    context.hasAppliedOperator = true;
+                if (!disableApplied || !hasApplied) {
+                    context.hasAppliedOperator = hasApplied;
                     return operator;
                 } else {
                     context.hasAppliedOperator = false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -783,6 +783,15 @@ public class LowCardinalityTest extends PlanTestBase {
                 "args: VARCHAR; result: VARCHAR; args nullable: true; result nullable: true]"));
         Assert.assertTrue(plan.contains("  |  common expressions:\n" +
                 "  |  13 <-> DictExpr(12: S_COMMENT,[upper(<place-holder>)])"));
+
+        // support(support(unsupport(Column), unsupport(Column)))
+        sql = "select REVERSE(SUBSTR(LEFT(REVERSE(S_ADDRESS),INSTR(REVERSE(S_ADDRESS),'/')-1),5)) FROM supplier";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 9> : reverse(substr(left(11: expr, CAST(CAST(instr(11: expr, '/') AS BIGINT)" +
+                " - 1 AS INT)), 5))\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 11> : DictExpr(10: S_ADDRESS,[reverse(<place-holder>)])");
     }
 
     @Test
@@ -1577,7 +1586,6 @@ public class LowCardinalityTest extends PlanTestBase {
                         "AND (<place-holder> < 'b'), TRUE, FALSE)])");
     }
 
-
     @Test
     public void testComplexScalarOperator_1() throws Exception {
         String sql = "select case when s_address = 'test' then 'a' " +
@@ -1591,7 +1599,6 @@ public class LowCardinalityTest extends PlanTestBase {
                 "WHEN coalesce(DictExpr(10: S_ADDRESS,[<place-holder>]), 'c') = 'c' THEN 'c' " +
                 "ELSE 'a' END\n" +
                 "  |");
-
 
         sql = "select case when s_address = 'test' then 'a' " +
                 "when s_phone = 'b' then 'b' " +
@@ -1661,8 +1668,9 @@ public class LowCardinalityTest extends PlanTestBase {
 
     @Test
     public void testTopNWithProjection() throws Exception {
-        String sql = "select t2.s_address, cast(t1.a as date), concat(t1.b, '') from (select max(s_address) a, min(s_phone) b " +
-                "from supplier group by s_address) t1 join (select s_address from supplier) t2 order by t1.a";
+        String sql =
+                "select t2.s_address, cast(t1.a as date), concat(t1.b, '') from (select max(s_address) a, min(s_phone) b " +
+                        "from supplier group by s_address) t1 join (select s_address from supplier) t2 order by t1.a";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "10:Decode\n" +
                 "  |  <dict id 23> : <string id 13>\n" +


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
disableApplied is false means Expr won't prevent low-cardinality optimization from propagating upward.
hasApplied is true means we have applied low-cardinality optimization in subExprs.

if we have applied lowcardinality optimize. we will set context.hasApplied = true.

eg:
```
UPPER (has_applied)
- dict_col (has_applied)
```

if we meet a unsupported operator. we will set context.hasApplied = false to avoid nested wrap DictMapping Expr
```
unsupported_function (has_applied = false)
- UPPER (has_applied)
  - dict_col (has_applied)
```

if outer has a supported function. at this time has_applied = false. it should be a normal case. we don't have to do any thing. and set context.has_applied=false
```
Lower (has_applied=false)
- unsupported_function (has_applied = false)
 - UPPER (has_applied)
   - dict_col (has_applied)
```

the main change should be:
if hasApplied is false. There are no columns that are using low-cardinality optimization (except for DictMappingExpr).
we just only set context.hasAppliedOperator=false (means we don't have to any column to apply lowcardinality optimize)

```
if (!disableApplied || !hasApplied) {
    context.hasAppliedOperator = hasApplied;
    return operator;
} else {
```



## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
