### PR TITLE
[BugFix] Fix the memory leak of lambda function

### DIFF
--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -101,11 +101,4 @@ StatusOr<ColumnPtr> LambdaFunction::evaluate_checked(ExprContext* context, Chunk
     return get_child(0)->evaluate_checked(context, chunk);
 }
 
-void LambdaFunction::close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
-    _arguments_ids.clear();
-    _captured_slot_ids.clear();
-    _common_sub_expr_ids.clear();
-    _common_sub_expr.clear();
-}
-
 } // namespace starrocks

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -59,8 +59,6 @@ public:
 
     Expr* get_lambda_expr() const { return _children[0]; }
 
-    void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
-
 private:
     std::vector<SlotId> _captured_slot_ids;
     std::vector<SlotId> _arguments_ids;

--- a/be/test/exprs/lambda_array_expr_test.cpp
+++ b/be/test/exprs/lambda_array_expr_test.cpp
@@ -51,104 +51,15 @@ ColumnPtr build_int_column(const std::vector<int>& values) {
     return data;
 }
 
-ColumnPtr build_int_column(const std::vector<int>& values, const std::vector<uint8_t>& nullflags) {
-    DCHECK_EQ(values.size(), nullflags.size());
-    auto null = NullColumn::create();
-    null->append_numbers(nullflags.data(), nullflags.size());
-
-    auto data = build_int_column(values);
-
-    return NullableColumn::create(std::move(data), std::move(null));
-}
-
 class VectorizedLambdaFunctionExprTest : public ::testing::Test {
 public:
     void SetUp() override {
-        // init the int_type.
-        TTypeNode node;
-        node.__set_type(TTypeNodeType::SCALAR);
-        TScalarType scalar_type;
-        scalar_type.__set_type(TPrimitiveType::INT);
-        node.__set_scalar_type(scalar_type);
-        int_type.types.push_back(node);
-
-        // init expr_node
-        expr_node.opcode = TExprOpcode::ADD;
-        expr_node.child_type = TPrimitiveType::INT;
-        expr_node.node_type = TExprNodeType::BINARY_PRED;
-        expr_node.num_children = 2;
-        expr_node.__isset.opcode = true;
-        expr_node.__isset.child_type = true;
-        expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
-
         create_array_expr();
-        create_lambda_expr();
     }
 
-    void create_lambda_expr() {
-        // create lambda functions
-        TExprNode tlambda_func;
-        tlambda_func.opcode = TExprOpcode::ADD;
-        tlambda_func.child_type = TPrimitiveType::INT;
-        tlambda_func.node_type = TExprNodeType::LAMBDA_FUNCTION_EXPR;
-        tlambda_func.num_children = 2;
-        tlambda_func.__isset.opcode = true;
-        tlambda_func.__isset.child_type = true;
-        tlambda_func.type = gen_type_desc(TPrimitiveType::INT);
-        LambdaFunction* lambda_func = _objpool.add(new LambdaFunction(tlambda_func));
+    static TExprNode create_expr_node();
 
-        // x -> x
-        TExprNode slot_ref;
-        slot_ref.node_type = TExprNodeType::SLOT_REF;
-        slot_ref.type = int_type;
-        slot_ref.num_children = 0;
-        slot_ref.__isset.slot_ref = true;
-        slot_ref.slot_ref.slot_id = 100000;
-        slot_ref.slot_ref.tuple_id = 0;
-        slot_ref.__set_is_nullable(true);
-
-        ColumnRef* col1 = _objpool.add(new ColumnRef(slot_ref));
-        ColumnRef* col2 = _objpool.add(new ColumnRef(slot_ref));
-        lambda_func->add_child(col1);
-        lambda_func->add_child(col2);
-        _lambda_func.push_back(lambda_func);
-
-        // x -> x is null
-        lambda_func = _objpool.add(new LambdaFunction(tlambda_func));
-        ColumnRef* col3 = _objpool.add(new ColumnRef(slot_ref));
-        ColumnRef* col4 = _objpool.add(new ColumnRef(slot_ref));
-        expr_node.fn.name.function_name = "is_null_pred";
-        auto* is_null = _objpool.add(VectorizedIsNullPredicateFactory::from_thrift(expr_node));
-        is_null->add_child(col4);
-        lambda_func->add_child(is_null);
-        lambda_func->add_child(col3);
-        _lambda_func.push_back(lambda_func);
-
-        // x -> x + a (captured columns)
-        lambda_func = _objpool.add(new LambdaFunction(tlambda_func));
-        ColumnRef* col5 = _objpool.add(new ColumnRef(slot_ref));
-        expr_node.opcode = TExprOpcode::ADD;
-        expr_node.type = gen_type_desc(TPrimitiveType::INT);
-        auto* add_expr = _objpool.add(VectorizedArithmeticExprFactory::from_thrift(expr_node));
-        ColumnRef* col6 = _objpool.add(new ColumnRef(slot_ref));
-        slot_ref.slot_ref.slot_id = 1;
-        ColumnRef* col7 = _objpool.add(new ColumnRef(slot_ref));
-        add_expr->_children.push_back(col6);
-        add_expr->_children.push_back(col7);
-        lambda_func->add_child(add_expr);
-        lambda_func->add_child(col5);
-        _lambda_func.push_back(lambda_func);
-
-        // x -> -110
-        lambda_func = _objpool.add(new LambdaFunction(tlambda_func));
-        auto tint_literal = create_int_literal_node(-110);
-        auto int_literal = _objpool.add(new VectorizedLiteral(tint_literal));
-        slot_ref.slot_ref.slot_id = 100000;
-        ColumnRef* col8 = _objpool.add(new ColumnRef(slot_ref));
-        lambda_func->add_child(int_literal);
-        lambda_func->add_child(col8);
-        _lambda_func.push_back(lambda_func);
-    }
+    static std::vector<Expr*> create_lambda_expr(ObjectPool* pool);
 
     void create_array_expr() {
         TypeDescriptor type_arr_int;
@@ -222,6 +133,7 @@ public:
         const_array = new_fake_const_expr(const_col, type_arr_int);
         _array_expr.push_back(const_array);
     }
+
     FakeConstExpr* new_fake_const_expr(ColumnPtr value, const TypeDescriptor& type) {
         TExprNode node;
         node.__set_node_type(TExprNodeType::INT_LITERAL);
@@ -232,49 +144,106 @@ public:
         return e;
     }
 
-    MockExpr* new_mock_expr(ColumnPtr value, const LogicalType& type) {
-        return new_mock_expr(std::move(value), TypeDescriptor(type));
-    }
-
-    MockExpr* new_mock_expr(ColumnPtr value, const TypeDescriptor& type) {
-        TExprNode node;
-        node.__set_node_type(TExprNodeType::INT_LITERAL);
-        node.__set_num_children(0);
-        node.__set_type(type.to_thrift());
-        MockExpr* e = _objpool.add(new MockExpr(node, std::move(value)));
-        return e;
-    }
-    Expr* create_array_expr(const TTypeDesc& type) {
-        TExprNode node;
-        node.__set_node_type(TExprNodeType::ARRAY_EXPR);
-        node.__set_is_nullable(true);
-        node.__set_type(type);
-        node.__set_num_children(0);
-
-        auto* expr = _objpool.add(ArrayExprFactory::from_thrift(node));
-        return expr;
-    }
-    TExprNode create_int_literal_node(int64_t value_literal) {
+    static TExprNode create_int_literal_node(int64_t value_literal) {
         TExprNode lit_node;
         lit_node.__set_node_type(TExprNodeType::INT_LITERAL);
         lit_node.__set_num_children(0);
-        lit_node.__set_type(int_type);
+        lit_node.__set_type(gen_type_desc(TPrimitiveType::INT));
         TIntLiteral lit_value;
         lit_value.__set_value(value_literal);
         lit_node.__set_int_literal(lit_value);
         return lit_node;
     }
 
-    TExprNode expr_node;
-    std::vector<Expr*> _lambda_func;
     std::vector<Expr*> _array_expr;
     std::vector<Chunk*> _chunks;
 
-private:
-    TTypeDesc int_type;
+protected:
     RuntimeState _runtime_state;
     ObjectPool _objpool;
 };
+
+TExprNode VectorizedLambdaFunctionExprTest::create_expr_node() {
+    TExprNode expr_node;
+    expr_node.opcode = TExprOpcode::ADD;
+    expr_node.child_type = TPrimitiveType::INT;
+    expr_node.node_type = TExprNodeType::BINARY_PRED;
+    expr_node.num_children = 2;
+    expr_node.__isset.opcode = true;
+    expr_node.__isset.child_type = true;
+    expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+    return expr_node;
+}
+
+std::vector<Expr*> VectorizedLambdaFunctionExprTest::create_lambda_expr(ObjectPool* pool) {
+    std::vector<Expr*> lambda_funcs;
+
+    // create lambda functions
+    TExprNode tlambda_func;
+    tlambda_func.opcode = TExprOpcode::ADD;
+    tlambda_func.child_type = TPrimitiveType::INT;
+    tlambda_func.node_type = TExprNodeType::LAMBDA_FUNCTION_EXPR;
+    tlambda_func.num_children = 2;
+    tlambda_func.__isset.opcode = true;
+    tlambda_func.__isset.child_type = true;
+    tlambda_func.type = gen_type_desc(TPrimitiveType::INT);
+    LambdaFunction* lambda_func = pool->add(new LambdaFunction(tlambda_func));
+
+    // x -> x
+    TExprNode slot_ref;
+    slot_ref.node_type = TExprNodeType::SLOT_REF;
+    slot_ref.type = gen_type_desc(TPrimitiveType::INT);
+    slot_ref.num_children = 0;
+    slot_ref.__isset.slot_ref = true;
+    slot_ref.slot_ref.slot_id = 100000;
+    slot_ref.slot_ref.tuple_id = 0;
+    slot_ref.__set_is_nullable(true);
+
+    ColumnRef* col1 = pool->add(new ColumnRef(slot_ref));
+    ColumnRef* col2 = pool->add(new ColumnRef(slot_ref));
+    lambda_func->add_child(col1);
+    lambda_func->add_child(col2);
+    lambda_funcs.push_back(lambda_func);
+
+    // x -> x is null
+    lambda_func = pool->add(new LambdaFunction(tlambda_func));
+    ColumnRef* col3 = pool->add(new ColumnRef(slot_ref));
+    ColumnRef* col4 = pool->add(new ColumnRef(slot_ref));
+    TExprNode node = create_expr_node();
+    node.fn.name.function_name = "is_null_pred";
+    auto* is_null = pool->add(VectorizedIsNullPredicateFactory::from_thrift(node));
+    is_null->add_child(col4);
+    lambda_func->add_child(is_null);
+    lambda_func->add_child(col3);
+    lambda_funcs.push_back(lambda_func);
+
+    // x -> x + a (captured columns)
+    lambda_func = pool->add(new LambdaFunction(tlambda_func));
+    ColumnRef* col5 = pool->add(new ColumnRef(slot_ref));
+    node = create_expr_node();
+    node.opcode = TExprOpcode::ADD;
+    node.type = gen_type_desc(TPrimitiveType::INT);
+    auto* add_expr = pool->add(VectorizedArithmeticExprFactory::from_thrift(node));
+    ColumnRef* col6 = pool->add(new ColumnRef(slot_ref));
+    slot_ref.slot_ref.slot_id = 1;
+    ColumnRef* col7 = pool->add(new ColumnRef(slot_ref));
+    add_expr->_children.push_back(col6);
+    add_expr->_children.push_back(col7);
+    lambda_func->add_child(add_expr);
+    lambda_func->add_child(col5);
+    lambda_funcs.push_back(lambda_func);
+
+    // x -> -110
+    lambda_func = pool->add(new LambdaFunction(tlambda_func));
+    auto tint_literal = create_int_literal_node(-110);
+    auto int_literal = pool->add(new VectorizedLiteral(tint_literal));
+    slot_ref.slot_ref.slot_id = 100000;
+    ColumnRef* col8 = pool->add(new ColumnRef(slot_ref));
+    lambda_func->add_child(int_literal);
+    lambda_func->add_child(col8);
+    lambda_funcs.push_back(lambda_func);
+    return lambda_funcs;
+}
 
 TypeDescriptor array_type(const LogicalType& child_type) {
     TypeDescriptor t;
@@ -292,16 +261,17 @@ TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_normal_array) {
     std::vector<int> vec_a = {1, 1, 1};
     cur_chunk->append_column(build_int_column(vec_a), 1);
     for (int i = 0; i < 1; ++i) {
-        for (int j = 0; j < _lambda_func.size(); ++j) {
+        auto lambda_funcs = create_lambda_expr(&_objpool);
+        for (int j = 0; j < lambda_funcs.size(); ++j) {
             ArrayMapExpr array_map_expr(array_type(TYPE_INT));
             array_map_expr.clear_children();
-            array_map_expr.add_child(_lambda_func[j]);
+            array_map_expr.add_child(lambda_funcs[j]);
             array_map_expr.add_child(_array_expr[i]);
             ExprContext exprContext(&array_map_expr);
             std::vector<ExprContext*> expr_ctxs = {&exprContext};
             ASSERT_OK(Expr::prepare(expr_ctxs, &_runtime_state));
             ASSERT_OK(Expr::open(expr_ctxs, &_runtime_state));
-            auto lambda = dynamic_cast<LambdaFunction*>(_lambda_func[j]);
+            auto lambda = dynamic_cast<LambdaFunction*>(lambda_funcs[j]);
 
             // check LambdaFunction::prepare()
             std::vector<SlotId> ids, arguments;
@@ -367,16 +337,17 @@ TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_special_array) {
     std::vector<int> vec_a = {1, 1, 1};
     cur_chunk->append_column(build_int_column(vec_a), 1);
     for (int i = 1; i < 5; ++i) {
-        for (int j = 0; j < _lambda_func.size(); ++j) {
+        auto lambda_funcs = create_lambda_expr(&_objpool);
+        for (int j = 0; j < lambda_funcs.size(); ++j) {
             ArrayMapExpr array_map_expr(array_type(TYPE_INT));
             array_map_expr.clear_children();
-            array_map_expr.add_child(_lambda_func[j]);
+            array_map_expr.add_child(lambda_funcs[j]);
             array_map_expr.add_child(_array_expr[i]);
             ExprContext exprContext(&array_map_expr);
             std::vector<ExprContext*> expr_ctxs = {&exprContext};
             ASSERT_OK(Expr::prepare(expr_ctxs, &_runtime_state));
             ASSERT_OK(Expr::open(expr_ctxs, &_runtime_state));
-            auto lambda = dynamic_cast<LambdaFunction*>(_lambda_func[j]);
+            auto lambda = dynamic_cast<LambdaFunction*>(lambda_funcs[j]);
 
             // check LambdaFunction::prepare()
             std::vector<SlotId> ids, arguments;
@@ -437,16 +408,17 @@ TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_const_array) {
     std::vector<int> vec_a = {1, 1, 1};
     cur_chunk->append_column(build_int_column(vec_a), 1);
     for (int i = 5; i < _array_expr.size(); ++i) {
-        for (int j = 0; j < _lambda_func.size(); ++j) {
+        auto lambda_funcs = create_lambda_expr(&_objpool);
+        for (int j = 0; j < lambda_funcs.size(); ++j) {
             ArrayMapExpr array_map_expr(array_type(j == 1 ? TYPE_BOOLEAN : TYPE_INT));
             array_map_expr.clear_children();
-            array_map_expr.add_child(_lambda_func[j]);
+            array_map_expr.add_child(lambda_funcs[j]);
             array_map_expr.add_child(_array_expr[i]);
             ExprContext exprContext(&array_map_expr);
             std::vector<ExprContext*> expr_ctxs = {&exprContext};
             ASSERT_OK(Expr::prepare(expr_ctxs, &_runtime_state));
             ASSERT_OK(Expr::open(expr_ctxs, &_runtime_state));
-            auto lambda = dynamic_cast<LambdaFunction*>(_lambda_func[j]);
+            auto lambda = dynamic_cast<LambdaFunction*>(lambda_funcs[j]);
 
             // check LambdaFunction::prepare()
             std::vector<SlotId> ids, arguments;

--- a/test/sql/test_array_fn/R/test_array_fn
+++ b/test/sql/test_array_fn/R/test_array_fn
@@ -3839,3 +3839,10 @@ select array_intersect([[1,2,3], [2,3,4]], [[1,2,3], [2,3,4]]) from array_test o
 [[1,2,3],[2,3,4]]
 [[1,2,3],[2,3,4]]
 -- !result
+select array_sum(array_map(x->not like(x, 'starRocks'),s_1)) from array_test order by 1;
+-- result:
+None
+3
+4
+5
+-- !result

--- a/test/sql/test_array_fn/T/test_array_fn
+++ b/test/sql/test_array_fn/T/test_array_fn
@@ -663,3 +663,5 @@ select array_intersect([[1,2,3], [2,3,4]], [1.0,2.1,3.2,4.3]) from array_test or
 select array_intersect([[1,2,3], [2,3,4]], ['a', 'b', 'c']) from array_test order by pk;
 select array_intersect([[1,2,3], [2,3,4]], [[1,2,3], [2,3,4]]) from array_test order by pk;
 
+select array_sum(array_map(x->not like(x, 'starRocks'),s_1)) from array_test order by 1;
+


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Sub expr of LambdaFunction is not closed;

```
Direct leak of 120 byte(s) in 1 object(s) allocated from:
    #0 0x9596567 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x1252065c in starrocks::LikePredicate::like_prepare(starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope) /root/starrocks/be/src/exprs/like_predicate.cpp:107
    #2 0xe64d8b4 in starrocks::VectorizedFunctionCallExpr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope) /root/starrocks/be/src/exprs/function_call_expr.cpp:90
    #3 0xd62805c in starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope) /root/starrocks/be/src/exprs/expr.cpp:453
    #4 0xd62805c in starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope) /root/starrocks/be/src/exprs/expr.cpp:453
    #5 0xd62805c in starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope) /root/starrocks/be/src/exprs/expr.cpp:453
    #6 0xd62805c in starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope) /root/starrocks/be/src/exprs/expr.cpp:453
    #7 0xe64d085 in starrocks::VectorizedFunctionCallExpr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope) /root/starrocks/be/src/exprs/function_call_expr.cpp:71
    #8 0xd61b983 in starrocks::ExprContext::open(starrocks::RuntimeState*) /root/starrocks/be/src/exprs/expr_context.cpp:86
    #9 0xd627b0d in starrocks::Expr::open(std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&, starrocks::RuntimeState*) /root/starrocks/be/src/exprs/expr.cpp:445
    #10 0xa95e33a in starrocks::pipeline::ProjectOperatorFactory::prepare(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/project_operator.cpp:99
    #11 0x12279e75 in starrocks::pipeline::Pipeline::prepare(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/pipeline.h:76
    #12 0x1227bf24 in starrocks::pipeline::FragmentContext::prepare_all_pipelines() /root/starrocks/be/src/exec/pipeline/fragment_context.h:97
    #13 0x1226c76b in starrocks::pipeline::FragmentExecutor::_prepare_pipeline_driver(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&) /root/starrocks/be/src/exec/pipeline/fragment_executor.cpp:551
    #14 0x1227099c in starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) /root/starrocks/be/src/exec/pipeline/fragment_executor.cpp:673
    #15 0x12b78a15 in starrocks::PInternalServiceImplBase<doris::PBackendService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&) /root/starrocks/be/src/service/internal_service.cpp:412
    #16 0x12b73b0d in starrocks::PInternalServiceImplBase<doris::PBackendService>::_exec_batch_plan_fragments(google::protobuf::RpcController*, starrocks::PExecBatchPlanFragmentsRequest const*, starrocks::PExecBatchPlanFragmentsResult*, google::protobuf::Closure*) /root/starrocks/be/src/service/internal_service.cpp:342
    #17 0x12b82795 in starrocks::PInternalServiceImplBase<doris::PBackendService>::exec_batch_plan_fragments(google::protobuf::RpcController*, starrocks::PExecBatchPlanFragmentsRequest const*, starrocks::PExecBatchPlanFragmentsResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() const /root/starrocks/be/src/service/internal_service.cpp:308
    #18 0x12b8f869 in void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<doris::PBackendService>::exec_batch_plan_fragments(google::protobuf::RpcController*, starrocks::PExecBatchPlanFragmentsRequest const*, starrocks::PExecBatchPlanFragmentsResult*, google::protobuf::Closure*)::{lambda()#1}&>(std::__invoke_other, starrocks::PInternalServiceImplBase<doris::PBackendService>::exec_batch_plan_fragments(google::protobuf::RpcController*, starrocks::PExecBatchPlanFragmentsRequest const*, starrocks::PExecBatchPlanFragmentsResult*, google::protobuf::Closure*)::{lambda()#1}&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
