### PR TITLE
[Enhancement][Cherry_pick][Branch-2.3] Change primary index hash from crc32 to XXH3_64 (#22123)

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -467,7 +467,7 @@ public:
     std::size_t memory_usage() const final { return _map.capacity() * (1 + S * 4 + sizeof(RowIdPack4)); }
 };
 
-struct StringHasher1 {
+struct StringHash {
     size_t operator()(const string& v) const { return XXH3_64bits(v.data(), v.length()); }
 };
 


### PR DESCRIPTION

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

We use the function `crc_hash_64` to generate a hash key for each record in the primary index but`crc_hash_64` will return a crc32 actually, so when the size of the hash map is very large(> 400 million), the hash conflict will increase greatly which resulting in a dramatic drop in efficiency.

This pr changed the hash function from `crc_hash_64` to `XXH3_64bits` and the apply time of 860M records was reduced from 300 minutes to 250 seconds.

crc_hash_64
```
I0421 02:31:08.932478 144344 tablet_updates.cpp:1266] apply_rowset_commit finish. tablet:151206 version:2 txn_id: 142113 total del/row:0/864001869 0% rowset:0 #seg:1688 #op(upsert:864001869 del:0) #del:0+0=0 #dv:1688 duration:14720605ms(115/14720481/1/8)
```
XXH3_64bits
```
I0421 11:04:06.185981 3331257 tablet_updates.cpp:1266] apply_rowset_commit finish. tablet:151298 version:2 txn_id: 142184 total del/row:0/864001869 0% rowset:0 #seg:1688 #op(upsert:864001869 del:0) #del:0+0=0 #dv:1688 duration:247193ms(122/247070/0/1)
```


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
