### PR TITLE
[Enhancement] Optimize compensatePartitionPredicateForOlapScan to use getPrunedPartitionPredicates instead

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -200,91 +200,102 @@ public class MaterializedViewRewriter {
         final PredicateSplit mvPredicateSplit = PredicateSplit.splitPredicate(mvPredicate);
 
         if (matchMode == MatchMode.VIEW_DELTA) {
-            List<TableScanDesc> mvTableScanDescs = MvUtils.getTableScanDescs(mvExpression);
-            List<TableScanDesc> queryTableScanDescs = MvUtils.getTableScanDescs(queryExpression);
-            // do not support external table now
-            if (queryTableScanDescs.stream().anyMatch(
-                    tableScanDesc -> !isSupportViewDeltaJoin(tableScanDesc.getTable()))) {
-                return null;
-            }
-            if (mvTableScanDescs.stream().anyMatch(
-                    tableScanDesc -> !isSupportViewDeltaJoin(tableScanDesc.getTable()))) {
-                return null;
-            }
-
-            // NOTE: When queries/mvs have multi same tables in snowflake-schema mode, eg:
-            // MV   : B <-> A <-> D <-> C <-> E <-> A <-> B
-            // QUERY:  A <-> D <-> C <-> E <-> A <-> B
-            // It's not easy to decide which tables are needed to compensate into query,
-            // so iterate the possible permutations to tryRewrite.
-            Map<Table, List<TableScanDesc>> mvTableToTableScanDecs = Maps.newHashMap();
-            for (TableScanDesc mvTableScanDesc : mvTableScanDescs) {
-                mvTableToTableScanDecs.computeIfAbsent(mvTableScanDesc.getTable(), x -> Lists.newArrayList())
-                        .add(mvTableScanDesc);
-            }
-            List<List<TableScanDesc>> mvExtraTableScanDescLists = Lists.newArrayList();
-            for (TableScanDesc mvTableScanDesc : mvTableScanDescs) {
-                if (!queryTableScanDescs.contains(mvTableScanDesc)) {
-                    mvExtraTableScanDescLists.add(mvTableToTableScanDecs.get(mvTableScanDesc.getTable()));
-                }
-            }
-
-            List<Set<TableScanDesc>> mvDistinctScanDescs = Lists.newArrayList();
-            // `mvExtraTableScanDescLists` may generate duplicated tables, eg:
-            // MV   : B(1) <-> A <-> D <-> C <-> E <-> A <-> B (2)
-            // QUERY:  A <-> D <-> C <-> E <-> A
-            // `mvExtraTableScanDescLists`: [B1, B2], [B1, B2]
-            // `PermutationGenerator` will generate all permutations of input tables:
-            // [B1, B1], [B1, B2], [B2, B1], [B2, B1].
-            // In the next step, remove some redundant permutations below.
-            PermutationGenerator generator = new PermutationGenerator(mvExtraTableScanDescLists);
-            while (generator.hasNext()) {
-                List<TableScanDesc> mvExtraTableScanDescs = generator.next();
-                if (mvExtraTableScanDescs.stream().distinct().count() != mvExtraTableScanDescs.size()) {
-                    continue;
-                }
-                Set<TableScanDesc> mvExtraTableScanDescsSet = new HashSet<>(mvExtraTableScanDescs);
-                if (mvDistinctScanDescs.contains(mvExtraTableScanDescsSet)) {
-                    continue;
-                }
-                mvDistinctScanDescs.add(mvExtraTableScanDescsSet);
-
-                OptExpression rewritten = tryRewrite(queryTables, mvTables, matchMode, mvPredicateSplit,
-                        mvColumnRefRewriter, mvTableScanDescs, mvExtraTableScanDescs);
-                if (rewritten != null) {
-                    return rewritten;
-                }
-            }
+            return rewriteViewDelta(queryTables, mvTables, mvPredicateSplit, mvColumnRefRewriter,
+                    queryExpression, mvExpression);
         } else {
-            return tryRewrite(queryTables, mvTables, matchMode, mvPredicateSplit, mvColumnRefRewriter,
-                    null, null);
+            Preconditions.checkState(matchMode == MatchMode.COMPLETE);
+            return rewriteComplete(queryTables, mvTables, matchMode, mvPredicateSplit, mvColumnRefRewriter,
+                    null, null, null);
+        }
+    }
+
+    private OptExpression rewriteViewDelta(List<Table> queryTables,
+                                           List<Table> mvTables,
+                                           PredicateSplit mvPredicateSplit,
+                                           ReplaceColumnRefRewriter mvColumnRefRewriter,
+                                           OptExpression queryExpression,
+                                           OptExpression mvExpression) {
+        List<TableScanDesc> queryTableScanDescs = MvUtils.getTableScanDescs(queryExpression);
+        List<TableScanDesc> mvTableScanDescs = MvUtils.getTableScanDescs(mvExpression);
+        // do not support external table now
+        if (queryTableScanDescs.stream().anyMatch(
+                tableScanDesc -> !isSupportViewDeltaJoin(tableScanDesc.getTable()))) {
+            return null;
+        }
+        if (mvTableScanDescs.stream().anyMatch(
+                tableScanDesc -> !isSupportViewDeltaJoin(tableScanDesc.getTable()))) {
+            return null;
+        }
+
+        // NOTE: When queries/mvs have multi same tables in snowflake-schema mode, eg:
+        // MV   : B <-> A <-> D <-> C <-> E <-> A <-> B
+        // QUERY:  A <-> D <-> C <-> E <-> A <-> B
+        // It's not easy to decide which tables are needed to compensate into query,
+        // so iterate the possible permutations to tryRewrite.
+        Map<Table, List<TableScanDesc>> mvTableToTableScanDecs = Maps.newHashMap();
+        for (TableScanDesc mvTableScanDesc : mvTableScanDescs) {
+            mvTableToTableScanDecs.computeIfAbsent(mvTableScanDesc.getTable(), x -> Lists.newArrayList())
+                    .add(mvTableScanDesc);
+        }
+        List<List<TableScanDesc>> mvExtraTableScanDescLists = Lists.newArrayList();
+        for (TableScanDesc mvTableScanDesc : mvTableScanDescs) {
+            if (!queryTableScanDescs.contains(mvTableScanDesc)) {
+                mvExtraTableScanDescLists.add(mvTableToTableScanDecs.get(mvTableScanDesc.getTable()));
+            }
+        }
+
+        List<Set<TableScanDesc>> mvDistinctScanDescs = Lists.newArrayList();
+        // `mvExtraTableScanDescLists` may generate duplicated tables, eg:
+        // MV   : B(1) <-> A <-> D <-> C <-> E <-> A <-> B (2)
+        // QUERY:  A <-> D <-> C <-> E <-> A
+        // `mvExtraTableScanDescLists`: [B1, B2], [B1, B2]
+        // `PermutationGenerator` will generate all permutations of input tables:
+        // [B1, B1], [B1, B2], [B2, B1], [B2, B1].
+        // In the next step, remove some redundant permutations below.
+        PermutationGenerator generator = new PermutationGenerator(mvExtraTableScanDescLists);
+        while (generator.hasNext()) {
+            List<TableScanDesc> mvExtraTableScanDescs = generator.next();
+            if (mvExtraTableScanDescs.stream().distinct().count() != mvExtraTableScanDescs.size()) {
+                continue;
+            }
+            Set<TableScanDesc> mvExtraTableScanDescsSet = new HashSet<>(mvExtraTableScanDescs);
+            if (mvDistinctScanDescs.contains(mvExtraTableScanDescsSet)) {
+                continue;
+            }
+            mvDistinctScanDescs.add(mvExtraTableScanDescsSet);
+
+            final ScalarOperator mvEqualPredicate = mvPredicateSplit.getEqualPredicates();
+            EquivalenceClasses viewEquivalenceClasses = createEquivalenceClasses(mvEqualPredicate);
+            final Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns = ArrayListMultimap.create();
+            final Map<Table, Set<Integer>> compensationRelations = Maps.newHashMap();
+            final Map<Integer, Integer> expectedExtraQueryToMVRelationIds = Maps.newHashMap();
+            if (!compensateViewDelta(viewEquivalenceClasses, mvTableScanDescs, mvExtraTableScanDescs,
+                    materializationContext.getQueryRefFactory(), materializationContext.getMvColumnRefFactory(),
+                    compensationJoinColumns, compensationRelations, expectedExtraQueryToMVRelationIds)) {
+                continue;
+            }
+
+            OptExpression rewritten = rewriteComplete(queryTables, mvTables,
+                    MatchMode.VIEW_DELTA, mvPredicateSplit, mvColumnRefRewriter,
+                    compensationJoinColumns, compensationRelations, expectedExtraQueryToMVRelationIds);
+            if (rewritten != null) {
+                return rewritten;
+            }
         }
         return null;
     }
 
-    private OptExpression tryRewrite(List<Table> queryTables,
-                                     List<Table> mvTables,
-                                     MatchMode matchMode,
-                                     PredicateSplit mvPredicateSplit,
-                                     ReplaceColumnRefRewriter mvColumnRefRewriter,
-                                     List<TableScanDesc> mvTableScanDescs,
-                                     List<TableScanDesc> mvExtraTableScanDescs) {
+    private OptExpression rewriteComplete(List<Table> queryTables,
+                                          List<Table> mvTables,
+                                          MatchMode matchMode,
+                                          PredicateSplit mvPredicateSplit,
+                                          ReplaceColumnRefRewriter mvColumnRefRewriter,
+                                          Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns,
+                                          Map<Table, Set<Integer>> compensationRelations,
+                                          Map<Integer, Integer> expectedExtraQueryToMVRelationIds) {
         final OptExpression queryExpression = mvRewriteContext.getQueryExpression();
         final OptExpression mvExpression = materializationContext.getMvExpression();
         final ScalarOperator mvEqualPredicate = mvPredicateSplit.getEqualPredicates();
-
-        final Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns = ArrayListMultimap.create();
-        final Map<Table, Set<Integer>> compensationRelations = Maps.newHashMap();
-        final Map<Integer, Integer> expectedExtraQueryToMVRelationIds = Maps.newHashMap();
-        if (matchMode == MatchMode.VIEW_DELTA) {
-            EquivalenceClasses viewEquivalenceClasses = createEquivalenceClasses(mvEqualPredicate);
-            if (!compensateViewDelta(viewEquivalenceClasses, mvTableScanDescs, mvExtraTableScanDescs,
-                    materializationContext.getQueryRefFactory(), materializationContext.getMvColumnRefFactory(),
-                    compensationJoinColumns, compensationRelations, expectedExtraQueryToMVRelationIds)) {
-                return null;
-            }
-        }
-
         final Map<Integer, Map<String, ColumnRefOperator>> queryRelationIdToColumns =
                 getRelationIdToColumns(materializationContext.getQueryRefFactory());
         final Map<Integer, Map<String, ColumnRefOperator>> mvRelationIdToColumns =
@@ -1444,7 +1455,7 @@ public class MaterializedViewRewriter {
             }
         }
 
-        if (expectedExtraQueryToMVRelationIds.isEmpty()) {
+        if (expectedExtraQueryToMVRelationIds == null || expectedExtraQueryToMVRelationIds.isEmpty()) {
             return result;
         } else {
             List<BiMap<Integer, Integer>> finalResult = Lists.newArrayList();
@@ -1578,7 +1589,7 @@ public class MaterializedViewRewriter {
         ScalarOperator srcPr = srcPredicateSplit.getRangePredicates();
         ScalarOperator targetPr = targetPredicateSplit.getRangePredicates();
         ScalarOperator compensationPr =
-                getCompensationRangePredicate(srcPr, targetPr, columnRewriter, isQueryAgainstView);
+                getCompensationPredicate(srcPr, targetPr, columnRewriter, true, isQueryAgainstView);
         if (compensationPr == null) {
             return null;
         }
@@ -1598,7 +1609,7 @@ public class MaterializedViewRewriter {
             }
         }
         ScalarOperator compensationPu =
-                getCompensationResidualPredicate(srcPu, targetPu, columnRewriter, isQueryAgainstView);
+                getCompensationPredicate(srcPu, targetPu, columnRewriter, false, isQueryAgainstView);
         if (compensationPu == null) {
             return null;
         }
@@ -1606,14 +1617,17 @@ public class MaterializedViewRewriter {
         return PredicateSplit.of(compensationEqualPredicate, compensationPr, compensationPu);
     }
 
-    private ScalarOperator getCompensationResidualPredicate(ScalarOperator srcPu,
-                                                            ScalarOperator targetPu,
-                                                            ColumnRewriter columnRewriter,
-                                                            boolean isQueryAgainstView) {
-        ScalarOperator compensationPu;
+    private ScalarOperator getCompensationPredicate(ScalarOperator srcPu,
+                                                    ScalarOperator targetPu,
+                                                    ColumnRewriter columnRewriter,
+                                                    boolean isRangePredicate,
+                                                    boolean isQueryAgainstView) {
         if (srcPu == null && targetPu == null) {
-            compensationPu = ConstantOperator.createBoolean(true);
-        } else if (srcPu == null) {
+            return ConstantOperator.TRUE;
+        }
+
+        ScalarOperator compensationPu;
+        if (srcPu == null) {
             return null;
         } else if (targetPu == null) {
             compensationPu = srcPu;
@@ -1634,16 +1648,19 @@ public class MaterializedViewRewriter {
             ScalarOperator canonizedSrcPu = MvUtils.canonizePredicateForRewrite(swappedSrcPu);
             ScalarOperator canonizedTargetPu = MvUtils.canonizePredicateForRewrite(swappedTargetPu);
 
-            compensationPu = MvUtils.getCompensationPredicateForDisjunctive(canonizedSrcPu, canonizedTargetPu);
-            if (compensationPu == null) {
-                compensationPu = getCompensationResidualPredicate(canonizedSrcPu, canonizedTargetPu);
+            if (isRangePredicate) {
+                compensationPu = getCompensationRangePredicate(canonizedSrcPu, canonizedTargetPu);
+            } else {
+                compensationPu = MvUtils.getCompensationPredicateForDisjunctive(canonizedSrcPu, canonizedTargetPu);
                 if (compensationPu == null) {
-                    return null;
+                    compensationPu = getCompensationResidualPredicate(canonizedSrcPu, canonizedTargetPu);
+                    if (compensationPu == null) {
+                        return null;
+                    }
                 }
             }
         }
-        compensationPu = MvUtils.canonizePredicate(compensationPu);
-        return compensationPu;
+        return MvUtils.canonizePredicate(compensationPu);
     }
 
     private ScalarOperator getCompensationResidualPredicate(ScalarOperator srcPu, ScalarOperator targetPu) {
@@ -1658,41 +1675,6 @@ public class MaterializedViewRewriter {
             }
         }
         return null;
-    }
-
-    private ScalarOperator getCompensationRangePredicate(ScalarOperator srcPr,
-                                                         ScalarOperator targetPr,
-                                                         ColumnRewriter columnRewriter,
-                                                         boolean isQueryAgainstView) {
-        if (srcPr == null && targetPr == null) {
-            return ConstantOperator.TRUE;
-        }
-
-        ScalarOperator compensationPr;
-        if (targetPr == null) {
-            compensationPr = srcPr;
-        } else if (srcPr == null) {
-            return null;
-        } else {
-            // swap column by query EC
-            ScalarOperator swappedSrcPr;
-            ScalarOperator swappedTargetPr;
-            if (isQueryAgainstView) {
-                // for query
-                swappedSrcPr = columnRewriter.rewriteByQueryEc(srcPr.clone());
-                // for view, swap column by relation mapping and query ec
-                swappedTargetPr = columnRewriter.rewriteViewToQueryWithQueryEc(targetPr.clone());
-            } else {
-                // for view
-                swappedSrcPr = columnRewriter.rewriteViewToQueryWithViewEc(srcPr.clone());
-                // for query
-                swappedTargetPr = columnRewriter.rewriteByViewEc(targetPr.clone());
-            }
-            ScalarOperator canonizedSrcPr = MvUtils.canonizePredicateForRewrite(swappedSrcPr);
-            ScalarOperator canonizedTargetPr = MvUtils.canonizePredicateForRewrite(swappedTargetPr);
-            compensationPr = getCompensationRangePredicate(canonizedSrcPr, canonizedTargetPr);
-        }
-        return MvUtils.canonizePredicate(compensationPr);
     }
 
     private ScalarOperator getCompensationRangePredicate(ScalarOperator srcPr, ScalarOperator targetPr) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -28,10 +28,8 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.LiteralExpr;
-import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
@@ -39,7 +37,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
-import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
@@ -49,9 +46,6 @@ import com.starrocks.connector.PartitionUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
-import com.starrocks.sql.analyzer.RelationFields;
-import com.starrocks.sql.analyzer.RelationId;
-import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
@@ -84,7 +78,6 @@ import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.RuleType;
-import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
@@ -95,7 +88,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -706,74 +698,6 @@ public class MvUtils {
         return mergedRanges;
     }
 
-    private static List<ScalarOperator> compensatePartitionPredicateForOlapScan(LogicalOlapScanOperator olapScanOperator,
-                                                                                ColumnRefFactory columnRefFactory) {
-        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
-        Preconditions.checkState(olapScanOperator.getTable().isNativeTableOrMaterializedView());
-        OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
-
-        if (olapTable.getPartitionInfo() instanceof SinglePartitionInfo) {
-            return partitionPredicates;
-        }
-
-        if (olapScanOperator.getSelectedPartitionId() != null
-                && olapScanOperator.getSelectedPartitionId().size() == olapTable.getPartitions().size()) {
-            return partitionPredicates;
-        }
-
-        if (olapTable.getPartitionInfo() instanceof ExpressionRangePartitionInfo) {
-            ExpressionRangePartitionInfo partitionInfo =
-                    (ExpressionRangePartitionInfo) olapTable.getPartitionInfo();
-            Expr partitionExpr = partitionInfo.getPartitionExprs().get(0);
-            List<SlotRef> slotRefs = Lists.newArrayList();
-            partitionExpr.collect(SlotRef.class, slotRefs);
-            Preconditions.checkState(slotRefs.size() == 1);
-            Optional<ColumnRefOperator> partitionColumn =
-                    olapScanOperator.getColRefToColumnMetaMap().keySet().stream()
-                            .filter(columnRefOperator -> columnRefOperator.getName()
-                                    .equals(slotRefs.get(0).getColumnName()))
-                            .findFirst();
-            if (!partitionColumn.isPresent()) {
-                return null;
-            }
-            ExpressionMapping mapping =
-                    new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()));
-            mapping.put(slotRefs.get(0), partitionColumn.get());
-            ScalarOperator partitionScalarOperator =
-                    SqlToScalarOperatorTranslator.translate(partitionExpr, mapping, columnRefFactory);
-            List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
-            for (long pid : olapScanOperator.getSelectedPartitionId()) {
-                selectedRanges.add(partitionInfo.getRange(pid));
-            }
-            List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
-            List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionScalarOperator, mergedRanges);
-            ScalarOperator partitionPredicate = Utils.compoundOr(rangePredicates);
-            partitionPredicates.add(partitionPredicate);
-        } else if (olapTable.getPartitionInfo() instanceof RangePartitionInfo) {
-            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
-            List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
-            if (partitionColumns.size() != 1) {
-                // now do not support more than one partition columns
-                return null;
-            }
-            List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
-            for (long pid : olapScanOperator.getSelectedPartitionId()) {
-                selectedRanges.add(rangePartitionInfo.getRange(pid));
-            }
-            List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
-            ColumnRefOperator partitionColumnRef = olapScanOperator.getColumnReference(partitionColumns.get(0));
-            List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionColumnRef, mergedRanges);
-            ScalarOperator partitionPredicate = Utils.compoundOr(rangePredicates);
-            if (partitionPredicate != null) {
-                partitionPredicates.add(partitionPredicate);
-            }
-        } else {
-            return null;
-        }
-
-        return partitionPredicates;
-    }
-
     private static boolean supportCompensatePartitionPredicateForHiveScan(List<PartitionKey> partitionKeys) {
         for (PartitionKey partitionKey : partitionKeys) {
             // only support one partition column now.
@@ -841,8 +765,7 @@ public class MvUtils {
         for (LogicalScanOperator scanOperator : scanOperators) {
             List<ScalarOperator> partitionPredicate = null;
             if (scanOperator instanceof LogicalOlapScanOperator) {
-                partitionPredicate = compensatePartitionPredicateForOlapScan((LogicalOlapScanOperator) scanOperator,
-                        columnRefFactory);
+                partitionPredicate = ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates();
             } else if (scanOperator instanceof LogicalHiveScanOperator) {
                 partitionPredicate = compensatePartitionPredicateForHiveScan((LogicalHiveScanOperator) scanOperator);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -104,15 +104,17 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                     mvContext, queryTables, queryExpression, queryColumnRefRewriter, queryPredicateSplit, onPredicates);
             MaterializedViewRewriter mvRewriter = getMaterializedViewRewrite(mvRewriteContext);
             OptExpression candidate = mvRewriter.rewrite();
-            if (candidate != null) {
-                candidate = postRewriteMV(context, mvRewriteContext, candidate);
-                if (queryExpression.getGroupExpression() != null) {
-                    int currentRootGroupId = queryExpression.getGroupExpression().getGroup().getId();
-                    mvContext.addMatchedGroup(currentRootGroupId);
-                }
-                results.add(candidate);
-                mvContext.updateMVUsedCount();
+            if (candidate == null) {
+                continue;
             }
+
+            candidate = postRewriteMV(context, mvRewriteContext, candidate);
+            if (queryExpression.getGroupExpression() != null) {
+                int currentRootGroupId = queryExpression.getGroupExpression().getGroup().getId();
+                mvContext.addMatchedGroup(currentRootGroupId);
+            }
+            results.add(candidate);
+            mvContext.updateMVUsedCount();
         }
 
         return results;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -109,6 +109,7 @@ public abstract class StatisticsCollectJob {
             // Normally, if the page cache is enabled, the page cache must be full. Page cache is used for query 
             // acceleration, then page cache is better filled with the user's data. 
             sessionVariable.setUsePageCache(false);
+            sessionVariable.setEnableMaterializedViewRewrite(false);
             context.setExecutor(executor);
             context.setQueryId(UUIDUtil.genUUID());
             context.setStartTime();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -178,14 +178,8 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     partitions=5/5\n" +
                         "     rollup: test_base_part");
 
-        // test union all
         sql("select c1, c3, c2 from test_base_part where c2 < 3000 and c3 < 3000")
-                .contains("UNION")
-                .contains("TABLE: partial_mv_6\n" +
-                        "     PREAGGREGATION: ON\n" +
-                        "     partitions=5/5\n" +
-                        "     rollup: partial_mv_6")
-                .contains("PREDICATES: 9: c2 < 3000, 9: c2 > 1999\n" +
+                .contains("PREDICATES: 2: c2 < 3000\n" +
                         "     partitions=5/5\n" +
                         "     rollup: test_base_part");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -28,7 +28,6 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.planner.MaterializedViewTPCHTest;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -571,7 +570,7 @@ public class PlanTestNoneDBBase {
     }
 
     public static String getFileContent(String fileName) throws Exception {
-        ClassLoader loader = MaterializedViewTPCHTest.class.getClassLoader();
+        ClassLoader loader = PlanTestNoneDBBase.class.getClassLoader();
         System.out.println("file name:" + fileName);
         String content = "";
         try {

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q10.sql
@@ -36,6 +36,6 @@ TOP-N (order by [[39: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{39: sum=sum(39: sum)}] group by [[1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment]] having [null]
             EXCHANGE SHUFFLE[1, 2, 6, 5, 35, 3, 8]
                 AGGREGATE ([LOCAL] aggregate [{39: sum=sum(38: expr)}] group by [[1: c_custkey, 2: c_name, 6: c_acctbal, 5: c_phone, 35: n_name, 3: c_address, 8: c_comment]] having [null]
-                    SCAN (mv[lineitem_mv] columns[88: c_address, 89: c_acctbal, 90: c_comment, 92: c_name, 94: c_phone, 102: l_returnflag, 107: o_custkey, 108: o_orderdate, 121: l_saleprice, 127: n_name2] predicate[108: o_orderdate >= 1994-05-01 AND 108: o_orderdate < 1994-08-01 AND 102: l_returnflag = R AND 108: o_orderdate >= 1994-01-01 AND 108: o_orderdate < 1995-01-01])
+                    SCAN (mv[lineitem_mv] columns[69: c_address, 70: c_acctbal, 71: c_comment, 73: c_name, 75: c_phone, 83: l_returnflag, 88: o_custkey, 89: o_orderdate, 102: l_saleprice, 108: n_name2] predicate[89: o_orderdate >= 1994-05-01 AND 89: o_orderdate < 1994-08-01 AND 83: l_returnflag = R])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q14.sql
@@ -15,7 +15,7 @@ where
 [result]
 AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(28: sum), 29: sum=sum(29: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
-        AGGREGATE ([LOCAL] aggregate [{28: sum=sum(if(102: p_type LIKE PROMO%, 106: l_saleprice, 0)), 29: sum=sum(27: expr)}] group by [[]] having [null]
-            SCAN (mv[lineitem_mv] columns[88: l_shipdate, 102: p_type, 106: l_saleprice] predicate[88: l_shipdate >= 1997-02-01 AND 88: l_shipdate < 1997-03-01 AND 88: l_shipdate >= 1997-01-01 AND 88: l_shipdate < 1998-01-01])
+        AGGREGATE ([LOCAL] aggregate [{28: sum=sum(if(83: p_type LIKE PROMO%, 87: l_saleprice, 0)), 29: sum=sum(27: expr)}] group by [[]] having [null]
+            SCAN (mv[lineitem_mv] columns[69: l_shipdate, 83: p_type, 87: l_saleprice] predicate[69: l_shipdate >= 1997-02-01 AND 69: l_shipdate < 1997-03-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15-1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15-1.sql
@@ -16,7 +16,7 @@ from
 AGGREGATE ([GLOBAL] aggregate [{19: max=max(19: max)}] group by [[]] having [null]
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{19: max=max(18: sum)}] group by [[]] having [null]
-            AGGREGATE ([GLOBAL] aggregate [{110: sum=sum(33: sum_disc_price)}] group by [[24: l_suppkey]] having [null]
-                SCAN (mv[lineitem_agg_mv2] columns[24: l_suppkey, 25: l_shipdate, 33: sum_disc_price] predicate[25: l_shipdate >= 1995-07-01 AND 25: l_shipdate < 1995-10-01 AND 25: l_shipdate >= 1995-01-01 AND 25: l_shipdate < 1996-01-01])
+            AGGREGATE ([GLOBAL] aggregate [{107: sum=sum(102: sum_disc_price)}] group by [[93: l_suppkey]] having [null]
+                SCAN (mv[lineitem_agg_mv2] columns[93: l_suppkey, 94: l_shipdate, 102: sum_disc_price] predicate[94: l_shipdate >= 1995-07-01 AND 94: l_shipdate < 1995-10-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15-2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15-2.sql
@@ -37,19 +37,19 @@ TOP-N (order by [[19: s_suppkey ASC NULLS FIRST]])
             SCAN (table[supplier] columns[19: s_suppkey, 20: s_name, 21: s_address, 23: s_phone] predicate[null])
             EXCHANGE SHUFFLE[30]
                 INNER JOIN (join-predicate [43: sum = 62: max] post-join-predicate [null])
-                    AGGREGATE ([GLOBAL] aggregate [{167: sum=sum(167: sum)}] group by [[68: l_suppkey]] having [167: sum IS NOT NULL]
-                        EXCHANGE SHUFFLE[68]
-                            AGGREGATE ([LOCAL] aggregate [{167: sum=sum(77: sum_disc_price)}] group by [[68: l_suppkey]] having [null]
-                                SCAN (mv[lineitem_agg_mv2] columns[68: l_suppkey, 69: l_shipdate, 77: sum_disc_price] predicate[69: l_shipdate <= 1995-03-31 AND 69: l_shipdate >= 1995-01-01 AND 69: l_shipdate < 1996-01-01])
+                    AGGREGATE ([GLOBAL] aggregate [{167: sum=sum(167: sum)}] group by [[152: l_suppkey]] having [167: sum IS NOT NULL]
+                        EXCHANGE SHUFFLE[152]
+                            AGGREGATE ([LOCAL] aggregate [{167: sum=sum(161: sum_disc_price)}] group by [[152: l_suppkey]] having [null]
+                                SCAN (mv[lineitem_agg_mv2] columns[152: l_suppkey, 153: l_shipdate, 161: sum_disc_price] predicate[153: l_shipdate <= 1995-03-31 AND 153: l_shipdate >= 1995-01-01])
                     EXCHANGE BROADCAST
                         PREDICATE 62: max IS NOT NULL
                             ASSERT LE 1
                                 AGGREGATE ([GLOBAL] aggregate [{62: max=max(62: max)}] group by [[]] having [null]
                                     EXCHANGE GATHER
                                         AGGREGATE ([LOCAL] aggregate [{62: max=max(61: sum)}] group by [[]] having [null]
-                                            AGGREGATE ([GLOBAL] aggregate [{168: sum=sum(168: sum)}] group by [[68: l_suppkey]] having [null]
-                                                EXCHANGE SHUFFLE[68]
-                                                    AGGREGATE ([LOCAL] aggregate [{168: sum=sum(77: sum_disc_price)}] group by [[68: l_suppkey]] having [null]
-                                                        SCAN (mv[lineitem_agg_mv2] columns[68: l_suppkey, 69: l_shipdate, 77: sum_disc_price] predicate[69: l_shipdate <= 1995-03-31 AND 69: l_shipdate >= 1995-01-01 AND 69: l_shipdate < 1996-01-01])
+                                            AGGREGATE ([GLOBAL] aggregate [{168: sum=sum(168: sum)}] group by [[152: l_suppkey]] having [null]
+                                                EXCHANGE SHUFFLE[152]
+                                                    AGGREGATE ([LOCAL] aggregate [{168: sum=sum(161: sum_disc_price)}] group by [[152: l_suppkey]] having [null]
+                                                        SCAN (mv[lineitem_agg_mv2] columns[152: l_suppkey, 153: l_shipdate, 161: sum_disc_price] predicate[153: l_shipdate <= 1995-03-31 AND 153: l_shipdate >= 1995-01-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q15.sql
@@ -43,19 +43,19 @@ TOP-N (order by [[1: s_suppkey ASC NULLS FIRST]])
             SCAN (table[supplier] columns[1: s_suppkey, 2: s_name, 3: s_address, 5: s_phone] predicate[null])
             EXCHANGE SHUFFLE[12]
                 INNER JOIN (join-predicate [25: sum = 44: max] post-join-predicate [null])
-                    AGGREGATE ([GLOBAL] aggregate [{148: sum=sum(148: sum)}] group by [[50: l_suppkey]] having [148: sum IS NOT NULL]
-                        EXCHANGE SHUFFLE[50]
-                            AGGREGATE ([LOCAL] aggregate [{148: sum=sum(59: sum_disc_price)}] group by [[50: l_suppkey]] having [null]
-                                SCAN (mv[lineitem_agg_mv2] columns[50: l_suppkey, 51: l_shipdate, 59: sum_disc_price] predicate[51: l_shipdate >= 1995-07-01 AND 51: l_shipdate < 1995-10-01 AND 51: l_shipdate >= 1995-01-01 AND 51: l_shipdate < 1996-01-01])
+                    AGGREGATE ([GLOBAL] aggregate [{148: sum=sum(148: sum)}] group by [[134: l_suppkey]] having [148: sum IS NOT NULL]
+                        EXCHANGE SHUFFLE[134]
+                            AGGREGATE ([LOCAL] aggregate [{148: sum=sum(143: sum_disc_price)}] group by [[134: l_suppkey]] having [null]
+                                SCAN (mv[lineitem_agg_mv2] columns[134: l_suppkey, 135: l_shipdate, 143: sum_disc_price] predicate[135: l_shipdate >= 1995-07-01 AND 135: l_shipdate < 1995-10-01])
                     EXCHANGE BROADCAST
                         PREDICATE 44: max IS NOT NULL
                             ASSERT LE 1
                                 AGGREGATE ([GLOBAL] aggregate [{44: max=max(44: max)}] group by [[]] having [null]
                                     EXCHANGE GATHER
                                         AGGREGATE ([LOCAL] aggregate [{44: max=max(43: sum)}] group by [[]] having [null]
-                                            AGGREGATE ([GLOBAL] aggregate [{149: sum=sum(149: sum)}] group by [[50: l_suppkey]] having [null]
-                                                EXCHANGE SHUFFLE[50]
-                                                    AGGREGATE ([LOCAL] aggregate [{149: sum=sum(59: sum_disc_price)}] group by [[50: l_suppkey]] having [null]
-                                                        SCAN (mv[lineitem_agg_mv2] columns[50: l_suppkey, 51: l_shipdate, 59: sum_disc_price] predicate[51: l_shipdate >= 1995-07-01 AND 51: l_shipdate < 1995-10-01 AND 51: l_shipdate >= 1995-01-01 AND 51: l_shipdate < 1996-01-01])
+                                            AGGREGATE ([GLOBAL] aggregate [{149: sum=sum(149: sum)}] group by [[134: l_suppkey]] having [null]
+                                                EXCHANGE SHUFFLE[134]
+                                                    AGGREGATE ([LOCAL] aggregate [{149: sum=sum(143: sum_disc_price)}] group by [[134: l_suppkey]] having [null]
+                                                        SCAN (mv[lineitem_agg_mv2] columns[134: l_suppkey, 135: l_shipdate, 143: sum_disc_price] predicate[135: l_shipdate >= 1995-07-01 AND 135: l_shipdate < 1995-10-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q3.sql
@@ -27,6 +27,6 @@ TOP-N (order by [[35: sum DESC NULLS LAST, 10: o_orderdate ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{35: sum=sum(35: sum)}] group by [[19: l_orderkey, 10: o_orderdate, 16: o_shippriority]] having [null]
             EXCHANGE SHUFFLE[19, 10, 16]
                 AGGREGATE ([LOCAL] aggregate [{35: sum=sum(34: expr)}] group by [[19: l_orderkey, 10: o_orderdate, 16: o_shippriority]] having [null]
-                    SCAN (mv[lineitem_mv] columns[72: c_mktsegment, 79: l_orderkey, 84: l_shipdate, 89: o_orderdate, 92: o_shippriority, 102: l_saleprice] predicate[72: c_mktsegment = HOUSEHOLD AND 89: o_orderdate < 1995-03-11 AND 84: l_shipdate > 1995-03-11 AND 89: o_orderdate >= 1992-01-01 AND 89: o_orderdate < 1996-01-01 AND 84: l_shipdate >= 1995-01-01 AND 84: l_shipdate < 1999-01-01])
+                    SCAN (mv[lineitem_mv] columns[53: c_mktsegment, 60: l_orderkey, 65: l_shipdate, 70: o_orderdate, 73: o_shippriority, 83: l_saleprice] predicate[53: c_mktsegment = HOUSEHOLD AND 70: o_orderdate < 1995-03-11 AND 65: l_shipdate > 1995-03-11])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q4.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q4.sql
@@ -23,9 +23,9 @@ order by
 [result]
 TOP-N (order by [[6: o_orderpriority ASC NULLS FIRST]])
     TOP-N (order by [[6: o_orderpriority ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{119: count=sum(119: count)}] group by [[53: o_orderpriority]] having [null]
-            EXCHANGE SHUFFLE[53]
-                AGGREGATE ([LOCAL] aggregate [{119: count=sum(54: order_count)}] group by [[53: o_orderpriority]] having [null]
-                    SCAN (mv[query4_mv] columns[52: o_orderdate, 53: o_orderpriority, 54: order_count] predicate[52: o_orderdate >= 1994-09-01 AND 52: o_orderdate < 1994-12-01 AND 52: o_orderdate >= 1994-01-01 AND 52: o_orderdate < 1995-01-01])
+        AGGREGATE ([GLOBAL] aggregate [{115: count=sum(115: count)}] group by [[113: o_orderpriority]] having [null]
+            EXCHANGE SHUFFLE[113]
+                AGGREGATE ([LOCAL] aggregate [{115: count=sum(114: order_count)}] group by [[113: o_orderpriority]] having [null]
+                    SCAN (mv[query4_mv] columns[112: o_orderdate, 113: o_orderpriority, 114: order_count] predicate[112: o_orderdate >= 1994-09-01 AND 112: o_orderdate < 1994-12-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q7.sql
@@ -41,9 +41,9 @@ order by
 [result]
 TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
     TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{243: sum=sum(243: sum)}] group by [[68: n_name1, 69: n_name2, 70: l_shipyear]] having [null]
-            EXCHANGE SHUFFLE[68, 69, 70]
-                AGGREGATE ([LOCAL] aggregate [{243: sum=sum(71: sum_saleprice)}] group by [[68: n_name1, 69: n_name2, 70: l_shipyear]] having [null]
-                    SCAN (mv[lineitem_mv_agg_mv2] columns[67: l_shipdate, 68: n_name1, 69: n_name2, 70: l_shipyear, 71: sum_saleprice] predicate[67: l_shipdate <= 1996-12-31 AND 67: l_shipdate >= 1995-01-01 AND 67: l_shipdate < 1997-01-01 AND 68: n_name1 = CANADA AND 69: n_name2 = IRAN OR 68: n_name1 = IRAN AND 69: n_name2 = CANADA AND 68: n_name1 IN (CANADA, IRAN) AND 69: n_name2 IN (IRAN, CANADA)])
+        AGGREGATE ([GLOBAL] aggregate [{368: sum=sum(368: sum)}] group by [[142: n_name1, 143: n_name2, 144: l_shipyear]] having [null]
+            EXCHANGE SHUFFLE[142, 143, 144]
+                AGGREGATE ([LOCAL] aggregate [{368: sum=sum(145: sum_saleprice)}] group by [[142: n_name1, 143: n_name2, 144: l_shipyear]] having [null]
+                    SCAN (mv[lineitem_mv_agg_mv2] columns[141: l_shipdate, 142: n_name1, 143: n_name2, 144: l_shipyear, 145: sum_saleprice] predicate[141: l_shipdate <= 1996-12-31 AND 141: l_shipdate >= 1995-01-01 AND 142: n_name1 = CANADA AND 143: n_name2 = IRAN OR 142: n_name1 = IRAN AND 143: n_name2 = CANADA AND 142: n_name1 IN (CANADA, IRAN) AND 143: n_name2 IN (IRAN, CANADA)])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q8.sql
@@ -42,6 +42,6 @@ TOP-N (order by [[61: year ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{65: sum=sum(65: sum), 64: sum=sum(64: sum)}] group by [[61: year]] having [null]
             EXCHANGE SHUFFLE[61]
                 AGGREGATE ([LOCAL] aggregate [{65: sum=sum(62: expr), 64: sum=sum(63: case)}] group by [[61: year]] having [null]
-                    SCAN (mv[lineitem_mv] columns[135: o_orderdate, 144: p_type, 148: l_saleprice, 151: o_orderyear, 152: n_name1, 157: r_name2] predicate[135: o_orderdate <= 1996-12-31 AND 144: p_type = ECONOMY ANODIZED STEEL AND 157: r_name2 = MIDDLE EAST AND 135: o_orderdate >= 1995-01-01 AND 135: o_orderdate < 1997-01-01])
+                    SCAN (mv[lineitem_mv] columns[116: o_orderdate, 125: p_type, 129: l_saleprice, 132: o_orderyear, 133: n_name1, 138: r_name2] predicate[116: o_orderdate <= 1996-12-31 AND 125: p_type = ECONOMY ANODIZED STEEL AND 138: r_name2 = MIDDLE EAST AND 116: o_orderdate >= 1995-01-01])
 [end]
 


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required):

  - Split `tryRewrite` to `rewriteViewDelta` and `rewriteCompelete`.
  - Optimize compensatePartitionPredicateForOlapScan to use getPrunedPartitionPredicates instead.
  - Disable mv rewrite for statics colloctor.

TODO:
- Optimize external table's compensatePartitionPredicateForOlapScan like olap table.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
