### PR TITLE
[BugFix] fix segment zonemap filter in primary key

### DIFF
--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -216,6 +216,19 @@ Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial
     return Status::OK();
 }
 
+bool Segment::_use_segment_zone_map_filter(const SegmentReadOptions& read_options) {
+    if (!read_options.is_primary_keys || read_options.dcg_loader == nullptr) {
+        return true;
+    }
+    SCOPED_RAW_TIMER(&read_options.stats->get_delta_column_group_ns);
+    DeltaColumnGroupList dcgs;
+    TabletSegmentId tsid;
+    tsid.tablet_id = read_options.tablet_id;
+    tsid.segment_id = read_options.rowset_id + _segment_id;
+    auto st = read_options.dcg_loader->load(tsid, read_options.version, &dcgs);
+    return st.ok() && dcgs.size() == 0;
+}
+
 StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const Schema& schema, const SegmentReadOptions& read_options) {
     DCHECK(read_options.stats != nullptr);
     // trying to prune the current segment by segment-level zone map
@@ -225,8 +238,14 @@ StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const Schema& schema, const Se
             continue;
         }
         if (!_column_readers[column_id]->segment_zone_map_filter(pair.second)) {
-            read_options.stats->segment_stats_filtered += _column_readers[column_id]->num_rows();
-            return Status::EndOfFile(strings::Substitute("End of file $0, empty iterator", _fname));
+            // skip segment zonemap filter when this segment has column files link to it.
+            const TabletColumn& tablet_column = _tablet_schema->column(column_id);
+            if (tablet_column.is_key() || _use_segment_zone_map_filter(read_options)) {
+                read_options.stats->segment_stats_filtered += _column_readers[column_id]->num_rows();
+                return Status::EndOfFile(strings::Substitute("End of file $0, empty iterator", _fname));
+            } else {
+                break;
+            }
         }
     }
     return new_segment_iterator(shared_from_this(), schema, read_options);

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -215,6 +215,8 @@ private:
 
     void _prepare_adapter_info();
 
+    bool _use_segment_zone_map_filter(const SegmentReadOptions& read_options);
+
     friend class SegmentIterator;
 
     std::shared_ptr<FileSystem> _fs;

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_zonemap
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_zonemap
@@ -1,0 +1,33 @@
+-- name: test_partial_update_zonemap
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values(100, "100", 100, 100, 100), (200, "200", 200, 200, 200), (300, "300", 300, 300, 300);
+-- result:
+-- !result
+select * from tab1 where v2 = 200;
+-- result:
+200	200	200	200	200
+-- !result
+update tab1 set v2 = 500;
+-- result:
+-- !result
+select * from tab1 where v2 = 500;
+-- result:
+100	100	100	500	100
+300	300	300	500	300
+200	200	200	500	200
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_zonemap
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_zonemap
@@ -1,0 +1,20 @@
+-- name: test_partial_update_zonemap
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into tab1 values(100, "100", 100, 100, 100), (200, "200", 200, 200, 200), (300, "300", 300, 300, 300);
+select * from tab1 where v2 = 200;
+update tab1 set v2 = 500;
+select * from tab1 where v2 = 500;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20436

## Problem Summary(Required) ：
Because primary table default use zonemap filter in value column, after this PR : https://github.com/StarRocks/starrocks/pull/22423 .
When a segment has delta column files that correspond to it, the zonemap filter at the segment level will not be correct, need skip.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
