### PR TITLE
[Enhancement] remove some unused memset

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -172,11 +172,17 @@ void append_fixed_length(const Buffer<Slice>& strs, Bytes* bytes, typename Binar
 
     size_t offset = bytes->size();
     bytes->resize(size + copy_length);
-    for (const auto& s : strs) {
-        strings::memcpy_inlined(&(*bytes)[offset], s.data, copy_length);
-        offset += s.size;
-        offsets->emplace_back(offset);
+
+    size_t rows = strs.size();
+    size_t length = offsets->size();
+    raw::stl_vector_resize_uninitialized(offsets, offsets->size() + rows);
+
+    for (size_t i = 0; i < rows; ++i) {
+        memcpy(&(*bytes)[offset], strs[i].get_data(), copy_length);
+        offset += strs[i].get_size();
+        (*offsets)[length++] = offset;
     }
+
     bytes->resize(offset);
 }
 

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -133,9 +133,12 @@ public:
     }
 
     size_t append_numbers(const void* buff, size_t length) override {
+        DCHECK(length % sizeof(ValueType) == 0);
         const size_t count = length / sizeof(ValueType);
-        const T* const ptr = reinterpret_cast<const T*>(buff);
-        _data.insert(_data.end(), ptr, ptr + count);
+        size_t dst_offset = _data.size();
+        raw::stl_vector_resize_uninitialized(&_data, _data.size() + count);
+        T* dst = _data.data() + dst_offset;
+        memcpy(dst, buff, length);
         return count;
     }
 

--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -246,17 +246,18 @@ Status BinaryDictPageDecoder<Type>::next_batch(const SparseRange& range, Column*
     using cast_type = CppTypeTraits<TYPE_INT>::CppType;
     const auto* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
     std::vector<Slice> slices;
-    slices.reserve(nread);
+    raw::stl_vector_resize_uninitialized(&slices, nread);
+
     if constexpr (Type == TYPE_CHAR) {
         for (int i = 0; i < nread; ++i) {
             Slice element = _dict_decoder->string_at_index(codewords[i]);
             // Strip trailing '\x00'
             element.size = strnlen(element.data, element.size);
-            slices.emplace_back(element);
+            slices[i] = element;
         }
     } else {
         for (int i = 0; i < nread; ++i) {
-            slices.emplace_back(_dict_decoder->string_at_index(codewords[i]));
+            slices[i] = _dict_decoder->string_at_index(codewords[i]);
         }
     }
 

--- a/be/src/storage/rowset/dictcode_column_iterator.cpp
+++ b/be/src/storage/rowset/dictcode_column_iterator.cpp
@@ -26,12 +26,12 @@ Status GlobalDictCodeColumnIterator::decode_dict_codes(const Column& codes, Colu
     const auto& code_data = down_cast<const Int32Column*>(ColumnHelper::get_data_column(&codes))->get_data();
     const size_t size = code_data.size();
 
-    LowCardDictColumn::Container* container =
-            &down_cast<LowCardDictColumn*>(ColumnHelper::get_data_column(words))->get_data();
+    auto* low_card = down_cast<LowCardDictColumn*>(ColumnHelper::get_data_column(words));
+    low_card->resize_uninitialized(size);
+    LowCardDictColumn::Container* container = &down_cast<LowCardDictColumn*>(low_card)->get_data();
     bool output_nullable = words->is_nullable();
 
     auto& res_data = *container;
-    res_data.resize(size);
 #ifndef NDEBUG
     for (size_t i = 0; i < size; ++i) {
         DCHECK(code_data[i] <= DICT_DECODE_MAX_SIZE);

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -248,7 +248,7 @@ TEST_F(RowsetMergerTest, horizontal_merge) {
     std::vector<int64_t> pks;
     for (int i = 0; i < num_segment; i++) {
         Int64Column deletes;
-        deletes.append_numbers(segments[i].data(), sizeof(int64_t) * segments[i].size() / 2);
+        deletes.append_numbers(segments[i].data(), sizeof(int64_t) * (segments[i].size() / 2));
         auto rs = create_rowset(_tablet, {}, &deletes);
         ASSERT_TRUE(_tablet->rowset_commit(i + 2 + num_segment, rs).ok());
         rowsets[i + num_segment] = rs;
@@ -297,7 +297,7 @@ TEST_F(RowsetMergerTest, vertical_merge) {
     std::vector<int64_t> pks;
     for (int i = 0; i < num_segment; i++) {
         Int64Column deletes;
-        deletes.append_numbers(segments[i].data(), sizeof(int64_t) * segments[i].size() / 2);
+        deletes.append_numbers(segments[i].data(), sizeof(int64_t) * (segments[i].size() / 2));
         auto rs = create_rowset(_tablet, {}, &deletes);
         ASSERT_TRUE(_tablet->rowset_commit(i + 2 + num_segment, rs).ok());
         rowsets[i + num_segment] = rs;
@@ -310,8 +310,8 @@ TEST_F(RowsetMergerTest, vertical_merge) {
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
     ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
-    writer.non_key_columns.emplace_back(std::move(Int16Column::create_mutable()));
-    writer.non_key_columns.emplace_back(std::move(Int32Column::create_mutable()));
+    writer.non_key_columns.emplace_back(Int16Column::create_mutable());
+    writer.non_key_columns.emplace_back(Int32Column::create_mutable());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
 
     ASSERT_EQ(pks.size(), writer.all_pks->size());
@@ -360,7 +360,7 @@ TEST_F(RowsetMergerTest, horizontal_merge_seq) {
     std::vector<int64_t> pks;
     for (int i = 0; i < num_segment; i++) {
         Int64Column deletes;
-        deletes.append_numbers(segments[i].data(), sizeof(int64_t) * segments[i].size() / 2);
+        deletes.append_numbers(segments[i].data(), sizeof(int64_t) * (segments[i].size() / 2));
         auto rs = create_rowset(_tablet, {}, &deletes);
         ASSERT_TRUE(_tablet->rowset_commit(i + 2 + num_segment, rs).ok());
         rowsets[i + num_segment] = rs;
@@ -408,7 +408,7 @@ TEST_F(RowsetMergerTest, vertical_merge_seq) {
     std::vector<int64_t> pks;
     for (int i = 0; i < num_segment; i++) {
         Int64Column deletes;
-        deletes.append_numbers(segments[i].data(), sizeof(int64_t) * segments[i].size() / 2);
+        deletes.append_numbers(segments[i].data(), sizeof(int64_t) * (segments[i].size() / 2));
         auto rs = create_rowset(_tablet, {}, &deletes);
         ASSERT_TRUE(_tablet->rowset_commit(i + 2 + num_segment, rs).ok());
         rowsets[i + num_segment] = rs;


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):

SSB-SF=100
```
set pipeline_dop=1;
set cbo_enable_low_cardinality_optimize=true;
select count(lo_shipmode) from lineorder;
```
baseline:
![image](https://user-images.githubusercontent.com/34912776/235102491-65214bfa-39cd-4a7c-ac25-50390dff94f5.png)
patched:
![image](https://user-images.githubusercontent.com/34912776/235102516-13a3ce3e-8136-4866-b86b-11ef0a9eeb03.png)

```
set pipeline_dop=1;
set cbo_enable_low_cardinality_optimize=false;
select count(lo_shipmode) from lineorder;
```

  baseline: 1.74s
```
  41.36%  starrocks_be      [.] starrocks::BinaryDictPageDecoder<(starrocks::LogicalType)17>::next_batch
  14.71%  starrocks_be      [.] starrocks::append_fixed_length<unsigned int, 8ul>
   7.67%  starrocks_be      [.] strings::memcpy_inlined
   3.03%  starrocks_be      [.] starrocks::pipeline::PipelineDriverPoller::run_internal
   2.99%  [vdso]            [.] 0x00000000000006e5
   2.77%  libc.so.6         [.] __memmove_evex_unaligned_erms
   1.65%  libc.so.6         [.] pthread_mutex_unlock@@GLIBC_2.2.5
   1.62%  libc.so.6         [.] pthread_mutex_lock@@GLIBC_2.2.5
   1.09%  starrocks_be      [.] starrocks::pipeline::ScanOperator::has_output
   1.03%  libc.so.6         [.] pthread_rwlock_unlock@@GLIBC_2.34
   0.86%  starrocks_be      [.] starrocks::pipeline::ScanOperator::is_finished
```

  patched: 1.14s
```
  32.84%  starrocks_be      [.] starrocks::BinaryDictPageDecoder<(starrocks::LogicalType)17>::next_batch
  22.18%  starrocks_be      [.] starrocks::append_fixed_length<unsigned int, 8ul>
   4.39%  libc.so.6         [.] __memmove_evex_unaligned_erms
   3.10%  [vdso]            [.] 0x00000000000006e5
   3.02%  starrocks_be      [.] starrocks::pipeline::PipelineDriverPoller::run_internal
   2.01%  libc.so.6         [.] pthread_mutex_unlock@@GLIBC_2.2.5
   1.84%  libc.so.6         [.] pthread_mutex_lock@@GLIBC_2.2.5
   1.12%  libc.so.6         [.] pthread_rwlock_unlock@@GLIBC_2.34
   0.84%  starrocks_be      [.] je_tcache_bin_flush_small
   0.81%  starrocks_be      [.] starrocks::pipeline::ScanOperator::has_output
   0.74%  starrocks_be      [.] starrocks::pipeline::ResultSinkOperator::need_input
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
