### PR TITLE
[Enhancement] Enable physical split morsel to contain multiple rowsets and segments

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -82,14 +82,16 @@ public:
     void set_from_version(int64_t from_version) { _from_version = from_version; }
     int64_t from_version() { return _from_version; }
 
-    void set_rowsets(std::vector<RowsetSharedPtr> rowsets) { _rowsets = std::move(rowsets); }
-    const std::vector<RowsetSharedPtr>& rowsets() const { return _rowsets; }
+    void set_rowsets(const std::vector<RowsetSharedPtr>& rowsets) { _rowsets = &rowsets; }
+    const std::vector<RowsetSharedPtr>& rowsets() const { return *_rowsets; }
 
 private:
     int32_t _plan_node_id;
     int64_t _from_version = 0;
 
-    std::vector<RowsetSharedPtr> _rowsets;
+    static const std::vector<RowsetSharedPtr> kEmptyRowsets;
+    // _rowsets is owned by MorselQueue, whose lifecycle is longer than that of Morsel.
+    const std::vector<RowsetSharedPtr>* _rowsets = &kEmptyRowsets;
 };
 
 class ScanMorsel : public Morsel {
@@ -105,6 +107,8 @@ public:
             _tablet_id = _scan_range->binlog_scan_range.tablet_id;
         }
     }
+
+    ~ScanMorsel() override = default;
 
     ScanMorsel(int32_t plan_node_id, const TScanRangeParams& scan_range)
             : ScanMorsel(plan_node_id, scan_range.scan_range) {}
@@ -128,6 +132,8 @@ public:
     PhysicalSplitScanMorsel(int32_t plan_node_id, const TScanRange& scan_range, RowidRangeOptionPtr rowid_range_option)
             : ScanMorsel(plan_node_id, scan_range), _rowid_range_option(std::move(rowid_range_option)) {}
 
+    ~PhysicalSplitScanMorsel() override = default;
+
     void init_tablet_reader_params(TabletReaderParams* params) override;
 
 private:
@@ -139,6 +145,8 @@ public:
     LogicalSplitScanMorsel(int32_t plan_node_id, const TScanRange& scan_range,
                            std::vector<ShortKeyRangeOptionPtr> short_key_ranges)
             : ScanMorsel(plan_node_id, scan_range), _short_key_ranges(std::move(short_key_ranges)) {}
+
+    ~LogicalSplitScanMorsel() override = default;
 
     void init_tablet_reader_params(TabletReaderParams* params) override;
 
@@ -316,6 +324,9 @@ private:
     // Load the meta of the new rowset and the index of the new segment,
     // and find the rowid range of each key range in this segment.
     Status _init_segment();
+    // Obtain row id ranges from multiple segments of multiple rowsets within a single tablet,
+    // until _splitted_scan_rows rows are retrieved.
+    StatusOr<RowidRangeOptionPtr> _try_get_split_from_single_tablet();
 
 private:
     std::mutex _mutex;

--- a/be/src/storage/binlog_reader.cpp
+++ b/be/src/storage/binlog_reader.cpp
@@ -268,8 +268,7 @@ Status BinlogReader::_init_segment_iterator() {
     if (log_entry_info->start_seq_id < _next_seq_id) {
         // for duplicate key, LogEntryInfo#start_row_id is 0
         rowid_t start_row_id = _next_seq_id - log_entry_info->start_seq_id;
-        SparseRange range(start_row_id, seg_ptr->num_rows());
-        seg_options.rowid_range_option = std::make_shared<RowidRangeOption>(_rowset->rowset_id(), segment_index, range);
+        seg_options.rowid_range_option = std::make_shared<SparseRange>(start_row_id, seg_ptr->num_rows());
     }
     ASSIGN_OR_RETURN(_segment_iterator, seg_ptr->new_iterator(_data_schema, seg_options));
     VLOG(3) << "Create segment iterator for reader: " << _reader_id << ", tablet: " << _tablet->full_name()

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -97,9 +97,12 @@ StatusOr<ChunkIteratorPtr> Rowset::read(const Schema& schema, const RowsetReadOp
             continue;
         }
 
-        if (options.rowid_range_option != nullptr && !options.rowid_range_option->match_segment(seg_ptr.get())) {
-            continue;
-        }
+        //        if (options.rowid_range_option != nullptr) {
+        //            seg_options.rowid_range_option = options.rowid_range_option->get_segment_rowid_range(this, seg_ptr.get());
+        //            if (seg_options.rowid_range_option == nullptr) {
+        //                continue;
+        //            }
+        //        }
 
         auto res = seg_ptr->new_iterator(*segment_schema, seg_options);
         if (res.status().is_end_of_file()) {

--- a/be/src/storage/range.h
+++ b/be/src/storage/range.h
@@ -200,6 +200,7 @@ private:
 
     std::vector<Range> _ranges;
 };
+using SparseRangePtr = std::shared_ptr<SparseRange>;
 
 inline void SparseRange::_add_uncheck(const Range& r) {
     if (!r.empty()) {

--- a/be/src/storage/rowset/rowid_range_option.h
+++ b/be/src/storage/rowset/rowid_range_option.h
@@ -27,15 +27,18 @@ class Segment;
 // It represents a specific rowid range on the segment with `segment_id` of the rowset with `rowset_id`.
 struct RowidRangeOption {
 public:
-    RowidRangeOption(const RowsetId& rowset_id, uint64_t segment_id, SparseRange rowid_range);
+    RowidRangeOption() = default;
+
+    void add(const Rowset* rowset, const Segment* segment, SparseRangePtr rowid_range);
 
     bool match_rowset(const Rowset* rowset) const;
-    bool match_segment(const Segment* segment) const;
+    SparseRangePtr get_segment_rowid_range(const Rowset* rowset, const Segment* segment);
 
 public:
-    const RowsetId rowset_id;
-    const uint64_t segment_id;
-    const SparseRange rowid_range;
+    using SetgmentRowidRangeMap = std::unordered_map<uint64_t, SparseRangePtr>;
+    using RowsetRowidRangeMap = std::map<RowsetId, SetgmentRowidRangeMap>;
+
+    RowsetRowidRangeMap rowid_range_per_segment_per_rowset;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1611,7 +1611,7 @@ Status SegmentIterator::_get_row_ranges_by_rowid_range() {
         return Status::OK();
     }
 
-    _scan_range = _scan_range.intersection(_opts.rowid_range_option->rowid_range);
+    _scan_range = _scan_range.intersection(*_opts.rowid_range_option);
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -78,7 +78,7 @@ public:
 
     bool has_delete_pred = false;
 
-    RowidRangeOptionPtr rowid_range_option = nullptr;
+    SparseRangePtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
     OlapRuntimeScanRangePruner runtime_range_pruner;


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
### Problem
Currently, a physical split morsel is only capable of retrieving row id ranges from one segment. When dealing with high-frequency data loads that generate many small rowsets, a tablet will split into too many physical split morsels. This can lead to an excessive number of `TabletReader` instances, which can negatively impact performance.

This is a [CPU pprofile graph](https://user-images.githubusercontent.com/13313784/236594491-ea42128e-670b-45f3-935d-3b9ffbea82d0.svg) from customers.



### Solution
Make  a physical split morsel able to retrieve row id ranges from multiple rowsets and segments within a single tablet.

BTW, avoid copy `rowsets` when calling `Morsel::set_rowsets`.


### Experiment

Create a table with 2048 rowsets, each of which contains one row.
```sql
CREATE TABLE `t3` (
  `k1` int(11) NULL COMMENT "",
  `c1` int(11) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`k1`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`) BUCKETS 2
PROPERTIES (
  "replication_num" = "1"
);

mysqlslap \
    -i 2048 \
    --concurrency=1 \
    --number-of-queries=1 \
    --query="insert into t3 values (1, 2)" \
    --delimiter=";" -h <ip>  -P 9030 -u root --create-schema=<db>

-- be.conf
-- Disable compaction.
max_compaction_concurrency=0
```

Query
```sql
set global enable_tablet_internal_parallel = true;
set global tablet_internal_parallel_mode = force_split;

select count(1) from t3;
```

Result
- Disable tablet internal parallel: 61ms
- Enable tablet internal parallel:
    - Before PR: 383ms
    - After    PR: 62ms 


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
