### PR TITLE
[BugFix] fix group_concat for empty column

### DIFF
--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -274,6 +274,9 @@ public:
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         const std::string& value = this->data(state).intermediate_string;
+        if (value.empty()) {
+            return;
+        }
         // Remove first sep_length.
         const char* data = value.data();
         uint32_t size = value.size();

--- a/test/sql/test_agg_function/R/test_group_concat
+++ b/test/sql/test_agg_function/R/test_group_concat
@@ -1,0 +1,44 @@
+-- name: testForEmptySetInput
+CREATE TABLE IF NOT EXISTS `lineorder` (
+    `lo_orderkey` int(11) NOT NULL COMMENT "",
+    `lo_linenumber` int(11) NOT NULL COMMENT "",
+    `lo_custkey` int(11) NOT NULL COMMENT "",
+    `lo_partkey` int(11) NOT NULL COMMENT "",
+    `lo_suppkey` int(11) NOT NULL COMMENT "",
+    `lo_orderdate` int(11) NOT NULL COMMENT "",
+    `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
+    `lo_shippriority` int(11) NOT NULL COMMENT "",
+    `lo_quantity` int(11) NOT NULL COMMENT "",
+    `lo_extendedprice` int(11) NOT NULL COMMENT "",
+    `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
+    `lo_discount` int(11) NOT NULL COMMENT "",
+    `lo_revenue` int(11) NOT NULL COMMENT "",
+    `lo_supplycost` int(11) NOT NULL COMMENT "",
+    `lo_tax` int(11) NOT NULL COMMENT "",
+    `lo_commitdate` int(11) NOT NULL COMMENT "",
+    `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`lo_orderkey`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`lo_orderdate`)
+(
+    PARTITION p1 VALUES [("-2147483648"), ("19930101")),
+    PARTITION p2 VALUES [("19930101"), ("19940101")),
+    PARTITION p3 VALUES [("19940101"), ("19950101")),
+    PARTITION p4 VALUES [("19950101"), ("19960101")),
+    PARTITION p5 VALUES [("19960101"), ("19970101")),
+    PARTITION p6 VALUES [("19970101"), ("19980101")),
+    PARTITION p7 VALUES [("19980101"), ("19990101")))
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1",
+    "colocate_with" = "groupa1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT"
+);
+-- result:
+-- !result
+SELECT GROUP_CONCAT(lo_shipmode) orgs FROM lineorder WHERE 1 = 2;
+-- result:
+None
+-- !result

--- a/test/sql/test_agg_function/R/test_group_concat
+++ b/test/sql/test_agg_function/R/test_group_concat
@@ -1,40 +1,13 @@
 -- name: testForEmptySetInput
 CREATE TABLE IF NOT EXISTS `lineorder` (
     `lo_orderkey` int(11) NOT NULL COMMENT "",
-    `lo_linenumber` int(11) NOT NULL COMMENT "",
-    `lo_custkey` int(11) NOT NULL COMMENT "",
-    `lo_partkey` int(11) NOT NULL COMMENT "",
-    `lo_suppkey` int(11) NOT NULL COMMENT "",
-    `lo_orderdate` int(11) NOT NULL COMMENT "",
-    `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
-    `lo_shippriority` int(11) NOT NULL COMMENT "",
-    `lo_quantity` int(11) NOT NULL COMMENT "",
-    `lo_extendedprice` int(11) NOT NULL COMMENT "",
-    `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
-    `lo_discount` int(11) NOT NULL COMMENT "",
-    `lo_revenue` int(11) NOT NULL COMMENT "",
-    `lo_supplycost` int(11) NOT NULL COMMENT "",
-    `lo_tax` int(11) NOT NULL COMMENT "",
-    `lo_commitdate` int(11) NOT NULL COMMENT "",
     `lo_shipmode` varchar(11) NOT NULL COMMENT ""
 ) ENGINE=OLAP
 DUPLICATE KEY(`lo_orderkey`)
 COMMENT "OLAP"
-PARTITION BY RANGE(`lo_orderdate`)
-(
-    PARTITION p1 VALUES [("-2147483648"), ("19930101")),
-    PARTITION p2 VALUES [("19930101"), ("19940101")),
-    PARTITION p3 VALUES [("19940101"), ("19950101")),
-    PARTITION p4 VALUES [("19950101"), ("19960101")),
-    PARTITION p5 VALUES [("19960101"), ("19970101")),
-    PARTITION p6 VALUES [("19970101"), ("19980101")),
-    PARTITION p7 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
-    "replication_num" = "1",
-    "colocate_with" = "groupa1",
-    "in_memory" = "false",
-    "storage_format" = "DEFAULT"
+    "replication_num" = "1"
 );
 -- result:
 -- !result

--- a/test/sql/test_agg_function/T/test_group_concat
+++ b/test/sql/test_agg_function/T/test_group_concat
@@ -1,0 +1,39 @@
+-- name: testForEmptySetInput
+CREATE TABLE IF NOT EXISTS `lineorder` (
+    `lo_orderkey` int(11) NOT NULL COMMENT "",
+    `lo_linenumber` int(11) NOT NULL COMMENT "",
+    `lo_custkey` int(11) NOT NULL COMMENT "",
+    `lo_partkey` int(11) NOT NULL COMMENT "",
+    `lo_suppkey` int(11) NOT NULL COMMENT "",
+    `lo_orderdate` int(11) NOT NULL COMMENT "",
+    `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
+    `lo_shippriority` int(11) NOT NULL COMMENT "",
+    `lo_quantity` int(11) NOT NULL COMMENT "",
+    `lo_extendedprice` int(11) NOT NULL COMMENT "",
+    `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
+    `lo_discount` int(11) NOT NULL COMMENT "",
+    `lo_revenue` int(11) NOT NULL COMMENT "",
+    `lo_supplycost` int(11) NOT NULL COMMENT "",
+    `lo_tax` int(11) NOT NULL COMMENT "",
+    `lo_commitdate` int(11) NOT NULL COMMENT "",
+    `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`lo_orderkey`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`lo_orderdate`)
+(
+    PARTITION p1 VALUES [("-2147483648"), ("19930101")),
+    PARTITION p2 VALUES [("19930101"), ("19940101")),
+    PARTITION p3 VALUES [("19940101"), ("19950101")),
+    PARTITION p4 VALUES [("19950101"), ("19960101")),
+    PARTITION p5 VALUES [("19960101"), ("19970101")),
+    PARTITION p6 VALUES [("19970101"), ("19980101")),
+    PARTITION p7 VALUES [("19980101"), ("19990101")))
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1",
+    "colocate_with" = "groupa1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT"
+);
+SELECT GROUP_CONCAT(lo_shipmode) orgs FROM lineorder WHERE 1 = 2;

--- a/test/sql/test_agg_function/T/test_group_concat
+++ b/test/sql/test_agg_function/T/test_group_concat
@@ -1,39 +1,12 @@
 -- name: testForEmptySetInput
 CREATE TABLE IF NOT EXISTS `lineorder` (
     `lo_orderkey` int(11) NOT NULL COMMENT "",
-    `lo_linenumber` int(11) NOT NULL COMMENT "",
-    `lo_custkey` int(11) NOT NULL COMMENT "",
-    `lo_partkey` int(11) NOT NULL COMMENT "",
-    `lo_suppkey` int(11) NOT NULL COMMENT "",
-    `lo_orderdate` int(11) NOT NULL COMMENT "",
-    `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
-    `lo_shippriority` int(11) NOT NULL COMMENT "",
-    `lo_quantity` int(11) NOT NULL COMMENT "",
-    `lo_extendedprice` int(11) NOT NULL COMMENT "",
-    `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
-    `lo_discount` int(11) NOT NULL COMMENT "",
-    `lo_revenue` int(11) NOT NULL COMMENT "",
-    `lo_supplycost` int(11) NOT NULL COMMENT "",
-    `lo_tax` int(11) NOT NULL COMMENT "",
-    `lo_commitdate` int(11) NOT NULL COMMENT "",
     `lo_shipmode` varchar(11) NOT NULL COMMENT ""
 ) ENGINE=OLAP
 DUPLICATE KEY(`lo_orderkey`)
 COMMENT "OLAP"
-PARTITION BY RANGE(`lo_orderdate`)
-(
-    PARTITION p1 VALUES [("-2147483648"), ("19930101")),
-    PARTITION p2 VALUES [("19930101"), ("19940101")),
-    PARTITION p3 VALUES [("19940101"), ("19950101")),
-    PARTITION p4 VALUES [("19950101"), ("19960101")),
-    PARTITION p5 VALUES [("19960101"), ("19970101")),
-    PARTITION p6 VALUES [("19970101"), ("19980101")),
-    PARTITION p7 VALUES [("19980101"), ("19990101")))
 DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
 PROPERTIES (
-    "replication_num" = "1",
-    "colocate_with" = "groupa1",
-    "in_memory" = "false",
-    "storage_format" = "DEFAULT"
+    "replication_num" = "1"
 );
 SELECT GROUP_CONCAT(lo_shipmode) orgs FROM lineorder WHERE 1 = 2;


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
sql like "SELECT GROUP_CONCAT(lo_shipmode) orgs FROM lineorder WHERE 1 = 2;" will cause be crash
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
