### PR TITLE
[Enhancement] Refactor parquet late materialize

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -59,8 +59,7 @@ Status ColumnChunkReader::init(int chunk_size) {
 }
 
 Status ColumnChunkReader::load_header() {
-    RETURN_IF_ERROR(_parse_page_header());
-    return Status::OK();
+    return _parse_page_header();
 }
 
 Status ColumnChunkReader::load_page() {
@@ -121,7 +120,6 @@ Status ColumnChunkReader::_parse_page_data() {
     default:
         return Status::NotSupported(
                 strings::Substitute("Not supported page type: $0", _page_reader->current_header()->type));
-        break;
     }
     return Status::OK();
 }

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -112,9 +112,7 @@ public:
     }
 
     // You need to make sure that values_to_skip will not out-of-bound access
-    Status skip(size_t values_to_skip) {
-        return _cur_decoder->skip(values_to_skip);
-    }
+    Status skip(size_t values_to_skip) { return _cur_decoder->skip(values_to_skip); }
 
 private:
     // May return EOF in this function

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -72,7 +72,7 @@ public:
         return _rep_level_decoder.decode_batch(n, levels);
     }
 
-    Status decode_values(size_t n, const uint8_t* is_nulls, ColumnContentType content_type, Column* dst) {
+    Status decode_values(size_t n, const uint8_t* is_nulls, ColumnContentType* content_type, Column* dst) {
         size_t idx = 0;
         while (idx < n) {
             bool is_null = is_nulls[idx++];
@@ -90,7 +90,7 @@ public:
         return Status::OK();
     }
 
-    Status decode_values(size_t n, ColumnContentType content_type, Column* dst) {
+    Status decode_values(size_t n, ColumnContentType* content_type, Column* dst) {
         return _cur_decoder->next_batch(n, content_type, dst);
     }
 
@@ -111,12 +111,17 @@ public:
         return _cur_decoder->get_dict_codes(dict_values, dict_codes);
     }
 
+    // You need to make sure that values_to_skip will not out-of-bound access
+    Status skip(size_t values_to_skip) {
+        return _cur_decoder->skip(values_to_skip);
+    }
+
 private:
+    // May return EOF in this function
     Status _parse_page_header();
     Status _parse_page_data();
 
     Status _try_load_dictionary();
-    Status _read_and_decompress_page_data();
     Status _parse_data_page();
     Status _parse_dict_page();
 

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -82,9 +82,7 @@ public:
         return StoredColumnReader::create(_opts, field, chunk_metadata, &_reader);
     }
 
-    StatusOr<size_t> skip(size_t rows_to_skip) override {
-        return _reader->skip(rows_to_skip);
-    }
+    StatusOr<size_t> skip(size_t rows_to_skip) override { return _reader->skip(rows_to_skip); }
 
     StatusOr<size_t> prepare_batch(size_t rows_to_read, ColumnContentType* content_type, Column* dst) override {
         DCHECK(_field->is_nullable ? dst->is_nullable() : true);
@@ -140,9 +138,7 @@ public:
         return Status::OK();
     }
 
-    StatusOr<size_t> skip(size_t rows_to_skip) override {
-        return _element_reader->skip(rows_to_skip);
-    }
+    StatusOr<size_t> skip(size_t rows_to_skip) override { return _element_reader->skip(rows_to_skip); }
 
     StatusOr<size_t> prepare_batch(size_t rows_to_read, ColumnContentType* content_type, Column* dst) override {
         NullableColumn* nullable_column = nullptr;
@@ -253,7 +249,8 @@ public:
         }
 
         if (_value_reader != nullptr) {
-            ASSIGN_OR_RETURN(size_t tmp_rows_read, _value_reader->prepare_batch(rows_to_read, content_type, value_column));
+            ASSIGN_OR_RETURN(size_t tmp_rows_read,
+                             _value_reader->prepare_batch(rows_to_read, content_type, value_column));
             DCHECK(rows_read > 0 ? rows_read == tmp_rows_read : true);
             rows_read = tmp_rows_read;
         }
@@ -357,7 +354,7 @@ public:
 
     StatusOr<size_t> skip(const size_t rows_to_skip) override {
         size_t rows_skip = 0;
-        for(const auto& reader : _child_readers) {
+        for (const auto& reader : _child_readers) {
             if (reader != nullptr) {
                 if (rows_skip == 0) {
                     ASSIGN_OR_RETURN(rows_skip, reader->skip(rows_to_skip));
@@ -393,9 +390,11 @@ public:
             Column* child_column = fields_column[i].get();
             if (_child_readers[i] != nullptr) {
                 if (rows_read == 0) {
-                    ASSIGN_OR_RETURN(rows_read, _child_readers[i]->prepare_batch(rows_to_read, content_type, child_column));
+                    ASSIGN_OR_RETURN(rows_read,
+                                     _child_readers[i]->prepare_batch(rows_to_read, content_type, child_column));
                 } else {
-                    ASSIGN_OR_RETURN(size_t tmp_rows_read, _child_readers[i]->prepare_batch(rows_to_read, content_type, child_column));
+                    ASSIGN_OR_RETURN(size_t tmp_rows_read,
+                                     _child_readers[i]->prepare_batch(rows_to_read, content_type, child_column));
                     DCHECK_EQ(rows_read, tmp_rows_read);
                 }
             }

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -23,13 +23,6 @@ struct HdfsScanStats;
 } // namespace starrocks
 
 namespace starrocks::parquet {
-struct ColumnReaderContext {
-    Buffer<uint8_t>* filter = nullptr;
-    size_t next_row = 0;
-    size_t rows_to_skip = 0;
-
-    void advance(size_t num_rows) { next_row += num_rows; }
-};
 
 struct ColumnReaderOptions {
     std::string timezone;
@@ -39,7 +32,6 @@ struct ColumnReaderOptions {
     RandomAccessFile* file = nullptr;
     io::SharedBufferedInputStream* sb_stream = nullptr;
     tparquet::RowGroup* row_group_meta = nullptr;
-    ColumnReaderContext* context = nullptr;
 };
 
 class ColumnReader {
@@ -55,12 +47,20 @@ public:
 
     virtual ~ColumnReader() = default;
 
-    virtual Status prepare_batch(size_t* num_records, ColumnContentType content_type, Column* column) = 0;
+    // Will return actually rows read or InternalError
+    // If meet EOF, will return 0
+    virtual StatusOr<size_t> prepare_batch(size_t rows_to_read, ColumnContentType* content_type, Column* dst) = 0;
+
+    // Will return actually rows skipped or InternalError
+    // If meet EOF, will return 0
+    virtual StatusOr<size_t> skip(const size_t rows_to_skip) = 0;
+
     virtual Status finish_batch() = 0;
 
-    Status next_batch(size_t* num_records, ColumnContentType content_type, Column* column) {
-        RETURN_IF_ERROR(prepare_batch(num_records, content_type, column));
-        return finish_batch();
+    StatusOr<size_t> next_batch(size_t rows_to_read, ColumnContentType* content_type, Column* dst) {
+        ASSIGN_OR_RETURN(size_t rows_read, prepare_batch(rows_to_read, content_type, dst));
+        RETURN_IF_ERROR(finish_batch());
+        return rows_read;
     }
 
     virtual void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) = 0;

--- a/be/src/formats/parquet/encoding.h
+++ b/be/src/formats/parquet/encoding.h
@@ -72,6 +72,9 @@ public:
     // For history reason, decoder don't known how many elements encoded in one page.
     // Caller must assure that no out-of-bounds access.
     // It will return ERROR if caller wants to read out-of-bound data.
+    Status next_batch(size_t count, ColumnContentType* content_type, Column* dst) {
+        return next_batch(count, *content_type, dst);
+    }
     virtual Status next_batch(size_t count, ColumnContentType content_type, Column* dst) = 0;
 
     virtual Status skip(size_t values_to_skip) = 0;

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -408,6 +408,8 @@ void GroupReader::_init_read_chunk() {
 }
 
 StatusOr<size_t> GroupReader::_skip(const std::vector<int>& read_columns, size_t rows_to_skip) {
+    DCHECK(!read_columns.empty());
+
     size_t rows_skip = 0;
     for (int col_idx : read_columns) {
         auto& column = _param.read_cols[col_idx];
@@ -422,10 +424,7 @@ StatusOr<size_t> GroupReader::_skip(const std::vector<int>& read_columns, size_t
 }
 
 StatusOr<size_t> GroupReader::_read(const std::vector<int>& read_columns, size_t rows_to_read, ChunkPtr* chunk) {
-    if (read_columns.empty()) {
-        DCHECK(false);
-        return 0;
-    }
+    DCHECK(!read_columns.empty());
 
     size_t rows_read = 0;
     for (int col_idx : read_columns) {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -117,6 +117,7 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
 
     size_t active_rows = active_chunk->num_rows();
     if (active_rows > 0 && !_lazy_column_indices.empty()) {
+        SCOPED_RAW_TIMER(&_param.stats->group_chunk_read_ns);
         ChunkPtr lazy_chunk = _create_read_chunk(_lazy_column_indices);
         // skip previous accumulate rows to skip first
         if (_previous_rows_to_skip > 0) {
@@ -124,7 +125,6 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
             DCHECK_EQ(rows_skip, _previous_rows_to_skip);
             _previous_rows_to_skip = 0;
         }
-        SCOPED_RAW_TIMER(&_param.stats->group_chunk_read_ns);
         for (size_t index = 0; index < chunk_filter.size();) {
             bool is_selected = chunk_filter[index++];
             size_t run = 1;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -140,10 +140,10 @@ private:
     std::shared_ptr<tparquet::RowGroup> _row_group_metadata;
 
     // Used to support an Iceberg v2 format
-    std::int64_t _row_group_start_row = 0;
-    const std::set<std::int64_t>* _need_skip_rowids;
+    int64_t _row_group_start_row = 0;
+    const std::set<int64_t>* _need_skip_rowids;
     // Accumulate read rows in this RowGroup
-    std::int64_t _accumulate_rows_read = 0;
+    int64_t _accumulate_rows_read = 0;
 
     // column readers for column chunk in row group
     std::unordered_map<SlotId, std::unique_ptr<ColumnReader>> _column_readers;

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -242,12 +242,15 @@ public:
     void set_need_parse_levels(bool needs_levels) override { _need_parse_levels = needs_levels; }
 
     void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
-        // _needs_levels must be true
-        DCHECK(_need_parse_levels);
-
-        *def_levels = &_def_levels[0];
-        *rep_levels = nullptr;
-        *num_levels = _levels_parsed;
+        if (_need_parse_levels) {
+            *def_levels = &_def_levels[0];
+            *rep_levels = nullptr;
+            *num_levels = _levels_parsed;
+        } else {
+            *def_levels = nullptr;
+            *rep_levels = nullptr;
+            *num_levels = 0;
+        }
     }
 
     StatusOr<size_t> do_read_or_skip_rows(size_t rows_to_do, ColumnContentType* content_type, Column* dst) override {

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -38,9 +38,19 @@ public:
         return Status::OK();
     }
 
-    void reset() override;
+    void reset() override {
+        _meet_first_record = false;
+        size_t num_levels = _levels_decoded - _levels_parsed;
+        if (_levels_parsed == 0 || num_levels == 0) {
+            _levels_parsed = _levels_decoded = 0;
+            return;
+        }
 
-    Status do_read_records(size_t* num_rows, ColumnContentType content_type, Column* dst) override;
+        memmove(&_def_levels[0], &_def_levels[_levels_parsed], num_levels * sizeof(level_t));
+        memmove(&_rep_levels[0], &_rep_levels[_levels_parsed], num_levels * sizeof(level_t));
+        _levels_decoded -= _levels_parsed;
+        _levels_parsed = 0;
+    }
 
     void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
         *def_levels = &_def_levels[0];
@@ -49,18 +59,137 @@ public:
     }
 
 protected:
-    bool page_selected(size_t num_values) override;
+    StatusOr<size_t> do_read_or_skip_rows(size_t rows_to_do, ColumnContentType* content_type, Column* dst) override {
+        bool is_do_skip = dst == nullptr;
+        size_t rows_do = 0;
+        while (rows_do < rows_to_do) {
+            if (_num_values_left_in_cur_page == 0) {
+                // For repeated columns, it is difficult to skip rows according the num_values in header because
+                // there may be multiple values in one row.
+                // So we don't realize it until the page index is ready later.
+                auto st = load_next_page(0);
+                if (!st.ok()) {
+                    if (st.status().is_end_of_file()) {
+                        if (_meet_first_record) {
+                            rows_do++;
+                        }
+                        break;
+                    } else {
+                        return st.status();
+                    }
+                }
+                continue;
+            }
+
+            // NOTE: must have values in current page.
+            DCHECK_GT(_num_values_left_in_cur_page, 0);
+
+            size_t remain_rows_to_do = std::min(rows_to_do - rows_do, _num_values_left_in_cur_page);
+            _decode_levels(remain_rows_to_do);
+
+            auto res = _delimit_rows(remain_rows_to_do);
+            remain_rows_to_do = res.first;
+            size_t levels_parsed = res.second;
+
+            // decode value read from reader
+            // TODO(zc): optimized here
+            {
+                // ensure enough capacity
+                _is_nulls.resize(levels_parsed);
+                int null_pos = 0;
+                for (int i = 0; i < levels_parsed; ++i) {
+                    level_t def_level = _def_levels[i + _levels_parsed];
+                    _is_nulls[null_pos] = (def_level < _field->max_def_level());
+                    // If current def level < ancestor def level, the ancestor will be not defined too, so that we don't
+                    // need to add null value to this column. Otherwise, we need to add null value to this column.
+                    null_pos += (def_level >= _field->level_info.immediate_repeated_ancestor_def_level);
+                }
+                if (is_do_skip) {
+                    RETURN_IF_ERROR(_reader->skip(null_pos));
+                } else {
+                    RETURN_IF_ERROR(_reader->decode_values(null_pos, &_is_nulls[0], content_type, dst));
+                }
+            }
+
+            rows_do += remain_rows_to_do;
+            _levels_parsed += levels_parsed;
+            _num_values_left_in_cur_page -= levels_parsed;
+        }
+        return rows_do;
+    }
 
 private:
     // Try to deocde enough levels in levels buffer, except there is no enough levels in current
-    void _decode_levels(size_t num_levels);
+    void _decode_levels(size_t num_levels) {
+        constexpr size_t min_level_batch_size = 4096;
+        size_t levels_remaining = _levels_decoded - _levels_parsed;
+        if (num_levels <= levels_remaining) {
+            return;
+        }
+        size_t levels_to_decode = std::max(min_level_batch_size, num_levels - levels_remaining);
+        levels_to_decode = std::min(levels_to_decode, _num_values_left_in_cur_page - levels_remaining);
 
-    void _delimit_rows(size_t* num_rows, size_t* num_levels_parsed);
+        size_t new_capacity = _levels_decoded + levels_to_decode;
+        if (new_capacity > _levels_capacity) {
+            new_capacity = BitUtil::next_power_of_two(new_capacity);
+            _def_levels.resize(new_capacity);
+            _rep_levels.resize(new_capacity);
 
-private:
+            _levels_capacity = new_capacity;
+        }
+
+        size_t res_def = _reader->decode_def_levels(levels_to_decode, &_def_levels[_levels_decoded]);
+        size_t res_rep = _reader->decode_rep_levels(levels_to_decode, &_rep_levels[_levels_decoded]);
+        DCHECK_EQ(res_def, res_rep);
+
+        _levels_decoded += levels_to_decode;
+    }
+
+    std::pair<size_t, size_t> _delimit_rows(size_t rows_to_read) {
+        DCHECK_GT(_levels_decoded - _levels_parsed, 0);
+        size_t levels_pos = _levels_parsed;
+
+#ifndef NDEBUG
+        std::stringstream ss;
+        ss << "rep=[";
+        for (int i = levels_pos; i < _levels_decoded; ++i) {
+            ss << ", " << _rep_levels[i];
+        }
+        ss << "], def=[";
+        for (int i = levels_pos; i < _levels_decoded; ++i) {
+            ss << ", " << _def_levels[i];
+        }
+        ss << "]";
+        VLOG_FILE << ss.str();
+#endif
+
+        if (!_meet_first_record) {
+            _meet_first_record = true;
+            DCHECK_EQ(_rep_levels[levels_pos], 0);
+            levels_pos++;
+        }
+
+        size_t rows_read = 0;
+        for (; levels_pos < _levels_decoded && rows_read < rows_to_read; ++levels_pos) {
+            rows_read += _rep_levels[levels_pos] == 0;
+        }
+
+        if (rows_read == rows_to_read) {
+            // Notice, ++levels_pos in for-loop will take one step forward, so we need -1
+            levels_pos--;
+            DCHECK_EQ(0, _rep_levels[levels_pos]);
+        } // else {
+        //  means  rows_read < *num_rows, levels_pos >= _levels_decoded,
+        //  so we need to decode more levels to obtain a complete line or
+        //  we have read all the records in this column chunk.
+        // }
+
+        VLOG_FILE << "rows_reader=" << rows_read << ", level_parsed=" << levels_pos - _levels_parsed;
+        return std::make_pair(rows_read, levels_pos - _levels_parsed);
+    }
+
     const ParquetField* _field = nullptr;
 
-    bool _eof = false;
     bool _meet_first_record = false;
 
     size_t _levels_parsed = 0;
@@ -87,14 +216,16 @@ public:
     }
 
     // Reset internal state and ready for next read_values
-    void reset() override;
-
-    Status do_read_records(size_t* num_records, ColumnContentType content_type, Column* dst) override {
-        if (_need_parse_levels) {
-            return _read_records_and_levels(num_records, content_type, dst);
-        } else {
-            return _read_records_only(num_records, content_type, dst);
+    void reset() override {
+        size_t num_levels = _levels_decoded - _levels_parsed;
+        if (_levels_parsed == 0 || num_levels == 0) {
+            _levels_parsed = _levels_decoded = 0;
+            return;
         }
+
+        memmove(&_def_levels[0], &_def_levels[_levels_parsed], num_levels * sizeof(level_t));
+        _levels_decoded -= _levels_parsed;
+        _levels_parsed = 0;
     }
 
     // If need_levels is set, client will get all levels through get_levels function.
@@ -111,10 +242,144 @@ public:
         *num_levels = _levels_parsed;
     }
 
+    StatusOr<size_t> do_read_or_skip_rows(size_t rows_to_do, ColumnContentType* content_type, Column* dst) override {
+        bool is_do_skip = dst == nullptr;
+        SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
+        size_t rows_do = 0;
+        while (rows_do < rows_to_do) {
+            if (_num_values_left_in_cur_page == 0) {
+                StatusOr<size_t> st;
+                if (is_do_skip) {
+                    st = load_next_page(rows_to_do - rows_do);
+                } else {
+                    st = load_next_page(0);
+                }
+                if (st.ok()) {
+                    rows_do += st.value();
+                } else {
+                    if (st.status().is_end_of_file()) {
+                        break;
+                    } else {
+                        return st.status();
+                    }
+                }
+                continue;
+            }
+
+            // NOTE: must have values in current page.
+            DCHECK_GT(_num_values_left_in_cur_page, 0);
+
+            size_t remain_rows_to_do = std::min(rows_to_do - rows_do, _num_values_left_in_cur_page);
+            DCHECK(remain_rows_to_do > 0);
+
+            if (_need_parse_levels) {
+                {
+                    SCOPED_RAW_TIMER(&_opts.stats->level_decode_ns);
+                    // TODO Support to skip _decode_levels
+                    _decode_levels(remain_rows_to_do);
+                }
+                if (is_do_skip) {
+                    RETURN_IF_ERROR(_reader->skip(remain_rows_to_do));
+                } else {
+                    // TODO(zc): make it better
+                    _is_nulls.resize(remain_rows_to_do);
+                    // decode def levels
+                    for (size_t i = 0; i < remain_rows_to_do; ++i) {
+                        _is_nulls[i] = _def_levels[_levels_parsed + i] < _field->max_def_level();
+                    }
+                    SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
+                    RETURN_IF_ERROR(_reader->decode_values(remain_rows_to_do, &_is_nulls[0], content_type, dst));
+                }
+                _levels_parsed += remain_rows_to_do;
+                _num_values_left_in_cur_page -= remain_rows_to_do;
+                rows_do += remain_rows_to_do;
+            } else {
+                size_t repeated_count = _reader->def_level_decoder().next_repeated_count();
+                if (repeated_count > 0) {
+                    remain_rows_to_do = std::min(remain_rows_to_do, repeated_count);
+                    level_t def_level = 0;
+                    {
+                        // just advance cursor
+                        SCOPED_RAW_TIMER(&_opts.stats->level_decode_ns);
+                        def_level = _reader->def_level_decoder().get_repeated_value(remain_rows_to_do);
+                    }
+                    SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
+                    if (is_do_skip) {
+                        if (def_level >= _field->max_def_level()) {
+                            RETURN_IF_ERROR(_reader->skip(remain_rows_to_do));
+                        }
+                    } else {
+                        if (def_level >= _field->max_def_level()) {
+                            RETURN_IF_ERROR(_reader->decode_values(remain_rows_to_do, content_type, dst));
+                        } else {
+                            dst->append_nulls(remain_rows_to_do);
+                        }
+                    }
+                } else {
+                    {
+                        SCOPED_RAW_TIMER(&_opts.stats->level_decode_ns);
+
+                        size_t new_capacity = remain_rows_to_do;
+                        if (new_capacity > _levels_capacity) {
+                            new_capacity = BitUtil::next_power_of_two(new_capacity);
+                            _def_levels.resize(new_capacity);
+
+                            _levels_capacity = new_capacity;
+                        }
+                        _reader->decode_def_levels(remain_rows_to_do, &_def_levels[0]);
+                    }
+                    SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
+                    size_t i = 0;
+                    while (i < remain_rows_to_do) {
+                        size_t j = i;
+                        bool is_null = _def_levels[j] < _field->max_def_level();
+                        j++;
+                        while (j < remain_rows_to_do && is_null == (_def_levels[j] < _field->max_def_level())) {
+                            j++;
+                        }
+                        if (is_do_skip) {
+                            if (!is_null) {
+                                RETURN_IF_ERROR(_reader->skip(j - i));
+                            }
+                        } else {
+                            if (is_null) {
+                                dst->append_nulls(j - i);
+                            } else {
+                                RETURN_IF_ERROR(_reader->decode_values(j - i, content_type, dst));
+                            }
+                        }
+                        i = j;
+                    }
+                }
+                _num_values_left_in_cur_page -= remain_rows_to_do;
+                rows_do += remain_rows_to_do;
+            }
+        }
+        return rows_do;
+    }
+
 private:
-    void _decode_levels(size_t num_levels);
-    Status _read_records_only(size_t* num_records, ColumnContentType content_type, Column* dst);
-    Status _read_records_and_levels(size_t* num_records, ColumnContentType content_type, Column* dst);
+    void _decode_levels(size_t num_levels) {
+        constexpr size_t min_level_batch_size = 4096;
+        size_t levels_remaining = _levels_decoded - _levels_parsed;
+        if (num_levels <= levels_remaining) {
+            return;
+        }
+        size_t levels_to_decode = std::max(min_level_batch_size, num_levels - levels_remaining);
+        levels_to_decode = std::min(levels_to_decode, _num_values_left_in_cur_page - levels_remaining);
+
+        size_t new_capacity = _levels_decoded + levels_to_decode;
+        if (new_capacity > _levels_capacity) {
+            new_capacity = BitUtil::next_power_of_two(new_capacity);
+            _def_levels.resize(new_capacity);
+
+            _levels_capacity = new_capacity;
+        }
+
+        _reader->decode_def_levels(levels_to_decode, &_def_levels[_levels_decoded]);
+
+        _levels_decoded += levels_to_decode;
+    }
 
     const ParquetField* _field = nullptr;
 
@@ -122,8 +387,6 @@ private:
     // so that the advantages of RLE encoding can be fully utilized and a lot of overhead
     // can be saved in decoding.
     bool _need_parse_levels = false;
-
-    bool _eof = false;
 
     size_t _levels_parsed = 0;
     size_t _levels_decoded = 0;
@@ -148,12 +411,50 @@ public:
 
     void reset() override {}
 
-    Status do_read_records(size_t* num_rows, ColumnContentType content_type, Column* dst) override;
-
     void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
         *def_levels = nullptr;
         *rep_levels = nullptr;
         *num_levels = 0;
+    }
+
+    StatusOr<size_t> do_read_or_skip_rows(size_t rows_to_do, ColumnContentType* content_type, Column* dst) override {
+        bool is_do_skip = dst == nullptr;
+        SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
+        size_t rows_do = 0;
+        while (rows_do < rows_to_do) {
+            if (_num_values_left_in_cur_page == 0) {
+                StatusOr<size_t> st;
+                if (is_do_skip) {
+                    st = load_next_page(rows_to_do);
+                } else {
+                    st = load_next_page(0);
+                }
+                if (st.ok()) {
+                    rows_do += st.value();
+                } else {
+                    if (st.status().is_end_of_file()) {
+                        break;
+                    } else {
+                        return st;
+                    }
+                }
+                continue;
+            }
+
+            // NOTE: must have values in current page.
+            DCHECK_GT(_num_values_left_in_cur_page, 0);
+
+            size_t remain_rows_to_do = std::min(rows_to_do - rows_do, _num_values_left_in_cur_page);
+            if (is_do_skip) {
+                RETURN_IF_ERROR(_reader->skip(remain_rows_to_do));
+            } else {
+                RETURN_IF_ERROR(_reader->decode_values(remain_rows_to_do, content_type, dst));
+            }
+
+            rows_do += remain_rows_to_do;
+            _num_values_left_in_cur_page -= remain_rows_to_do;
+        }
+        return rows_do;
     }
 
 private:
@@ -161,356 +462,6 @@ private:
     const tparquet::ColumnChunk _chunk_metadata;
     const ParquetField* _field = nullptr;
 };
-
-void RepeatedStoredColumnReader::reset() {
-    _meet_first_record = false;
-    size_t num_levels = _levels_decoded - _levels_parsed;
-    if (_levels_parsed == 0 || num_levels == 0) {
-        _levels_parsed = _levels_decoded = 0;
-        return;
-    }
-
-    memmove(&_def_levels[0], &_def_levels[_levels_parsed], num_levels * sizeof(level_t));
-    memmove(&_rep_levels[0], &_rep_levels[_levels_parsed], num_levels * sizeof(level_t));
-    _levels_decoded -= _levels_parsed;
-    _levels_parsed = 0;
-}
-
-Status RepeatedStoredColumnReader::do_read_records(size_t* num_records, ColumnContentType content_type, Column* dst) {
-    if (_eof) {
-        *num_records = 0;
-        return Status::EndOfFile("");
-    }
-
-    size_t records_read = 0;
-    do {
-        if (_num_values_left_in_cur_page == 0) {
-            size_t read_count = 0;
-            auto st = next_page(*num_records - records_read, content_type, &read_count, dst);
-            DCHECK(read_count <= (*num_records - records_read));
-            records_read += read_count;
-            if (!st.ok()) {
-                if (st.is_end_of_file()) {
-                    if (_meet_first_record) {
-                        records_read++;
-                    }
-                    _eof = true;
-                    break;
-                } else {
-                    return st;
-                }
-            }
-        }
-
-        // NOTE: must have values in current page.
-        DCHECK_GT(_num_values_left_in_cur_page, 0);
-
-        size_t records_to_read = *num_records - records_read;
-        _decode_levels(records_to_read);
-
-        size_t num_parsed_levels = 0;
-        _delimit_rows(&records_to_read, &num_parsed_levels);
-
-        // decode value read from reader
-        // TODO(zc): optimized here
-        {
-            // ensure enough capacity
-            _is_nulls.resize(num_parsed_levels);
-            int null_pos = 0;
-            for (int i = 0; i < num_parsed_levels; ++i) {
-                level_t def_level = _def_levels[i + _levels_parsed];
-                _is_nulls[null_pos] = (def_level < _field->max_def_level());
-                // if current def level < ancestor def level, the ancestor will be not defined too, so that we don't
-                // need to add null value to this column. Otherwise, we need to add null value to this column.
-                null_pos += (def_level >= _field->level_info.immediate_repeated_ancestor_def_level);
-            }
-            RETURN_IF_ERROR(_reader->decode_values(null_pos, &_is_nulls[0], content_type, dst));
-        }
-
-        records_read += records_to_read;
-        _levels_parsed += num_parsed_levels;
-        _num_values_left_in_cur_page -= num_parsed_levels;
-        update_read_context(records_to_read);
-    } while (records_read < *num_records);
-
-    DCHECK(records_read <= *num_records);
-
-    *num_records = records_read;
-    return Status::OK();
-}
-
-// For repeated columns, it is difficult to skip rows according the num_values in header because
-// there may be multiple values in one row. So we don't realize it util the page index is ready later.
-bool RepeatedStoredColumnReader::page_selected(size_t num_values) {
-    return true;
-}
-
-void RepeatedStoredColumnReader::_delimit_rows(size_t* num_rows, size_t* num_levels_parsed) {
-    DCHECK_GT(_levels_decoded - _levels_parsed, 0);
-    size_t levels_pos = _levels_parsed;
-
-#ifndef NDEBUG
-    std::stringstream ss;
-    ss << "rep=[";
-    for (int i = levels_pos; i < _levels_decoded; ++i) {
-        ss << ", " << _rep_levels[i];
-    }
-    ss << "], def=[";
-    for (int i = levels_pos; i < _levels_decoded; ++i) {
-        ss << ", " << _def_levels[i];
-    }
-    ss << "]";
-    VLOG_FILE << ss.str();
-#endif
-
-    if (!_meet_first_record) {
-        _meet_first_record = true;
-        DCHECK_EQ(_rep_levels[levels_pos], 0);
-        levels_pos++;
-    }
-
-    size_t rows_read = 0;
-    for (; levels_pos < _levels_decoded && rows_read < *num_rows; ++levels_pos) {
-        rows_read += _rep_levels[levels_pos] == 0;
-    }
-
-    if (rows_read == *num_rows) {
-        // Notice, ++levels_pos in for-loop will take one step forward, so we need -1
-        levels_pos--;
-        DCHECK_EQ(0, _rep_levels[levels_pos]);
-    } // else {
-      //  means  rows_read < *num_rows, levels_pos >= _levels_decoded,
-      //  so we need to decode more levels to obtain a complete line or
-      //  we have read all the records in this column chunk.
-    // }
-
-    VLOG_FILE << "rows_reader=" << rows_read << ", level_parsed=" << levels_pos - _levels_parsed;
-    *num_rows = rows_read;
-    *num_levels_parsed = levels_pos - _levels_parsed;
-}
-
-void RepeatedStoredColumnReader::_decode_levels(size_t num_levels) {
-    constexpr size_t min_level_batch_size = 4096;
-    size_t levels_remaining = _levels_decoded - _levels_parsed;
-    if (num_levels <= levels_remaining) {
-        return;
-    }
-    size_t levels_to_decode = std::max(min_level_batch_size, num_levels - levels_remaining);
-    levels_to_decode = std::min(levels_to_decode, _num_values_left_in_cur_page - levels_remaining);
-
-    size_t new_capacity = _levels_decoded + levels_to_decode;
-    if (new_capacity > _levels_capacity) {
-        new_capacity = BitUtil::next_power_of_two(new_capacity);
-        _def_levels.resize(new_capacity);
-        _rep_levels.resize(new_capacity);
-
-        _levels_capacity = new_capacity;
-    }
-
-    size_t res_def = _reader->decode_def_levels(levels_to_decode, &_def_levels[_levels_decoded]);
-    size_t res_rep = _reader->decode_rep_levels(levels_to_decode, &_rep_levels[_levels_decoded]);
-    DCHECK_EQ(res_def, res_rep);
-
-    _levels_decoded += levels_to_decode;
-}
-
-void OptionalStoredColumnReader::reset() {
-    size_t num_levels = _levels_decoded - _levels_parsed;
-    if (_levels_parsed == 0 || num_levels == 0) {
-        _levels_parsed = _levels_decoded = 0;
-        return;
-    }
-
-    memmove(&_def_levels[0], &_def_levels[_levels_parsed], num_levels * sizeof(level_t));
-    _levels_decoded -= _levels_parsed;
-    _levels_parsed = 0;
-}
-
-Status OptionalStoredColumnReader::_read_records_and_levels(size_t* num_records, ColumnContentType content_type,
-                                                            Column* dst) {
-    SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
-    if (_eof) {
-        *num_records = 0;
-        return Status::EndOfFile("");
-    }
-    size_t records_read = 0;
-    do {
-        if (_num_values_left_in_cur_page == 0) {
-            SCOPED_RAW_TIMER(&_opts.stats->page_read_ns);
-            size_t read_count = 0;
-            auto st = next_page(*num_records - records_read, content_type, &read_count, dst);
-            records_read += read_count;
-            if (!st.ok()) {
-                if (st.is_end_of_file()) {
-                    _eof = true;
-                    break;
-                } else {
-                    return st;
-                }
-            }
-        }
-
-        size_t records_to_read = std::min(*num_records - records_read, _num_values_left_in_cur_page);
-        if (records_to_read == 0) {
-            break;
-        }
-
-        {
-            SCOPED_RAW_TIMER(&_opts.stats->level_decode_ns);
-            _decode_levels(records_to_read);
-        }
-
-        {
-            // TODO(zc): make it better
-            _is_nulls.resize(records_to_read);
-            // decode def levels
-            for (size_t i = 0; i < records_to_read; ++i) {
-                _is_nulls[i] = _def_levels[_levels_parsed + i] < _field->max_def_level();
-            }
-            SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
-            RETURN_IF_ERROR(_reader->decode_values(records_to_read, &_is_nulls[0], content_type, dst));
-        }
-        _num_values_left_in_cur_page -= records_to_read;
-        _levels_parsed += records_to_read;
-        records_read += records_to_read;
-        update_read_context(records_to_read);
-    } while (records_read < *num_records);
-    *num_records = records_read;
-    return Status::OK();
-}
-
-Status OptionalStoredColumnReader::_read_records_only(size_t* num_records, ColumnContentType content_type,
-                                                      Column* dst) {
-    SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
-    if (_eof) {
-        return Status::EndOfFile("");
-    }
-    size_t records_read = 0;
-    do {
-        if (_num_values_left_in_cur_page == 0) {
-            SCOPED_RAW_TIMER(&_opts.stats->page_read_ns);
-            size_t read_count = 0;
-            auto st = next_page(*num_records - records_read, content_type, &read_count, dst);
-            records_read += read_count;
-            if (!st.ok()) {
-                if (st.is_end_of_file()) {
-                    _eof = true;
-                    break;
-                } else {
-                    return st;
-                }
-            }
-        }
-
-        size_t records_to_read = std::min(*num_records - records_read, _num_values_left_in_cur_page);
-        if (records_to_read == 0) {
-            break;
-        }
-
-        size_t repeated_count = _reader->def_level_decoder().next_repeated_count();
-        if (repeated_count > 0) {
-            records_to_read = std::min(records_to_read, repeated_count);
-            level_t def_level = 0;
-            {
-                SCOPED_RAW_TIMER(&_opts.stats->level_decode_ns);
-                def_level = _reader->def_level_decoder().get_repeated_value(records_to_read);
-            }
-            SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
-            if (def_level >= _field->max_def_level()) {
-                RETURN_IF_ERROR(_reader->decode_values(records_to_read, content_type, dst));
-            } else {
-                dst->append_nulls(records_to_read);
-            }
-        } else {
-            {
-                SCOPED_RAW_TIMER(&_opts.stats->level_decode_ns);
-
-                size_t new_capacity = records_to_read;
-                if (new_capacity > _levels_capacity) {
-                    new_capacity = BitUtil::next_power_of_two(new_capacity);
-                    _def_levels.resize(new_capacity);
-
-                    _levels_capacity = new_capacity;
-                }
-                _reader->decode_def_levels(records_to_read, &_def_levels[0]);
-            }
-
-            SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
-            size_t i = 0;
-            while (i < records_to_read) {
-                size_t j = i;
-                bool is_null = _def_levels[j] < _field->max_def_level();
-                j++;
-                while (j < records_to_read && is_null == (_def_levels[j] < _field->max_def_level())) {
-                    j++;
-                }
-                if (is_null) {
-                    dst->append_nulls(j - i);
-                } else {
-                    RETURN_IF_ERROR(_reader->decode_values(j - i, content_type, dst));
-                }
-                i = j;
-            }
-        }
-
-        _num_values_left_in_cur_page -= records_to_read;
-        records_read += records_to_read;
-        update_read_context(records_to_read);
-    } while (records_read < *num_records);
-    *num_records = records_read;
-    return Status::OK();
-}
-
-void OptionalStoredColumnReader::_decode_levels(size_t num_levels) {
-    constexpr size_t min_level_batch_size = 4096;
-    size_t levels_remaining = _levels_decoded - _levels_parsed;
-    if (num_levels <= levels_remaining) {
-        return;
-    }
-    size_t levels_to_decode = std::max(min_level_batch_size, num_levels - levels_remaining);
-    levels_to_decode = std::min(levels_to_decode, _num_values_left_in_cur_page - levels_remaining);
-
-    size_t new_capacity = _levels_decoded + levels_to_decode;
-    if (new_capacity > _levels_capacity) {
-        new_capacity = BitUtil::next_power_of_two(new_capacity);
-        _def_levels.resize(new_capacity);
-
-        _levels_capacity = new_capacity;
-    }
-
-    _reader->decode_def_levels(levels_to_decode, &_def_levels[_levels_decoded]);
-
-    _levels_decoded += levels_to_decode;
-}
-
-Status RequiredStoredColumnReader::do_read_records(size_t* num_records, ColumnContentType content_type, Column* dst) {
-    size_t records_read = 0;
-    while (records_read < *num_records) {
-        if (_num_values_left_in_cur_page == 0) {
-            size_t read_count = 0;
-            auto st = next_page(*num_records - records_read, content_type, &read_count, dst);
-            records_read += read_count;
-            if (!st.ok()) {
-                if (st.is_end_of_file()) {
-                    break;
-                } else {
-                    return st;
-                }
-            }
-        }
-
-        size_t records_to_read = std::min(*num_records - records_read, _num_values_left_in_cur_page);
-        if (records_to_read == 0) {
-            break;
-        }
-        RETURN_IF_ERROR(_reader->decode_values(records_to_read, content_type, dst));
-        records_read += records_to_read;
-        _num_values_left_in_cur_page -= records_to_read;
-        update_read_context(records_to_read);
-    }
-    *num_records = records_read;
-    return Status::OK();
-}
 
 Status StoredColumnReader::create(const ColumnReaderOptions& opts, const ParquetField* field,
                                   const tparquet::ColumnChunk* chunk_metadata,
@@ -531,115 +482,34 @@ Status StoredColumnReader::create(const ColumnReaderOptions& opts, const Parquet
     return Status::OK();
 }
 
-Status StoredColumnReader::next_page(size_t records_to_read, ColumnContentType content_type, size_t* records_read,
-                                     Column* dst) {
-    *records_read = 0;
-    size_t records_to_skip = 0;
-    RETURN_IF_ERROR(_next_selected_page(records_to_read, content_type, &records_to_skip, dst));
-    if (records_to_skip == 0) {
-        return Status::OK();
-    }
-
-    if (_opts.context->rows_to_skip > 0) {
-        _opts.context->rows_to_skip -= records_to_skip;
-    }
-    if (_opts.context->filter) {
-        dst->append_default(records_to_skip);
-        *records_read = records_to_skip;
-    }
-    return Status::OK();
-}
-
-Status StoredColumnReader::_next_selected_page(size_t records_to_read, ColumnContentType content_type,
-                                               size_t* records_to_skip, Column* dst) {
-    *records_to_skip = 0;
-    do {
-        size_t remain_values =
-                _num_values_skip_in_cur_page > 0 ? _reader->num_values() - _num_values_skip_in_cur_page : 0;
-        if (remain_values == 0) {
-            RETURN_IF_ERROR(_reader->load_header());
-            size_t num_values = _reader->num_values();
-            if (num_values == 0) {
-                if (_reader->current_page_is_dict()) {
-                    RETURN_IF_ERROR(_reader->load_page());
-                } else {
-                    RETURN_IF_ERROR(_reader->skip_page());
-                }
-                continue;
-            }
-            _num_values_skip_in_cur_page = 0;
-            remain_values = num_values;
-        }
-
-        size_t to_read = records_to_read - *records_to_skip;
-        if (page_selected(remain_values)) {
+// Load next page
+// You need make sure _num_values_left_in_cur_page is 0
+// Will return the values your skipped, Status::EndOfFile() or Status::InternalError()
+StatusOr<size_t> StoredColumnReader::load_next_page(size_t values_to_skip) {
+    SCOPED_RAW_TIMER(&_opts.stats->page_read_ns);
+    // Only cur page's num values are consumed can load next page
+    DCHECK(_num_values_left_in_cur_page == 0);
+    // may return EOF here
+    RETURN_IF_ERROR(_reader->load_header());
+    size_t num_values = _reader->num_values();
+    if (num_values == 0) {
+        if (_reader->current_page_is_dict()) {
+            // load dict page
             RETURN_IF_ERROR(_reader->load_page());
-            _num_values_left_in_cur_page = _reader->num_values();
-            size_t batch_size = records_to_read;
-            _lazy_load_page_rows(batch_size, content_type, dst);
-            _num_values_skip_in_cur_page = 0;
-            break;
+        } else {
+            RETURN_IF_ERROR(_reader->skip_page());
         }
+        return 0;
+    }
 
-        if (_opts.context->filter) {
-            _opts.context->advance(std::min(to_read, remain_values));
-        }
-        if (to_read < remain_values) {
-            _num_values_skip_in_cur_page += to_read;
-            *records_to_skip += to_read;
-            break;
-        }
+    if (values_to_skip >= num_values) {
         RETURN_IF_ERROR(_reader->skip_page());
-        *records_to_skip += remain_values;
-        _num_values_skip_in_cur_page = 0;
-    } while (*records_to_skip < records_to_read);
+        return num_values;
+    }
 
-    return Status::OK();
+    // start to read data page
+    RETURN_IF_ERROR(_reader->load_page());
+    _num_values_left_in_cur_page = num_values;
+    return 0;
 }
-
-Status StoredColumnReader::_lazy_load_page_rows(size_t batch_size, ColumnContentType content_type, Column* dst) {
-    size_t load_rows = _num_values_skip_in_cur_page;
-    if (load_rows == 0) {
-        return Status::OK();
-    }
-
-    // TODO: We simply use reading records to decode and seek rows position now, it may cause some extra
-    // memory copy. A more efficient way requires major changes to the current code, but it is necessary.
-    auto filter = _opts.context->filter;
-    auto rows_to_skip = _opts.context->rows_to_skip;
-    _opts.context->filter = nullptr;
-    _opts.context->rows_to_skip = 0;
-    while (load_rows > 0) {
-        size_t to_read = std::min(load_rows, batch_size);
-        auto temp_column = dst->clone_empty();
-        RETURN_IF_ERROR(do_read_records(&to_read, content_type, temp_column.get()));
-        // TODO(SmithCruise) Refactor it
-        // We need reset def/rep cursor after lazy load
-        reset();
-        load_rows -= to_read;
-    }
-    _opts.context->filter = filter;
-    _opts.context->rows_to_skip = rows_to_skip;
-    return Status::OK();
-}
-
-bool StoredColumnReader::page_selected(size_t num_values) {
-    auto filter = _opts.context->filter;
-    if (!filter) {
-        return true;
-    }
-    size_t start_row = _opts.context->next_row;
-    int end_row = std::min(start_row + num_values, filter->size()) - 1;
-    return SIMD::find_nonzero(*filter, start_row) <= end_row;
-}
-
-void StoredColumnReader::update_read_context(size_t records_read) {
-    if (_opts.context->rows_to_skip > 0) {
-        _opts.context->rows_to_skip -= records_read;
-    }
-    if (_opts.context->filter) {
-        _opts.context->advance(records_read);
-    }
-}
-
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/stored_column_reader.h
+++ b/be/src/formats/parquet/stored_column_reader.h
@@ -82,13 +82,15 @@ public:
     virtual Status get_dict_codes(const std::vector<Slice>& dict_values, std::vector<int32_t>* dict_codes) {
         return _reader->get_dict_codes(dict_values, dict_codes);
     }
+
 protected:
     // Load next page
     // Will return values you skipped(values, not rows)
     // If meet EOF, will return Status::EndOfFile()
     StatusOr<size_t> load_next_page(size_t values_to_skip);
     // Skip and read have similar logic, so we combine it into a function
-    virtual StatusOr<size_t> do_read_or_skip_rows(size_t rows_to_do, ColumnContentType* content_type = nullptr, Column* dst = nullptr) = 0;
+    virtual StatusOr<size_t> do_read_or_skip_rows(size_t rows_to_do, ColumnContentType* content_type = nullptr,
+                                                  Column* dst = nullptr) = 0;
 
     std::unique_ptr<ColumnChunkReader> _reader;
     size_t _num_values_left_in_cur_page = 0;

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -39,10 +39,13 @@ public:
     explicit MockColumnReader(tparquet::Type::type type) : _type(type) {}
     ~MockColumnReader() override = default;
 
-    Status prepare_batch(size_t* num_records, ColumnContentType content_type, Column* column) override {
+    StatusOr<size_t> skip(const size_t rows_to_skip) override {
+        return Status::NotSupported("Not implement");
+    }
+
+    StatusOr<size_t> prepare_batch(size_t num_records, ColumnContentType* content_type, Column* column) override {
         if (_step > 1) {
-            *num_records = 0;
-            return Status::EndOfFile("");
+            return 0;
         }
         size_t start = 0;
         size_t num_rows = 0;
@@ -69,8 +72,7 @@ public:
         }
 
         _step++;
-        *num_records = num_rows;
-        return Status::OK();
+        return num_rows;
     }
 
     Status finish_batch() override { return Status::OK(); }


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

In this pr, I refactor the parquet late materialize logic, making it easier to maintain. Especially for complex types.
* provide `skip()` ability in the parquet reader, and we use the skip ability to achieve late materialize. The logic code control late materializes only in `GroupReader`.
* Remove `ColumnReaderContext`, it is used to control late materialize, it is shared by all columns, so it's hard to maintain and easily produces bugs.
* Refactor function about `read()` and `skip()`, the return value will only be the number of rows proceeds or InternalError()
* Remove unnecessary judgment about EOF, we will only handle EOF situations in GroupReader. In `ColumnReader`, `StoredColumnReader` will only return 0 when facing an EOF situation.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
