### PR TITLE
[Enhancement] Add back pressure to OlapTableSink when too many memtable need flush

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -355,6 +355,7 @@ CONF_Int64(load_data_reserve_hours, "4");
 // log error log will be removed after this time
 CONF_mInt64(load_error_log_reserve_hours, "48");
 CONF_Int32(number_tablet_writer_threads, "16");
+CONF_mInt64(max_queueing_memtable_per_tablet, "2");
 
 // delta writer hang after this time, be will exit since storage is in error state
 CONF_Int32(be_exit_after_disk_write_hang_second, "60");

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -667,6 +667,7 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
     if (closure->result.has_execution_time_us()) {
         _add_batch_counter.add_batch_execution_time_us += closure->result.execution_time_us();
         _add_batch_counter.add_batch_wait_lock_time_us += closure->result.wait_lock_time_us();
+        _add_batch_counter.add_batch_wait_memtable_flush_time_us += closure->result.wait_memtable_flush_time_us();
         _add_batch_counter.add_batch_num++;
     }
 
@@ -964,6 +965,7 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     _compress_timer = ADD_CHILD_TIMER(_profile, "CompressTime", "SendRpcTime");
     _client_rpc_timer = ADD_TIMER(_profile, "RpcClientSideTime");
     _server_rpc_timer = ADD_TIMER(_profile, "RpcServerSideTime");
+    _server_wait_flush_timer = ADD_TIMER(_profile, "RpcServerWaitFlushTime");
 
     _schema = std::make_shared<OlapTableSchemaParam>();
     RETURN_IF_ERROR(_schema->init(table_sink.schema));
@@ -1837,16 +1839,19 @@ Status OlapTableSink::close_wait(RuntimeState* state, Status close_status) {
         COUNTER_SET(_send_rpc_timer, actual_consume_ns);
 
         int64_t total_server_rpc_time_us = 0;
+        int64_t total_server_wait_memtable_flush_time_us = 0;
         // print log of add batch time of all node, for tracing load performance easily
         std::stringstream ss;
         ss << "Olap table sink statistics. load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
            << ", add chunk time(ms)/wait lock time(ms)/num: ";
         for (auto const& pair : node_add_batch_counter_map) {
             total_server_rpc_time_us += pair.second.add_batch_execution_time_us;
+            total_server_wait_memtable_flush_time_us += pair.second.add_batch_wait_memtable_flush_time_us;
             ss << "{" << pair.first << ":(" << (pair.second.add_batch_execution_time_us / 1000) << ")("
                << (pair.second.add_batch_wait_lock_time_us / 1000) << ")(" << pair.second.add_batch_num << ")} ";
         }
         _server_rpc_timer->update(total_server_rpc_time_us * 1000);
+        _server_wait_flush_timer->update(total_server_wait_memtable_flush_time_us * 1000);
         LOG(INFO) << ss.str();
     } else {
         COUNTER_SET(_input_rows_counter, _number_input_rows);

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -83,11 +83,14 @@ struct AddBatchCounter {
     int64_t add_batch_num = 0;
     // total time of client rpc
     int64_t client_prc_time_us = 0;
+    // total time of wait memtable flush
+    int64_t add_batch_wait_memtable_flush_time_us = 0;
 
     AddBatchCounter& operator+=(const AddBatchCounter& rhs) {
         add_batch_execution_time_us += rhs.add_batch_execution_time_us;
         add_batch_wait_lock_time_us += rhs.add_batch_wait_lock_time_us;
         add_batch_num += rhs.add_batch_num;
+        add_batch_wait_memtable_flush_time_us += rhs.add_batch_wait_memtable_flush_time_us;
         return *this;
     }
     friend AddBatchCounter operator+(const AddBatchCounter& lhs, const AddBatchCounter& rhs) {
@@ -472,6 +475,7 @@ private:
     RuntimeProfile::Counter* _client_rpc_timer = nullptr;
     RuntimeProfile::Counter* _server_rpc_timer = nullptr;
     RuntimeProfile::Counter* _alloc_auto_increment_timer = nullptr;
+    RuntimeProfile::Counter* _server_wait_flush_timer = nullptr;
 
     // load mem limit is for remote load channel
     int64_t _load_mem_limit = 0;

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -118,6 +118,7 @@ void LocalTabletsChannel::add_segment(brpc::Controller* cntl, const PTabletWrite
 void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request,
                                     PTabletWriterAddBatchResult* response) {
     auto t0 = std::chrono::steady_clock::now();
+    int64_t wait_memtable_flush_time_us = 0;
 
     if (UNLIKELY(!request.has_sender_id())) {
         response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
@@ -215,6 +216,19 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         auto it = _delta_writers.find(tablet_id);
         DCHECK(it != _delta_writers.end());
         auto& delta_writer = it->second;
+
+        // back pressure OlapTableSink since there are too many memtables need to flush
+        while (delta_writer->get_flush_stats().queueing_memtable_num >= config::max_queueing_memtable_per_tablet) {
+            auto t1 = std::chrono::steady_clock::now();
+            if (std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000 > request.timeout_ms()) {
+                LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
+                          << " wait tablet " << tablet_id << " flush memtable " << request.timeout_ms()
+                          << "ms still has queueing num " << delta_writer->get_flush_stats().queueing_memtable_num;
+                break;
+            }
+            bthread_usleep(10000); // 10ms
+            wait_memtable_flush_time_us += 10000;
+        }
 
         AsyncDeltaWriterRequest req;
         req.chunk = chunk;
@@ -350,6 +364,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     response->set_execution_time_us(last_execution_time_us +
                                     std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
     response->set_wait_lock_time_us(0); // We didn't measure the lock wait time, just give the caller a fake time
+    response->set_wait_memtable_flush_time_us(wait_memtable_flush_time_us);
 }
 
 void LocalTabletsChannel::_commit_tablets(const PTabletWriterAddChunkRequest& request,

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -90,6 +90,8 @@ public:
 
     const std::vector<PNetworkAddress>& replicas() const { return _writer->replicas(); }
 
+    const FlushStatistic& get_flush_stats() const { return _writer->get_flush_stats(); }
+
 private:
     struct private_type {
         explicit private_type(int) {}

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -20,6 +20,7 @@
 #include "gen_cpp/internal_service.pb.h"
 #include "gen_cpp/olap_common.pb.h"
 #include "gutil/macros.h"
+#include "storage/memtable_flush_executor.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/segment_flush_executor.h"
 #include "storage/tablet.h"
@@ -144,6 +145,8 @@ public:
     State get_state() const;
 
     Status get_err_status() const;
+
+    const FlushStatistic& get_flush_stats() const { return _flush_token->get_stats(); }
 
 private:
     DeltaWriter(DeltaWriterOptions opt, MemTracker* parent, StorageEngine* storage_engine);

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -51,6 +51,7 @@ public:
     ~MemtableFlushTask() override = default;
 
     void run() override {
+        _flush_token->_stats.queueing_memtable_num--;
         std::unique_ptr<SegmentPB> segment = nullptr;
         if (_memtable) {
             SCOPED_THREAD_LOCAL_MEM_SETTER(_memtable->mem_tracker(), false);
@@ -99,6 +100,7 @@ Status FlushToken::submit(std::unique_ptr<MemTable> memtable, bool eos,
     // Does not acount the size of MemtableFlushTask into any memory tracker
     SCOPED_THREAD_LOCAL_MEM_SETTER(nullptr, false);
     auto task = std::make_shared<MemtableFlushTask>(this, std::move(memtable), eos, std::move(cb));
+    _stats.queueing_memtable_num++;
     return _flush_token->submit(std::move(task));
 }
 

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -57,6 +57,7 @@ struct FlushStatistic {
     int64_t flush_count = 0;
     int64_t flush_size_bytes = 0;
     int64_t cur_flush_count = 0;
+    std::atomic<int64_t> queueing_memtable_num = 0;
 };
 
 std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -236,6 +236,7 @@ message PTabletWriterAddBatchResult {
     optional int64 execution_time_us = 3;
     optional int64 wait_lock_time_us = 4;
     repeated PTabletInfo failed_tablet_vec = 5;
+    optional int64 wait_memtable_flush_time_us = 6;
 };
 
 message PTabletWriterAddSegmentRequest {


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Now, storage engine only back pressure  to OlapTableSink when memtable runout load memory(limit by `load_process_max_memory_limit_percent`).
So that we add `max_queueing_memtable_per_tablet` to avoid too many memtable runout load memory.
The test found that the performance of data ingestion did not decrease when the peak memory usage was greatly reduced.

### main
type:broker_load    table:clickbench    key_type:duplicate    data_type:csv    bucket:15    concurrency:24    time_cost(s):84
type:broker_load    table:clickbench    key_type:duplicate    data_type:csv    bucket:60    concurrency:24    time_cost(s):85
peak load memory usage: 13G

### new
type:broker_load    table:clickbench    key_type:duplicate    data_type:csv    bucket:15    concurrency:24    time_cost(s):82
type:broker_load    table:clickbench    key_type:duplicate    data_type:csv    bucket:60    concurrency:24    time_cost(s):83
peak load memory usage: 5G

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
