### PR TITLE
[BugFix] Unable to build from source, fix cmake error and use correct dependencies specified by third-party, clean unused variable.

### DIFF
--- a/be/src/exprs/agg/stream/retract_maxmin.h
+++ b/be/src/exprs/agg/stream/retract_maxmin.h
@@ -236,10 +236,6 @@ public:
         }
 
         // sync previous records from detail state table
-        InputColumnType* column;
-        if constexpr (!lt_is_string<LT>) {
-            column = down_cast<InputColumnType*>(columns[0].get());
-        }
         DCHECK((*columns[1]).is_numeric());
         for (size_t i = 0; i < chunk_size; i++) {
             T value = get_row_value(columns[0].get(), i);


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #23111 

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

TLDR; 
Users can't build Starrocks from the source.  And Starrocks is now using incorrect dependencies which does not follow the restriction.

### All the libraries mentioned below are now used in starrocks in a wrong way (not the restricted version), starrocks is searching on users local environment instead of using specified third-party, which may cause unknown behavior.

**Furthermore, even if we successfully pack the project for distribution, the several packages inside the libraries may come from the "packing machine", not the wanted versions of the library indicated in Starrocks' third-party restrictions.**

Mainly because the wrong build script and a little unused variable.

More **IMPORTATNT**, this PR enable Starrocks use correct and specified dependencies indicated by third-party file. 

Before this, many packages are used from system or python environment. 

In issue #23111 , I described the situation in detail, including how to locate the bug and a description of the solution.
Errors:
1. CMake Error: Could NOT find Snappy (missing: Snappy_LIB)
2. CMakeError: Count NOT find RapidJSONAlt
3. Could NOT find Lz4 (missing: LZ4_LIB LZ4_INCLUDE_DIR)
4. Not using zlib in third-party
5. Brotli is also using library in the environment 
6. Copy files missing
7. Declared but not used variable




If a user can build from the source, then these dependencies are installed manually by apt on Ubuntu or yum on CentOS, which is strongly not recommended.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
