### PR TITLE
[BugFix] Fix _is_last_split_of_current_morsel for empty rowset

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -275,12 +275,12 @@ bool PhysicalSplitMorselQueue::_is_last_split_of_current_morsel() {
         return true;
     }
 
-    // Reach the last rowset of the current tablet.
+    // Check if reach the last rowset of the current tablet.
     if (_rowset_idx + 1 < num_rowsets) {
         return false;
     }
 
-    // Reach the last segment of the current rowset.
+    // Check if reach the last segment of the current rowset.
     const size_t num_segments = _tablet_rowsets[_tablet_idx][_rowset_idx]->segments().size();
     if (_segment_idx + 1 < num_segments) {
         return false;

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -264,8 +264,8 @@ bool PhysicalSplitMorselQueue::_is_last_split_of_current_morsel() {
     if (_tablet_idx >= _tablet_rowsets.size()) {
         return true;
     }
-    return _num_segment_rest_rows == 0 && _rowset_idx + 1 == _tablet_rowsets[_tablet_idx].size() &&
-           _segment_idx + 1 == _cur_rowset()->segments().size();
+    return _num_segment_rest_rows == 0 && _rowset_idx + 1 >= _tablet_rowsets[_tablet_idx].size() &&
+           _segment_idx + 1 >= _cur_rowset()->segments().size();
 }
 
 bool PhysicalSplitMorselQueue::_next_segment() {


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Add a new daily case:
nosetests-3.4 --with-flaky --force-flaky --max-runs=3 --min-passes=1 -s --with-xunit --xunit-file=./result/test_tablet_internal_parallel_py_TestTabletInternalParallel_test_duplicate_key.xml -
-verbose case/system_case/test_dql/test_tablet_internal_parallel.py:TestTabletInternalParallel.test_duplicate_key --nologcapture

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`_is_last_split_of_current_morsel` uses `_segment_idx + 1 == _cur_rowset()->segments().size()` to check whether the segment is the last segment of this rowset. 
However, `segments` is empty sometimes, but `_segment_idx + 1 == _cur_rowset()->segments().size()` is false for this case.

```C++
bool PhysicalSplitMorselQueue::_is_last_split_of_current_morsel() {
    if (_tablet_idx >= _tablet_rowsets.size()) {
        return true;
    }
    return _num_segment_rest_rows == 0 && _rowset_idx + 1 == _tablet_rowsets[_tablet_idx].size() &&
           _segment_idx + 1 == _cur_rowset()->segments().size();
}
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
