### PR TITLE
[BugFix] set inString flag correctly when removing comment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -156,6 +156,7 @@ public class SqlParser {
         boolean isBracketComment = false;
 
         boolean inComment = false;
+        boolean isNeedEscape = false;
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < sql.length(); ++i) {
             if (inComment) {
@@ -190,16 +191,25 @@ public class SqlParser {
                 }
             }
 
+            if (inString && sql.charAt(i) == '\\') {
+                isNeedEscape = true;
+                sb.append("\\");
+                i++;
+            }
+
             sb.append(sql.charAt(i));
 
             if (!inString && (sql.charAt(i) == '\"' || sql.charAt(i) == '\'' || sql.charAt(i) == '`')) {
                 inString = true;
                 inStringStart = sql.charAt(i);
-            } else if (inString && (sql.charAt(i) == inStringStart) && i > 0 && sql.charAt(i - 1) != '\\') {
+            } else if (!isNeedEscape && inString && (sql.charAt(i) == inStringStart)) {
                 inString = false;
             }
+            isNeedEscape = false;
         }
         return sb.toString();
     }
+
+
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/RemoveCommentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/RemoveCommentTest.java
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+import com.clearspring.analytics.util.Lists;
+import com.starrocks.common.Pair;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class RemoveCommentTest {
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("sqlList")
+    void testRemoveComment(Pair<String, String> test) {
+        try {
+            Class<?> clazz = SqlParser.class;
+            String methodName = "removeComment";
+
+            Class<?>[] parameterTypes = new Class<?>[] { String.class };
+
+            Method method = clazz.getDeclaredMethod(methodName, parameterTypes);
+
+            method.setAccessible(true);
+
+            Object result = method.invoke(null, test.second);
+            System.out.println(result);
+            assertEquals(test.first, result);
+        } catch (Exception e) {
+            fail("sql: " + test.second + " failed");
+        }
+    }
+
+
+    public static Stream<Arguments> sqlList() {
+        List<Pair<String, String>> list = Lists.newArrayList();
+        list.add(Pair.create("insert INTO tbl (col) VALUES ('a-\\\\'),('Q--8')",
+                "insert INTO tbl (col) VALUES ('a-\\\\'),('Q--8')"));
+        list.add(Pair.create("insert INTO tbl (col) VALUES ('a-\\\\\\''),('Q--8')",
+                "insert INTO tbl (col) VALUES ('a-\\\\\\''),('Q--8')"));
+        list.add(Pair.create("insert INTO tbl (col) VALUES ('a-\\\\')           ,('Q--8')",
+                "insert INTO tbl (col) VALUES ('a-\\\\') -- '\'abcd'\n,('Q--8')"));
+        list.add(Pair.create("select concat(\"\\\"abc--\\\\\\\\\\\\\", '\\'ac--abc\\\\\\\\\\'')",
+                "select concat(\"\\\"abc--\\\\\\\\\\\\\", '\\'ac--abc\\\\\\\\\\'')"));
+        list.add(Pair.create("select concat(\"\\\"abc\\\\\\\\\\\\\"           , '\\'abc\\\\\\\\\\'');",
+                "select concat(\"\\\"abc\\\\\\\\\\\\\" /* \\\"abc\" */, '\\'abc\\\\\\\\\\'');"));
+        return list.stream().map(e -> Arguments.of(e));
+    }
+}


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #23119

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The root cause is becasue of not setting end flag when there are multiple escape characters in the end of a string value.
```
else if (inString && (sql.charAt(i) == inStringStart) && i > 0 && sql.charAt(i - 1) != '\\') {
                inString = false;
            }
```


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [x] 2.4
  - [ ] 2.3
