### PR TITLE
[Enhancement] Support shortcut compaction when only one rowset has data

### DIFF
--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -19,6 +19,8 @@
 #include "runtime/current_thread.h"
 #include "runtime/mem_tracker.h"
 #include "storage/compaction_manager.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_writer.h"
 #include "storage/storage_engine.h"
 #include "util/scoped_cleanup.h"
 #include "util/starrocks_metrics.h"
@@ -178,6 +180,63 @@ void CompactionTask::_failure_callback(const Status& st) {
         _tablet->set_last_base_compaction_failure_time(UnixMillis());
     }
     LOG(WARNING) << "compaction task:" << _task_info.task_id << ", tablet:" << _task_info.tablet_id << " failed.";
+}
+
+Status CompactionTask::_shortcut_compact(Statistics* statistics) {
+    // if there is only one rowset has data, we can shortcut compact
+    // shortcut compact means hard link old rowset to new rowset directly
+    // no need to read and write data
+    std::vector<RowsetSharedPtr> data_rowsets;
+    for (auto rowset : _input_rowsets) {
+        if (rowset->num_rows() > 0) {
+            // if rowset has data, we should compact it
+            data_rowsets.emplace_back(rowset);
+        } else if (rowset->rowset_meta()->has_delete_predicate()) {
+            // if rowset has delete predicate, we should compact it
+            data_rowsets.emplace_back(rowset);
+        }
+    }
+
+    if (data_rowsets.size() == 1 && !data_rowsets.back()->rowset_meta()->is_segments_overlapping()) {
+        TRACE("[Compaction] start shortcut comapction data");
+        int64_t max_rows_per_segment = CompactionUtils::get_segment_max_rows(
+                config::max_segment_file_size, _task_info.input_rows_num, _task_info.input_rowsets_size);
+
+        std::unique_ptr<RowsetWriter> output_rs_writer;
+        RETURN_IF_ERROR(CompactionUtils::construct_output_rowset_writer(_tablet.get(), max_rows_per_segment,
+                                                                        _task_info.algorithm, _task_info.output_version,
+                                                                        &output_rs_writer));
+        Status status = output_rs_writer->add_rowset(data_rowsets.back());
+        if (!status.ok()) {
+            LOG(WARNING) << "fail to compact rowset."
+                         << ", tablet=" << _tablet->full_name() << ", version=" << output_rs_writer->version();
+            return status;
+        }
+        StatusOr<RowsetSharedPtr> build_res = output_rs_writer->build();
+        if (!build_res.ok()) {
+            LOG(WARNING) << "rowset writer build failed. compaction task_id:" << _task_info.task_id
+                         << ", tablet:" << _task_info.tablet_id << " output_version=" << _task_info.output_version;
+            return build_res.status();
+        } else {
+            _output_rowset = build_res.value();
+        }
+        _task_info.output_num_rows = _output_rowset->num_rows();
+        _task_info.output_segments_num = _output_rowset->num_segments();
+        _task_info.output_rowset_size = _output_rowset->data_disk_size();
+        _task_info.is_shortcut_compaction = true;
+        TRACE_COUNTER_INCREMENT("output_rowset_data_size", _output_rowset->data_disk_size());
+        TRACE_COUNTER_INCREMENT("output_segments_num", _output_rowset->num_segments());
+        TRACE("[Compaction] output rowset built");
+
+        // collect statistics if necessary
+        if (statistics) {
+            statistics->output_rows = _output_rowset->num_rows();
+            statistics->merged_rows = 0;
+            statistics->filtered_rows = 0;
+        }
+    }
+
+    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -68,6 +68,7 @@ struct CompactionTaskInfo {
     size_t filtered_rows{0};
     size_t output_num_rows{0};
     CompactionType compaction_type{CompactionType::INVALID_COMPACTION};
+    bool is_shortcut_compaction{false};
 
     // for vertical compaction
     size_t column_group_size{0};
@@ -117,6 +118,7 @@ struct CompactionTaskInfo {
         ss << ", total_output_num_rows:" << total_output_num_rows;
         ss << ", total_merged_rows:" << total_merged_rows;
         ss << ", total_del_filtered_rows:" << total_del_filtered_rows;
+        ss << ", is_shortcut_compaction:" << is_shortcut_compaction;
         ss << ", progress:" << get_progress();
         return ss.str();
     }
@@ -208,6 +210,8 @@ public:
         return _task_info.to_string();
     }
 
+    bool is_shortcut_compaction() const { return _task_info.is_shortcut_compaction; }
+
 protected:
     virtual Status run_impl() = 0;
 
@@ -263,6 +267,8 @@ protected:
     void _success_callback();
 
     void _failure_callback(const Status& st);
+
+    Status _shortcut_compact(Statistics* statistics);
 
 protected:
     CompactionTaskInfo _task_info;

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -33,6 +33,7 @@ namespace starrocks {
 
 Status HorizontalCompactionTask::run_impl() {
     Statistics statistics;
+    RETURN_IF_ERROR(_shortcut_compact(&statistics));
     RETURN_IF_ERROR(_horizontal_compact_data(&statistics));
 
     TRACE_COUNTER_INCREMENT("merged_rows", statistics.merged_rows);
@@ -49,6 +50,9 @@ Status HorizontalCompactionTask::run_impl() {
 }
 
 Status HorizontalCompactionTask::_horizontal_compact_data(Statistics* statistics) {
+    if (_output_rowset != nullptr) {
+        return Status::OK();
+    }
     TRACE("[Compaction] start horizontal comapction data");
     // 1: init
     int64_t max_rows_per_segment = CompactionUtils::get_segment_max_rows(

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -34,6 +34,7 @@ namespace starrocks {
 
 Status VerticalCompactionTask::run_impl() {
     Statistics statistics;
+    RETURN_IF_ERROR(_shortcut_compact(&statistics));
     RETURN_IF_ERROR(_vertical_compaction_data(&statistics));
     TRACE_COUNTER_INCREMENT("merged_rows", statistics.merged_rows);
     TRACE_COUNTER_INCREMENT("filtered_rows", statistics.filtered_rows);
@@ -49,6 +50,9 @@ Status VerticalCompactionTask::run_impl() {
 }
 
 Status VerticalCompactionTask::_vertical_compaction_data(Statistics* statistics) {
+    if (_output_rowset != nullptr) {
+        return Status::OK();
+    }
     TRACE("[Compaction] start vertical comapction data");
     int64_t max_rows_per_segment = CompactionUtils::get_segment_max_rows(
             config::max_segment_file_size, _task_info.input_rows_num, _task_info.input_rowsets_size);


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
if there is only one rowset has data, we can shortcut compact.
shortcut compact means hard link old rowset to new rowset directly, no need to read and write data.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
