### PR TITLE
[BugFix] Disable dervie not null predicates for mv rewrite plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -205,7 +205,7 @@ public class Optimizer {
             memo = new Memo();
         }
 
-        context = new OptimizerContext(memo, columnRefFactory, connectContext);
+        context = new OptimizerContext(memo, columnRefFactory, connectContext, optimizerConfig);
         OptimizerTraceInfo traceInfo;
         if (connectContext.getExecutor() == null) {
             traceInfo = new OptimizerTraceInfo(connectContext.getQueryId(), null);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerConfig.java
@@ -31,6 +31,8 @@ public class OptimizerConfig {
     private BitSet ruleSetSwitches;
     private BitSet ruleSwitches;
 
+    private boolean isMVRewritePlan;
+
     private static final OptimizerConfig DEFAULT_CONFIG = new OptimizerConfig();
 
     public static OptimizerConfig defaultConfig() {
@@ -67,5 +69,13 @@ public class OptimizerConfig {
 
     public boolean isRuleDisable(RuleType ruleType) {
         return !ruleSwitches.get(ruleType.ordinal());
+    }
+
+    public boolean isMVRewritePlan() {
+        return this.isMVRewritePlan;
+    }
+
+    public void setMVRewritePlan(boolean MVRewritePlan) {
+        this.isMVRewritePlan = MVRewritePlan;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerConfig.java
@@ -75,7 +75,7 @@ public class OptimizerConfig {
         return this.isMVRewritePlan;
     }
 
-    public void setMVRewritePlan(boolean MVRewritePlan) {
-        this.isMVRewritePlan = MVRewritePlan;
+    public void setMVRewritePlan(boolean isMVRewritePlan) {
+        this.isMVRewritePlan = isMVRewritePlan;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -56,6 +56,7 @@ public class OptimizerContext {
         this.candidateMvs = Lists.newArrayList();
     }
 
+    @VisibleForTesting
     public OptimizerContext(Memo memo, ColumnRefFactory columnRefFactory, ConnectContext connectContext) {
         this(memo, columnRefFactory, connectContext, OptimizerConfig.defaultConfig());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/IsNullPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/IsNullPredicateOperator.java
@@ -22,13 +22,17 @@ public class IsNullPredicateOperator extends PredicateOperator {
     private final boolean isNotNull;
 
     public IsNullPredicateOperator(ScalarOperator arguments) {
-        super(OperatorType.IS_NULL, arguments);
-        this.isNotNull = false;
+        this(false, arguments, false);
     }
 
     public IsNullPredicateOperator(boolean isNotNull, ScalarOperator arguments) {
+        this(isNotNull, arguments, false);
+
+    }
+    public IsNullPredicateOperator(boolean isNotNull, ScalarOperator arguments, boolean isRedundant) {
         super(OperatorType.IS_NULL, arguments);
         this.isNotNull = isNotNull;
+        this.isRedundant = isRedundant;
     }
 
     public boolean isNotNull() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -32,6 +32,10 @@ public abstract class ScalarOperator implements Cloneable {
     protected boolean notEvalEstimate = false;
     // Used to determine if it is derive from predicate range extractor
     protected boolean fromPredicateRangeDerive = false;
+    // Check weather the scalar operator is redundant which will not affect the final
+    // if it's not considered. eg, `IsNullPredicateOperator` which is pushed down
+    // from JoinNode.
+    protected boolean isRedundant = false;
 
     private List<String> hints = Collections.emptyList();
 
@@ -187,5 +191,13 @@ public abstract class ScalarOperator implements Cloneable {
 
     public List<String> getHints() {
         return hints;
+    }
+
+    public boolean isRedundant() {
+        return isRedundant;
+    }
+
+    public void setRedundant(boolean redundant) {
+        isRedundant = redundant;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -54,7 +54,8 @@ public class PushDownJoinOnClauseRule extends PushDownJoinPredicateBase {
         on = rangePredicateDerive(on);
         on = equivalenceDeriveOnPredicate(on, input, join);
 
-        OptExpression root = pushDownOnPredicate(input, on);
+        OptExpression root = pushDownOnPredicate(input, on,
+                !context.getOptimizerConfig().isMVRewritePlan());
         ((LogicalJoinOperator) root.getOp()).setHasPushDownJoinOnClause(true);
         if (root.getOp().equals(input.getOp()) && on.equals(join.getOnPredicate()) &&
                 children.equals(root.getInputs())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
@@ -63,7 +63,8 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
         return root;
     }
 
-    public static OptExpression pushDownOnPredicate(OptExpression input, ScalarOperator conjunct) {
+    public static OptExpression pushDownOnPredicate(OptExpression input, ScalarOperator conjunct,
+                                                    boolean needDeriveIsNotNullPredicate) {
         LogicalJoinOperator join = (LogicalJoinOperator) input.getOp();
 
         List<ScalarOperator> conjunctList = Utils.extractConjuncts(conjunct);
@@ -136,7 +137,7 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
                 .setOriginalOnPredicate(join.getOnPredicate())
                 .build();
         root = OptExpression.create(newJoinOperator, input.getInputs());
-        if (!join.hasDeriveIsNotNullPredicate()) {
+        if (needDeriveIsNotNullPredicate && !join.hasDeriveIsNotNullPredicate()) {
             deriveIsNotNullPredicate(eqConjuncts, root, leftPushDown, rightPushDown);
         }
         return pushDownPredicate(root, leftPushDown, rightPushDown);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinPredicateBase.java
@@ -212,10 +212,10 @@ public abstract class PushDownJoinPredicateBase extends TransformationRule {
         LogicalJoinOperator joinOp = ((LogicalJoinOperator) join.getOp());
         JoinOperator joinType = joinOp.getJoinType();
         if ((joinType.isInnerJoin() || joinType.isRightSemiJoin()) && leftPushDown.isEmpty()) {
-            leftEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone())).forEach(leftPushDown::add);
+            leftEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone(), true)).forEach(leftPushDown::add);
         }
         if ((joinType.isInnerJoin() || joinType.isLeftSemiJoin()) && rightPushDown.isEmpty()) {
-            rightEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone())).forEach(rightPushDown::add);
+            rightEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone(), true)).forEach(rightPushDown::add);
         }
         joinOp.setHasDeriveIsNotNullPredicate(true);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
@@ -212,13 +212,14 @@ public class PushDownPredicateJoinRule extends PushDownJoinPredicateBase {
         LogicalFilterOperator filter = (LogicalFilterOperator) input.getOp();
         OptExpression joinOpt = input.getInputs().get(0);
         LogicalJoinOperator join = (LogicalJoinOperator) joinOpt.getOp();
+        boolean isMVRewritePlan = context.getOptimizerConfig().isMVRewritePlan();
 
         if (join.getJoinType().isCrossJoin() || join.getJoinType().isInnerJoin()) {
             // The effect will be better, first do the range derive, and then do the equivalence derive
             ScalarOperator predicate =
                     rangePredicateDerive(Utils.compoundAnd(join.getOnPredicate(), filter.getPredicate()));
             predicate = equivalenceDerive(predicate, true);
-            return Lists.newArrayList(pushDownOnPredicate(input.getInputs().get(0), predicate));
+            return Lists.newArrayList(pushDownOnPredicate(input.getInputs().get(0), predicate, !isMVRewritePlan));
         } else {
             if (join.getJoinType().isOuterJoin()) {
                 convertOuterToInner(input, context);
@@ -229,7 +230,7 @@ public class PushDownPredicateJoinRule extends PushDownJoinPredicateBase {
                 ScalarOperator predicate =
                         rangePredicateDerive(Utils.compoundAnd(join.getOnPredicate(), filter.getPredicate()));
                 predicate = equivalenceDerive(predicate, true);
-                return Lists.newArrayList(pushDownOnPredicate(input.getInputs().get(0), predicate));
+                return Lists.newArrayList(pushDownOnPredicate(input.getInputs().get(0), predicate, !isMVRewritePlan));
             } else {
                 ScalarOperator predicate = rangePredicateDerive(filter.getPredicate());
                 List<ScalarOperator> leftPushDown = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -338,6 +338,7 @@ public class MvUtils {
         optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
         optimizerConfig.disableRuleSet(RuleSetType.SINGLE_TABLE_MV_REWRITE);
         optimizerConfig.disableRule(RuleType.TF_REWRITE_GROUP_BY_COUNT_DISTINCT);
+        optimizerConfig.setMVRewritePlan(true);
         Optimizer optimizer = new Optimizer(optimizerConfig);
         OptExpression optimizedPlan = optimizer.optimize(
                 connectContext,

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -179,4 +179,29 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "group by ts").nonMatch("test_partition_expr_mv1");
         starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
     }
+
+    @Test
+    public void testNullableTestCase1() throws Exception {
+        String mv = "create materialized view join_null_mv_2\n" +
+                "distributed by hash(empid)\n" +
+                "as\n" +
+                "select empid, depts.deptno, depts.name from emps_null join depts using (deptno);";
+        starRocksAssert.withMaterializedView(mv);
+        sql("select empid, emps_null.deptno \n" +
+                "from emps_null join depts using (deptno) \n" +
+                "where empid < 10")
+                .match("join_null_mv_2");
+    }
+
+    @Test
+    public void testNullableTestCase2() throws Exception {
+        String mv = "create materialized view join_null_mv\n" +
+                "distributed by hash(empid)\n" +
+                "as\n" +
+                "select empid, depts_null.deptno, depts_null.name from emps_null join depts_null using (deptno)\n";
+        starRocksAssert.withMaterializedView(mv);
+        sql("select empid, depts_null.deptno, depts_null.name from emps_null " +
+                "join depts_null using (deptno) where depts_null.deptno < 10;")
+                .match("join_null_mv");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -556,7 +556,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv, "select count(*) from " +
                 "locations join emps on emps.locationid = locations.locationid + 1 " +
                 "group by emps.deptno");
-        testRewriteFail(mv, "select count(*) , emps.deptno from " +
+        testRewriteOK(mv, "select count(*) , emps.deptno from " +
                 "locations join emps on emps.locationid = locations.locationid + 1 " +
                 "where emps.deptno > 10 " +
                 "group by emps.deptno");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -164,12 +164,29 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\"\n" +
                 ");";
+        String nullableEmps = "create table emps_null (\n" +
+                "empid int null,\n" +
+                "deptno int null,\n" +
+                "name varchar(25) null,\n" +
+                "salary double\n" +
+                ")\n" +
+                "distributed by hash(`empid`) buckets 10\n" +
+                "properties (\"replication_num\" = \"1\");";
+        String nullableDepts = "create table depts_null (\n" +
+                "deptno int null,\n" +
+                "name varchar(25) null\n" +
+                ")\n" +
+                "distributed by hash(`deptno`) buckets 10\n" +
+                "properties (\"replication_num\" = \"1\");";
+
         starRocksAssert
                 .withTable(deptsTable)
                 .withTable(empsTable)
                 .withTable(locationsTable)
                 .withTable(ependentsTable)
-                .withTable(empsWithBigintTable);
+                .withTable(empsWithBigintTable)
+                .withTable(nullableEmps)
+                .withTable(nullableDepts);
 
     }
 
@@ -236,8 +253,8 @@ public class MaterializedViewTestBase extends PlanTestBase {
         }
 
         public MVRewriteChecker match(String targetMV) {
+            contains(targetMV);
             Assert.assertTrue(this.exception == null);
-            Assert.assertTrue(this.rewritePlan.contains(targetMV));
             return this;
         }
 


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required):
- To support nullable column joins, disable derive not null predicates for mv rewrite plan, so can compensate join with predicates.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
