### PR TITLE
[UT] Forbid decimal fast mul in UT for non-x86_64 target

### DIFF
--- a/be/test/exprs/decimal_binary_function_test.cpp
+++ b/be/test/exprs/decimal_binary_function_test.cpp
@@ -2974,6 +2974,7 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s14_div_decimal128p38s14_eq_
 template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op>
 void test_decimal_fast_mul_help(const DecimalTestCaseArray& test_cases, int lhs_precision, int lhs_scale,
                                 int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
+#if defined(__x86_64__) && defined(__GNUC__)
     test_vector_vector<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
                                                                 rhs_scale, result_precision, result_scale);
     test_vector_const<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
@@ -2990,6 +2991,7 @@ void test_decimal_fast_mul_help(const DecimalTestCaseArray& test_cases, int lhs_
             test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
     test_vector_vector<ResultType, ResultType, ResultType, MulOp, false>(
             test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+#endif
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal_fast_mul_32x32) {
     DecimalTestCaseArray test_cases = {{"0.14", "3348947.24", "468852.6136"},


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/StarRocks/starrocks/issues/22733
Decimal fast multiply only support x86_64 targets, so forbid it in UT for non-X86_64 targets.
## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
