### PR TITLE
[Enhancement] Add bloom filter for persistent index when doing large data import

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -917,9 +917,10 @@ CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
 CONF_mInt64(max_tmp_l1_num, "10");
 CONF_mBool(enable_parallel_get_and_bf, "false");
-CONF_mInt64(page_shard_read_ratio, "20");
-CONF_mInt64(min_get_kv_thread_num, "1");
-CONF_mInt64(max_get_kv_thread_num, "10");
+CONF_mInt64(min_enable_bf_kv_num, "100000000");
+CONF_mInt32(page_shard_read_ratio, "20");
+CONF_mInt32(min_get_kv_thread_num, "1");
+CONF_mInt32(max_get_kv_thread_num, "10");
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -917,7 +917,6 @@ CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
 CONF_mInt64(max_tmp_l1_num, "10");
 CONF_mBool(enable_parallel_get_and_bf, "false");
-CONF_mInt64(max_kv_num_for_bf, "400000000");
 CONF_mInt64(page_shard_read_ratio, "20");
 CONF_mInt64(min_get_kv_thread_num, "1");
 CONF_mInt64(max_get_kv_thread_num, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -917,9 +917,6 @@ CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
 CONF_mInt64(max_tmp_l1_num, "10");
 CONF_mBool(enable_parallel_get_and_bf, "true");
-CONF_mInt64(min_enable_bf_kv_num, "100000000");
-CONF_mInt32(min_get_kv_thread_num, "1");
-CONF_mInt32(max_get_kv_thread_num, "10");
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -916,6 +916,7 @@ CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
 CONF_mInt64(max_tmp_l1_num, "10");
+CONF_Bool(enable_bloom_filter, "true");
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -916,9 +916,8 @@ CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
 CONF_mInt64(max_tmp_l1_num, "10");
-CONF_mBool(enable_parallel_get_and_bf, "false");
+CONF_mBool(enable_parallel_get_and_bf, "true");
 CONF_mInt64(min_enable_bf_kv_num, "100000000");
-CONF_mInt32(page_shard_read_ratio, "20");
 CONF_mInt32(min_get_kv_thread_num, "1");
 CONF_mInt32(max_get_kv_thread_num, "10");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -916,7 +916,11 @@ CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
 CONF_mInt64(max_tmp_l1_num, "10");
-CONF_Bool(enable_bloom_filter, "true");
+CONF_mBool(enable_parallel_get_and_bf, "false");
+CONF_mInt64(max_kv_num_for_bf, "400000000");
+CONF_mInt64(page_shard_read_ratio, "20");
+CONF_mInt64(min_get_kv_thread_num, "1");
+CONF_mInt64(max_get_kv_thread_num, "10");
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2800,7 +2800,7 @@ Status PersistentIndex::prepare(const EditVersion& version, size_t n) {
     _dump_snapshot = false;
     _flushed = false;
     _version = version;
-    if (config::enable_parallel_get_and_bf && n > _size / 2) {
+    if (config::enable_parallel_get_and_bf && n > _size / 2 && n > config::min_enable_bf_kv_num) {
         _need_bloom_filter = true;
         RETURN_IF_ERROR(ThreadPoolBuilder("get_kv_thread")
                                 .set_min_threads(config::min_get_kv_thread_num)

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2248,8 +2248,6 @@ Status ImmutableIndex::get(size_t n, const Slice* keys, KeysInfo& keys_info, Ind
                 check_keys_info.emplace_back(std::make_pair(key_idx, hash));
             }
         }
-        LOG(INFO) << "L1 total size: " << total_size() << " bloom filter memory usage: " << memory_usage()
-                  << " origin kv size: " << keys_info.size() << ", kv size after filter: " << check_keys_info.size();
         filter = true;
     }
 
@@ -2812,7 +2810,7 @@ Status PersistentIndex::prepare(const EditVersion& version, size_t n) {
                                 .build(&_get_thread_pool));
         LOG(INFO) << "get kv thread num: " << _get_thread_pool->num_threads();
     }
-    _set_error(false);
+    _set_error(false, "");
     return Status::OK();
 }
 
@@ -2962,8 +2960,10 @@ Status PersistentIndex::get_from_one_immutable_index(size_t n, const Slice* keys
     auto st = _l1_vec[idx]->get(n, keys, *keys_info, values, found_keys_info, key_size);
     std::unique_lock<std::mutex> ul(_lock);
     if (!st.ok()) {
-        LOG(WARNING) << "get failed:" << st.to_string();
-        _set_error(true);
+        std::string msg =
+                strings::Substitute("get from one immutableindex failed, l1 idx: $0, status: $1", idx, st.to_string());
+        LOG(ERROR) << msg;
+        _set_error(true, msg);
     }
     _running_get_task--;
     if (_running_get_task == 0) {
@@ -2982,6 +2982,7 @@ Status PersistentIndex::_get_from_immutable_index_parallel(size_t n, const Slice
 
     std::unique_lock<std::mutex> ul(_lock);
     std::map<size_t, KeysInfo>::iterator iter;
+    std::string error_msg;
     for (iter = keys_info_by_key_size.begin(); iter != keys_info_by_key_size.end(); iter++) {
         if (iter->second.size() == 0) {
             break;
@@ -2995,15 +2996,16 @@ Status PersistentIndex::_get_from_immutable_index_parallel(size_t n, const Slice
             std::shared_ptr<Runnable> r(std::make_shared<GetFromImmutableIndexTask>(task));
             auto st = _get_thread_pool->submit(std::move(r));
             if (!st.ok()) {
-                LOG(WARNING) << "get from immutable index failed: " << st.to_string();
+                error_msg = strings::Substitute("get from immutable index failed: $0", st.to_string());
+                LOG(ERROR) << error_msg;
                 return st;
             }
             _running_get_task++;
         }
         _get_task_finished.wait(ul, [&] { return _running_get_task == 0; });
         if (is_error()) {
-            LOG(WARNING) << "get from immutable index failed";
-            return Status::InternalError("get failed");
+            LOG(ERROR) << _error_msg;
+            return Status::InternalError(_error_msg);
         }
 
         // wait all task finished

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2800,7 +2800,7 @@ Status PersistentIndex::prepare(const EditVersion& version, size_t n) {
     _dump_snapshot = false;
     _flushed = false;
     _version = version;
-    if (config::enable_parallel_get_and_bf && n > config::max_kv_num_for_bf) {
+    if (config::enable_parallel_get_and_bf && n > _size / 2) {
         _need_bloom_filter = true;
         RETURN_IF_ERROR(ThreadPoolBuilder("get_kv_thread")
                                 .set_min_threads(config::min_get_kv_thread_num)
@@ -3154,7 +3154,11 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
     size_t num_erased = 0;
     RETURN_IF_ERROR(_l0->erase(n, keys, old_values, &num_erased, not_founds_by_key_size));
     _dump_snapshot |= _can_dump_directly();
-    RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
+    if (_get_thread_pool != nullptr) {
+        RETURN_IF_ERROR(_get_from_immutable_index_parallel(n, keys, old_values, not_founds_by_key_size));
+    } else {
+        RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
+    }
     std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() != NullIndexValue) {
@@ -3220,7 +3224,7 @@ Status PersistentIndex::flush_advance() {
     std::string l1_tmp_file =
             strings::Substitute("$0/index.l1.$1.$2.$3.tmp", _path, _version.major(), _version.minor(), idx);
     _bf.reset();
-    if (_need_bloom_filter && _l0->size() < config::max_kv_num_for_bf) {
+    if (_need_bloom_filter) {
         Status st = BloomFilter::create(BLOCK_BLOOM_FILTER, &_bf);
         if (!st.ok()) {
             LOG(WARNING) << "failed to create bloom filter, status: " << st;
@@ -3791,7 +3795,7 @@ Status PersistentIndex::_merge_compaction_advance() {
     for (int i = merge_l1_start_idx; i < merge_l1_end_idx; i++) {
         total_merge_size += _l1_vec[i]->total_size();
     }
-    if (_need_bloom_filter && total_merge_size < config::max_kv_num_for_bf) {
+    if (_need_bloom_filter) {
         Status st = BloomFilter::create(BLOCK_BLOOM_FILTER, &_bf);
         if (!st.ok()) {
             LOG(WARNING) << "failed to create bloom filter, status: " << st;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -62,6 +62,13 @@ constexpr size_t kMaxKeyLength = 128; // we only support key length is less than
 
 const char* const kIndexFileMagic = "IDX1";
 
+size_t bloom_filter_time = 0;
+size_t diskio_time = 0;
+size_t get_kv_in_shard_time = 0;
+size_t sort_time = 0;
+size_t split_time = 0;
+size_t set_difference_time = 0;
+
 using KVPairPtr = const uint8_t*;
 
 template <class T, class P>
@@ -813,13 +820,14 @@ public:
     }
 
     Status flush_to_immutable_index(std::unique_ptr<ImmutableIndexWriter>& writer, size_t nshard, size_t npage_hint,
-                                    size_t nbucket, bool without_null, std::unique_ptr<BloomFilter>* bf) const override {
+                                    size_t nbucket, bool without_null,
+                                    std::unique_ptr<BloomFilter>* bf) const override {
         if (nshard > 0) {
             const auto& kv_ref_by_shard = get_kv_refs_by_shard(nshard, size(), without_null);
             if (bf != nullptr) {
                 for (const auto& kvs : kv_ref_by_shard) {
                     for (const auto& kv : kvs) {
-                        bf->add_bytes(kv.kv_pos, kv.size);
+                        (*bf)->add_hash(kv.hash);
                     }
                 }
             }
@@ -1217,13 +1225,15 @@ public:
     }
 
     Status flush_to_immutable_index(std::unique_ptr<ImmutableIndexWriter>& writer, size_t nshard, size_t npage_hint,
-                                    size_t nbucket, bool without_null, std::unique_ptr<BloomFilter>* bf) const override {
+                                    size_t nbucket, bool without_null,
+                                    std::unique_ptr<BloomFilter>* bf) const override {
         if (nshard > 0) {
             const auto& kv_ref_by_shard = get_kv_refs_by_shard(nshard, size(), without_null);
             if (bf != nullptr) {
                 for (const auto& kvs : kv_ref_by_shard) {
                     for (const auto& kv : kvs) {
-                        bf->add_bytes(kv.kv_pos, kv.size);
+                        //(*bf)->add_bytes(reinterpret_cast<const char*>(kv.kv_pos), kv.size - kIndexValueSize);
+                        (*bf)->add_hash(kv.hash);
                     }
                 }
             }
@@ -2094,19 +2104,101 @@ Status ImmutableIndex::_get_in_varlen_shard(size_t shard_idx, size_t n, const Sl
     return Status::OK();
 }
 
-Status ImmutableIndex::_get_in_shard(size_t shard_idx, size_t n, const Slice* keys, const KeysInfo& keys_info,
-                                     IndexValue* values, KeysInfo* found_keys_info) const {
+Status ImmutableIndex::_get_page_idxes(size_t shard_idx, KeysInfo& keys_info, std::vector<size_t>* page_idxes) const {
     const auto& shard_info = _shards[shard_idx];
-    if (shard_info.size == 0 || shard_info.npage == 0 || keys_info.size() == 0) {
-        return Status::OK();
+    for (size_t i = 0; i < keys_info.size(); i++) {
+        IndexHash h(keys_info.key_infos[i].second);
+        auto pageid = h.page() % shard_info.npage;
+        page_idxes->emplace_back(pageid);
     }
+    return Status::OK();
+}
+
+Status ImmutableIndex::_get_in_shard_by_pages(size_t shard_idx, size_t n, const Slice* keys, KeysInfo& keys_info,
+                                              IndexValue* values, KeysInfo* found_keys_info,
+                                              std::vector<size_t>& page_idxes) const {
+    const auto& shard_info = _shards[shard_idx];
     std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
     CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
-    RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, shard->pages.data(), shard_info.bytes));
+    int64_t t_start = MonotonicMillis();
+    for (auto page_id : page_idxes) {
+        RETURN_IF_ERROR(
+                _file->read_at_fully(shard_info.offset + page_id * kPageSize, shard->pages[page_id].data, kPageSize));
+    }
+    int64_t t_read = MonotonicMillis();
+    diskio_time += t_read - t_start;
+    //LOG(INFO) << "t_read cost time " << t_read - t_start;
     if (shard_info.key_size != 0) {
-        return _get_in_fixlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
+        Status st = _get_in_fixlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
+        int64_t t_end = MonotonicMillis();
+        get_kv_in_shard_time += t_end - t_read;
+        return st;
     } else {
-        return _get_in_varlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
+        Status st = _get_in_varlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
+        int64_t t_end = MonotonicMillis();
+        get_kv_in_shard_time += t_end - t_read;
+        return st;
+    }
+}
+
+Status ImmutableIndex::_get_in_shard(size_t shard_idx, size_t n, const Slice* keys, KeysInfo& keys_info,
+                                     IndexValue* values, KeysInfo* found_keys_info) const {
+    if (config::enable_bloom_filter) {
+        int64_t t_start = MonotonicMillis();
+        if (_bf != nullptr) {
+            std::vector<std::pair<uint32_t, uint64_t>> need_find_keys_info;
+            for (size_t i = 0; i < keys_info.size(); i++) {
+                auto key_idx = keys_info.key_infos[i].first;
+                auto hash = keys_info.key_infos[i].second;
+                if (_bf->test_hash(hash)) {
+                    need_find_keys_info.emplace_back(std::make_pair(key_idx, hash));
+                }
+                /*
+                if (_bf->test_bytes(keys[key_idx].get_data(), keys[key_idx].get_size())) {
+                    need_find_keys_info.emplace_back(std::make_pair(key_idx, hash));
+                }
+                */
+            }
+            //LOG(INFO) << "origin kv num: " << keys_info.size() << ", need to check kv num " << need_find_keys_info.size();
+            keys_info.key_infos.swap(need_find_keys_info);
+        }
+        int64_t t_filter = MonotonicMillis();
+        bloom_filter_time += t_filter - t_start;
+        const auto& shard_info = _shards[shard_idx];
+        if (shard_info.size == 0 || shard_info.npage == 0 || keys_info.size() == 0) {
+            return Status::OK();
+        }
+
+        std::vector<size_t> page_idxes;
+        RETURN_IF_ERROR(_get_page_idxes(shard_idx, keys_info, &page_idxes));
+        //if (page_idxes.size() * 20 < shard_info.npage) {
+        //LOG(INFO) << "shard pages: " << shard_info.npage << ", read pages: " << page_idxes.size();
+        Status st = _get_in_shard_by_pages(shard_idx, n, keys, keys_info, values, found_keys_info, page_idxes);
+
+        //LOG(INFO) << "get_in_shard cost time " << t_end - t_start << " filter cost time: " << t_filter - t_start;
+        return st;
+        //}
+    } else {
+        const auto& shard_info = _shards[shard_idx];
+        if (shard_info.size == 0 || shard_info.npage == 0 || keys_info.size() == 0) {
+            return Status::OK();
+        }
+
+        std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
+        CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
+        RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, shard->pages.data(), shard_info.bytes));
+
+        if (shard_info.key_size != 0) {
+            Status st = _get_in_fixlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
+
+            //LOG(INFO) << "get_in_shard cost time " << t_end - t_start << " read cost time: " << t_read - t_start;
+            return st;
+        } else {
+            Status st = _get_in_varlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
+
+            //LOG(INFO) << "get_in_shard cost time " << t_end - t_start << " read cost time: " << t_read - t_start;
+            return st;
+        }
     }
 }
 
@@ -2194,8 +2286,9 @@ static void split_keys_info_by_shard(const KeysInfo& keys_info, std::vector<Keys
     }
 }
 
-Status ImmutableIndex::get(size_t n, const Slice* keys, const KeysInfo& keys_info, IndexValue* values,
+Status ImmutableIndex::get(size_t n, const Slice* keys, KeysInfo& keys_info, IndexValue* values,
                            KeysInfo* found_keys_info, size_t key_size) const {
+    split_time = 0;
     auto iter = _shard_info_by_length.find(key_size);
     if (iter == _shard_info_by_length.end()) {
         return Status::OK();
@@ -2203,7 +2296,10 @@ Status ImmutableIndex::get(size_t n, const Slice* keys, const KeysInfo& keys_inf
     const auto [shard_off, nshard] = iter->second;
     if (nshard > 1) {
         std::vector<KeysInfo> keys_info_by_shard(nshard);
+        int64_t t_start = MonotonicMillis();
         split_keys_info_by_shard(keys_info, keys_info_by_shard);
+        int64_t t_split = MonotonicMillis();
+        split_time += t_split - t_start;
         for (size_t i = 0; i < nshard; i++) {
             RETURN_IF_ERROR(_get_in_shard(shard_off + i, n, keys, keys_info_by_shard[i], values, found_keys_info));
         }
@@ -2827,12 +2923,20 @@ Status PersistentIndex::on_commited() {
 
 Status PersistentIndex::_get_from_immutable_index(size_t n, const Slice* keys, IndexValue* values,
                                                   std::map<size_t, KeysInfo>& keys_info_by_key_size) {
+    bloom_filter_time = 0;
+    diskio_time = 0;
+    get_kv_in_shard_time = 0;
+    sort_time = 0;
+    set_difference_time = 0;
     if (_l1_vec.empty()) {
         return Status::OK();
     }
+    int64_t t_start = MonotonicMillis();
     for (auto& [_, keys_info] : keys_info_by_key_size) {
         std::sort(keys_info.key_infos.begin(), keys_info.key_infos.end());
     }
+    int64_t t_sort = MonotonicMillis();
+    sort_time += t_sort - t_start;
 
     for (auto& [key_size, keys_info] : keys_info_by_key_size) {
         for (int i = _l1_vec.size(); i > 0; i--) {
@@ -2842,9 +2946,14 @@ Status PersistentIndex::_get_from_immutable_index(size_t n, const Slice* keys, I
             KeysInfo found_keys_info;
             // get data from tmp_l1
             RETURN_IF_ERROR(_l1_vec[i - 1]->get(n, keys, keys_info, values, &found_keys_info, key_size));
-            std::sort(found_keys_info.key_infos.begin(), found_keys_info.key_infos.end());
-            // modify keys_info
-            keys_info.set_difference(found_keys_info);
+            if (found_keys_info.size() != 0) {
+                int64_t t_d_start = MonotonicMillis();
+                std::sort(found_keys_info.key_infos.begin(), found_keys_info.key_infos.end());
+                // modify keys_info
+                keys_info.set_difference(found_keys_info);
+                int64_t t_d_end = MonotonicMillis();
+                set_difference_time += t_d_end - t_d_start;
+            }
         }
     }
     return Status::OK();
@@ -2861,6 +2970,20 @@ Status PersistentIndex::_flush_advance_or_append_wal(size_t n, const Slice* keys
     bool need_flush_advance = _need_flush_advance();
     _flushed |= need_flush_advance;
 
+    if (need_flush_advance) {
+        RETURN_IF_ERROR(flush_advance());
+    }
+
+    if (_need_merge_advance()) {
+        RETURN_IF_ERROR(_merge_compaction_advance());
+    } else if (!_flushed) {
+        _dump_snapshot |= _can_dump_directly();
+        if (!_dump_snapshot) {
+            RETURN_IF_ERROR(_l0->append_wal(n, keys, values));
+        }
+    }
+
+    /*
     if (_need_merge_advance()) {
         RETURN_IF_ERROR(_merge_compaction_advance());
     } else if (need_flush_advance) {
@@ -2871,6 +2994,7 @@ Status PersistentIndex::_flush_advance_or_append_wal(size_t n, const Slice* keys
             RETURN_IF_ERROR(_l0->append_wal(n, keys, values));
         }
     }
+    */
     return Status::OK();
 }
 
@@ -2922,10 +3046,14 @@ Status PersistentIndex::_update_usage_and_size_by_key_length(
 }
 
 Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values) {
+    int64_t t_start = MonotonicMillis();
     std::map<size_t, KeysInfo> not_founds_by_key_size;
     size_t num_found = 0;
+    size_t before_upsert = _l0->size();
     RETURN_IF_ERROR(_l0->upsert(n, keys, values, old_values, &num_found, not_founds_by_key_size));
+    int64_t t_upsert = MonotonicMillis();
     RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
+    int64_t t_get_l1 = MonotonicMillis();
     std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() == NullIndexValue) {
@@ -2935,8 +3063,18 @@ Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* va
             add_usage_and_size[keys[i].size].second++;
         }
     }
+
+    size_t after_upsert = _l0->size();
     RETURN_IF_ERROR(_update_usage_and_size_by_key_length(add_usage_and_size));
-    return _flush_advance_or_append_wal(n, keys, values);
+    Status st = _flush_advance_or_append_wal(n, keys, values);
+    size_t after_flush = _l0->size();
+    int64_t t_end = MonotonicMillis();
+    LOG(INFO) << "upsert " << n << " kvs cost time " << t_end - t_start << ", upsert time: " << t_upsert - t_start
+              << ", get_l1_time: " << t_get_l1 - t_upsert << "[" << bloom_filter_time << "/" << diskio_time << "/"
+              << get_kv_in_shard_time << "/" << sort_time << "/" << split_time << "/" << set_difference_time << "]"
+              << ", flush_or_append_wal cost time " << t_end - t_get_l1 << ", l0 kv num:[" << before_upsert << "/"
+              << after_upsert << "/" << after_flush << "]";
+    return st;
 }
 
 Status PersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* values, bool check_l1) {
@@ -3044,7 +3182,9 @@ Status PersistentIndex::flush_advance() {
             return st;
         }
     }
-    _bf->init(_l0->size(), 0.05, HASH_MURMUR3_X64_64);
+    if (_need_bloom_filter) {
+        _bf->init(_l0->size(), 0.05, HASH_MURMUR3_X64_64);
+    }
     RETURN_IF_ERROR(_l0->flush_to_immutable_index(l1_tmp_file, _version, true, &_bf));
 
     LOG(INFO) << "flush tmp l1, idx: " << idx << ", file_path: " << l1_tmp_file << " success";
@@ -3066,7 +3206,7 @@ Status PersistentIndex::flush_advance() {
 }
 
 Status PersistentIndex::_flush_l0() {
-    return _l0->flush_to_immutable_index(_path, _version, nullptr);
+    return _l0->flush_to_immutable_index(_path, _version, false, nullptr);
 }
 
 Status PersistentIndex::_reload(const PersistentIndexMetaPB& index_meta) {
@@ -3520,7 +3660,8 @@ Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer,
             }
             if (bf != nullptr) {
                 for (const auto& kv : kvs) {
-                    bf->add_bytes(kv.kv_pos, kv.size);
+                    //(*bf)->add_bytes(reinterpret_cast<const char*>(kv.kv_pos), kv.size - kIndexValueSize);
+                    (*bf)->add_hash(kv.hash);
                 }
             }
             // write shard
@@ -3550,7 +3691,8 @@ Status PersistentIndex::_merge_compaction() {
     const std::string idx_file_path =
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
     RETURN_IF_ERROR(writer->init(idx_file_path, _version, true));
-    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage_and_size_by_key_length, false, nullptr));
+    RETURN_IF_ERROR(
+            _merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage_and_size_by_key_length, false, nullptr));
     // _usage should be equal to total_kv_size. But they may be differen because of compatibility problem when we upgrade
     // from old version and _usage maybe not accurate.
     // so we use total_kv_size to correct the _usage.
@@ -3612,15 +3754,15 @@ Status PersistentIndex::_merge_compaction_advance() {
             LOG(WARNING) << "failed to create bloom filter, status: " << st;
             return st;
         }
-        _bf->init(total_merge_size, 0.05, HASH_MURMUR3_X64_64);   
+        _bf->init(total_merge_size, 0.05, HASH_MURMUR3_X64_64);
     }
-
 
     RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx, usage_and_size_stat,
                                                keep_delete, &_bf));
     RETURN_IF_ERROR(writer->finish());
     std::vector<std::unique_ptr<ImmutableIndex>> new_l1_vec;
     std::vector<int> new_l1_merged_num;
+    size_t merge_num = _l1_merged_num[merge_l1_start_idx];
     for (int i = 0; i < merge_l1_start_idx; i++) {
         new_l1_vec.emplace_back(std::move(_l1_vec[i]));
         new_l1_merged_num.emplace_back(_l1_merged_num[i]);
@@ -3641,7 +3783,7 @@ Status PersistentIndex::_merge_compaction_advance() {
     }
     new_l1_vec.emplace_back(std::move(l1_st).value());
     new_l1_vec.back()->_bf = std::move(_bf);
-    new_l1_merged_num.emplace_back(merge_l1_end_idx - merge_l1_start_idx);
+    new_l1_merged_num.emplace_back((merge_l1_end_idx - merge_l1_start_idx) * merge_num);
     _l1_vec.swap(new_l1_vec);
     _l1_merged_num.swap(new_l1_merged_num);
     _l0->clear();

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -50,6 +50,7 @@ constexpr uint64_t kPageMax = 1ULL << 32;
 constexpr size_t kPackSize = 16;
 constexpr size_t kPagePackLimit = (kPageSize - kPageHeaderSize) / kPackSize;
 constexpr size_t kBucketSizeMax = 256;
+constexpr size_t kMinEnableBFKVNum = 10000000;
 // if l0_mem_size exceeds this value, l0 need snapshot
 #if BE_TEST
 constexpr size_t kL0SnapshotSizeMax = 1 * 1024 * 1024;
@@ -2779,15 +2780,18 @@ Status PersistentIndex::prepare(const EditVersion& version, size_t n) {
     _dump_snapshot = false;
     _flushed = false;
     _version = version;
-    if (config::enable_parallel_get_and_bf && n > _size / 2 && n > config::min_enable_bf_kv_num) {
+
+    if (config::enable_parallel_get_and_bf) {
         _need_bloom_filter = true;
-        RETURN_IF_ERROR(ThreadPoolBuilder("get_kv_thread")
-                                .set_min_threads(config::min_get_kv_thread_num)
-                                .set_max_threads(config::max_get_kv_thread_num)
-                                .set_max_queue_size(4096)
-                                .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))
-                                .build(&_get_thread_pool));
-        LOG(INFO) << "get kv thread num: " << _get_thread_pool->num_threads();
+        if (n > _size / 4 && n > kMinEnableBFKVNum) {
+            RETURN_IF_ERROR(ThreadPoolBuilder("get_kv_thread")
+                                    .set_min_threads(1)
+                                    .set_max_threads(config::l0_l1_merge_ratio)
+                                    .set_max_queue_size(4096)
+                                    .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))
+                                    .build(&_get_thread_pool));
+            LOG(INFO) << "get kv thread num: " << _get_thread_pool->num_threads();
+        }
     }
     _set_error(false, "");
     return Status::OK();

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1879,7 +1879,8 @@ Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
 }
 
 Status ShardByLengthMutableIndex::flush_to_immutable_index(const std::string& path, const EditVersion& version,
-                                                           bool write_tmp_l1, BloomFilter* bf) {
+                                                           bool write_tmp_l1,
+                                                           std::map<size_t, std::unique_ptr<BloomFilter>>* bf_map) {
     auto writer = std::make_unique<ImmutableIndexWriter>();
     std::string idx_file_path;
     if (!write_tmp_l1) {
@@ -1905,8 +1906,21 @@ Status ShardByLengthMutableIndex::flush_to_immutable_index(const std::string& pa
             const auto nbucket = MutableIndex::estimate_nbucket(key_size, size, nshard, npage_hint);
             const auto expand_exponent = nshard / shard_size;
             for (auto i = 0; i < shard_size; ++i) {
-                RETURN_IF_ERROR(_shards[shard_offset + i]->flush_to_immutable_index(writer, expand_exponent, npage_hint,
-                                                                                    nbucket, !write_tmp_l1, bf));
+                if (bf_map != nullptr) {
+                    std::unique_ptr<BloomFilter> bf;
+                    Status st = BloomFilter::create(BLOCK_BLOOM_FILTER, &bf);
+                    if (!st.ok()) {
+                        LOG(WARNING) << "failed to create bloom filter, status: " << st;
+                        return st;
+                    }
+                    bf->init(size, 0.05, HASH_MURMUR3_X64_64);
+                    RETURN_IF_ERROR(_shards[shard_offset + i]->flush_to_immutable_index(
+                            writer, expand_exponent, npage_hint, nbucket, !write_tmp_l1, bf.get()));
+                    (*bf_map)[key_size] = std::move(bf);
+                } else {
+                    RETURN_IF_ERROR(_shards[shard_offset + i]->flush_to_immutable_index(
+                            writer, expand_exponent, npage_hint, nbucket, !write_tmp_l1, nullptr));
+                }
             }
         }
     }
@@ -2095,55 +2109,19 @@ Status ImmutableIndex::_get_in_varlen_shard(size_t shard_idx, size_t n, const Sl
     return Status::OK();
 }
 
-Status ImmutableIndex::_get_page_idxes(size_t shard_idx, std::vector<KeyInfo>& keys_info,
-                                       std::vector<size_t>* page_idxes) const {
-    const auto& shard_info = _shards[shard_idx];
-    for (size_t i = 0; i < keys_info.size(); i++) {
-        IndexHash h(keys_info[i].second);
-        auto pageid = h.page() % shard_info.npage;
-        page_idxes->emplace_back(pageid);
-    }
-    return Status::OK();
-}
-
-Status ImmutableIndex::_get_in_shard_by_pages(size_t shard_idx, size_t n, const Slice* keys,
-                                              std::vector<KeyInfo>& keys_info, IndexValue* values,
-                                              KeysInfo* found_keys_info, std::vector<size_t>& page_idxes) const {
-    const auto& shard_info = _shards[shard_idx];
-    std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
-    CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
-    for (auto page_id : page_idxes) {
-        RETURN_IF_ERROR(
-                _file->read_at_fully(shard_info.offset + page_id * kPageSize, shard->pages[page_id].data, kPageSize));
-    }
-    if (shard_info.key_size != 0) {
-        return _get_in_fixlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
-    } else {
-        return _get_in_varlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
-    }
-}
-
 Status ImmutableIndex::_get_in_shard(size_t shard_idx, size_t n, const Slice* keys, std::vector<KeyInfo>& keys_info,
                                      IndexValue* values, KeysInfo* found_keys_info) const {
     const auto& shard_info = _shards[shard_idx];
     if (shard_info.size == 0 || shard_info.npage == 0 || keys_info.size() == 0) {
         return Status::OK();
     }
-
-    std::vector<size_t> page_idxes;
-    RETURN_IF_ERROR(_get_page_idxes(shard_idx, keys_info, &page_idxes));
-
-    if (page_idxes.size() * config::page_shard_read_ratio < shard_info.npage) {
-        return _get_in_shard_by_pages(shard_idx, n, keys, keys_info, values, found_keys_info, page_idxes);
+    std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
+    CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
+    RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, shard->pages.data(), shard_info.bytes));
+    if (shard_info.key_size != 0) {
+        return _get_in_fixlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
     } else {
-        std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
-        CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
-        RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, shard->pages.data(), shard_info.bytes));
-        if (shard_info.key_size != 0) {
-            return _get_in_fixlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
-        } else {
-            return _get_in_varlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
-        }
+        return _get_in_varlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
     }
 }
 
@@ -2240,11 +2218,12 @@ Status ImmutableIndex::get(size_t n, const Slice* keys, KeysInfo& keys_info, Ind
 
     std::vector<KeyInfo> check_keys_info;
     bool filter = false;
-    if (config::enable_parallel_get_and_bf && _bf != nullptr) {
+    std::map<size_t, std::unique_ptr<BloomFilter>>::iterator bf_iter = _bf_map.find(key_size);
+    if (config::enable_parallel_get_and_bf && bf_iter != _bf_map.end()) {
         for (size_t i = 0; i < keys_info.size(); i++) {
             auto key_idx = keys_info.key_infos[i].first;
             auto hash = keys_info.key_infos[i].second;
-            if (_bf->test_hash(hash)) {
+            if (bf_iter->second->test_hash(hash)) {
                 check_keys_info.emplace_back(std::make_pair(key_idx, hash));
             }
         }
@@ -3223,16 +3202,12 @@ Status PersistentIndex::flush_advance() {
     int idx = _l1_vec.size();
     std::string l1_tmp_file =
             strings::Substitute("$0/index.l1.$1.$2.$3.tmp", _path, _version.major(), _version.minor(), idx);
-    _bf.reset();
+    std::map<size_t, std::unique_ptr<BloomFilter>> bf_map;
     if (_need_bloom_filter) {
-        Status st = BloomFilter::create(BLOCK_BLOOM_FILTER, &_bf);
-        if (!st.ok()) {
-            LOG(WARNING) << "failed to create bloom filter, status: " << st;
-            return st;
-        }
-        _bf->init(_l0->size(), 0.05, HASH_MURMUR3_X64_64);
+        RETURN_IF_ERROR(_l0->flush_to_immutable_index(l1_tmp_file, _version, true, &bf_map));
+    } else {
+        RETURN_IF_ERROR(_l0->flush_to_immutable_index(l1_tmp_file, _version, true, nullptr));
     }
-    RETURN_IF_ERROR(_l0->flush_to_immutable_index(l1_tmp_file, _version, true, _bf.get()));
 
     LOG(INFO) << "flush tmp l1, idx: " << idx << ", file_path: " << l1_tmp_file << " success";
     // load _l1_vec
@@ -3244,7 +3219,7 @@ Status PersistentIndex::flush_advance() {
     }
     _l1_vec.emplace_back(std::move(l1_st).value());
     _l1_merged_num.emplace_back(1);
-    _l1_vec.back()->_bf = std::move(_bf);
+    _l1_vec.back()->_bf_map.swap(bf_map);
 
     // clear l0
     _l0->clear();
@@ -3615,7 +3590,8 @@ static Status merge_shard_kvs_with_delete(size_t key_size, std::vector<KVRef>& l
 
 Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer, int l1_start_idx, int l1_end_idx,
                                                    std::map<uint32_t, std::pair<int64_t, int64_t>>& usage_and_size_stat,
-                                                   bool keep_delete, BloomFilter* bf) {
+                                                   bool keep_delete,
+                                                   std::map<size_t, std::unique_ptr<BloomFilter>>* bf_map) {
     for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
         size_t total_usage = 0;
         size_t total_size = 0;
@@ -3652,6 +3628,15 @@ Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer,
         }
         std::vector<std::unique_ptr<ImmutableIndexShard>> index_shards(index_num);
         uint32_t shard_bits = log2(nshard);
+        std::unique_ptr<BloomFilter> bf;
+        if (bf_map != nullptr) {
+            Status st = BloomFilter::create(BLOCK_BLOOM_FILTER, &bf);
+            if (!st.ok()) {
+                LOG(WARNING) << "failed to create bloom filter, status: " << st;
+                return st;
+            }
+            bf->init(total_size, 0.05, HASH_MURMUR3_X64_64);
+        }
         // shard iteration example:
         //
         // nshard_l1(4) < nshard(8)
@@ -3705,7 +3690,7 @@ Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer,
                 RETURN_IF_ERROR(
                         merge_shard_kvs(key_size, l0_kvs_by_shard[shard_idx], l1_kvs, estimate_size_per_shard, kvs));
             }
-            if (bf != nullptr) {
+            if (bf.get() != nullptr) {
                 for (const auto& kv : kvs) {
                     bf->add_hash(kv.hash);
                 }
@@ -3715,6 +3700,9 @@ Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer,
             // clear shard
             l0_kvs_by_shard[shard_idx].clear();
             l0_kvs_by_shard[shard_idx].shrink_to_fit();
+        }
+        if (bf_map != nullptr) {
+            (*bf_map)[key_size] = std::move(bf);
         }
     }
     return Status::OK();
@@ -3750,7 +3738,6 @@ Status PersistentIndex::_merge_compaction() {
 
 Status PersistentIndex::_merge_compaction_advance() {
     DCHECK(_l1_vec.size() >= config::max_tmp_l1_num);
-    _bf.reset();
     auto writer = std::make_unique<ImmutableIndexWriter>();
     const std::string idx_file_path_tmp =
             strings::Substitute("$0/index.l1.$1.$2.$3.tmp", _path, _version.major(), _version.minor(), _l1_vec.size());
@@ -3790,22 +3777,15 @@ Status PersistentIndex::_merge_compaction_advance() {
             }
         }
     }
-    size_t total_merge_size = 0;
-    total_merge_size += _l0->size();
-    for (int i = merge_l1_start_idx; i < merge_l1_end_idx; i++) {
-        total_merge_size += _l1_vec[i]->total_size();
-    }
-    if (_need_bloom_filter) {
-        Status st = BloomFilter::create(BLOCK_BLOOM_FILTER, &_bf);
-        if (!st.ok()) {
-            LOG(WARNING) << "failed to create bloom filter, status: " << st;
-            return st;
-        }
-        _bf->init(total_merge_size, 0.05, HASH_MURMUR3_X64_64);
-    }
 
-    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx, usage_and_size_stat,
-                                               keep_delete, _bf.get()));
+    std::map<size_t, std::unique_ptr<BloomFilter>> bf_map;
+    if (_need_bloom_filter) {
+        RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx,
+                                                   usage_and_size_stat, keep_delete, &bf_map));
+    } else {
+        RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx,
+                                                   usage_and_size_stat, keep_delete, nullptr));
+    }
     RETURN_IF_ERROR(writer->finish());
     std::vector<std::unique_ptr<ImmutableIndex>> new_l1_vec;
     std::vector<int> new_l1_merged_num;
@@ -3829,8 +3809,8 @@ Status PersistentIndex::_merge_compaction_advance() {
         return l1_st.status();
     }
     new_l1_vec.emplace_back(std::move(l1_st).value());
-    if (_bf != nullptr) {
-        new_l1_vec.back()->_bf = std::move(_bf);
+    if (_need_bloom_filter) {
+        new_l1_vec.back()->_bf_map.swap(bf_map);
     }
     new_l1_merged_num.emplace_back((merge_l1_end_idx - merge_l1_start_idx) * merge_num);
     _l1_vec.swap(new_l1_vec);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -67,6 +67,7 @@ size_t diskio_time = 0;
 size_t get_kv_in_shard_time = 0;
 size_t sort_time = 0;
 size_t split_time = 0;
+size_t get_pageid_time = 0;
 size_t set_difference_time = 0;
 
 using KVPairPtr = const uint8_t*;
@@ -824,7 +825,7 @@ public:
                                     std::unique_ptr<BloomFilter>* bf) const override {
         if (nshard > 0) {
             const auto& kv_ref_by_shard = get_kv_refs_by_shard(nshard, size(), without_null);
-            if (bf != nullptr) {
+            if ((*bf) != nullptr) {
                 for (const auto& kvs : kv_ref_by_shard) {
                     for (const auto& kv : kvs) {
                         (*bf)->add_hash(kv.hash);
@@ -1229,7 +1230,7 @@ public:
                                     std::unique_ptr<BloomFilter>* bf) const override {
         if (nshard > 0) {
             const auto& kv_ref_by_shard = get_kv_refs_by_shard(nshard, size(), without_null);
-            if (bf != nullptr) {
+            if ((*bf) != nullptr) {
                 for (const auto& kvs : kv_ref_by_shard) {
                     for (const auto& kv : kvs) {
                         //(*bf)->add_bytes(reinterpret_cast<const char*>(kv.kv_pos), kv.size - kIndexValueSize);
@@ -2143,59 +2144,34 @@ Status ImmutableIndex::_get_in_shard_by_pages(size_t shard_idx, size_t n, const 
 
 Status ImmutableIndex::_get_in_shard(size_t shard_idx, size_t n, const Slice* keys, KeysInfo& keys_info,
                                      IndexValue* values, KeysInfo* found_keys_info) const {
-    if (config::enable_bloom_filter) {
-        int64_t t_start = MonotonicMillis();
-        if (_bf != nullptr) {
-            std::vector<std::pair<uint32_t, uint64_t>> need_find_keys_info;
-            for (size_t i = 0; i < keys_info.size(); i++) {
-                auto key_idx = keys_info.key_infos[i].first;
-                auto hash = keys_info.key_infos[i].second;
-                if (_bf->test_hash(hash)) {
-                    need_find_keys_info.emplace_back(std::make_pair(key_idx, hash));
-                }
-                /*
-                if (_bf->test_bytes(keys[key_idx].get_data(), keys[key_idx].get_size())) {
-                    need_find_keys_info.emplace_back(std::make_pair(key_idx, hash));
-                }
-                */
-            }
-            //LOG(INFO) << "origin kv num: " << keys_info.size() << ", need to check kv num " << need_find_keys_info.size();
-            keys_info.key_infos.swap(need_find_keys_info);
-        }
-        int64_t t_filter = MonotonicMillis();
-        bloom_filter_time += t_filter - t_start;
-        const auto& shard_info = _shards[shard_idx];
-        if (shard_info.size == 0 || shard_info.npage == 0 || keys_info.size() == 0) {
-            return Status::OK();
-        }
+    int64_t t_start = MonotonicMillis();
+    const auto& shard_info = _shards[shard_idx];
+    if (shard_info.size == 0 || shard_info.npage == 0 || keys_info.size() == 0) {
+        return Status::OK();
+    }
 
-        std::vector<size_t> page_idxes;
-        RETURN_IF_ERROR(_get_page_idxes(shard_idx, keys_info, &page_idxes));
-        //if (page_idxes.size() * 20 < shard_info.npage) {
-        //LOG(INFO) << "shard pages: " << shard_info.npage << ", read pages: " << page_idxes.size();
-        Status st = _get_in_shard_by_pages(shard_idx, n, keys, keys_info, values, found_keys_info, page_idxes);
-
-        //LOG(INFO) << "get_in_shard cost time " << t_end - t_start << " filter cost time: " << t_filter - t_start;
-        return st;
-        //}
+    std::vector<size_t> page_idxes;
+    RETURN_IF_ERROR(_get_page_idxes(shard_idx, keys_info, &page_idxes));
+    int64_t t_getpage = MonotonicMillis();
+    get_pageid_time += t_getpage - t_start;
+    if (page_idxes.size() * 20 < shard_info.npage) {
+        return _get_in_shard_by_pages(shard_idx, n, keys, keys_info, values, found_keys_info, page_idxes);
     } else {
-        const auto& shard_info = _shards[shard_idx];
-        if (shard_info.size == 0 || shard_info.npage == 0 || keys_info.size() == 0) {
-            return Status::OK();
-        }
-
         std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
         CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
         RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, shard->pages.data(), shard_info.bytes));
-
+        int64_t t_read = MonotonicMillis();
+        diskio_time += t_read - t_start;
         if (shard_info.key_size != 0) {
             Status st = _get_in_fixlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
-
+            int64_t t_end = MonotonicMillis();
+            get_kv_in_shard_time += t_end - t_read;
             //LOG(INFO) << "get_in_shard cost time " << t_end - t_start << " read cost time: " << t_read - t_start;
             return st;
         } else {
             Status st = _get_in_varlen_shard(shard_idx, n, keys, keys_info, values, found_keys_info, &shard);
-
+            int64_t t_end = MonotonicMillis();
+            get_kv_in_shard_time += t_end - t_read;
             //LOG(INFO) << "get_in_shard cost time " << t_end - t_start << " read cost time: " << t_read - t_start;
             return st;
         }
@@ -2288,11 +2264,29 @@ static void split_keys_info_by_shard(const KeysInfo& keys_info, std::vector<Keys
 
 Status ImmutableIndex::get(size_t n, const Slice* keys, KeysInfo& keys_info, IndexValue* values,
                            KeysInfo* found_keys_info, size_t key_size) const {
-    split_time = 0;
     auto iter = _shard_info_by_length.find(key_size);
     if (iter == _shard_info_by_length.end()) {
         return Status::OK();
     }
+
+    if (config::enable_bloom_filter) {
+        int64_t t_start = MonotonicMillis();
+        if (_bf != nullptr) {
+            std::vector<std::pair<uint32_t, uint64_t>> need_find_keys_info;
+            for (size_t i = 0; i < keys_info.size(); i++) {
+                auto key_idx = keys_info.key_infos[i].first;
+                auto hash = keys_info.key_infos[i].second;
+                if (_bf->test_hash(hash)) {
+                    need_find_keys_info.emplace_back(std::make_pair(key_idx, hash));
+                }
+            }
+            //LOG(INFO) << "origin kv num: " << keys_info.size() << ", need to check kv num " << need_find_keys_info.size();
+            keys_info.key_infos.swap(need_find_keys_info);
+        }
+        int64_t t_filter = MonotonicMillis();
+        bloom_filter_time += t_filter - t_start;
+    }
+
     const auto [shard_off, nshard] = iter->second;
     if (nshard > 1) {
         std::vector<KeysInfo> keys_info_by_shard(nshard);
@@ -2927,6 +2921,8 @@ Status PersistentIndex::_get_from_immutable_index(size_t n, const Slice* keys, I
     diskio_time = 0;
     get_kv_in_shard_time = 0;
     sort_time = 0;
+    split_time = 0;
+    get_pageid_time = 0;
     set_difference_time = 0;
     if (_l1_vec.empty()) {
         return Status::OK();
@@ -3071,9 +3067,11 @@ Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* va
     int64_t t_end = MonotonicMillis();
     LOG(INFO) << "upsert " << n << " kvs cost time " << t_end - t_start << ", upsert time: " << t_upsert - t_start
               << ", get_l1_time: " << t_get_l1 - t_upsert << "[" << bloom_filter_time << "/" << diskio_time << "/"
-              << get_kv_in_shard_time << "/" << sort_time << "/" << split_time << "/" << set_difference_time << "]"
+              << get_kv_in_shard_time << "/" << sort_time << "/" << split_time << "/" << get_pageid_time << "/"
+              << set_difference_time << "]"
               << ", flush_or_append_wal cost time " << t_end - t_get_l1 << ", l0 kv num:[" << before_upsert << "/"
-              << after_upsert << "/" << after_flush << "]";
+              << after_upsert << "/" << after_flush << "]"
+              << " memory: " << memory_usage() << " bytes";
     return st;
 }
 
@@ -3658,7 +3656,7 @@ Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer,
                 RETURN_IF_ERROR(
                         merge_shard_kvs(key_size, l0_kvs_by_shard[shard_idx], l1_kvs, estimate_size_per_shard, kvs));
             }
-            if (bf != nullptr) {
+            if ((*bf) != nullptr) {
                 for (const auto& kv : kvs) {
                     //(*bf)->add_bytes(reinterpret_cast<const char*>(kv.kv_pos), kv.size - kIndexValueSize);
                     (*bf)->add_hash(kv.hash);
@@ -3704,6 +3702,7 @@ Status PersistentIndex::_merge_compaction() {
 
 Status PersistentIndex::_merge_compaction_advance() {
     DCHECK(_l1_vec.size() >= config::max_tmp_l1_num);
+    _bf.reset();
     auto writer = std::make_unique<ImmutableIndexWriter>();
     const std::string idx_file_path_tmp =
             strings::Substitute("$0/index.l1.$1.$2.$3.tmp", _path, _version.major(), _version.minor(), _l1_vec.size());
@@ -3748,13 +3747,14 @@ Status PersistentIndex::_merge_compaction_advance() {
     for (int i = merge_l1_start_idx; i < merge_l1_end_idx; i++) {
         total_merge_size += _l1_vec[i]->total_size();
     }
-    if (_need_bloom_filter) {
+    if (_need_bloom_filter && total_merge_size < kMinKVNumber) {
         Status st = BloomFilter::create(BLOCK_BLOOM_FILTER, &_bf);
         if (!st.ok()) {
             LOG(WARNING) << "failed to create bloom filter, status: " << st;
             return st;
         }
         _bf->init(total_merge_size, 0.05, HASH_MURMUR3_X64_64);
+        LOG(INFO) << "total kv size: " << total_merge_size << " bloom filter cost memory: " << _bf->size();
     }
 
     RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), merge_l1_start_idx, merge_l1_end_idx, usage_and_size_stat,
@@ -3782,7 +3782,9 @@ Status PersistentIndex::_merge_compaction_advance() {
         return l1_st.status();
     }
     new_l1_vec.emplace_back(std::move(l1_st).value());
-    new_l1_vec.back()->_bf = std::move(_bf);
+    if (_bf != nullptr) {
+        new_l1_vec.back()->_bf = std::move(_bf);
+    }
     new_l1_merged_num.emplace_back((merge_l1_end_idx - merge_l1_start_idx) * merge_num);
     _l1_vec.swap(new_l1_vec);
     _l1_merged_num.swap(new_l1_merged_num);

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -21,6 +21,7 @@
 #include "fs/fs.h"
 #include "gen_cpp/persistent_index.pb.h"
 #include "storage/edit_version.h"
+#include "storage/rowset/bloom_filter.h"
 #include "storage/rowset/rowset.h"
 #include "util/phmap/phmap.h"
 #include "util/phmap/phmap_dump.h"
@@ -437,6 +438,7 @@ private:
 
     std::vector<ShardInfo> _shards;
     std::map<size_t, std::pair<size_t, size_t>> _shard_info_by_length;
+    std::unique_ptr<BloomFilter> _bf;
 };
 
 class ImmutableIndexWriter {
@@ -635,6 +637,8 @@ private:
 
     bool _dump_snapshot = false;
     bool _flushed = false;
+    bool _need_bloom_filter = false;
+    std::unique_ptr<BloomFilter> _bf;
 };
 
 } // namespace starrocks

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -65,8 +65,9 @@ constexpr static size_t kSliceMaxFixLength = 64;
 
 uint64_t key_index_hash(const void* data, size_t len);
 
+using KeyInfo = std::pair<uint32_t, uint64_t>;
 struct KeysInfo {
-    std::vector<std::pair<uint32_t, uint64_t>> key_infos;
+    std::vector<KeyInfo> key_infos;
     size_t size() const { return key_infos.size(); }
 
     void set_difference(KeysInfo& input) {
@@ -88,40 +89,6 @@ struct KVRef {
 struct ImmutableIndexShard;
 class PersistentIndex;
 class ImmutableIndexWriter;
-
-/*
-enum MergeCompactionType {
-    kRange = 0,
-    kFull = 1,
-};
-
-using PersistentIndexSharedPtr = std::shared_ptr<PersistentIndex>;
-class MergeCompactionTask : public Runnable {
-public:
-    MergeCompactionTask(PersistentIndexSharedPtr index, MergeCompactionType type, int merge_start_idx, int merge_end_idx)
-            : _index(std::move(index)), _type(type), _merge_start_idx(merge_start_idx), _merge_end_idx(merge_end_idx) {}
-
-    void run() override {
-        switch (_type) {
-            case kRange: {
-                _index->_merge_compaction_advance(_merge_start_idx, _merge_end_idx);
-                break;
-            }
-            case kFull: {
-                _index->_merge_compaction();
-                break;
-            }
-            default: {}
-        }
-    }
-
-private:
-    MergeCompactionType _type;
-    PersistentIndexSharedPtr _index;
-    int _merge_start_idx;
-    int _merge_end_idx;
-};
-*/
 
 class MutableIndex {
 public:
@@ -209,7 +176,7 @@ public:
 
     virtual Status flush_to_immutable_index(std::unique_ptr<ImmutableIndexWriter>& writer, size_t nshard,
                                             size_t npage_hint, size_t nbucket, bool without_null,
-                                            std::unique_ptr<BloomFilter>* bf = nullptr) const = 0;
+                                            BloomFilter* bf = nullptr) const = 0;
 
     // get the number of entries in the index (including NullIndexValue)
     virtual size_t size() const = 0;
@@ -333,7 +300,7 @@ public:
                                                          const std::vector<size_t>& idxes);
 
     Status flush_to_immutable_index(const std::string& dir, const EditVersion& version, bool write_tmp_l1 = false,
-                                    std::unique_ptr<BloomFilter>* bf = nullptr);
+                                    BloomFilter* bf = nullptr);
 
     // get the number of entries in the index (including NullIndexValue)
     size_t size();
@@ -375,7 +342,7 @@ public:
     // |num_found|: add the number of keys found in L1 to this argument
     // |key_size|: the key size of keys array
     Status get(size_t n, const Slice* keys, KeysInfo& keys_info, IndexValue* values, KeysInfo* found_keys_info,
-               size_t key_size) const;
+               size_t key_size);
 
     // batch check key existence
     Status check_not_exist(size_t n, const Slice* keys, size_t key_size);
@@ -445,21 +412,21 @@ private:
     Status _get_kvs_for_shard(std::vector<std::vector<KVRef>>& kvs_by_shard, size_t shard_idx, uint32_t shard_bits,
                               std::unique_ptr<ImmutableIndexShard>* shard) const;
 
-    Status _get_in_fixlen_shard(size_t shard_idx, size_t n, const Slice* keys, const KeysInfo& keys_info,
+    Status _get_in_fixlen_shard(size_t shard_idx, size_t n, const Slice* keys, const std::vector<KeyInfo>& keys_info,
                                 IndexValue* values, KeysInfo* found_keys_info,
                                 std::unique_ptr<ImmutableIndexShard>* shard) const;
 
-    Status _get_page_idxes(size_t shard_idx, KeysInfo& keys_info, std::vector<size_t>* page_idxes) const;
+    Status _get_page_idxes(size_t shard_idx, std::vector<KeyInfo>& keys_info, std::vector<size_t>* page_idxes) const;
 
-    Status _get_in_varlen_shard(size_t shard_idx, size_t n, const Slice* keys, const KeysInfo& keys_info,
+    Status _get_in_varlen_shard(size_t shard_idx, size_t n, const Slice* keys, std::vector<KeyInfo>& keys_info,
                                 IndexValue* values, KeysInfo* found_keys_info,
                                 std::unique_ptr<ImmutableIndexShard>* shard) const;
 
-    Status _get_in_shard_by_pages(size_t shard_idx, size_t n, const Slice* keys, KeysInfo& keys_info,
+    Status _get_in_shard_by_pages(size_t shard_idx, size_t n, const Slice* keys, std::vector<KeyInfo>& keys_info,
                                   IndexValue* values, KeysInfo* found_keys_info, std::vector<size_t>& page_idxes) const;
 
-    Status _get_in_shard(size_t shard_idx, size_t n, const Slice* keys, KeysInfo& keys_info, IndexValue* values,
-                         KeysInfo* found_keys_info) const;
+    Status _get_in_shard(size_t shard_idx, size_t n, const Slice* keys, std::vector<KeyInfo>& keys_info,
+                         IndexValue* values, KeysInfo* found_keys_info) const;
 
     Status _check_not_exist_in_fixlen_shard(size_t shard_idx, size_t n, const Slice* keys, const KeysInfo& keys_info,
                                             std::unique_ptr<ImmutableIndexShard>* shard) const;
@@ -587,6 +554,9 @@ public:
     // |values|: value array for return values
     Status get(size_t n, const Slice* keys, IndexValue* values);
 
+    Status get_from_one_immutable_index(size_t n, const Slice* keys, IndexValue* values, KeysInfo* keys_info,
+                                        KeysInfo* found_keys_info, size_t idx, size_t key_size);
+
     // batch upsert
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
@@ -633,9 +603,12 @@ public:
     Status test_flush_varlen_to_immutable_index(const std::string& dir, const EditVersion& version, size_t num_entry,
                                                 const Slice* keys, const IndexValue* values);
 
+    bool is_error() { return _error; }
+
 private:
     size_t _dump_bound();
 
+    void _set_error(bool error) { _error = error; }
     // check _l0 should dump as snapshot or not
     bool _can_dump_directly();
     bool _need_flush_advance();
@@ -649,7 +622,7 @@ private:
 
     Status _merge_compaction_internal(ImmutableIndexWriter* writer, int l1_start_idx, int l1_end_idx,
                                       std::map<uint32_t, std::pair<int64_t, int64_t>>& usage_and_size_stat,
-                                      bool keep_delete, std::unique_ptr<BloomFilter>* bf);
+                                      bool keep_delete, BloomFilter* bf);
     Status _merge_compaction_advance();
     // merge l0 and l1 into new l1, then clear l0
     Status _merge_compaction();
@@ -666,6 +639,9 @@ private:
 
     Status _get_from_immutable_index(size_t n, const Slice* keys, IndexValue* values,
                                      std::map<size_t, KeysInfo>& keys_info_by_key_size);
+
+    Status _get_from_immutable_index_parallel(size_t n, const Slice* keys, IndexValue* values,
+                                              std::map<size_t, KeysInfo>& keys_info_by_key_size);
 
     Status _update_usage_and_size_by_key_length(std::vector<std::pair<int64_t, int64_t>>& add_usage_and_size);
 
@@ -693,6 +669,13 @@ private:
     bool _flushed = false;
     bool _need_bloom_filter = false;
     std::unique_ptr<BloomFilter> _bf;
+
+    mutable std::mutex _lock;
+    std::unique_ptr<ThreadPool> _get_thread_pool;
+    std::condition_variable _get_task_finished;
+    size_t _running_get_task = 0;
+    std::atomic<bool> _error{false};
+    std::vector<KeysInfo> _found_keys_info;
 };
 
 } // namespace starrocks

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -608,7 +608,10 @@ public:
 private:
     size_t _dump_bound();
 
-    void _set_error(bool error) { _error = error; }
+    void _set_error(bool error, const string& msg) {
+        _error = error;
+        _error_msg = msg;
+    }
     // check _l0 should dump as snapshot or not
     bool _can_dump_directly();
     bool _need_flush_advance();
@@ -675,6 +678,7 @@ private:
     std::condition_variable _get_task_finished;
     size_t _running_get_task = 0;
     std::atomic<bool> _error{false};
+    std::string _error_msg;
     std::vector<KeysInfo> _found_keys_info;
 };
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -89,6 +89,40 @@ struct ImmutableIndexShard;
 class PersistentIndex;
 class ImmutableIndexWriter;
 
+/*
+enum MergeCompactionType {
+    kRange = 0,
+    kFull = 1,
+};
+
+using PersistentIndexSharedPtr = std::shared_ptr<PersistentIndex>;
+class MergeCompactionTask : public Runnable {
+public:
+    MergeCompactionTask(PersistentIndexSharedPtr index, MergeCompactionType type, int merge_start_idx, int merge_end_idx)
+            : _index(std::move(index)), _type(type), _merge_start_idx(merge_start_idx), _merge_end_idx(merge_end_idx) {}
+
+    void run() override {
+        switch (_type) {
+            case kRange: {
+                _index->_merge_compaction_advance(_merge_start_idx, _merge_end_idx);
+                break;
+            }
+            case kFull: {
+                _index->_merge_compaction();
+                break;
+            }
+            default: {}
+        }
+    }
+
+private:
+    MergeCompactionType _type;
+    PersistentIndexSharedPtr _index;
+    int _merge_start_idx;
+    int _merge_end_idx;
+};
+*/
+
 class MutableIndex {
 public:
     MutableIndex();
@@ -386,6 +420,13 @@ public:
         return size;
     }
 
+    size_t memory_usage() {
+        if (_bf) {
+            return _bf->size();
+        }
+        return 0;
+    }
+
     static StatusOr<std::unique_ptr<ImmutableIndex>> load(std::unique_ptr<RandomAccessFile>&& rb);
 
 private:
@@ -507,7 +548,13 @@ public:
 
     size_t size() const { return _size; }
     size_t capacity() const { return _l0 ? _l0->capacity() : 0; }
-    size_t memory_usage() const { return _l0 ? _l0->memory_usage() : 0; }
+    size_t memory_usage() const {
+        size_t memory_usage = _l0 ? _l0->memory_usage() : 0;
+        for (int i = 0; i < _l1_vec.size(); i++) {
+            memory_usage += _l1_vec[i]->memory_usage();
+        }
+        return memory_usage;
+    }
 
     EditVersion version() const { return _version; }
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -983,9 +983,9 @@ static string int_list_to_string(const vector<uint32_t>& l) {
     return ret;
 }
 
-Status PrimaryIndex::prepare(const EditVersion& version) {
+Status PrimaryIndex::prepare(const EditVersion& version, size_t n) {
     if (_persistent_index != nullptr) {
-        return _persistent_index->prepare(version);
+        return _persistent_index->prepare(version, n);
     }
     return Status::OK();
 }

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -105,7 +105,7 @@ public:
 
     void get(const Column& pks, std::vector<uint64_t>* rowids) const;
 
-    Status prepare(const EditVersion& version);
+    Status prepare(const EditVersion& version, size_t n);
 
     Status commit(PersistentIndexMetaPB* index_meta);
 

--- a/be/src/storage/short_key_index.cpp
+++ b/be/src/storage/short_key_index.cpp
@@ -77,7 +77,7 @@ Status ShortKeyIndexDecoder::parse(const Slice& body, const ShortKeyFooterPB& fo
     }
 
     // set index buffer
-    _key_data = Slice(body.data, _footer.key_bytes());
+    _key_data = Slice(body.data, _footer.key_bytes());Bloom
 
     // parse offset information
     Slice offset_slice(body.data + _footer.key_bytes(), _footer.offset_bytes());

--- a/be/src/storage/short_key_index.cpp
+++ b/be/src/storage/short_key_index.cpp
@@ -77,7 +77,7 @@ Status ShortKeyIndexDecoder::parse(const Slice& body, const ShortKeyFooterPB& fo
     }
 
     // set index buffer
-    _key_data = Slice(body.data, _footer.key_bytes());Bloom
+    _key_data = Slice(body.data, _footer.key_bytes());
 
     // parse offset information
     Slice offset_slice(body.data + _footer.key_bytes(), _footer.offset_bytes());

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -979,7 +979,24 @@ void TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version_i
     // `enable_persistent_index` of tablet maybe change by alter, we should get `enable_persistent_index` from index to
     // avoid inconsistency between persistent index file and PersistentIndexMeta
     bool enable_persistent_index = index.enable_persistent_index();
-    st = index.prepare(version);
+    size_t merge_num = 0;
+    {
+        std::lock_guard lg(_rowset_stats_lock);
+        auto iter = _rowset_stats.find(rowset_id);
+        if (iter == _rowset_stats.end()) {
+            string msg = strings::Substitute("inconsistent rowset_stats, rowset not found tablet=$0 rowsetid=$1",
+                                             _tablet.tablet_id(), rowset_id);
+            DCHECK(false) << msg;
+            LOG(ERROR) << msg;
+            _set_error(msg);
+            return;
+        } else {
+            size_t num_adds = iter->second->num_rows;
+            size_t num_dels = iter->second->num_dels;
+            merge_num = num_adds + num_dels;
+        }
+    }
+    st = index.prepare(version, merge_num);
     if (!st.ok()) {
         manager->index_cache().remove(index_entry);
         std::string msg = strings::Substitute("_apply_rowset_commit error: primary index prepare failed: $0 $1",
@@ -1676,7 +1693,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         _set_error(msg);
         return;
     }
-    index.prepare(version);
+    index.prepare(version, 0);
     int64_t t_load = MonotonicMillis();
     // 2. iterator new rowset's pks, update primary index, generate delvec
     size_t total_deletes = 0;

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -425,13 +425,13 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         PersistentIndex index(kPersistentIndexDir);
         // flush l0 first
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(1, 0)));
+        ASSERT_OK(index.prepare(EditVersion(1, 0), N));
         ASSERT_OK(index.upsert(N, key_slices.data(), values.data(), old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
         //std::vector<IndexValue> old_values(second_keys.size());
-        ASSERT_OK(index.prepare(EditVersion(2, 0)));
+        ASSERT_OK(index.prepare(EditVersion(2, 0), N));
         ASSERT_OK(index.upsert(second_n, second_key_slices.data(), second_values.data(), old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
@@ -447,7 +447,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         }
 
         vector<IndexValue> erase_old_values(erase_keys.size());
-        ASSERT_TRUE(index.prepare(EditVersion(3, 0)).ok());
+        ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
         ASSERT_TRUE(index.commit(&index_meta).ok());
@@ -482,7 +482,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
 
         // upsert key/value to new_index
         vector<IndexValue> old_values(invalid_keys.size());
-        ASSERT_TRUE(new_index.prepare(EditVersion(4, 0)).ok());
+        ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
                                     old_values.data())
@@ -549,7 +549,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
     // do snapshot twice, when cannot do flush_l0, which mean index_file checker works
     for (auto i = 0; i < 2; ++i) {
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(i + 1, 0)));
+        ASSERT_OK(index.prepare(EditVersion(i + 1, 0), one_time_num));
         ASSERT_OK(index.upsert(one_time_num, key_slices.data() + one_time_num * i, values.data() + one_time_num * i,
                                old_values.data() + one_time_num * i));
         ASSERT_OK(index.commit(&index_meta));
@@ -560,7 +560,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
     // do flush_l0,
     for (auto i = 2; i < 3; ++i) {
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(i + 1, 0)));
+        ASSERT_OK(index.prepare(EditVersion(i + 1, 0), one_time_num));
         ASSERT_OK(index.upsert(one_time_num, key_slices.data() + one_time_num * i, values.data() + one_time_num * i,
                                old_values.data() + one_time_num * i));
         ASSERT_OK(index.commit(&index_meta));
@@ -573,7 +573,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
     one_time_num /= 10;
     for (auto i = 3; i < 4; ++i) {
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(i + 1, 0)));
+        ASSERT_OK(index.prepare(EditVersion(i + 1, 0), one_time_num));
         ASSERT_OK(index.upsert(one_time_num, key_slices.data() + loaded_num, values.data() + loaded_num,
                                old_values.data() + loaded_num));
         ASSERT_OK(index.commit(&index_meta));
@@ -625,7 +625,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot) {
         PersistentIndex index(kPersistentIndexDir);
 
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(1, 0)));
+        ASSERT_OK(index.prepare(EditVersion(1, 0), N));
         ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
@@ -692,7 +692,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
         PersistentIndex index(kPersistentIndexDir);
 
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(1, 0)));
+        ASSERT_OK(index.prepare(EditVersion(1, 0), N));
         ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
@@ -709,7 +709,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
         }
 
         std::vector<IndexValue> old_values(NUM_SNAPSHOT);
-        ASSERT_OK(index.prepare(EditVersion(2, 0)));
+        ASSERT_OK(index.prepare(EditVersion(2, 0), NUM_SNAPSHOT));
         ASSERT_OK(index.upsert(NUM_SNAPSHOT, snapshot_key_slices.data(), snapshot_values.data(), old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
@@ -727,7 +727,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
 
         config::l0_l1_merge_ratio = 1;
         std::vector<IndexValue> wal_old_values(NUM_WAL);
-        ASSERT_OK(index.prepare(EditVersion(3, 0)));
+        ASSERT_OK(index.prepare(EditVersion(3, 0), NUM_WAL));
         ASSERT_OK(index.upsert(NUM_WAL, wal_key_slices.data(), wal_values.data(), wal_old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
@@ -806,19 +806,19 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
         PersistentIndex index(kPersistentIndexDir);
 
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(1, 0)));
+        ASSERT_OK(index.prepare(EditVersion(1, 0), N));
         ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
         std::vector<IndexValue> old_values(keys.size());
-        ASSERT_TRUE(index.prepare(EditVersion(2, 0)).ok());
+        ASSERT_TRUE(index.prepare(EditVersion(2, 0), keys.size()).ok());
         ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
         vector<IndexValue> erase_old_values(erase_keys.size());
-        ASSERT_TRUE(index.prepare(EditVersion(3, 0)).ok());
+        ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
         ASSERT_TRUE(index.commit(&index_meta).ok());
@@ -852,7 +852,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
 
         // upsert key/value to new_index
         vector<IndexValue> old_values(invalid_keys.size());
-        ASSERT_TRUE(new_index.prepare(EditVersion(4, 0)).ok());
+        ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
                                     old_values.data())
@@ -931,19 +931,19 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
         PersistentIndex index(kPersistentIndexDir);
 
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(1, 0)));
+        ASSERT_OK(index.prepare(EditVersion(1, 0), N));
         ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
         std::vector<IndexValue> old_values(keys.size());
-        ASSERT_TRUE(index.prepare(EditVersion(2, 0)).ok());
+        ASSERT_TRUE(index.prepare(EditVersion(2, 0), keys.size()).ok());
         ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
         vector<IndexValue> erase_old_values(erase_keys.size());
-        ASSERT_TRUE(index.prepare(EditVersion(3, 0)).ok());
+        ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
         ASSERT_TRUE(index.commit(&index_meta).ok());
@@ -977,7 +977,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
 
         // upsert key/value to new_index
         vector<IndexValue> old_values(invalid_keys.size());
-        ASSERT_TRUE(new_index.prepare(EditVersion(4, 0)).ok());
+        ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
                                     old_values.data())
@@ -1367,7 +1367,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_replace) {
     PersistentIndex index(kPersistentIndexDir);
 
     ASSERT_TRUE(index.load(index_meta).ok());
-    ASSERT_TRUE(index.prepare(EditVersion(1, 0)).ok());
+    ASSERT_TRUE(index.prepare(EditVersion(1, 0), N).ok());
     ASSERT_TRUE(index.insert(N, key_slices.data(), values.data(), false).ok());
     ASSERT_TRUE(index.commit(&index_meta).ok());
     ASSERT_TRUE(index.on_commited().ok());
@@ -1440,7 +1440,7 @@ PARALLEL_TEST(PersistentIndexTest, test_varlen_replace) {
     PersistentIndex index(kPersistentIndexDir);
 
     ASSERT_TRUE(index.load(index_meta).ok());
-    ASSERT_TRUE(index.prepare(EditVersion(1, 0)).ok());
+    ASSERT_TRUE(index.prepare(EditVersion(1, 0), N).ok());
     ASSERT_TRUE(index.insert(N, key_slices.data(), values.data(), false).ok());
     ASSERT_TRUE(index.commit(&index_meta).ok());
     ASSERT_TRUE(index.on_commited().ok());
@@ -1533,8 +1533,8 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
 
         PersistentIndex index(kPersistentIndexDir);
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(1, 0)));
         const int N = 10000;
+        ASSERT_OK(index.prepare(EditVersion(1, 0), N));
         for (int i = 0; i < 50; i++) {
             vector<Key> keys(N);
             vector<Slice> key_slices;
@@ -1574,8 +1574,8 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
     {
         PersistentIndex index(kPersistentIndexDir);
         ASSERT_OK(index.load(index_meta));
-        ASSERT_OK(index.prepare(EditVersion(2, 0)));
         const int N = 100000;
+        ASSERT_OK(index.prepare(EditVersion(2, 0), N));
         for (int i = 0; i < 5; i++) {
             vector<IndexValue> values;
             key_slices.reserve(N);


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This pr(https://github.com/StarRocks/starrocks/pull/15729) limits the memory usage of primary key index and resolve the OOM issue when we doing large data import, but it will increase the time consumed in apply phase and the most time consuming part is the IO time of reading persistent index.

This pr will create a bloom filter for the temp L1 index and will filter the KV by bloom filter to reduce the IO time. At my test env, the best case apply time is reduced from 100 minutes to 15 minutes.

The following is my test result, one FE, three BEs, 16 core 64GB, one HDD.
|PrimaryKey Length| RowNum|BucketNum| Column Num|  Load time(s)| Apply time(s)| Peak UpdateMemory usage | Max CPU usage | branch |
|---------------------|-----------|--------------------|------------------------------|----|-----|-----|----|-----|
|16 Bytes| 864001869 |1 |  23 |  1860| 6374|82MB  | 100% | branch-main |
|16 Bytes| 864001869 |1 |  23 | 1881| 929|508MB| 260%| branch-opt |
|16 Bytes| 864001869 |10 |  23 |  1772| 201|203MB | 300%| branch-main |
|16 Bytes| 864001869 |10 |  23 | 1780| 124|278MB| 410%| branch-opt |

This pr is for the large data import especially import a large amount data to one tablet. This pr will reduce the time consumed by apply, but will use more memory and cpu and we can  configure `enable_parallel_get_and_bf` to decide whether to enable this optimization or not. If you want to speed up apply and the memory is not the bottleneck, you can set 
`enable_parallel_get_and_bf` to true to enable this optimization.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
