### PR TITLE
[BugFix] Maintaining consistency in BE and FE for the parameter validtion in LEAD/LAG function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -978,6 +978,9 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     /**
+     * Attention: if you just want check whether the expr is a constant literal, please consider
+     * use isLiteral()
+     *
      * Returns true if this expression should be treated as constant. I.e. if the frontend
      * and backend should assume that two evaluations of the expression within a query will
      * return the same value. Examples of constant expressions include:

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -56,7 +56,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class FunctionCallExpr extends Expr {
     private FunctionName fnName;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -161,7 +161,7 @@ public class InsertPlanner {
 
             Optimizer optimizer = new Optimizer();
             PhysicalPropertySet requiredPropertySet = createPhysicalPropertySet(insertStmt, outputColumns);
-            LOG.debug("property" + requiredPropertySet);
+            LOG.debug("property {}", requiredPropertySet);
             OptExpression optimizedPlan;
 
             try (PlannerProfile.ScopedTimer ignore2 = PlannerProfile.getScopedTimer("Optimizer")) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -356,7 +356,8 @@ public class FunctionAnalyzer {
                 throw new SemanticException(
                         "percentile_approx requires the first parameter's type is numeric type");
             }
-            if (!functionCallExpr.getChild(1).getType().isNumericType() || !functionCallExpr.getChild(1).isConstant()) {
+            if (!functionCallExpr.getChild(1).getType().isNumericType() ||
+                    !functionCallExpr.getChild(1).isLiteral()) {
                 throw new SemanticException(
                         "percentile_approx requires the second parameter's type is numeric constant type");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -385,7 +385,8 @@ public class StarRocksAssert {
             try {
                 explainQuery();
             } catch (AnalysisException | StarRocksPlannerException analysisException) {
-                Assert.assertTrue(Stream.of(keywords).allMatch(analysisException.getMessage()::contains));
+                Assert.assertTrue(analysisException.getMessage(),
+                        Stream.of(keywords).allMatch(analysisException.getMessage()::contains));
                 return;
             } catch (Exception ex) {
                 Assert.fail();

--- a/test/sql/test_lead_lag/R/test_lead_lag
+++ b/test/sql/test_lead_lag/R/test_lead_lag
@@ -1,0 +1,140 @@
+-- name: test_lead_lag
+CREATE DATABASE test_lead_lag;
+-- result:
+-- !result
+USE test_lead_lag;
+-- result:
+-- !result
+CREATE TABLE `common_duplicate` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL COMMENT "",
+  `c2` varchar(500) NOT NULL COMMENT "",
+  `c3` varchar(500) NULL COMMENT "",
+  `c4` float NULL COMMENT "",
+  `c5` decimal128(38, 20) NOT NULL COMMENT "",
+  `c6` date NOT NULL COMMENT "",
+  INDEX index1_c0 (`c0`) USING BITMAP
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`, `c2`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c1`)
+(PARTITION p0 VALUES [("0"), ("500000")),
+PARTITION p500000 VALUES [("500000"), ("1000000")))
+DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"bloom_filter_columns" = "c3",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into common_duplicate values (1, 1, 'a', 'b', 1.23, 3.33, '2021-11-11'),(2, 600000, 'aa', 'bb', 2.23, 4.33, '2022-12-11'),(3, 400000, 'aaa', 'bbb', 3.23, 5.33, '2022-06-11');
+-- result:
+-- !result
+select c0, lead(c1, 5) over() from common_duplicate;
+-- result:
+1	None
+3	None
+2	None
+-- !result
+select c0, lag(c1, 5) over() from common_duplicate;
+-- result:
+3	None
+1	None
+2	None
+-- !result
+select c0, lead(c1, 5, null) over() from common_duplicate;
+-- result:
+2	None
+1	None
+3	None
+-- !result
+select c0, lag(c1, 5, null) over() from common_duplicate;
+-- result:
+1	None
+3	None
+2	None
+-- !result
+select c0, lead(c1, 5, 1) over() from common_duplicate;
+-- result:
+3	1
+1	1
+2	1
+-- !result
+select c0, lag(c1, 5, 1+2+3) over() from common_duplicate;
+-- result:
+1	6
+2	6
+3	6
+-- !result
+select c0, lag(c1, 5, abs(1)) over() from common_duplicate;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: The type of the third parameter of LEAD/LAG not match the type INT.')
+-- !result
+select c0, lead(c2, 5) over() from common_duplicate;
+-- result:
+1	None
+2	None
+3	None
+-- !result
+select c0, lead(c2, 5, 1+2+3) over() from common_duplicate;
+-- result:
+3	6
+1	6
+2	6
+-- !result
+select c0, lead(c2, 5, day('2021-01-02')) over() from common_duplicate;
+-- result:
+2	2
+3	2
+1	2
+-- !result
+select c0, lag(c2, 5, 'abc') over() from common_duplicate;
+-- result:
+3	abc
+2	abc
+1	abc
+-- !result
+select c0, lead(c4, 5, 1) over() from common_duplicate;
+-- result:
+3	1.0
+2	1.0
+1	1.0
+-- !result
+select c0, lag(c4, 5, 1+2+3) over() from common_duplicate;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: The type of the third parameter of LEAD/LAG not match the type FLOAT.')
+-- !result
+select c0, lag(c4, 5, 3.456) over() from common_duplicate;
+-- result:
+2	3.456
+1	3.456
+3	3.456
+-- !result
+select c0, lead(c5, 5, '12345') over() from common_duplicate;
+-- result:
+2	12345.00000000000000000000
+3	12345.00000000000000000000
+1	12345.00000000000000000000
+-- !result
+select c0, lag(c5, 5, 123) over() from common_duplicate;
+-- result:
+2	123.00000000000000000000
+1	123.00000000000000000000
+3	123.00000000000000000000
+-- !result
+select c0, lag(c5, 5, 123.456) over() from common_duplicate;
+-- result:
+2	123.45600000000000000000
+1	123.45600000000000000000
+3	123.45600000000000000000
+-- !result
+select c0, lead(c6, 5, '2021-11-11') over() from common_duplicate;
+-- result:
+3	2021-11-11
+2	2021-11-11
+1	2021-11-11
+-- !result

--- a/test/sql/test_lead_lag/T/test_lead_lag
+++ b/test/sql/test_lead_lag/T/test_lead_lag
@@ -1,0 +1,51 @@
+-- name: test_lead_lag
+CREATE DATABASE test_lead_lag;
+USE test_lead_lag;
+CREATE TABLE `common_duplicate` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL COMMENT "",
+  `c2` varchar(500) NOT NULL COMMENT "",
+  `c3` varchar(500) NULL COMMENT "",
+  `c4` float NULL COMMENT "",
+  `c5` decimal128(38, 20) NOT NULL COMMENT "",
+  `c6` date NOT NULL COMMENT "",
+  INDEX index1_c0 (`c0`) USING BITMAP
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`, `c2`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c1`)
+(PARTITION p0 VALUES [("0"), ("500000")),
+PARTITION p500000 VALUES [("500000"), ("1000000")))
+DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"bloom_filter_columns" = "c3",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into common_duplicate values (1, 1, 'a', 'b', 1.23, 3.33, '2021-11-11'),(2, 600000, 'aa', 'bb', 2.23, 4.33, '2022-12-11'),(3, 400000, 'aaa', 'bbb', 3.23, 5.33, '2022-06-11');
+
+select c0, lead(c1, 5) over() from common_duplicate;
+select c0, lag(c1, 5) over() from common_duplicate;
+select c0, lead(c1, 5, null) over() from common_duplicate;
+select c0, lag(c1, 5, null) over() from common_duplicate;
+select c0, lead(c1, 5, 1) over() from common_duplicate;
+select c0, lag(c1, 5, 1+2+3) over() from common_duplicate;
+select c0, lag(c1, 5, abs(1)) over() from common_duplicate;
+
+
+select c0, lead(c2, 5) over() from common_duplicate;
+select c0, lead(c2, 5, 1+2+3) over() from common_duplicate;
+select c0, lead(c2, 5, day('2021-01-02')) over() from common_duplicate;
+select c0, lag(c2, 5, 'abc') over() from common_duplicate;
+select c0, lead(c4, 5, 1) over() from common_duplicate;
+select c0, lag(c4, 5, 1+2+3) over() from common_duplicate;
+select c0, lag(c4, 5, 3.456) over() from common_duplicate;
+
+select c0, lead(c5, 5, '12345') over() from common_duplicate;
+select c0, lag(c5, 5, 123) over() from common_duplicate;
+select c0, lag(c5, 5, 123.456) over() from common_duplicate;
+select c0, lead(c6, 5, '2021-11-11') over() from common_duplicate;


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #22945

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The root cause of the problem is that the BE sets the corresponding column based on the `isConst` and `isNullable` information of the third parameter of the lead/lag function passed by the FE. If `isNullable=true`, a const null column will be set. However, the `isNullable` information provided by the FE is not always accurate, and it may mistakenly set a non-null column as nullable. This causes the column set by the BE for the third parameter to not match the actual input column in the chunk, leading to a BE crash. Considering that FE is currently unable to accurately set the isNullable information, the only option is to temporarily disable the cases when `isNullable=true`.

```
for (size_t j = 0; j < _agg_expr_ctxs[i].size(); ++j) {
            // Currently, only lead and lag window function have multi args.
            // For performance, we do this special handle.
            // In future, if need, we could remove this if else easily.
            if (j == 0) {
                _agg_intput_columns[i][j] =
                        ColumnHelper::create_column(_agg_expr_ctxs[i][j]->root()->type(), is_input_nullable);
            } else {
                _agg_intput_columns[i][j] = ColumnHelper::create_column(_agg_expr_ctxs[i][j]->root()->type(),
                                                                        _agg_expr_ctxs[i][j]->root()->is_nullable(),
                                                                        _agg_expr_ctxs[i][j]->root()->is_constant(), 0);
            }
        }


ColumnPtr ColumnHelper::create_column(const TypeDescriptor& type_desc, bool nullable, bool is_const, size_t size,
                                      bool use_adaptive_nullable_column) {
    auto type = type_desc.type;
    if (is_const && (nullable || type == TYPE_NULL)) {
        return ColumnHelper::create_const_null_column(size);
    } else if (type == TYPE_NULL) {
        if (use_adaptive_nullable_column) {
            return AdaptiveNullableColumn::create(BooleanColumn::create(size), NullColumn::create(size, DATUM_NULL));
        } else {
            return NullableColumn::create(BooleanColumn::create(size), NullColumn::create(size, DATUM_NULL));
        }
    }
```


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
