### PR TITLE
[Enhancement] Use memory data size to calculate reader chunk size in cloud native tablet compaction

### DIFF
--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -18,37 +18,24 @@
 #include "storage/chunk_helper.h"
 #include "storage/compaction_utils.h"
 #include "storage/lake/rowset.h"
-#include "storage/lake/tablet_metadata.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/txn_log.h"
+#include "storage/rowset/column_reader.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_reader_params.h"
 #include "util/defer_op.h"
 
 namespace starrocks::lake {
 
-HorizontalCompactionTask::~HorizontalCompactionTask() = default;
-
 Status HorizontalCompactionTask::execute(Progress* progress) {
     ASSIGN_OR_RETURN(auto tablet_schema, _tablet->get_schema());
-    const KeysType keys_type = tablet_schema->keys_type();
-    int64_t num_rows = 0;
-    int64_t num_size = 0;
+    int64_t total_num_rows = 0;
     for (auto& rowset : _input_rowsets) {
-        num_rows += rowset->num_rows();
-        num_size += rowset->data_size();
+        total_num_rows += rowset->num_rows();
     }
-    int64_t max_input_segs = 0;
-    if (keys_type == DUP_KEYS) {
-        max_input_segs = 1;
-    } else {
-        for (auto& rowset : _input_rowsets) {
-            max_input_segs += rowset->is_overlapped() ? rowset->num_segments() : 1;
-        }
-    }
-    const int32_t chunk_size = CompactionUtils::get_read_chunk_size(
-            config::compaction_memory_limit_per_worker, config::vector_chunk_size, num_rows, num_size, max_input_segs);
+
+    ASSIGN_OR_RETURN(auto chunk_size, calculate_chunk_size());
 
     Schema schema = ChunkHelper::convert_schema(*tablet_schema);
     TabletReader reader(*_tablet, _version, schema, _input_rowsets);
@@ -84,8 +71,8 @@ Status HorizontalCompactionTask::execute(Progress* progress) {
         chunk->reset();
 
         if (progress != nullptr) {
-            progress->update(100 * reader.stats().raw_rows_read / num_rows);
-            VLOG(3) << "Compaction progress: " << progress->value();
+            progress->update(100 * reader.stats().raw_rows_read / total_num_rows);
+            VLOG_EVERY_N(3, 1000) << "Compaction progress: " << progress->value();
         }
     }
     RETURN_IF_ERROR(writer->finish());
@@ -105,6 +92,28 @@ Status HorizontalCompactionTask::execute(Progress* progress) {
     op_compaction->mutable_output_rowset()->set_overlapped(false);
     Status st = _tablet->put_txn_log(std::move(txn_log));
     return st;
+}
+
+StatusOr<int32_t> HorizontalCompactionTask::calculate_chunk_size() {
+    int64_t total_num_rows = 0;
+    int64_t total_input_segs = 0;
+    int64_t total_mem_footprint = 0;
+    for (auto& rowset : _input_rowsets) {
+        total_num_rows += rowset->num_rows();
+        total_input_segs += rowset->is_overlapped() ? rowset->num_segments() : 1;
+        ASSIGN_OR_RETURN(auto segments, rowset->segments());
+        for (auto& segment : segments) {
+            for (size_t i = 0; i < segment->num_columns(); ++i) {
+                const auto* column_reader = segment->column(i);
+                if (column_reader == nullptr) {
+                    continue;
+                }
+                total_mem_footprint += column_reader->total_mem_footprint();
+            }
+        }
+    }
+    return CompactionUtils::get_read_chunk_size(config::compaction_memory_limit_per_worker, config::vector_chunk_size,
+                                                total_num_rows, total_mem_footprint, total_input_segs);
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/horizontal_compaction_task.h
+++ b/be/src/storage/lake/horizontal_compaction_task.h
@@ -39,11 +39,13 @@ public:
               _tablet(std::move(tablet)),
               _input_rowsets(std::move(input_rowsets)) {}
 
-    ~HorizontalCompactionTask() override;
+    ~HorizontalCompactionTask() override = default;
 
     Status execute(Progress* progress) override;
 
 private:
+    StatusOr<int32_t> calculate_chunk_size();
+
     int64_t _txn_id;
     int64_t _version;
     std::shared_ptr<Tablet> _tablet;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -176,6 +176,13 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
     return seg_iterators;
 }
 
+StatusOr<std::vector<SegmentPtr>> Rowset::segments() {
+    std::vector<SegmentPtr> segments;
+    // currently used in compaction, not fill cache
+    RETURN_IF_ERROR(load_segments(&segments, false));
+    return segments;
+}
+
 Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_cache) {
     size_t footer_size_hint = 16 * 1024;
     uint32_t seg_id = 0;

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -67,6 +67,8 @@ public:
 
     [[nodiscard]] const RowsetMetadata& metadata() const { return *_rowset_metadata; }
 
+    [[nodiscard]] StatusOr<std::vector<SegmentPtr>> segments();
+
 private:
     [[nodiscard]] Status load_segments(std::vector<SegmentPtr>* segments, bool fill_cache);
 


### PR DESCRIPTION

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Use memory data size is more accurate than the compressed size.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
