### PR TITLE
[Enhancement] Support materialized view delta join for hive table [2/N]

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1735,7 +1735,8 @@ public class SchemaChangeHandler extends AlterHandler {
         if (tableProperty != null) {
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {
                 try {
-                    List<UniqueConstraint> newUniqueConstraints = PropertyAnalyzer.analyzeUniqueConstraint(properties, olapTable);
+                    List<UniqueConstraint> newUniqueConstraints = PropertyAnalyzer.analyzeUniqueConstraint(properties, db,
+                            olapTable);
                     List<UniqueConstraint> originalUniqueConstraints = tableProperty.getUniqueConstraints();
                     if (originalUniqueConstraints == null
                             || !newUniqueConstraints.toString().equals(originalUniqueConstraints.toString())) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -149,6 +149,10 @@ public class BaseTableInfo {
         }
     }
 
+    public String getReadableString() {
+        return catalogName + "." + getDbName() + "." + getTableName();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -150,7 +150,11 @@ public class BaseTableInfo {
     }
 
     public String getReadableString() {
-        return catalogName + "." + getDbName() + "." + getTableName();
+        String dbName = getDbName();
+        dbName = dbName != null ? dbName : "null";
+        String tableName = getTableName();
+        tableName = tableName != null ? tableName : "null";
+        return catalogName + "." + dbName + "." + tableName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ForeignKeyConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ForeignKeyConstraint.java
@@ -37,13 +37,17 @@ import java.util.stream.Collectors;
 // a table may have multi foreign key constraints.
 public class ForeignKeyConstraint {
     private static final Logger LOG = LogManager.getLogger(ForeignKeyConstraint.class);
+    private static final String FOREIGN_KEY_REGEX = "((\\.?\\w+:?)*)\\s*\\(((,?\\s*\\w+\\s*)+)\\)\\s+((?i)REFERENCES)\\s+" +
+            "((\\.?\\w+:?)+)\\s*\\(((,?\\s*\\w+\\s*)+)\\)";
 
-    private static final String FOREIGN_KEY_REGEX = "\\(((,?\\s*\\w+\\s*)+)\\)\\s+((?i)REFERENCES)\\s+" +
-            "((\\.?\\w+)+)\\s*\\(((,?\\s*\\w+\\s*)+)\\)";
     public static final Pattern FOREIGN_KEY_PATTERN = Pattern.compile(FOREIGN_KEY_REGEX);
+
     // table with primary key or unique key
     // if parent table is dropped, the foreign key is not dropped cascade now.
     private final BaseTableInfo parentTableInfo;
+
+    // table with foreign key, it only used for materialized view.
+    private final BaseTableInfo childTableInfo;
 
     // here id is preferred, but meta of column does not have id.
     // have to use name here, so column rename is not supported
@@ -52,8 +56,10 @@ public class ForeignKeyConstraint {
 
     public ForeignKeyConstraint(
             BaseTableInfo parentTableInfo,
+            BaseTableInfo childTableInfo,
             List<Pair<String, String>> columnRefPairs) {
         this.parentTableInfo = parentTableInfo;
+        this.childTableInfo = childTableInfo;
         this.columnRefPairs = columnRefPairs;
     }
 
@@ -61,24 +67,32 @@ public class ForeignKeyConstraint {
         return parentTableInfo;
     }
 
+    public BaseTableInfo getChildTableInfo() {
+        return childTableInfo;
+    }
+
     public List<Pair<String, String>> getColumnRefPairs() {
         return columnRefPairs;
     }
 
-    // for default catalog, the format is: (column1, column2) REFERENCES default_catalog.dbid.tableid(column1', column2')
-    // for other catalog, the format is: (column1, column2) REFERENCES default_catalog.dbname.tablename(column1', column2')
+    // for olap table, the format is: (column1, column2) REFERENCES default_catalog.dbid.tableid(column1', column2')
+    // for materialized view, the format is: catalog1.dbName1.tableName1(column1, column2) REFERENCES
+    // catalog2.dbName2.tableName2(column1', column2')
     @Override
     public String toString() {
         if (parentTableInfo == null || columnRefPairs == null) {
             return "";
         }
         StringBuilder sb = new StringBuilder();
+        if (childTableInfo != null) {
+            sb.append(childTableInfo);
+        }
         sb.append("(");
         String baseColumns = Joiner.on(",").join(columnRefPairs.stream().map(pair -> pair.first).collect(Collectors.toList()));
         sb.append(baseColumns);
         sb.append(")");
         sb.append(" REFERENCES ");
-        sb.append(parentTableInfo.toString());
+        sb.append(parentTableInfo);
         sb.append("(");
         String parentColumns = Joiner.on(",").join(columnRefPairs.stream().map(pair -> pair.second).collect(Collectors.toList()));
         sb.append(parentColumns);
@@ -103,30 +117,81 @@ public class ForeignKeyConstraint {
                 LOG.warn("invalid constraint:{}", foreignKeyConstraintDescs);
                 continue;
             }
-            String sourceColumns = foreignKeyMatcher.group(1);
-            String tablePath = foreignKeyMatcher.group(4);
-            String targetColumns = foreignKeyMatcher.group(6);
-            List<String> baseColumns = Arrays.asList(sourceColumns.split(","))
-                    .stream().map(String::trim).collect(Collectors.toList());
-            List<String> parentColumns = Arrays.asList(targetColumns.split(","))
-                    .stream().map(String::trim).collect(Collectors.toList());
 
-            String[] parts = tablePath.split("\\.");
-            Preconditions.checkState(parts.length == 3);
-            String catalogName = parts[0];
-            String db = parts[1];
-            String table = parts[2];
+            String sourceTablePath = foreignKeyMatcher.group(1);
+            String sourceColumns = foreignKeyMatcher.group(3);
+
+            String targetTablePath = foreignKeyMatcher.group(6);
+            String targetColumns = foreignKeyMatcher.group(8);
+
+            List<String> childColumns = Arrays.stream(sourceColumns.split(",")).
+                    map(String::trim).collect(Collectors.toList());
+            List<String> parentColumns = Arrays.stream(targetColumns.split(",")).
+                    map(String::trim).collect(Collectors.toList());
+
+            String[] targetTableParts = targetTablePath.split("\\.");
+            Preconditions.checkState(targetTableParts.length == 3);
+            String targetCatalogName = targetTableParts[0];
+            String targetDb = targetTableParts[1];
+            String targetTable = targetTableParts[2];
+            BaseTableInfo parentTableInfo = getTableBaseInfo(targetCatalogName, targetDb, targetTable);
+
+            BaseTableInfo childTableInfo = null;
+            if (!Strings.isNullOrEmpty(sourceTablePath)) {
+                String[] sourceTableParts = sourceTablePath.split("\\.");
+                Preconditions.checkState(sourceTableParts.length == 3);
+                String sourceCatalogName = sourceTableParts[0];
+                String sourceDb = sourceTableParts[1];
+                String sourceTable = sourceTableParts[2];
+                childTableInfo = getTableBaseInfo(sourceCatalogName, sourceDb, sourceTable);
+            }
 
             List<Pair<String, String>> columnRefPairs =
-                    Streams.zip(baseColumns.stream(), parentColumns.stream(), Pair::create).collect(Collectors.toList());
-            if (catalogName.equals(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
-                BaseTableInfo parentTableInfo = new BaseTableInfo(Long.parseLong(db), Long.parseLong(table));
-                foreignKeyConstraints.add(new ForeignKeyConstraint(parentTableInfo, columnRefPairs));
-            } else {
-                BaseTableInfo parentTableInfo = new BaseTableInfo(catalogName, db, table);
-                foreignKeyConstraints.add(new ForeignKeyConstraint(parentTableInfo, columnRefPairs));
-            }
+                    Streams.zip(childColumns.stream(), parentColumns.stream(), Pair::create).collect(Collectors.toList());
+            foreignKeyConstraints.add(new ForeignKeyConstraint(parentTableInfo, childTableInfo, columnRefPairs));
         }
         return foreignKeyConstraints;
+    }
+
+    private static BaseTableInfo getTableBaseInfo(String catalog, String db, String table) {
+        BaseTableInfo baseTableInfo;
+        if (catalog.equals(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
+            baseTableInfo = new BaseTableInfo(Long.parseLong(db), Long.parseLong(table));
+        } else {
+            baseTableInfo = new BaseTableInfo(catalog, db, table);
+        }
+        return baseTableInfo;
+    }
+
+    public static String getShowCreateTableConstraintDesc(List<ForeignKeyConstraint> constraints) {
+        StringBuilder sb = new StringBuilder();
+
+        List<String> constraintStrs = Lists.newArrayList();
+        for (ForeignKeyConstraint constraint : constraints) {
+            BaseTableInfo parentTableInfo = constraint.getParentTableInfo();
+            BaseTableInfo childTableInfo = constraint.getChildTableInfo();
+
+            StringBuilder constraintSb = new StringBuilder();
+            if (childTableInfo != null) {
+                constraintSb.append(childTableInfo.getReadableString());
+            }
+            constraintSb.append("(");
+            String baseColumns = Joiner.on(",").join(constraint.getColumnRefPairs()
+                    .stream().map(pair -> pair.first).collect(Collectors.toList()));
+            constraintSb.append(baseColumns);
+            constraintSb.append(")");
+            constraintSb.append(" REFERENCES ");
+            constraintSb.append(parentTableInfo.getReadableString());
+
+            constraintSb.append("(");
+            String parentColumns = Joiner.on(",").join(constraint.getColumnRefPairs()
+                    .stream().map(pair -> pair.second).collect(Collectors.toList()));
+            constraintSb.append(parentColumns);
+            constraintSb.append(")");
+            constraintStrs.add(constraintSb.toString());
+        }
+
+        sb.append(Joiner.on(";").join(constraintStrs));
+        return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -834,6 +834,21 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
             sb.append(properties.get(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)).append("\"");
         }
 
+        // unique constraints
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {
+            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)
+                    .append("\" = \"");
+            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)).append("\"");
+        }
+
+        // foreign keys constraints
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)) {
+            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)
+                    .append("\" = \"");
+            sb.append(ForeignKeyConstraint.getShowCreateTableConstraintDesc(getForeignKeyConstraints()))
+                    .append("\"");
+        }
+
         appendUniqueProperties(sb);
 
         sb.append("\n)");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2276,11 +2276,6 @@ public class OlapTable extends Table {
         tableProperty.clearBinlogAvailableVersion();
     }
 
-    public boolean hasUniqueConstraints() {
-        List<UniqueConstraint> uniqueConstraint = getUniqueConstraints();
-        return uniqueConstraint != null;
-    }
-
     @Override
     public List<UniqueConstraint> getUniqueConstraints() {
         if (tableProperty == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -296,6 +296,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         return isOlapTableOrMaterializedView() || isCloudNativeTableOrMaterializedView();
     }
 
+    public boolean isNativeTable() {
+        return isOlapTable() || isCloudNativeTable();
+    }
+
     public boolean isHiveTable() {
         return type == TableType.HIVE;
     }
@@ -674,6 +678,11 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
 
     public boolean supportInsert() {
         return false;
+    }
+
+    public boolean hasUniqueConstraints() {
+        List<UniqueConstraint> uniqueConstraint = getUniqueConstraints();
+        return uniqueConstraint != null;
     }
 
     public void setUniqueConstraints(List<UniqueConstraint> uniqueConstraints) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -369,7 +369,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
             uniqueConstraints = UniqueConstraint.parse(
                 properties.getOrDefault(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT, ""));
         } catch (AnalysisException e) {
-            LOG.warn("Failed to parse unique constraint: {} , ignore this unique constraint", e.getMessage());
+            LOG.warn("Failed to parse unique constraint, ignore this unique constraint", e);
         }
 
         foreignKeyConstraints = ForeignKeyConstraint.parse(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/UniqueConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/UniqueConstraint.java
@@ -17,6 +17,10 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spark_project.guava.base.Strings;
 
 import java.util.Arrays;
@@ -30,11 +34,19 @@ import java.util.stream.Collectors;
 //
 // a table may have multi unique constraints.
 public class UniqueConstraint {
+    private static final Logger LOG = LogManager.getLogger(UniqueConstraint.class);
     // here id is preferred, but meta of column does not have id.
     // have to use name here, so column rename is not supported
     private final List<String> uniqueColumns;
 
-    public UniqueConstraint(List<String> uniqueColumns) {
+    private final String catalogName;
+    private final String dbName;
+    private final String tableName;
+
+    public UniqueConstraint(String catalogName, String dbName, String tableName, List<String> uniqueColumns) {
+        this.catalogName = catalogName;
+        this.dbName = dbName;
+        this.tableName = tableName;
         this.uniqueColumns = uniqueColumns;
     }
 
@@ -42,17 +54,50 @@ public class UniqueConstraint {
         return uniqueColumns;
     }
 
-    // foreignKeys must be in lower case for case insensitive
-    public boolean isMatch(Set<String> foreignKeys) {
+    // foreignKeys must be in lower case for case-insensitive
+    public boolean isMatch(Table parentTable, Set<String> foreignKeys) {
+        if (catalogName != null && dbName != null && tableName != null) {
+            Table uniqueTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+            if (uniqueTable == null) {
+                LOG.warn("can not find unique constraint table: {}.{}.{}", catalogName, dbName, tableName);
+                return false;
+            }
+            if (!uniqueTable.equals(parentTable)) {
+                return false;
+            }
+        }
         Set<String> uniqueColumnSet = uniqueColumns.stream().map(String::toLowerCase).collect(Collectors.toSet());
         return uniqueColumnSet.equals(foreignKeys);
     }
 
     public String toString() {
-        return Joiner.on(",").join(uniqueColumns);
+        StringBuilder sb = new StringBuilder();
+        if (catalogName != null) {
+            sb.append(catalogName).append(".");
+        }
+        if (dbName != null) {
+            sb.append(dbName).append(".");
+        }
+        if (tableName != null) {
+            sb.append(tableName).append(".");
+        }
+        sb.append(Joiner.on(",").join(uniqueColumns));
+        return sb.toString();
     }
 
-    public static List<UniqueConstraint> parse(String constraintDescs) {
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public static List<UniqueConstraint> parse(String constraintDescs) throws AnalysisException {
         if (Strings.isNullOrEmpty(constraintDescs)) {
             return null;
         }
@@ -64,9 +109,62 @@ public class UniqueConstraint {
             }
             String[] uniqueColumns = constraintDesc.split(",");
             List<String> columnNames =
-                    Arrays.asList(uniqueColumns).stream().map(String::trim).collect(Collectors.toList());
-            uniqueConstraints.add(new UniqueConstraint(columnNames));
+                    Arrays.stream(uniqueColumns).map(String::trim).collect(Collectors.toList());
+            try {
+                parseUniqueConstraintColumns(columnNames, uniqueConstraints);
+            } catch (AnalysisException e) {
+                LOG.warn("parse unique constraint failed, unique constraint: {}", constraintDesc);
+                throw e;
+            }
         }
         return uniqueConstraints;
+    }
+
+    private static void parseUniqueConstraintColumns(List<String> columnNames, List<UniqueConstraint> uniqueConstraints)
+            throws AnalysisException {
+        String catalogName = null;
+        String dbName = null;
+        String tableName = null;
+        List<String> uniqueConstraintColumns = Lists.newArrayList();
+        for (String columnName : columnNames) {
+            String[] parts = columnName.split("\\.");
+            if (parts.length == 1) {
+                uniqueConstraintColumns.add(parts[0]);
+            } else if (parts.length == 2) {
+                if (tableName != null && !tableName.equals(parts[0])) {
+                    throw new AnalysisException("unique constraint column should be in same table");
+                }
+                tableName = parts[0];
+                uniqueConstraintColumns.add(parts[1]);
+            } else if (parts.length == 3) {
+                if (dbName != null && !dbName.equals(parts[0])) {
+                    throw new AnalysisException("unique constraint column should be in same table");
+                }
+                if (tableName != null && !tableName.equals(parts[1])) {
+                    throw new AnalysisException("unique constraint column should be in same table");
+                }
+                dbName = parts[0];
+                tableName = parts[1];
+                uniqueConstraintColumns.add(parts[2]);
+            } else if (parts.length == 4) {
+                if (catalogName != null && !catalogName.equals(parts[0])) {
+                    throw new AnalysisException("unique constraint column should be in same table");
+                }
+                if (dbName != null && !dbName.equals(parts[1])) {
+                    throw new AnalysisException("unique constraint column should be in same table");
+                }
+                if (tableName != null && !tableName.equals(parts[2])) {
+                    throw new AnalysisException("unique constraint column should be in same table");
+                }
+                catalogName = parts[0];
+                dbName = parts[1];
+                tableName = parts[2];
+                uniqueConstraintColumns.add(parts[3]);
+            } else {
+                throw new AnalysisException("invalid unique constraint" + columnName);
+            }
+        }
+
+        uniqueConstraints.add(new UniqueConstraint(catalogName, dbName, tableName, uniqueConstraintColumns));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/UniqueConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/UniqueConstraint.java
@@ -113,7 +113,7 @@ public class UniqueConstraint {
             try {
                 parseUniqueConstraintColumns(columnNames, uniqueConstraints);
             } catch (AnalysisException e) {
-                LOG.warn("parse unique constraint failed, unique constraint: {}", constraintDesc);
+                LOG.warn("parse unique constraint failed, unique constraint: {}", constraintDesc, e);
                 throw e;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -661,8 +661,10 @@ public class PropertyAnalyzer {
     }
 
     public static List<UniqueConstraint> analyzeUniqueConstraint(
-            Map<String, String> properties, OlapTable table) throws AnalysisException {
+            Map<String, String> properties, Database db, OlapTable table) throws AnalysisException {
         List<UniqueConstraint> uniqueConstraints = Lists.newArrayList();
+        List<UniqueConstraint> analyzedUniqueConstraints = Lists.newArrayList();
+
         if (properties != null && properties.containsKey(PROPERTIES_UNIQUE_CONSTRAINT)) {
             String uniqueConstraintStr = properties.get(PROPERTIES_UNIQUE_CONSTRAINT);
             if (Strings.isNullOrEmpty(uniqueConstraintStr)) {
@@ -674,29 +676,156 @@ public class PropertyAnalyzer {
             }
 
             for (UniqueConstraint uniqueConstraint : uniqueConstraints) {
-                boolean columnExist = uniqueConstraint.getUniqueColumns().stream().allMatch(table::containColumn);
-                if (!columnExist) {
-                    throw new AnalysisException(
-                            String.format("some columns of:%s do not exist in table:%s",
-                                    uniqueConstraint.getUniqueColumns(), table.getName()));
+                if (table.isMaterializedView()) {
+                    String catalogName = uniqueConstraint.getCatalogName() != null ? uniqueConstraint.getCatalogName()
+                            : InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+                    String dbName = uniqueConstraint.getDbName() != null ? uniqueConstraint.getDbName()
+                            : db.getFullName();
+                    if (uniqueConstraint.getTableName() == null) {
+                        throw new AnalysisException("must set table name for unique constraint in materialized view");
+                    }
+                    String tableName = uniqueConstraint.getTableName();
+                    Table uniqueConstraintTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName,
+                            dbName, tableName);
+                    if (uniqueConstraintTable == null) {
+                        throw new AnalysisException(
+                                String.format("table:%s.%s.%s does not exist", catalogName, dbName, tableName));
+                    }
+                    boolean columnExist = uniqueConstraint.getUniqueColumns().stream()
+                            .allMatch(uniqueConstraintTable::containColumn);
+                    if (!columnExist) {
+                        throw new AnalysisException(
+                                String.format("some columns of:%s do not exist in table:%s.%s.%s",
+                                        uniqueConstraint.getUniqueColumns(), catalogName, dbName, tableName));
+                    }
+                    analyzedUniqueConstraints.add(new UniqueConstraint(catalogName, dbName, tableName,
+                            uniqueConstraint.getUniqueColumns()));
+                } else {
+                    boolean columnExist = uniqueConstraint.getUniqueColumns().stream().allMatch(table::containColumn);
+                    if (!columnExist) {
+                        throw new AnalysisException(
+                                String.format("some columns of:%s do not exist in table:%s",
+                                        uniqueConstraint.getUniqueColumns(), table.getName()));
+                    }
+                    analyzedUniqueConstraints.add(uniqueConstraint);
                 }
             }
             properties.remove(PROPERTIES_UNIQUE_CONSTRAINT);
         }
-        return uniqueConstraints;
+        return analyzedUniqueConstraints;
+    }
+
+    private static Pair<BaseTableInfo, Table> analyzeForeignKeyConstraintTablePath(String tablePath,
+                                                                                   String foreignKeyConstraintDesc,
+                                                                                   Database db)
+            throws AnalysisException {
+        String[] parts = tablePath.split("\\.");
+        String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+        String dbName = db.getFullName();
+        String tableName = "";
+        if (parts.length == 3) {
+            catalogName = parts[0];
+            dbName = parts[1];
+            tableName = parts[2];
+        } else if (parts.length == 2) {
+            dbName = parts[0];
+            tableName = parts[1];
+        } else if (parts.length == 1) {
+            tableName = parts[0];
+        } else {
+            throw new AnalysisException(String.format("invalid foreign key constraint:%s," +
+                    "table path is invalid", foreignKeyConstraintDesc));
+        }
+
+        if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
+            throw new AnalysisException(String.format("catalog: %s do not exist", catalogName));
+        }
+        Database parentDb = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        if (parentDb == null) {
+            throw new AnalysisException(
+                    String.format("catalog: %s, database: %s do not exist", catalogName, dbName));
+        }
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(catalogName, dbName, tableName);
+        if (table == null) {
+            throw new AnalysisException(String.format("catalog:%s, database: %s, table:%s do not exist",
+                    catalogName, dbName, tableName));
+        }
+
+        BaseTableInfo tableInfo;
+        if (catalogName.equals(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
+            tableInfo = new BaseTableInfo(parentDb.getId(), dbName, table.getId());
+        } else {
+            tableInfo = new BaseTableInfo(catalogName, dbName, table.getTableIdentifier());
+        }
+
+        return Pair.create(tableInfo, table);
+    }
+
+    private static void analyzeForeignKeyUniqueConstraint(Table parentTable, List<String> parentColumns,
+                                                          Table analyzedTable)
+            throws AnalysisException {
+        KeysType parentTableKeyType = KeysType.DUP_KEYS;
+        if (parentTable.isNativeTableOrMaterializedView()) {
+            OlapTable parentOlapTable = (OlapTable) parentTable;
+            parentTableKeyType =
+                    parentOlapTable.getIndexMetaByIndexId(parentOlapTable.getBaseIndexId()).getKeysType();
+        }
+
+        List<UniqueConstraint> mvUniqueConstraints = Lists.newArrayList();
+        if (analyzedTable.isMaterializedView() && analyzedTable.hasUniqueConstraints()) {
+            mvUniqueConstraints = analyzedTable.getUniqueConstraints().stream().filter(
+                    uniqueConstraint -> parentTable.getName().equals(uniqueConstraint.getTableName()))
+                    .collect(Collectors.toList());
+        }
+
+        if (parentTableKeyType == KeysType.AGG_KEYS) {
+            throw new AnalysisException(
+                    String.format("do not support reference agg table:%s", parentTable.getName()));
+        } else if (parentTableKeyType == KeysType.DUP_KEYS) {
+            // for DUP_KEYS type olap table or external table
+            if (!parentTable.hasUniqueConstraints() && mvUniqueConstraints.isEmpty()) {
+                throw new AnalysisException(
+                        String.format("dup table:%s has no unique constraint", parentTable.getName()));
+            } else {
+                List<UniqueConstraint> uniqueConstraints = parentTable.getUniqueConstraints();
+                if (uniqueConstraints == null) {
+                    uniqueConstraints = mvUniqueConstraints;
+                } else {
+                    uniqueConstraints.addAll(mvUniqueConstraints);
+                }
+                boolean matched = false;
+                for (UniqueConstraint uniqueConstraint : uniqueConstraints) {
+                    if (uniqueConstraint.isMatch(parentTable, Sets.newHashSet(parentColumns))) {
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched) {
+                    throw new AnalysisException(
+                            String.format("columns:%s are not dup table:%s's unique constraint", parentColumns,
+                                    parentTable.getName()));
+                }
+            }
+        } else {
+            // for PRIMARY_KEYS and UNIQUE_KEYS type table
+            // parent columns should be keys
+            if (!((OlapTable) parentTable).isKeySet(Sets.newHashSet(parentColumns))) {
+                throw new AnalysisException(String.format("columns:%s are not key columns of table:%s",
+                        parentColumns, parentTable.getName()));
+            }
+        }
     }
 
     public static List<ForeignKeyConstraint> analyzeForeignKeyConstraint(
-            Map<String, String> properties, Database db, Table baseTable) throws AnalysisException {
+            Map<String, String> properties, Database db, Table analyzedTable) throws AnalysisException {
         List<ForeignKeyConstraint> foreignKeyConstraints = Lists.newArrayList();
         if (properties != null && properties.containsKey(PROPERTIES_FOREIGN_KEY_CONSTRAINT)) {
             String foreignKeyConstraintsDesc = properties.get(PROPERTIES_FOREIGN_KEY_CONSTRAINT);
             if (Strings.isNullOrEmpty(foreignKeyConstraintsDesc)) {
                 return foreignKeyConstraints;
             }
-            if (Strings.isNullOrEmpty(foreignKeyConstraintsDesc)) {
-                throw new AnalysisException("empty foreign key constraint is invalid");
-            }
+
             String[] foreignKeyConstraintDescArray = foreignKeyConstraintsDesc.trim().split(";");
             for (String foreignKeyConstraintDesc : foreignKeyConstraintDescArray) {
                 String trimed = foreignKeyConstraintDesc.trim();
@@ -704,111 +833,60 @@ public class PropertyAnalyzer {
                     continue;
                 }
                 Matcher foreignKeyMatcher = ForeignKeyConstraint.FOREIGN_KEY_PATTERN.matcher(trimed);
-                if (!foreignKeyMatcher.find() || foreignKeyMatcher.groupCount() != 7) {
+                if (!foreignKeyMatcher.find() || foreignKeyMatcher.groupCount() != 9) {
                     throw new AnalysisException(
                             String.format("invalid foreign key constraint:%s", foreignKeyConstraintDesc));
                 }
-                String sourceColumns = foreignKeyMatcher.group(1);
-                String tablePath = foreignKeyMatcher.group(4);
-                String targetColumns = foreignKeyMatcher.group(6);
+                String sourceTablePath = foreignKeyMatcher.group(1);
+                String sourceColumns = foreignKeyMatcher.group(3);
+
+                String targetTablePath = foreignKeyMatcher.group(6);
+                String targetColumns = foreignKeyMatcher.group(8);
                 // case insensitive
-                List<String> originalBaseColumns = Arrays.asList(sourceColumns.split(","))
-                        .stream().map(String::trim).collect(Collectors.toList());
-                List<String> originalParentColumns = Arrays.asList(targetColumns.split(","))
-                        .stream().map(String::trim).map(String::toLowerCase).collect(Collectors.toList());
-                if (originalBaseColumns.size() != originalParentColumns.size()) {
+                List<String> childColumns = Arrays.stream(sourceColumns.split(",")).
+                        map(String::trim).map(String::toLowerCase).collect(Collectors.toList());
+                List<String> parentColumns = Arrays.stream(targetColumns.split(",")).
+                        map(String::trim).map(String::toLowerCase).collect(Collectors.toList());
+                if (childColumns.size() != parentColumns.size()) {
                     throw new AnalysisException(String.format("invalid foreign key constraint:%s," +
                             " columns' size does not match", foreignKeyConstraintDesc));
                 }
-                List<String> baseColumns =
-                        originalBaseColumns.stream().map(String::toLowerCase).collect(Collectors.toList());
-                List<String> parentColumns =
-                        originalParentColumns.stream().map(String::toLowerCase).collect(Collectors.toList());
-
-                String[] parts = tablePath.split("\\.");
-                String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
-                String dbName = db.getFullName();
-                String parentTableName = "";
-                if (parts.length == 3) {
-                    catalogName = parts[0];
-                    dbName = parts[1];
-                    parentTableName = parts[2];
-                } else if (parts.length == 2) {
-                    dbName = parts[0];
-                    parentTableName = parts[1];
-                } else if (parts.length == 1) {
-                    parentTableName = parts[0];
-                } else {
-                    throw new AnalysisException(String.format("invalid foreign key constraint:%s," +
-                            "table path is invalid", foreignKeyConstraintDesc));
-                }
-
-                if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
-                    throw new AnalysisException(String.format("catalog: %s do not exist", catalogName));
-                }
-                Database parentDb = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
-                if (parentDb == null) {
-                    throw new AnalysisException(
-                            String.format("catalog: %s, database: %s do not exist", catalogName, dbName));
-                }
-                Table parentTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                        .getTable(catalogName, dbName, parentTableName);
-                if (parentTable == null) {
-                    throw new AnalysisException(String.format("catalog:%s, database: %s, table:%s do not exist",
-                            catalogName, dbName, parentTableName));
-                }
-
-                if (!baseTable.isOlapTableOrMaterializedView()) {
-                    throw new AnalysisException("now do not support add foreign key on external table");
-                }
-
-                OlapTable baseOlapTable = (OlapTable) baseTable;
-                if (!baseColumns.stream().allMatch(baseOlapTable::containColumn)) {
-                    throw new AnalysisException(String.format("some columns of:%s do not exist in table:%s",
-                            baseColumns, baseOlapTable.getName()));
-                }
-
-                OlapTable parentOlapTable = (OlapTable) parentTable;
-                if (!parentColumns.stream().allMatch(parentOlapTable::containColumn)) {
+                // analyze table exist for foreign key constraint
+                Pair<BaseTableInfo, Table> parentTablePair = analyzeForeignKeyConstraintTablePath(targetTablePath,
+                        foreignKeyConstraintDesc, db);
+                BaseTableInfo parentTableInfo = parentTablePair.first;
+                Table parentTable = parentTablePair.second;
+                if (!parentColumns.stream().allMatch(parentTable::containColumn)) {
                     throw new AnalysisException(String.format("some columns of:%s do not exist in parent table:%s",
-                            parentColumns, parentOlapTable.getName()));
+                            parentColumns, parentTable.getName()));
                 }
-                KeysType parentTableKeyType =
-                        parentOlapTable.getIndexMetaByIndexId(parentOlapTable.getBaseIndexId()).getKeysType();
-                if (parentTableKeyType == KeysType.AGG_KEYS) {
-                    throw new AnalysisException(
-                            String.format("do not support reference agg table:%s", parentTable.getName()));
-                } else if (parentTableKeyType == KeysType.DUP_KEYS) {
-                    if (!parentOlapTable.hasUniqueConstraints()) {
-                        throw new AnalysisException(
-                                String.format("dup table:%s has no unique constraint", parentTable.getName()));
-                    } else {
-                        List<UniqueConstraint> uniqueConstraints = parentOlapTable.getUniqueConstraints();
-                        boolean matched = false;
-                        for (UniqueConstraint uniqueConstraint : uniqueConstraints) {
-                            if (uniqueConstraint.isMatch(Sets.newHashSet(parentColumns))) {
-                                matched = true;
-                                break;
-                            }
-                        }
-                        if (!matched) {
-                            throw new AnalysisException(
-                                    String.format("columns:%s are not dup table:%s's unique constraint", parentColumns,
-                                            parentTable.getName()));
-                        }
+
+                Pair<BaseTableInfo, Table> childTablePair = Pair.create(null, analyzedTable);
+                Table childTable = analyzedTable;
+                if (analyzedTable.isMaterializedView()) {
+                    childTablePair = analyzeForeignKeyConstraintTablePath(sourceTablePath, foreignKeyConstraintDesc,
+                            db);
+                    childTable = childTablePair.second;
+                    if (!childColumns.stream().allMatch(childTable::containColumn)) {
+                        throw new AnalysisException(String.format("some columns of:%s do not exist in table:%s",
+                                childColumns, childTable.getName()));
                     }
                 } else {
-                    // for PRIMARY_KEYS and UNIQUE_KEYS type table
-                    // parent columns should be keys
-                    if (!parentOlapTable.isKeySet(Sets.newHashSet(parentColumns))) {
-                        throw new AnalysisException(String.format("columns:%s are not key columns of table:%s",
-                                parentColumns, parentTable.getName()));
+                    if (!analyzedTable.isNativeTable()) {
+                        throw new AnalysisException("do not support add foreign key on external table");
+                    }
+                    if (!childColumns.stream().allMatch(analyzedTable::containColumn)) {
+                        throw new AnalysisException(String.format("some columns of:%s do not exist in table:%s",
+                                childColumns, analyzedTable.getName()));
                     }
                 }
-                List<Pair<String, String>> columnRefPairs = Streams.zip(originalBaseColumns.stream(),
-                        originalParentColumns.stream(), Pair::create).collect(Collectors.toList());
+
+                analyzeForeignKeyUniqueConstraint(parentTable, parentColumns, analyzedTable);
+                
+                List<Pair<String, String>> columnRefPairs = Streams.zip(childColumns.stream(),
+                        parentColumns.stream(), Pair::create).collect(Collectors.toList());
                 for (Pair<String, String> pair : columnRefPairs) {
-                    Column childColumn = baseOlapTable.getColumn(pair.first);
+                    Column childColumn = childTable.getColumn(pair.first);
                     Column parentColumn = parentTable.getColumn(pair.second);
                     if (!childColumn.getType().equals(parentColumn.getType())) {
                         throw new AnalysisException(String.format(
@@ -816,14 +894,9 @@ public class PropertyAnalyzer {
                     }
                 }
 
-                BaseTableInfo parentTableInfo;
-                if (catalogName.equals(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
-                    parentTableInfo = new BaseTableInfo(parentDb.getId(), dbName, parentTable.getId());
-                } else {
-                    parentTableInfo = new BaseTableInfo(catalogName, dbName, parentTable.getTableIdentifier());
-                }
-
-                ForeignKeyConstraint foreignKeyConstraint = new ForeignKeyConstraint(parentTableInfo, columnRefPairs);
+                BaseTableInfo childTableInfo = childTablePair.first;
+                ForeignKeyConstraint foreignKeyConstraint = new ForeignKeyConstraint(parentTableInfo, childTableInfo,
+                        columnRefPairs);
                 foreignKeyConstraints.add(foreignKeyConstraint);
             }
             if (foreignKeyConstraints.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -689,7 +689,7 @@ public class PropertyAnalyzer {
                             dbName, tableName);
                     if (uniqueConstraintTable == null) {
                         throw new AnalysisException(
-                                String.format("table:%s.%s.%s does not exist", catalogName, dbName, tableName));
+                                String.format("table: %s.%s.%s does not exist", catalogName, dbName, tableName));
                     }
                     boolean columnExist = uniqueConstraint.getUniqueColumns().stream()
                             .allMatch(uniqueConstraintTable::containColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -313,7 +313,6 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 public class GlobalStateMgr {
     private static final Logger LOG = LogManager.getLogger(GlobalStateMgr.class);
@@ -2464,36 +2463,8 @@ public class GlobalStateMgr {
                         && !Strings.isNullOrEmpty(properties.get(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT))) {
                     sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)
                             .append("\" = \"");
-                    List<ForeignKeyConstraint> constraints = olapTable.getForeignKeyConstraints();
-                    List<String> constraintStrs = Lists.newArrayList();
-                    for (ForeignKeyConstraint constraint : constraints) {
-                        BaseTableInfo parentTableInfo = constraint.getParentTableInfo();
-                        StringBuilder constraintSb = new StringBuilder();
-                        constraintSb.append("(");
-                        String baseColumns = Joiner.on(",").join(constraint.getColumnRefPairs()
-                                .stream().map(pair -> pair.first).collect(Collectors.toList()));
-                        constraintSb.append(baseColumns);
-                        constraintSb.append(")");
-                        constraintSb.append(" REFERENCES ");
-                        if (parentTableInfo.getCatalogName().equals(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
-                            Database parentDb = GlobalStateMgr.getCurrentState().getDb(parentTableInfo.getDbId());
-                            constraintSb.append(parentDb.getFullName());
-                            constraintSb.append(".");
-                            Table parentTable = parentDb.getTable(parentTableInfo.getTableId());
-                            constraintSb.append(parentTable.getName());
-                        } else {
-                            constraintSb.append(parentTableInfo);
-                        }
-
-                        constraintSb.append("(");
-                        String parentColumns = Joiner.on(",").join(constraint.getColumnRefPairs()
-                                .stream().map(pair -> pair.second).collect(Collectors.toList()));
-                        constraintSb.append(parentColumns);
-                        constraintSb.append(")");
-                        constraintStrs.add(constraintSb.toString());
-                    }
-
-                    sb.append(Joiner.on(";").join(constraintStrs)).append("\"");
+                    sb.append(ForeignKeyConstraint.getShowCreateTableConstraintDesc(olapTable.getForeignKeyConstraints()))
+                            .append("\"");
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -62,6 +62,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.ForeignKeyConstraint;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.HiveTable;
@@ -84,6 +85,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.catalog.View;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.clone.DynamicPartitionScheduler;
@@ -2863,6 +2865,16 @@ public class LocalMetastore implements ConnectorMetadata {
                         put(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE,
                                 String.valueOf(forceExternalTableQueryReWrite));
                 materializedView.getTableProperty().setForceExternalTableQueryRewrite(forceExternalTableQueryReWrite);
+            }
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {
+                List<UniqueConstraint> uniqueConstraints = PropertyAnalyzer.analyzeUniqueConstraint(properties, db,
+                        materializedView);
+                materializedView.setUniqueConstraints(uniqueConstraints);
+            }
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)) {
+                List<ForeignKeyConstraint> foreignKeyConstraints = PropertyAnalyzer.analyzeForeignKeyConstraint(
+                        properties, db, materializedView);
+                materializedView.setForeignKeyConstraints(foreignKeyConstraints);
             }
 
             if (materializedView.isCloudNativeMaterializedView()) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -613,7 +613,7 @@ public class OlapTableFactory implements AbstractTableFactory {
 
     private void processConstraint(
             Database db, OlapTable olapTable, Map<String, String> properties) throws AnalysisException {
-        List<UniqueConstraint> uniqueConstraints = PropertyAnalyzer.analyzeUniqueConstraint(properties, olapTable);
+        List<UniqueConstraint> uniqueConstraints = PropertyAnalyzer.analyzeUniqueConstraint(properties, db, olapTable);
         if (uniqueConstraints != null) {
             olapTable.setUniqueConstraints(uniqueConstraints);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendOptions.java
@@ -174,7 +174,7 @@ public class FrontendOptions {
         try {
             uncheckedInetAddress = InetAddress.getByName(fqdnString);
         } catch (UnknownHostException e) {
-            LOG.error("Got a UnknownHostException when try to parse FQDN, " 
+            LOG.error("Got a UnknownHostException when try to parse FQDN, "
                     + "FQDN: {}, message: {}", fqdnString, e.getMessage());
             System.exit(-1);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -47,6 +47,7 @@ public class ShowCreateMaterializedViewStmtTest {
         Config.enable_experimental_mv = true;
         UtFrameUtils.createMinStarRocksCluster();
         ctx = UtFrameUtils.createDefaultCtx();
+        ConnectorPlanTestBase.mockHiveCatalog(ctx);
         starRocksAssert = new StarRocksAssert(ctx);
         starRocksAssert.withDatabase("test").useDatabase("test")
                 .withTable("CREATE TABLE test.tbl1\n" +
@@ -62,7 +63,80 @@ public class ShowCreateMaterializedViewStmtTest {
                         ")\n" +
                         "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
                         "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.tbl2\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(`k1`, `k2`)\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2020-02-01'),\n" +
+                        "    PARTITION p2 values less than('2020-03-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
                 .useDatabase("test");
+    }
+
+    @Test
+    public void testShowInternalCatalogConstraints() throws Exception {
+        String createMvSql = "create materialized view mv9 " +
+                "distributed by hash(k1) buckets 10 " +
+                "refresh manual " +
+                "properties(\"unique_constraints\" = \"tbl2.k1\", " +
+                "\"foreign_key_constraints\" = \"tbl1(k1) REFERENCES tbl2(k1)\") " +
+                "as select tbl1.k1, tbl2.k2 from tbl1 join tbl2 on tbl1.k1 = tbl2.k1;";
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(createMvSql, ctx);
+        GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
+        currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+        Table table = currentState.getDb("test").getTable("mv9");
+        List<String> createTableStmt = Lists.newArrayList();
+        GlobalStateMgr.getDdlStmt(table, createTableStmt, null, null, false, true);
+        Assert.assertEquals("CREATE MATERIALIZED VIEW `mv9`\n" +
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 10 \n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"unique_constraints\" = \"default_catalog.test.tbl2.k1\",\n" +
+                "\"foreign_key_constraints\" = \"default_catalog.test.tbl1(k1) REFERENCES default_catalog.test.tbl2(k1)\",\n" +
+                "\"storage_medium\" = \"HDD\"\n" +
+                ")\n" +
+                "AS SELECT `tbl1`.`k1`, `tbl2`.`k2`\n" +
+                "FROM `test`.`tbl1` INNER JOIN `test`.`tbl2` ON `tbl1`.`k1` = `tbl2`.`k1`;", createTableStmt.get(0));
+    }
+
+    @Test
+    public void testShowExternalCatalogConstraints() throws Exception {
+        String createMvSql = "create materialized view mv10 " +
+                "distributed by hash(c1) buckets 10 " +
+                "refresh manual " +
+                "properties(\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\", " +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) REFERENCES hive0.partitioned_db2.t2(c2)\") " +
+                "as select t2.c1, t1.c2 from hive0.partitioned_db.t1 join hive0.partitioned_db2.t2 on t1.c2 = t2.c2;";
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(createMvSql, ctx);
+        GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
+        currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
+        Table table = currentState.getDb("test").getTable("mv10");
+        List<String> createTableStmt = Lists.newArrayList();
+        GlobalStateMgr.getDdlStmt(table, createTableStmt, null, null, false, true);
+        Assert.assertEquals("CREATE MATERIALIZED VIEW `mv10`\n" +
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "DISTRIBUTED BY HASH(`c1`) BUCKETS 10 \n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\",\n" +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) REFERENCES hive0.partitioned_db2.t2(c2)\",\n" +
+                "\"storage_medium\" = \"HDD\"\n" +
+                ")\n" +
+                "AS SELECT `hive0`.`partitioned_db2`.`t2`.`c1`, `hive0`.`partitioned_db`.`t1`.`c2`\n" +
+                "FROM `hive0`.`partitioned_db`.`t1` INNER JOIN `hive0`.`partitioned_db2`.`t2` ON `hive0`.`partitioned_db`.`t1`.`c2` = `hive0`.`partitioned_db2`.`t2`.`c2`;",
+                createTableStmt.get(0));
     }
 
     @Test
@@ -306,7 +380,6 @@ public class ShowCreateMaterializedViewStmtTest {
     @Test
     public void testShowExternalTableCreateMvSql() throws Exception {
         MetadataMgr oldMetadataMgr = ctx.getGlobalStateMgr().getMetadataMgr();
-        ConnectorPlanTestBase.mockHiveCatalog(ctx);
 
         String createMvSql = "create materialized view mv8 " +
                 "distributed by hash(l_orderkey) buckets 10 " +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ForeignKeyConstraintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ForeignKeyConstraintTest.java
@@ -163,4 +163,75 @@ public class ForeignKeyConstraintTest {
         Assert.assertEquals(0, foreignKeyConstraints5.size());
     }
 
+    @Test
+    public void testParseMV() {
+        String constraintDescs = "catalog.db.table1(column1)  REFERENCES  catalog.db.table2(newColumn1)";
+        List<ForeignKeyConstraint> foreignKeyConstraints1 = ForeignKeyConstraint.parse(constraintDescs);
+        Assert.assertEquals(1, foreignKeyConstraints1.size());
+        Assert.assertEquals("catalog", foreignKeyConstraints1.get(0).getParentTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints1.get(0).getParentTableInfo().getDbName());
+        Assert.assertEquals("table2", foreignKeyConstraints1.get(0).getParentTableInfo().getTableName());
+        Assert.assertEquals("catalog", foreignKeyConstraints1.get(0).getChildTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints1.get(0).getChildTableInfo().getDbName());
+        Assert.assertEquals("table1", foreignKeyConstraints1.get(0).getChildTableInfo().getTableName());
+        Assert.assertEquals(1, foreignKeyConstraints1.get(0).getColumnRefPairs().size());
+        Assert.assertEquals("column1", foreignKeyConstraints1.get(0).getColumnRefPairs().get(0).first);
+        Assert.assertEquals("newColumn1", foreignKeyConstraints1.get(0).getColumnRefPairs().get(0).second);
+
+        String constraintDescs2 = "catalog.db.table1(column1, column2)  REFERENCES  catalog.db.table2(newColumn1, newColumn2)";
+        List<ForeignKeyConstraint> foreignKeyConstraints2 = ForeignKeyConstraint.parse(constraintDescs2);
+        Assert.assertEquals(1, foreignKeyConstraints2.size());
+        Assert.assertEquals("catalog", foreignKeyConstraints2.get(0).getParentTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints2.get(0).getParentTableInfo().getDbName());
+        Assert.assertEquals("table2", foreignKeyConstraints2.get(0).getParentTableInfo().getTableName());
+        Assert.assertEquals("catalog", foreignKeyConstraints2.get(0).getChildTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints2.get(0).getChildTableInfo().getDbName());
+        Assert.assertEquals("table1", foreignKeyConstraints2.get(0).getChildTableInfo().getTableName());
+        Assert.assertEquals(2, foreignKeyConstraints2.get(0).getColumnRefPairs().size());
+        Assert.assertEquals("column1", foreignKeyConstraints2.get(0).getColumnRefPairs().get(0).first);
+        Assert.assertEquals("newColumn1", foreignKeyConstraints2.get(0).getColumnRefPairs().get(0).second);
+        Assert.assertEquals("column2", foreignKeyConstraints2.get(0).getColumnRefPairs().get(1).first);
+        Assert.assertEquals("newColumn2", foreignKeyConstraints2.get(0).getColumnRefPairs().get(1).second);
+
+        String constraintDescs3 = "catalog.db.table1(column1)  REFERENCES catalog.db.table2(newColumn1);" +
+                " catalog.db.table3(column1, column2 )  REFERENCES catalog.db.table4(newColumn1, newColumn2);" +
+                " catalog.db.table5(column1, column2,column3)  REFERENCES catalog.db.table6(newColumn1, newColumn2, newColumn3)";
+        List<ForeignKeyConstraint> foreignKeyConstraints3 = ForeignKeyConstraint.parse(constraintDescs3);
+        Assert.assertEquals(3, foreignKeyConstraints3.size());
+        Assert.assertEquals("catalog", foreignKeyConstraints3.get(0).getParentTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints3.get(0).getParentTableInfo().getDbName());
+        Assert.assertEquals("table2", foreignKeyConstraints3.get(0).getParentTableInfo().getTableName());
+        Assert.assertEquals("catalog", foreignKeyConstraints3.get(0).getChildTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints3.get(0).getChildTableInfo().getDbName());
+        Assert.assertEquals("table1", foreignKeyConstraints3.get(0).getChildTableInfo().getTableName());
+
+        Assert.assertEquals("catalog", foreignKeyConstraints3.get(1).getParentTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints3.get(1).getParentTableInfo().getDbName());
+        Assert.assertEquals("table4", foreignKeyConstraints3.get(1).getParentTableInfo().getTableName());
+        Assert.assertEquals("catalog", foreignKeyConstraints3.get(1).getChildTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints3.get(1).getChildTableInfo().getDbName());
+        Assert.assertEquals("table3", foreignKeyConstraints3.get(1).getChildTableInfo().getTableName());
+
+        Assert.assertEquals("catalog", foreignKeyConstraints3.get(2).getParentTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints3.get(2).getParentTableInfo().getDbName());
+        Assert.assertEquals("table6", foreignKeyConstraints3.get(2).getParentTableInfo().getTableName());
+        Assert.assertEquals("catalog", foreignKeyConstraints3.get(2).getChildTableInfo().getCatalogName());
+        Assert.assertEquals("db", foreignKeyConstraints3.get(2).getChildTableInfo().getDbName());
+        Assert.assertEquals("table5", foreignKeyConstraints3.get(2).getChildTableInfo().getTableName());
+
+        Assert.assertEquals(1, foreignKeyConstraints3.get(0).getColumnRefPairs().size());
+        Assert.assertEquals(2, foreignKeyConstraints3.get(1).getColumnRefPairs().size());
+        Assert.assertEquals(3, foreignKeyConstraints3.get(2).getColumnRefPairs().size());
+
+        String constraintDescs4 = "hive_catalog.hive_ssb_1g_csv.lineorder:1643182323(lo_custkey) " +
+                "REFERENCES hive_catalog.hive_ssb_1g_csv.customer:1643182415(c_custkey)";
+        List<ForeignKeyConstraint> foreignKeyConstraints4 = ForeignKeyConstraint.parse(constraintDescs4);
+        Assert.assertEquals(1, foreignKeyConstraints4.size());
+        Assert.assertEquals("hive_catalog", foreignKeyConstraints4.get(0).getParentTableInfo().getCatalogName());
+        Assert.assertEquals("hive_ssb_1g_csv", foreignKeyConstraints4.get(0).getParentTableInfo().getDbName());
+        Assert.assertEquals("customer", foreignKeyConstraints4.get(0).getParentTableInfo().getTableName());
+        Assert.assertEquals("hive_catalog", foreignKeyConstraints4.get(0).getChildTableInfo().getCatalogName());
+        Assert.assertEquals("hive_ssb_1g_csv", foreignKeyConstraints4.get(0).getChildTableInfo().getDbName());
+        Assert.assertEquals("lineorder", foreignKeyConstraints4.get(0).getChildTableInfo().getTableName());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/UniqueConstraintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/UniqueConstraintTest.java
@@ -14,15 +14,21 @@
 
 package com.starrocks.catalog;
 
+import com.starrocks.common.AnalysisException;
 import jersey.repackaged.com.google.common.collect.Lists;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 
 public class UniqueConstraintTest {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
     @Test
-    public void testParse() {
+    public void testParse() throws AnalysisException {
         String constraintDescs = "col1, col2  , col3 ";
         List<UniqueConstraint> results = UniqueConstraint.parse(constraintDescs);
         Assert.assertEquals(1, results.size());
@@ -34,5 +40,41 @@ public class UniqueConstraintTest {
         Assert.assertEquals(Lists.newArrayList("col1", "col2", "col3"), results2.get(0).getUniqueColumns());
         Assert.assertEquals(Lists.newArrayList("col4", "col5", "col6", "col7"), results2.get(1).getUniqueColumns());
         Assert.assertEquals(Lists.newArrayList("col8"), results2.get(2).getUniqueColumns());
+
+        String constraintDescs3 = "hive_catalog.db1.table1.col1, hive_catalog.db1.table1.col2, hive_catalog.db1.table1.col3;";
+        List<UniqueConstraint> results3 = UniqueConstraint.parse(constraintDescs3);
+        Assert.assertEquals(1, results3.size());
+        Assert.assertEquals(Lists.newArrayList("col1", "col2", "col3"), results.get(0).getUniqueColumns());
+        Assert.assertEquals("hive_catalog", results3.get(0).getCatalogName());
+        Assert.assertEquals("db1", results3.get(0).getDbName());
+        Assert.assertEquals("table1", results3.get(0).getTableName());
+
+        String constraintDescs4 = "hive_catalog.db1.table1.col1, col2, col3;";
+        List<UniqueConstraint> results4 = UniqueConstraint.parse(constraintDescs4);
+        Assert.assertEquals(1, results4.size());
+        Assert.assertEquals(Lists.newArrayList("col1", "col2", "col3"), results4.get(0).getUniqueColumns());
+        Assert.assertEquals("hive_catalog", results4.get(0).getCatalogName());
+        Assert.assertEquals("db1", results4.get(0).getDbName());
+        Assert.assertEquals("table1", results4.get(0).getTableName());
+
+        String constraintDescs5 = "hive_catalog.db1.table1.col1, col2, col3; hive_catalog.db1.table2.col1, col2, col3;";
+        List<UniqueConstraint> results5 = UniqueConstraint.parse(constraintDescs5);
+        Assert.assertEquals(2, results5.size());
+        Assert.assertEquals(Lists.newArrayList("col1", "col2", "col3"), results5.get(0).getUniqueColumns());
+        Assert.assertEquals("hive_catalog", results5.get(0).getCatalogName());
+        Assert.assertEquals("db1", results5.get(0).getDbName());
+        Assert.assertEquals("table1", results5.get(0).getTableName());
+        Assert.assertEquals(Lists.newArrayList("col1", "col2", "col3"), results5.get(1).getUniqueColumns());
+        Assert.assertEquals("hive_catalog", results5.get(1).getCatalogName());
+        Assert.assertEquals("db1", results5.get(1).getDbName());
+        Assert.assertEquals("table2", results5.get(1).getTableName());
+    }
+
+    @Test
+    public void testParseException() throws AnalysisException {
+        String constraintDescs = "hive_catalog.db1.table1.col1, col2, hive_catalog.db1.table2.col3";
+        exception.expect(AnalysisException.class);
+        exception.expectMessage("unique constraint column should be in same table");
+        UniqueConstraint.parse(constraintDescs);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -21,17 +21,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.IntLiteral;
-import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ForeignKeyConstraint;
 import com.starrocks.catalog.HiveMetaStoreTable;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
-import com.starrocks.catalog.UniqueConstraint;
-import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorMetadata;
@@ -715,13 +711,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         mockSimpleTable(MOCKED_PARTITIONED_DB_NAME, "t1");
         HiveTable  t1 = (HiveTable) MOCK_TABLE_MAP.get(MOCKED_PARTITIONED_DB_NAME).
                 get("t1").table;
-        // add foreign key constraint
-        // t1.c2 referenced to t2.c2, t1.c3 referenced to t2.c2
-        t1.setForeignKeyConstraints(ImmutableList.of(
-                new ForeignKeyConstraint(new BaseTableInfo(MOCKED_HIVE_CATALOG_NAME, MOCKED_PARTITIONED_DB_NAME2,
-                        "t2"), ImmutableList.of(new Pair<>("c2", "c2"))),
-                new ForeignKeyConstraint(new BaseTableInfo(MOCKED_HIVE_CATALOG_NAME, MOCKED_PARTITIONED_DB_NAME2,
-                        "t2"), ImmutableList.of(new Pair<>("c3", "c2")))));
+        // todo(ywb) remove mock not null later
         // c2, c3 is not null
         t1.setColumnAllowNull("c2", false);
         t1.setColumnAllowNull("c3", false);
@@ -730,9 +720,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     public static void mockT2() {
         mockSimpleTable(MOCKED_PARTITIONED_DB_NAME2, "t2");
         HiveTable t2 = (HiveTable) MOCK_TABLE_MAP.get(MOCKED_PARTITIONED_DB_NAME2).get("t2").table;
-        // add unique constraint
-        t2.setUniqueConstraints(ImmutableList.of(
-                new UniqueConstraint(ImmutableList.of("c2"))));
+        // todo(ywb) remove mock not null later
         // c2 is not null
         t2.setColumnAllowNull("c2", false);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -1450,7 +1450,9 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 + "(select * from hive0.partitioned_db.t1 where c1 = 1) a\n"
                 + "join hive0.partitioned_db2.t2 using (c2)";
         String query = "select c2 from hive0.partitioned_db.t1 where c1 = 1";
-        testRewriteOK(mv, query)
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2)\" ";
+        testRewriteOK(mv, query, constraint)
                 .contains("0:OlapScanNode\n" +
                         "     TABLE: mv0\n" +
                         "     PREAGGREGATION: ON\n");
@@ -1462,7 +1464,10 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "join hive0.partitioned_db2.t2 l on t1.c2= l.c2 " +
                 "join hive0.partitioned_db2.t2 r on t1.c3 = r.c2";
         String query = "select t1.c1, t2.c2 from hive0.partitioned_db.t1 join hive0.partitioned_db2.t2 on t1.c2 = t2.c2";
-        testRewriteOK(mv, query)
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2); " +
+                "hive0.partitioned_db.t1(c3) references hive0.partitioned_db2.t2(c2)\" ";
+        testRewriteOK(mv, query, constraint)
                 .contains("0:OlapScanNode\n" +
                         "     TABLE: mv0\n" +
                         "     PREAGGREGATION: ON\n");
@@ -1475,7 +1480,10 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "join hive0.partitioned_db2.t2 r on t1.c3 = r.c2 " +
                 "join hive0.partitioned_db.t3 on t1.c2 = t3.c2";
         String query = "select t1.c1, t3.c1 from hive0.partitioned_db.t1 join hive0.partitioned_db.t3 on t1.c2 = t3.c2";
-        testRewriteOK(mv, query)
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2); " +
+                "hive0.partitioned_db.t1(c3) references hive0.partitioned_db2.t2(c2)\" ";
+        testRewriteOK(mv, query, constraint)
                 .contains("0:OlapScanNode\n" +
                         "     TABLE: mv0\n" +
                         "     PREAGGREGATION: ON\n");
@@ -1489,7 +1497,9 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "join hive0.partitioned_db.t3 on a.c2 = t3.c2";
         String query = "select a.c2 from (select * from hive0.partitioned_db.t1 where c1 = 1) a join hive0.partitioned_db.t3 " +
                 "on a.c2 = hive0.partitioned_db.t3.c2";
-        testRewriteOK(mv, query)
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2);\" ";
+        testRewriteOK(mv, query, constraint)
                 .contains("0:OlapScanNode\n" +
                         "     TABLE: mv0\n" +
                         "     PREAGGREGATION: ON\n");
@@ -1503,7 +1513,9 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "join hive0.partitioned_db.t3 on a.c2 = t3.c2";
         String query = "select a.c3 from (select * from hive0.partitioned_db.t1 where c1 = 1) a join hive0.partitioned_db.t3 " +
                 "on a.c2 = hive0.partitioned_db.t3.c2";
-        testRewriteFail(mv, query);
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2);\" ";
+        testRewriteFail(mv, query, constraint);
     }
 
     @Test
@@ -1514,7 +1526,10 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "where t1.c1 = 1";
         String query = "select t1.c1, t2.c2 from hive0.partitioned_db.t1 join hive0.partitioned_db2.t2 on t1.c2 = t2.c2 " +
                 "where t1.c1 = 1";
-        testRewriteOK(mv, query)
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2); " +
+                "hive0.partitioned_db.t1(c3) references hive0.partitioned_db2.t2(c2)\" ";
+        testRewriteOK(mv, query, constraint)
                 .contains("0:OlapScanNode\n" +
                         "     TABLE: mv0\n" +
                         "     PREAGGREGATION: ON\n");
@@ -1528,7 +1543,10 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "where t1.c1 = 1";
         String query = "select t1.c1, t2.c2 from hive0.partitioned_db.t1 join hive0.partitioned_db2.t2 on t1.c2 = t2.c1 " +
                 "where t1.c1 = 1";
-        testRewriteFail(mv, query);
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2); " +
+                "hive0.partitioned_db.t1(c3) references hive0.partitioned_db2.t2(c2)\" ";
+        testRewriteFail(mv, query, constraint);
     }
 
     @Test
@@ -1540,19 +1558,25 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "where t1.c1 = 1";
         String query = "select t1.c1, t3.c3 from hive0.partitioned_db.t1 join hive0.partitioned_db.t3 on t1.c2 = t3.c2 " +
                 "where t1.c1 = 1";
-        testRewriteOK(mv, query);
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2); " +
+                "hive0.partitioned_db.t1(c3) references hive0.partitioned_db2.t2(c2)\" ";
+        testRewriteOK(mv, query, constraint);
     }
 
     @Test
     public void testHiveViewDeltaJoinUKFK9() {
         String mv = "select t1.c1, l.c2 as c2_1, r.c2 as c2_2, t3.c3 from hive0.partitioned_db.t1 " +
                 "join hive0.partitioned_db.t3 on t1.c2 = t3.c2 " +
-                "left join hive0.partitioned_db2.t2 l on t1.c2= l.c2 " +
+                "left join hive0.partitioned_db2.t2 l on t1.c2 = l.c2 " +
                 "join hive0.partitioned_db2.t2 r on t1.c3 = r.c2 " +
                 "where t1.c1 = 1";
         String query = "select t1.c1, t3.c3 from hive0.partitioned_db.t1 join hive0.partitioned_db.t3 on t1.c2 = t3.c2 " +
                 "where t1.c1 = 1";
-        testRewriteOK(mv, query);
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2); " +
+                "hive0.partitioned_db.t1(c3) references hive0.partitioned_db2.t2(c2)\" ";
+        testRewriteOK(mv, query, constraint);
     }
 
     @Test
@@ -1560,11 +1584,14 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         String mv = "select t1.c1, l.c2 as c2_1, r.c2 as c2_2, t3.c3 from hive0.partitioned_db.t1 " +
                 "join hive0.partitioned_db.t3 on t1.c2 = t3.c2 " +
                 "join hive0.partitioned_db2.t2 r on t1.c3 = r.c2 " +
-                "left join hive0.partitioned_db2.t2 l on t1.c2= l.c2 " +
+                "left join hive0.partitioned_db2.t2 l on t1.c2 = l.c2 " +
                 "where t1.c1 = 1";
         String query = "select t1.c1, t3.c3 from hive0.partitioned_db.t1 join hive0.partitioned_db.t3 on t1.c2 = t3.c2 " +
                 "where t1.c1 = 1";
-        testRewriteOK(mv, query);
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) references hive0.partitioned_db2.t2(c2); " +
+                "hive0.partitioned_db.t1(c3) references hive0.partitioned_db2.t2(c2)\" ";
+        testRewriteOK(mv, query, constraint);
     }
 
     @Test
@@ -1575,7 +1602,9 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "where t1.c1 = 1";
         String query = "select t1.c1, t3.c3 from hive0.partitioned_db.t1 left join hive0.partitioned_db.t3 on t1.c2 = t3.c2 " +
                 "where t1.c1 = 1";
-        testRewriteOK(mv, query);
+        String constraint = "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\"," +
+                "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c3) references hive0.partitioned_db2.t2(c2);\" ";
+        testRewriteOK(mv, query, constraint);
     }
 
     // mv: t1, t2, t2
@@ -1759,6 +1788,93 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 + "left outer join dependents using (empid)\n"
                 + "where emps.empid = 1";
         testRewriteOK(mv, query);
+    }
+
+    @Test
+    public void testViewDeltaJoinUKFKInMV1() {
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps\n"
+                + "join dependents using (empid)";
+        String query = "select empid, deptno from emps\n"
+                + "where emps.empid = 1";
+        String constraint = "\"unique_constraints\" = \"dependents.empid\"," +
+                "\"foreign_key_constraints\" = \"emps(empid) references dependents(empid)\" ";
+        testRewriteOK(mv, query, constraint).
+                contains("0:OlapScanNode\n" +
+                "     TABLE: mv0");
+    }
+
+    @Test
+    public void testViewDeltaJoinUKFKInMV2() {
+        String mv = "select emps_no_constraint.empid, emps_no_constraint.deptno, dependents.name from emps_no_constraint\n"
+                + "join dependents using (empid)";
+        String query = "select empid, deptno from emps_no_constraint\n"
+                + "where empid = 1";
+        String constraint = "\"unique_constraints\" = \"dependents.empid\"," +
+                "\"foreign_key_constraints\" = \"emps_no_constraint(empid) references dependents(empid)\" ";
+        testRewriteOK(mv, query, constraint).
+                contains("0:OlapScanNode\n" +
+                        "     TABLE: mv0");
+    }
+
+    @Test
+    public void testViewDeltaJoinUKFKInMV3() {
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps_no_constraint emps\n"
+                + "join dependents using (empid)"
+                + "inner join depts b on (emps.deptno=b.deptno)\n"
+                + "where emps.empid = 1";
+        String query = "select empid, emps.deptno from emps_no_constraint emps join depts b on (emps.deptno=b.deptno) \n"
+                + "where empid = 1";
+        String constraint = "\"unique_constraints\" = \"dependents.empid\"," +
+                "\"foreign_key_constraints\" = \"emps_no_constraint(empid) references dependents(empid)\" ";
+        testRewriteOK(mv, query, constraint).
+                contains("0:OlapScanNode\n" +
+                        "     TABLE: mv0");
+    }
+
+    @Test
+    public void testViewDeltaJoinUKFKInMV4() {
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps_no_constraint emps\n"
+                + "left join dependents using (empid)"
+                + "inner join depts b on (emps.deptno=b.deptno)\n"
+                + "where emps.empid = 1";
+        String query = "select empid, emps.deptno from emps_no_constraint emps join depts b on (emps.deptno=b.deptno) \n"
+                + "where empid = 1";
+        String constraint = "\"unique_constraints\" = \"dependents.empid\"," +
+                "\"foreign_key_constraints\" = \"emps_no_constraint(empid) references dependents(empid)\" ";
+        testRewriteOK(mv, query, constraint).
+                contains("0:OlapScanNode\n" +
+                        "     TABLE: mv0");
+    }
+
+    @Test
+    public void testViewDeltaJoinUKFKInMV5() {
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps_no_constraint emps\n"
+                + "left join dependents using (empid)"
+                + "inner join depts b on (emps.deptno=b.deptno)\n"
+                + "left outer join depts a on (emps.deptno=a.deptno)\n"
+                + "where emps.empid = 1";
+        String query = "select empid, emps.deptno from emps_no_constraint emps join depts b on (emps.deptno=b.deptno) \n"
+                + "where empid = 1";
+        String constraint = "\"unique_constraints\" = \"dependents.empid\"," +
+                "\"foreign_key_constraints\" = \"emps_no_constraint(empid) references dependents(empid)\" ";
+        testRewriteFail(mv, query, constraint);
+    }
+
+    @Test
+    public void testViewDeltaJoinUKFKInMV6() {
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps_no_constraint emps\n"
+                + "left join dependents using (empid)"
+                + "inner join depts b on (emps.deptno=b.deptno)\n"
+                + "left outer join depts a on (emps.deptno=a.deptno)\n"
+                + "where emps.empid = 1";
+        String query = "select empid, emps.deptno from emps_no_constraint emps join depts b on (emps.deptno=b.deptno) \n"
+                + "where empid = 1";
+        String constraint = "\"unique_constraints\" = \"dependents.empid; depts.deptno\"," +
+                "\"foreign_key_constraints\" = \"emps_no_constraint(empid) references dependents(empid);" +
+                "emps_no_constraint(deptno) references depts(deptno)\" ";
+        testRewriteOK(mv, query, constraint).
+                contains("0:OlapScanNode\n" +
+                        "     TABLE: mv0");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -149,6 +149,22 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 "    \"replication_num\" = \"1\"\n" +
                 ");";
 
+        String empsTableWithoutConstraints = "" +
+                "CREATE TABLE emps_no_constraint\n" +
+                "(\n" +
+                "    empid      INT         NOT NULL,\n" +
+                "    deptno     INT         NOT NULL,\n" +
+                "    locationid INT         NOT NULL,\n" +
+                "    commission INT         NOT NULL,\n" +
+                "    name       VARCHAR(20) NOT NULL,\n" +
+                "    salary     DECIMAL(18, 2)\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`empid`)\n" +
+                "DISTRIBUTED BY HASH(`empid`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");";
+
         String empsWithBigintTable = "" +
                 "CREATE TABLE emps_bigint\n" +
                 "(\n" +
@@ -186,8 +202,8 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 .withTable(ependentsTable)
                 .withTable(empsWithBigintTable)
                 .withTable(nullableEmps)
-                .withTable(nullableDepts);
-
+                .withTable(nullableDepts)
+                .withTable(empsTableWithoutConstraints);
     }
 
     @AfterClass
@@ -204,14 +220,20 @@ public class MaterializedViewTestBase extends PlanTestBase {
         private final String query;
         private String rewritePlan;
         private Exception exception;
+        private String properties;
 
         public MVRewriteChecker(String query) {
             this.query = query;
         }
 
         public MVRewriteChecker(String mv, String query) {
+            this(mv, query, null);
+        }
+
+        public MVRewriteChecker(String mv, String query, String properties) {
             this.mv = mv;
             this.query = query;
+            this.properties = properties;
         }
 
         public MVRewriteChecker rewrite() {
@@ -225,9 +247,11 @@ public class MaterializedViewTestBase extends PlanTestBase {
                     LOG.info("start to create mv:" + mv);
                     ExecPlan mvPlan = getExecPlan(mv);
                     List<String> outputNames = mvPlan.getColNames();
+                    String properties = this.properties != null ? "PROPERTIES (\n" +
+                            this.properties + ")" : "";
                     String mvSQL = "CREATE MATERIALIZED VIEW mv0 \n" +
                             "   DISTRIBUTED BY HASH(`"+ outputNames.get(0) +"`) BUCKETS 12\n" +
-                            " AS " +
+                            properties + " AS " +
                             mv;
                     starRocksAssert.withMaterializedView(mvSQL);
                 }
@@ -300,13 +324,21 @@ public class MaterializedViewTestBase extends PlanTestBase {
     }
 
     protected MVRewriteChecker testRewriteOK(String mv, String query) {
-        MVRewriteChecker fixture = new MVRewriteChecker(mv, query);
+        return testRewriteOK(mv, query, null);
+    }
+
+    protected MVRewriteChecker testRewriteOK(String mv, String query, String properties) {
+        MVRewriteChecker fixture = new MVRewriteChecker(mv, query, properties);
         return fixture.rewrite().ok();
     }
 
-    protected MVRewriteChecker testRewriteFail(String mv, String query) {
-        MVRewriteChecker fixture = new MVRewriteChecker(mv, query);
+    protected MVRewriteChecker testRewriteFail(String mv, String query, String properties) {
+        MVRewriteChecker fixture = new MVRewriteChecker(mv, query, properties);
         return fixture.rewrite().nonMatch();
+    }
+
+    protected MVRewriteChecker testRewriteFail(String mv, String query) {
+        return testRewriteFail(mv, query, null);
     }
 
     protected static Table getTable(String dbName, String mvName) {


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 
#22046

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support create materialzed view with unique/foreign key constraint, for example: 
```
CREATE MATERIALIZED VIEW `lineorder_flat_mv`
DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
REFRESH MANUAL
PROPERTIES (
"replication_num" = "1", 
"storage_medium" = "HDD"，
"unique_constraints" = "hive_catalog.ssb_1g.customer.c_custkey; 
                        hive_catalog.ssb_1g.supplier.s_suppkey;
                        hive_catalog.ssb_1g.part.p_partkey;
                        hive_catalog.ssb_1g.dates.d_datekey",
"foreign_key_constraints" = "
hive_catalog.ssb_1g.lineorder(lo_custkey) REFERENCES hive_catalog.ssb_1g.customer(c_custkey);
hive_catalog.ssb_1g.lineorder(lo_partkey) REFERENCES hive_catalog.ssb_1g.part(p_partkey);
hive_catalog.ssb_1g.lineorder(lo_suppkey) REFERENCES hive_catalog.ssb_1g.supplier(s_suppkey);
hive_catalog.ssb_1g.lineorder(lo_orderdate) REFERENCES hive_catalog.ssb_1g.dates(d_datekey)"
)
AS
SELECT `l`.`LO_ORDERKEY`,
       `l`.`LO_ORDERDATE`,
       `l`.`LO_LINENUMBER`,
       `l`.`LO_CUSTKEY`,
       `l`.`LO_PARTKEY`,
       `l`.`LO_SUPPKEY`,
       `l`.`LO_ORDERPRIORITY`,
       `l`.`LO_SHIPPRIORITY`,
       `l`.`LO_QUANTITY`,
       `l`.`LO_EXTENDEDPRICE`,
       `l`.`LO_ORDTOTALPRICE`,
       `l`.`LO_DISCOUNT`,
       `c`.`C_NAME`,
       `c`.`C_ADDRESS`,
       `c`.`C_CITY`,
       `c`.`C_NATION`,
       `c`.`C_REGION`,
       `c`.`C_PHONE`,
       `c`.`C_MKTSEGMENT`,
       `s`.`S_NAME`,
       `s`.`S_ADDRESS`,
       `s`.`S_CITY`,
       `s`.`S_NATION`,
       `s`.`S_REGION`,
       `s`.`S_PHONE`,
       `p`.`P_NAME`,
       `p`.`P_MFGR`,
       `p`.`P_CATEGORY`,
       `p`.`P_BRAND`,
       `p`.`P_COLOR`,
       `p`.`P_TYPE`,
       `p`.`P_SIZE`,
       `p`.`P_CONTAINER`,
       `d`.`D_DATE`,
       `d`.`D_DAYOFWEEK`,
       `d`.`D_MONTH`,
       `d`.`D_YEAR`,
       `d`.`D_YEARMONTHNUM`,
       `d`.`D_YEARMONTH`
FROM `ssb`.`lineorder` AS `l`
INNER JOIN `ssb`.`customer` AS `c` ON `c`.`C_CUSTKEY` = `l`.`LO_CUSTKEY`
INNER JOIN `ssb`.`supplier` AS `s` ON `s`.`S_SUPPKEY` = `l`.`LO_SUPPKEY`
INNER JOIN `ssb`.`part` AS `p` ON `p`.`P_PARTKEY` = `l`.`LO_PARTKEY`
INNER JOIN `ssb`.`dates` AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`;
```
Note:
This PR does not fully implement the materialized view delta join for hive table, we need to check that the join key is not null later

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
