### PR TITLE
[Enhancement] Iceberg table sink support checking if `static_partition_insert` is used without explicitly specifying the partition in sql.

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -805,6 +805,10 @@ public class InsertPlanTest extends PlanTestBase {
                 icebergTable.getUUID();
                 result = 12345566;
                 minTimes = 0;
+
+                icebergTable.isUnPartitioned();
+                result = true;
+                minTimes = 0;
             }
         };
 


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
This patch is mainly to support `insert into iceberg_partitioned_table select <constant_partition_value>` to use bigger dop.

Currently, insert into iceberg partitioned tables can be divided into two kinds.
prepare: create table iceberg_target_table (k1 int, k2 int) partition by (k2);
- static partition insert. insert statement can write the one specify partition of table. eg: `insert into iceberg_target_table partition(k2=11) select c2 from source_table`;
- dynamic partition insert. insert statement can write multiple partitions of table. eg: `insert into iceberg_target_table select c1, c2 from source_table`;

for static partition insert, we could use bigger dop to write files.
for dynamic partition insert, each partition will only use one concurrent write currently.

for `insert into iceberg_target_table select c1, `**1+2+3**` from source_table`, also a kind of static partition insert. 
but currently we will treat this as dynamic partition insert, it will use the only one concurrent to write files for each fragment instance. So we need to treat this kind of sql as static partition insert.

we used the `SelectListItems` after analyze in this patch to check if this sql is static partition insert. Why we don't use the `Expr` or `ScalarOpeartor` after optimizer, because the `is_constant` attribute may be lost during the optimizer. The `is_constant` in the output_expr or physicalPlan isn't accurate after optimizer.

limitation：
We can cover the usage scenarios of most users with the current implementation. but some query we will treat it as dynamic partition insert. 
for example： `insert into iceberg_partitioned_table select t1.v1,  t1.a+ t2.b from (select v1, 1 as a from tbl1) t1, (select v2, 2 as b from tbl2) t2;`

https://github.com/StarRocks/starrocks/issues/21502
## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
