### PR TITLE
[BugFix] Fix the bug of MemTracker use after free when gracefully exit (#22963)

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -537,9 +537,9 @@ void ExecEnv::_destroy() {
         _lake_tablet_manager->prune_metacache();
     }
 
+    SAFE_DELETE(_query_context_mgr);
     // WorkGroupManager should release MemTracker of WorkGroups belongs to itself before deallocate _query_pool_mem_tracker.
     workgroup::WorkGroupManager::instance()->destroy();
-    SAFE_DELETE(_query_context_mgr);
     SAFE_DELETE(_runtime_filter_cache);
     SAFE_DELETE(_driver_limiter);
     SAFE_DELETE(_broker_client_cache);


### PR DESCRIPTION
When destruct query, the mem_tracker of workgroup is already destructed, so it will crash because of use of after free.