### PR TITLE
[Enhancement] Add session variable enable_query_tablet_affinity

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -442,7 +442,7 @@ public class OlapScanNode extends ScanNode {
                                       PhysicalPartition physicalPartition,
                                       MaterializedIndex index,
                                       List<Tablet> tablets,
-                                      long localBeId) throws UserException {
+                                      long localBeId, boolean needShuffleReplicas) throws UserException {
         int logNum = 0;
         int schemaHash = olapTable.getSchemaHashByIndexId(index.getId());
         String schemaHashStr = String.valueOf(schemaHash);
@@ -512,7 +512,10 @@ public class OlapScanNode extends ScanNode {
                 }
             }
 
-            Collections.shuffle(replicas);
+            if (needShuffleReplicas) {
+                Collections.shuffle(replicas);
+            }
+
             boolean tabletIsNull = true;
             boolean collectedStat = false;
             for (Replica replica : replicas) {
@@ -631,7 +634,7 @@ public class OlapScanNode extends ScanNode {
                 }
                 totalTabletsNum += selectedIndex.getTablets().size();
                 selectedTabletsNum += tablets.size();
-                addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, localBeId);
+                addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, localBeId, true);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/BackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/BackendSelector.java
@@ -15,7 +15,22 @@
 package com.starrocks.qe;
 
 import com.starrocks.common.UserException;
+import com.starrocks.thrift.TScanRangeLocations;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public interface BackendSelector {
     void computeScanRangeAssignment() throws UserException;
+
+    default void shuffleScanRangeLocations(TScanRangeLocations scanRange) {
+        if (!scanRange.getScan_range().isSetInternal_scan_range()) {
+            Collections.shuffle(scanRange.getLocations());
+        } else {
+            List<Integer> indexes = IntStream.range(0, scanRange.getLocationsSize()).boxed().collect(Collectors.toList());
+
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -212,9 +212,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
      * and scan distribution keys, when there is only one BE.
      */
     public static final String ENABLE_LOCAL_SHUFFLE_AGG = "enable_local_shuffle_agg";
-
     public static final String ENABLE_TABLET_INTERNAL_PARALLEL = "enable_tablet_internal_parallel";
     public static final String ENABLE_TABLET_INTERNAL_PARALLEL_V2 = "enable_tablet_internal_parallel_v2";
+
+    public static final String QUERY_TABLET_AFFINITY_MODE = "query_tablet_affinity_mode";
 
     public static final String TABLET_INTERNAL_PARALLEL_MODE = "tablet_internal_parallel_mode";
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
@@ -573,6 +574,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = LOG_REJECTED_RECORD_NUM)
     private long logRejectedRecordNum = 0;
+
+    /**
+     * Determines whether to enable query tablet affinity. When enabled, attempts to schedule
+     * fragments that access the same tablet to run on the same node to improve cache hit.
+     */
+    @VariableMgr.VarAttr(name = QUERY_TABLET_AFFINITY_MODE)
+    private String enableQueryTabletAffinityMode = "disable";
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_SCAN_WAIT_TIME, flag = VariableMgr.INVISIBLE)
     private long runtimeFilterScanWaitTime = 20L;
@@ -1410,6 +1418,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_STRICT_TYPE, flag = VariableMgr.INVISIBLE)
     private boolean enableStrictType = false;
+
+
+    public QueryTabletAffinityMode getQueryTabletAffinityMode() {
+        return QueryTabletAffinityMode.valueOf(enableQueryTabletAffinityMode.toUpperCase());
+    }
+
+    public void setEnableQueryTabletAffinityMode(QueryTabletAffinityMode value) {
+        this.enableQueryTabletAffinityMode = value.toString();
+    }
 
     public boolean isCboUseDBLock() {
         return cboUseDBLock;
@@ -2737,6 +2754,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             return GSON.fromJson(content, new TypeToken<Map<String, NonDefaultValue>>() {
             }.getType());
         }
+    }
+
+    public enum QueryTabletAffinityMode {
+        AUTO,
+        FORCE_AFFINITY,
+        DISABLE
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
@@ -59,7 +59,8 @@ public class BackendSelectorFactory {
         FragmentScanRangeAssignment assignment = execFragment.getScanRangeAssignment();
 
         if (scanNode instanceof SchemaScanNode) {
-            return new NormalBackendSelector(scanNode, locations, assignment, workerProvider, false);
+            return new NormalBackendSelector(scanNode, locations, assignment, workerProvider, false,
+                    sessionVariable.getQueryTabletAffinityMode());
         } else if (scanNode instanceof HdfsScanNode || scanNode instanceof IcebergScanNode ||
                 scanNode instanceof HudiScanNode || scanNode instanceof DeltaLakeScanNode ||
                 scanNode instanceof FileTableScanNode || scanNode instanceof PaimonScanNode) {
@@ -80,9 +81,11 @@ public class BackendSelectorFactory {
                 boolean isRightOrFullBucketShuffleFragment = execFragment.isRightOrFullBucketShuffle();
                 return new ColocatedBackendSelector((OlapScanNode) scanNode, assignment,
                         colocatedAssignment, isRightOrFullBucketShuffleFragment, workerProvider,
-                        sessionVariable.getMaxBucketsPerBeToUseBalancerAssignment());
+                        sessionVariable.getMaxBucketsPerBeToUseBalancerAssignment(),
+                        sessionVariable.getQueryTabletAffinityMode());
             } else {
-                return new NormalBackendSelector(scanNode, locations, assignment, workerProvider, isLoadType);
+                return new NormalBackendSelector(scanNode, locations, assignment, workerProvider, isLoadType,
+                        sessionVariable.getQueryTabletAffinityMode());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -57,6 +57,7 @@ import com.starrocks.thrift.TWorkGroup;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class SetStmtAnalyzer {
@@ -176,6 +177,10 @@ public class SetStmtAnalyzer {
             validateTabletInternalParallelModeValue(resolvedExpression.getStringValue());
         }
 
+        if (variable.equalsIgnoreCase(SessionVariable.QUERY_TABLET_AFFINITY_MODE)) {
+            validateQueryTabletAffinityModeValue(resolvedExpression.getStringValue());
+        }
+
         if (variable.equalsIgnoreCase(SessionVariable.DEFAULT_TABLE_COMPRESSION)) {
             String compressionName = resolvedExpression.getStringValue();
             TCompressionType compressionType = CompressionUtils.getCompressTypeByName(compressionName);
@@ -212,6 +217,16 @@ public class SetStmtAnalyzer {
             TTabletInternalParallelMode.valueOf(val.toUpperCase());
         } catch (Exception ignored) {
             throw new SemanticException("Invalid tablet_internal_parallel_mode, now we support {auto, force_split}");
+        }
+    }
+
+    private static void validateQueryTabletAffinityModeValue(String val) {
+        try {
+            SessionVariable.QueryTabletAffinityMode.valueOf(val.toUpperCase());
+        } catch (Exception ignored) {
+            throw new SemanticException(String.format("Invalid %s, now we support %s",
+                    SessionVariable.QUERY_TABLET_AFFINITY_MODE,
+                    Arrays.toString(SessionVariable.QueryTabletAffinityMode.values())));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -747,7 +747,7 @@ public class PlanFragmentBuilder {
                         scanNode.setTabletId2BucketSeq(tabletId2BucketSeq);
                         List<Tablet> tablets =
                                 selectTabletIds.stream().map(selectedTable::getTablet).collect(Collectors.toList());
-                        scanNode.addScanRangeLocations(partition, physicalPartition, selectedTable, tablets, localBeId);
+                        scanNode.addScanRangeLocations(partition, physicalPartition, selectedTable, tablets, localBeId, false);
                     }
                 }
                 scanNode.setTotalTabletsNum(totalTabletsNum);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
@@ -274,7 +274,8 @@ public class ColocatedBackendSelectorTest {
         for (OlapScanNode scanNode : scanNodes) {
             ColocatedBackendSelector backendSelector =
                     new ColocatedBackendSelector(scanNode, assignment, colocatedAssignemnt, false,
-                            workerProvider, maxBucketsPerBeToUseBalancerAssignment);
+                            workerProvider, maxBucketsPerBeToUseBalancerAssignment,
+                            SessionVariable.QueryTabletAffinityMode.DISABLE);
             backendSelector.computeScanRangeAssignment();
         }
 


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Add a session variable `enable_query_tablet_affinity` to determine whether to enable query tablet affinity. 

When enabled, attempts to schedule fragments that access the same tablet to run on the same node to improve cache hit. 
For now, we don't shuffle the order of replications when enabled. We will implement a more robust strategy for tablet affinity in the future.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
