### PR TITLE
[BugFix] Make all SchemaScanners return one row at a time

### DIFF
--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -87,6 +87,7 @@ public:
     virtual Status init(SchemaScannerParam* param, ObjectPool* pool);
     // Start to work
     virtual Status start(RuntimeState* state);
+    // Must only return one row at most each time
     virtual Status get_next(ChunkPtr* chunk, bool* eos);
     // factory function
     static std::unique_ptr<SchemaScanner> create(TSchemaTableType::type type);

--- a/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
@@ -66,7 +66,7 @@ Status SchemaBeCloudNativeCompactionsScanner::start(RuntimeState* state) {
 
 Status SchemaBeCloudNativeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    const auto end = std::min<size_t>(_infos.size(), _cur_idx + _chunk_size);
+    auto end = _cur_idx + 1;
     for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {

--- a/be/src/exec/schema_scanner/schema_be_compactions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_compactions_scanner.cpp
@@ -59,7 +59,8 @@ Status SchemaBeCompactionsScanner::start(RuntimeState* state) {
 
 Status SchemaBeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    for (; _cur_idx < _infos.size(); _cur_idx++) {
+    auto end = _cur_idx + 1;
+    for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
             if (slot_id < 1 || slot_id > 8) {

--- a/be/src/exec/schema_scanner/schema_be_configs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_configs_scanner.cpp
@@ -45,7 +45,8 @@ Status SchemaBeConfigsScanner::start(RuntimeState* state) {
 
 Status SchemaBeConfigsScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    for (; _cur_idx < _infos.size(); _cur_idx++) {
+    auto end = _cur_idx + 1;
+    for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
             ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);

--- a/be/src/exec/schema_scanner/schema_be_logs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_logs_scanner.cpp
@@ -79,7 +79,8 @@ Status SchemaBeLogsScanner::start(RuntimeState* state) {
 
 Status SchemaBeLogsScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    for (; _cur_idx < _infos.size(); _cur_idx++) {
+    auto end = _cur_idx + 1;
+    for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
             if (slot_id < 1 || slot_id > 5) {

--- a/be/src/exec/schema_scanner/schema_be_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_metrics_scanner.cpp
@@ -79,7 +79,8 @@ Status SchemaBeMetricsScanner::start(RuntimeState* state) {
 
 Status SchemaBeMetricsScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    for (; _cur_idx < _infos.size(); _cur_idx++) {
+    auto end = _cur_idx + 1;
+    for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
             if (slot_id < 1 || slot_id > 14) {

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -88,7 +88,8 @@ static const char* keys_type_to_string(KeysType type) {
 
 Status SchemaBeTabletsScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    for (; _cur_idx < _infos.size(); _cur_idx++) {
+    auto end = _cur_idx + 1;
+    for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
             if (slot_id < 1 || slot_id > 17) {

--- a/be/src/exec/schema_scanner/schema_be_threads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_threads_scanner.cpp
@@ -49,7 +49,8 @@ Status SchemaBeThreadsScanner::start(RuntimeState* state) {
 
 Status SchemaBeThreadsScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    for (; _cur_idx < _infos.size(); _cur_idx++) {
+    auto end = _cur_idx + 1;
+    for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
             if (slot_id < 1 || slot_id > 7) {

--- a/be/src/exec/schema_scanner/schema_be_txns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_txns_scanner.cpp
@@ -51,7 +51,8 @@ Status SchemaBeTxnsScanner::start(RuntimeState* state) {
 
 Status SchemaBeTxnsScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    for (; _cur_idx < _infos.size(); _cur_idx++) {
+    auto end = _cur_idx + 1;
+    for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
             if (slot_id < 1 || slot_id > 14) {

--- a/be/src/exec/schema_scanner/schema_fe_tablet_schedules_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_fe_tablet_schedules_scanner.cpp
@@ -78,7 +78,8 @@ Status SchemaFeTabletSchedulesScanner::start(RuntimeState* state) {
 
 Status SchemaFeTabletSchedulesScanner::fill_chunk(ChunkPtr* chunk) {
     const auto& slot_id_to_index_map = (*chunk)->get_slot_id_to_index_map();
-    for (; _cur_idx < _infos.size(); _cur_idx++) {
+    auto end = _cur_idx + 1;
+    for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
             if (slot_id < 1 || slot_id > 15) {


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
To prevent crashs like `F0505 19:04:03.558640 60832 aggregate_blocking_sink_operator.cpp:83] Check failed: chunk_size <= state->chunk_size() (113235 vs. 4096)` in test, all SchemaScanners should return one row at a time, to make sure chunk size is  within chunk size limit.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
