### PR TITLE
[BugFix] Fix CTAS set sql limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -52,7 +52,7 @@ public class DeletePlanner {
         QueryRelation query = deleteStatement.getQueryStatement().getQueryRelation();
         List<String> colNames = query.getColumnOutputNames();
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
-        LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, session).transformWithSelectLimit(query);
+        LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, session).transform(query);
 
         // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
         boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -54,7 +54,7 @@ public class UpdatePlanner {
         QueryRelation query = updateStmt.getQueryStatement().getQueryRelation();
         List<String> colNames = query.getColumnOutputNames();
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
-        LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, session).transformWithSelectLimit(query);
+        LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, session).transform(query);
 
         // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
         boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -14,11 +14,9 @@
 
 package com.starrocks.sql.analyzer;
 
-import com.starrocks.analysis.LimitElement;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.AddSqlBlackListStmt;
 import com.starrocks.sql.ast.AdminCancelRepairTableStmt;
 import com.starrocks.sql.ast.AdminCheckTabletsStmt;
@@ -91,7 +89,6 @@ import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.InstallPluginStmt;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.PauseRoutineLoadStmt;
-import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RecoverDbStmt;
 import com.starrocks.sql.ast.RecoverPartitionStmt;
@@ -360,12 +357,6 @@ public class Analyzer {
         @Override
         public Void visitQueryStatement(QueryStatement stmt, ConnectContext session) {
             new QueryAnalyzer(session).analyze(stmt);
-
-            QueryRelation queryRelation = stmt.getQueryRelation();
-            long selectLimit = session.getSessionVariable().getSqlSelectLimit();
-            if (!queryRelation.hasLimit() && selectLimit != SessionVariable.DEFAULT_SELECT_LIMIT) {
-                queryRelation.setLimit(new LimitElement(selectLimit));
-            }
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -157,9 +157,8 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
         OptExprBuilder root = plan.getRootBuilder();
         // Set limit if user set sql_select_limit.
         long selectLimit = ConnectContext.get().getSessionVariable().getSqlSelectLimit();
-        if (!root.getRoot().getOp().hasLimit() &&
-                selectLimit != SessionVariable.DEFAULT_SELECT_LIMIT) {
-            LogicalLimitOperator limitOperator = LogicalLimitOperator.local(selectLimit);
+        if (!root.getRoot().getOp().hasLimit() && selectLimit != SessionVariable.DEFAULT_SELECT_LIMIT) {
+            LogicalLimitOperator limitOperator = LogicalLimitOperator.init(selectLimit);
             root = root.withNewRoot(limitOperator);
             return new LogicalPlan(root, plan.getOutputColumn(), plan.getCorrelation());
         }
@@ -604,13 +603,13 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
             LogicalPlan leftPlan = visit(node.getLeft());
             LogicalPlan rightPlan = visit(node.getRight(), leftPlan.getRootBuilder().getExpressionMapping());
 
-
             List<ColumnRefOperator> leftFieldMappings = leftPlan.getRootBuilder().getFieldMappings();
             List<ColumnRefOperator> rightFieldMappings = rightPlan.getRootBuilder().getFieldMappings();
 
             ExpressionMapping expressionMapping = new ExpressionMapping(new Scope(RelationId.of(node),
                     node.getLeft().getRelationFields().joinWith(node.getRight().getRelationFields())),
-                    Streams.concat(leftFieldMappings.stream(), rightFieldMappings.stream()).collect(Collectors.toList()));
+                    Streams.concat(leftFieldMappings.stream(), rightFieldMappings.stream())
+                            .collect(Collectors.toList()));
 
             Operator root = LogicalApplyOperator.builder().setCorrelationColumnRefs(correlation)
                     .setNeedCheckMaxRows(false)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -485,7 +485,7 @@ public class CTASAnalyzerTest {
     @Test
     public void testCTASDefaultLimit() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
-        String sql = "create table ctas_limit (c1, c2, c3) as select t1.c1, t1.c2, t1.c3 from test_notnull t1;";
+        String sql = "create table ctas_limit as select * from test_notnull t1;";
         try {
             ctx.getSessionVariable().setSqlSelectLimit(10);
             CreateTableAsSelectStmt ctasStmt =

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -24,6 +24,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.CreateDbStmt;
@@ -478,6 +479,21 @@ public class CTASAnalyzerTest {
             SlotRef col1 = (SlotRef) queryStatement.getQueryRelation().getOutputExpression().get(0);
             Assert.assertFalse(col1.isNullable());
             starRocksAssert.dropTable("emps");
+        }
+    }
+
+    @Test
+    public void testCTASDefaultLimit() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String sql = "create table ctas_limit (c1, c2, c3) as select t1.c1, t1.c2, t1.c3 from test_notnull t1;";
+        try {
+            ctx.getSessionVariable().setSqlSelectLimit(10);
+            CreateTableAsSelectStmt ctasStmt =
+                    (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+            QueryStatement query = ctasStmt.getQueryStatement();
+            Assert.assertFalse(query.getQueryRelation().hasLimit());
+        } finally {
+            ctx.getSessionVariable().setSqlSelectLimit(SessionVariable.DEFAULT_SELECT_LIMIT);
         }
     }
 }


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
The default value for a new connection is the maximum number of rows that the server permits per table. Typical default values are (2^32)−1 or (2^64)−1. If you have changed the limit, the default value can be restored by assigning a value of DEFAULT.
If a [SELECT](https://dev.mysql.com/doc/refman/8.0/en/select.html) has a LIMIT clause, the LIMIT takes precedence over the value of [sql_select_limit](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_sql_select_limit).

[sql_select_limit](https://docs.oracle.com/cd/E19078-01/mysql/mysql-refman-5.0/server-administration.html#sysvar_sql_select_limit) does not apply to [SELECT](https://docs.oracle.com/cd/E19078-01/mysql/mysql-refman-5.0/sql-syntax.html#select) statements executed within stored routines. It also does not apply to [SELECT](https://docs.oracle.com/cd/E19078-01/mysql/mysql-refman-5.0/sql-syntax.html#select) statements that do not produce a result set to be returned to the client. These include [SELECT](https://docs.oracle.com/cd/E19078-01/mysql/mysql-refman-5.0/sql-syntax.html#select) statements in subqueries, [CREATE TABLE ... SELECT](https://docs.oracle.com/cd/E19078-01/mysql/mysql-refman-5.0/sql-syntax.html#create-table), and [INSERT INTO ... SELECT](https://docs.oracle.com/cd/E19078-01/mysql/mysql-refman-5.0/sql-syntax.html#insert-select).

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
