### PR TITLE
[BugFix] analyse in be to handle case like percentile_approx(a,1+2)

### DIFF
--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -52,7 +52,12 @@ public:
         DCHECK(!columns[1]->is_null(0));
 
         data(state).percentile->add(implicit_cast<float>(column_value));
-        data(state).targetQuantile = columns[1]->get(0).get_double();
+        double targetQuantile = columns[1]->get(0).get_double();
+        if (targetQuantile < 0 || targetQuantile > 1) {
+            ctx->set_error("agg function percentile_approx's second parameter should be between 0 and 1");
+            return;
+        }
+        data(state).targetQuantile = targetQuantile;
         data(state).is_null = false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -16,13 +16,11 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.starrocks.analysis.DecimalLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.FunctionParams;
 import com.starrocks.analysis.IntLiteral;
-import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.AggregateFunction;
@@ -360,13 +358,6 @@ public class FunctionAnalyzer {
                 throw new SemanticException(
                         "percentile_approx requires the second parameter's type is numeric constant type");
             }
-
-            double rate = ((LiteralExpr) functionCallExpr.getChild(1)).getDoubleValue();
-            if (rate < 0 || rate > 1) {
-                throw new SemanticException(
-                        fnName + " second parameter'value must be between 0 and 1");
-            }
-
             if (functionCallExpr.getChildren().size() == 3) {
                 if (!functionCallExpr.getChild(2).getType().isNumericType() ||
                         !functionCallExpr.getChild(2).isConstant()) {
@@ -389,14 +380,9 @@ public class FunctionAnalyzer {
             if (functionCallExpr.getChildren().size() != 2) {
                 throw new SemanticException(fnName + " requires two parameters");
             }
-            if (!(functionCallExpr.getChild(1) instanceof DecimalLiteral) &&
-                    !(functionCallExpr.getChild(1) instanceof IntLiteral)) {
+            if (!(functionCallExpr.getChild(1).getType().isNumericType()) ||
+                    !(functionCallExpr.getChild(1).isConstant())) {
                 throw new SemanticException(fnName + " 's second parameter's data type is wrong ");
-            }
-            double rate = ((LiteralExpr) functionCallExpr.getChild(1)).getDoubleValue();
-            if (rate < 0 || rate > 1) {
-                throw new SemanticException(
-                        fnName + " second parameter'value should be between 0 and 1");
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -227,10 +227,10 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx(0.5) from tall group by tb");
         analyzeFail("select percentile_approx('c',0.5) from tall group by tb");
         analyzeFail("select percentile_approx(1,'c') from tall group by tb");
-        analyzeFail("select percentile_approx(1,5) from tall group by tb");
         analyzeFail("select percentile_approx(1,1,'c') from tall group by tb");
         analyzeFail("select percentile_approx(1,1,tc) from tall group by tb");
         analyzeFail("select percentile_approx(1,1,0.5,tc) from tall group by tb");
+        analyzeSuccess("select percentile_approx(1,5) from tall group by tb");
         analyzeSuccess("select percentile_approx(1,0.5,1047) from tall group by tb");
         analyzeSuccess("select percentile_disc(tj,0.5) from tall group by tb");
     }

--- a/test/sql/test_agg_function/R/test_percentile
+++ b/test/sql/test_agg_function/R/test_percentile
@@ -1,0 +1,53 @@
+-- name: testPercentileParameter
+CREATE TABLE IF NOT EXISTS `lineorder` (
+    `lo_orderkey` int(11) NOT NULL COMMENT "",
+    `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`lo_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into lineorder values(1,'test');
+-- result:
+-- !result
+SELECT percentile_cont(lo_orderkey, -1) FROM lineorder;
+-- result:
+E: (1064, "percentile_cont/percentile_disc's second parameter should be between 0 and 1")
+-- !result
+SELECT percentile_disc(lo_orderkey, -1) FROM lineorder;
+-- result:
+E: (1064, "percentile_cont/percentile_disc's second parameter should be between 0 and 1")
+-- !result
+SELECT percentile_approx(lo_orderkey, -1) FROM lineorder;
+-- result:
+E: (1064, "agg function percentile_approx's second parameter should be between 0 and 1")
+-- !result
+-- name: testPercentileEmptyTable
+CREATE TABLE IF NOT EXISTS `lineorder` (
+    `lo_orderkey` int(11) NOT NULL COMMENT "",
+    `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`lo_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+SELECT percentile_cont(lo_orderkey, -1) FROM lineorder;
+-- result:
+None
+-- !result
+SELECT percentile_disc(lo_orderkey, -1) FROM lineorder;
+-- result:
+None
+-- !result
+SELECT percentile_approx(lo_orderkey, -1) FROM lineorder;
+-- result:
+None
+-- !result

--- a/test/sql/test_agg_function/T/test_percentile
+++ b/test/sql/test_agg_function/T/test_percentile
@@ -1,0 +1,30 @@
+-- name: testPercentileParameter
+CREATE TABLE IF NOT EXISTS `lineorder` (
+    `lo_orderkey` int(11) NOT NULL COMMENT "",
+    `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`lo_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into lineorder values(1,'test');
+SELECT percentile_cont(lo_orderkey, -1) FROM lineorder;
+SELECT percentile_disc(lo_orderkey, -1) FROM lineorder;
+SELECT percentile_approx(lo_orderkey, -1) FROM lineorder;
+
+-- name: testPercentileEmptyTable
+CREATE TABLE IF NOT EXISTS `lineorder` (
+    `lo_orderkey` int(11) NOT NULL COMMENT "",
+    `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`lo_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+SELECT percentile_cont(lo_orderkey, -1) FROM lineorder;
+SELECT percentile_disc(lo_orderkey, -1) FROM lineorder;
+SELECT percentile_approx(lo_orderkey, -1) FROM lineorder;


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
some agg function need check parameter's value, but if check in fe,  we can't handle case like 1+2 or cast(). this pr also fix percentile_cont/percentile_disc crash when input is an empty table.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3