### PR TITLE
[Feature] Parquet writer merged the last small row group.

### DIFF
--- a/be/src/exec/parquet_builder.cpp
+++ b/be/src/exec/parquet_builder.cpp
@@ -33,9 +33,10 @@ namespace starrocks {
 ParquetBuilder::ParquetBuilder(std::unique_ptr<WritableFile> writable_file,
                                std::shared_ptr<::parquet::WriterProperties> properties,
                                std::shared_ptr<::parquet::schema::GroupNode> schema,
-                               const std::vector<ExprContext*>& output_expr_ctxs, int64_t row_group_max_size) {
+                               const std::vector<ExprContext*>& output_expr_ctxs, int64_t row_group_max_size,
+                               int64_t max_file_size) {
     _writer = std::make_unique<starrocks::parquet::SyncFileWriter>(std::move(writable_file), std::move(properties),
-                                                                   std::move(schema), output_expr_ctxs);
+                                                                   std::move(schema), output_expr_ctxs, max_file_size);
     _writer->set_max_row_group_size(row_group_max_size);
     _writer->init();
 }

--- a/be/src/exec/parquet_builder.h
+++ b/be/src/exec/parquet_builder.h
@@ -44,7 +44,8 @@ class ParquetBuilder : public FileBuilder {
 public:
     ParquetBuilder(std::unique_ptr<WritableFile> writable_file, std::shared_ptr<::parquet::WriterProperties> properties,
                    std::shared_ptr<::parquet::schema::GroupNode> schema,
-                   const std::vector<ExprContext*>& output_expr_ctxs, int64_t row_group_max_size);
+                   const std::vector<ExprContext*>& output_expr_ctxs, int64_t row_group_max_size,
+                   int64_t max_file_size);
 
     ~ParquetBuilder() override = default;
 

--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -61,7 +61,7 @@ Status RollingAsyncParquetWriter::_new_file_writer() {
     ASSIGN_OR_RETURN(auto writable_file, _fs->new_writable_file(options, new_file_location))
     _writer = std::make_shared<starrocks::parquet::AsyncFileWriter>(
             std::move(writable_file), new_file_location, _partition_location, _properties, _schema, _output_expr_ctxs,
-            ExecEnv::GetInstance()->pipeline_sink_io_pool(), _parent_profile);
+            ExecEnv::GetInstance()->pipeline_sink_io_pool(), _parent_profile, _max_file_size);
     auto st = _writer->init();
     return st;
 }

--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -113,9 +113,9 @@ Status FileResultWriter::_create_file_writer() {
             return Status::NotSupported(result.status().message());
         }
         auto schema = result.ValueOrDie();
-        _file_builder =
-                std::make_unique<ParquetBuilder>(std::move(writable_file), std::move(properties), std::move(schema),
-                                                 _output_expr_ctxs, _file_opts->parquet_options.row_group_max_size);
+        _file_builder = std::make_unique<ParquetBuilder>(
+                std::move(writable_file), std::move(properties), std::move(schema), _output_expr_ctxs,
+                _file_opts->parquet_options.row_group_max_size, _file_opts->max_file_size_bytes);
         break;
     }
     default:


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
we assume parquet file max size is 100MB, and row group max size is 50MB. row group size estimation is not accurate. If the the first row group and the second row size are both 49MB.  Therefore, an additional row group of 2MB will be generated. Some engine like spark may use the row group count as a reference for parallelism. So we merge the last small row group.

https://github.com/StarRocks/starrocks/issues/21502

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
