### PR TITLE
[Cherry-Pick][Enhancement] Optimize tablet scheduler for large pending tablets case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -62,7 +62,6 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         VERSION_INCOMPLETE, // alive replica num is enough, but version is missing.
         REPLICA_RELOCATING, // replica is healthy, but is under relocating (e.g. BE is decommission).
         REDUNDANT, // too much replicas.
-        REPLICA_MISSING_IN_CLUSTER, // not enough healthy replicas in correct cluster.
         FORCE_REDUNDANT, // some replica is missing or bad, but there is no other backends for repair,
         // at least one replica has to be deleted first to make room for new replica.
         COLOCATE_MISMATCH, // replicas do not all locate in right colocate backends set.
@@ -592,10 +591,8 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             }
         }
 
-        // 4. healthy replicas in cluster are not enough
-        if (availableInCluster < replicationNum) {
-            return Pair.create(TabletStatus.REPLICA_MISSING_IN_CLUSTER, TabletSchedCtx.Priority.LOW);
-        } else if (replicas.size() > replicationNum) {
+        // 4. replica redundant
+        if (replicas.size() > replicationNum) {
             // we set REDUNDANT as VERY_HIGH, because delete redundant replicas can free the space quickly.
             return createRedundantSchedCtx(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
                     needFurtherRepairReplica);

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -71,28 +71,6 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     private static final Logger LOG = LogManager.getLogger(TabletSchedCtx.class);
 
     /*
-     * SCHED_FAILED_COUNTER_THRESHOLD:
-     *    threshold of times a tablet failed to be scheduled
-     *
-     * MIN_ADJUST_PRIORITY_INTERVAL_MS:
-     *    min interval time of adjusting a tablet's priority
-     *
-     * MAX_NOT_BEING_SCHEDULED_INTERVAL_MS:
-     *    max gap time of a tablet NOT being scheduled.
-     *
-     * These 3 params is for adjusting priority.
-     * If a tablet being scheduled failed for more than SCHED_FAILED_COUNTER_THRESHOLD times, its priority
-     * will be downgraded. And the interval between adjustment is larger than MIN_ADJUST_PRIORITY_INTERVAL_MS,
-     * to avoid being downgraded too soon.
-     * And if a tablet is not being scheduled longer than MAX_NOT_BEING_SCHEDULED_INTERVAL_MS, its priority
-     * will be upgraded, to avoid starvation.
-     *
-     */
-    private static final int SCHED_FAILED_COUNTER_THRESHOLD = 5;
-    private static final long MIN_ADJUST_PRIORITY_INTERVAL_MS = 5 * 60 * 1000L; // 5 min
-    private static final long MAX_NOT_BEING_SCHEDULED_INTERVAL_MS = 30 * 60 * 1000L; // 30 min
-
-    /*
      *  A clone task timeout is between Config.min_clone_task_timeout_sec and Config.max_clone_task_timeout_sec,
      *  estimated by tablet size / MIN_CLONE_SPEED_MB_PER_SECOND.
      */
@@ -114,18 +92,18 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         HIGH,
         VERY_HIGH;
 
-        // VERY_HIGH can only be downgraded to NORMAL
+        // try to upgrade the priority
         // LOW can only be upgraded to HIGH
-        public Priority adjust(Priority origPriority, boolean isUp) {
+        public Priority adjust(Priority origPriority) {
             switch (this) {
                 case VERY_HIGH:
-                    return isUp ? VERY_HIGH : HIGH;
+                    return VERY_HIGH;
                 case HIGH:
-                    return isUp ? (origPriority == LOW ? HIGH : VERY_HIGH) : NORMAL;
+                    return origPriority == LOW ? HIGH : VERY_HIGH;
                 case NORMAL:
-                    return isUp ? HIGH : (origPriority == Priority.VERY_HIGH ? NORMAL : LOW);
+                    return HIGH;
                 default:
-                    return isUp ? NORMAL : LOW;
+                    return NORMAL;
             }
         }
 
@@ -757,7 +735,6 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         return tablet.deleteReplicaByBackendId(replica.getBackendId());
     }
 
-    // database lock should be held.
     public CloneTask createCloneReplicaAndTask() throws SchedException {
         Backend srcBe = infoService.getBackend(srcReplica.getBackendId());
         if (srcBe == null) {
@@ -792,74 +769,90 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
         // if this is a balance task, or this is a repair task with REPLICA_MISSING/REPLICA_RELOCATING or REPLICA_MISSING_IN_CLUSTER,
         // we create a new replica with state CLONE
-        if (tabletStatus == TabletStatus.REPLICA_MISSING || tabletStatus == TabletStatus.REPLICA_MISSING_IN_CLUSTER
-                || tabletStatus == TabletStatus.REPLICA_RELOCATING || tabletStatus == TabletStatus.COLOCATE_MISMATCH
-                || (type == Type.BALANCE && !cloneTask.isLocal())) {
-            Replica cloneReplica = new Replica(
-                    GlobalStateMgr.getCurrentState().getNextId(), destBackendId,
-                    -1 /* version */, schemaHash,
-                    -1 /* data size */, -1 /* row count */,
-                    ReplicaState.CLONE,
-                    committedVersion,
-                    -1 /* last success version */);
+        Database db = GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(dbId);
+        if (db == null || !db.writeLockAndCheckExist()) {
+            throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " not exist");
+        }
+        try {
+            if (tabletStatus == TabletStatus.REPLICA_MISSING
+                    || tabletStatus == TabletStatus.REPLICA_RELOCATING
+                    || tabletStatus == TabletStatus.COLOCATE_MISMATCH
+                    || (type == Type.BALANCE && !cloneTask.isLocal())) {
+                Replica cloneReplica = new Replica(
+                        GlobalStateMgr.getCurrentState().getNextId(), destBackendId,
+                        -1 /* version */, schemaHash,
+                        -1 /* data size */, -1 /* row count */,
+                        ReplicaState.CLONE,
+                        committedVersion,
+                        -1 /* last success version */);
 
-            // addReplica() method will add this replica to tablet inverted index too.
-            tablet.addReplica(cloneReplica);
-        } else if (tabletStatus == TabletStatus.VERSION_INCOMPLETE) {
-            Preconditions.checkState(type == Type.REPAIR, type);
-            // double check
-            Replica replica = tablet.getReplicaByBackendId(destBackendId);
-            if (replica == null) {
-                throw new SchedException(Status.UNRECOVERABLE, "dest replica does not exist on BE " + destBackendId);
-            }
+                // addReplica() method will add this replica to tablet inverted index too.
+                tablet.addReplica(cloneReplica);
+            } else if (tabletStatus == TabletStatus.VERSION_INCOMPLETE) {
+                Preconditions.checkState(type == Type.REPAIR, type);
+                // double check
+                Replica replica = tablet.getReplicaByBackendId(destBackendId);
+                if (replica == null) {
+                    throw new SchedException(Status.UNRECOVERABLE, "dest replica does not exist on BE " + destBackendId);
+                }
 
-            if (replica.getPathHash() != destPathHash) {
-                throw new SchedException(Status.UNRECOVERABLE, "dest replica's path hash is changed. "
-                        + "current: " + replica.getPathHash() + ", scheduled: " + destPathHash);
+                if (replica.getPathHash() != destPathHash) {
+                    throw new SchedException(Status.UNRECOVERABLE, "dest replica's path hash is changed. "
+                            + "current: " + replica.getPathHash() + ", scheduled: " + destPathHash);
+                }
+            } else if (type == Type.BALANCE && cloneTask.isLocal()) {
+                if (tabletStatus != TabletStatus.HEALTHY) {
+                    throw new SchedException(Status.SCHEDULE_RETRY, "tablet " + tabletId + " is not healthy");
+                }
             }
-        } else if (type == Type.BALANCE && cloneTask.isLocal()) {
-            if (tabletStatus != TabletStatus.HEALTHY) {
-                throw new SchedException(Status.SCHEDULE_RETRY, "tablet " + tabletId + " is not healthy");
-            }
+        } finally {
+            db.writeUnlock();
         }
 
         this.state = State.RUNNING;
         return cloneTask;
     }
 
-    public CreateReplicaTask createEmptyReplicaAndTask() {
+    public CreateReplicaTask createEmptyReplicaAndTask() throws SchedException {
         // only create this task if force recovery is true
         LOG.warn("tablet {} has only one replica {} on backend {}"
                         + " and it is lost. create an empty replica to recover it on backend {}",
                 tabletId, tablet.getSingleReplica(), tablet.getSingleReplica().getBackendId(), destBackendId);
 
         final GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(
-                globalStateMgr.getDbIncludeRecycleBin(dbId),
-                tblId);
-        MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
-        CreateReplicaTask createReplicaTask = new CreateReplicaTask(destBackendId, dbId,
-                tblId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
-                indexMeta.getSchemaHash(), visibleVersion,
-                indexMeta.getKeysType(),
-                TStorageType.COLUMN,
-                TStorageMedium.HDD, indexMeta.getSchema(), olapTable.getCopiedBfColumns(), olapTable.getBfFpp(), null,
-                olapTable.getCopiedIndexes(),
-                olapTable.isInMemory(),
-                olapTable.enablePersistentIndex(),
-                olapTable.getPartitionInfo().getTabletType(partitionId),
-                olapTable.getCompressionType(), indexMeta.getSortKeyIdxes());
-        createReplicaTask.setIsRecoverTask(true);
-        taskTimeoutMs = Config.tablet_sched_min_clone_task_timeout_sec * 1000;
+        Database db = globalStateMgr.getDbIncludeRecycleBin(dbId);
+        if (db == null || !db.writeLockAndCheckExist()) {
+            throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " not exist");
+        }
+        try {
+            OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(
+                    globalStateMgr.getDbIncludeRecycleBin(dbId),
+                    tblId);
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+            CreateReplicaTask createReplicaTask = new CreateReplicaTask(destBackendId, dbId,
+                    tblId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
+                    indexMeta.getSchemaHash(), visibleVersion,
+                    indexMeta.getKeysType(),
+                    TStorageType.COLUMN,
+                    TStorageMedium.HDD, indexMeta.getSchema(), olapTable.getCopiedBfColumns(), olapTable.getBfFpp(), null,
+                    olapTable.getCopiedIndexes(),
+                    olapTable.isInMemory(),
+                    olapTable.enablePersistentIndex(),
+                    olapTable.getPartitionInfo().getTabletType(partitionId),
+                    olapTable.getCompressionType(), indexMeta.getSortKeyIdxes());
+            createReplicaTask.setIsRecoverTask(true);
+            taskTimeoutMs = Config.tablet_sched_min_clone_task_timeout_sec * 1000;
 
-        Replica emptyReplica =
-                new Replica(tablet.getSingleReplica().getId(), destBackendId, ReplicaState.NORMAL, visibleVersion,
-                        indexMeta.getSchemaHash());
-        // addReplica() method will add this replica to tablet inverted index too.
-        tablet.addReplica(emptyReplica);
-
-        state = State.RUNNING;
-        return createReplicaTask;
+            Replica emptyReplica =
+                    new Replica(tablet.getSingleReplica().getId(), destBackendId, ReplicaState.NORMAL, visibleVersion,
+                            indexMeta.getSchemaHash());
+            // addReplica() method will add this replica to tablet inverted index too.
+            tablet.addReplica(emptyReplica);
+            state = State.RUNNING;
+            return createReplicaTask;
+        } finally {
+            db.writeUnlock();
+        }
     }
 
     // timeout is between MIN_CLONE_TASK_TIMEOUT_MS and MAX_CLONE_TASK_TIMEOUT_MS
@@ -1062,25 +1055,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 reportedTablet.getMin_readable_version());
     }
 
-    /*
-     * we try to adjust the priority based on schedule history
-     * 1. If failed counter is larger than FAILED_COUNTER_THRESHOLD, which means this tablet is being scheduled
-     *    at least FAILED_TIME_THRESHOLD times and all are failed. So we downgrade its priority.
-     *    Also reset the failedCounter, or it will be downgraded forever.
-     *
-     * 2. Else, if it has been a long time since last time the tablet being scheduled, we upgrade its
-     *    priority to let it more available to be scheduled.
-     *
-     * The time gap between adjustment should be larger than MIN_ADJUST_PRIORITY_INTERVAL_MS, to avoid
-     * being downgraded too fast.
-     *
-     * eg:
-     *    A tablet has been scheduled for 5 times and all were failed. its priority will be downgraded. And if it is
-     *    scheduled for 5 times and all are failed again, it will be downgraded again, until to the LOW.
-     *    And then, because of LOW, this tablet can not be scheduled for a long time, and it will be upgraded
-     *    to NORMAL, if still not being scheduled, it will be upgraded up to VERY_HIGH.
-     *
-     * return true if dynamic priority changed
+    /**
+     * try to upgrade the priority if this tablet has not been scheduled for a long time
      */
     public boolean adjustPriority(TabletSchedulerStat stat) {
         long currentTime = System.currentTimeMillis();
@@ -1089,42 +1065,20 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             lastAdjustPrioTime = currentTime;
             return false;
         } else {
-            if (currentTime - lastAdjustPrioTime < MIN_ADJUST_PRIORITY_INTERVAL_MS) {
+            if (currentTime - lastAdjustPrioTime < Config.tablet_sched_max_not_being_scheduled_interval_ms) {
                 return false;
             }
         }
 
-        boolean isDowngrade = false;
-        boolean isUpgrade = false;
-
-        if (failedSchedCounter > SCHED_FAILED_COUNTER_THRESHOLD) {
-            isDowngrade = true;
-        } else {
-            long lastTime = lastSchedTime == 0 ? createTime : lastSchedTime;
-            if (currentTime - lastTime > MAX_NOT_BEING_SCHEDULED_INTERVAL_MS) {
-                isUpgrade = true;
-            }
-        }
+        lastAdjustPrioTime = System.currentTimeMillis();
 
         Priority originDynamicPriority = dynamicPriority;
-        if (isDowngrade) {
-            dynamicPriority = dynamicPriority.adjust(origPriority, false /* downgrade */);
-            failedSchedCounter = 0;
-            if (originDynamicPriority != dynamicPriority) {
-                LOG.debug("downgrade dynamic priority from {} to {}, origin: {}, tablet: {}",
-                        originDynamicPriority.name(), dynamicPriority.name(), origPriority.name(), tabletId);
-                stat.counterTabletPrioDowngraded.incrementAndGet();
-                return true;
-            }
-        } else if (isUpgrade) {
-            dynamicPriority = dynamicPriority.adjust(origPriority, true /* upgrade */);
-            // no need to set lastSchedTime, lastSchedTime is set each time we schedule this tablet
-            if (originDynamicPriority != dynamicPriority) {
-                LOG.debug("upgrade dynamic priority from {} to {}, origin: {}, tablet: {}",
-                        originDynamicPriority.name(), dynamicPriority.name(), origPriority.name(), tabletId);
-                stat.counterTabletPrioUpgraded.incrementAndGet();
-                return true;
-            }
+        dynamicPriority = dynamicPriority.adjust(origPriority);
+        if (originDynamicPriority != dynamicPriority) {
+            LOG.debug("upgrade dynamic priority from {} to {}, origin: {}, tablet: {}",
+                    originDynamicPriority.name(), dynamicPriority.name(), origPriority.name(), tabletId);
+            stat.counterTabletPrioUpgraded.incrementAndGet();
+            return true;
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -822,13 +822,19 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         final GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         Database db = globalStateMgr.getDbIncludeRecycleBin(dbId);
         if (db == null || !db.writeLockAndCheckExist()) {
-            throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " not exist");
+            throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " does not exist");
         }
         try {
             OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(
                     globalStateMgr.getDbIncludeRecycleBin(dbId),
                     tblId);
+            if (olapTable == null) {
+                throw new SchedException(Status.UNRECOVERABLE, "table " + tblId + " does not exist");
+            }
             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+            if (indexMeta == null) {
+                throw new SchedException(Status.UNRECOVERABLE, "materialized view " + indexId + " does not exist");
+            }
             CreateReplicaTask createReplicaTask = new CreateReplicaTask(destBackendId, dbId,
                     tblId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
                     indexMeta.getSchemaHash(), visibleVersion,

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -44,6 +44,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Partition.PartitionState;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.clone.SchedException.Status;
 import com.starrocks.clone.TabletSchedCtx.Priority;
@@ -914,6 +915,7 @@ public class TabletScheduler extends LeaderDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         try {
+            checkMetaExist(tabletCtx);
             if (deleteBackendDropped(tabletCtx, force)
                     || deleteBadReplica(tabletCtx, force)
                     || deleteBackendUnavailable(tabletCtx, force)
@@ -1119,6 +1121,7 @@ public class TabletScheduler extends LeaderDaemon {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         try {
+            checkMetaExist(tabletCtx);
             List<Replica> replicas = tabletCtx.getReplicas();
             for (Replica replica : replicas) {
                 boolean forceDropBad = false;
@@ -1438,14 +1441,6 @@ public class TabletScheduler extends LeaderDaemon {
         return list;
     }
 
-    private int getCurrentAvailableSlotNum() {
-        int total = 0;
-        for (PathSlot pathSlot : backendsWorkingSlots.values()) {
-            total += pathSlot.getTotalAvailSlotNum();
-        }
-        return total;
-    }
-
     /**
      * return true if we want to remove the clone task from AgentTaskQueue
      */
@@ -1672,6 +1667,34 @@ public class TabletScheduler extends LeaderDaemon {
         response.setTablet_schedules(
                 tabletCtxs.stream().map(t -> t.toTabletScheduleThrift()).collect(Collectors.toList()));
         return response;
+    }
+
+    // caller should hold db lock
+    private void checkMetaExist(TabletSchedCtx ctx) throws SchedException {
+        Database db = globalStateMgr.getDbIncludeRecycleBin(ctx.getDbId());
+        if (db == null) {
+            throw new SchedException(Status.UNRECOVERABLE, "db " + ctx.getDbId() + " dose not exist");
+        }
+
+        OlapTable tbl = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, ctx.getTblId());
+        if (tbl == null) {
+            throw new SchedException(Status.UNRECOVERABLE, "table " + ctx.getTblId() + " dose not exist");
+        }
+
+        Partition partition = globalStateMgr.getPartitionIncludeRecycleBin(tbl, ctx.getPartitionId());
+        if (partition == null) {
+            throw new SchedException(Status.UNRECOVERABLE, "partition " + ctx.getPartitionId() + " dose not exist");
+        }
+
+        MaterializedIndex idx = partition.getIndex(ctx.getIndexId());
+        if (idx == null) {
+            throw new SchedException(Status.UNRECOVERABLE, "materialized index " + ctx.getIndexId() + " dose not exist");
+        }
+
+        Tablet tablet = idx.getTablet(ctx.getTabletId());
+        if (tablet == null) {
+            throw new SchedException(Status.UNRECOVERABLE, "tablet " + ctx.getTabletId() + " dose not exist");
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -506,7 +506,7 @@ public class TabletScheduler extends LeaderDaemon {
                                 tabletCtx.releaseResource(this);
                                 // adjust priority to avoid some higher priority always be the first in pendingTablets
                                 stat.counterTabletScheduledFailed.incrementAndGet();
-                                dynamicAdjustPrioAndAddBackToPendingTablets(tabletCtx, e.getMessage());
+                                addBackToPendingTablets(tabletCtx, e.getMessage());
                             }
                         }
                     } else {
@@ -514,7 +514,7 @@ public class TabletScheduler extends LeaderDaemon {
                         tabletCtx.releaseResource(this);
                         // adjust priority to avoid some higher priority always be the first in pendingTablets
                         stat.counterTabletScheduledFailed.incrementAndGet();
-                        dynamicAdjustPrioAndAddBackToPendingTablets(tabletCtx, e.getMessage());
+                        addBackToPendingTablets(tabletCtx, e.getMessage());
                     }
                 } else if (e.getStatus() == Status.FINISHED) {
                     // schedule redundant tablet will throw this exception
@@ -595,7 +595,7 @@ public class TabletScheduler extends LeaderDaemon {
         }
 
         Pair<TabletStatus, TabletSchedCtx.Priority> statusPair;
-        db.writeLock();
+        db.readLock();
         try {
             OlapTable tbl = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tabletCtx.getTblId());
             if (tbl == null) {
@@ -703,10 +703,11 @@ public class TabletScheduler extends LeaderDaemon {
             tabletCtx.setSchemaHash(tbl.getSchemaHashByIndexId(idx.getId()));
             tabletCtx.setStorageMedium(dataProperty.getStorageMedium());
 
-            handleTabletByTypeAndStatus(statusPair.first, tabletCtx, batchTask);
         } finally {
-            db.writeUnlock();
+            db.readUnlock();
         }
+
+        handleTabletByTypeAndStatus(statusPair.first, tabletCtx, batchTask);
     }
 
     /**
@@ -772,9 +773,6 @@ public class TabletScheduler extends LeaderDaemon {
                     break;
                 case FORCE_REDUNDANT:
                     handleRedundantReplica(tabletCtx, true);
-                    break;
-                case REPLICA_MISSING_IN_CLUSTER:
-                    handleReplicaClusterMigration(tabletCtx, batchTask);
                     break;
                 case COLOCATE_MISMATCH:
                     handleColocateMismatch(tabletCtx, batchTask);
@@ -911,19 +909,27 @@ public class TabletScheduler extends LeaderDaemon {
     private void handleRedundantReplica(TabletSchedCtx tabletCtx, boolean force) throws SchedException {
         stat.counterReplicaRedundantErr.incrementAndGet();
 
-        if (deleteBackendDropped(tabletCtx, force)
-                || deleteBadReplica(tabletCtx, force)
-                || deleteBackendUnavailable(tabletCtx, force)
-                || deleteCloneOrDecommissionReplica(tabletCtx, force)
-                || deleteReplicaWithFailedVersion(tabletCtx, force)
-                || deleteReplicaWithLowerVersion(tabletCtx, force)
-                || deleteReplicaOnSameHost(tabletCtx, force)
-                || deleteReplicaNotInCluster(tabletCtx, force)
-                || deleteReplicaChosenByRebalancer(tabletCtx, force)
-                || deleteReplicaOnHighLoadBackend(tabletCtx, force)) {
-            // if we delete at least one redundant replica, we still throw a SchedException with status FINISHED
-            // to remove this tablet from the pendingTablets(consider it as finished)
-            throw new SchedException(Status.FINISHED, "redundant replica is deleted");
+        Database db = globalStateMgr.getDbIncludeRecycleBin(tabletCtx.getDbId());
+        if (db == null || !db.writeLockAndCheckExist()) {
+            throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
+        }
+        try {
+            if (deleteBackendDropped(tabletCtx, force)
+                    || deleteBadReplica(tabletCtx, force)
+                    || deleteBackendUnavailable(tabletCtx, force)
+                    || deleteCloneOrDecommissionReplica(tabletCtx, force)
+                    || deleteReplicaWithFailedVersion(tabletCtx, force)
+                    || deleteReplicaWithLowerVersion(tabletCtx, force)
+                    || deleteReplicaOnSameHost(tabletCtx, force)
+                    || deleteReplicaNotInCluster(tabletCtx, force)
+                    || deleteReplicaChosenByRebalancer(tabletCtx, force)
+                    || deleteReplicaOnHighLoadBackend(tabletCtx, force)) {
+                // if we delete at least one redundant replica, we still throw a SchedException with status FINISHED
+                // to remove this tablet from the pendingTablets(consider it as finished)
+                throw new SchedException(Status.FINISHED, "redundant replica is deleted");
+            }
+        } finally {
+            db.writeUnlock();
         }
         throw new SchedException(Status.UNRECOVERABLE, "unable to delete any redundant replicas");
     }
@@ -1108,24 +1114,32 @@ public class TabletScheduler extends LeaderDaemon {
         Set<Long> backendSet = tabletCtx.getColocateBackendsSet();
         Preconditions.checkNotNull(backendSet);
         stat.counterReplicaColocateRedundant.incrementAndGet();
-        List<Replica> replicas = tabletCtx.getReplicas();
-        for (Replica replica : replicas) {
-            boolean forceDropBad = false;
-            if (backendSet.contains(replica.getBackendId())) {
-                if (replica.isBad() && replicas.size() > 1) {
-                    forceDropBad = true;
-                    LOG.info("colocate tablet {}, replica {} is bad," +
-                                    "will forcefully drop it, current backend set: {}",
-                            tabletCtx.getTabletId(), replica.getBackendId(), backendSet);
-                } else {
-                    continue;
-                }
-            }
-
-            deleteReplicaInternal(tabletCtx, replica, "colocate redundant", forceDropBad);
-            throw new SchedException(Status.FINISHED, "colocate redundant replica is deleted");
+        Database db = globalStateMgr.getDbIncludeRecycleBin(tabletCtx.getDbId());
+        if (db == null || !db.writeLockAndCheckExist()) {
+            throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
-        throw new SchedException(Status.UNRECOVERABLE, "unable to delete any colocate redundant replicas");
+        try {
+            List<Replica> replicas = tabletCtx.getReplicas();
+            for (Replica replica : replicas) {
+                boolean forceDropBad = false;
+                if (backendSet.contains(replica.getBackendId())) {
+                    if (replica.isBad() && replicas.size() > 1) {
+                        forceDropBad = true;
+                        LOG.info("colocate tablet {}, replica {} is bad," +
+                                        "will forcefully drop it, current backend set: {}",
+                                tabletCtx.getTabletId(), replica.getBackendId(), backendSet);
+                    } else {
+                        continue;
+                    }
+                }
+
+                deleteReplicaInternal(tabletCtx, replica, "colocate redundant", forceDropBad);
+                throw new SchedException(Status.FINISHED, "colocate redundant replica is deleted");
+            }
+            throw new SchedException(Status.UNRECOVERABLE, "unable to delete any colocate redundant replicas");
+        } finally {
+            db.writeUnlock();
+        }
     }
 
     private void deleteReplicaInternal(TabletSchedCtx tabletCtx, Replica replica, String reason, boolean force)
@@ -1206,19 +1220,6 @@ public class TabletScheduler extends LeaderDaemon {
         batchTask.addTask(task);
         AgentTaskExecutor.submit(batchTask);
         LOG.info("send delete replica task for tablet {} in backend {}", tabletId, backendId);
-    }
-
-    /**
-     * Cluster migration, which means the tablet has enough healthy replicas,
-     * but some replicas are not in right cluster.
-     * It is just same as 'replica missing'.
-     * <p>
-     * after clone finished, the replica in wrong cluster will be treated as redundant, and will be deleted soon.
-     */
-    private void handleReplicaClusterMigration(TabletSchedCtx tabletCtx, AgentBatchTask batchTask)
-            throws SchedException {
-        stat.counterReplicaMissingInClusterErr.incrementAndGet();
-        handleReplicaMissing(tabletCtx, batchTask);
     }
 
     /**
@@ -1388,11 +1389,10 @@ public class TabletScheduler extends LeaderDaemon {
 
     /**
      * For some reason, a tablet info failed to be scheduled this time,
-     * So we dynamically change its priority and add back to queue, waiting for next round.
+     * Add back to queue, waiting for next round.
      */
-    private void dynamicAdjustPrioAndAddBackToPendingTablets(TabletSchedCtx tabletCtx, String message) {
+    private void addBackToPendingTablets(TabletSchedCtx tabletCtx, String message) {
         Preconditions.checkState(tabletCtx.getState() == TabletSchedCtx.State.PENDING);
-        tabletCtx.adjustPriority(stat);
         addBackToPendingTablets(tabletCtx);
     }
 
@@ -1421,7 +1421,7 @@ public class TabletScheduler extends LeaderDaemon {
     // get next batch of tablets from queue.
     private synchronized List<TabletSchedCtx> getNextTabletCtxBatch() {
         List<TabletSchedCtx> list = Lists.newArrayList();
-        int count = Math.max(MIN_BATCH_NUM, getCurrentAvailableSlotNum());
+        int count = pendingTablets.size();
         while (count > 0) {
             TabletSchedCtx tablet = pendingTablets.poll();
             if (tablet == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedulerStat.java
@@ -84,8 +84,6 @@ public class TabletSchedulerStat {
      */
     @StatField("num of tablet priority upgraded")
     public AtomicLong counterTabletPrioUpgraded = new AtomicLong(0L);
-    @StatField("num of tablet priority downgraded")
-    public AtomicLong counterTabletPrioDowngraded = new AtomicLong(0L);
 
     /*
      * Clone task related
@@ -197,17 +195,5 @@ public class TabletSchedulerStat {
 
         snapshot();
         return sb.toString();
-    }
-
-    // for test
-    public static void main(String[] args) {
-        TabletSchedulerStat stat = new TabletSchedulerStat();
-
-        stat.counterCloneTask.addAndGet(300);
-        System.out.println(stat.incrementalBrief());
-
-        stat.counterCloneTask.addAndGet(3);
-        stat.counterTabletChecked.incrementAndGet();
-        System.out.println(stat.incrementalBrief());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1120,6 +1120,14 @@ public class Config extends ConfigBase {
     public static long tablet_sched_storage_cooldown_second = -1L; // won't cool down by default
 
     /**
+     * If the tablet in scheduler queue has not been scheduled for tablet_sched_max_not_being_scheduled_interval_ms,
+     * its priority will upgrade.
+     * default is 15min
+     */
+    @ConfField(mutable = true)
+    public static long tablet_sched_max_not_being_scheduled_interval_ms = 15 * 60 * 1000;
+
+    /**
      * FOR DiskAndTabletLoadBalancer:
      * upper limit of the difference in disk usage of all backends, exceeding this threshold will cause
      * disk balance


### PR DESCRIPTION
- [ ] #23062
- [ ] 
Now, there are some bad cases in the logic of tablet scheduler when the number of tablets to be repaired is large: the priority of tablet will be downgraded if there is not enough resource(be path slot), and the tablet in low priority will never be scheduled if there are new tablets to repair continuously, because the new tablets will be put to the head of schedule queue. The tablet in low priority can be upgraded to high priority, but the time interval is very big, it's 30 mins.
To cover this bad case:
1. do not downgrade the priority of tablet if there is not enough resource, because the resource should be allocated to the selected tablet before first.
2. schedule all the tablet in queue one time, because the tablet on the head and tablet on the tail may use different be resource.
3. since the number of tablet to schedule in one batch is increased, we should optimize the granularity of db lock: use db read lock to check existence of meta, and use db write lock when add or drop replica.