### PR TITLE
[BugFix] Preserve the order of the producer in the passthrough queue of Adaptive DOP

### DIFF
--- a/be/src/exec/pipeline/adaptive/collect_stats_context.cpp
+++ b/be/src/exec/pipeline/adaptive/collect_stats_context.cpp
@@ -152,6 +152,8 @@ bool PassthroughState::is_downstream_finished(int32_t driver_seq) const {
 
     const auto& buffer_chunk_queue = _ctx->_buffer_chunk_queue(driver_seq);
     const auto& passthrough_chunk_queue = _in_chunk_queue_per_driver_seq[driver_seq].queue;
+    // _is_finishing_per_driver_seq is set to true using memory_order_release after all the chunks are enqueued.
+    // Therefore, enqueueing chunk hapens before setting _is_finishing_per_driver_seq to true.
     return buffer_chunk_queue.empty() && passthrough_chunk_queue.size_approx() <= 0;
 }
 bool PassthroughState::is_upstream_finished(int32_t driver_seq) const {

--- a/be/src/exec/pipeline/adaptive/collect_stats_context.cpp
+++ b/be/src/exec/pipeline/adaptive/collect_stats_context.cpp
@@ -92,7 +92,8 @@ bool PassthroughState::need_input(int32_t driver_seq) const {
 }
 
 Status PassthroughState::push_chunk(int32_t driver_seq, ChunkPtr chunk) {
-    _in_chunk_queue_per_driver_seq[driver_seq].queue.enqueue(std::move(chunk));
+    auto& [chunk_queue, token] = _in_chunk_queue_per_driver_seq[driver_seq];
+    chunk_queue.enqueue(token, std::move(chunk));
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/adaptive/collect_stats_context.h
+++ b/be/src/exec/pipeline/adaptive/collect_stats_context.h
@@ -179,7 +179,7 @@ private:
         ChunkQueueWrapper() : queue(), token(queue) {}
 
         ChunkQueue queue;
-        //_producer_token is used to ensure that the order of dequeueing is the same as enqueueing
+        // token is used to ensure that the order of dequeueing is the same as enqueueing.
         ChunkQueue::producer_token_t token;
     };
     std::vector<ChunkQueueWrapper> _in_chunk_queue_per_driver_seq;

--- a/be/src/exec/pipeline/adaptive/collect_stats_context.h
+++ b/be/src/exec/pipeline/adaptive/collect_stats_context.h
@@ -175,7 +175,14 @@ private:
     static constexpr size_t UNPLUG_THRESHOLD_PER_DRIVER_SEQ = MAX_PASSTHROUGH_CHUNKS_PER_DRIVER_SEQ / 2;
 
     using ChunkQueue = moodycamel::ConcurrentQueue<ChunkPtr>;
-    std::vector<ChunkQueue> _in_chunk_queue_per_driver_seq;
+    struct ChunkQueueWrapper {
+        ChunkQueueWrapper() : queue(), token(queue) {}
+
+        ChunkQueue queue;
+        //_producer_token is used to ensure that the order of dequeueing is the same as enqueueing
+        ChunkQueue::producer_token_t token;
+    };
+    std::vector<ChunkQueueWrapper> _in_chunk_queue_per_driver_seq;
     mutable std::vector<uint8_t> _unpluging_per_driver_seq;
 };
 

--- a/be/src/exec/pipeline/adaptive/collect_stats_context.h
+++ b/be/src/exec/pipeline/adaptive/collect_stats_context.h
@@ -105,7 +105,7 @@ private:
     const int64_t _max_output_amplification_factor;
 
     std::vector<BufferChunkQueue> _buffer_chunk_queue_per_driver_seq;
-    std::vector<uint8_t> _is_finishing_per_driver_seq;
+    std::vector<std::atomic<uint8_t>> _is_finishing_per_driver_seq;
     std::vector<uint8_t> _is_finished_per_driver_seq;
 
     RuntimeState* const _runtime_state;


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22826.

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`PassthroughState::_in_chunk_queue` uses `moodycamel::ConcurrentQueue`, which doesn't preserve the order of the input by default.
We must hold the `producer_token` when enqueueing chunks.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
