### PR TITLE
[Enhancement] Support graceful exit, make it easy to troubleshoot memory leaks (#22871)

### DIFF
--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -279,29 +279,6 @@ private:
     size_t _compaction_check_one_round();
 
 private:
-    struct CompactionCandidate {
-        CompactionCandidate(uint32_t nicumulative_compaction_, int64_t tablet_id_, uint32_t index_)
-                : nice(nicumulative_compaction_), tablet_id(tablet_id_), disk_index(index_) {}
-        uint32_t nice;
-        int64_t tablet_id;
-        uint32_t disk_index = -1;
-    };
-
-    // In descending order
-    struct CompactionCandidateComparator {
-        bool operator()(const CompactionCandidate& a, const CompactionCandidate& b) { return a.nice > b.nice; }
-    };
-
-    struct CompactionDiskStat {
-        CompactionDiskStat(std::string path, uint32_t index, bool used)
-                : storage_path(std::move(path)), disk_index(index), task_running(0), task_remaining(0), is_used(used) {}
-        const std::string storage_path;
-        const uint32_t disk_index;
-        uint32_t task_running;
-        uint32_t task_remaining;
-        bool is_used;
-    };
-
     EngineOptions _options;
     std::mutex _store_lock;
     std::map<std::string, DataDir*> _store_map;


### PR DESCRIPTION
Thread _update_cache_evict_thread, _manual_compaction_threads is not joined.

```
*** Aborted at 1682419565 (unix time) try "date -d @1682419565" if you are using GNU date ***
PC: @     0x7fac9a306387 __GI_raise
*** SIGABRT (@0x3f0000193f3) received by PID 103411 (TID 0x7fac9c5f07c0) from PID 103411; stack trace: ***
    @         0x118a57e2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fac9a6ad630 (unknown)
    @     0x7fac9a306387 __GI_raise
    @     0x7fac9a307a78 __GI_abort
    @          0x8ef1251 _ZN9__gnu_cxx27__verbose_terminate_handlerEv.cold
    @         0x13e08486 __cxxabiv1::__terminate()
    @         0x13e084f1 std::terminate()
    @          0x9011eac std::thread::~thread()
    @          0xd68f2e2 starrocks::StorageEngine::~StorageEngine()
    @          0xd68f344 starrocks::StorageEngine::~StorageEngine()
    @          0x900f5a0 main
    @     0x7fac9a2f2555 __libc_start_main
    @          0x8f4663f (unknown)
    @                0x0 (unknown)

```
