### PR TITLE
[Feature] lpad/rpad function support default value

### DIFF
--- a/docs/sql-reference/sql-functions/string-functions/lpad.md
+++ b/docs/sql-reference/sql-functions/string-functions/lpad.md
@@ -7,8 +7,20 @@ This function returns strings with a length of len (starting counting from the f
 ## Syntax
 
 ```Haskell
-VARCHAR lpad(VARCHAR str, INT len, VARCHAR pad)
+VARCHAR lpad(VARCHAR str, INT len[, VARCHAR pad])
 ```
+
+## Parameters
+
+`str`: required, the string to be padded, which must evaluate to a VARCHAR value.
+
+`len`: required, the length of return value, it means the length of characters, not bytes, which must evaluate to an INT value.
+
+`pad`: optional, the characters to be added in front of str, which must be a VARCHAR value. If this parameter is not specified, spaces are added by default.
+
+## Return value
+
+Returns a VARCHAR value.
 
 ## Examples
 
@@ -25,6 +37,13 @@ MySQL > SELECT lpad("hi", 1, "xy");
 | lpad('hi', 1, 'xy') |
 +---------------------+
 | h                   |
++---------------------+
+
+MySQL > SELECT lpad("hi", 5);
++---------------------+
+| lpad('hi', 5, ' ')  |
++---------------------+
+|    hi               |
 +---------------------+
 ```
 

--- a/docs/sql-reference/sql-functions/string-functions/rpad.md
+++ b/docs/sql-reference/sql-functions/string-functions/rpad.md
@@ -2,13 +2,25 @@
 
 ## Description
 
-This function returns strings with a length of len (starting counting from the first syllable) in str. If len is longer than str, the return value is lengthened to len characters by adding pad characters in front of str.  If str is longer than len, the return value is shortened to len characters. Len means the length of characters, not bytes.
+This function returns strings with a length of len (starting counting from the first syllable) in str. If len is longer than str, the return value is lengthened to len characters by adding pad characters behind str.  If str is longer than len, the return value is shortened to len characters. Len means the length of characters, not bytes.
 
 ## Syntax
 
 ```Haskell
-VARCHAR rpad(VARCHAR str, INT len, VARCHAR pad)
+VARCHAR rpad(VARCHAR str, INT len[, VARCHAR pad])
 ```
+
+## Parameters
+
+`str`: required, the string to be padded, which must evaluate to a VARCHAR value.
+
+`len`: required, the length of return value, it means the length of characters, not bytes, which must evaluate to an INT value.
+
+`pad`: optional, the characters to be added behind str, which must be a VARCHAR value. If this parameter is not specified, spaces are added by default.
+
+## Return value
+
+Returns a VARCHAR value.
 
 ## Examples
 
@@ -25,6 +37,13 @@ MySQL > SELECT rpad("hi", 1, "xy");
 | rpad('hi', 1, 'xy') |
 +---------------------+
 | h                   |
++---------------------+
+
+MySQL > SELECT rpad("hi", 5);
++---------------------+
+| rpad('hi', 5, ' ')  |
++---------------------+
+| hi                  |
 +---------------------+
 ```
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5422,6 +5422,16 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             return new FunctionCallExpr(fnName, exprs, pos);
         }
 
+        if (functionName.equals(FunctionSet.LPAD) || functionName.equals(FunctionSet.RPAD)) {
+            if (context.expression().size() == 2) {
+                Expr e1 = (Expr) visit(context.expression(0));
+                Expr e2 = (Expr) visit(context.expression(1));
+                FunctionCallExpr functionCallExpr = new FunctionCallExpr(
+                        fnName, Lists.newArrayList(e1, e2, new StringLiteral(" ")), pos);
+                return functionCallExpr;
+            }
+        }
+
         FunctionCallExpr functionCallExpr = new FunctionCallExpr(fnName,
                 new FunctionParams(false, visit(context.expression(), Expr.class)), pos);
         if (context.over() != null) {

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -1,0 +1,147 @@
+-- name: test_string_functions
+select lpad('test', 8, '');
+-- result:
+test
+-- !result
+select lpad('test', 8, ' ');
+-- result:
+    test
+-- !result
+select lpad('test', 8, '中文，');
+-- result:
+中文，中test
+-- !result
+select lpad('test', 8);
+-- result:
+    test
+-- !result
+select lpad('test', 2, '');
+-- result:
+te
+-- !result
+select lpad('test', 2, ' ');
+-- result:
+te
+-- !result
+select lpad('test', 2, '中文，');
+-- result:
+te
+-- !result
+select lpad('test', 2);
+-- result:
+te
+-- !result
+select lpad('test', 0, '');
+-- result:
+-- !result
+select lpad('test', 0, ' ');
+-- result:
+-- !result
+select lpad('test', 0, '中文，');
+-- result:
+-- !result
+select lpad('test', 0);
+-- result:
+-- !result
+select rpad('test', 8, '');
+-- result:
+test
+-- !result
+select rpad('test', 8, ' ');
+-- result:
+test    
+-- !result
+select rpad('test', 8, '中文，');
+-- result:
+test中文，中
+-- !result
+select rpad('test', 8);
+-- result:
+test    
+-- !result
+select rpad('test', 2, '');
+-- result:
+te
+-- !result
+select rpad('test', 2, ' ');
+-- result:
+te
+-- !result
+select rpad('test', 2, '中文，');
+-- result:
+te
+-- !result
+select rpad('test', 2);
+-- result:
+te
+-- !result
+select rpad('test', 0, '');
+-- result:
+-- !result
+select rpad('test', 0, ' ');
+-- result:
+-- !result
+select rpad('test', 0, '中文，');
+-- result:
+-- !result
+select rpad('test', 0);
+-- result:
+-- !result
+create table t0(c0 varchar(16), c1 INT(16))
+        DUPLICATE KEY(c0)
+        DISTRIBUTED BY HASH(c0)
+        BUCKETS 1
+        PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t0 values ('test', 8), ('test', 2), ('test', 0);
+-- result:
+-- !result
+select lpad(c0, c1, ' ') from t0;
+-- result:
+    test
+te
+
+-- !result
+select lpad(c0, c1, '中文，') from t0;
+-- result:
+中文，中test
+te
+
+-- !result
+select lpad(c0, c1, '') from t0;
+-- result:
+test
+te
+
+-- !result
+select lpad(c0, c1) from t0;
+-- result:
+    test
+te
+
+-- !result
+select rpad(c0, c1, ' ') from t0;
+-- result:
+test    
+te
+
+-- !result
+select rpad(c0, c1, '中文，') from t0;
+-- result:
+test中文，中
+te
+
+-- !result
+select rpad(c0, c1, '') from t0;
+-- result:
+test
+te
+
+-- !result
+select rpad(c0, c1) from t0;
+-- result:
+test    
+te
+
+-- !result

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -1,0 +1,44 @@
+-- name: test_string_functions
+-- function: lpad
+select lpad('test', 8, '');
+select lpad('test', 8, ' ');
+select lpad('test', 8, '中文，');
+select lpad('test', 8);
+select lpad('test', 2, '');
+select lpad('test', 2, ' ');
+select lpad('test', 2, '中文，');
+select lpad('test', 2);
+select lpad('test', 0, '');
+select lpad('test', 0, ' ');
+select lpad('test', 0, '中文，');
+select lpad('test', 0);
+
+-- function: rpad
+select rpad('test', 8, '');
+select rpad('test', 8, ' ');
+select rpad('test', 8, '中文，');
+select rpad('test', 8);
+select rpad('test', 2, '');
+select rpad('test', 2, ' ');
+select rpad('test', 2, '中文，');
+select rpad('test', 2);
+select rpad('test', 0, '');
+select rpad('test', 0, ' ');
+select rpad('test', 0, '中文，');
+select rpad('test', 0);
+
+create table t0(c0 varchar(16), c1 INT(16))
+        DUPLICATE KEY(c0)
+        DISTRIBUTED BY HASH(c0)
+        BUCKETS 1
+        PROPERTIES('replication_num'='1');
+-- insert 3 rows
+insert into t0 values ('test', 8), ('test', 2), ('test', 0);
+select lpad(c0, c1, ' ') from t0;
+select lpad(c0, c1, '中文，') from t0;
+select lpad(c0, c1, '') from t0;
+select lpad(c0, c1) from t0;
+select rpad(c0, c1, ' ') from t0;
+select rpad(c0, c1, '中文，') from t0;
+select rpad(c0, c1, '') from t0;
+select rpad(c0, c1) from t0;


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
Fixes #15021

## Problem Summary(Required):
make the third value of lpad function optional with a default value ' ', a single blank

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function
