### PR TITLE
[BugFix] fix issues on `show proc '/current_queries'` command when query is running on CN

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryInfoProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryInfoProvider.java
@@ -47,8 +47,7 @@ import com.starrocks.qe.QueryStatisticsItem;
 import com.starrocks.rpc.BackendServiceClient;
 import com.starrocks.rpc.PCollectQueryStatisticsRequest;
 import com.starrocks.rpc.RpcException;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.logging.log4j.LogManager;
@@ -85,7 +84,7 @@ public class CurrentQueryInfoProvider {
             TNetworkAddress brpcNetAddress = brpcAddresses.get(instanceInfo.getAddress());
             if (brpcNetAddress == null) {
                 try {
-                    brpcNetAddress = toBrpcHost(instanceInfo.getAddress());
+                    brpcNetAddress = SystemInfoService.toBrpcHost(instanceInfo.getAddress());
                     brpcAddresses.put(instanceInfo.getAddress(), brpcNetAddress);
                 } catch (Exception e) {
                     LOG.warn(e.getMessage());
@@ -141,7 +140,7 @@ public class CurrentQueryInfoProvider {
                 TNetworkAddress brpcNetAddress = brpcAddresses.get(instanceInfo.getAddress());
                 if (brpcNetAddress == null) {
                     try {
-                        brpcNetAddress = toBrpcHost(instanceInfo.getAddress());
+                        brpcNetAddress = SystemInfoService.toBrpcHost(instanceInfo.getAddress());
                         brpcAddresses.put(instanceInfo.getAddress(), brpcNetAddress);
                     } catch (Exception e) {
                         LOG.warn(e.getMessage());
@@ -211,23 +210,6 @@ public class CurrentQueryInfoProvider {
             }
         }
         return statisticsMap;
-    }
-
-    private TNetworkAddress toBrpcHost(TNetworkAddress host) throws AnalysisException {
-        final Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackendWithBePort(
-                host.getHostname(), host.getPort());
-        if (backend == null) {
-            throw new AnalysisException(new StringBuilder("Backend ")
-                    .append(host.getHostname())
-                    .append(":")
-                    .append(host.getPort())
-                    .append(" does not exist")
-                    .toString());
-        }
-        if (backend.getBrpcPort() < 0) {
-            throw new AnalysisException("BRPC port is't exist.");
-        }
-        return new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
     }
 
     public static class QueryStatistics {


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22546

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

After CN is introduced, `toBrpcHost` should consider both compute node and backend node, the implementation in CurrentQueryInfoProvider doesn't consider CN. I saw there is already a good implementation in SystemInfoService, so use it directly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
