### PR TITLE
[BugFix] fix recover tablet not work

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -378,6 +378,22 @@ public class Replica implements Writable {
                 this.lastSuccessVersion, this.minReadableVersion, dataSize, rowCount);
     }
 
+    public void updateVersionInfoForRecovery(
+            long newVersion,
+            long lastFailedVersion,
+            long lastSuccessVersion) {
+
+        LOG.warn("update replica {} on backend {}'s version for recovery. current_version: {}, new_version: {}."
+                 + " last failed version: {}:{}, last success version: {}:{}",
+                this.id, this.backendId, this.version, newVersion,
+                this.lastFailedVersion, lastFailedVersion,
+                this.lastSuccessVersion, lastSuccessVersion);
+
+        this.version = newVersion;
+        this.lastFailedVersion = lastFailedVersion;
+        this.lastSuccessVersion = lastSuccessVersion;
+    }
+
     /* last failed version:  LFV
      * last success version: LSV
      * version:              V

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -394,20 +394,6 @@ public class TabletInvertedIndex {
             return false;
         }
 
-        if (backendTabletInfo.getVersion() == replicaInFe.getVersion() - 1) {
-            /*
-             * This is very tricky:
-             * 1. Assume that we want to create a replica with version (X, Y), the init version of replica in FE
-             *      is (X, Y), and BE will create a replica with version (X+1, 0).
-             * 2. BE will report version (X+1, 0), and FE will sync with this version, change to (X+1, 0), too.
-             * 3. When restore, BE will restore the replica with version (X, Y) (which is the visible version of partition)
-             * 4. BE report the version (X-Y), and then we fall into here
-             *
-             * Actually, the version (X+1, 0) is a 'virtual' version, so here we ignore this kind of report
-             */
-            return false;
-        }
-
         if (backendTabletInfo.isSetVersion_miss() && backendTabletInfo.isVersion_miss()) {
             // even if backend version is less than fe's version, but if version_miss is false,
             // which means this may be a stale report.

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1102,6 +1102,27 @@ public class ReportHandler extends Daemon {
                                 }
                                 break;
                             }
+
+                            if (replica.getVersion() > tTabletInfo.getVersion()) {
+                                LOG.warn("recover for replica {} of tablet {} on backend {}",
+                                        replica.getId(), tabletId, backendId);
+                                if (replica.getVersion() == tTabletInfo.getVersion() + 1) {
+                                    // this missing version is the last version of this replica
+                                    replica.updateVersionInfoForRecovery(
+                                            tTabletInfo.getVersion(), /* set version to BE report version */
+                                            replica.getVersion(), /* set LFV to current FE version */
+                                            tTabletInfo.getVersion()); /* set LSV to BE report version */
+                                } else {
+                                    // this missing version is a hole
+                                    replica.updateVersionInfoForRecovery(
+                                            tTabletInfo.getVersion(), /* set version to BE report version */
+                                            tTabletInfo.getVersion() + 1, /* LFV */
+                                            /* remain LSV unchanged, which should be equal to replica.version */
+                                            replica.getLastSuccessVersion());
+                                }
+                                // no need to write edit log, if FE crashed, this will be recovered again
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #23362

## Problem Summary(Required):
After full clone finish, the new replica may report tablet status with missing versions. And then it will trigger the recover tablet. But we don't set `LFV` in recover tablet, it will cause two issues:
1. The missing version replica will be select as queryable replica, and query will return error "version not found".
2. Repair clone will not trigger.

So we need to call `updateVersionInfoForRecovery` to set `LFV`.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
