### PR TITLE
[Enhancement] disable preload partial update data when tracker out of limit

### DIFF
--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -144,7 +144,7 @@ private:
                                    std::vector<ChunkIteratorPtr>& update_iterators, std::vector<uint32_t>& rowids,
                                    Chunk* result_chunk);
 
-    void _check_if_preload_column_mode_update_data(Rowset* rowset, MemTracker* update_mem_tracker);
+    void _check_if_preload_column_mode_update_data(Rowset* rowset);
 
 private:
     int64_t _tablet_id = 0;
@@ -155,8 +155,10 @@ private:
     // cache chunks read from update segment files
     std::vector<ChunkPtr> _update_chunk_cache;
     // total memory usage in current state.
-    // it will not record the temp memory usage.
+    // it will not record the temp memory usage and update chunk cache's memory
     size_t _memory_usage = 0;
+    // memory usage in update chunk cache
+    size_t _update_chunk_cache_memory_usage = 0;
 
     // maintain the reference from rowids in segment files been updated to rowids in update files.
     std::vector<ColumnPartialUpdateState> _partial_update_states;
@@ -170,6 +172,8 @@ private:
 
     // if need to pre load update data from rowset
     bool _enable_preload_column_mode_update_data = false;
+
+    MemTracker* _update_mem_tracker = nullptr;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetColumnUpdateState& o) {

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -49,7 +49,7 @@ UpdateManager::UpdateManager(MemTracker* mem_tracker)
     _index_cache_mem_tracker = std::make_unique<MemTracker>(-1, "index_cache", mem_tracker);
     _del_vec_cache_mem_tracker = std::make_unique<MemTracker>(-1, "del_vec_cache", mem_tracker);
     _compaction_state_mem_tracker = std::make_unique<MemTracker>(-1, "compaction_state", mem_tracker);
-    _delta_column_group_cache_mem_tracker = std::make_unique<MemTracker>(-1, "delta_column_group_cache");
+    _delta_column_group_cache_mem_tracker = std::make_unique<MemTracker>(-1, "delta_column_group_cache", mem_tracker);
 
     _index_cache.set_mem_tracker(_index_cache_mem_tracker.get());
     _update_state_cache.set_mem_tracker(_update_state_mem_tracker.get());


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #20436

## Problem Summary(Required):
Currently, we will check if current update's mem tracker is out of limit at the beginning of update state load, but it isn't enough, because when multi updates run concurrently, this check wouldn't work.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
