### PR TITLE
Feature: Added ClusterName into AuditLog event

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -68,6 +68,10 @@ public class AuditEvent {
     // make them all "public" so that easy to visit.
     @AuditField(value = "Timestamp")
     public long timestamp = -1;
+
+    @AuditField(value = "ClusterName")
+    public String clusterName = "";
+
     @AuditField(value = "Client")
     public String clientIp = "";
     // The original login user
@@ -142,6 +146,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setTimestamp(long timestamp) {
             auditEvent.timestamp = timestamp;
+            return this;
+        }
+
+        public AuditEventBuilder setClusterName(String clustername) {
+            auditEvent.clusterName = clustername;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -316,6 +316,7 @@ public class ConnectProcessor {
         ctx.getAuditEventBuilder().reset();
         ctx.getAuditEventBuilder()
                 .setTimestamp(System.currentTimeMillis())
+                .setClusterName(Config.cluster_name)
                 .setClientIp(ctx.getMysqlChannel().getRemoteHostPortString())
                 .setUser(ctx.getQualifiedUser())
                 .setAuthorizedUser(

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -46,6 +46,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.DeepCopy;
@@ -710,6 +711,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         ctx.getAuditEventBuilder().reset();
         ctx.getAuditEventBuilder()
                 .setTimestamp(System.currentTimeMillis())
+                .setClusterName(Config.cluster_name)
                 .setClientIp(mvContext.getRemoteIp())
                 .setUser(ctx.getQualifiedUser())
                 .setDb(ctx.getDatabase());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.scheduler;
 
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import org.apache.logging.log4j.LogManager;
@@ -32,6 +33,7 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
             ctx.getAuditEventBuilder().reset();
             ctx.getAuditEventBuilder()
                     .setTimestamp(System.currentTimeMillis())
+                    .setClusterName(Config.cluster_name)
                     .setClientIp(context.getRemoteIp())
                     .setUser(ctx.getQualifiedUser())
                     .setDb(ctx.getDatabase())

--- a/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/AuditEventProcessorTest.java
@@ -57,6 +57,7 @@ public class AuditEventProcessorTest {
     public void testAuditEvent() {
         AuditEvent event = new AuditEvent.AuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                 .setTimestamp(System.currentTimeMillis())
+                .setClusterName("test_cluster")
                 .setClientIp("127.0.0.1")
                 .setUser("user1")
                 .setAuthorizedUser("user2")
@@ -86,6 +87,7 @@ public class AuditEventProcessorTest {
             for (int i = 0; i < 10000; i++) {
                 AuditEvent event = new AuditEvent.AuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                         .setTimestamp(System.currentTimeMillis())
+                        .setClusterName("test_cluster")
                         .setClientIp("127.0.0.1")
                         .setUser("user1")
                         .setAuthorizedUser("user2")
@@ -113,6 +115,7 @@ public class AuditEventProcessorTest {
         for (int i = 0; i < 10000; i++) {
             AuditEvent event = new AuditEvent.AuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                     .setTimestamp(System.currentTimeMillis())
+                    .setClusterName("test_cluster")
                     .setClientIp("127.0.0.1")
                     .setUser("user1")
                     .setAuthorizedUser("user2")


### PR DESCRIPTION
Description
===========
Some companies may have more than one StarRocks Cluster, And for manage StarRocks
Metadata, normally have this kind of link, report StarRocks metadata onto one metadata management
centre, So need identify the data coms from which StarRocks clusters

Solution
========
Added one more filed StarRocks cluster name into AuditLogEvent

## What type of PR is this:

- [x] Feature


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

