### PR TITLE
aarch64: optimizations to test_hash, make_mask using Neon intrinsics

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -122,9 +122,6 @@ void SimdBlockFilter::merge(const SimdBlockFilter& bf) {
     }
 }
 
-static constexpr uint32_t SALT[8] = {0x47b6137b, 0x44974d91, 0x8824ad5b, 0xa2b7289d,
-                                     0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31};
-
 // For scalar version:
 void SimdBlockFilter::make_mask(uint32_t key, uint32_t* masks) const {
     for (int i = 0; i < BITS_SET_PER_BLOCK; ++i) {

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -85,6 +85,9 @@ public:
     static LogicalType from_serialize_type(PrimitiveType type);
 };
 
+static constexpr uint32_t SALT[8] = {0x47b6137b, 0x44974d91, 0x8824ad5b, 0xa2b7289d,
+                                     0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31};
+
 // Modify from https://github.com/FastFilter/fastfilter_cpp/blob/master/src/bloom/simd-block.h
 // This is avx2 simd implementation for paper <<Cache-, Hash- and Space-Efficient Bloom Filters>>
 class SimdBlockFilter {
@@ -127,6 +130,19 @@ public:
         // our case, the result is zero everywhere iff there is a one in 'bucket' wherever
         // 'mask' is one. testc returns 1 if the result is 0 everywhere and returns 0 otherwise.
         return _mm256_testc_si256(bucket, mask);
+#elif defined(__ARM_NEON)
+        uint32x4_t masks[2];
+        uint32x4_t directory_1 = vdupq_n_u32(_directory[bucket_idx][0]);
+        uint32x4_t directory_2 = vdupq_n_u32(_directory[bucket_idx][4]);
+        make_mask(hash >> _log_num_buckets, masks);
+        uint32x4_t out_1 = vbicq_u32(directory_1, masks[0]);
+        uint32x4_t out_2 = vbicq_u32(directory_2, masks[1]);
+        out_1 = vorrq_u32(out_1, out_2);
+        uint32x2_t low_1 = vget_low_u32(out_1);
+        uint32x2_t high_1 = vget_high_u32(out_1);
+        low_1 = vorr_u32(low_1, high_1);
+        uint32_t res = vget_lane_u32(low_1, 0) | vget_lane_u32(low_1, 1);
+        return !(res);
 #else
         uint32_t masks[BITS_SET_PER_BLOCK];
         make_mask(hash >> _log_num_buckets, masks);
@@ -151,6 +167,23 @@ private:
 
     // For scalar version:
     void make_mask(uint32_t key, uint32_t* masks) const;
+
+#ifdef __ARM_NEON
+    // For Neon version:
+    void make_mask(uint32_t key, uint32x4_t* masks) const noexcept {
+        uint32x4_t hash_data_1 = vdupq_n_u32(key);
+        uint32x4_t hash_data_2 = vdupq_n_u32(key);
+        uint32x4_t rehash_1 = vld1q_u32(&SALT[0]);
+        uint32x4_t rehash_2 = vld1q_u32(&SALT[4]);
+        hash_data_1 = vmulq_u32(rehash_1, hash_data_1);
+        hash_data_2 = vmulq_u32(rehash_2, hash_data_2);
+        hash_data_1 = vshrq_n_u32(hash_data_1, 27);
+        hash_data_2 = vshrq_n_u32(hash_data_2, 27);
+        const uint32x4_t ones = vdupq_n_u32(1);
+        masks[0] = vshlq_u32(ones, reinterpret_cast<int32x4_t>(hash_data_1));
+        masks[1] = vshlq_u32(ones, reinterpret_cast<int32x4_t>(hash_data_2));
+    }
+#endif
 
 #ifdef __AVX2__
     // For simd version:


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
This PR improves performance of StarRocks for non-flat databases. The optimizations are implemented in the BE functions: SimdBlockFilter::test_hash and SimdBlockFilter::make_mask for aarch64 using Neon vector intrinsics. In some of our tests, the average perf gain using this patch vs. baseline on an AWS Graviton3 based instance was ~1.9x.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
