### PR TITLE
[Feature] rpad function support default value

### DIFF
--- a/docs/sql-reference/sql-functions/string-functions/lpad.md
+++ b/docs/sql-reference/sql-functions/string-functions/lpad.md
@@ -7,7 +7,7 @@ This function returns strings with a length of len (starting counting from the f
 ## Syntax
 
 ```Haskell
-VARCHAR lpad(VARCHAR str, INT len, VARCHAR pad)
+VARCHAR lpad(VARCHAR str, INT len[, VARCHAR pad])
 ```
 
 ## Parameters
@@ -41,7 +41,7 @@ MySQL > SELECT lpad("hi", 1, "xy");
 
 MySQL > SELECT lpad("hi", 5);
 +---------------------+
-| lpad('hi', 5, 'xy') |
+| lpad('hi', 5)       |
 +---------------------+
 |    hi               |
 +---------------------+

--- a/docs/sql-reference/sql-functions/string-functions/lpad.md
+++ b/docs/sql-reference/sql-functions/string-functions/lpad.md
@@ -10,6 +10,18 @@ This function returns strings with a length of len (starting counting from the f
 VARCHAR lpad(VARCHAR str, INT len, VARCHAR pad)
 ```
 
+## Parameters
+
+`str`: required, the string to be padded, which must evaluate to a VARCHAR value.
+
+`len`: required, the length of return value, it means the length of characters, not bytes, which must evaluate to an INT value.
+
+`pad`: optional, the characters to be added in front of str, which must be a VARCHAR value. If this parameter is not specified, spaces are added by default.
+
+## Return value
+
+Returns a VARCHAR value.
+
 ## Examples
 
 ```Plain Text
@@ -25,6 +37,13 @@ MySQL > SELECT lpad("hi", 1, "xy");
 | lpad('hi', 1, 'xy') |
 +---------------------+
 | h                   |
++---------------------+
+
+MySQL > SELECT lpad("hi", 5);
++---------------------+
+| lpad('hi', 5, 'xy') |
++---------------------+
+|    hi               |
 +---------------------+
 ```
 

--- a/docs/sql-reference/sql-functions/string-functions/rpad.md
+++ b/docs/sql-reference/sql-functions/string-functions/rpad.md
@@ -2,13 +2,25 @@
 
 ## Description
 
-This function returns strings with a length of len (starting counting from the first syllable) in str. If len is longer than str, the return value is lengthened to len characters by adding pad characters in front of str.  If str is longer than len, the return value is shortened to len characters. Len means the length of characters, not bytes.
+This function returns strings with a length of len (starting counting from the first syllable) in str. If len is longer than str, the return value is lengthened to len characters by adding pad characters behind str.  If str is longer than len, the return value is shortened to len characters. Len means the length of characters, not bytes.
 
 ## Syntax
 
 ```Haskell
-VARCHAR rpad(VARCHAR str, INT len, VARCHAR pad)
+VARCHAR rpad(VARCHAR str, INT len[, VARCHAR pad])
 ```
+
+## Parameters
+
+`str`: required, the string to be padded, which must evaluate to a VARCHAR value.
+
+`len`: required, the length of return value, it means the length of characters, not bytes, which must evaluate to an INT value.
+
+`pad`: optional, the characters to be added behind str, which must be a VARCHAR value. If this parameter is not specified, spaces are added by default.
+
+## Return value
+
+Returns a VARCHAR value.
 
 ## Examples
 
@@ -25,6 +37,13 @@ MySQL > SELECT rpad("hi", 1, "xy");
 | rpad('hi', 1, 'xy') |
 +---------------------+
 | h                   |
++---------------------+
+
+MySQL > SELECT rpad("hi", 5);
++---------------------+
+| lpad('hi', 5)       |
++---------------------+
+| hi                  |
 +---------------------+
 ```
 

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -251,6 +251,7 @@ vectorized_functions = [
     [30090, 'lpad', 'VARCHAR', ['VARCHAR', 'INT', 'VARCHAR'], 'StringFunctions::lpad', 'StringFunctions::pad_prepare', 'StringFunctions::pad_close'],
     [30091, 'lpad', 'VARCHAR', ['VARCHAR', 'INT'], 'StringFunctions::lpad', 'StringFunctions::pad_prepare', 'StringFunctions::pad_close'],
     [30100, 'rpad', 'VARCHAR', ['VARCHAR', 'INT', 'VARCHAR'], 'StringFunctions::rpad', 'StringFunctions::pad_prepare', 'StringFunctions::pad_close'],
+    [30101, 'rpad', 'VARCHAR', ['VARCHAR', 'INT'], 'StringFunctions::rpad', 'StringFunctions::pad_prepare', 'StringFunctions::pad_close'],
 
     [30110, 'append_trailing_char_if_absent', 'VARCHAR', ['VARCHAR', 'VARCHAR'],
      'StringFunctions::append_trailing_char_if_absent'],

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -249,6 +249,7 @@ vectorized_functions = [
     [30080, 'repeat', 'VARCHAR', ['VARCHAR', 'INT'], 'StringFunctions::repeat'],
 
     [30090, 'lpad', 'VARCHAR', ['VARCHAR', 'INT', 'VARCHAR'], 'StringFunctions::lpad', 'StringFunctions::pad_prepare', 'StringFunctions::pad_close'],
+    [30091, 'lpad', 'VARCHAR', ['VARCHAR', 'INT'], 'StringFunctions::lpad', 'StringFunctions::pad_prepare', 'StringFunctions::pad_close'],
     [30100, 'rpad', 'VARCHAR', ['VARCHAR', 'INT', 'VARCHAR'], 'StringFunctions::rpad', 'StringFunctions::pad_prepare', 'StringFunctions::pad_close'],
 
     [30110, 'append_trailing_char_if_absent', 'VARCHAR', ['VARCHAR', 'VARCHAR'],

--- a/test/sql/test_array/R/test_array
+++ b/test/sql/test_array/R/test_array
@@ -3,6 +3,58 @@ select ARRAY<INT>[], [], ARRAY<STRING>['abc'], [123, NULL, 1.0], ['abc', NULL];
 -- result:
 []	[]	["abc"]	[123.0,null,1.0]	["abc",null]
 -- !result
+-- name: testArrayVarchar
+CREATE TABLE array_data_type_1
+    (c1 int,
+    c2  array<datetime>,
+    c3  array<float>,
+    c4  array<varchar(10)>,
+    c5  array<varchar(20)>,
+    c6  array<array<varchar(10)>>)
+    PRIMARY KEY(c1)
+    DISTRIBUTED BY HASH(c1)
+    buckets 1
+    PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into array_data_type_1 values
+(1, ['2020-11-11', '2021-11-11', '2022-01-01'], [1.23, 1.35, 2.7894], ['a', 'b'], ['sss', 'eee', 'fff'], [['a', 'b']]),
+(2, ['2020-01-11', null, '2022-11-01'], [2.23, 2.35, 3.7894], ['aa', null], ['ssss', 'eeee', null], [['a', null], null]),
+(3, null, null, null, null, null);
+-- result:
+-- !result
+select * from array_data_type_1 where c4 != ['a'] or c6 = [['a', 'b']];
+-- result:
+1	["2020-11-11 00:00:00","2021-11-11 00:00:00","2022-01-01 00:00:00"]	[1.23,1.35,2.7894]	["a","b"]	["sss","eee","fff"]	[["a","b"]]
+2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
+-- !result
+select * from array_data_type_1 where c4 = ['a'] or c6 != [['a', 'b']];
+-- result:
+2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
+-- !result
+select * from array_data_type_1 where c4 = cast(c4 as array<char(10)>);
+-- result:
+1	["2020-11-11 00:00:00","2021-11-11 00:00:00","2022-01-01 00:00:00"]	[1.23,1.35,2.7894]	["a","b"]	["sss","eee","fff"]	[["a","b"]]
+2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
+-- !result
+select * from array_data_type_1 where c5 = c4 or c6 = [['a']];
+-- result:
+-- !result
+select * from array_data_type_1 where array_map((x) -> concat(x, 'a'), c5) = c4;
+-- result:
+-- !result
+select c6[0] = ['a'] from array_data_type_1;
+-- result:
+None
+None
+None
+-- !result
+select c6[0] > array_map((x) -> concat(x, 'a'), c5) from array_data_type_1;
+-- result:
+None
+None
+None
+-- !result
 -- name: testArrayPredicate
 CREATE TABLE array_data_type
     (c1 int,
@@ -76,56 +128,4 @@ select c4 > c5 from array_data_type;
 0
 0
 1
--- !result
--- name: testArrayVarchar
-CREATE TABLE array_data_type_1
-    (c1 int,
-    c2  array<datetime>,
-    c3  array<float>,
-    c4  array<varchar(10)>,
-    c5  array<varchar(20)>,
-    c6  array<array<varchar(10)>>)
-    PRIMARY KEY(c1)
-    DISTRIBUTED BY HASH(c1)
-    buckets 1
-    PROPERTIES ("replication_num" = "1");
--- result:
--- !result
-insert into array_data_type_1 values
-(1, ['2020-11-11', '2021-11-11', '2022-01-01'], [1.23, 1.35, 2.7894], ['a', 'b'], ['sss', 'eee', 'fff'], [['a', 'b']]),
-(2, ['2020-01-11', null, '2022-11-01'], [2.23, 2.35, 3.7894], ['aa', null], ['ssss', 'eeee', null], [['a', null], null]),
-(3, null, null, null, null, null);
--- result:
--- !result
-select * from array_data_type_1 where c4 != ['a'] or c6 = [['a', 'b']];
--- result:
-1	["2020-11-11 00:00:00","2021-11-11 00:00:00","2022-01-01 00:00:00"]	[1.23,1.35,2.7894]	["a","b"]	["sss","eee","fff"]	[["a","b"]]
-2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
--- !result
-select * from array_data_type_1 where c4 = ['a'] or c6 != [['a', 'b']];
--- result:
-2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
--- !result
-select * from array_data_type_1 where c4 = cast(c4 as array<char(10)>);
--- result:
-1	["2020-11-11 00:00:00","2021-11-11 00:00:00","2022-01-01 00:00:00"]	[1.23,1.35,2.7894]	["a","b"]	["sss","eee","fff"]	[["a","b"]]
-2	["2020-01-11 00:00:00",null,"2022-11-01 00:00:00"]	[2.23,2.35,3.7894]	["aa",null]	["ssss","eeee",null]	[["a",null],null]
--- !result
-select * from array_data_type_1 where c5 = c4 or c6 = [['a']];
--- result:
--- !result
-select * from array_data_type_1 where array_map((x) -> concat(x, 'a'), c5) = c4;
--- result:
--- !result
-select c6[0] = ['a'] from array_data_type_1;
--- result:
-None
-None
-None
--- !result
-select c6[0] > array_map((x) -> concat(x, 'a'), c5) from array_data_type_1;
--- result:
-None
-None
-None
 -- !result

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -23,8 +23,9 @@ select lpad('test', 2, ' ');
 -- result:
 te
 -- !result
-select lpad('test', 0, '中文，');
+select lpad('test', 2, '中文，');
 -- result:
+te
 -- !result
 select lpad('test', 2);
 -- result:
@@ -40,6 +41,50 @@ select lpad('test', 0, '中文，');
 -- result:
 -- !result
 select lpad('test', 0);
+-- result:
+-- !result
+select rpad('test', 8, '');
+-- result:
+test
+-- !result
+select rpad('test', 8, ' ');
+-- result:
+test    
+-- !result
+select rpad('test', 8, '中文，');
+-- result:
+test中文，中
+-- !result
+select rpad('test', 8);
+-- result:
+test    
+-- !result
+select rpad('test', 2, '');
+-- result:
+te
+-- !result
+select rpad('test', 2, ' ');
+-- result:
+te
+-- !result
+select rpad('test', 2, '中文，');
+-- result:
+te
+-- !result
+select rpad('test', 2);
+-- result:
+te
+-- !result
+select rpad('test', 0, '');
+-- result:
+-- !result
+select rpad('test', 0, ' ');
+-- result:
+-- !result
+select rpad('test', 0, '中文，');
+-- result:
+-- !result
+select rpad('test', 0);
 -- result:
 -- !result
 create table t0(c0 varchar(16), c1 INT(16))
@@ -73,6 +118,30 @@ te
 select lpad(c0, c1) from t0;
 -- result:
     test
+te
+
+-- !result
+select rpad(c0, c1, ' ') from t0;
+-- result:
+test    
+te
+
+-- !result
+select rpad(c0, c1, '中文，') from t0;
+-- result:
+test中文，中
+te
+
+-- !result
+select rpad(c0, c1, '') from t0;
+-- result:
+test
+te
+
+-- !result
+select rpad(c0, c1) from t0;
+-- result:
+test    
 te
 
 -- !result

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -1,0 +1,78 @@
+-- name: test_string_functions
+select lpad('test', 8, '');
+-- result:
+test
+-- !result
+select lpad('test', 8, ' ');
+-- result:
+    test
+-- !result
+select lpad('test', 8, '中文，');
+-- result:
+中文，中test
+-- !result
+select lpad('test', 8);
+-- result:
+    test
+-- !result
+select lpad('test', 2, '');
+-- result:
+te
+-- !result
+select lpad('test', 2, ' ');
+-- result:
+te
+-- !result
+select lpad('test', 0, '中文，');
+-- result:
+-- !result
+select lpad('test', 2);
+-- result:
+te
+-- !result
+select lpad('test', 0, '');
+-- result:
+-- !result
+select lpad('test', 0, ' ');
+-- result:
+-- !result
+select lpad('test', 0, '中文，');
+-- result:
+-- !result
+select lpad('test', 0);
+-- result:
+-- !result
+create table t0(c0 varchar(16), c1 INT(16))
+        DUPLICATE KEY(c0) 
+        DISTRIBUTED BY HASH(c0) 
+        BUCKETS 1 
+        PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t0 values ('test', 8), ('test', 2), ('test', 0);
+-- result:
+-- !result
+select lpad(c0, c1, ' ') from t0;
+-- result:
+    test
+te
+
+-- !result
+select lpad(c0, c1, '中文，') from t0;
+-- result:
+中文，中test
+te
+
+-- !result
+select lpad(c0, c1, '') from t0;
+-- result:
+test
+te
+
+-- !result
+select lpad(c0, c1) from t0;
+-- result:
+    test
+te
+
+-- !result

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -1,16 +1,31 @@
 -- name: test_string_functions
+-- function: lpad
 select lpad('test', 8, '');
 select lpad('test', 8, ' ');
 select lpad('test', 8, '中文，');
 select lpad('test', 8);
 select lpad('test', 2, '');
 select lpad('test', 2, ' ');
-select lpad('test', 0, '中文，');
+select lpad('test', 2, '中文，');
 select lpad('test', 2);
 select lpad('test', 0, '');
 select lpad('test', 0, ' ');
 select lpad('test', 0, '中文，');
 select lpad('test', 0);
+
+-- function: rpad
+select rpad('test', 8, '');
+select rpad('test', 8, ' ');
+select rpad('test', 8, '中文，');
+select rpad('test', 8);
+select rpad('test', 2, '');
+select rpad('test', 2, ' ');
+select rpad('test', 2, '中文，');
+select rpad('test', 2);
+select rpad('test', 0, '');
+select rpad('test', 0, ' ');
+select rpad('test', 0, '中文，');
+select rpad('test', 0);
 
 create table t0(c0 varchar(16), c1 INT(16))
         DUPLICATE KEY(c0) 
@@ -23,3 +38,7 @@ select lpad(c0, c1, ' ') from t0;
 select lpad(c0, c1, '中文，') from t0;
 select lpad(c0, c1, '') from t0;
 select lpad(c0, c1) from t0;
+select rpad(c0, c1, ' ') from t0;
+select rpad(c0, c1, '中文，') from t0;
+select rpad(c0, c1, '') from t0;
+select rpad(c0, c1) from t0;

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -1,0 +1,25 @@
+-- name: test_string_functions
+select lpad('test', 8, '');
+select lpad('test', 8, ' ');
+select lpad('test', 8, '中文，');
+select lpad('test', 8);
+select lpad('test', 2, '');
+select lpad('test', 2, ' ');
+select lpad('test', 0, '中文，');
+select lpad('test', 2);
+select lpad('test', 0, '');
+select lpad('test', 0, ' ');
+select lpad('test', 0, '中文，');
+select lpad('test', 0);
+
+create table t0(c0 varchar(16), c1 INT(16))
+        DUPLICATE KEY(c0) 
+        DISTRIBUTED BY HASH(c0) 
+        BUCKETS 1 
+        PROPERTIES('replication_num'='1');
+-- insert 3 rows
+insert into t0 values ('test', 8), ('test', 2), ('test', 0);
+select lpad(c0, c1, ' ') from t0;
+select lpad(c0, c1, '中文，') from t0;
+select lpad(c0, c1, '') from t0;
+select lpad(c0, c1) from t0;


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
Fixes #15021 

## Problem Summary(Required):
make the third value of rpad function optional with a default value ' ', a single blank

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function