### PR TITLE
[Enhancement] Optimize a subtle inline performance problem

### DIFF
--- a/be/src/common/compiler_util.h
+++ b/be/src/common/compiler_util.h
@@ -59,6 +59,7 @@
 /// needs to be inlined for a specific reason or the compiler's heuristics make a bad
 /// decision, e.g. not inlining a small function on a hot path.
 #define ALWAYS_INLINE __attribute__((always_inline))
+#define ALWAYS_NOINLINE __attribute__((noinline))
 
 #define ALIGN_CACHE_LINE __attribute__((aligned(CACHE_LINE_SIZE)))
 

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -171,9 +171,10 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     // Non Nullble
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
-                                         Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                         std::vector<uint8_t>* not_founds) {
+    __attribute__((noinline)) void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns,
+                                                                   MemPool* pool, Func&& allocate_func,
+                                                                   Buffer<AggDataPtr>* agg_states,
+                                                                   std::vector<uint8_t>* not_founds) {
         DCHECK(!key_columns[0]->is_nullable());
         auto column = down_cast<ColumnType*>(key_columns[0].get());
 
@@ -196,8 +197,10 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     // Nullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
-                                     Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
+    __attribute__((noinline)) void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns,
+                                                               MemPool* pool, Func&& allocate_func,
+                                                               Buffer<AggDataPtr>* agg_states,
+                                                               std::vector<uint8_t>* not_founds) {
         // Assign not_founds vector when needs compute not founds.
         if constexpr (compute_not_founds) {
             DCHECK(not_founds);
@@ -215,7 +218,6 @@ struct AggHashMapWithOneNumberKeyWithNullable
             DCHECK(key_columns[0]->is_nullable());
             auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
             auto* data_column = down_cast<ColumnType*>(nullable_column->data_column().get());
-            const auto& null_data = nullable_column->null_column_data();
 
             // Shortcut: if nullable column has no nulls.
             if (!nullable_column->has_null()) {
@@ -226,31 +228,17 @@ struct AggHashMapWithOneNumberKeyWithNullable
                     this->template compute_agg_prefetch<Func, allocate_and_compute_state, compute_not_founds>(
                             data_column, agg_states, std::forward<Func>(allocate_func), not_founds);
                 }
-                return;
-            }
-
-            for (size_t i = 0; i < chunk_size; i++) {
-                if (null_data[i]) {
-                    if (UNLIKELY(null_key_data == nullptr)) {
-                        null_key_data = allocate_func(nullptr);
-                    }
-                    (*agg_states)[i] = null_key_data;
-                } else {
-                    if constexpr (allocate_and_compute_state) {
-                        this->template _handle_data_key_column<Func, compute_not_founds>(
-                                data_column, i, std::forward<Func>(allocate_func), agg_states, not_founds);
-                    } else if constexpr (compute_not_founds) {
-                        _handle_data_key_column_without_allocate(data_column, i, agg_states, not_founds);
-                    }
-                }
+            } else {
+                this->template compute_agg_through_null_data<Func, allocate_and_compute_state, compute_not_founds>(
+                        chunk_size, nullable_column, agg_states, std::forward<Func>(allocate_func), not_founds);
             }
         }
     }
 
     // prefetch branch better performance in case with larger hash tables
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_prefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                              std::vector<uint8_t>* not_founds) {
+    __attribute__((noinline)) void compute_agg_prefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states,
+                                                        Func&& allocate_func, std::vector<uint8_t>* not_founds) {
         AGG_HASH_MAP_PRECOMPUTE_HASH_VALUES(column, AGG_HASH_MAP_DEFAULT_PREFETCH_DIST);
         for (size_t i = 0; i < column_size; i++) {
             AGG_HASH_MAP_PREFETCH_HASH_VALUE();
@@ -280,8 +268,8 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     // prefetch branch better performance in case with small hash tables
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_noprefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                                std::vector<uint8_t>* not_founds) {
+    __attribute__((noinline)) void compute_agg_noprefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states,
+                                                          Func&& allocate_func, std::vector<uint8_t>* not_founds) {
         size_t num_rows = column->size();
         for (size_t i = 0; i < num_rows; i++) {
             FieldType key = column->get_data()[i];
@@ -301,6 +289,29 @@ struct AggHashMapWithOneNumberKeyWithNullable
                     (*agg_states)[i] = iter->second;
                 } else {
                     (*not_founds)[i] = 1;
+                }
+            }
+        }
+    }
+
+    template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
+    __attribute__((noinline)) void compute_agg_through_null_data(size_t chunk_size, NullableColumn* nullable_column,
+                                                                 Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
+                                                                 std::vector<uint8_t>* not_founds) {
+        auto* data_column = down_cast<ColumnType*>(nullable_column->data_column().get());
+        const auto& null_data = nullable_column->null_column_data();
+        for (size_t i = 0; i < chunk_size; i++) {
+            if (null_data[i]) {
+                if (UNLIKELY(null_key_data == nullptr)) {
+                    null_key_data = allocate_func(nullptr);
+                }
+                (*agg_states)[i] = null_key_data;
+            } else {
+                if constexpr (allocate_and_compute_state) {
+                    this->template _handle_data_key_column<Func, compute_not_founds>(
+                            data_column, i, std::forward<Func>(allocate_func), agg_states, not_founds);
+                } else if constexpr (compute_not_founds) {
+                    _handle_data_key_column_without_allocate(data_column, i, agg_states, not_founds);
                 }
             }
         }
@@ -381,9 +392,10 @@ struct AggHashMapWithOneStringKeyWithNullable
 
     // Non Nullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
-                                         Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                         std::vector<uint8_t>* not_founds) {
+    __attribute__((noinline)) void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns,
+                                                                   MemPool* pool, Func&& allocate_func,
+                                                                   Buffer<AggDataPtr>* agg_states,
+                                                                   std::vector<uint8_t>* not_founds) {
         DCHECK(key_columns[0]->is_binary());
         auto column = down_cast<BinaryColumn*>(key_columns[0].get());
 
@@ -404,8 +416,10 @@ struct AggHashMapWithOneStringKeyWithNullable
 
     // Nullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
-                                     Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
+    __attribute__((noinline)) void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns,
+                                                               MemPool* pool, Func&& allocate_func,
+                                                               Buffer<AggDataPtr>* agg_states,
+                                                               std::vector<uint8_t>* not_founds) {
         // Assign not_founds vector when needs compute not founds.
         if constexpr (compute_not_founds) {
             DCHECK(not_founds);
@@ -423,7 +437,6 @@ struct AggHashMapWithOneStringKeyWithNullable
             DCHECK(key_columns[0]->is_nullable());
             auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
             auto* data_column = down_cast<BinaryColumn*>(nullable_column->data_column().get());
-            const auto& null_data = nullable_column->null_column_data();
             DCHECK(data_column->is_binary());
 
             if (!nullable_column->has_null()) {
@@ -434,23 +447,96 @@ struct AggHashMapWithOneStringKeyWithNullable
                     this->template compute_agg_prefetch<Func, allocate_and_compute_state, compute_not_founds>(
                             data_column, agg_states, pool, std::forward<Func>(allocate_func), not_founds);
                 }
-                return;
+            } else {
+                this->template compute_agg_through_null_data<Func, allocate_and_compute_state, compute_not_founds>(
+                        chunk_size, nullable_column, agg_states, pool, std::forward<Func>(allocate_func), not_founds);
             }
+        }
+    }
 
-            for (size_t i = 0; i < chunk_size; i++) {
-                if (null_data[i]) {
-                    if (UNLIKELY(null_key_data == nullptr)) {
-                        null_key_data = allocate_func(nullptr);
-                    }
-                    (*agg_states)[i] = null_key_data;
-                } else {
-                    if constexpr (allocate_and_compute_state) {
-                        this->template _handle_data_key_column<Func, compute_not_founds>(
-                                data_column, i, pool, std::forward<Func>(allocate_func), agg_states, not_founds);
-                    } else if constexpr (compute_not_founds) {
+    template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
+    __attribute__((noinline)) void compute_agg_prefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states,
+                                                        MemPool* pool, Func&& allocate_func,
+                                                        std::vector<uint8_t>* not_founds) {
+        AGG_HASH_MAP_PRECOMPUTE_HASH_VALUES(column, AGG_HASH_MAP_DEFAULT_PREFETCH_DIST);
+        for (size_t i = 0; i < column_size; i++) {
+            AGG_HASH_MAP_PREFETCH_HASH_VALUE();
+            auto key = column->get_slice(i);
+            if constexpr (allocate_and_compute_state) {
+                auto iter = this->hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
+                    if constexpr (compute_not_founds) {
                         DCHECK(not_founds);
-                        _handle_data_key_column_without_allocate(data_column, i, agg_states, not_founds);
+                        (*not_founds)[i] = 1;
                     }
+                    uint8_t* pos = pool->allocate(key.size);
+                    strings::memcpy_inlined(pos, key.data, key.size);
+                    Slice pk{pos, key.size};
+                    AggDataPtr pv = allocate_func(pk);
+                    ctor(pk, pv);
+                });
+                (*agg_states)[i] = iter->second;
+            } else if constexpr (compute_not_founds) {
+                DCHECK(not_founds);
+                if (auto iter = this->hash_map.find(key); iter != this->hash_map.end()) {
+                    (*agg_states)[i] = iter->second;
+                } else {
+                    (*not_founds)[i] = 1;
+                }
+            }
+        }
+    }
+
+    template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
+    __attribute__((noinline)) void compute_agg_noprefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states,
+                                                          MemPool* pool, Func&& allocate_func,
+                                                          std::vector<uint8_t>* not_founds) {
+        size_t num_rows = column->size();
+        for (size_t i = 0; i < num_rows; i++) {
+            auto key = column->get_slice(i);
+            if constexpr (allocate_and_compute_state) {
+                auto iter = this->hash_map.lazy_emplace(key, [&](const auto& ctor) {
+                    if constexpr (compute_not_founds) {
+                        DCHECK(not_founds);
+                        (*not_founds)[i] = 1;
+                    }
+                    uint8_t* pos = pool->allocate(key.size);
+                    strings::memcpy_inlined(pos, key.data, key.size);
+                    Slice pk{pos, key.size};
+                    AggDataPtr pv = allocate_func(pk);
+                    ctor(pk, pv);
+                });
+                (*agg_states)[i] = iter->second;
+            } else if constexpr (compute_not_founds) {
+                DCHECK(not_founds);
+                if (auto iter = this->hash_map.find(key); iter != this->hash_map.end()) {
+                    (*agg_states)[i] = iter->second;
+                } else {
+                    (*not_founds)[i] = 1;
+                }
+            }
+        }
+    }
+
+    template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
+    __attribute__((noinline)) void compute_agg_through_null_data(size_t chunk_size, NullableColumn* nullable_column,
+                                                                 Buffer<AggDataPtr>* agg_states, MemPool* pool,
+                                                                 Func&& allocate_func,
+                                                                 std::vector<uint8_t>* not_founds) {
+        auto* data_column = down_cast<BinaryColumn*>(nullable_column->data_column().get());
+        const auto& null_data = nullable_column->null_column_data();
+        for (size_t i = 0; i < chunk_size; i++) {
+            if (null_data[i]) {
+                if (UNLIKELY(null_key_data == nullptr)) {
+                    null_key_data = allocate_func(nullptr);
+                }
+                (*agg_states)[i] = null_key_data;
+            } else {
+                if constexpr (allocate_and_compute_state) {
+                    this->template _handle_data_key_column<Func, compute_not_founds>(
+                            data_column, i, pool, std::forward<Func>(allocate_func), agg_states, not_founds);
+                } else if constexpr (compute_not_founds) {
+                    DCHECK(not_founds);
+                    _handle_data_key_column_without_allocate(data_column, i, agg_states, not_founds);
                 }
             }
         }
@@ -496,67 +582,6 @@ struct AggHashMapWithOneStringKeyWithNullable
             auto* column = down_cast<BinaryColumn*>(key_columns[0].get());
             keys.resize(chunk_size);
             column->append_strings(keys);
-        }
-    }
-
-    template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_prefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states, MemPool* pool, Func&& allocate_func,
-                              std::vector<uint8_t>* not_founds) {
-        AGG_HASH_MAP_PRECOMPUTE_HASH_VALUES(column, AGG_HASH_MAP_DEFAULT_PREFETCH_DIST);
-        for (size_t i = 0; i < column_size; i++) {
-            AGG_HASH_MAP_PREFETCH_HASH_VALUE();
-            auto key = column->get_slice(i);
-            if constexpr (allocate_and_compute_state) {
-                auto iter = this->hash_map.lazy_emplace_with_hash(key, hash_values[i], [&](const auto& ctor) {
-                    if constexpr (compute_not_founds) {
-                        DCHECK(not_founds);
-                        (*not_founds)[i] = 1;
-                    }
-                    uint8_t* pos = pool->allocate(key.size);
-                    strings::memcpy_inlined(pos, key.data, key.size);
-                    Slice pk{pos, key.size};
-                    AggDataPtr pv = allocate_func(pk);
-                    ctor(pk, pv);
-                });
-                (*agg_states)[i] = iter->second;
-            } else if constexpr (compute_not_founds) {
-                DCHECK(not_founds);
-                if (auto iter = this->hash_map.find(key); iter != this->hash_map.end()) {
-                    (*agg_states)[i] = iter->second;
-                } else {
-                    (*not_founds)[i] = 1;
-                }
-            }
-        }
-    }
-
-    template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_noprefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states, MemPool* pool,
-                                Func&& allocate_func, std::vector<uint8_t>* not_founds) {
-        size_t num_rows = column->size();
-        for (size_t i = 0; i < num_rows; i++) {
-            auto key = column->get_slice(i);
-            if constexpr (allocate_and_compute_state) {
-                auto iter = this->hash_map.lazy_emplace(key, [&](const auto& ctor) {
-                    if constexpr (compute_not_founds) {
-                        DCHECK(not_founds);
-                        (*not_founds)[i] = 1;
-                    }
-                    uint8_t* pos = pool->allocate(key.size);
-                    strings::memcpy_inlined(pos, key.data, key.size);
-                    Slice pk{pos, key.size};
-                    AggDataPtr pv = allocate_func(pk);
-                    ctor(pk, pv);
-                });
-                (*agg_states)[i] = iter->second;
-            } else if constexpr (compute_not_founds) {
-                DCHECK(not_founds);
-                if (auto iter = this->hash_map.find(key); iter != this->hash_map.end()) {
-                    (*agg_states)[i] = iter->second;
-                } else {
-                    (*not_founds)[i] = 1;
-                }
-            }
         }
     }
 
@@ -712,8 +737,9 @@ struct AggHashMapWithSerializedKeyFixedSize
     AggDataPtr get_null_key_data() { return nullptr; }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_prefetch(size_t chunk_size, const Columns& key_columns, Buffer<AggDataPtr>* agg_states,
-                              Func&& allocate_func, std::vector<uint8_t>* not_founds) {
+    __attribute__((noinline)) void compute_agg_prefetch(size_t chunk_size, const Columns& key_columns,
+                                                        Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
+                                                        std::vector<uint8_t>* not_founds) {
         auto* buffer = reinterpret_cast<uint8_t*>(caches.data());
         for (const auto& key_column : key_columns) {
             key_column->serialize_batch(buffer, slice_sizes, chunk_size, max_fixed_size);
@@ -755,8 +781,9 @@ struct AggHashMapWithSerializedKeyFixedSize
     }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    void compute_agg_noprefetch(size_t chunk_size, const Columns& key_columns, Buffer<AggDataPtr>* agg_states,
-                                Func&& allocate_func, std::vector<uint8_t>* not_founds) {
+    __attribute__((noinline)) void compute_agg_noprefetch(size_t chunk_size, const Columns& key_columns,
+                                                          Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
+                                                          std::vector<uint8_t>* not_founds) {
         constexpr int key_size = sizeof(FixedSizeSliceKey);
         auto* buffer = reinterpret_cast<uint8_t*>(caches.data());
         for (const auto& key_column : key_columns) {

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -171,10 +171,9 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     // Non Nullble
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns,
-                                                                   MemPool* pool, Func&& allocate_func,
-                                                                   Buffer<AggDataPtr>* agg_states,
-                                                                   std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
+                                                         Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
+                                                         std::vector<uint8_t>* not_founds) {
         DCHECK(!key_columns[0]->is_nullable());
         auto column = down_cast<ColumnType*>(key_columns[0].get());
 
@@ -197,10 +196,9 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     // Nullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns,
-                                                               MemPool* pool, Func&& allocate_func,
-                                                               Buffer<AggDataPtr>* agg_states,
-                                                               std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
+                                                     Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
+                                                     std::vector<uint8_t>* not_founds) {
         // Assign not_founds vector when needs compute not founds.
         if constexpr (compute_not_founds) {
             DCHECK(not_founds);
@@ -237,8 +235,8 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     // prefetch branch better performance in case with larger hash tables
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_prefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states,
-                                                        Func&& allocate_func, std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_prefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
+                                              std::vector<uint8_t>* not_founds) {
         AGG_HASH_MAP_PRECOMPUTE_HASH_VALUES(column, AGG_HASH_MAP_DEFAULT_PREFETCH_DIST);
         for (size_t i = 0; i < column_size; i++) {
             AGG_HASH_MAP_PREFETCH_HASH_VALUE();
@@ -268,8 +266,8 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     // prefetch branch better performance in case with small hash tables
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_noprefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states,
-                                                          Func&& allocate_func, std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_noprefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states,
+                                                Func&& allocate_func, std::vector<uint8_t>* not_founds) {
         size_t num_rows = column->size();
         for (size_t i = 0; i < num_rows; i++) {
             FieldType key = column->get_data()[i];
@@ -295,9 +293,9 @@ struct AggHashMapWithOneNumberKeyWithNullable
     }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_through_null_data(size_t chunk_size, NullableColumn* nullable_column,
-                                                                 Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                                                                 std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_through_null_data(size_t chunk_size, NullableColumn* nullable_column,
+                                                       Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
+                                                       std::vector<uint8_t>* not_founds) {
         auto* data_column = down_cast<ColumnType*>(nullable_column->data_column().get());
         const auto& null_data = nullable_column->null_column_data();
         for (size_t i = 0; i < chunk_size; i++) {
@@ -392,10 +390,9 @@ struct AggHashMapWithOneStringKeyWithNullable
 
     // Non Nullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns,
-                                                                   MemPool* pool, Func&& allocate_func,
-                                                                   Buffer<AggDataPtr>* agg_states,
-                                                                   std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
+                                                         Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
+                                                         std::vector<uint8_t>* not_founds) {
         DCHECK(key_columns[0]->is_binary());
         auto column = down_cast<BinaryColumn*>(key_columns[0].get());
 
@@ -416,10 +413,9 @@ struct AggHashMapWithOneStringKeyWithNullable
 
     // Nullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns,
-                                                               MemPool* pool, Func&& allocate_func,
-                                                               Buffer<AggDataPtr>* agg_states,
-                                                               std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
+                                                     Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
+                                                     std::vector<uint8_t>* not_founds) {
         // Assign not_founds vector when needs compute not founds.
         if constexpr (compute_not_founds) {
             DCHECK(not_founds);
@@ -455,9 +451,8 @@ struct AggHashMapWithOneStringKeyWithNullable
     }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_prefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states,
-                                                        MemPool* pool, Func&& allocate_func,
-                                                        std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_prefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states, MemPool* pool,
+                                              Func&& allocate_func, std::vector<uint8_t>* not_founds) {
         AGG_HASH_MAP_PRECOMPUTE_HASH_VALUES(column, AGG_HASH_MAP_DEFAULT_PREFETCH_DIST);
         for (size_t i = 0; i < column_size; i++) {
             AGG_HASH_MAP_PREFETCH_HASH_VALUE();
@@ -487,9 +482,8 @@ struct AggHashMapWithOneStringKeyWithNullable
     }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_noprefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states,
-                                                          MemPool* pool, Func&& allocate_func,
-                                                          std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_noprefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states, MemPool* pool,
+                                                Func&& allocate_func, std::vector<uint8_t>* not_founds) {
         size_t num_rows = column->size();
         for (size_t i = 0; i < num_rows; i++) {
             auto key = column->get_slice(i);
@@ -518,10 +512,9 @@ struct AggHashMapWithOneStringKeyWithNullable
     }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_through_null_data(size_t chunk_size, NullableColumn* nullable_column,
-                                                                 Buffer<AggDataPtr>* agg_states, MemPool* pool,
-                                                                 Func&& allocate_func,
-                                                                 std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_through_null_data(size_t chunk_size, NullableColumn* nullable_column,
+                                                       Buffer<AggDataPtr>* agg_states, MemPool* pool,
+                                                       Func&& allocate_func, std::vector<uint8_t>* not_founds) {
         auto* data_column = down_cast<BinaryColumn*>(nullable_column->data_column().get());
         const auto& null_data = nullable_column->null_column_data();
         for (size_t i = 0; i < chunk_size; i++) {
@@ -737,9 +730,9 @@ struct AggHashMapWithSerializedKeyFixedSize
     AggDataPtr get_null_key_data() { return nullptr; }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_prefetch(size_t chunk_size, const Columns& key_columns,
-                                                        Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                                                        std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_prefetch(size_t chunk_size, const Columns& key_columns,
+                                              Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
+                                              std::vector<uint8_t>* not_founds) {
         auto* buffer = reinterpret_cast<uint8_t*>(caches.data());
         for (const auto& key_column : key_columns) {
             key_column->serialize_batch(buffer, slice_sizes, chunk_size, max_fixed_size);
@@ -781,9 +774,9 @@ struct AggHashMapWithSerializedKeyFixedSize
     }
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
-    __attribute__((noinline)) void compute_agg_noprefetch(size_t chunk_size, const Columns& key_columns,
-                                                          Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                                                          std::vector<uint8_t>* not_founds) {
+    ALWAYS_NOINLINE void compute_agg_noprefetch(size_t chunk_size, const Columns& key_columns,
+                                                Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
+                                                std::vector<uint8_t>* not_founds) {
         constexpr int key_size = sizeof(FixedSizeSliceKey);
         auto* buffer = reinterpret_cast<uint8_t*>(caches.data());
         for (const auto& key_column : key_columns) {


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Reproduce

we can reproduce it by the following steps:

1. table creation statement.
    ```sql
    CREATE TABLE `datachangeset` (
    `Id` varchar(2000) NOT NULL COMMENT "",
    `PublishStatus` varchar(2000) NULL COMMENT ""
    ) ENGINE=OLAP
    PRIMARY KEY(`Id`)
    COMMENT "OLAP"
    DISTRIBUTED BY HASH(`Id`) BUCKETS 5
    PROPERTIES (
    "replication_num" = "3",
    "in_memory" = "false",
    "storage_format" = "DEFAULT",
    "enable_persistent_index" = "false",
    "replicated_storage" = "true",
    "compression" = "LZ4"
    );
    ```
1. populate the table with:
    * `Id` densely increase from `"1"` to `"500'0000"`
    * `PublishStatus` is a const value `New`
1. test sql
    ```sql
    select PublishStatus, COUNT(*) from datachangeset group by 1;
    
    +---------------+----------+
    | PublishStatus | count(*) |
    +---------------+----------+
    | New           | 5000000  |
    +---------------+----------+
    ```

## Analysis

It's a subtle performance problem, it is introduced by #13968, which is a refactor pr, only for extracting and reusing the common codes, and there are no logic changes(at least the above case).

The main reason is that the size of instructions of  function is too large, and this case only go through a certain subset of the instructions. But unfortunately, some part of the instructions are put together with those won't be executed in this case(see the blow code, this case only go through branch 2). When instructions are loaded into the instruction cache, they are typically loaded in multiple cache line-sized chunks, which may lead to substantial cache miss.

```cpp
template <typename HashMap, bool is_nullable>
struct AggHashMapWithOneStringKeyWithNullable {
    // Nullable
    template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
    void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
                                     Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
        // ... omit details

        if (key_columns[0]->only_null()) {
            // -----branch 1 ----
            // ... omit details
        } else {
            if (!nullable_column->has_null()) {
                // -----branch 2 ----
                // .. omit details
                return;
            }

            // -----branch 3 ----
            // .. omit details
        }
    }
};
```


In order to illustrate it more clearly. I present a graph down below(It is just a assumption of mine, which is not proved):

* Assume a function has two branchs, branchA and branchB, each of them contains some instructions.
* We organize these instructions into mutiply blocks, each block euqlas to the size of cache line.
* In `block4`, it contains instructions both belongs to branchA and branchB.
* When the processor is about to execute the `instructorA1`, and it will loaded the `block4` from memory to cache system. But practically, current processor will load many blocks at a time, which means the `block4`, `block5`, `block6`, `block7` may all be loaded to cache. The total code size of `starrocks_be` is huge which is absolutely greater than the total cache size(at least L1 cache), so it may replace some hot instructions which may be re-executed before long, the re-execution of these hot instructions my occur further cache miss.  All these may lead to the processor being bussy replacing the cache used for code. And then the performence deduction happens.

```
                                                                 
               Each block represents a bunch of                  
               instructions with the size of cache line          
                                                                 
                      +------------------+                       
                      | instructorA...   |     block1            
                      +------------------+                       
                      +------------------+                       
 branchA              | instructorA...   |     block2            
                      +------------------+                       
                      +------------------+                       
                      | instructorA...   |     block3            
                      +------------------+                       
                      +------------------+                       
                      | instructorA1     |                       
                      | instructorA2     |     block4            
                      | instructorB...   |                       
                      +------------------+                       
                      +------------------+                       
                      | instructorB...   |     block5            
 branchB              +------------------+                       
                      +------------------+                       
                      | instructorB...   |     block6            
                      +------------------+                       
                      +------------------+                       
                      | instructorB...   |     block7            
                      +------------------+                       
```

## Solution

For those functions that process a whole chunk's data, we can mark it as `__attribute__((noinline))` to avoid being inlined by compiler.

This makes each function's instructions highly related without containing too many un-executed instructions.

## Experiment

Since this sql runs very fast, so we use `mysqlslap` to test it

|  | `-c 1 -n 1000` | `-c 10 -n 1000` | `-c 100 -n 1000` |
|:--|:--|:--|:--|
| main-Before | 24.992s | 5.325s | 4.436s |
| main-After | 22.027s | 4.720s | 3.859s |
| 2.5.4 | 22.839s | 4.794s | 4.219s |
| 3.0.0 | 25.903s | 5.912s | 4.898s |
| 3.0.0 + This PR | 22.355s | 5.294s | 4.290s |

Notic that `3.0.0 + This PR` still has dedecution of 10 concurrency scenerio, this can be fixed by #22744 which is already cherry picked to branch-3.0.0, we can just ignore it here.

Perf top 

* main-Before
    ```
    34.47%  starrocks_be        [.] phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<starrocks::Slice, unsigned char*>, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, starrocks::SliceEqual, std::allocator<std::pair<starrocks::Slice const, unsigned char*> >
    16.52%  starrocks_be        [.] starrocks::AggHashMapWithOneStringKeyWithNullable<phmap::flat_hash_map<starrocks::Slice, unsigned char*, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, starrocks::SliceEqual, std::allocator<std::pair<starrocks::Slice const, unsi
    10.31%  starrocks_be        [.] starrocks::append_fixed_length<unsigned int, 8ul>
    6.86%  starrocks_be        [.] starrocks::BinaryDictPageDecoder<(starrocks::LogicalType)17>::next_batch
    4.42%  starrocks_be        [.] starrocks::AggregateFunctionBatchHelper<starrocks::AggregateCountFunctionState<false>, starrocks::CountAggregateFunction<false> >::update_batch
    3.23%  starrocks_be        [.] std::vector<starrocks::Slice, starrocks::raw::RawAllocator<starrocks::Slice, 0ul, std::allocator<starrocks::Slice> > >::_M_default_append
    2.22%  starrocks_be        [.] starrocks::pipeline::PipelineDriverPoller::run_internal
    1.41%  libc-2.17.so        [.] __memcpy_ssse3_back
    1.40%  [vdso]              [.] __vdso_clock_gettime
    ```
* main-After
    ```
    44.09%  starrocks_be        [.] starrocks::AggHashMapWithOneStringKeyWithNullable<phmap::flat_hash_map<starrocks::Slice, unsigned char*, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, starrocks::SliceEqual, std::allocator<std::pair<starrocks::Slice const, unsi
    11.98%  starrocks_be        [.] starrocks::append_fixed_length<unsigned int, 8ul>
    7.81%  starrocks_be        [.] starrocks::BinaryDictPageDecoder<(starrocks::LogicalType)17>::next_batch
    5.07%  starrocks_be        [.] starrocks::AggregateFunctionBatchHelper<starrocks::AggregateCountFunctionState<false>, starrocks::CountAggregateFunction<false> >::update_batch
    3.15%  starrocks_be        [.] std::vector<starrocks::Slice, starrocks::raw::RawAllocator<starrocks::Slice, 0ul, std::allocator<starrocks::Slice> > >::_M_default_append
    2.21%  starrocks_be        [.] starrocks::pipeline::PipelineDriverPoller::run_internal
    1.68%  libc-2.17.so        [.] __memcpy_ssse3_back
    1.59%  [vdso]              [.] __vdso_clock_gettime
    0.64%  libc-2.17.so        [.] __memset_sse2
    0.60%  libc-2.17.so        [.] __memcmp_sse4_1
    0.60%  starrocks_be        [.] jemalloc
    0.55%  libpthread-2.17.so  [.] pthread_mutex_unlock
    0.53%  starrocks_be        [.] my_malloc
    ```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
