### PR TITLE
aarch64: use isb instead of yield

### DIFF
--- a/be/src/util/spinlock.cc
+++ b/be/src/util/spinlock.cc
@@ -28,7 +28,13 @@ void SpinLock::slow_acquire() {
 #if (defined(__i386) || defined(__x86_64__))
             asm volatile("pause\n" : : : "memory");
 #elif defined(__aarch64__)
-            asm volatile("yield\n" ::: "memory");
+            // A "yield" instruction in aarch64 is essentially a nop, and does
+            // not cause enough delay to help backoff. "isb" is a barrier that,
+            // especially inside a loop, creates a small delay without consuming
+            // ALU resources.  Experiments shown that adding the isb instruction
+            // improves stability and reduces result jitter. Adding more delay
+            // to the UT_RELAX_CPU than a single isb reduces performance.
+            asm volatile("isb\n" ::: "memory");
 #endif
         }
         if (try_lock()) {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：
This patch is fixing a performance issue on arm64.
The patch follows the same pattern we have [fixed in mysql](https://github.com/mysql/mysql-server/pull/305/commits/c4e5505fe410e3dbd2b76f011d6db3aa64aa9cef) and other software using spin loops.
A `yield` instruction in aarch64 is essentially a `nop`, and does not cause enough delay to help backoff. `isb` is a barrier that, especially inside a loop, creates a small delay without consuming ALU resources.  Experiments shown that adding the `isb` instruction improves stability and reduces result jitter. Adding more delay to the UT_RELAX_CPU than a single `isb` reduces performance.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
