### PR TITLE
[Enhancement] fix memcpy inlined to handle short string

### DIFF
--- a/be/src/gutil/strings/fastmem.h
+++ b/be/src/gutil/strings/fastmem.h
@@ -104,17 +104,57 @@ inline void memcpy_inlined(void* __restrict _dst, const void* __restrict _src, s
     auto src = static_cast<const uint8_t*>(_src);
 
     [[maybe_unused]] tail : if (size <= 16) {
-        if (size >= 8) {
-            __builtin_memcpy(dst + size - 8, src + size - 8, 8);
-            __builtin_memcpy(dst, src, 8);
-        } else if (size >= 4) {
-            __builtin_memcpy(dst + size - 4, src + size - 4, 4);
-            __builtin_memcpy(dst, src, 4);
-        } else if (size >= 2) {
-            __builtin_memcpy(dst + size - 2, src + size - 2, 2);
+        switch (size) {
+        case 0:
+            break;
+        case 1:
+            __builtin_memcpy(dst, src, 1);
+            break;
+        case 2:
             __builtin_memcpy(dst, src, 2);
-        } else if (size >= 1) {
-            *dst = *src;
+            break;
+        case 3:
+            __builtin_memcpy(dst, src, 3);
+            break;
+        case 4:
+            __builtin_memcpy(dst, src, 4);
+            break;
+        case 5:
+            __builtin_memcpy(dst, src, 5);
+            break;
+        case 6:
+            __builtin_memcpy(dst, src, 6);
+            break;
+        case 7:
+            __builtin_memcpy(dst, src, 7);
+            break;
+        case 8:
+            __builtin_memcpy(dst, src, 8);
+            break;
+        case 9:
+            __builtin_memcpy(dst, src, 9);
+            break;
+        case 10:
+            __builtin_memcpy(dst, src, 10);
+            break;
+        case 11:
+            __builtin_memcpy(dst, src, 11);
+            break;
+        case 12:
+            __builtin_memcpy(dst, src, 12);
+            break;
+        case 13:
+            __builtin_memcpy(dst, src, 13);
+            break;
+        case 14:
+            __builtin_memcpy(dst, src, 14);
+            break;
+        case 15:
+            __builtin_memcpy(dst, src, 15);
+            break;
+        case 16:
+            __builtin_memcpy(dst, src, 16);
+            break;
         }
     }
     else {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1138,7 +1138,7 @@ void Tablet::get_compaction_status(std::string* json_result) {
     double compaction_score;
     std::string compaction_type;
     vector<RowsetSharedPtr> compaction_rowsets;
-    int64_t compaction_start_time = 1;
+    int64_t compaction_start_time = 0;
 
     {
         std::shared_lock rdlock(_meta_lock);

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1138,7 +1138,7 @@ void Tablet::get_compaction_status(std::string* json_result) {
     double compaction_score;
     std::string compaction_type;
     vector<RowsetSharedPtr> compaction_rowsets;
-    int64_t compaction_start_time;
+    int64_t compaction_start_time = 1;
 
     {
         std::shared_lock rdlock(_meta_lock);


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Use switch to efficiently handle short-sized string

before this pr, there are many if-else

![image](https://github.com/StarRocks/starrocks/assets/1081215/d2dd490e-bd59-40fb-802f-3b757c1ad976)

and after this pr, you can see there is a jmp table for efficiently handle short-sized string

![image](https://github.com/StarRocks/starrocks/assets/1081215/41704576-b967-45bd-a1be-0000be00db21)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
