### PR TITLE
[BugFix] Fix BE access S3 failed when S3 bucket name contains dots

### DIFF
--- a/be/src/common/s3_uri.cpp
+++ b/be/src/common/s3_uri.cpp
@@ -17,6 +17,7 @@
 #include <brpc/uri.h>
 #include <fmt/format.h>
 #include <gutil/strings/util.h>
+
 #include <boost/algorithm/string.hpp>
 
 namespace starrocks {

--- a/be/src/common/s3_uri.cpp
+++ b/be/src/common/s3_uri.cpp
@@ -18,7 +18,7 @@
 #include <fmt/format.h>
 #include <gutil/strings/util.h>
 
-#include <boost/algorithm/string.hpp>
+#include <algorithm>
 
 namespace starrocks {
 
@@ -28,8 +28,8 @@ bool S3URI::parse(const char* uri_str) {
         return false;
     }
 
-    _scheme = boost::algorithm::to_lower_copy(uri.scheme());
-
+    _scheme = uri.scheme();
+    std::transform(_scheme.begin(), _scheme.end(), _scheme.begin(), ::tolower);
     const std::string& host = uri.host();
     std::string_view path;
 

--- a/be/test/common/s3_uri_test.cpp
+++ b/be/test/common/s3_uri_test.cpp
@@ -41,13 +41,42 @@ PARALLEL_TEST(S3URITest, path_style_url) {
 }
 
 PARALLEL_TEST(S3URITest, s3_scheme) {
-    S3URI uri;
-    ASSERT_TRUE(uri.parse("s3://mybucket/puppy.jpg"));
-    EXPECT_EQ("s3", uri.scheme());
-    EXPECT_EQ("", uri.region());
-    EXPECT_EQ("mybucket", uri.bucket());
-    EXPECT_EQ("puppy.jpg", uri.key());
-    EXPECT_EQ("", uri.endpoint());
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("s3://mybucket/puppy.jpg"));
+        EXPECT_EQ("s3", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("mybucket", uri.bucket());
+        EXPECT_EQ("puppy.jpg", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("S3://test.name.with.dot/another.test/foo.parquet"));
+        EXPECT_EQ("s3", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("test.name.with.dot", uri.bucket());
+        EXPECT_EQ("another.test/foo.parquet", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("s3A://test.name.with.dot/another.test/foo.parquet"));
+        EXPECT_EQ("s3a", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("test.name.with.dot", uri.bucket());
+        EXPECT_EQ("another.test/foo.parquet", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("s3n://test.name.with.dot/another.test/foo.parquet"));
+        EXPECT_EQ("s3n", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("test.name.with.dot", uri.bucket());
+        EXPECT_EQ("another.test/foo.parquet", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
 }
 
 PARALLEL_TEST(S3URITest, virtual_host_non_s3_url) {
@@ -78,6 +107,16 @@ PARALLEL_TEST(S3URITest, empty) {
 PARALLEL_TEST(S3URITest, missing_scheme) {
     S3URI uri;
     ASSERT_FALSE(uri.parse("/bucket/puppy.jpg"));
+}
+
+PARALLEL_TEST(S3URITest, oss_bucket) {
+    S3URI uri;
+    ASSERT_TRUE(uri.parse("oss://sr-test/dataset/smith/foo.parquet"));
+    EXPECT_EQ("oss", uri.scheme());
+    EXPECT_EQ("", uri.region());
+    EXPECT_EQ("sr-test", uri.bucket());
+    EXPECT_EQ("dataset/smith/foo.parquet", uri.key());
+    EXPECT_EQ("", uri.endpoint());
 }
 
 } // namespace starrocks

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -558,7 +558,6 @@ under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.3.3</version>
             <exclusions>
                 <exclusion>
                     <artifactId>zookeeper</artifactId>


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

S3 does not recommend the user to create a bucket with dots, but if you do, you need to enable s3 path_style_access. Below is an example that can works now(after this PR merged):

```sql
CREATE EXTERNAL TABLE file_table 
(
  ACTIVITY string
) 
ENGINE=FILE
PROPERTIES
(
  "path" = "s3://test.name.with.dot/another.test/foo.parquet",
  "format" = "parquet",
  "aws.s3.enable_path_style_access"="true",
  "aws.s3.access_key"="hello",
  "aws.s3.secret_key"="world",
  "aws.s3.region"="us-west-2"
);
```

About this problem, already discussed in:
https://issues.apache.org/jira/browse/HADOOP-17412
https://issues.apache.org/jira/browse/HADOOP-17017


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
