### PR TITLE
[BugFix] Fix parquet column name case sensitive problem in min-max filter

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -516,7 +516,8 @@ const tparquet::ColumnMetaData* FileReader::_get_column_meta(const tparquet::Row
                 return &column.meta_data;
             }
         } else {
-            if (boost::algorithm::to_lower_copy(column.meta_data.path_in_schema[0]) == col_name) {
+            if (boost::algorithm::to_lower_copy(column.meta_data.path_in_schema[0]) ==
+                boost::algorithm::to_lower_copy(col_name)) {
                 return &column.meta_data;
             }
         }

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -516,8 +516,7 @@ const tparquet::ColumnMetaData* FileReader::_get_column_meta(const tparquet::Row
                 return &column.meta_data;
             }
         } else {
-            if (boost::algorithm::to_lower_copy(column.meta_data.path_in_schema[0]) ==
-                boost::algorithm::to_lower_copy(col_name)) {
+            if (boost::algorithm::iequals(column.meta_data.path_in_schema[0], col_name)) {
                 return &column.meta_data;
             }
         }


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

If the user query SQL: `SELECT * FROM tbl WHERE Bb=1;` it will return empty, because of min-max filter does not handle column name's case-sensitive properly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
