### PR TITLE
[BugFix] Fix the bug of MemTracker use after free when gracefully exit

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -533,10 +533,10 @@ void ExecEnv::_destroy() {
         _lake_tablet_manager->prune_metacache();
     }
 
+    SAFE_DELETE(_query_context_mgr);
     // WorkGroupManager should release MemTracker of WorkGroups belongs to itself before deallocate
     // _query_pool_mem_tracker.
     workgroup::WorkGroupManager::instance()->destroy();
-    SAFE_DELETE(_query_context_mgr);
     SAFE_DELETE(_runtime_filter_cache);
     SAFE_DELETE(_driver_limiter);
     SAFE_DELETE(_broker_client_cache);


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

When destruct query, the mem_tracker of workgroup is already destructed, so it will crash because of use of after free.

```
==169976==ERROR: AddressSanitizer: heap-use-after-free on address 0x6030079cbc70 at pc 0x000010b2d3fa bp 0x7ffeabc6e2b0 sp 0x7ffeabc6e2a8
READ of size 8 at 0x6030079cbc70 thread T0
    #0 0x10b2d3f9 in std::__cxx11::list<starrocks::MemTracker*, std::allocator<starrocks::MemTracker*> >::erase(std::_List_const_iterator<starrocks::MemTracker*>) /opt/gcc/usr/include/c++/10.3.0/bits/list.tcc:157
    #1 0x10b2cc50 in starrocks::MemTracker::unregister_from_parent() /root/starrocks/be/src/runtime/mem_tracker.h:118
    #2 0x10b2b8db in starrocks::MemTracker::~MemTracker() /root/starrocks/be/src/runtime/mem_tracker.cpp:129
    #3 0x9a63b69 in void __gnu_cxx::new_allocator<starrocks::MemTracker>::destroy<starrocks::MemTracker>(starrocks::MemTracker*) /opt/gcc/usr/include/c++/10.3.0/ext/new_allocator.h:156
    #4 0x9a639a8 in void std::allocator_traits<std::allocator<starrocks::MemTracker> >::destroy<starrocks::MemTracker>(std::allocator<starrocks::MemTracker>&, starrocks::MemTracker*) /opt/gcc/usr/include/c++/10.3.0/bits/alloc_traits.h:531
    #5 0x9a62ff0 in std::_Sp_counted_ptr_inplace<starrocks::MemTracker, std::allocator<starrocks::MemTracker>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:560
    #6 0x960a204 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:158
    #7 0x96073d7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:733
    #8 0x9602f75 in std::__shared_ptr<starrocks::MemTracker, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:1183
    #9 0x9602f91 in std::shared_ptr<starrocks::MemTracker>::~shared_ptr() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr.h:121
    #10 0x9a34281 in starrocks::pipeline::QueryContext::~QueryContext() /root/starrocks/be/src/exec/pipeline/query_context.cpp:49
    #11 0x9a63adf in void __gnu_cxx::new_allocator<starrocks::pipeline::QueryContext>::destroy<starrocks::pipeline::QueryContext>(starrocks::pipeline::QueryContext*) /opt/gcc/usr/include/c++/10.3.0/ext/new_allocator.h:156
    #12 0x9a6390e in void std::allocator_traits<std::allocator<starrocks::pipeline::QueryContext> >::destroy<starrocks::pipeline::QueryContext>(std::allocator<starrocks::pipeline::QueryContext>&, starrocks::pipeline::QueryContext*) /opt/gcc/usr/include/c++/10.3.0/bits/alloc
_traits.h:531
    #13 0x9a628d0 in std::_Sp_counted_ptr_inplace<starrocks::pipeline::QueryContext, std::allocator<starrocks::pipeline::QueryContext>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:560
    #14 0x960a204 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:158
    #15 0x96073d7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:733
    #16 0x9a4304b in std::__shared_ptr<starrocks::pipeline::QueryContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:1183
    #17 0x9a43067 in std::shared_ptr<starrocks::pipeline::QueryContext>::~shared_ptr() /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr.h:121
    #18 0x9a5e8ad in std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >::~pair() (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x9a5e8ad)
    #19 0x9a5e8d9 in void __gnu_cxx::new_allocator<std::__detail::_Hash_node<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >, true> >::destroy<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext>
 > >(std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >*) (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x9a5e8d9)
    #20 0x9a5d160 in void std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >, true> > >::destroy<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline:
:QueryContext> > >(std::allocator<std::__detail::_Hash_node<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >, true> >&, std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >*) (/home/disk2/lxh/do
ris/output/be/lib/starrocks_be+0x9a5d160)
    #21 0x9a5a202 in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >, true> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<starrocks::TUniqueId c
onst, std::shared_ptr<starrocks::pipeline::QueryContext> >, true>*) (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x9a5a202)
    #22 0x9a5fdef in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >, true> > >::_M_deallocate_nodes(std::__detail::_Hash_node<std::pair<starrocks::TUniqueId 
const, std::shared_ptr<starrocks::pipeline::QueryContext> >, true>*) (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x9a5fdef)
    #23 0x9a5e531 in std::_Hashtable<starrocks::TUniqueId, std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >, std::allocator<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> > >, std::__detail:
:_Select1st, std::equal_to<starrocks::TUniqueId>, std::hash<starrocks::TUniqueId>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::clear() (/home/disk2/lxh/do
ris/output/be/lib/starrocks_be+0x9a5e531)
    #24 0x9a5cc71 in std::_Hashtable<starrocks::TUniqueId, std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> >, std::allocator<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> > >, std::__detail::_Select1st, std::equal_to<starrocks::TUniqueId>, std::hash<starrocks::TUniqueId>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::~_Hashtable() (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x9a5cc71)
    #25 0x9a5999b in std::unordered_map<starrocks::TUniqueId, std::shared_ptr<starrocks::pipeline::QueryContext>, std::hash<starrocks::TUniqueId>, std::equal_to<starrocks::TUniqueId>, std::allocator<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> > > >::~unordered_map() (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x9a5999b)
    #26 0x9a599b6 in void std::_Destroy<std::unordered_map<starrocks::TUniqueId, std::shared_ptr<starrocks::pipeline::QueryContext>, std::hash<starrocks::TUniqueId>, std::equal_to<starrocks::TUniqueId>, std::allocator<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> > > > >(std::unordered_map<starrocks::TUniqueId, std::shared_ptr<starrocks::pipeline::QueryContext>, std::hash<starrocks::TUniqueId>, std::equal_to<starrocks::TUniqueId>, std::allocator<std::pair<starrocks::TUniqueId const, std::shared_ptr<starrocks::pipeline::QueryContext> > > >*) (/home/disk2/lxh/doris/output/be/lib/starrocks_be+0x9a599b6)

```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
