### PR TITLE
[Feature] support mv resource group.

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -179,11 +179,13 @@ Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams&
     }
 
     WorkGroupPtr wg = nullptr;
-    if (request.common().__isset.workgroup && request.common().workgroup.id != WorkGroup::DEFAULT_WG_ID) {
+    if (!request.common().__isset.workgroup || request.common().workgroup.id == WorkGroup::DEFAULT_WG_ID) {
+        wg = WorkGroupManager::instance()->get_default_workgroup();
+    } else if (request.common().workgroup.id == WorkGroup::DEFAULT_MV_WG_ID) {
+        wg = WorkGroupManager::instance()->get_default_mv_workgroup();
+    } else {
         wg = std::make_shared<WorkGroup>(request.common().workgroup);
         wg = WorkGroupManager::instance()->add_workgroup(wg);
-    } else {
-        wg = WorkGroupManager::instance()->get_default_workgroup();
     }
     DCHECK(wg != nullptr);
     RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get()));

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -403,6 +403,13 @@ WorkGroupPtr WorkGroupManager::get_default_workgroup() {
     return _workgroups[unique_id];
 }
 
+WorkGroupPtr WorkGroupManager::get_default_mv_workgroup() {
+    std::shared_lock read_lock(_mutex);
+    auto unique_id = WorkGroup::create_unique_id(WorkGroup::DEFAULT_MV_VERSION, WorkGroup::DEFAULT_MV_WG_ID);
+    DCHECK(_workgroups.count(unique_id));
+    return _workgroups[unique_id];
+}
+
 void WorkGroupManager::apply(const std::vector<TWorkGroupOp>& ops) {
     std::unique_lock write_lock(_mutex);
 
@@ -545,6 +552,13 @@ DefaultWorkGroupInitialization::DefaultWorkGroupInitialization() {
     auto default_wg = std::make_shared<WorkGroup>("default_wg", WorkGroup::DEFAULT_WG_ID, WorkGroup::DEFAULT_VERSION,
                                                   cpu_limit, memory_limit, 0, WorkGroupType::WG_DEFAULT);
     WorkGroupManager::instance()->add_workgroup(default_wg);
+
+    int64_t mv_cpu_limit = 1;
+    double mv_memory_limit = 0.8;
+    auto default_mv_wg =
+            std::make_shared<WorkGroup>("default_mv_wg", WorkGroup::DEFAULT_MV_WG_ID, WorkGroup::DEFAULT_MV_VERSION,
+                                        mv_cpu_limit, mv_memory_limit, 0, WorkGroupType::WG_MV);
+    WorkGroupManager::instance()->add_workgroup(default_mv_wg);
 }
 
 } // namespace starrocks::workgroup

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -195,7 +195,9 @@ public:
     int64_t big_query_scan_rows_limit() const { return _big_query_scan_rows_limit; }
 
     static constexpr int64 DEFAULT_WG_ID = 0;
+    static constexpr int64 DEFAULT_MV_WG_ID = 1;
     static constexpr int64 DEFAULT_VERSION = 0;
+    static constexpr int64 DEFAULT_MV_VERSION = 1;
 
 private:
     static constexpr double ABSENT_MEMORY_LIMIT = -1;
@@ -244,6 +246,8 @@ public:
     WorkGroupPtr add_workgroup(const WorkGroupPtr& wg);
     // return reserved beforehand default workgroup for query is not bound to any workgroup
     WorkGroupPtr get_default_workgroup();
+    // return reserved beforehand default mv workgroup for MV query is not bound to any workgroup
+    WorkGroupPtr get_default_mv_workgroup();
     // destruct workgroups
     void destroy();
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -131,6 +131,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTabletType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -405,6 +406,11 @@ public class AlterJobMgr {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {
             partitionRefreshNumber = PropertyAnalyzer.analyzePartitionRefreshNumber(properties);
         }
+        String resourceGroup = null;
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)) {
+            resourceGroup = PropertyAnalyzer.analyzeResourceGroup(properties);
+            properties.remove(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP);
+        }
         int autoRefreshPartitionsLimit = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)) {
             autoRefreshPartitionsLimit = PropertyAnalyzer.analyzeAutoRefreshPartitionsLimit(properties, materializedView);
@@ -464,6 +470,11 @@ public class AlterJobMgr {
                 materializedView.getTableProperty().getAutoRefreshPartitionsLimit() != autoRefreshPartitionsLimit) {
             curProp.put(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT, String.valueOf(autoRefreshPartitionsLimit));
             materializedView.getTableProperty().setAutoRefreshPartitionsLimit(autoRefreshPartitionsLimit);
+            isChanged = true;
+        } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP) &&
+                !StringUtils.equals(materializedView.getTableProperty().getResourceGroup(), resourceGroup)) {
+            curProp.put(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP, resourceGroup);
+            materializedView.getTableProperty().setResourceGroup(resourceGroup);
             isChanged = true;
         }
         if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -956,6 +956,12 @@ public class MaterializedView extends OlapTable implements GsonPostProcessable {
             sb.append(colocateGroup).append("\"");
         }
 
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)) {
+            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(
+                    PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP).append("\" = \"");
+            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)).append("\"");
+        }
+
         appendUniqueProperties(sb);
 
         sb.append("\n)");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -46,6 +46,9 @@ public class ResourceGroup implements Writable {
     public static final String BIG_QUERY_CPU_SECOND_LIMIT = "big_query_cpu_second_limit";
     public static final String CONCURRENCY_LIMIT = "concurrency_limit";
     public static final String DEFAULT_RESOURCE_GROUP_NAME = "default_wg";
+    public static final String DEFAULT_MV_RESOURCE_GROUP_NAME = "default_mv_wg";
+    public static final long DEFAULT_MV_WG_ID = 1;
+    public static final long DEFAULT_MV_VERSION = 1;
 
     public static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -116,6 +116,16 @@ public class ResourceGroupMgr implements Writable {
                                 shortQueryResourceGroup.getName()));
             }
 
+            if (wg.getClassifiers() != null && !wg.getClassifiers().isEmpty() &&
+                    wg.getResourceGroupType().equals(TWorkGroupType.WG_MV)) {
+                throw new DdlException("MV Resource Group not support classifiers.");
+            }
+
+            if (wg.getClassifiers() == null || wg.getClassifiers().isEmpty() &&
+                    !wg.getResourceGroupType().equals(TWorkGroupType.WG_MV)) {
+                throw new DdlException("This type Resource Group need define classifiers.");
+            }
+
             wg.setId(GlobalStateMgr.getCurrentState().getNextId());
             wg.setVersion(wg.getId());
             for (ResourceGroupClassifier classifier : wg.getClassifiers()) {
@@ -310,6 +320,10 @@ public class ResourceGroupMgr implements Writable {
             }
             ResourceGroup wg = resourceGroupMap.get(name);
             AlterResourceGroupStmt.SubCommand cmd = stmt.getCmd();
+            if (wg.getResourceGroupType() == TWorkGroupType.WG_MV &&
+                    !(cmd instanceof AlterResourceGroupStmt.AlterProperties)) {
+                throw new DdlException("MV Resource Group not support classifiers.");
+            }
             if (cmd instanceof AlterResourceGroupStmt.AddClassifiers) {
                 List<ResourceGroupClassifier> newAddedClassifiers = stmt.getNewAddedClassifiers();
                 for (ResourceGroupClassifier classifier : newAddedClassifiers) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -122,6 +122,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
      */
     private String storageVolume;
 
+    // This property only applies to materialized views
+    private String resourceGroup = null;
+
     // the default compression type of this table.
     private TCompressionType compressionType = TCompressionType.LZ4_FRAME;
 
@@ -226,6 +229,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildPartitionRefreshNumber();
         buildAutoRefreshPartitionsLimit();
         buildExcludedTriggerTables();
+        buildResourceGroup();
         return this;
     }
 
@@ -301,6 +305,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
     public TableProperty buildPartitionRefreshNumber() {
         partitionRefreshNumber = Integer.parseInt(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER,
                 String.valueOf(INVALID)));
+        return this;
+    }
+
+    public TableProperty buildResourceGroup() {
+        resourceGroup = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP,
+                null);
         return this;
     }
 
@@ -419,6 +429,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public void setPartitionRefreshNumber(int partitionRefreshNumber) {
         this.partitionRefreshNumber = partitionRefreshNumber;
+    }
+
+    public void setResourceGroup(String resourceGroup) {
+        this.resourceGroup = resourceGroup;
+    }
+
+    public String getResourceGroup() {
+        return resourceGroup;
     }
 
     public List<TableName> getExcludedTriggerTables() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -150,6 +150,7 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_PARTITION_REFRESH_NUMBER = "partition_refresh_number";
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE = "force_external_table_query_rewrite";
+    public static final String PROPERTIES_RESOURCE_GROUP = "resource_group";
 
     public static final String PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX = "session.";
 
@@ -394,6 +395,15 @@ public class PropertyAnalyzer {
         short replicationNum = Short.parseShort(properties.get(key));
         checkReplicationNum(replicationNum);
         return replicationNum;
+    }
+
+    public static String analyzeResourceGroup(Map<String, String> properties) {
+        String resourceGroup = null;
+        if (properties != null && properties.containsKey(PROPERTIES_RESOURCE_GROUP)) {
+            resourceGroup = properties.get(PROPERTIES_RESOURCE_GROUP);
+            properties.remove(PROPERTIES_RESOURCE_GROUP);
+        }
+        return resourceGroup;
     }
 
     private static void checkReplicationNum(short replicationNum) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1346,6 +1346,13 @@ public class CoordinatorPreprocessor {
         if (StringUtils.isNotEmpty(sessionVariable.getResourceGroup())) {
             String rgName = sessionVariable.getResourceGroup();
             resourceGroup = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByName(rgName);
+            if (rgName.equalsIgnoreCase(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME)) {
+                ResourceGroup defaultMVResourceGroup = new ResourceGroup();
+                defaultMVResourceGroup.setId(ResourceGroup.DEFAULT_MV_WG_ID);
+                defaultMVResourceGroup.setName(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME);
+                defaultMVResourceGroup.setVersion(ResourceGroup.DEFAULT_MV_VERSION);
+                resourceGroup = defaultMVResourceGroup.toThrift();
+            }
         }
 
         // 2. try to use the resource group specified by workgroup_id

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -42,6 +42,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
@@ -188,6 +189,13 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
                     extraMessage.setBasePartitionsToRefreshMap(sourceTablePartitions);
                 }
 
+                if (mvContext.getCtx().getSessionVariable().isEnableResourceGroup()) {
+                    String rg = materializedView.getTableProperty().getResourceGroup();
+                    if (rg == null || rg.isEmpty()) {
+                        rg = ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME;
+                    }
+                    mvContext.getCtx().getSessionVariable().setResourceGroup(rg);
+                }
                 // create ExecPlan
                 insertStmt = generateInsertStmt(partitionsToRefresh, sourceTablePartitions);
                 execPlan = generateRefreshPlan(mvContext.getCtx(), insertStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2959,6 +2959,16 @@ public class LocalMetastore implements ConnectorMetadata {
                         .put(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES, tableSb.toString());
                 materializedView.getTableProperty().setExcludedTriggerTables(tables);
             }
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)) {
+                String resourceGroup = PropertyAnalyzer.analyzeResourceGroup(properties);
+                if (GlobalStateMgr.getCurrentState().getResourceGroupMgr().getResourceGroup(resourceGroup) == null) {
+                    throw new AnalysisException(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP
+                            + " " + resourceGroup + " does not exist.");
+                }
+                materializedView.getTableProperty().getProperties()
+                        .put(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP, resourceGroup);
+                materializedView.getTableProperty().setResourceGroup(resourceGroup);
+            }
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
                 boolean forceExternalTableQueryReWrite = PropertyAnalyzer.
                         analyzeForceExternalTableQueryRewrite(properties);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
@@ -201,11 +201,12 @@ public class ResourceGroupAnalyzer {
                 try {
                     resourceGroup.setResourceGroupType(TWorkGroupType.valueOf("WG_" + value.toUpperCase()));
                     if (resourceGroup.getResourceGroupType() != TWorkGroupType.WG_NORMAL &&
-                            resourceGroup.getResourceGroupType() != TWorkGroupType.WG_SHORT_QUERY) {
-                        throw new SemanticException("Only support 'normal' and 'short_query' type");
+                            resourceGroup.getResourceGroupType() != TWorkGroupType.WG_SHORT_QUERY &&
+                            resourceGroup.getResourceGroupType() != TWorkGroupType.WG_MV) {
+                        throw new SemanticException("Only support 'normal', 'mv' and 'short_query' type");
                     }
                 } catch (Exception ignored) {
-                    throw new SemanticException("Only support 'normal' and 'short_query' type");
+                    throw new SemanticException("Only support 'normal', 'mv' and 'short_query' type");
                 }
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1086,7 +1086,7 @@ killAnalyzeStatement
 
 createResourceGroupStatement
     : CREATE RESOURCE GROUP (IF NOT EXISTS)? (OR REPLACE)? identifier
-        TO classifier (',' classifier)*  WITH '(' property (',' property)* ')'
+        (TO classifier (',' classifier)*)?  WITH '(' property (',' property)* ')'
     ;
 
 dropResourceGroupStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -303,7 +303,7 @@ public class ResourceGroupStmtTest {
                 "    'concurrency_limit' = '11',\n" +
                 "    'type' = 'illegal-type'" +
                 ");";
-        Assert.assertThrows("Only support 'normal' and 'short_query' type",
+        Assert.assertThrows("Only support 'normal', 'mv' and 'short_query' type",
                 SemanticException.class, () -> starRocksAssert.executeResourceGroupDdlSql(illegalTypeSql));
 
         String illegalDefaultTypeSql = "create resource group rg_unknown\n" +
@@ -316,7 +316,7 @@ public class ResourceGroupStmtTest {
                 "    'concurrency_limit' = '11',\n" +
                 "    'type' = 'default'" +
                 ");";
-        Assert.assertThrows("Only support 'normal' and 'short_query' type",
+        Assert.assertThrows("Only support 'normal', 'mv' and 'short_query' type",
                 SemanticException.class, () -> starRocksAssert.executeResourceGroupDdlSql(illegalDefaultTypeSql));
     }
 

--- a/gensrc/thrift/WorkGroup.thrift
+++ b/gensrc/thrift/WorkGroup.thrift
@@ -20,7 +20,8 @@ enum TWorkGroupType {
   WG_REALTIME,
   WG_NORMAL,
   WG_DEFAULT,
-  WG_SHORT_QUERY
+  WG_SHORT_QUERY,
+  WG_MV
 }
 
 struct TWorkGroup {


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

What I have done:
1.create default mv resource group in be.
2.modify create resource group sql syntax,  allow create mv resource group without classifiers. 
3.run mv task with resorce group defined in properties, if not define, use default mv resource group.

To disccuss:
1.Is separated mv default resource group necessary？
2.If 1 is necessary, since default resource group properties can not be modify, how to suitable define cpu and memory limit parameters?

Example:
```
CREATE RESOURCE GROUP rg_realtime 
WITH (
    "cpu_core_limit" = "2",
    "mem_limit" = "20%",
    "concurrency_limit" = "3",
    "type" = "mv" 
);

create materialized view mv1 
properties('resource_group' = 'rg_realtime')
as select xxx;
```

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
