### PR TITLE
[Enhancement][Cherry-Pick][Branch-2.5] Change primary index hash from crc32 to XXH3_64 (#22123)

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -16,6 +16,7 @@
 #include "storage/tablet_updates.h"
 #include "util/stack_util.h"
 #include "util/starrocks_metrics.h"
+#include "util/xxh3.h"
 
 namespace starrocks {
 
@@ -87,9 +88,14 @@ const uint32_t PREFETCHN = 8;
 template <typename Key>
 class HashIndexImpl : public HashIndex {
 private:
+<<<<<<< HEAD
     phmap::parallel_flat_hash_map<Key, RowIdPack4, vectorized::StdHashWithSeed<Key, vectorized::PhmapSeed1>,
                                   phmap::priv::hash_default_eq<Key>,
                                   TraceAlloc<phmap::priv::Pair<const Key, RowIdPack4>>, 4, phmap::NullMutex, false>
+=======
+    phmap::parallel_flat_hash_map<Key, RowIdPack4, StdHashWithSeed<Key, PhmapSeed1>, phmap::priv::hash_default_eq<Key>,
+                                  TraceAlloc<phmap::priv::Pair<const Key, RowIdPack4>>, 4, phmap::NullMutex, true>
+>>>>>>> e771c35... [Enhancement] Change primary index hash from crc32 to XXH3_64 (#22123)
             _map;
 
 public:
@@ -231,7 +237,11 @@ struct FixSlice {
 
 template <size_t S>
 struct FixSliceHash {
+<<<<<<< HEAD
     size_t operator()(const FixSlice<S>& v) const { return vectorized::crc_hash_64(v.v, 4 * S, 0x811C9DC5); }
+=======
+    size_t operator()(const FixSlice<S>& v) const { return XXH3_64bits(v.v, 4 * S); }
+>>>>>>> e771c35... [Enhancement] Change primary index hash from crc32 to XXH3_64 (#22123)
 };
 
 template <size_t S>
@@ -239,7 +249,7 @@ class FixSliceHashIndex : public HashIndex {
 private:
     phmap::parallel_flat_hash_map<FixSlice<S>, RowIdPack4, FixSliceHash<S>, phmap::priv::hash_default_eq<FixSlice<S>>,
                                   TraceAlloc<phmap::priv::Pair<const FixSlice<S>, RowIdPack4>>, 4, phmap::NullMutex,
-                                  false>
+                                  true>
             _map;
 
 public:
@@ -525,7 +535,11 @@ public:
 };
 
 struct StringHasher1 {
+<<<<<<< HEAD
     size_t operator()(const string& v) const { return vectorized::crc_hash_64(v.data(), v.length(), 0x811C9DC5); }
+=======
+    size_t operator()(const string& v) const { return XXH3_64bits(v.data(), v.length()); }
+>>>>>>> e771c35... [Enhancement] Change primary index hash from crc32 to XXH3_64 (#22123)
 };
 
 class SliceHashIndex : public HashIndex {
@@ -533,7 +547,7 @@ private:
     using StringMap =
             phmap::parallel_flat_hash_map<string, tablet_rowid_t, StringHasher1, phmap::priv::hash_default_eq<string>,
                                           TraceAlloc<phmap::priv::Pair<const string, tablet_rowid_t>>, 4,
-                                          phmap::NullMutex, false>;
+                                          phmap::NullMutex, true>;
     StringMap _map;
     size_t _total_length = 0;
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -88,14 +88,9 @@ const uint32_t PREFETCHN = 8;
 template <typename Key>
 class HashIndexImpl : public HashIndex {
 private:
-<<<<<<< HEAD
     phmap::parallel_flat_hash_map<Key, RowIdPack4, vectorized::StdHashWithSeed<Key, vectorized::PhmapSeed1>,
                                   phmap::priv::hash_default_eq<Key>,
-                                  TraceAlloc<phmap::priv::Pair<const Key, RowIdPack4>>, 4, phmap::NullMutex, false>
-=======
-    phmap::parallel_flat_hash_map<Key, RowIdPack4, StdHashWithSeed<Key, PhmapSeed1>, phmap::priv::hash_default_eq<Key>,
                                   TraceAlloc<phmap::priv::Pair<const Key, RowIdPack4>>, 4, phmap::NullMutex, true>
->>>>>>> e771c35... [Enhancement] Change primary index hash from crc32 to XXH3_64 (#22123)
             _map;
 
 public:
@@ -237,11 +232,7 @@ struct FixSlice {
 
 template <size_t S>
 struct FixSliceHash {
-<<<<<<< HEAD
-    size_t operator()(const FixSlice<S>& v) const { return vectorized::crc_hash_64(v.v, 4 * S, 0x811C9DC5); }
-=======
     size_t operator()(const FixSlice<S>& v) const { return XXH3_64bits(v.v, 4 * S); }
->>>>>>> e771c35... [Enhancement] Change primary index hash from crc32 to XXH3_64 (#22123)
 };
 
 template <size_t S>
@@ -535,11 +526,7 @@ public:
 };
 
 struct StringHasher1 {
-<<<<<<< HEAD
-    size_t operator()(const string& v) const { return vectorized::crc_hash_64(v.data(), v.length(), 0x811C9DC5); }
-=======
     size_t operator()(const string& v) const { return XXH3_64bits(v.data(), v.length()); }
->>>>>>> e771c35... [Enhancement] Change primary index hash from crc32 to XXH3_64 (#22123)
 };
 
 class SliceHashIndex : public HashIndex {


### PR DESCRIPTION


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We use the function `crc_hash_64` to generate a hash key for each record in the primary index but`crc_hash_64` will return a crc32 actually, so when the size of the hash map is very large(> 400 million), the hash conflict will increase greatly which resulting in a dramatic drop in efficiency.

This pr changed the hash function from `crc_hash_64` to `XXH3_64bits` and the apply time of 860M records was reduced from 300 minutes to 250 seconds.

crc_hash_64
```
I0421 02:31:08.932478 144344 tablet_updates.cpp:1266] apply_rowset_commit finish. tablet:151206 version:2 txn_id: 142113 total del/row:0/864001869 0% rowset:0 #seg:1688 #op(upsert:864001869 del:0) #del:0+0=0 #dv:1688 duration:14720605ms(115/14720481/1/8)
```
XXH3_64bits
```
I0421 11:04:06.185981 3331257 tablet_updates.cpp:1266] apply_rowset_commit finish. tablet:151298 version:2 txn_id: 142184 total del/row:0/864001869 0% rowset:0 #seg:1688 #op(upsert:864001869 del:0) #del:0+0=0 #dv:1688 duration:247193ms(122/247070/0/1)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
