### PR TITLE
[Enhancement] Avoid printing too many irrelevant logs when be hang

### DIFF
--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -139,6 +139,10 @@ public:
     void set_is_stream_test(bool is_stream_test) { _is_stream_test = is_stream_test; }
     bool is_stream_test() const { return _is_stream_test; }
 
+    size_t expired_log_count() { return _expired_log_count; }
+
+    void set_expired_log_count(size_t val) { _expired_log_count = val; }
+
 private:
     // Id of this query
     TUniqueId _query_id;
@@ -184,6 +188,8 @@ private:
 
     bool _enable_adaptive_dop = false;
     AdaptiveDopParam _adaptive_dop_param;
+
+    size_t _expired_log_count = 0;
 };
 
 class FragmentContextManager {

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -79,8 +79,12 @@ void PipelineDriverPoller::run_internal() {
                     //
                     // If the fragment is expired when the source operator is already pending i/o task,
                     // The state of driver shouldn't be changed.
-                    LOG(WARNING) << "[Driver] Timeout, query_id=" << print_id(driver->query_ctx()->query_id())
-                                 << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id());
+                    size_t expired_log_count = driver->fragment_ctx()->expired_log_count();
+                    if (expired_log_count <= 100) {
+                        LOG(WARNING) << "[Driver] Timeout, query_id=" << print_id(driver->query_ctx()->query_id())
+                                     << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id());
+                        driver->fragment_ctx()->set_expired_log_count(++expired_log_count);
+                    }
                     driver->fragment_ctx()->cancel(
                             Status::TimedOut(fmt::format("Query exceeded time limit of {} seconds",
                                                          driver->query_ctx()->get_query_expire_seconds())));


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
when be hang, it may print lots of identical logs like:
```
W0428 13:18:03.195717 1585615 pipeline_driver_poller.cpp:70] [Driver] Timeout, query_id=f4e2353b-e56b-11ed-a391-00163e0483b9, instance_id=f4e2353b-e56b-11ed-a391-00163e0483c7
```
which is not useful for debugging

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
