### PR TITLE
[BugFix] ensure a valid cast clause for MySQL/JDBC table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
@@ -124,13 +124,10 @@ public class CastExpr extends Expr {
 
     @Override
     public String toSqlImpl() {
-        if (isImplicit) {
-            return getChild(0).toSql();
-        }
-        if (isAnalyzed) {
+        if (targetTypeDef == null) {
             return "CAST(" + getChild(0).toSql() + " AS " + type.toString() + ")";
         } else {
-            return "CAST(" + getChild(0).toSql() + " AS " + targetTypeDef.toString() + ")";
+            return "CAST(" + getChild(0).toSql() + " AS " + targetTypeDef + ")";
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -719,7 +719,7 @@ public class Load {
                 }
 
                 SlotRef slotRef = (SlotRef) child;
-                String columnName = slotRef.getColumn().getName();
+                String columnName = slotRef.getColumnName();
                 if (excludedColumns.contains(columnName)) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ExternalTablePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ExternalTablePredicateExtractor.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.sql.optimizer.rewrite;
 
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
@@ -30,14 +32,24 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 // Extract predicates that can be pushed down to external table
 // and predicates that must be reserved
 // from the entire predicate
 // To be safe, we only allow push down simple  predicates
 public class ExternalTablePredicateExtractor {
+
+    private static Set<PrimitiveType> MYSQL_CAST_TYPE = ImmutableSet.of(PrimitiveType.DATE, PrimitiveType.CHAR,
+            PrimitiveType.DATETIME, PrimitiveType.DECIMALV2, PrimitiveType.DOUBLE, PrimitiveType.FLOAT, PrimitiveType.JSON);
+
+    private final boolean isMySQL;
     private List<ScalarOperator> pushedPredicates = new LinkedList<>();
     private List<ScalarOperator> reservedPredicates = new LinkedList<>();
+
+    public ExternalTablePredicateExtractor(boolean isMySQL) {
+        this.isMySQL = isMySQL;
+    }
 
     public ScalarOperator getPushPredicate() {
         return Utils.compoundAnd(pushedPredicates);
@@ -48,9 +60,6 @@ public class ExternalTablePredicateExtractor {
     }
 
     public void extract(ScalarOperator op) {
-        pushedPredicates.clear();
-        reservedPredicates.clear();
-
         if (op.getOpType().equals(OperatorType.COMPOUND)) {
             CompoundPredicateOperator operator = (CompoundPredicateOperator) op;
             switch (operator.getCompoundType()) {
@@ -59,7 +68,7 @@ public class ExternalTablePredicateExtractor {
                     // for CNF, we can push down each predicate independently
                     for (ScalarOperator conjunct : conjuncts) {
                         if (conjunct.accept(new CanFullyPushDownVisitor(), null)) {
-                            pushedPredicates.add(conjunct);
+                            pushedPredicates.add(removeImplicitCast(conjunct));
                         } else {
                             reservedPredicates.add(conjunct);
                         }
@@ -74,12 +83,12 @@ public class ExternalTablePredicateExtractor {
                             return;
                         }
                     }
-                    pushedPredicates.add(operator);
+                    pushedPredicates.add(removeImplicitCast(operator));
                     return;
                 }
                 case NOT: {
                     if (op.getChild(0).accept(new CanFullyPushDownVisitor(), null)) {
-                        pushedPredicates.add(op);
+                        pushedPredicates.add(removeImplicitCast(op));
                     } else {
                         reservedPredicates.add(op);
                     }
@@ -90,14 +99,33 @@ public class ExternalTablePredicateExtractor {
             return;
         }
         if (op.accept(new CanFullyPushDownVisitor(), null)) {
-            pushedPredicates.add(op);
+
+            pushedPredicates.add(removeImplicitCast(op));
         } else {
             reservedPredicates.add(op);
         }
     }
 
+    private ScalarOperator removeImplicitCast(ScalarOperator operator) {
+        BaseScalarOperatorShuttle removeImplicitCastShuttle = new BaseScalarOperatorShuttle() {
+            @Override
+            public ScalarOperator visitCastOperator(CastOperator operator, Void context) {
+                boolean[] update = {false};
+                List<ScalarOperator> clonedOperators = visitList(operator.getChildren(), update);
+                if (operator.isImplicit()) {
+                    return update[0] ? clonedOperators.get(0) : operator.getChild(0);
+                } else {
+                    return update[0] ? new CastOperator(operator.getType(), clonedOperators.get(0), operator.isImplicit())
+                            : operator;
+                }
+            }
+        };
+
+        return operator.accept(removeImplicitCastShuttle, null);
+    }
+
     // check whether a predicate can be pushed down as a whole
-    private static class CanFullyPushDownVisitor extends ScalarOperatorVisitor<Boolean, Void> {
+    private class CanFullyPushDownVisitor extends ScalarOperatorVisitor<Boolean, Void> {
         public CanFullyPushDownVisitor() {
         }
 
@@ -152,6 +180,9 @@ public class ExternalTablePredicateExtractor {
 
         @Override
         public Boolean visitCastOperator(CastOperator op, Void context) {
+            if (!op.isImplicit() && isMySQL && !MYSQL_CAST_TYPE.contains(op.getType().getPrimitiveType())) {
+                return false;
+            }
             return visitAllChildren(op, context);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateToExternalTableScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateToExternalTableScanRule.java
@@ -62,8 +62,8 @@ public class PushDownPredicateToExternalTableScanRule extends TransformationRule
         ScalarOperator predicate = Utils.compoundAnd(lfo.getPredicate(), operator.getPredicate());
         ScalarOperator scanPredicate = operator.getPredicate();
         ScalarOperator filterPredicate = lfo.getPredicate();
-
-        ExternalTablePredicateExtractor extractor = new ExternalTablePredicateExtractor();
+        ExternalTablePredicateExtractor extractor = new ExternalTablePredicateExtractor(
+                operator.getOpType() == OperatorType.LOGICAL_MYSQL_SCAN);
         extractor.extract(predicate);
         ScalarOperator pushedPredicate = extractor.getPushPredicate();
         ScalarOperator reservedPredicate = extractor.getReservePredicate();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1264,7 +1264,6 @@ public class PlanFragmentBuilder {
             List<ScalarOperator> predicates = Utils.extractConjuncts(node.getPredicate());
             ScalarOperatorToExpr.FormatterContext formatterContext =
                     new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr());
-            formatterContext.setImplicitCast(true);
             for (ScalarOperator predicate : predicates) {
                 scanNode.getConjuncts().add(ScalarOperatorToExpr.buildExecExpression(predicate, formatterContext));
             }
@@ -1348,7 +1347,6 @@ public class PlanFragmentBuilder {
             List<ScalarOperator> predicates = Utils.extractConjuncts(node.getPredicate());
             ScalarOperatorToExpr.FormatterContext formatterContext =
                     new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr());
-            formatterContext.setImplicitCast(true);
             for (ScalarOperator predicate : predicates) {
                 scanNode.getConjuncts().add(ScalarOperatorToExpr.buildExecExpression(predicate, formatterContext));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -108,7 +108,6 @@ public class ScalarOperatorToExpr {
     public static class FormatterContext {
         private final Map<ColumnRefOperator, Expr> colRefToExpr;
         private final Map<ColumnRefOperator, ScalarOperator> projectOperatorMap;
-        private boolean implicitCast = false;
 
         public FormatterContext(Map<ColumnRefOperator, Expr> variableToSlotRef) {
             this.colRefToExpr = variableToSlotRef;
@@ -121,9 +120,6 @@ public class ScalarOperatorToExpr {
             this.projectOperatorMap = projectOperatorMap;
         }
 
-        public void setImplicitCast(boolean isImplicit) {
-            this.implicitCast = isImplicit;
-        }
     }
 
     public static class Formatter extends ScalarOperatorVisitor<Expr, FormatterContext> {
@@ -533,7 +529,7 @@ public class ScalarOperatorToExpr {
         public Expr visitCastOperator(CastOperator operator, FormatterContext context) {
             CastExpr expr =
                     new CastExpr(operator.getType(), buildExpr.build(operator.getChild(0), context));
-            expr.setImplicit(context.implicitCast);
+            expr.setImplicit(operator.isImplicit());
             hackTypeNull(expr);
             return expr;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -158,13 +158,13 @@ public class ExternalTableTest extends PlanTestBase {
     public void testJDBCTableFilter() throws Exception {
         String sql = "select * from test.jdbc_test where a > 10 and b < 'abc' limit 10";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("0:SCAN JDBC\n" +
+        Assert.assertTrue(plan, plan.contains("0:SCAN JDBC\n" +
                 "     TABLE: `test_table`\n" +
                 "     QUERY: SELECT a, b, c FROM `test_table` WHERE (a > 10) AND (b < 'abc')\n" +
                 "     limit: 10"));
         sql = "select * from test.jdbc_test where a > 10 and length(b) < 20 limit 10";
         plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains(
+        Assert.assertTrue(plan, plan.contains(
                 "  1:SELECT\n" +
                         "  |  predicates: length(b) < 20\n" +
                         "  |  limit: 10\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MySQLTableCastTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MySQLTableCastTest.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.api.client.util.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class MySQLTableCastTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+    }
+
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("explicitCastSqls")
+    void testExplicitCast(Pair<String, String> pair) throws Exception {
+        String sql = pair.first;
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, pair.second);
+    }
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("implicitCastSqls")
+    void testImplicitCast(Pair<String, String> pair) throws Exception {
+        String sql = pair.first;
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, pair.second);
+    }
+
+    private static Stream<Arguments> explicitCastSqls() {
+        List<Pair<String, String>> sqls = Lists.newArrayList();
+        sqls.add(Pair.create("select * from ods_order where cast(cast(org_order_no as float) as date)",
+                "WHERE (CAST(CAST(org_order_no AS FLOAT) AS DATE))"));
+
+        sqls.add(Pair.create("select * from ods_order where cast(org_order_no as varchar)", "WHERE (org_order_no)"));
+
+        sqls.add(Pair.create("select * from ods_order where cast(org_order_no as date)", "WHERE (CAST(org_order_no AS DATE))"));
+
+        sqls.add(Pair.create("select * from ods_order join mysql_table where cast(org_order_no as date) " +
+                        "and k1 = cast(k2 as date)", "WHERE (k1 = CAST(k2 AS DATE))"));
+
+        sqls.add(Pair.create("select * from ods_order where cast(org_order_no as int)",
+                "predicates: CAST(CAST(org_order_no AS INT) AS BOOLEAN)"));
+
+        return sqls.stream().map(e -> Arguments.of(e));
+    }
+
+    private static Stream<Arguments> implicitCastSqls() {
+        List<Pair<String, String>> sqls = Lists.newArrayList();
+        sqls.add(Pair.create("select * from ods_order where org_order_no", "WHERE (org_order_no)"));
+        sqls.add(Pair.create("select * from ods_order where org_order_no or up_trade_no",
+                "WHERE ((org_order_no) OR (up_trade_no))"));
+        sqls.add(Pair.create("select * from ods_order where org_order_no and cast(up_trade_no as date)",
+                "WHERE (org_order_no) AND (CAST(up_trade_no AS DATE))"));
+        sqls.add(Pair.create("select * from ods_order where org_order_no or (up_trade_no = order_dt) or (mchnt_no = pay_st)",
+                "WHERE (((org_order_no) OR (up_trade_no = order_dt)) OR (mchnt_no = pay_st))"));
+        sqls.add(Pair.create("select * from ods_order join mysql_table where k1  = 'a' and order_dt = 'c'",
+                "WHERE (order_dt = 'c')"));
+        sqls.add(Pair.create("select * from (select * from ods_order join mysql_table where k1  = 'a' and order_dt = 'c')" +
+                " t1 where t1.k2 = 'c'", "WHERE (k2 = 'c') AND (k1 = 'a')"));
+
+        return sqls.stream().map(e -> Arguments.of(e));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
@@ -445,4 +445,12 @@ public class ScanTest extends PlanTestBase {
                 "sum[([count_t1a, VARCHAR, true]); args: BIGINT; result: BIGINT; " +
                 "args nullable: true; result nullable: true]");
     }
+
+    @Test
+    public void testImplicitCast() throws Exception {
+        String sql = "select count(distinct v1||v2) from t0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count((CAST(1: v1 AS BOOLEAN)) OR (CAST(2: v2 AS BOOLEAN)))");
+    }
 }


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #23434

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
The root casue is when translate scalarOperator to expr, the implicit flag is not being set correctly.  Only when the scanNode is JDBC/MySQL scanNode, the formatterContext.implicitCast is true.
```
public Expr visitCastOperator(CastOperator operator, FormatterContext context) {
            CastExpr expr =
                    new CastExpr(operator.getType(), buildExpr.build(operator.getChild(0), context));
            expr.setImplicit(context.implicitCast);
            hackTypeNull(expr);
            return expr;
        }
```
To ensure these unnecessary implicit cast not being pushed to MySQL/JDBC scanNode, we remove these implicit cast in `PushDownPredicateToExternalTableScanRule`. Only valid cast caluse in both in SR and [MySQL](https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#function_cast) can be pushed then only implicit cast will be removed for MySQL table.
```
# col_1 is a varchar, col_2 is a varchar, col_3 is a int
select * from table where col_1 and cast(col_2 as date) and cast(col_3 as string);

# in SR
select * from table where cast(col_1 as boolean) and cast(col_2 as date) and cast(col_3 as string);

# in MySQL the scan will be
select * from table where col_1 and cast(col_2 as date) -- the cast(col_3 as string) will do in the SR because MySQL don't support cast as string.
```

Changes in Load.java
When use VectorizedLoad, we need analyzeMappingExprs which will replace the origin slotRef to a new slotRef without description and it may lead NPE in`slotRef.getColumn()` . So use `slotRef.getColumnName()` instead of `slotRef.getColumn().getName()`;
```
public static Expr analyzeAndCastFold(Expr expr) {
        ExpressionAnalyzer.analyzeExpressionIgnoreSlot(expr, ConnectContext.get());
        // Translating expr to scalar in order to do some rewrites
        try {
            ScalarOperator scalarOperator = SqlToScalarOperatorTranslator.translate(expr);
            ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
            // Add cast and constant fold
            scalarOperator = scalarRewriter.rewrite(scalarOperator, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
            return ScalarOperatorToExpr.buildExprIgnoreSlot(scalarOperator,
                    new ScalarOperatorToExpr.FormatterContext(Maps.newHashMap()));
        } catch (UnsupportedException e) {
            return expr;
        }
    }
```



## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
