### PR TITLE
[BugFix][Cherry-pick][Branch-2.5] Fix the loss of bucket info after disable the dynamic partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -285,11 +285,6 @@ public class DynamicPartitionUtil {
             checkBuckets(bucketsValue);
             properties.remove(DynamicPartitionProperty.BUCKETS);
             analyzedProperties.put(DynamicPartitionProperty.BUCKETS, bucketsValue);
-        } else {
-            String bucketsValue = "0";
-            checkBuckets(bucketsValue);
-            properties.remove(DynamicPartitionProperty.BUCKETS);
-            analyzedProperties.put(DynamicPartitionProperty.BUCKETS, bucketsValue);
         }
         if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
             String enableValue = properties.get(DynamicPartitionProperty.ENABLE);
@@ -412,10 +407,14 @@ public class DynamicPartitionUtil {
             TableProperty tableProperty = olapTable.getTableProperty();
             if (tableProperty != null) {
                 tableProperty.modifyTableProperties(dynamicPartitionProperties);
-                tableProperty.buildDynamicProperty();
             } else {
-                olapTable.setTableProperty(new TableProperty(dynamicPartitionProperties).buildDynamicProperty());
+                tableProperty = new TableProperty(dynamicPartitionProperties);
+                olapTable.setTableProperty(tableProperty);
             }
+            if (!tableProperty.getProperties().containsKey(DynamicPartitionProperty.BUCKETS)) {
+                tableProperty.modifyTableProperties(DynamicPartitionProperty.BUCKETS, "0");
+            }
+            tableProperty.buildDynamicProperty();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -156,6 +156,56 @@ public class CreateTableAutoTabletTest {
     }
 
     @Test
+    public void test1AutoTabletWithModifyDynamicPartitionProperty() throws Exception {
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.runSql("db_for_auto_tablets",
+                " CREATE TABLE test_modify_dynamic_partition_property (" +
+                     "    k1 date," +
+                     "    k2 int(11)," +
+                     "    k3 smallint(6)," +
+                     "    v1 varchar(2048)," +
+                     "    v2 datetime" +
+                     "  ) ENGINE=OLAP" +
+                     "  DUPLICATE KEY(k1, k2, k3) " +
+                     "  PARTITION BY RANGE(k1)" +
+                     "  (PARTITION p20230306 VALUES [('2023-03-06'), ('2023-03-07')))" +
+                     "  DISTRIBUTED BY HASH(k2) BUCKETS 10" +
+                     "  PROPERTIES (" +
+                     "   'replication_num' = '1'," +
+                     "   'dynamic_partition.enable' = 'true'," +
+                     "   'dynamic_partition.time_unit' = 'DAY'," +
+                     "   'dynamic_partition.time_zone' = 'Asia/Shanghai'," +
+                     "   'dynamic_partition.start' = '-1'," +
+                     "   'dynamic_partition.end' = '3'," +
+                     "   'dynamic_partition.buckets' = '3'," +
+                     "   'dynamic_partition.prefix' = 'p');");
+        Thread.sleep(1000); // wait for the dynamic partition created
+        Database db = GlobalStateMgr.getCurrentState().getDb("db_for_auto_tablets");
+        if (db == null) {
+            return;
+        }
+
+        OlapTable table = (OlapTable) db.getTable("test_modify_dynamic_partition_property");
+        if (table == null) {
+            return;
+        }
+
+        cluster.runSql("db_for_auto_tablets", "ALTER TABLE test_modify_dynamic_partition_property SET ('dynamic_partition.enable' = 'false')");
+        cluster.runSql("db_for_auto_tablets", "ALTER TABLE test_modify_dynamic_partition_property ADD PARTITION p20230305 VALUES [('2023-03-05'), ('2023-03-06'))");
+        cluster.runSql("db_for_auto_tablets", "ALTER TABLE test_modify_dynamic_partition_property SET ('dynamic_partition.enable' = 'true')");
+
+        int bucketNum = 0;
+        db.readLock();
+        try {
+            Partition partition = table.getPartition("p20230305");
+            bucketNum = partition.getDistributionInfo().getBucketNum();
+        } finally {
+            db.readUnlock();
+        }
+        Assert.assertEquals(bucketNum, 20);
+    }
+
+    @Test
     public void test1AutoTabletWithColocate() throws Exception {
         PseudoCluster cluster = PseudoCluster.getInstance();
         cluster.runSql("db_for_auto_tablets",


### PR DESCRIPTION
If user create table using dynamic partition with dynamic_partition.buckets. After they `SET ('dynamic_partition.enable' = 'true')` the buckets info is lost. The pull request fix this by eliminate the remove the buckets info

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
