### PR TITLE
[Enhancement] support postgresql db/schema/table/column name upercase and numeric without precision

### DIFF
--- a/be/src/exec/jdbc_scanner.cpp
+++ b/be/src/exec/jdbc_scanner.cpp
@@ -269,10 +269,11 @@ StatusOr<LogicalType> JDBCScanner::_precheck_data_type(const std::string& java_c
         }
         return TYPE_VARCHAR;
     } else if (java_class == "java.math.BigDecimal") {
-        if (type != TYPE_DECIMAL32 && type != TYPE_DECIMAL64 && type != TYPE_DECIMAL128) {
-            return Status::NotSupported(fmt::format(
-                    "Type mismatches on column[{}], JDBC result type is BigDecimal, please set the type to decimal",
-                    slot_desc->col_name()));
+        if (type != TYPE_DECIMAL32 && type != TYPE_DECIMAL64 && type != TYPE_DECIMAL128 && type != TYPE_VARCHAR) {
+            return Status::NotSupported(
+                    fmt::format("Type mismatches on column[{}], JDBC result type is BigDecimal, please set the type to "
+                                "decimal or varchar",
+                                slot_desc->col_name()));
         }
         return TYPE_VARCHAR;
     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.connector.jdbc;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.PrimitiveType;
@@ -46,9 +47,27 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
     }
 
     @Override
+    public List<Column> convertToSRTable(ResultSet columnSet) throws SQLException {
+        List<Column> fullSchema = Lists.newArrayList();
+        while (columnSet.next()) {
+            Type type = convertColumnType(columnSet.getInt("DATA_TYPE"),
+                    columnSet.getString("TYPE_NAME"),
+                    columnSet.getInt("COLUMN_SIZE"),
+                    columnSet.getInt("DECIMAL_DIGITS"));
+            String columnName = columnSet.getString("COLUMN_NAME");
+            if (!columnName.equals(columnName.toLowerCase())) {
+                columnName = "\"" + columnName + "\"";
+            }
+            fullSchema.add(new Column(columnName, type,
+                    columnSet.getString("IS_NULLABLE").equals("YES")));
+        }
+        return fullSchema;
+    }
+
+    @Override
     public Table getTable(long id, String name, List<Column> schema, String dbName, String catalogName,
                           Map<String, String> properties) throws DdlException {
-        return new JDBCTable(id, dbName + "." + name, schema, "", catalogName, properties);
+        return new JDBCTable(id, "\"" + dbName + "\"" + "." + "\"" + name + "\"", schema, "", catalogName, properties);
     }
 
     @Override
@@ -101,6 +120,11 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
             return ScalarType.createType(primitiveType);
         } else {
             int precision = columnSize + max(-digits, 0);
+            // if user not specify numeric precision and scale, the default value is 0,
+            // we can't defer the precision and scale, can only deal it as string.
+            if (precision == 0) {
+                return ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+            }
             return ScalarType.createUnifiedDecimalType(precision, max(digits, 0));
         }
     }


### PR DESCRIPTION
PostgreSQL conventionally use lowercase as db/schema/table/column name and it's converted defaultly, but user can force use uppercase with double quotes, this pr support access these case in starrocks.

If users use numeric in PostgreSQL without precision and scale, we can't get precision from the column type, we can only treat it as Varchar.  

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
