### PR TITLE
[BugFix] fix delta column read when using bitmap & remove pk column from delta column

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -254,6 +254,10 @@ private:
 
     void _update_stats(RandomAccessFile* rfile);
 
+    //  This function will search and build the segment from delta column group,
+    // and also return the columns's index in this segment if need.
+    StatusOr<std::shared_ptr<Segment>> _get_dcg_segment(uint32_t ucid, int32_t* col_index);
+
 private:
     using RawColumnIterators = std::vector<std::unique_ptr<ColumnIterator>>;
     using ColumnDecoders = std::vector<ColumnDecoder>;
@@ -420,23 +424,36 @@ Status SegmentIterator::_try_to_update_ranges_by_runtime_filter() {
             _opts.stats->raw_rows_read);
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> SegmentIterator::_new_dcg_column_iterator(uint32_t ucid,
-                                                                                    std::string* filename) {
-    // build column iter from delta column group
+StatusOr<std::shared_ptr<Segment>> SegmentIterator::_get_dcg_segment(uint32_t ucid, int32_t* col_index) {
     // iterate dcg from new ver to old ver
     for (const auto& dcg : _dcgs) {
-        int idx = dcg->get_column_idx(ucid);
+        int32_t idx = dcg->get_column_idx(ucid);
         if (idx >= 0) {
             std::string column_file = dcg->column_file(parent_name(_segment->file_name()));
             if (_dcg_segments.count(column_file) == 0) {
                 ASSIGN_OR_RETURN(auto dcg_segment, _segment->new_dcg_segment(*dcg));
                 _dcg_segments[column_file] = dcg_segment;
             }
-            if (filename != nullptr) {
-                *filename = column_file;
+            if (col_index != nullptr) {
+                *col_index = idx;
             }
-            return _dcg_segments[column_file]->new_column_iterator(idx);
+            return _dcg_segments[column_file];
         }
+    }
+    // the column not exist in delta column group
+    return nullptr;
+}
+
+StatusOr<std::unique_ptr<ColumnIterator>> SegmentIterator::_new_dcg_column_iterator(uint32_t ucid,
+                                                                                    std::string* filename) {
+    // build column iter from delta column group
+    int32_t col_index = 0;
+    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(ucid, &col_index));
+    if (dcg_segment != nullptr) {
+        if (filename != nullptr) {
+            *filename = dcg_segment->file_name();
+        }
+        return dcg_segment->new_column_iterator(col_index);
     }
     return nullptr;
 }
@@ -1477,11 +1494,24 @@ Status SegmentIterator::_encode_to_global_id(ScanContext* ctx) {
 Status SegmentIterator::_init_bitmap_index_iterators() {
     DCHECK_EQ(_predicate_columns, _opts.predicates.size());
     _bitmap_index_iterators.resize(ChunkHelper::max_column_id(_schema) + 1, nullptr);
+    std::unordered_map<ColumnId, ColumnUID> cid_2_ucid;
+    for (auto& field : _schema.fields()) {
+        cid_2_ucid[field->id()] = field->uid();
+    }
     for (const auto& pair : _opts.predicates) {
         ColumnId cid = pair.first;
         if (_bitmap_index_iterators[cid] == nullptr) {
-            RETURN_IF_ERROR(
-                    _segment->new_bitmap_index_iterator(cid, &_bitmap_index_iterators[cid], _skip_fill_local_cache()));
+            ColumnUID ucid = cid_2_ucid[cid];
+            // the column's index in this segment file
+            int32_t col_index = 0;
+            ASSIGN_OR_RETURN(std::shared_ptr<Segment> segment_ptr, _get_dcg_segment(ucid, &col_index));
+            if (segment_ptr == nullptr) {
+                // find segment from delta column group failed, using main segment
+                segment_ptr = _segment;
+                col_index = cid;
+            }
+            RETURN_IF_ERROR(segment_ptr->new_bitmap_index_iterator(col_index, &_bitmap_index_iterators[cid],
+                                                                   _skip_fill_local_cache()));
             _has_bitmap_index |= (_bitmap_index_iterators[cid] != nullptr);
         }
     }
@@ -1655,11 +1685,13 @@ void SegmentIterator::close() {
     if (_del_vec) {
         _del_vec.reset();
     }
+    _dcgs.clear();
     _context_list[0].close();
     _context_list[1].close();
     _column_iterators.resize(0);
     _obj_pool.clear();
     _segment.reset();
+    _dcg_segments.clear();
     _column_decoders.clear();
 
     for (auto& [cid, rfile] : _column_files) {

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -93,11 +93,15 @@ void SegmentWriter::_init_column_meta(ColumnMetaPB* meta, uint32_t column_id, co
 }
 
 Status SegmentWriter::init() {
+    return init(true);
+}
+
+Status SegmentWriter::init(bool has_key) {
     std::vector<uint32_t> all_column_indexes;
     for (uint32_t i = 0; i < _tablet_schema->num_columns(); ++i) {
         all_column_indexes.emplace_back(i);
     }
-    return init(all_column_indexes, true);
+    return init(all_column_indexes, has_key);
 }
 
 Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has_key, SegmentFooterPB* footer) {
@@ -205,7 +209,8 @@ Status SegmentWriter::finalize(uint64_t* segment_file_size, uint64_t* index_size
 }
 
 Status SegmentWriter::finalize_columns(uint64_t* index_size) {
-    if (_has_key) {
+    if (_has_key || _num_rows == 0) {
+        // _num_rows == 0 && !_has_key means this segment not contains key columns
         _num_rows = _num_rows_written;
     } else if (_num_rows != _num_rows_written) {
         return Status::InternalError(strings::Substitute("num rows written $0 is not equal to segment num rows $1",

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -98,6 +98,8 @@ public:
 
     Status init();
 
+    Status init(bool has_key);
+
     // Used for vertical compaction
     // footer is used for partial update
     Status init(const std::vector<uint32_t>& column_indexes, bool has_key, SegmentFooterPB* footer = nullptr);

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -96,12 +96,17 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx) {
         pk_columns.push_back((uint32_t)i);
     }
     std::vector<uint32_t> update_columns;
+    std::vector<uint32_t> update_columns_with_keys;
     const auto& txn_meta = rowset->rowset_meta()->get_meta_pb().txn_meta();
     for (uint32_t cid : txn_meta.partial_update_column_ids()) {
-        update_columns.push_back(cid);
+        update_columns_with_keys.push_back(cid);
+        if (cid >= schema.num_key_columns()) {
+            update_columns.push_back(cid);
+        }
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     Schema update_schema = ChunkHelper::convert_schema(schema, update_columns);
+    Schema update_schema_with_keys = ChunkHelper::convert_schema(schema, update_columns_with_keys);
     std::unique_ptr<Column> pk_column;
     if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
         std::string err_msg = fmt::format("create column for primary key encoder failed, tablet_id: {}", _tablet_id);
@@ -116,8 +121,8 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx) {
     // if we want to preload update cache, create chunk with update columns
     if (_enable_preload_column_mode_update_data) {
         _update_chunk_cache[idx] = ChunkHelper::new_chunk(update_schema, DEFAULT_CONTAINER_SIZE);
-        chunk_shared_ptr = ChunkHelper::new_chunk(update_schema, DEFAULT_CONTAINER_SIZE);
-        ASSIGN_OR_RETURN(itrs, rowset->get_update_file_iterators(update_schema, &stats));
+        chunk_shared_ptr = ChunkHelper::new_chunk(update_schema_with_keys, DEFAULT_CONTAINER_SIZE);
+        ASSIGN_OR_RETURN(itrs, rowset->get_update_file_iterators(update_schema_with_keys, &stats));
     } else {
         _update_chunk_cache[idx] = ChunkHelper::new_chunk(update_schema, 0);
         chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, DEFAULT_CONTAINER_SIZE);
@@ -147,8 +152,10 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx) {
             } else {
                 PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
                 if (_enable_preload_column_mode_update_data) {
-                    _memory_usage += chunk->memory_usage();
-                    dest_chunk->append(*chunk);
+                    for (int i = pk_columns.size(); i < update_columns_with_keys.size(); i++) {
+                        _memory_usage += chunk->columns()[i]->byte_size();
+                        dest_chunk->columns()[i - pk_columns.size()]->append(*chunk->columns()[i]);
+                    }
                 }
             }
         }
@@ -335,7 +342,7 @@ StatusOr<std::unique_ptr<SegmentWriter>> RowsetColumnUpdateState::_prepare_delta
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(opts, path));
     SegmentWriterOptions writer_options;
     auto segment_writer = std::make_unique<SegmentWriter>(std::move(wfile), rssid, tschema.get(), writer_options);
-    RETURN_IF_ERROR(segment_writer->init());
+    RETURN_IF_ERROR(segment_writer->init(false));
     return std::move(segment_writer);
 }
 
@@ -422,19 +429,24 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, const P
     RETURN_IF_ERROR(tablet->updates()->get_latest_applied_version(&latest_applied_version));
     RETURN_IF_ERROR(_finalize_partial_update_state(tablet, rowset, latest_applied_version, index));
 
-    std::vector<uint32_t> update_column_ids;
-    std::vector<int32_t> update_column_indexes;
+    std::vector<int32_t> update_column_ids;
+    std::vector<uint32_t> update_column_uids;
     std::vector<uint32_t> unique_update_column_ids;
     const auto& tschema = rowset->schema();
-    for (uint32_t cid : txn_meta.partial_update_column_ids()) {
-        update_column_ids.push_back(cid);
-        update_column_indexes.push_back((int32_t)cid);
+    for (int32_t cid : txn_meta.partial_update_column_ids()) {
+        if (cid >= tschema.num_key_columns()) {
+            update_column_ids.push_back(cid);
+            update_column_uids.push_back((uint32_t)cid);
+        }
     }
     for (uint32_t cid : txn_meta.partial_update_column_unique_ids()) {
-        unique_update_column_ids.push_back(cid);
+        auto& column = tschema.column(cid);
+        if (!column.is_key()) {
+            unique_update_column_ids.push_back(cid);
+        }
     }
-    auto partial_tschema = TabletSchema::create(tschema, update_column_indexes);
-    Schema partial_schema = ChunkHelper::convert_schema(tschema, update_column_ids);
+    auto partial_tschema = TabletSchema::create(tschema, update_column_ids);
+    Schema partial_schema = ChunkHelper::convert_schema(tschema, update_column_uids);
 
     // rss_id -> delta column group writer
     std::map<uint32_t, std::unique_ptr<SegmentWriter>> delta_column_group_writer;
@@ -470,8 +482,10 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, const P
     int64_t total_read_column_from_update_time = 0;
     int64_t total_finalize_dcg_time = 0;
     int64_t total_merge_column_time = 0;
+    int64_t update_rows = 0;
     // 4. read from raw segment file and update file, and generate `.col` files one by one
     for (const auto& each : rss_rowid_to_update_rowid) {
+        update_rows += each.second.size();
         int64_t t1 = MonotonicMillis();
         ASSIGN_OR_RETURN(auto rowsetid_segid, _find_rowset_seg_id(each.first));
         const std::string seg_path = Rowset::segment_file_path(rowset->rowset_path(), rowsetid_segid.unique_rowset_id,
@@ -515,8 +529,9 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, const P
             "avg_finalize_dcg_time(ms):$3 ",
             total_seek_source_segment_time, total_read_column_from_update_time, total_merge_column_time,
             total_finalize_dcg_time);
-    cost_str << strings::Substitute("rss_cnt:$0 update_cnt:$1 column_cnt:$2", rss_rowid_to_update_rowid.size(),
-                                    _partial_update_states.size(), update_column_ids.size());
+    cost_str << strings::Substitute("rss_cnt:$0 update_cnt:$1 column_cnt:$2 update_rows:$3",
+                                    rss_rowid_to_update_rowid.size(), _partial_update_states.size(),
+                                    update_column_ids.size(), update_rows);
 
     LOG(INFO) << "RowsetColumnUpdateState tablet_id: " << tablet->tablet_id() << " finalize cost:" << cost_str.str();
     _finalize_finished = true;

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_bf
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_bf
@@ -1,0 +1,48 @@
+-- name: test_partial_update_bf
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 varchar(50),
+      v3 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1",
+    "bloom_filter_columns" = "v2"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (200, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (300, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (400, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (500, "100", 100, "100", "100");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	100	100	100	100
+200	100	100	100	100
+500	100	100	100	100
+400	100	100	100	100
+300	100	100	100	100
+-- !result
+update tab1 set v2 = "600";
+-- result:
+-- !result
+select count(*) from tab1 where v2 = "600";
+-- result:
+5
+-- !result

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_bitmap
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_bitmap
@@ -1,0 +1,48 @@
+-- name: test_partial_update_bitmap
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 varchar(50),
+      v3 varchar(50),
+      INDEX b2 (v2) USING BITMAP
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (200, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (300, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (400, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (500, "100", 100, "100", "100");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+500	100	100	100	100
+100	100	100	100	100
+300	100	100	100	100
+400	100	100	100	100
+200	100	100	100	100
+-- !result
+update tab1 set v2 = "600";
+-- result:
+-- !result
+select count(*) from tab1 where v2 = "600";
+-- result:
+5
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_bf
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_bf
@@ -1,0 +1,26 @@
+-- name: test_partial_update_bf
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 varchar(50),
+      v3 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1",
+    "bloom_filter_columns" = "v2"
+);
+
+insert into tab1 values (100, "100", 100, "100", "100");
+insert into tab1 values (200, "100", 100, "100", "100");
+insert into tab1 values (300, "100", 100, "100", "100");
+insert into tab1 values (400, "100", 100, "100", "100");
+insert into tab1 values (500, "100", 100, "100", "100");
+
+select * from tab1;
+update tab1 set v2 = "600";
+select count(*) from tab1 where v2 = "600";

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_bitmap
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_bitmap
@@ -1,0 +1,26 @@
+-- name: test_partial_update_bitmap
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 varchar(50),
+      v3 varchar(50),
+      INDEX b2 (v2) USING BITMAP
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into tab1 values (100, "100", 100, "100", "100");
+insert into tab1 values (200, "100", 100, "100", "100");
+insert into tab1 values (300, "100", 100, "100", "100");
+insert into tab1 values (400, "100", 100, "100", "100");
+insert into tab1 values (500, "100", 100, "100", "100");
+
+select * from tab1;
+update tab1 set v2 = "600";
+select count(*) from tab1 where v2 = "600";


### PR DESCRIPTION

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20436

## Problem Summary(Required):
This PR contains two parts:
1. It fix the bug that bitmap on delta column segment not work.
2. It remove the pk column from delta column group when update, to save disk space.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
