### PR TITLE
[BugFix] Return script execution output as ResultSet

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -994,8 +994,14 @@ public class StmtExecutor {
         ExecuteAsExecutor.execute((ExecuteAsStmt) parsedStmt, context);
     }
 
-    private void handleExecScriptStmt() throws PrivilegeException, UserException {
-        ExecuteScriptExecutor.execute((ExecuteScriptStmt) parsedStmt, context);
+    private void handleExecScriptStmt() throws IOException, UserException {
+        ShowResultSet resultSet = ExecuteScriptExecutor.execute((ExecuteScriptStmt) parsedStmt, context);
+        if (isProxy) {
+            proxyResultSet = resultSet;
+            context.getState().setEof();
+            return;
+        }
+        sendShowResult(resultSet);
     }
 
     private void handleSetRole() throws PrivilegeException, UserException {

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -999,7 +999,18 @@ public class PseudoBackend {
 
         @Override
         public Future<ExecuteCommandResultPB> executeCommandAsync(ExecuteCommandRequestPB request) {
-            throw new org.apache.commons.lang3.NotImplementedException("TODO");
+            ExecuteCommandResultPB result = new ExecuteCommandResultPB();
+            StatusPB pStatus = new StatusPB();
+            pStatus.statusCode = 0;
+            result.status = pStatus;
+            if (request.command.equals("execute_script")) {
+                result.result = "dummy result";
+            } else if (request.command.equals("set_config")) {
+                result.result = "";
+            } else {
+                throw new org.apache.commons.lang3.NotImplementedException("TODO");
+            }
+            return CompletableFuture.completedFuture(result);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ExecuteScriptTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ExecuteScriptTest.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.pseudocluster.PseudoCluster;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class ExecuteScriptTest {
+    @BeforeClass
+    public static void setUp() throws Exception {
+        PseudoCluster.getOrCreateWithRandomPort(true, 3);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        PseudoCluster.getInstance().shutdown(true);
+    }
+
+    @Test
+    public void testFEScript() throws Exception {
+        Connection connection = PseudoCluster.getInstance().getQueryConnection();
+        Statement stmt = connection.createStatement();
+        try {
+            Assert.assertTrue(stmt.execute("admin execute on frontend 'out.append(\"aaa\\\\nbbb\")'"));
+            ResultSet result = stmt.getResultSet();
+            Assert.assertTrue(result.next());
+            Assert.assertEquals("aaa", result.getString(1));
+            Assert.assertTrue(result.next());
+            Assert.assertEquals("bbb", result.getString(1));
+            Assert.assertFalse(result.next());
+        } finally {
+            stmt.close();
+            connection.close();
+        }
+    }
+
+    @Test
+    public void testBEScript() throws Exception {
+        Connection connection = PseudoCluster.getInstance().getQueryConnection();
+        Statement stmt = connection.createStatement();
+        try {
+            Assert.assertTrue(stmt.execute("admin execute on 10001 'System.print(\"aaa\")'"));
+            ResultSet result = stmt.getResultSet();
+            Assert.assertTrue(result.next());
+        } finally {
+            stmt.close();
+            connection.close();
+        }
+    }
+
+}


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #23044

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Script execution result only shows in MySQL client cli, not showing in GUI client(GUI client only shows resultset, not showing info message. This PR splits script output to lines and makes those as ResultSet, so GUI clients cant show them correctly.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
