### PR TITLE
[BugFix] Disable using bucket keys as local shuffle keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -215,6 +215,7 @@ public class OlapScanNode extends ScanNode {
         return bucketColumns;
     }
 
+    // TODO: Determine local shuffle keys by FE to make local shuffle use bucket columns of OlapScanNode.
     public void setBucketColumns(List<ColumnRefOperator> bucketColumns) {
         this.bucketColumns = bucketColumns;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -315,8 +315,6 @@ public class PlanFragmentBuilder {
         }
         Collections.reverse(fragments);
 
-        fragments.forEach(PlanFragmentBuilder::maybeClearOlapScanNodePartitions);
-
         // compute local_rf_waiting_set for each PlanNode.
         // when enable_pipeline_engine=true and enable_global_runtime_filter=false, we should clear
         // runtime filters from PlanNode.
@@ -764,20 +762,6 @@ public class PlanFragmentBuilder {
             scanNode.setDictStringIdToIntIds(node.getDictStringIdToIntIds());
             scanNode.updateAppliedDictStringColumns(node.getGlobalDicts().stream().
                     map(entry -> entry.first).collect(Collectors.toSet()));
-
-            if (node.getDistributionSpec() instanceof HashDistributionSpec) {
-                List<ColumnRefOperator> bucketColumns = getShuffleColumns((HashDistributionSpec) node.getDistributionSpec());
-                boolean useAllBucketColumns =
-                        bucketColumns.stream().allMatch(c -> node.getColRefToColumnMetaMap().containsKey(c));
-                if (useAllBucketColumns) {
-                    List<Expr> bucketExprs = bucketColumns.stream()
-                            .map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                    new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
-                            .collect(Collectors.toList());
-                    scanNode.setBucketExprs(bucketExprs);
-                    scanNode.setBucketColumns(bucketColumns);
-                }
-            }
 
             context.getScanNodes().add(scanNode);
             PlanFragment fragment =
@@ -1531,7 +1515,6 @@ public class PlanFragmentBuilder {
                 }
             }
 
-            clearOlapScanNodePartitions(sourceFragment.getPlanRoot());
             sourceFragment.clearDestination();
             sourceFragment.clearOutputPartition();
             return sourceFragment;
@@ -1772,9 +1755,6 @@ public class PlanFragmentBuilder {
             aggregationNode.computeStatistics(optExpr.getStatistics());
 
             if (node.isOnePhaseAgg() || node.isMergedLocalAgg() || node.getType().isDistinctGlobal()) {
-                if (optExpr.getLogicalProperty().oneTabletProperty().supportOneTabletOpt) {
-                    clearOlapScanNodePartitions(aggregationNode);
-                }
                 // For ScanNode->LocalShuffle->AggNode, we needn't assign scan ranges per driver sequence.
                 inputFragment.setAssignScanRangesPerDriverSeq(!withLocalShuffle);
                 aggregationNode.setWithLocalShuffle(withLocalShuffle);
@@ -2413,10 +2393,6 @@ public class PlanFragmentBuilder {
             if (root instanceof SortNode) {
                 SortNode sortNode = (SortNode) root;
                 sortNode.setAnalyticPartitionExprs(analyticEvalNode.getPartitionExprs());
-            }
-
-            if (optExpr.getLogicalProperty().oneTabletProperty().supportOneTabletOpt) {
-                clearOlapScanNodePartitions(analyticEvalNode);
             }
 
             inputFragment.setPlanRoot(analyticEvalNode);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithCaseWhenTest.java
@@ -97,9 +97,6 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
-                                "     LocalShuffleColumns:\n" +
-                                "     - 1: region\n" +
-                                "     - 2: order_date\n" +
                                 "     cardinality: 1",
                 },
                 {"select * from test.t0 where \n" +
@@ -193,9 +190,6 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
-                                "     LocalShuffleColumns:\n" +
-                                "     - 1: region\n" +
-                                "     - 2: order_date\n" +
                                 "     cardinality: 1",
                 },
 
@@ -352,9 +346,6 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
-                                "     LocalShuffleColumns:\n" +
-                                "     - 1: region\n" +
-                                "     - 2: order_date\n" +
                                 "     cardinality: 1",
                 },
                 // Q21
@@ -434,9 +425,6 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
-                                "     LocalShuffleColumns:\n" +
-                                "     - 1: region\n" +
-                                "     - 2: order_date\n" +
                                 "     cardinality: 1"},
                 {"in ('A','B','C','D','E','F')",
                         "  0:OlapScanNode\n" +
@@ -445,9 +433,6 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
-                                "     LocalShuffleColumns:\n" +
-                                "     - 1: region\n" +
-                                "     - 2: order_date\n" +
                                 "     cardinality: 1"},
                 {"not in ('A','B')",
                         "(4: ship_mode < 80) OR (4: ship_mode >= 90), [4: ship_mode, INT, false] < 90, " +
@@ -469,9 +454,6 @@ public class SelectStmtWithCaseWhenTest {
                                 "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                                 "     tabletList=\n" +
                                 "     actualRows=0, avgRowSize=4.0\n" +
-                                "     LocalShuffleColumns:\n" +
-                                "     - 1: region\n" +
-                                "     - 2: order_date\n" +
                                 "     cardinality: 1"},
         };
         for (String[] tc : testCases) {
@@ -500,9 +482,6 @@ public class SelectStmtWithCaseWhenTest {
                         "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                         "     tabletList=\n" +
                         "     actualRows=0, avgRowSize=4.0\n" +
-                        "     LocalShuffleColumns:\n" +
-                        "     - 1: region\n" +
-                        "     - 2: order_date\n" +
                         "     cardinality: 1"},
                 {"select * from test.t0 where if(region='USA', 1, 0) in (1)",
                         "[1: region, VARCHAR, false] = 'USA', 1: region = 'USA' IS NOT NULL"},
@@ -512,9 +491,6 @@ public class SelectStmtWithCaseWhenTest {
                         "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                         "     tabletList=\n" +
                         "     actualRows=0, avgRowSize=4.0\n" +
-                        "     LocalShuffleColumns:\n" +
-                        "     - 1: region\n" +
-                        "     - 2: order_date\n" +
                         "     cardinality: 1\n"},
                 {"select * from test.t0 where if(region='USA', 1, 0) in (2,3)", "0:EMPTYSET"},
                 {"select * from test.t0 where if(region='USA', 1, 0) not in (0)",
@@ -526,9 +502,6 @@ public class SelectStmtWithCaseWhenTest {
                         "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                         "     tabletList=\n" +
                         "     actualRows=0, avgRowSize=4.0\n" +
-                        "     LocalShuffleColumns:\n" +
-                        "     - 1: region\n" +
-                        "     - 2: order_date\n" +
                         "     cardinality: 1\n"},
                 {"select * from test.t0 where if(region='USA', 1, 0) is NULL", "0:EMPTYSET"},
                 {"select * from test.t0 where if(region='USA', 1, 0) is NOT NULL", "  0:OlapScanNode\n" +
@@ -537,9 +510,6 @@ public class SelectStmtWithCaseWhenTest {
                         "     partitionsRatio=0/3, tabletsRatio=0/0\n" +
                         "     tabletList=\n" +
                         "     actualRows=0, avgRowSize=4.0\n" +
-                        "     LocalShuffleColumns:\n" +
-                        "     - 1: region\n" +
-                        "     - 2: order_date\n" +
                         "     cardinality: 1\n"},
                 // Q14
                 {"select * from test.t0 where nullif('China', region) = 'China'",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1452,7 +1452,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         // lineorder_new_l contains more than one tablet.
         sql = "select count(P_TYPE), LO_ORDERKEY from lineorder_new_l group by LO_ORDERKEY";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "     LocalShuffleColumns:\n" +
+        assertNotContains(plan, "     LocalShuffleColumns:\n" +
                 "     - 1: LO_ORDERKEY");
         assertContains(plan, "  1:AGGREGATE (update finalize)");
         assertContains(plan, "  0:OlapScanNode");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -904,8 +904,6 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
                     "     tabletList=" + tabletIdsStrList.get(1) + "\n" +
                     "     actualRows=0, avgRowSize=4.0\n" +
-                    "     LocalShuffleColumns:\n" +
-                    "     - 5: v4\n" +
                     "     cardinality: 360000\n" +
                     "     probe runtime filters:\n" +
                     "     - filter_id = 0, probe_expr = (5: v4 + 2)");
@@ -916,8 +914,6 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
                     "     tabletList=" + tabletIdsStrList.get(0) + "\n" +
                     "     actualRows=0, avgRowSize=4.0\n" +
-                    "     LocalShuffleColumns:\n" +
-                    "     - 1: v1\n" +
                     "     cardinality: 360000\n" +
                     "     probe runtime filters:\n" +
                     "     - filter_id = 0, probe_expr = (1: v1 + 1)");
@@ -1043,8 +1039,6 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "     partitionsRatio=1/1, tabletsRatio=3/3\n" +
                 "     tabletList=" + tabletIdsStrList.get(0) + "\n" +
                 "     actualRows=0, avgRowSize=1.0\n" +
-                "     LocalShuffleColumns:\n" +
-                "     - 1: v4\n" +
                 "     cardinality: 400000");
 
         assertContains(plan, "  5:EXCHANGE\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1622,7 +1622,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             sql = "select sum(v1) from colocate_t0 group by v1";
             execPlan = getExecPlan(sql);
             olapScanNode = (OlapScanNode) execPlan.getScanNodes().get(0);
-            Assert.assertEquals(1, olapScanNode.getBucketExprs().size());
+            Assert.assertEquals(0, olapScanNode.getBucketExprs().size());
             Assert.assertTrue(containAnyColocateNode(execPlan.getFragments().get(1).getPlanRoot()));
             plan = execPlan.getExplainString(TExplainLevel.NORMAL);
             assertContains(plan, "1:AGGREGATE (update finalize)\n" +


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
To avoid duplicate local shuffles in a fragment instance, we need use bucket columns of `OlapScanNode` as local shuffle keys.
However, it's hard to determine the actual local shuffle keys by BE itself due to column pruned, if we use bucket columns as local shuffle keys.

Therefore, we temporarily disable using bucket keys as local shuffle keys.
In the future, we could determine local shuffle keys by FE to make local shuffle use bucket columns of OlapScanNode.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
