### PR TITLE
[BugFix] check brpc stub in exchange sink

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -174,6 +174,13 @@ Status ExchangeSinkOperator::Channel::init(RuntimeState* state) {
         return Status::OK();
     }
     _brpc_stub = state->exec_env()->brpc_stub_cache()->get_stub(_brpc_dest_addr);
+
+    if (_brpc_stub == nullptr) {
+        auto msg = fmt::format("The brpc stub of {}:{} is null.", _brpc_dest_addr.hostname, _brpc_dest_addr.port);
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
+
     _prepare_pass_through();
     _ignore_local_data = _enable_exchange_perf && is_local();
 


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

```
PC: @          0x3fbffa2 starrocks::pipeline::SinkBuffer::_try_to_send_rpc()
*** SIGSEGV (@0x0) received by PID 769 (TID 0x7f489efff700) from PID 0; stack trace: ***
    @          0x487c722 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f49c5619630 (unknown)
    @          0x3fbffa2 starrocks::pipeline::SinkBuffer::_try_to_send_rpc()
    @          0x3fc0742 starrocks::pipeline::SinkBuffer::add_request()
    @          0x3fb4357 starrocks::pipeline::ExchangeSinkOperator::Channel::send_one_chunk()
    @          0x3fb4cb4 starrocks::pipeline::ExchangeSinkOperator::Channel::_close_internal()
    @          0x3fb4d46 starrocks::pipeline::ExchangeSinkOperator::Channel::close()
    @          0x3fb5137 starrocks::pipeline::ExchangeSinkOperator::set_finishing()
    @          0x1e5c1a7 starrocks::pipeline::PipelineDriver::_mark_operator_finishing()
    @          0x1e5cdc5 starrocks::pipeline::PipelineDriver::process()
    @          0x3ce8805 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x37adbf5 starrocks::ThreadPool::dispatch_thread()
    @          0x37a8a9a starrocks::Thread::supervise_thread()
    @     0x7f49c5611ea5 start_thread
    @     0x7f49c4c2cb0d __clone
    @                0x0 (unknown)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
