### PR TITLE
[BugFix] Fix use wrong hash table when spill left/right outer join has other conjuncts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ fs_brokers/apache_hdfs_broker/jindosdk-4.6.2
 dependency-reduced-pom.xml
 test/conf/
 test/conf/sr.conf
+test/nosetests.xml
 tags
 .tags
 .cache

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -34,7 +34,7 @@ StatusOr<ChunkPtr> HashJoinProber::probe_chunk(RuntimeState* state, JoinHashTabl
     if (!_current_probe_has_remain) {
         _probe_chunk = nullptr;
     }
-    RETURN_IF_ERROR(_hash_joiner.filter_probe_output_chunk(chunk));
+    RETURN_IF_ERROR(_hash_joiner.filter_probe_output_chunk(chunk, *hash_table));
     TRY_CATCH_ALLOC_SCOPE_END()
     return chunk;
 }

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -273,13 +273,13 @@ public:
     HashJoinProber* new_prober(ObjectPool* pool) { return _hash_join_prober->clone_empty(pool); }
     HashJoinBuilder* new_builder(ObjectPool* pool) { return _hash_join_builder->clone_empty(pool); }
 
-    Status filter_probe_output_chunk(ChunkPtr& chunk) {
+    Status filter_probe_output_chunk(ChunkPtr& chunk, JoinHashTable& hash_table) {
         // Probe in JoinHashMap is divided into probe with other_conjuncts and without other_conjuncts.
         // Probe without other_conjuncts directly labels the hash table as hit, while _process_other_conjunct()
         // only remains the rows which are not hit the hash table before. Therefore, _process_other_conjunct can
         // not be called when other_conjuncts is empty.
         if (chunk && !chunk->is_empty() && !_other_join_conjunct_ctxs.empty()) {
-            RETURN_IF_ERROR(_process_other_conjunct(&chunk));
+            RETURN_IF_ERROR(_process_other_conjunct(&chunk, hash_table));
         }
 
         // TODO(satanson): _conjunct_ctxs shouldn't include local runtime in-filters.
@@ -365,10 +365,11 @@ private:
     static void _process_row_for_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
                                                 bool filter_all, bool hit_all, const Filter& filter);
 
-    Status _process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count);
-    Status _process_semi_join_with_other_conjunct(ChunkPtr* chunk);
-    Status _process_right_anti_join_with_other_conjunct(ChunkPtr* chunk);
-    Status _process_other_conjunct(ChunkPtr* chunk);
+    Status _process_outer_join_with_other_conjunct(ChunkPtr* chunk, size_t start_column, size_t column_count,
+                                                   JoinHashTable& hash_table);
+    Status _process_semi_join_with_other_conjunct(ChunkPtr* chunk, JoinHashTable& hash_table);
+    Status _process_right_anti_join_with_other_conjunct(ChunkPtr* chunk, JoinHashTable& hash_table);
+    Status _process_other_conjunct(ChunkPtr* chunk, JoinHashTable& hash_table);
     Status _process_where_conjunct(ChunkPtr* chunk);
 
     Status _create_runtime_in_filters(RuntimeState* state);

--- a/test/sql/test_spill/R/test_spill_hash_join
+++ b/test/sql/test_spill/R/test_spill_hash_join
@@ -1,0 +1,60 @@
+-- name: test_spill_hash_join
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+create table t1 like t0;
+-- result:
+-- !result
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(4096,  8192));
+-- result:
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+8192	2048.5	8192	8192	0
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+-- result:
+2	4096.0	2
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left anti join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+-- result:
+8190	2048.0	8190
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0;
+-- result:
+1	4096.0	1
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right anti join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+4097	6144.0	4097
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0	0	4097
+-- !result

--- a/test/sql/test_spill/T/test_spill_hash_join
+++ b/test/sql/test_spill/T/test_spill_hash_join
@@ -1,0 +1,22 @@
+-- name: test_spill_hash_join
+set enable_spill=true;
+set spill_mode="force";
+set pipeline_dop=1;
+-- 
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+insert into t0 select * from t0;
+create table t1 like t0;
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(4096,  8192));
+
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left anti join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right anti join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
Fixes https://github.com/StarRocks/starrocks/issues/23130

## Problem Summary(Required):

for spillable left/right outer join. hash table in hash_joiner is empty. we should use the hash table in hash_join builder.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
