### PR TITLE
[BugFix] The hdfs client repeatedly executes disconnect when destruct HdfsFsCache

### DIFF
--- a/be/src/fs/hdfs/hdfs_fs_cache.h
+++ b/be/src/fs/hdfs/hdfs_fs_cache.h
@@ -44,11 +44,7 @@ public:
 // Cache for HDFS file system
 class HdfsFsCache {
 public:
-    ~HdfsFsCache() {
-        for (size_t i = 0; i < _cur_client_idx; i++) {
-            hdfsDisconnect(_cache_clients[i]->hdfs_fs);
-        }
-    }
+    ~HdfsFsCache() = default;
     static HdfsFsCache* instance() {
         static HdfsFsCache s_instance;
         return &s_instance;


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

hdfsDisconnect will be executed when destruct HdfsFsClient, so no need to disconnet when destruct HdfsFsCache.

```
*** Aborted at 1683510315 (unix time) try "date -d @1683510315" if you are using GNU date ***
PC: @     0x7f4ce8f114c6 Fingerprinter::Fingerprinter()
*** SIGSEGV (@0x8) received by PID 23320 (TID 0x7f4ce9a21480) from PID 8; stack trace: ***
    @         0x13496372 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f4ce914be9b os::Linux::chained_handler()
    @     0x7f4ce915090c JVM_handle_linux_signal
    @     0x7f4ce9143858 signalHandler()
    @     0x7f4ce7f1d630 (unknown)
    @     0x7f4ce8f114c6 Fingerprinter::Fingerprinter()
    @     0x7f4ce8f07d49 jni_invoke_nonstatic()
    @     0x7f4ce8f09fba jni_CallVoidMethodV
    @         0x12e68988 invokeMethodOnJclass
    @         0x12e68d4f invokeMethod
    @         0x12e6b69a hdfsDisconnect
    @          0xe9362ac starrocks::HdfsFsClient::~HdfsFsClient()
    @          0xe9377d4 __gnu_cxx::new_allocator<>::destroy<>()
    @          0xe9377a7 std::allocator_traits<>::destroy<>()
    @          0xe9375c5 std::_Sp_counted_ptr_inplace<>::_M_dispose()
    @          0x960a205 std::_Sp_counted_base<>::_M_release()
    @          0x96073d8 std::__shared_count<>::~__shared_count()
    @          0xe92c49c std::__shared_ptr<>::~__shared_ptr()
    @          0xe92c4b8 std::shared_ptr<>::~shared_ptr()
    @          0xe92c5a7 starrocks::HdfsFsCache::~HdfsFsCache()
    @     0x7f4ce7b79ce9 __run_exit_handlers
    @     0x7f4ce7b79d37 __GI_exit
    @     0x7f4ce7b6255c __libc_start_main
    @          0x9535d7f (unknown)
    @                0x0 (unknown)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
