### PR TITLE
[BugFix] Fix show tablet order by limit bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1833,6 +1833,7 @@ public class ShowExecutor {
                 } else if (showStmt.hasLimit()) {
                     sizeLimit = showStmt.getLimit();
                 }
+
                 boolean stop = false;
                 Collection<Partition> partitions = new ArrayList<>();
                 if (showStmt.hasPartition()) {
@@ -1880,11 +1881,6 @@ public class ShowExecutor {
                         }
                     }
                 }
-                if (sizeLimit > -1 && tabletInfos.size() < sizeLimit) {
-                    tabletInfos.clear();
-                } else if (sizeLimit > -1) {
-                    tabletInfos = tabletInfos.subList((int) showStmt.getOffset(), (int) sizeLimit);
-                }
 
                 // order by
                 List<OrderByPair> orderByPairs = showStmt.getOrderByPairs();
@@ -1897,6 +1893,10 @@ public class ShowExecutor {
                     comparator = new ListComparator<>(0, 1);
                 }
                 tabletInfos.sort(comparator);
+
+                if (sizeLimit > -1 && tabletInfos.size() > sizeLimit) {
+                    tabletInfos = tabletInfos.subList((int) showStmt.getOffset(), (int) sizeLimit);
+                }
 
                 for (List<Comparable> tabletInfo : tabletInfos) {
                     List<String> oneTablet = new ArrayList<>(tabletInfo.size());


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
for the sql:

```
show tablet from test_basic order by datasize desc limit 1 \G;
```
we get the wrong result, the result not order by.

## Problem Summary(Required):

**we should handle order by first**

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
