### PR TITLE
[BugFix] Be maybe crash due to the incorrect overlap info

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1654,6 +1654,7 @@ Status ShardByLengthMutableIndex::update_overlap_info(size_t key_size, size_t nu
             }
         }
         if (erase) {
+            num_overlap *= 2;
             overlap_size *= 2;
         }
         for (size_t i = 0; i < shard_size; ++i) {


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/starrocks/issues/23190

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We record the overlap info(including overlap kv num and overlap kv size) during L0 and L1, but we don't update the overlap info correctly when we try to delete the row which primary key length is more than 64 Bytes. And this maybe cause BE crash in the future merge compaction.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [x] 2.4
  - [ ] 2.3
