### PR TITLE
[Refactor] Refactor MaterializedViewRule to support complex sync mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -52,6 +52,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
@@ -134,6 +135,11 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         return schemaVersion;
     }
 
+    public List<Column> getNonAggregatedColumns() {
+        return schema.stream().filter(column -> !column.isAggregated())
+                .collect(Collectors.toList());
+    }
+
     public String getOriginStmt() {
         if (defineStmt == null) {
             return null;
@@ -153,15 +159,6 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
                 }
             }
         }
-    }
-
-    public Column getColumnByName(String columnName) {
-        for (Column column : schema) {
-            if (column.getName().equalsIgnoreCase(columnName)) {
-                return column;
-            }
-        }
-        return null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.CaseExpr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
@@ -50,8 +51,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -74,36 +75,45 @@ public class MaterializedViewRule extends Rule {
         super(RuleType.TF_MATERIALIZED_VIEW, Pattern.create(OperatorType.PATTERN));
     }
 
-    private final Map<Integer, Set<Integer>> columnIdsInPredicates = Maps.newHashMap();
-    private final Map<Integer, Set<Integer>> columnIdsInGrouping = Maps.newHashMap();
-    private final Map<Integer, Set<CallOperator>> aggFunctions = Maps.newHashMap();
-    private final ColumnRefSet columnIdsInAggregate = new ColumnRefSet();
-    private final Map<Integer, Set<Integer>> columnIdsInQueryOutput = Maps.newHashMap();
-    private final Map<Integer, Map<String, Integer>> columnNameToIds = Maps.newHashMap();
-    private final List<LogicalOlapScanOperator> scanOperators = Lists.newArrayList();
+    // each table relation id -> set<column ids>
+    private final Map<Integer, Set<Integer>> queryRelIdToColumnIdsInPredicates = Maps.newHashMap();
+    // each table relation id -> set<group by column ids>
+    private final Map<Integer, Set<Integer>> queryRelIdToGroupByIds = Maps.newHashMap();
+    // each table relation id -> set<agg functions>
+    private final Map<Integer, Set<CallOperator>> queryRelIdToAggFunctions = Maps.newHashMap();
+    // each table relation id -> set<aggregate column ids>
+    private final ColumnRefSet queryRelIdToAggregateIds = new ColumnRefSet();
+    // each table relation id -> set<column name -> column ref id>
+    private final Map<Integer, Set<Integer>> queryRelIdToScanNodeOutputColumnIds = Maps.newHashMap();
+    // each table relation id -> map<output column ids>
+    private final Map<Integer, Map<String, Integer>> queryRelIdToColumnNameIds = Maps.newHashMap();
+    // each query scan operator
+    private final List<LogicalOlapScanOperator> queryScanOperators = Lists.newArrayList();
 
-    private final Map<Long, List<RewriteContext>> rewriteContexts = Maps.newHashMap();
-
-    private ColumnRefFactory factory;
     // record the relation id -> disableSPJGMV flag
     // this can be set to true when query has count(*) or count(1)
-    private final Map<Integer, Boolean> disableSPJGMVs = Maps.newHashMap();
+    private final Map<Integer, Boolean> queryRelIdToEnableMVRewrite = Maps.newHashMap();
     // record the relation id -> isSPJQuery flag
-    private final Map<Integer, Boolean> isSPJQueries = Maps.newHashMap();
+    private final Map<Integer, Boolean> queryRelIdToIsSPJQuery = Maps.newHashMap();
     // record the scan node relation id which has been accessed.
-    private final Set<Integer> traceRelationIds = Sets.newHashSet();
+    private final Set<Integer> visitedQueryRelIds = Sets.newHashSet();
+
+    // mv index id -> each RewriteContext
+    private final Map<Long, List<RewriteContext>> mvIdToRewriteContexts = Maps.newHashMap();
+    // current optimize context factory
+    private ColumnRefFactory factory;
 
     private void init(OptExpression root) {
         collectAllPredicates(root);
         collectGroupByAndAggFunctions(root);
         collectScanOutputColumns(root);
-        for (Integer scanId : traceRelationIds) {
-            if (!isSPJQueries.containsKey(scanId) && !aggFunctions.containsKey(scanId) &&
-                    !columnIdsInGrouping.containsKey(scanId)) {
-                isSPJQueries.put(scanId, true);
+        for (Integer scanId : visitedQueryRelIds) {
+            if (!queryRelIdToIsSPJQuery.containsKey(scanId) && !queryRelIdToAggFunctions.containsKey(scanId) &&
+                    !queryRelIdToGroupByIds.containsKey(scanId)) {
+                queryRelIdToIsSPJQuery.put(scanId, true);
             }
-            if (!disableSPJGMVs.containsKey(scanId)) {
-                disableSPJGMVs.put(scanId, false);
+            if (!queryRelIdToEnableMVRewrite.containsKey(scanId)) {
+                queryRelIdToEnableMVRewrite.put(scanId, false);
             }
         }
     }
@@ -118,21 +128,20 @@ public class MaterializedViewRule extends Rule {
 
         init(optExpression);
 
-        if (scanOperators.stream().anyMatch(LogicalOlapScanOperator::hasTableHints)) {
+        if (queryScanOperators.stream().anyMatch(LogicalOlapScanOperator::hasTableHints)) {
             return Lists.newArrayList(optExpression);
         }
 
-        for (LogicalOlapScanOperator scan : scanOperators) {
+        for (LogicalOlapScanOperator scan : queryScanOperators) {
             int relationId = factory.getRelationId(scan.getOutputColumns().get(0).getId());
             // clear rewrite context since we are going to handle another scan operator.
-            rewriteContexts.clear();
-            Map<Long, List<Column>> candidateIndexIdToSchema = selectValidIndexes(scan, relationId);
+            mvIdToRewriteContexts.clear();
+            Map<Long, List<Column>> candidateIndexIdToSchema = selectValidMVs(scan, relationId);
             if (candidateIndexIdToSchema.isEmpty()) {
                 continue;
             }
 
-            long bestIndex = selectBestIndexes(scan, candidateIndexIdToSchema, relationId);
-
+            long bestIndex = selectBestMV(scan, candidateIndexIdToSchema, relationId);
             if (bestIndex == scan.getSelectedIndexId()) {
                 continue;
             }
@@ -140,8 +149,8 @@ public class MaterializedViewRule extends Rule {
             BestIndexRewriter bestIndexRewriter = new BestIndexRewriter(scan);
             optExpression = bestIndexRewriter.rewrite(optExpression, bestIndex);
 
-            if (rewriteContexts.containsKey(bestIndex)) {
-                List<RewriteContext> rewriteContext = rewriteContexts.get(bestIndex);
+            if (mvIdToRewriteContexts.containsKey(bestIndex)) {
+                List<RewriteContext> rewriteContext = mvIdToRewriteContexts.get(bestIndex);
                 List<RewriteContext> percentileContexts = rewriteContext.stream().
                         filter(e -> e.aggCall.getFnName().equals(FunctionSet.PERCENTILE_APPROX))
                         .collect(Collectors.toList());
@@ -176,21 +185,59 @@ public class MaterializedViewRule extends Rule {
         return false;
     }
 
-    private Map<Long, List<Column>> selectValidIndexes(LogicalOlapScanOperator scanOperator, int relationId) {
+    private Map<Long, List<Column>> selectValidMVs(LogicalOlapScanOperator scanOperator, int relationId) {
         OlapTable table = (OlapTable) scanOperator.getTable();
         Map<Long, MaterializedIndexMeta> candidateIndexIdToMeta = table.getVisibleIndexIdToMeta();
-        // Step2: check all columns in compensating predicates are available in the view output
-        checkCompensatingPredicates(columnNameToIds.get(relationId), columnIdsInPredicates.get(relationId),
-                candidateIndexIdToMeta);
-        // Step3: group by list in query is the subset of group by list in view or view contains no aggregation
-        checkGrouping(columnNameToIds.get(relationId), columnIdsInGrouping.get(relationId), candidateIndexIdToMeta,
-                disableSPJGMVs.get(relationId), isSPJQueries.get(relationId));
-        // Step4: aggregation functions are available in the view output
-        checkAggregationFunction(columnNameToIds.get(relationId), aggFunctions.get(relationId), candidateIndexIdToMeta,
-                disableSPJGMVs.get(relationId), isSPJQueries.get(relationId));
-        // Step5: columns required to compute output expr are available in the view output
-        checkOutputColumns(columnNameToIds.get(relationId), columnIdsInQueryOutput.get(relationId),
-                candidateIndexIdToMeta);
+        // column name -> column id
+        Map<String, Integer> queryScanNodeColumnNameToIds = queryRelIdToColumnNameIds.get(relationId);
+
+        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToMeta.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
+            Long mvIdx = entry.getKey();
+            MaterializedIndexMeta mvMeta = entry.getValue();
+
+            // Ignore original query index.
+            if (mvIdx == scanOperator.getSelectedIndexId()) {
+                iterator.remove();
+                continue;
+            }
+
+            // Ignore indexes which cannot be remapping with query by column names.
+            List<Column> mvNonAggregatedColumns = mvMeta.getNonAggregatedColumns();
+            if (mvNonAggregatedColumns.stream().anyMatch(x -> !queryScanNodeColumnNameToIds.containsKey(x.getName()))) {
+                iterator.remove();
+                continue;
+            }
+
+            // Step2: check all columns in compensating predicates are available in the view output
+            if (!checkCompensatingPredicates(queryScanNodeColumnNameToIds,
+                    queryRelIdToColumnIdsInPredicates.get(relationId), mvMeta)) {
+                iterator.remove();
+                continue;
+            }
+
+            // Step3: group by list in query is the subset of group by list in view or view contains no aggregation
+            if (!checkGrouping(queryScanNodeColumnNameToIds, queryRelIdToGroupByIds.get(relationId), mvMeta,
+                    queryRelIdToEnableMVRewrite.get(relationId), queryRelIdToIsSPJQuery.get(relationId))) {
+                iterator.remove();
+                continue;
+            }
+
+            // Step4: aggregation functions are available in the view output
+            if (!checkAggregationFunction(queryScanNodeColumnNameToIds, queryRelIdToAggFunctions.get(relationId),
+                    mvIdx, mvMeta, queryRelIdToEnableMVRewrite.get(relationId), queryRelIdToIsSPJQuery.get(relationId))) {
+                iterator.remove();
+                continue;
+            }
+
+            // Step5: columns required to compute output expr are available in the view output
+            if (!checkOutputColumns(queryScanNodeColumnNameToIds, queryRelIdToScanNodeOutputColumnIds.get(relationId),
+                    mvIdx, mvMeta)) {
+                iterator.remove();
+            }
+        }
+
         // Step6: if table type is aggregate and the candidateIndexIdToSchema is empty,
         if ((table.getKeysType() == KeysType.AGG_KEYS || table.getKeysType() == KeysType.UNIQUE_KEYS)
                 && candidateIndexIdToMeta.size() == 0) {
@@ -211,9 +258,20 @@ public class MaterializedViewRule extends Rule {
              */
             compensateCandidateIndex(candidateIndexIdToMeta, table.getVisibleIndexIdToMeta(),
                     table);
-            checkOutputColumns(columnNameToIds.get(relationId), columnIdsInQueryOutput.get(relationId),
-                    candidateIndexIdToMeta);
+
+            iterator = candidateIndexIdToMeta.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
+                Long mvIdx = entry.getKey();
+                MaterializedIndexMeta mvMeta = entry.getValue();
+
+                if (!checkOutputColumns(queryRelIdToColumnNameIds.get(relationId),
+                        queryRelIdToScanNodeOutputColumnIds.get(relationId), mvIdx, mvMeta)) {
+                    iterator.remove();
+                }
+            }
         }
+
         Map<Long, List<Column>> result = Maps.newHashMap();
         for (Map.Entry<Long, MaterializedIndexMeta> entry : candidateIndexIdToMeta.entrySet()) {
             result.put(entry.getKey(), entry.getValue().getSchema());
@@ -221,17 +279,18 @@ public class MaterializedViewRule extends Rule {
         return result;
     }
 
-    private Long selectBestIndexes(LogicalOlapScanOperator scanOperator,
-                                   Map<Long, List<Column>> candidateIndexIdToSchema,
-                                   int tableId) {
+    private Long selectBestMV(LogicalOlapScanOperator scanOperator,
+                              Map<Long, List<Column>> candidateIndexIdToSchema,
+                              int tableId) {
         // Step1: the candidate indexes that satisfies the most prefix index
         final Set<Integer> equivalenceColumns = Sets.newHashSet();
-        final Set<Integer> unequivalenceColumns = Sets.newHashSet();
-        collectColumns(scanOperator, equivalenceColumns, unequivalenceColumns);
+        final Set<Integer> unEquivalenceColumns = Sets.newHashSet();
+        splitScanConjuncts(scanOperator, equivalenceColumns, unEquivalenceColumns);
+
         Set<Long> indexesMatchingBestPrefixIndex =
                 matchBestPrefixIndex(
-                        columnNameToIds.get(tableId),
-                        candidateIndexIdToSchema, equivalenceColumns, unequivalenceColumns);
+                        queryRelIdToColumnNameIds.get(tableId),
+                        candidateIndexIdToSchema, equivalenceColumns, unEquivalenceColumns);
 
         // Step2: the best index that satisfies the least number of rows
         return selectBestRowCountIndex(indexesMatchingBestPrefixIndex, (OlapTable) scanOperator.getTable());
@@ -250,7 +309,7 @@ public class MaterializedViewRule extends Rule {
         if (logicalOperator.getPredicate() != null) {
             ScalarOperator scalarOperator = logicalOperator.getPredicate();
             if (!scalarOperator.isConstantRef()) {
-                updateTableToColumns(scalarOperator, columnIdsInPredicates);
+                updateTableToColumns(scalarOperator, queryRelIdToColumnIdsInPredicates);
             }
         }
         if (logicalOperator instanceof LogicalJoinOperator) {
@@ -258,7 +317,7 @@ public class MaterializedViewRule extends Rule {
             if (joinOperator.getOnPredicate() != null) {
                 List<ScalarOperator> conjuncts = Utils.extractConjuncts(joinOperator.getOnPredicate());
                 for (ScalarOperator conjunct : conjuncts) {
-                    updateTableToColumns(conjunct, columnIdsInPredicates);
+                    updateTableToColumns(conjunct, queryRelIdToColumnIdsInPredicates);
                 }
             }
         }
@@ -270,11 +329,7 @@ public class MaterializedViewRule extends Rule {
         for (int columnId : columns.getColumnIds()) {
             int table = factory.getRelationId(columnId);
             if (table != -1) {
-                if (tableToColumns.containsKey(table)) {
-                    tableToColumns.get(table).add(columnId);
-                } else {
-                    tableToColumns.put(table, Sets.newHashSet(columnId));
-                }
+                tableToColumns.computeIfAbsent(table, k -> Sets.newHashSet()).add(columnId);
             }
         }
     }
@@ -287,7 +342,7 @@ public class MaterializedViewRule extends Rule {
         Operator operator = root.getOp();
         if (operator instanceof LogicalOlapScanOperator) {
             LogicalOlapScanOperator scanOperator = (LogicalOlapScanOperator) operator;
-            traceRelationIds.add(factory.getRelationId(scanOperator.getOutputColumns().get(0).getId()));
+            visitedQueryRelIds.add(factory.getRelationId(scanOperator.getOutputColumns().get(0).getId()));
         }
 
         if (operator instanceof LogicalAggregationOperator) {
@@ -327,9 +382,9 @@ public class MaterializedViewRule extends Rule {
 
     // Disable SPJG materialized view for traced scan node which not has aggregation
     private void disableSPJGMaterializedView() {
-        for (Integer scanId : traceRelationIds) {
-            if (!columnIdsInGrouping.containsKey(scanId) && !aggFunctions.containsKey(scanId)) {
-                disableSPJGMVs.put(scanId, true);
+        for (Integer scanId : visitedQueryRelIds) {
+            if (!queryRelIdToGroupByIds.containsKey(scanId) && !queryRelIdToAggFunctions.containsKey(scanId)) {
+                queryRelIdToEnableMVRewrite.put(scanId, true);
             }
         }
     }
@@ -337,11 +392,11 @@ public class MaterializedViewRule extends Rule {
     // set table is not SPJ query
     private void disableSPJQueries(int table) {
         if (table != -1) {
-            isSPJQueries.put(table, false);
+            queryRelIdToIsSPJQuery.put(table, false);
         } else {
-            for (Integer scanId : traceRelationIds) {
-                if (!isSPJQueries.containsKey(scanId)) {
-                    isSPJQueries.put(scanId, false);
+            for (Integer scanId : visitedQueryRelIds) {
+                if (!queryRelIdToIsSPJQuery.containsKey(scanId)) {
+                    queryRelIdToIsSPJQuery.put(scanId, false);
                 }
             }
         }
@@ -349,8 +404,8 @@ public class MaterializedViewRule extends Rule {
 
     private void collectGroupByAndAggFunction(List<ScalarOperator> groupBys,
                                               List<CallOperator> aggs) {
-        if (groupBys.stream().map(ScalarOperator::getUsedColumns).anyMatch(columnIdsInAggregate::isIntersect) ||
-                aggs.stream().map(ScalarOperator::getUsedColumns).anyMatch(columnIdsInAggregate::isIntersect)) {
+        if (groupBys.stream().map(ScalarOperator::getUsedColumns).anyMatch(queryRelIdToAggregateIds::isIntersect) ||
+                aggs.stream().map(ScalarOperator::getUsedColumns).anyMatch(queryRelIdToAggregateIds::isIntersect)) {
             // Has been collect from other aggregate, only check aggregate node which is closest to scan node
             return;
         }
@@ -360,10 +415,10 @@ public class MaterializedViewRule extends Rule {
             for (int columnId : columns.getColumnIds()) {
                 int table = factory.getRelationId(columnId);
                 if (table != -1) {
-                    if (columnIdsInGrouping.containsKey(table)) {
-                        columnIdsInGrouping.get(table).add(columnId);
+                    if (queryRelIdToGroupByIds.containsKey(table)) {
+                        queryRelIdToGroupByIds.get(table).add(columnId);
                     } else {
-                        columnIdsInGrouping.put(table, Sets.newHashSet(columnId));
+                        queryRelIdToGroupByIds.put(table, Sets.newHashSet(columnId));
                     }
                 }
                 // This table has group by, disable isSPJQuery
@@ -376,10 +431,10 @@ public class MaterializedViewRule extends Rule {
             for (int columnId : columns.getColumnIds()) {
                 int table = factory.getRelationId(columnId);
                 if (table != -1) {
-                    if (aggFunctions.containsKey(table)) {
-                        aggFunctions.get(table).add(agg);
+                    if (queryRelIdToAggFunctions.containsKey(table)) {
+                        queryRelIdToAggFunctions.get(table).add(agg);
                     } else {
-                        aggFunctions.put(table, Sets.newHashSet(agg));
+                        queryRelIdToAggFunctions.put(table, Sets.newHashSet(agg));
                     }
                 }
                 // This table has aggregation, disable isSPJQuery
@@ -387,19 +442,21 @@ public class MaterializedViewRule extends Rule {
             }
         }
 
-        groupBys.stream().map(ScalarOperator::getUsedColumns).forEach(columnIdsInAggregate::union);
-        aggs.stream().map(ScalarOperator::getUsedColumns).forEach(columnIdsInAggregate::union);
+        groupBys.stream().map(ScalarOperator::getUsedColumns).forEach(queryRelIdToAggregateIds::union);
+        aggs.stream().map(ScalarOperator::getUsedColumns).forEach(queryRelIdToAggregateIds::union);
     }
 
-    public void collectColumns(LogicalOlapScanOperator scanOperator,
-                               Set<Integer> equivalenceColumns,
-                               Set<Integer> unEquivalenceColumns) {
+    // split scan operators' conjuncts into equal and non-equal column ids
+    public void splitScanConjuncts(LogicalOlapScanOperator scanOperator,
+                                   Set<Integer> equivalenceColumns,
+                                   Set<Integer> unEquivalenceColumns) {
         List<ScalarOperator> conjuncts = Utils.extractConjuncts(scanOperator.getPredicate());
         // 1. Get columns which has predicate on it.
         for (ScalarOperator operator : conjuncts) {
             if (!MVUtils.isPredicateUsedForPrefixIndex(operator)) {
                 continue;
             }
+
             if (MVUtils.isEquivalencePredicate(operator)) {
                 equivalenceColumns.add(operator.getUsedColumns().getFirstId());
             } else {
@@ -418,21 +475,17 @@ public class MaterializedViewRule extends Rule {
         Operator operator = root.getOp();
         if (operator instanceof LogicalOlapScanOperator) {
             LogicalOlapScanOperator scanOperator = (LogicalOlapScanOperator) operator;
-            scanOperators.add(scanOperator);
+            queryScanOperators.add(scanOperator);
 
             int tableId = factory.getRelationId(scanOperator.getOutputColumns().get(0).getId());
-            Map<String, Integer> nameToIDs = new HashMap<>();
-            if (!columnNameToIds.containsKey(tableId)) {
-                columnNameToIds.put(tableId, nameToIDs);
-            }
-
-            for (Map.Entry<Column, ColumnRefOperator> entry : scanOperator.getColumnMetaToColRefMap().entrySet()) {
-                nameToIDs.put(entry.getKey().getName(), entry.getValue().getId());
-            }
-
-            for (ColumnRefOperator column : scanOperator.getColRefToColumnMetaMap().keySet()) {
-                updateTableToColumns(column, columnIdsInQueryOutput);
-            }
+            scanOperator.getColumnMetaToColRefMap().entrySet()
+                    .stream()
+                    .forEach(x -> queryRelIdToColumnNameIds
+                            .computeIfAbsent(tableId, k -> new CaseInsensitiveMap())
+                            .put(x.getKey().getName(), x.getValue().getId()));
+            scanOperator.getColRefToColumnMetaMap().keySet()
+                    .stream()
+                    .forEach(x -> updateTableToColumns(x, queryRelIdToScanNodeOutputColumnIds));
         }
     }
 
@@ -459,26 +512,36 @@ public class MaterializedViewRule extends Rule {
         return selectedIndexId;
     }
 
+    // Map MV's column to query's column id.
+    private int getMVColumnToQueryColumnId(Map<String, Integer> columnToIds, Column mvColumn) {
+        // Assume sync mv's column names are mapping with query scan node's columns by column name.
+        // We can find the according query column id by the mv column name.
+        // Once mv's column name is not the same with scan node, how can we do it?
+        return columnToIds.get(mvColumn.getName());
+    }
+
     private Set<Long> matchBestPrefixIndex(
             Map<String, Integer> columnToIds,
             Map<Long, List<Column>> candidateIndexIdToSchema,
             Set<Integer> equivalenceColumns,
-            Set<Integer> unequivalenceColumns) {
-        if (equivalenceColumns.size() == 0 && unequivalenceColumns.size() == 0) {
+            Set<Integer> unEquivalenceColumns) {
+        if (equivalenceColumns.size() == 0 && unEquivalenceColumns.size() == 0) {
             return candidateIndexIdToSchema.keySet();
         }
+
         Set<Long> indexesMatchingBestPrefixIndex = Sets.newHashSet();
         int maxPrefixMatchCount = 0;
         for (Map.Entry<Long, List<Column>> entry : candidateIndexIdToSchema.entrySet()) {
-            int prefixMatchCount = 0;
             long indexId = entry.getKey();
             List<Column> indexSchema = entry.getValue();
+
+            int prefixMatchCount = 0;
             for (Column col : indexSchema) {
-                Integer columnId = columnToIds.get(col.getName());
+                Integer columnId = getMVColumnToQueryColumnId(columnToIds, col);
                 if (equivalenceColumns.contains(columnId)) {
                     prefixMatchCount++;
-                } else if (unequivalenceColumns.contains(columnId)) {
-                    // Unequivalence predicate's columns can match only first column in rollup.
+                } else if (unEquivalenceColumns.contains(columnId)) {
+                    // UnEquivalence predicate's columns can only match first columns in rollup.
                     prefixMatchCount++;
                     break;
                 } else {
@@ -497,24 +560,23 @@ public class MaterializedViewRule extends Rule {
         return indexesMatchingBestPrefixIndex;
     }
 
-    private void checkCompensatingPredicates(
-            Map<String, Integer> columnToIds,
-            Set<Integer> columnsInPredicates, Map<Long, MaterializedIndexMeta>
-                    candidateIndexIdToMeta) {
+    private boolean checkCompensatingPredicates(
+            Map<String, Integer> queryScanColumnNameToIds,
+            Set<Integer> columnsInPredicates,
+            MaterializedIndexMeta mvMeta) {
         // When the query statement does not contain any columns in predicates, all candidate index can pass this check
         if (columnsInPredicates == null) {
-            return;
+            return true;
         }
-        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToMeta.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
-            Set<Integer> indexNonAggregatedColumns = Sets.newHashSet();
-            entry.getValue().getSchema().stream().filter(column -> !column.isAggregated())
-                    .forEach(column -> indexNonAggregatedColumns.add(columnToIds.get(column.getName())));
-            if (!indexNonAggregatedColumns.containsAll(columnsInPredicates)) {
-                iterator.remove();
-            }
+
+        List<Column> mvNonAggregatedColumns = mvMeta.getNonAggregatedColumns();
+        Set<Integer> indexNonAggregatedColumns = Sets.newHashSet();
+        mvNonAggregatedColumns
+                .forEach(col -> indexNonAggregatedColumns.add(getMVColumnToQueryColumnId(queryScanColumnNameToIds, col)));
+        if (!indexNonAggregatedColumns.containsAll(columnsInPredicates)) {
+            return false;
         }
+        return true;
     }
 
     /**
@@ -525,109 +587,102 @@ public class MaterializedViewRule extends Rule {
      * 1. grouping columns in query is subset of grouping columns in view
      * 2. the empty grouping columns in query is subset of all of views
      */
-    private void checkGrouping(
-            Map<String, Integer> columnToIds,
-            Set<Integer> columnsInGrouping, Map<Long, MaterializedIndexMeta> candidateIndexIdToMeta,
-            boolean disableSPJGMV, boolean isSPJQuery) {
-        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToMeta.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
-            Set<Integer> indexNonAggregatedColumns = Sets.newHashSet();
-            MaterializedIndexMeta candidateIndexMeta = entry.getValue();
-            List<Column> candidateIndexSchema = candidateIndexMeta.getSchema();
-            candidateIndexSchema.stream().filter(column -> !column.isAggregated())
-                    .forEach(column -> indexNonAggregatedColumns.add(columnToIds.get(column.getName())));
-            /*
-            If there is no aggregated column in duplicate index, the index will be SPJ.
-            For example:
-                duplicate table (k1, k2, v1)
-                duplicate mv index (k1, v1)
-            When the candidate index is SPJ type, it passes the verification directly
+    private boolean checkGrouping(Map<String, Integer> queryScanColumnNameToIds,
+                                  Set<Integer> queryGroupingIds,
+                                  MaterializedIndexMeta mvMeta,
+                                  boolean disableSPJGMV,
+                                  boolean isSPJQuery) {
+        List<Column> mvNonAggregatedColumns = mvMeta.getNonAggregatedColumns();
+        // Remap mv's non aggregated columns to query based.
+        Set<Integer> mvNonAggregatedColumnsBasedQuery = Sets.newHashSet();
+        mvNonAggregatedColumns.forEach(column ->
+                mvNonAggregatedColumnsBasedQuery.add(getMVColumnToQueryColumnId(queryScanColumnNameToIds, column)));
 
-            If there is no aggregated column in aggregate index, the index will be deduplicate index.
-            For example:
-                duplicate table (k1, k2, v1 sum)
-                aggregate mv index (k1, k2)
-            This kind of index is SPJG which same as select k1, k2 from aggregate_table group by k1, k2.
-            It also need to check the grouping column using following steps.
-
-            ISSUE-3016, MaterializedViewFunctionTest: testDeduplicateQueryInAgg
-             */
-            if (indexNonAggregatedColumns.size() == candidateIndexSchema.size()
-                    && candidateIndexMeta.getKeysType() == KeysType.DUP_KEYS) {
-                continue;
-            }
-            // When the query is SPJ type but the candidate index is SPJG type, it will not pass directly.
-            if (disableSPJGMV || isSPJQuery) {
-                iterator.remove();
-                continue;
-            }
-            // The query is SPJG. The candidate index is SPJG too.
-            // The grouping columns in query is empty. For example: select sum(A) from T
-            if (columnsInGrouping == null) {
-                continue;
-            }
-            // The grouping columns in query must be subset of the grouping columns in view
-            if (!indexNonAggregatedColumns.containsAll(columnsInGrouping)) {
-                iterator.remove();
-            }
+        // If there is no aggregated column in duplicate index, the index will be SPJ.
+        // For example:
+        //     duplicate table (k1, k2, v1)
+        //     duplicate mv index (k1, v1)
+        // When the candidate index is SPJ type, it passes the verification directly
+        //
+        // If there is no aggregated column in aggregate index, the index will be deduplicate index.
+        // For example:
+        //     duplicate table (k1, k2, v1 sum)
+        //     aggregate mv index (k1, k2)
+        // This kind of index is SPJG which same as select k1, k2 from aggregate_table group by k1, k2.
+        // It also need to check the grouping column using following steps.
+        //
+        // ISSUE-3016, MaterializedViewFunctionTest: testDeduplicateQueryInAgg
+        List<Column> mvMetaSchema = mvMeta.getSchema();
+        if (mvNonAggregatedColumns.size() == mvMetaSchema.size()
+                && mvMeta.getKeysType() == KeysType.DUP_KEYS) {
+            return true;
         }
+        // When the query is SPJ type but the candidate index is SPJG type, it will not pass directly.
+        if (disableSPJGMV || isSPJQuery) {
+            return false;
+        }
+        // The query is SPJG. The candidate index is SPJG too.
+        // The grouping columns in query is empty. For example: select sum(A) from T
+        if (queryGroupingIds == null) {
+            return true;
+        }
+        // The grouping columns in query must be subset of the grouping columns in view
+        if (!mvNonAggregatedColumnsBasedQuery.containsAll(queryGroupingIds)) {
+            return false;
+        }
+        return true;
     }
 
-    private void checkAggregationFunction(Map<String, Integer> columnToIds,
-                                          Set<CallOperator> aggregatedColumnsInQueryOutput,
-                                          Map<Long, MaterializedIndexMeta> candidateIndexIdToMeta,
-                                          boolean disableSPJGMV, boolean isSPJQuery) {
-        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToMeta.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
-            MaterializedIndexMeta candidateIndexMeta = entry.getValue();
-            List<CallOperator> indexAggColumnExprList = mvAggColumnsToExprList(columnToIds, candidateIndexMeta);
-            // When the candidate index is SPJ type, it passes the verification directly
-            if (indexAggColumnExprList.size() == 0 && candidateIndexMeta.getKeysType() == KeysType.DUP_KEYS) {
-                continue;
-            }
-            // When the query is SPJ type but the candidate index is SPJG type, it will not pass directly.
-            if (disableSPJGMV || isSPJQuery) {
-                iterator.remove();
-                continue;
-            }
-            // The query is SPJG. The candidate index is SPJG too.
-            /* Situation1: The query is deduplicate SPJG when aggregatedColumnsInQueryOutput is null.
-             * For example: select a , b from table group by a, b
-             * The aggregation function check should be pass directly when MV is SPJG.
-             */
-            if (aggregatedColumnsInQueryOutput == null) {
-                continue;
-            }
-            keyColumnsToExprList(columnToIds, candidateIndexMeta, indexAggColumnExprList);
-            // The aggregated columns in query output must be subset of the aggregated columns in view
-            if (!aggFunctionsMatchAggColumns(columnToIds, candidateIndexMeta, entry.getKey(),
-                    aggregatedColumnsInQueryOutput, indexAggColumnExprList)) {
-                iterator.remove();
-            }
+    private boolean checkAggregationFunction(Map<String, Integer> columnToIds,
+                                             Set<CallOperator> aggregatedColumnsInQueryOutput,
+                                             Long mvIdx,
+                                             MaterializedIndexMeta candidateIndexMeta,
+                                             boolean disableSPJGMV, boolean isSPJQuery) {
+        List<CallOperator> indexAggColumnExprList = mvAggColumnsToExprList(columnToIds, candidateIndexMeta);
+        // When the candidate index is SPJ type, it passes the verification directly
+        if (indexAggColumnExprList.size() == 0 && candidateIndexMeta.getKeysType() == KeysType.DUP_KEYS) {
+            return true;
         }
+        // When the query is SPJ type but the candidate index is SPJG type, it will not pass directly.
+        if (disableSPJGMV || isSPJQuery) {
+            return false;
+        }
+        // The query is SPJG. The candidate index is SPJG too.
+        /* Situation1: The query is deduplicate SPJG when aggregatedColumnsInQueryOutput is null.
+         * For example: select a , b from table group by a, b
+         * The aggregation function check should be pass directly when MV is SPJG.
+         */
+        if (aggregatedColumnsInQueryOutput == null) {
+            return true;
+        }
+        keyColumnsToExprList(columnToIds, candidateIndexMeta, indexAggColumnExprList);
+
+        // The aggregated columns in query output must be subset of the aggregated columns in view
+        if (!aggFunctionsMatchAggColumns(columnToIds, candidateIndexMeta, mvIdx,
+                aggregatedColumnsInQueryOutput, indexAggColumnExprList)) {
+            return false;
+        }
+        return true;
     }
 
-    private void checkOutputColumns(
+    private boolean checkOutputColumns(
             Map<String, Integer> columnToIds,
             Set<Integer> columnNamesInQueryOutput,
-            Map<Long, MaterializedIndexMeta> candidateIndexIdToMeta) {
+            Long mvIdx,
+            MaterializedIndexMeta mvMeta) {
         Preconditions.checkState(columnNamesInQueryOutput != null);
-        Iterator<Map.Entry<Long, MaterializedIndexMeta>> iterator = candidateIndexIdToMeta.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, MaterializedIndexMeta> entry = iterator.next();
-            if (rewriteContexts.containsKey(entry.getKey())) {
-                continue;
-            }
-            Set<Integer> indexColumns = Sets.newHashSet();
-            List<Column> candidateIndexSchema = entry.getValue().getSchema();
-            candidateIndexSchema.forEach(column -> indexColumns.add(columnToIds.get(column.getName())));
-            // The columns in query output must be subset of the columns in SPJ view
-            if (!indexColumns.containsAll(columnNamesInQueryOutput)) {
-                iterator.remove();
-            }
+        if (mvIdToRewriteContexts.containsKey(mvIdx)) {
+            return true;
         }
+        Set<Integer> indexColumns = Sets.newHashSet();
+        List<Column> candidateIndexSchema = mvMeta.getSchema();
+        candidateIndexSchema.forEach(column -> indexColumns.add(getMVColumnToQueryColumnId(columnToIds, column)));
+
+        // The columns in query output must be subset of the columns in SPJ view
+        if (!indexColumns.containsAll(columnNamesInQueryOutput)) {
+            return false;
+        }
+        return true;
     }
 
     private void compensateCandidateIndex(Map<Long, MaterializedIndexMeta> candidateIndexIdToMeta, Map<Long,
@@ -641,10 +696,12 @@ public class MaterializedViewRule extends Rule {
         }
     }
 
-    private List<CallOperator> mvAggColumnsToExprList(Map<String, Integer> columnToIds, MaterializedIndexMeta mvMeta) {
+    private List<CallOperator> mvAggColumnsToExprList(Map<String, Integer> columnToIds,
+                                                      MaterializedIndexMeta mvMeta) {
         List<CallOperator> result = Lists.newArrayList();
         List<Column> schema = mvMeta.getSchema();
-        for (Column column : schema) {
+        for (int i = 0; i < schema.size(); i++) {
+            Column column = schema.get(i);
             if (column.isAggregated()) {
                 ColumnRefOperator columnRef = factory.getColumnRef(columnToIds.get(column.getName()));
                 CallOperator fn = new CallOperator(column.getAggregationType().name().toLowerCase(),
@@ -660,7 +717,8 @@ public class MaterializedViewRule extends Rule {
                                       List<CallOperator> result) {
         for (Column column : mvMeta.getSchema()) {
             if (!column.isAggregated()) {
-                ColumnRefOperator columnRef = factory.getColumnRef(columnToIds.get(column.getName()));
+                int baseColumnId = getMVColumnToQueryColumnId(columnToIds, column);
+                ColumnRefOperator columnRef = factory.getColumnRef(baseColumnId);
                 for (String function : KEY_COLUMN_FUNCTION_NAMES) {
                     CallOperator fn = new CallOperator(function,
                             column.getType(),
@@ -675,14 +733,18 @@ public class MaterializedViewRule extends Rule {
                                                 MaterializedIndexMeta candidateIndexMeta,
                                                 Long indexId, Set<CallOperator> queryExprList,
                                                 List<CallOperator> mvColumnExprList) {
-
         ColumnRefSet aggregateColumns = new ColumnRefSet();
         ColumnRefSet keyColumns = new ColumnRefSet();
+        Set<Integer> usedBaseColumnIds = Sets.newHashSet();
         for (Column column : candidateIndexMeta.getSchema()) {
+            int baseColumnId = getMVColumnToQueryColumnId(columnToIds, column);
+            usedBaseColumnIds.add(baseColumnId);
+
+            ColumnRefOperator columnRef = factory.getColumnRef(baseColumnId);
             if (!column.isAggregated()) {
-                keyColumns.union(factory.getColumnRef(columnToIds.get(column.getName())));
+                keyColumns.union(columnRef);
             } else {
-                aggregateColumns.union(factory.getColumnRef(columnToIds.get(column.getName())));
+                aggregateColumns.union(columnRef);
             }
         }
 
@@ -691,29 +753,29 @@ public class MaterializedViewRule extends Rule {
         We should skip this query for given materialized view.
         ISSUE-6984: https://github.com/StarRocks/starrocks/issues/6984
         */
-        if (candidateIndexMeta.getKeysType() == KeysType.AGG_KEYS && !queryExprList.stream()
-                .filter(queryExpr -> {
+        if (candidateIndexMeta.getKeysType() == KeysType.AGG_KEYS && queryExprList.stream()
+                .anyMatch(queryExpr -> {
                     String fnName = queryExpr.getFnName();
-                    return !(fnName.equals(FunctionSet.COUNT) || fnName.equals(FunctionSet.SUM))
-                            || !keyColumns.containsAll(queryExpr.getUsedColumns());
-                }).findAny().isPresent()) {
+                    return (fnName.equals(FunctionSet.COUNT) || fnName.equals(FunctionSet.SUM))
+                            && keyColumns.containsAll(queryExpr.getUsedColumns());
+                })) {
             return false;
         }
 
-        for (CallOperator queryExpr : queryExprList) {
-            boolean match = false;
-            for (CallOperator mvExpr : mvColumnExprList) {
-                if (isMVMatchAggFunctions(indexId, queryExpr, mvExpr, mvColumnExprList, keyColumns, aggregateColumns)) {
-                    match = true;
-                    break;
-                }
-            }
+        return queryExprList.stream()
+                .allMatch(x -> canRewriteQueryAggFunc(x, mvColumnExprList, indexId,
+                    keyColumns, aggregateColumns, usedBaseColumnIds));
+    }
 
-            if (!match) {
-                return false;
-            }
-        }
-        return true;
+    private boolean canRewriteQueryAggFunc(CallOperator queryExpr,
+                                           List<CallOperator> mvColumnExprList,
+                                           Long indexId,
+                                           ColumnRefSet keyColumns,
+                                           ColumnRefSet aggregateColumns,
+                                           Set<Integer> usedBaseColumnIds) {
+        return mvColumnExprList.stream()
+                .anyMatch(x -> isMVMatchAggFunctions(indexId, queryExpr, x, keyColumns,
+                        aggregateColumns, usedBaseColumnIds));
     }
 
     private static final ImmutableSetMultimap<String, String> COLUMN_AGG_TYPE_MATCH_FN_NAME;
@@ -737,9 +799,9 @@ public class MaterializedViewRule extends Rule {
         COLUMN_AGG_TYPE_MATCH_FN_NAME = builder.build();
     }
 
-    public boolean isMVMatchAggFunctions(Long indexId, CallOperator queryFn, CallOperator mvColumnFn,
-                                         List<CallOperator> mvColumnExprList, ColumnRefSet keyColumns,
-                                         ColumnRefSet aggregateColumns) {
+    public boolean isMVMatchAggFunctions(Long indexId, CallOperator queryFn,
+                                         CallOperator mvColumnFn, ColumnRefSet keyColumns,
+                                         ColumnRefSet aggregateColumns, Set<Integer> usedBaseColumnIds) {
         String queryFnName = queryFn.getFnName();
         if (queryFn.getFnName().equals(FunctionSet.COUNT) && queryFn.isDistinct()) {
             queryFnName = FunctionSet.MULTI_DISTINCT_COUNT;
@@ -787,10 +849,11 @@ public class MaterializedViewRule extends Rule {
 
         if (queryFnChild0.getUsedColumns().equals(mvColumnFnChild0.getUsedColumns())) {
             return true;
-        } else if (isSupportScalarOperator(queryFnChild0)) {
+        }
+
+        if (isSupportScalarOperator(queryFnChild0)) {
             int[] queryColumnIds = queryFnChild0.getUsedColumns().getColumnIds();
-            Set<Integer> mvColumnIdSet = mvColumnExprList.stream()
-                    .map(u -> u.getUsedColumns().getFirstId())
+            Set<Integer> mvColumnIdSet = usedBaseColumnIds.stream()
                     .collect(Collectors.toSet());
             for (int queryColumnId : queryColumnIds) {
                 if (!mvColumnIdSet.contains(queryColumnId)) {
@@ -809,11 +872,8 @@ public class MaterializedViewRule extends Rule {
                 }
                 String mvColumnName = MVUtils.getMVColumnName(mvColumn, queryFnName, queryColumn.getName());
                 if (mvColumnName.equalsIgnoreCase(mvColumn.getName())) {
-                    if (!rewriteContexts.containsKey(indexId)) {
-                        rewriteContexts.put(indexId, Lists.newArrayList());
-                    }
-                    rewriteContexts.get(indexId).add(new RewriteContext(
-                            queryFn, queryColumnRef, mvColumnRef, mvColumn));
+                    mvIdToRewriteContexts.computeIfAbsent(indexId, k -> Lists.newArrayList())
+                            .add(new RewriteContext(queryFn, queryColumnRef, mvColumnRef, mvColumn));
                     return true;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.CaseExpr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1367,28 +1367,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String sql2 = "select LO_ORDERDATE, LO_ORDERKEY, sum(LO_REVENUE)" +
                 " from lineorder_flat_for_mv group by LO_ORDERDATE, LO_ORDERKEY";
         String plan2 = getFragmentPlan(sql2);
-        assertContains(plan2, "PLAN FRAGMENT 0\n" +
-                " OUTPUT EXPRS:1: LO_ORDERDATE | 2: LO_ORDERKEY | 41: sum\n" +
-                "  PARTITION: UNPARTITIONED\n" +
-                "\n" +
-                "  RESULT SINK\n" +
-                "\n" +
-                "  2:EXCHANGE\n" +
-                "\n" +
-                "PLAN FRAGMENT 1\n" +
-                " OUTPUT EXPRS:\n" +
-                "  PARTITION: RANDOM\n" +
-                "\n" +
-                "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 02\n" +
-                "    UNPARTITIONED\n" +
-                "\n" +
-                "  1:Project\n" +
-                "  |  <slot 1> : 1: LO_ORDERDATE\n" +
-                "  |  <slot 2> : 2: LO_ORDERKEY\n" +
-                "  |  <slot 41> : 13: LO_REVENUE\n" +
-                "  |  \n" +
-                "  0:OlapScanNode\n" +
+        assertContains(plan2, "  0:OlapScanNode\n" +
                 "     TABLE: lineorder_flat_for_mv\n" +
                 "     PREAGGREGATION: OFF. Reason: None aggregate function\n" +
                 "     partitions=7/7\n" +
@@ -1398,30 +1377,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String sql3 = "select LO_ORDERDATE, LO_ORDERKEY, sum(LO_REVENUE), count(C_NAME)" +
                 " from lineorder_flat_for_mv group by LO_ORDERDATE, LO_ORDERKEY";
         String plan3 = getFragmentPlan(sql3);
-        assertContains(plan3, "PLAN FRAGMENT 0\n" +
-                        " OUTPUT EXPRS:1: LO_ORDERDATE | 2: LO_ORDERKEY | 41: sum | 42: count\n" +
-                        "  PARTITION: UNPARTITIONED\n" +
-                        "\n" +
-                        "  RESULT SINK\n" +
-                        "\n" +
-                        "  2:EXCHANGE\n" +
-                        "\n" +
-                        "PLAN FRAGMENT 1\n" +
-                        " OUTPUT EXPRS:\n" +
-                        "  PARTITION: RANDOM\n" +
-                        "\n" +
-                        "  STREAM DATA SINK\n" +
-                        "    EXCHANGE ID: 02\n" +
-                        "    UNPARTITIONED\n" +
-                        "\n" +
-                        "  1:Project\n" +
-                        "  |  <slot 1> : 1: LO_ORDERDATE\n" +
-                        "  |  <slot 2> : 2: LO_ORDERKEY\n" +
-                        "  |  <slot 41> : 13: LO_REVENUE\n" +
-                        "  |  <slot 42> : ",
-                ": mv_count_c_name\n" +
-                        "  |  \n" +
-                        "  0:OlapScanNode\n" +
+        assertContains(plan3, "  0:OlapScanNode\n" +
                         "     TABLE: lineorder_flat_for_mv\n" +
                         "     PREAGGREGATION: OFF. Reason: None aggregate function\n" +
                         "     partitions=7/7\n" +
@@ -1431,14 +1387,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         String sql4 = "select LO_ORDERDATE, LO_ORDERKEY, sum(LO_REVENUE) + 1, count(C_NAME) * 3" +
                 " from lineorder_flat_for_mv group by LO_ORDERDATE, LO_ORDERKEY";
         String plan4 = getFragmentPlan(sql4);
-        assertContains(plan4, "1:Project\n" +
-                        "  |  <slot 1> : 1: LO_ORDERDATE\n" +
-                        "  |  <slot 2> : 2: LO_ORDERKEY\n" +
-                        "  |  <slot 43> : 13: LO_REVENUE + 1\n" +
-                        "  |  <slot 44> :",
-                ": mv_count_c_name * 3\n" +
-                        "  |  \n" +
-                        "  0:OlapScanNode\n" +
+        assertContains(plan4, "0:OlapScanNode\n" +
                         "     TABLE: lineorder_flat_for_mv\n" +
                         "     PREAGGREGATION: OFF. Reason: None aggregate function\n" +
                         "     partitions=7/7\n" +


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool



## Problem Summary(Required):
Fix https://github.com/StarRocks/starrocks/issues/22401

Now single-table-sync mv is implemented by the  MaterializedIndex which is a rollup index.  It presumes the mapping relation between the base table and the mv table by using the mv column's name.
eg:
```
      switch (functionName.toLowerCase()) {
            case "sum":
                mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                PrimitiveType baseColumnType = baseColumnRef.getType().getPrimitiveType();
                if (baseColumnType == PrimitiveType.TINYINT || baseColumnType == PrimitiveType.SMALLINT
                        || baseColumnType == PrimitiveType.INT) {
                    type = Type.BIGINT;
                } else if (baseColumnType == PrimitiveType.FLOAT) {
                    type = Type.DOUBLE;
                } else {
                    type = baseType;
                }
                break;
            case "min":
            case "max":
                mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                type = baseType;
                break;
            case FunctionSet.BITMAP_UNION:
                // Compatible aggregation models
                if (baseColumnRef.getType().getPrimitiveType() != PrimitiveType.BITMAP) {
                    defineExpr = functionChild0;
                }
                mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                type = Type.BITMAP;
                break;
            case FunctionSet.HLL_UNION:
                // Compatible aggregation models
                if (baseColumnRef.getType().getPrimitiveType() != PrimitiveType.HLL) {
                    defineExpr = functionChild0;
                }
                mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                type = Type.HLL;
                break;
            case FunctionSet.PERCENTILE_UNION:
                if (baseColumnRef.getType().getPrimitiveType() != PrimitiveType.PERCENTILE) {
                    defineExpr = functionChild0;
                }
                mvAggregateType = AggregateType.valueOf(functionName.toUpperCase());
                type = Type.PERCENTILE;
                break;
            case FunctionSet.COUNT:
                mvAggregateType = AggregateType.SUM;
                defineExpr = new CaseExpr(null, Lists.newArrayList(new CaseWhenClause(
                        new IsNullPredicate(baseColumnRef, false),
                        new IntLiteral(0, Type.BIGINT))), new IntLiteral(1, Type.BIGINT));
                type = Type.BIGINT;
                break;
            default:
                throw new SemanticException("Unsupported function:" + functionName);
        }
```
so when `MaterializedViewRule` rewrites the query by the single-sync-mv, it will use the name remapping relation to find
whether the query is matched with the single-sync-mv. And the sync-mv's schema is built into the `fullSchema` in OlapTable, the same name keeps the original basic column otherwise keeps the sync-mv's.
```
    public void rebuildFullSchema() {
        fullSchema.clear();
        nameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
        for (Column baseColumn : indexIdToMeta.get(baseIndexId).getSchema()) {
            fullSchema.add(baseColumn);
            nameToColumn.put(baseColumn.getName(), baseColumn);
        }
        for (MaterializedIndexMeta indexMeta : indexIdToMeta.values()) {
            for (Column column : indexMeta.getSchema()) {
                if (!nameToColumn.containsKey(column.getName())) {
                    fullSchema.add(column);
                    nameToColumn.put(column.getName(), column);
                }
            }
        }
        LOG.debug("after rebuild full schema. table {}, schema: {}", id, fullSchema);
    }
```


However, there are some problems for this:
- 1. this mapping is hidden and hard to read, we cannot distinguish the remapping clearly in the mv rewrite;
- 2. it's hard to extend for later, eg. to support complex expressions.

So this PR refactors `MaterializedViewRule ` 
- 1. add `getMVColumnToQueryColumnId` to  distinguish the remapping more clearly.
- 2. rename the variables to be better read.

```
    // Map MV's column to query's column id.
    private int getMVColumnToQueryColumnId(Map<String, Integer> columnToIds, Column mvColumn) {
        // Assume sync mv's column names are mapping with query scan node's columns by column name.
        // We can find the according query column id by the mv column name.
        // Once mv's column name is not the same with scan node, how can we do it?
        return columnToIds.get(mvColumn.getName());
    }

```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
