### PR TITLE
[Enhancement] Enable turn off deletion log printing of cloud native table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -815,15 +815,16 @@ CONF_Int32(starlet_fs_stream_buffer_size_bytes, "131072");
 #endif
 
 CONF_Int64(lake_metadata_cache_limit, /*2GB=*/"2147483648");
-CONF_Int64(lake_gc_metadata_max_versions, "10");
-CONF_Int64(lake_gc_metadata_check_interval, /*30 minutes=*/"1800");
-CONF_Int64(lake_gc_segment_check_interval, /*60 minutes=*/"3600");
+CONF_mBool(lake_print_delete_log, "true");
+CONF_mInt64(lake_gc_metadata_max_versions, "10");
+CONF_mInt64(lake_gc_metadata_check_interval, /*30 minutes=*/"1800");
+CONF_mInt64(lake_gc_segment_check_interval, /*60 minutes=*/"3600");
 // This value should be much larger than the maximum timeout of loading/compaction/schema change jobs.
 // The actual effective value is max(lake_gc_segment_expire_seconds, 86400)
-CONF_Int64(lake_gc_segment_expire_seconds, /*3 days=*/"259200");
-CONF_Bool(lake_compaction_check_txn_log_first, "false");
-CONF_Int64(experimental_lake_segment_gc_max_retries, "3");
-CONF_Bool(experimental_lake_enable_fast_gc, "false");
+CONF_mInt64(lake_gc_segment_expire_seconds, /*3 days=*/"259200");
+CONF_mBool(lake_compaction_check_txn_log_first, "false");
+CONF_mInt64(experimental_lake_segment_gc_max_retries, "3");
+CONF_mBool(experimental_lake_enable_fast_gc, "false");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/storage/lake/gc.cpp
+++ b/be/src/storage/lake/gc.cpp
@@ -109,7 +109,7 @@ static Status delete_rowset_files(FileSystem* fs, std::string_view data_dir, con
     for (const auto& segment : rowset.segments()) {
         auto seg_path = join_path(data_dir, segment);
         if (auto st = ignore_not_found(fs->delete_file(seg_path)); st.ok()) {
-            LOG(INFO) << "Deleted " << seg_path;
+            LOG_IF(INFO, config::lake_print_delete_log) << "Deleted " << seg_path;
         } else {
             LOG(WARNING) << "Fail to delete " << seg_path << ": " << st;
             return st;
@@ -226,7 +226,7 @@ static Status delete_tablet_metadata(TabletManager* tablet_mgr, std::string_view
             }
             auto path = join_path(metadata_root_location, tablet_metadata_filename(tablet_id, version));
             if (auto st = ignore_not_found(fs->delete_file(path)); st.ok()) {
-                LOG(INFO) << "Deleted " << path;
+                LOG_IF(INFO, config::lake_print_delete_log) << "Deleted " << path;
             } else {
                 LOG(WARNING) << "Fail to delete " << path << ": " << st;
             }
@@ -249,7 +249,8 @@ static Status delete_txn_log(std::string_view root_location, const std::set<int6
                 auto location = join_path(txn_log_root_location, name);
                 auto st = ignore_not_found(fs->delete_file(location));
                 if (st.ok()) {
-                    LOG(INFO) << "Deleted " << location << ". min_active_txn_id=" << min_active_txn_id;
+                    LOG_IF(INFO, config::lake_print_delete_log)
+                            << "Deleted " << location << ". min_active_txn_id=" << min_active_txn_id;
                 } else {
                     LOG(WARNING) << "Fail to delete " << name << ": " << st;
                 }
@@ -503,7 +504,7 @@ Status datafile_gc(std::string_view root_location, TabletManager* tablet_mgr) {
         auto location = join_path(segment_root_location, file);
         auto st = ignore_not_found(fs->delete_file(location));
         if (st.ok()) {
-            LOG(INFO) << "Deleted orphan data file: " << location;
+            LOG_IF(INFO, config::lake_print_delete_log) << "Deleted orphan data file: " << location;
         } else {
             LOG(WARNING) << "Fail to delete " << location << ": " << st;
         }


### PR DESCRIPTION
Add a new configuration item `lake_print_delete_log` to control whether to print GC module deletion logs.

Also make some configuration items mutable.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
