### PR TITLE
[Enhancement] Reduce compaction frequency of cloud native table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2097,7 +2097,7 @@ public class Config extends ConfigBase {
     public static long lake_compaction_simple_selector_threshold_seconds = 300;
 
     @ConfField(mutable = true)
-    public static double lake_compaction_score_selector_min_score = 2.0;
+    public static double lake_compaction_score_selector_min_score = 10.0;
 
     /**
      * -1 means calculate the value in an adaptive way.


### PR DESCRIPTION
Increase the default config value of lake_compaction_score_selector_min_score to reduce the compaction frequency of cloud native table

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
