### PR TITLE
[BugFix] Fix the loss of bucket info after disable the dynamic partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -299,11 +299,6 @@ public class DynamicPartitionUtil {
             checkBuckets(bucketsValue);
             properties.remove(DynamicPartitionProperty.BUCKETS);
             analyzedProperties.put(DynamicPartitionProperty.BUCKETS, bucketsValue);
-        } else {
-            String bucketsValue = "0";
-            checkBuckets(bucketsValue);
-            properties.remove(DynamicPartitionProperty.BUCKETS);
-            analyzedProperties.put(DynamicPartitionProperty.BUCKETS, bucketsValue);
         }
         if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
             String enableValue = properties.get(DynamicPartitionProperty.ENABLE);
@@ -430,10 +425,14 @@ public class DynamicPartitionUtil {
             TableProperty tableProperty = olapTable.getTableProperty();
             if (tableProperty != null) {
                 tableProperty.modifyTableProperties(dynamicPartitionProperties);
-                tableProperty.buildDynamicProperty();
             } else {
-                olapTable.setTableProperty(new TableProperty(dynamicPartitionProperties).buildDynamicProperty());
+                tableProperty = new TableProperty(dynamicPartitionProperties);
+                olapTable.setTableProperty(tableProperty);
             }
+            if (!tableProperty.getProperties().containsKey(DynamicPartitionProperty.BUCKETS)) {
+                tableProperty.modifyTableProperties(DynamicPartitionProperty.BUCKETS, "0");
+            }
+            tableProperty.buildDynamicProperty();
         }
     }
 


### PR DESCRIPTION
If user create table using dynamic partition with dynamic_partition.buckets. After they `SET ('dynamic_partition.enable' = 'true')` the buckets info is lost. The pull request fix this by eliminate the remove the buckets info

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
