### PR TITLE
[Enhancement] Increase the level multiple of duplicate key to reduce compaction frequency

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -329,6 +329,7 @@ CONF_Bool(enable_event_based_compaction_framework, "true");
 CONF_Bool(enable_size_tiered_compaction_strategy, "true");
 CONF_mInt64(size_tiered_min_level_size, "131072");
 CONF_mInt64(size_tiered_level_multiple, "5");
+CONF_mInt64(size_tiered_level_multiple_dupkey, "10");
 CONF_mInt64(size_tiered_level_num, "7");
 
 CONF_Bool(enable_check_string_lengths, "true");

--- a/be/src/storage/size_tiered_compaction_policy.cpp
+++ b/be/src/storage/size_tiered_compaction_policy.cpp
@@ -27,8 +27,13 @@ namespace starrocks {
 
 SizeTieredCompactionPolicy::SizeTieredCompactionPolicy(Tablet* tablet) : _tablet(tablet) {
     _compaction_type = INVALID_COMPACTION;
-    _max_level_size =
-            config::size_tiered_min_level_size * pow(config::size_tiered_level_multiple, config::size_tiered_level_num);
+    if (_tablet->keys_type() == KeysType::DUP_KEYS) {
+        _level_multiple = std::max(config::size_tiered_level_multiple_dupkey, config::size_tiered_level_multiple);
+    } else {
+        _level_multiple = config::size_tiered_level_multiple;
+    }
+
+    _max_level_size = config::size_tiered_min_level_size * pow(_level_multiple, config::size_tiered_level_num);
 }
 
 bool SizeTieredCompactionPolicy::need_compaction(double* score, CompactionType* type) {
@@ -93,7 +98,7 @@ double SizeTieredCompactionPolicy::_cal_compaction_score(int64_t segment_num, in
     // level bonus: The lower the level means the smaller the data volume of the compaction, the higher the execution priority
     int64_t level_bonus = 0;
     for (int64_t v = level_size; v < _max_level_size && level_bonus <= 7; ++level_bonus) {
-        v = v * config::size_tiered_level_multiple;
+        v = v * _level_multiple;
     }
     score += level_bonus;
 
@@ -159,11 +164,9 @@ Status SizeTieredCompactionPolicy::_pick_rowsets_to_size_tiered_compact(bool for
     std::set<SizeTieredLevel*, LevelComparator> priority_levels;
     std::vector<RowsetSharedPtr> transient_rowsets;
     size_t segment_num = 0;
-    int64_t level_multiple = config::size_tiered_level_multiple;
     auto keys_type = _tablet->keys_type();
     auto min_compaction_segment_num = std::max(
-            static_cast<int64_t>(2),
-            std::min(config::min_cumulative_compaction_num_singleton_deltas, config::size_tiered_level_multiple));
+            static_cast<int64_t>(2), std::min(config::min_cumulative_compaction_num_singleton_deltas, _level_multiple));
     // make sure compact to one nonoverlapping segment
     if (force_base_compaction) {
         min_compaction_segment_num = 2;
@@ -243,7 +246,7 @@ Status SizeTieredCompactionPolicy::_pick_rowsets_to_size_tiered_compact(bool for
         } else if ((!force_base_compaction ||
                     (!transient_rowsets.empty() && transient_rowsets[0]->start_version() != 0)) &&
                    level_size > config::size_tiered_min_level_size && rowset_size < level_size &&
-                   level_size / rowset_size > (level_multiple - 1)) {
+                   level_size / rowset_size > (_level_multiple - 1)) {
             if (!transient_rowsets.empty()) {
                 auto level = std::make_unique<SizeTieredLevel>(
                         transient_rowsets, segment_num, level_size, total_size,

--- a/be/src/storage/size_tiered_compaction_policy.h
+++ b/be/src/storage/size_tiered_compaction_policy.h
@@ -45,6 +45,7 @@ protected:
     double _score = 0;
     CompactionType _compaction_type;
     int64_t _max_level_size;
+    int64_t _level_multiple;
 };
 
 } // namespace starrocks

--- a/be/test/storage/size_tiered_compaction_policy_test.cpp
+++ b/be/test/storage/size_tiered_compaction_policy_test.cpp
@@ -301,13 +301,6 @@ protected:
     int64_t _version;
 };
 
-TEST_F(SizeTieredCompactionPolicyTest, test_init_succeeded) {
-    TabletMetaSharedPtr tablet_meta(new TabletMeta());
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
-    init_compaction_context(tablet);
-    ASSERT_FALSE(compact(tablet).ok());
-}
-
 TEST_F(SizeTieredCompactionPolicyTest, test_candidate_rowsets_empty) {
     TabletSchemaPB schema_pb;
     schema_pb.set_keys_type(KeysType::DUP_KEYS);
@@ -836,7 +829,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_two_delete_missed_version) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_write_descending_order_level_size) {
     LOG(INFO) << "test_write_descending_order_level_size";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -871,7 +864,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_write_descending_order_level_size) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_write_order_level_size) {
     LOG(INFO) << "test_write_order_level_size";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -902,7 +895,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_write_order_level_size) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_write_multi_descending_order_level_size) {
     LOG(INFO) << "test_write_multi_descending_order_level_size";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -972,7 +965,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_write_multi_descending_order_level_s
 
 TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_base_compaction) {
     LOG(INFO) << "test_backtrace_base_compaction";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1003,7 +996,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_base_compaction) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_base_and_backtrace_compaction) {
     LOG(INFO) << "test_base_and_backtrace_compaction";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1058,7 +1051,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_base_and_backtrace_compaction) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_delete_compaction) {
     LOG(INFO) << "test_backtrace_delete_compaction";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1091,7 +1084,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_delete_compaction) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_no_backtrace_compaction) {
     LOG(INFO) << "test_no_backtrace_compaction";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1120,7 +1113,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_no_backtrace_compaction) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_force_base_compaction) {
     LOG(INFO) << "test_force_base_compaction";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1171,7 +1164,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_force_base_compaction) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_manual_force_base_compaction) {
     LOG(INFO) << "test_manual_force_base_compaction";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1220,7 +1213,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_manual_force_base_compaction) {
 
 TEST_F(SizeTieredCompactionPolicyTest, test_manual_force_base_compaction_less_min) {
     LOG(INFO) << "test_manual_force_base_compaction_less_min";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1269,7 +1262,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_manual_force_base_compaction_less_mi
 
 TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_base_compaction_multi_delete) {
     LOG(INFO) << "test_backtrace_base_compaction_multi_delete";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1307,7 +1300,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_base_compaction_multi_dele
 
 TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_base_compaction_continous_delete) {
     LOG(INFO) << "test_backtrace_base_compaction_continous_delete";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());
@@ -1344,7 +1337,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_backtrace_base_compaction_continous_
 
 TEST_F(SizeTieredCompactionPolicyTest, test_delete_limit) {
     LOG(INFO) << "test_delete_limit";
-    create_tablet_schema(DUP_KEYS);
+    create_tablet_schema(UNIQUE_KEYS);
 
     TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
     create_tablet_meta(tablet_meta.get());


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Increase the level multiple of duplicate key to reduce compaction frequency, add a dedicate config `size_tiered_level_multiple_dupkey` to control.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
