### PR TITLE
[BugFix] Fix using wrong parquet column chunk index in dict filter

### DIFF
--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -186,7 +186,10 @@ public:
     }
 
     Status get_dict_values(Column* column) override {
-        [[maybe_unused]] auto ret = column->append_strings_overflow(_dict, _max_value_length);
+        auto ret = column->append_strings_overflow(_dict, _max_value_length);
+        if (UNLIKELY(!ret)) {
+            return Status::InternalError("DictDecoder append strings to column failed");
+        }
         return Status::OK();
     }
 
@@ -195,7 +198,10 @@ public:
         for (size_t i = 0; i < dict_codes.size(); i++) {
             slices[i] = _dict[dict_codes[i]];
         }
-        [[maybe_unused]] auto ret = column->append_strings_overflow(slices, _max_value_length);
+        auto ret = column->append_strings_overflow(slices, _max_value_length);
+        if (UNLIKELY(!ret)) {
+            return Status::InternalError("DictDecoder append strings to column failed");
+        }
         return Status::OK();
     }
 
@@ -231,7 +237,10 @@ public:
 
         switch (content_type) {
         case DICT_CODE: {
-            [[maybe_unused]] auto ret = dst->append_numbers(&_indexes[0], count * SIZE_OF_DICT_CODE_TYPE);
+            auto ret = dst->append_numbers(&_indexes[0], count * SIZE_OF_DICT_CODE_TYPE);
+            if (UNLIKELY(!ret)) {
+                return Status::InternalError("DictDecoder append numbers to column failed");
+            }
             DCHECK(ret) << "append_numbers failed";
             break;
         }
@@ -240,8 +249,10 @@ public:
             for (int i = 0; i < count; ++i) {
                 _slices[i] = _dict[_indexes[i]];
             }
-            [[maybe_unused]] auto ret = dst->append_strings_overflow(_slices, _max_value_length);
-            DCHECK(ret) << "append_strings_overflow failed";
+            auto ret = dst->append_strings_overflow(_slices, _max_value_length);
+            if (UNLIKELY(!ret)) {
+                return Status::InternalError("DictDecoder append strings to column failed");
+            }
             break;
         }
         default:

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -185,7 +185,10 @@ public:
             return Status::InternalError(strings::Substitute(
                     "going to read out-of-bounds data, offset=$0,count=$1,size=$2", _offset, count, _data.size));
         }
-        [[maybe_unused]] auto ret = dst->append_strings(slices);
+        auto ret = dst->append_strings(slices);
+        if (UNLIKELY(!ret)) {
+            return Status::InternalError("PlainDecoder append strings to column failed");
+        }
         return Status::OK();
     }
 
@@ -376,8 +379,10 @@ public:
             return Status::InternalError(strings::Substitute(
                     "going to read out-of-bounds data, offset=$0,count=$1,size=$2", _offset, count, _data.size));
         }
-        [[maybe_unused]] auto ret =
-                dst->append_continuous_fixed_length_strings(_data.data + _offset, count, _type_length);
+        auto ret = dst->append_continuous_fixed_length_strings(_data.data + _offset, count, _type_length);
+        if (UNLIKELY(!ret)) {
+            return Status::InternalError("FLBAPlainDecoder append strings to column failed");
+        }
         _offset += count * _type_length;
         return Status::OK();
     }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -184,7 +184,8 @@ Status GroupReader::_init_column_readers() {
 
 Status GroupReader::_create_column_reader(const GroupReaderParam::Column& column) {
     std::unique_ptr<ColumnReader> column_reader = nullptr;
-    const auto* schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.col_idx_in_parquet);
+    const auto* schema_node =
+            _param.file_metadata->schema().get_stored_column_by_field_idx(column.field_idx_in_parquet);
     {
         SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
         if (column.t_iceberg_schema_field == nullptr) {
@@ -198,7 +199,7 @@ Status GroupReader::_create_column_reader(const GroupReaderParam::Column& column
         if (column.col_type_in_chunk.is_complex_type()) {
             // For complex type columns, we need parse def & rep levels.
             // For OptionalColumnReader, by default, we will not parse it's def level for performance. But if
-            // column is complex type, we have to parse def level to calculate nullability.
+            // column is a complex type, we have to parse def level to calculate nullability.
             column_reader->set_need_parse_levels(true);
         }
     }
@@ -214,7 +215,8 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     for (auto& column : _param.read_cols) {
         int chunk_index = column.col_idx_in_chunk;
         SlotId slot_id = column.slot_id;
-        const auto* parquet_field = _param.file_metadata->schema().get_stored_column_by_field_idx(column.col_idx_in_parquet);
+        const auto* parquet_field =
+                _param.file_metadata->schema().get_stored_column_by_field_idx(column.field_idx_in_parquet);
         DCHECK(parquet_field != nullptr);
         const tparquet::ColumnMetaData& column_metadata =
                 _row_group_metadata->columns[parquet_field->physical_column_index].meta_data;
@@ -256,7 +258,7 @@ ChunkPtr GroupReader::_create_read_chunk(const std::vector<int>& column_indices)
 void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset) {
     int64_t end = 0;
     for (const auto& column : _param.read_cols) {
-        auto schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.col_idx_in_parquet);
+        auto schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.field_idx_in_parquet);
         _collect_field_io_range(*schema_node, ranges, &end);
     }
     *end_offset = end;

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -184,7 +184,7 @@ Status GroupReader::_init_column_readers() {
 
 Status GroupReader::_create_column_reader(const GroupReaderParam::Column& column) {
     std::unique_ptr<ColumnReader> column_reader = nullptr;
-    const auto* schema_node = _param.file_metadata->schema().get_stored_column_by_idx(column.col_idx_in_parquet);
+    const auto* schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.col_idx_in_parquet);
     {
         SCOPED_RAW_TIMER(&_param.stats->column_reader_init_ns);
         if (column.t_iceberg_schema_field == nullptr) {
@@ -198,7 +198,7 @@ Status GroupReader::_create_column_reader(const GroupReaderParam::Column& column
         if (column.col_type_in_chunk.is_complex_type()) {
             // For complex type columns, we need parse def & rep levels.
             // For OptionalColumnReader, by default, we will not parse it's def level for performance. But if
-            // column is complex type, we have to parse def level to calculate nullbility.
+            // column is complex type, we have to parse def level to calculate nullability.
             column_reader->set_need_parse_levels(true);
         }
     }
@@ -214,8 +214,10 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
     for (auto& column : _param.read_cols) {
         int chunk_index = column.col_idx_in_chunk;
         SlotId slot_id = column.slot_id;
+        const auto* parquet_field = _param.file_metadata->schema().get_stored_column_by_field_idx(column.col_idx_in_parquet);
+        DCHECK(parquet_field != nullptr);
         const tparquet::ColumnMetaData& column_metadata =
-                _row_group_metadata->columns[column.col_idx_in_parquet].meta_data;
+                _row_group_metadata->columns[parquet_field->physical_column_index].meta_data;
         if (_can_use_as_dict_filter_column(slots[chunk_index], conjunct_ctxs_by_slot, column_metadata)) {
             _dict_filter_ctx.use_as_dict_filter_column(read_col_idx, slot_id, conjunct_ctxs_by_slot.at(slot_id));
             _active_column_indices.emplace_back(read_col_idx);
@@ -254,7 +256,7 @@ ChunkPtr GroupReader::_create_read_chunk(const std::vector<int>& column_indices)
 void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset) {
     int64_t end = 0;
     for (const auto& column : _param.read_cols) {
-        auto schema_node = _param.file_metadata->schema().get_stored_column_by_idx(column.col_idx_in_parquet);
+        auto schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.col_idx_in_parquet);
         _collect_field_io_range(*schema_node, ranges, &end);
     }
     *end_offset = end;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -34,8 +34,8 @@ namespace starrocks::parquet {
 
 struct GroupReaderParam {
     struct Column {
-        // column index in parquet file
-        int32_t col_idx_in_parquet;
+        // parquet field index in root node's children
+        int32_t field_idx_in_parquet;
 
         // column index in chunk
         int32_t col_idx_in_chunk;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -35,10 +35,10 @@ namespace starrocks::parquet {
 struct GroupReaderParam {
     struct Column {
         // column index in parquet file
-        int col_idx_in_parquet;
+        int32_t col_idx_in_parquet;
 
         // column index in chunk
-        int col_idx_in_chunk;
+        int32_t col_idx_in_chunk;
 
         // column type in parquet file
         tparquet::Type::type col_type_in_parquet;
@@ -133,8 +133,6 @@ private:
 
     Status _read(const std::vector<int>& read_columns, size_t* row_count, ChunkPtr* chunk);
     Status _lazy_skip_rows(const std::vector<int>& read_columns, const ChunkPtr& chunk, size_t chunk_size);
-    void _dict_filter(ChunkPtr* chunk, Filter* filter_ptr);
-    Status _dict_decode(ChunkPtr* chunk);
     void _collect_field_io_range(const ParquetField& field, std::vector<io::SharedBufferedInputStream::IORange>* ranges,
                                  int64_t* end_offset);
 

--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -21,7 +21,7 @@ namespace starrocks::parquet {
 void ParquetMetaHelper::set_existed_column_names(std::unordered_set<std::string>* names) const {
     names->clear();
     for (size_t i = 0; i < _file_metadata->schema().get_fields_size(); i++) {
-        names->emplace(_file_metadata->schema().get_stored_column_by_idx(i)->name);
+        names->emplace(_file_metadata->schema().get_stored_column_by_field_idx(i)->name);
     }
 }
 
@@ -50,13 +50,13 @@ void ParquetMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
                                              std::vector<GroupReaderParam::Column>& read_cols,
                                              bool& _is_only_partition_scan) const {
     for (auto& materialized_column : materialized_columns) {
-        int32_t field_index = _file_metadata->schema().get_field_pos_by_column_name(materialized_column.col_name);
+        int32_t field_idx = _file_metadata->schema().get_field_idx_by_column_name(materialized_column.col_name);
+        if (field_idx < 0) continue;
 
-        if (field_index < 0) continue;
-
-        auto parquet_type = _file_metadata->schema().get_stored_column_by_idx(field_index)->physical_type;
-        GroupReaderParam::Column column = _build_column(field_index, materialized_column.col_idx, parquet_type,
-                                                        materialized_column.col_type, materialized_column.slot_id);
+        auto parquet_type = _file_metadata->schema().get_stored_column_by_field_idx(field_idx)->physical_type;
+        GroupReaderParam::Column column =
+                _build_column(field_idx, materialized_column.col_idx, parquet_type,
+                              materialized_column.col_type, materialized_column.slot_id);
         read_cols.emplace_back(column);
     }
     _is_only_partition_scan = read_cols.empty();
@@ -81,7 +81,7 @@ void IcebergMetaHelper::build_column_name_2_pos_in_meta(
         const std::vector<SlotDescriptor*>& slots) const {
     // Key is field name, value is unique iceberg field id.
     std::unordered_map<std::string, int32_t> column_name_2_field_id{};
-    for (auto each : _t_iceberg_schema->fields) {
+    for (const auto& each : _t_iceberg_schema->fields) {
         const std::string& format_field_name = _case_sensitive ? each.name : boost::algorithm::to_lower_copy(each.name);
         column_name_2_field_id.emplace(format_field_name, each.field_id);
     }
@@ -95,7 +95,7 @@ void IcebergMetaHelper::build_column_name_2_pos_in_meta(
         }
         // Put SlotDescriptor's origin column name here!
         column_name_2_pos_in_meta.emplace(slot->col_name(),
-                                          _file_metadata->schema().get_field_pos_by_field_id(it->second));
+                                          _file_metadata->schema().get_field_idx_by_field_id(it->second));
     }
 }
 
@@ -121,16 +121,14 @@ void IcebergMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
 
         int32_t field_id = iceberg_it->second->field_id;
 
-        int32_t field_pos = _file_metadata->schema().get_field_pos_by_field_id(field_id);
-        if (field_pos < 0) {
-            continue;
-        }
+        int32_t field_idx = _file_metadata->schema().get_field_idx_by_field_id(field_id);
+        if (field_idx < 0) continue;
 
         auto parquet_type = _file_metadata->schema().get_stored_column_by_field_id(field_id)->physical_type;
 
         GroupReaderParam::Column column =
-                _build_column(field_pos, materialized_column.col_idx, parquet_type, materialized_column.col_type,
-                              materialized_column.slot_id, iceberg_it->second);
+                _build_column(field_idx, materialized_column.col_idx, parquet_type,
+                              materialized_column.col_type, materialized_column.slot_id, iceberg_it->second);
         read_cols.emplace_back(column);
     }
     _is_only_partition_scan = read_cols.empty();

--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -54,9 +54,8 @@ void ParquetMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
         if (field_idx < 0) continue;
 
         auto parquet_type = _file_metadata->schema().get_stored_column_by_field_idx(field_idx)->physical_type;
-        GroupReaderParam::Column column =
-                _build_column(field_idx, materialized_column.col_idx, parquet_type,
-                              materialized_column.col_type, materialized_column.slot_id);
+        GroupReaderParam::Column column = _build_column(field_idx, materialized_column.col_idx, parquet_type,
+                                                        materialized_column.col_type, materialized_column.slot_id);
         read_cols.emplace_back(column);
     }
     _is_only_partition_scan = read_cols.empty();
@@ -127,8 +126,8 @@ void IcebergMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
         auto parquet_type = _file_metadata->schema().get_stored_column_by_field_id(field_id)->physical_type;
 
         GroupReaderParam::Column column =
-                _build_column(field_idx, materialized_column.col_idx, parquet_type,
-                              materialized_column.col_type, materialized_column.slot_id, iceberg_it->second);
+                _build_column(field_idx, materialized_column.col_idx, parquet_type, materialized_column.col_type,
+                              materialized_column.slot_id, iceberg_it->second);
         read_cols.emplace_back(column);
     }
     _is_only_partition_scan = read_cols.empty();

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -68,12 +68,12 @@ public:
     }
 
 protected:
-    GroupReaderParam::Column _build_column(int32_t col_idx_in_parquet, int32_t col_idx_in_chunk,
+    GroupReaderParam::Column _build_column(int32_t field_idx_in_parquet, int32_t col_idx_in_chunk,
                                            const tparquet::Type::type& col_type_in_parquet,
                                            const TypeDescriptor& col_type_in_chunk, const SlotId& slot_id,
                                            const TIcebergSchemaField* t_iceberg_schema_field = nullptr) const {
         GroupReaderParam::Column column{};
-        column.col_idx_in_parquet = col_idx_in_parquet;
+        column.field_idx_in_parquet = field_idx_in_parquet;
         column.col_idx_in_chunk = col_idx_in_chunk;
         column.col_type_in_parquet = col_type_in_parquet;
         column.col_type_in_chunk = col_type_in_chunk;

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -64,11 +64,11 @@ public:
         if (it == column_name_2_pos_in_meta.end()) {
             return nullptr;
         }
-        return _file_metadata->schema().get_stored_column_by_idx(it->second);
+        return _file_metadata->schema().get_stored_column_by_field_idx(it->second);
     }
 
 protected:
-    GroupReaderParam::Column _build_column(int col_idx_in_parquet, int col_idx_in_chunk,
+    GroupReaderParam::Column _build_column(int32_t col_idx_in_parquet, int32_t col_idx_in_chunk,
                                            const tparquet::Type::type& col_type_in_parquet,
                                            const TypeDescriptor& col_type_in_chunk, const SlotId& slot_id,
                                            const TIcebergSchemaField* t_iceberg_schema_field = nullptr) const {
@@ -89,7 +89,7 @@ protected:
 class ParquetMetaHelper : public MetaHelper {
 public:
     ParquetMetaHelper(std::shared_ptr<FileMetaData> file_metadata, bool case_sensitive) {
-        _file_metadata = file_metadata;
+        _file_metadata = std::move(file_metadata);
         _case_sensitive = case_sensitive;
     }
     ~ParquetMetaHelper() override = default;
@@ -109,7 +109,7 @@ class IcebergMetaHelper : public MetaHelper {
 public:
     IcebergMetaHelper(std::shared_ptr<FileMetaData> file_metadata, bool case_sensitive,
                       const TIcebergSchema* t_iceberg_schema) {
-        _file_metadata = file_metadata;
+        _file_metadata = std::move(file_metadata);
         _case_sensitive = case_sensitive;
         _t_iceberg_schema = t_iceberg_schema;
         DCHECK(_t_iceberg_schema != nullptr);

--- a/be/src/formats/parquet/schema.h
+++ b/be/src/formats/parquet/schema.h
@@ -84,14 +84,14 @@ public:
     std::string debug_string() const;
 
     const bool exist_filed_id() const { return _exist_field_id; }
-    const int32_t get_field_pos_by_column_name(const std::string& column_name) const;
-    const int32_t get_field_pos_by_field_id(int32_t field_id) const;
-    const ParquetField* get_stored_column_by_idx(size_t idx) const { return &_fields[idx]; }
+    const int32_t get_field_idx_by_column_name(const std::string& column_name) const;
+    const int32_t get_field_idx_by_field_id(int32_t field_id) const;
+    const ParquetField* get_stored_column_by_field_idx(size_t field_idx) const { return &_fields[field_idx]; }
     const ParquetField* get_stored_column_by_field_id(int32_t field_id) const;
     const ParquetField* get_stored_column_by_column_name(const std::string& column_name) const;
     const size_t get_fields_size() const { return _fields.size(); }
     const bool contain_field_id(int32_t field_id) const {
-        return _field_id_2_field_pos.find(field_id) != _field_id_2_field_pos.end();
+        return _field_id_2_field_idx.find(field_id) != _field_id_2_field_idx.end();
     }
 
 private:
@@ -115,22 +115,14 @@ private:
 
     std::vector<ParquetField> _fields;
     std::vector<ParquetField*> _physical_fields;
-    // Parquet filed name(formatted with case sensitive) mapping to field position in schema.
-    std::unordered_map<std::string, size_t> _formatted_column_name_2_field_pos;
+    // Parquet filed name(formatted with case-sensitive) mapping to field position in schema.
+    std::unordered_map<std::string, size_t> _formatted_column_name_2_field_idx;
     // Parquet unique field id mapping to field position in schema.
-    std::unordered_map<int32_t, size_t> _field_id_2_field_pos;
+    std::unordered_map<int32_t, size_t> _field_id_2_field_idx;
 
     // Not every parquet file contains field id, if field id not existed, we should not read it with iceberg schema.
     bool _exist_field_id = false;
     bool _case_sensitive = false;
-};
-
-template <typename T>
-class ColumnStats {
-public:
-private:
-    T _min_value;
-    T _max_value;
 };
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -317,7 +317,7 @@ Status GroupReaderTest::_create_filemeta(FileMetaData** file_meta, GroupReaderPa
 static GroupReaderParam::Column _create_group_reader_param_of_column(int idx, tparquet::Type::type par_type,
                                                                      LogicalType prim_type) {
     GroupReaderParam::Column c;
-    c.col_idx_in_parquet = idx;
+    c.field_idx_in_parquet = idx;
     c.col_idx_in_chunk = idx;
     c.col_type_in_parquet = par_type;
     c.col_type_in_chunk = TypeDescriptor::from_logical_type(prim_type);

--- a/be/test/formats/parquet/parquet_schema_test.cpp
+++ b/be/test/formats/parquet/parquet_schema_test.cpp
@@ -80,9 +80,9 @@ TEST_F(ParquetSchemaTest, OnlyLeafType) {
     ASSERT_TRUE(st.ok());
 
     {
-        auto idx = desc.get_field_pos_by_column_name("col1");
+        auto idx = desc.get_field_idx_by_column_name("col1");
         ASSERT_EQ(0, idx);
-        auto field = desc.get_stored_column_by_idx(0);
+        auto field = desc.get_stored_column_by_field_idx(0);
         ASSERT_STREQ("col1", field->name.c_str());
         ASSERT_EQ(0, field->physical_column_index);
         ASSERT_EQ(1, field->max_def_level());
@@ -91,9 +91,9 @@ TEST_F(ParquetSchemaTest, OnlyLeafType) {
     }
 
     {
-        auto idx = desc.get_field_pos_by_column_name("col2");
+        auto idx = desc.get_field_idx_by_column_name("col2");
         ASSERT_EQ(1, idx);
-        auto field = desc.get_stored_column_by_idx(1);
+        auto field = desc.get_stored_column_by_field_idx(1);
         ASSERT_STREQ("col2", field->name.c_str());
         ASSERT_EQ(1, field->physical_column_index);
         ASSERT_EQ(0, field->max_def_level());


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool



We should not use `col_idx_in_parquet` to get ColumnChunkMetaData in `GroupReader::_process_columns_and_conjunct_ctxs()`, otherwise dictionary filter will use the wrong ColumnChunk metadata when the parquet schema contains complex types.

In this pr, I do the following two things:
* Using the correct index to get ColumnChunk metadata.
* Add some defense code in the parquet decoder.
* Refactor some function names.

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
