### PR TITLE
[Refactor] Add default_replication_num in the FE config (#22493)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2193,4 +2193,7 @@ public class Config extends ConfigBase {
 
     @ConfField
     public static boolean only_use_compute_node = false;
+
+    @ConfField(mutable = true)
+    public static short default_replication_num = 3;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/RunMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/RunMode.java
@@ -99,7 +99,7 @@ public abstract class RunMode {
 
         @Override
         public short getDefaultReplicationNum() {
-            return 3;
+            return Config.default_replication_num;
         }
     }
 


### PR DESCRIPTION
The replication_num == 3 in the FE config.
In the allin1 env, there is only one BE node.
Add this config to the FE, users can set it to meet their needs.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
