### PR TITLE
[BugFix][Cherry-Pick][Branch-3.0] Fix BE access S3 failed when S3 bucket name contains dots

### DIFF
--- a/be/test/common/s3_uri_test.cpp
+++ b/be/test/common/s3_uri_test.cpp
@@ -41,13 +41,42 @@ PARALLEL_TEST(S3URITest, path_style_url) {
 }
 
 PARALLEL_TEST(S3URITest, s3_scheme) {
-    S3URI uri;
-    ASSERT_TRUE(uri.parse("s3://mybucket/puppy.jpg"));
-    EXPECT_EQ("s3", uri.scheme());
-    EXPECT_EQ("", uri.region());
-    EXPECT_EQ("mybucket", uri.bucket());
-    EXPECT_EQ("puppy.jpg", uri.key());
-    EXPECT_EQ("", uri.endpoint());
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("s3://mybucket/puppy.jpg"));
+        EXPECT_EQ("s3", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("mybucket", uri.bucket());
+        EXPECT_EQ("puppy.jpg", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("S3://test.name.with.dot/another.test/foo.parquet"));
+        EXPECT_EQ("s3", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("test.name.with.dot", uri.bucket());
+        EXPECT_EQ("another.test/foo.parquet", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("s3A://test.name.with.dot/another.test/foo.parquet"));
+        EXPECT_EQ("s3a", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("test.name.with.dot", uri.bucket());
+        EXPECT_EQ("another.test/foo.parquet", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("s3n://test.name.with.dot/another.test/foo.parquet"));
+        EXPECT_EQ("s3n", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("test.name.with.dot", uri.bucket());
+        EXPECT_EQ("another.test/foo.parquet", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
 }
 
 PARALLEL_TEST(S3URITest, virtual_host_non_s3_url) {
@@ -78,6 +107,16 @@ PARALLEL_TEST(S3URITest, empty) {
 PARALLEL_TEST(S3URITest, missing_scheme) {
     S3URI uri;
     ASSERT_FALSE(uri.parse("/bucket/puppy.jpg"));
+}
+
+PARALLEL_TEST(S3URITest, oss_bucket) {
+    S3URI uri;
+    ASSERT_TRUE(uri.parse("oss://sr-test/dataset/smith/foo.parquet"));
+    EXPECT_EQ("oss", uri.scheme());
+    EXPECT_EQ("", uri.region());
+    EXPECT_EQ("sr-test", uri.bucket());
+    EXPECT_EQ("dataset/smith/foo.parquet", uri.key());
+    EXPECT_EQ("", uri.endpoint());
 }
 
 } // namespace starrocks

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -554,7 +554,6 @@ under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.3.3</version>
             <exclusions>
                 <exclusion>
                     <artifactId>zookeeper</artifactId>


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Cherry-pick from #22828

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
